### PR TITLE
Replace assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -135,7 +135,7 @@ class TestNodeBuild(TaskTestBase):
       target_type=NodeModule,
       sources=['package.json'],
       build_script=build_script)
-    with self.assertRaisesRegexp(TaskError, build_script):
+    with self.assertRaisesRegex(TaskError, build_script):
       self._run_test_and_get_products([(target, [package_json_file])])
 
   def test_run_no_output_dir(self):
@@ -155,5 +155,5 @@ class TestNodeBuild(TaskTestBase):
       sources=['package.json'],
       build_script='my_build',
       output_dir=output_dir)
-    with self.assertRaisesRegexp(TaskError, output_dir):
+    with self.assertRaisesRegex(TaskError, output_dir):
       self._run_test_and_get_products([(target, [package_json_file])])

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
@@ -79,9 +79,9 @@ class TestNodeBundle(TaskTestBase):
         self.assertRaises(TargetDefinitionException, task.execute)
 
   def test_no_zip_for_archive(self):
-    with self.assertRaisesRegexp(TargetDefinitionException, 'zip'):
+    with self.assertRaisesRegex(TargetDefinitionException, 'zip'):
       NodeBundle(node_module=self.node_module_target_name_full, archive='zip')
 
   def test_require_node_module_for_bundle(self):
-    with self.assertRaisesRegexp(TargetDefinitionException, 'node_module'):
+    with self.assertRaisesRegex(TargetDefinitionException, 'node_module'):
       NodeBundle()

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -396,7 +396,7 @@ class NodeResolveTest(TaskTestBase):
 
     def test_resolve_default_no_options_npm_local(self):
       unsupported = 'not supported for NPM'
-      with self.assertRaisesRegexp(TaskError, unsupported):
+      with self.assertRaisesRegex(TaskError, unsupported):
         self._test_resolve_options_helper(
           install_optional=False,
           force_option_override=False,

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve_src_deps.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve_src_deps.py
@@ -324,7 +324,7 @@ class NodeResolveSourceDepsTest(TaskTestBase):
     dep = self._create_dep()
     app = self._create_app(dep, dep_not_found=True)
     error_msg = 'Local dependency in package.json not found in the build graph.'
-    with self.assertRaisesRegexp(TaskError, error_msg):
+    with self.assertRaisesRegex(TaskError, error_msg):
       self._resolve_target(app)
 
   def test_file_dependency_not_supported_npm(self):

--- a/src/python/pants/backend/project_info/rules/source_file_validator_test.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator_test.py
@@ -110,7 +110,7 @@ class MultiMatcherTest(unittest.TestCase):
                       self._rm.check_source_file('foo/bar/baz.py', py_file_content))
 
   def test_multiple_encodings_error(self):
-    with self.assertRaisesRegexp(ValueError, r'Path matched patterns with multiple content '
+    with self.assertRaisesRegex(ValueError, r'Path matched patterns with multiple content '
                                              r'encodings \(ascii, utf8\): hello\/world.foo'):
       self._rm.get_applicable_content_pattern_names('hello/world.foo')
 
@@ -121,7 +121,7 @@ class MultiMatcherTest(unittest.TestCase):
         'unknown_path_pattern2': (),
       }
     }
-    with self.assertRaisesRegexp(ValueError, 'required_matches uses unknown path pattern names: '
+    with self.assertRaisesRegex(ValueError, 'required_matches uses unknown path pattern names: '
                                              'unknown_path_pattern1, unknown_path_pattern2'):
       MultiMatcher(bad_config1)
 
@@ -131,6 +131,6 @@ class MultiMatcherTest(unittest.TestCase):
         'dummy': ('unknown_content_pattern1',)
       }
     }
-    with self.assertRaisesRegexp(ValueError, 'required_matches uses unknown content '
+    with self.assertRaisesRegex(ValueError, 'required_matches uses unknown content '
                                              'pattern names: unknown_content_pattern1'):
       MultiMatcher(bad_config2)

--- a/src/python/pants/subsystem/subsystem_test.py
+++ b/src/python/pants/subsystem/subsystem_test.py
@@ -201,7 +201,7 @@ class SubsystemTest(TestBase):
 
   def test_uninitialized_global(self) -> None:
     Subsystem.reset()
-    with self.assertRaisesRegexp(Subsystem.UninitializedSubsystemError,
+    with self.assertRaisesRegex(Subsystem.UninitializedSubsystemError,
                                  r'UninitializedSubsystem.*uninitialized-scope'):
       UninitializedSubsystem.global_instance()
 
@@ -212,7 +212,7 @@ class SubsystemTest(TestBase):
       options_scope = 'optional'
 
     optional = UninitializedOptional()
-    with self.assertRaisesRegexp(Subsystem.UninitializedSubsystemError,
+    with self.assertRaisesRegex(Subsystem.UninitializedSubsystemError,
                                  r'UninitializedSubsystem.*uninitialized-scope'):
       UninitializedSubsystem.scoped_instance(optional)
 

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -174,7 +174,7 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
       )
     """.format(**self.PARTS)))
 
-    with self.assertRaisesRegexp(TaskError, r'.*Antlr sources in multiple directories.*'):
+    with self.assertRaisesRegex(TaskError, r'.*Antlr sources in multiple directories.*'):
       self.execute(self.create_context())
 
   def test_generated_target_fingerprint_stable_v3(self):

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
@@ -16,7 +16,7 @@ class JavaAntlrLibraryTest(TestBase):
     return BuildFileAliases(targets={'java_antlr_library': JavaAntlrLibrary})
 
   def test_empty(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  "the sources parameter.*contains an empty snapshot."):
       self.add_to_build_file('BUILD', dedent('''
         java_antlr_library(name='foo',
@@ -34,7 +34,7 @@ class JavaAntlrLibraryTest(TestBase):
     self.assertIsInstance(self.foo, JavaAntlrLibrary)
 
   def test_invalid_compiler(self):
-    with self.assertRaisesRegexp(TargetDefinitionException, "Illegal value for 'compiler'"):
+    with self.assertRaisesRegex(TargetDefinitionException, "Illegal value for 'compiler'"):
       self.add_to_build_file('BUILD', dedent('''
         java_antlr_library(name='foo',
           sources=['foo'],

--- a/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
@@ -32,7 +32,7 @@ class JavaWireLibraryTest(TestBase):
     self.assertEqual(['foo', 'bar', 'baz'], target.payload.service_writer_options)
 
   def test_invalid_service_writer_opts(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'service_writer_options requires setting service_writer'):
       self.make_target('invalid:service_writer_opts', JavaWireLibrary,
                        service_writer_options=['one', 'two'])

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -115,13 +115,13 @@ This is the second readme file! Isn't it exciting?
 
   def test_no_sources(self):
     self.add_to_build_file('', "page(name='page', sources=['does-not-exist.md'])")
-    with self.assertRaisesRegexp(AddressLookupError, r'//:page.*exactly 1 source, but found 0'):
+    with self.assertRaisesRegex(AddressLookupError, r'//:page.*exactly 1 source, but found 0'):
       self.target(':page')
 
   def test_multiple_sources(self):
     self.create_files('', ['exists.md', 'also-exists.md'])
     self.add_to_build_file('', "page(name='page', sources=['exists.md', 'also-exists.md'])")
-    with self.assertRaisesRegexp(AddressLookupError, r'//:page.*exactly 1 source, but found 2'):
+    with self.assertRaisesRegex(AddressLookupError, r'//:page.*exactly 1 source, but found 2'):
       self.target(':page')
 
   def test_source_and_sources(self):
@@ -130,7 +130,7 @@ This is the second readme file! Isn't it exciting?
       '',
       "page(name='page', source=['exists.md'], sources=['also-exists.md'])",
     )
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
       AddressLookupError,
       r'//:page: Cannot specify both source and sources attribute'
     ):

--- a/tests/python/pants_test/backend/jvm/targets/test_junit_tests.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_junit_tests.py
@@ -40,7 +40,7 @@ class JUnitTestsTest(TestBase):
     tc4 = self.make_target('//:testconcurrency4', JUnitTests, sources=['Test.java'],
                            concurrency='PARALLEL_CLASSES_AND_METHODS')
     self.assertEqual(JUnitTests.CONCURRENCY_PARALLEL_CLASSES_AND_METHODS, tc4.concurrency)
-    with self.assertRaisesRegexp(TargetDefinitionException, r'concurrency'):
+    with self.assertRaisesRegex(TargetDefinitionException, r'concurrency'):
       self.make_target('//:testconcurrency5', JUnitTests, sources=['Test.java'],
                        concurrency='nonsense')
 
@@ -49,7 +49,7 @@ class JUnitTestsTest(TestBase):
     self.assertEqual(99, tt1.threads)
     tt2 = self.make_target('//:testthreads2', JUnitTests, sources=['Test.java'], threads="123")
     self.assertEqual(123, tt2.threads)
-    with self.assertRaisesRegexp(TargetDefinitionException, r'threads'):
+    with self.assertRaisesRegex(TargetDefinitionException, r'threads'):
       self.make_target('//:testthreads3', JUnitTests, sources=['Test.java'], threads="abc")
 
     # timeout parameter

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -45,7 +45,7 @@ class JvmAppTest(TestBase):
     self.assertEqual('zip', app_target.payload.archive)
 
   def test_bad_basename(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmApp.* basename must not equal name.'):
       self.make_target(':foo', JvmApp, basename='foo')
 
@@ -73,7 +73,7 @@ class JvmAppTest(TestBase):
 
   def test_no_binary(self):
     app = self.create_app('src/java/org/archimedes/buoyancy')
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmApp.*src/java/org/archimedes/buoyancy:app\).*'
                                  r' An app must define exactly one'):
       app.binary
@@ -82,7 +82,7 @@ class JvmAppTest(TestBase):
     self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     bin2 = self.make_target('src/java/org/archimedes/buoyancy:bin2', JvmBinary)
     app = self.create_app('src/java/org/archimedes/buoyancy', binary=':bin', dependencies=[bin2])
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmApp.*src/java/org/archimedes/buoyancy:app\).*'
                                  r' An app must define exactly one'):
       app.binary
@@ -91,7 +91,7 @@ class JvmAppTest(TestBase):
     bin = self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     bin2 = self.make_target('src/java/org/archimedes/buoyancy:bin2', JvmBinary)
     app = self.create_app('src/java/org/archimedes/buoyancy', dependencies=[bin, bin2])
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmApp.*src/java/org/archimedes/buoyancy:app\).*'
                                  r' An app must define exactly one'):
       app.binary
@@ -100,7 +100,7 @@ class JvmAppTest(TestBase):
     self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     self.create_app('src/java/org/archimedes/buoyancy', name='app', binary=':bin')
     app = self.create_app('src/java/org/archimedes/buoyancy', name='app2', binary=':app')
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmApp.*src/java/org/archimedes/buoyancy:app2\).*'
                                  r' Expected binary dependency'):
       app.binary

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -23,21 +23,21 @@ class JarRulesTest(unittest.TestCase):
     self.assertEqual('Skip(apply_pattern=foo)', repr(skip_rule))
 
   def test_invalid_apply_pattern(self):
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a str'):
+    with self.assertRaisesRegex(ValueError, r'The supplied apply_pattern is not a str'):
       Skip(None)
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a str'):
+    with self.assertRaisesRegex(ValueError, r'The supplied apply_pattern is not a str'):
       Duplicate(None, Duplicate.SKIP)
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern: \) is not a valid'):
+    with self.assertRaisesRegex(ValueError, r'The supplied apply_pattern: \) is not a valid'):
       Skip(r')')
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern: \) is not a valid'):
+    with self.assertRaisesRegex(ValueError, r'The supplied apply_pattern: \) is not a valid'):
       Duplicate(r')', Duplicate.SKIP)
 
   def test_bad_action(self):
-    with self.assertRaisesRegexp(ValueError, r'The supplied action must be one of'):
+    with self.assertRaisesRegex(ValueError, r'The supplied action must be one of'):
       Duplicate('foo', None)
 
   def test_duplicate_error(self):
-    with self.assertRaisesRegexp(Duplicate.Error, r'Duplicate entry encountered for path foo'):
+    with self.assertRaisesRegex(Duplicate.Error, r'Duplicate entry encountered for path foo'):
       raise Duplicate.Error('foo')
 
   def test_default(self):
@@ -47,7 +47,7 @@ class JarRulesTest(unittest.TestCase):
       self.assertTrue(rule.apply_pattern.pattern.startswith(r'^META-INF'))
 
   def test_set_bad_default(self):
-    with self.assertRaisesRegexp(ValueError, r'The default rules must be a JarRules'):
+    with self.assertRaisesRegex(ValueError, r'The default rules must be a JarRules'):
       JarRules.set_default(None)
 
 
@@ -121,7 +121,7 @@ class JvmBinaryTest(TestBase):
       '',
       'jvm_binary(name = "foo", main = "com.example.Foo", source = ["foo.py"])',
     )
-    with self.assertRaisesRegexp(AddressLookupError,
+    with self.assertRaisesRegex(AddressLookupError,
                                  r'Invalid target.*foo.*source must be a str'):
       self.target(':foo')
 
@@ -132,7 +132,7 @@ class JvmBinaryTest(TestBase):
       'foo',
       'jvm_binary(name = "foo", main = "com.example.Foo", sources = ["foo.py", "bar.py"])',
     )
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
       AddressLookupError,
       r'Invalid target.*foo.*jvm_binary must have exactly 0 or 1 sources'
     ):
@@ -140,7 +140,7 @@ class JvmBinaryTest(TestBase):
 
   def test_bad_main_declaration(self):
     self.add_to_build_file('', 'jvm_binary(name = "bar", main = ["com.example.Bar"])')
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*bar.*main must be a fully'):
       self.target(':bar')
 
@@ -149,7 +149,7 @@ class JvmBinaryTest(TestBase):
       '',
       'jvm_binary(name = "foo", main = "com.example.Foo", deploy_jar_rules="invalid")',
     )
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*'
                                  r'deploy_jar_rules must be a JarRules specification. '
                                  r'got (str|unicode)'):
@@ -204,7 +204,7 @@ class JvmBinaryTest(TestBase):
   main = "com.example.Foo",
   manifest_entries = "foo",
 )''')
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*: manifest_entries must be a '
                                  r'dict. got (str|unicode)'):
       self.target(':foo')
@@ -217,7 +217,7 @@ class JvmBinaryTest(TestBase):
   main = "com.example.Foo",
   manifest_entries = {jar("bad", "bad", "bad"): "foo"},
 )''')
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'entries must be dictionary of strings, got key .* '
                                  r'type JarDependency'):
       self.target(':foo')

--- a/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
@@ -142,7 +142,7 @@ class BootstrapJvmToolsNonOptionalNoDefaultTest(BootstrapJvmToolsTestBase):
     return cls.JvmToolTask
 
   def test_unsupplied(self):
-    with self.assertRaisesRegexp(BootstrapJvmTools.ToolResolveError,
+    with self.assertRaisesRegex(BootstrapJvmTools.ToolResolveError,
                                  r'\s*Failed to resolve target for tool: test:checkstyle\..*'):
       self.execute(context=self.context())
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -188,7 +188,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
         """
     ))
     task = self.prepare_execute(self.context(target_roots=[self.target('foo:empty')]))
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'must include a non-empty set of sources'):
       task.execute()
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command.py
@@ -33,11 +33,11 @@ class JvmPrepCommandTest(TaskTestBase):
     self.make_target('foo', JvmPrepCommand, mainclass='org.pantsbuild.FooMain')
 
   def test_invalid_target(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'mainclass must be specified'):
       self.make_target('foo', JvmPrepCommand,)
 
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'.*Got goal "baloney". Goal must be one of.*'):
       self.make_target('foo', JvmPrepCommand, mainclass='org.pantsbuild.FooMain', goal='baloney')
 

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -129,7 +129,7 @@ setup(
     pycountry_req_lib = self.target_dict['pycountry']
     conflicting_lib = self.target_dict['install_requires_conflict']
 
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         pex.resolver.Unsatisfiable,
         re.escape('Could not satisfy all requirements for pycountry==18.5.20:')):
       self._create_distribution_synthetic_target(

--- a/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
+++ b/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
@@ -82,6 +82,6 @@ class UnpackWheelsTest(TaskTestBase):
     self._assert_unpacking(module_name='pex')
 
   def test_unpack_missing_module_name(self):
-    with self.assertRaisesRegexp(UnpackWheels.WheelUnpackingError, re.escape(
+    with self.assertRaisesRegex(UnpackWheels.WheelUnpackingError, re.escape(
         'Error extracting wheel for target UnpackedWheels(unpack:foo): Exactly one dist was expected to match name not-a-real-module')):
       self._assert_unpacking(module_name='not-a-real-module')

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -159,7 +159,7 @@ class CoercingJsonEncodingTest(unittest.TestCase):
     self.assertEqual(self._coercing_json_encode(set([1])), '[1]')
 
   def test_rejects_ordered_dict(self):
-    with self.assertRaisesRegexp(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):
+    with self.assertRaisesRegex(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):
       self._coercing_json_encode(OrderedDict([('a', 3)]))
 
   def test_non_string_dict_key_coercion(self):
@@ -207,10 +207,10 @@ class JsonHashingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1({1}), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
   def test_rejects_ordered_collections(self):
-    with self.assertRaisesRegexp(TypeError,
+    with self.assertRaisesRegex(TypeError,
                                  re.escape('CoercingEncoder does not support OrderedDict inputs')):
       stable_json_sha1(OrderedDict([('a', 3)]))
-    with self.assertRaisesRegexp(TypeError,
+    with self.assertRaisesRegex(TypeError,
                                  re.escape('CoercingEncoder does not support OrderedSet inputs')):
       stable_json_sha1(OrderedSet([3]))
 

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -27,9 +27,9 @@ class ParseValidation(unittest.TestCase):
       assert_list(["file.txt"], allowable=(set,))  # Incorrect type
 
   def test_invalid_inputs_with_key_arg(self):
-    with self.assertRaisesRegexp(ValueError, "In key 'resources':"):
+    with self.assertRaisesRegex(ValueError, "In key 'resources':"):
       assert_list({"file3.txt": "source"}, key_arg='resources')  # Can't pass a dict
-    with self.assertRaisesRegexp(ValueError, "In key 'artifacts':"):
+    with self.assertRaisesRegex(ValueError, "In key 'artifacts':"):
       assert_list([["file3.txt"]], key_arg='artifacts')  # All values most be strings
-    with self.assertRaisesRegexp(ValueError, "In key 'jars':"):
+    with self.assertRaisesRegex(ValueError, "In key 'jars':"):
       assert_list(None, can_be_none=False, key_arg='jars')  # The default is ok as None only when can_be_none is true

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -283,14 +283,14 @@ class BuildGraphTest(TestBase):
 
   @unittest.skip(reason='TODO: #4515')
   def test_invalid_address(self):
-    with self.assertRaisesRegexp(AddressLookupError, '.* does not contain any BUILD files.'):
+    with self.assertRaisesRegex(AddressLookupError, '.* does not contain any BUILD files.'):
       self.inject_address_closure('//:a')
 
     self.add_to_build_file('BUILD',
                            'target(name="a", '
                            '  dependencies=["non-existent-path:b"],'
                            ')')
-    with self.assertRaisesRegexp(AddressLookupError,
+    with self.assertRaisesRegex(AddressLookupError,
                                  '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:b'
                                  '\s+referenced from //:a$'):
@@ -306,7 +306,7 @@ class BuildGraphTest(TestBase):
                            'target(name="b", '
                            '  dependencies=["non-existent-path:c"],'
                            ')')
-    with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
+    with self.assertRaisesRegex(BuildGraph.TransitiveLookupError,
                                  '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:c'
                                  '\s+referenced from goodpath:b'
@@ -337,7 +337,7 @@ class BuildGraphTest(TestBase):
                            'target(name="c", '
                            '  dependencies=["non-existent-path:d"],'
                            ')')
-    with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
+    with self.assertRaisesRegex(BuildGraph.TransitiveLookupError,
                                  '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:d'
                                  '\s+referenced from goodpath:c'
@@ -355,7 +355,7 @@ class BuildGraphTest(TestBase):
     self.add_to_build_file('other/BUILD',
                            'target(name="b")')
 
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         AddressLookupError,
         '''^Addresses in dependencies must be unique. 'other:b' is '''
         '''referenced more than once by target '//:a'.'''):

--- a/tests/python/pants_test/core_tasks/test_run_prep_command.py
+++ b/tests/python/pants_test/core_tasks/test_run_prep_command.py
@@ -104,12 +104,12 @@ class RunPrepCommandTest(TaskTestBase):
     self.assertEqual(frozenset({'binary', 'test'}), prep_command.goals)
 
   def test_invalid_target_no_executable(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'prep_executable must be specified'):
       self.make_target('foo', PrepCommand,)
 
   def test_invalid_target_unrecognized_goals(self):
-    with self.assertRaisesRegexp(TargetDefinitionException,
+    with self.assertRaisesRegex(TargetDefinitionException,
                                  r'.*Got unrecognized goals baloney, malarkey. '
                                  r'Goal must be one of.*'):
       self.make_target('foo', PrepCommand, prep_executable='foo.sh',

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -39,7 +39,7 @@ class GraphTest(TestBase):
                        '.*Did you mean one of:\n' \
                        '.*:Markdown\n' \
                        '.*:Pygments\n'
-    with self.assertRaisesRegexp(AddressLookupError, expected_message):
+    with self.assertRaisesRegex(AddressLookupError, expected_message):
       self.targets('3rdparty/python:rutabaga')
 
   def test_with_missing_directory_fails(self):

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -120,13 +120,13 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     expected_rx_str = re.escape(
       """"b" was not found in namespace "root". Did you mean one of:
   :a""")
-    with self.assertRaisesRegexp(ResolveError, expected_rx_str):
+    with self.assertRaisesRegex(ResolveError, expected_rx_str):
       self._resolve_build_file_addresses(
         specs, address_family, self._snapshot(), self._address_mapper())
 
     # Ensure that we still catch nonexistent targets later on in the list of command-line specs.
     specs = Specs([SingleAddress('root', 'a'), SingleAddress('root', 'b')])
-    with self.assertRaisesRegexp(ResolveError, expected_rx_str):
+    with self.assertRaisesRegex(ResolveError, expected_rx_str):
       self._resolve_build_file_addresses(
         specs, address_family, self._snapshot(), self._address_mapper())
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -139,7 +139,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       relative_symlink(dest_path, link_path)
 
     exc_reg = f'.*While expanding link.*{link}.*may not traverse outside of the buildroot.*{dest}.*'
-    with self.assertRaisesRegexp(Exception, exc_reg):
+    with self.assertRaisesRegex(Exception, exc_reg):
       self.assert_walk_files([link], [], prepare=prepare)
 
   def test_walk_recursive_all(self):

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -204,7 +204,7 @@ class SchedulerTest(TestBase):
     # But not a subset.
     expected_msg = ("No installed @rules can compute {} for input Params(A), but"
                     .format(str.__name__))
-    with self.assertRaisesRegexp(Exception, re.escape(expected_msg)):
+    with self.assertRaisesRegex(Exception, re.escape(expected_msg)):
       self.request_single_product(str, Params(a))
 
   def test_transitive_params(self):

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -166,28 +166,28 @@ class InvalidationCacheManagerTest(TestBase):
 
     # This only is caught here if the VT is still invalid for some reason, otherwise it's caught by the update() method.
     vt.force_invalidate()
-    with self.assertRaisesRegexp(ValueError, r'Path for link.*overwrite an existing directory*'):
+    with self.assertRaisesRegex(ValueError, r'Path for link.*overwrite an existing directory*'):
       vt.create_results_dir()
 
   def test_raises_for_clobbered_symlink(self):
     vt = self.make_vt()
     self.clobber_symlink(vt)
-    with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*symlink*'):
+    with self.assertRaisesRegex(VersionedTargetSet.IllegalResultsDir, r'The.*symlink*'):
       vt.ensure_legal()
 
   def test_raises_missing_current_results_dir(self):
     vt = self.make_vt()
     safe_rmtree(vt.current_results_dir)
-    with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*current_results_dir*'):
+    with self.assertRaisesRegex(VersionedTargetSet.IllegalResultsDir, r'The.*current_results_dir*'):
       vt.ensure_legal()
 
   def test_raises_both_clobbered_symlink_and_missing_current_results_dir(self):
     vt = self.make_vt()
     self.clobber_symlink(vt)
     safe_rmtree(vt.current_results_dir)
-    with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*symlink*'):
+    with self.assertRaisesRegex(VersionedTargetSet.IllegalResultsDir, r'The.*symlink*'):
       vt.ensure_legal()
-    with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*current_results_dir*'):
+    with self.assertRaisesRegex(VersionedTargetSet.IllegalResultsDir, r'The.*current_results_dir*'):
       vt.ensure_legal()
 
   def test_for_illegal_vts(self):

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -94,7 +94,7 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
 
   def test_impossible_distribution_requirements(self):
     with _distribution_locator() as locator:
-      with self.assertRaisesRegexp(Distribution.Error, "impossible constraints"):
+      with self.assertRaisesRegex(Distribution.Error, "impossible constraints"):
         locator.cached('2', '1', jdk=False)
 
   def _test_jvm_does_not_meet_distribution_requirements(self,

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -110,7 +110,7 @@ class FilesetRelPathWrapperTest(TestBase):
     self.add_to_build_file('y/BUILD', dedent("""
       dummy_target(name="y", sources=globs("*.java", exclude="fleem.java"))
       """))
-    with self.assertRaisesRegexp(AddressLookupError, 'Excludes of type.*are not supported.*'):
+    with self.assertRaisesRegex(AddressLookupError, 'Excludes of type.*are not supported.*'):
       self.context().scan()
 
   def test_glob_exclude_string_in_list(self):

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -219,7 +219,7 @@ class ContextutilTest(unittest.TestCase):
         file_symlink = os.path.join(tempdir, 'foo')
         os.symlink(not_zip.name, file_symlink)
         self.assertEqual(os.path.realpath(file_symlink), os.path.realpath(not_zip.name))
-        with self.assertRaisesRegexp(zipfile.BadZipfile, f'{not_zip.name}'), open_zip(file_symlink):
+        with self.assertRaisesRegex(zipfile.BadZipfile, f'{not_zip.name}'), open_zip(file_symlink):
           pass
 
   @contextmanager

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -356,21 +356,21 @@ class DirutilTest(unittest.TestCase):
   def test_relative_symlink_same_paths(self) -> None:
     with temporary_dir() as tmpdir_1:  # source is link
       source = os.path.join(tmpdir_1, 'source')
-      with self.assertRaisesRegexp(ValueError, r'Path for link is identical to source'):
+      with self.assertRaisesRegex(ValueError, r'Path for link is identical to source'):
         relative_symlink(source, source)
 
   def test_relative_symlink_bad_source(self) -> None:
     with temporary_dir() as tmpdir_1:  # source is not absolute
       source = os.path.join('foo', 'bar')
       link = os.path.join(tmpdir_1, 'link')
-      with self.assertRaisesRegexp(ValueError, r'Path for source.*absolute'):
+      with self.assertRaisesRegex(ValueError, r'Path for source.*absolute'):
         relative_symlink(source, link)
 
   def test_relative_symlink_bad_link(self) -> None:
     with temporary_dir() as tmpdir_1:  # link is not absolute
       source = os.path.join(tmpdir_1, 'source')
       link = os.path.join('foo', 'bar')
-      with self.assertRaisesRegexp(ValueError, r'Path for link.*absolute'):
+      with self.assertRaisesRegex(ValueError, r'Path for link.*absolute'):
         relative_symlink(source, link)
 
   def test_relative_symlink_overwrite_existing_file(self) -> None:
@@ -388,7 +388,7 @@ class DirutilTest(unittest.TestCase):
       link_path = os.path.join(tmpdir_1, 'link')
 
       safe_mkdir(link_path)
-      with self.assertRaisesRegexp(ValueError, r'Path for link.*overwrite an existing directory*'):
+      with self.assertRaisesRegex(ValueError, r'Path for link.*overwrite an existing directory*'):
         relative_symlink(source, link_path)
 
   def test_get_basedir(self) -> None:


### PR DESCRIPTION
Problem

assertRaisesRegexp changed names in 3.2 and now reports a deprecation
warning.

Solution

Rename all uses of assertRaisesRegexp to assertRaisesRegex

Result

No more deprecation warning


### Problem

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)