### PR TITLE
Replace unicode strings having regex escapes with raw strings

### DIFF
--- a/src/python/pants/backend/project_info/rules/source_file_validator_test.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator_test.py
@@ -16,12 +16,12 @@ from pants.backend.project_info.rules.source_file_validator import (
 # showcasing common use-cases.
 class MatcherTest(unittest.TestCase):
   def test_match(self):
-    m = Matcher('Here is a two-digit number: \d\d')
+    m = Matcher(r'Here is a two-digit number: \d\d')
     self.assertTrue(m.matches('Here is a two-digit number: 42'))
     self.assertFalse(m.matches('Here is a two-digit number: 4'))
 
   def test_inverse_match(self):
-    m = Matcher('Here is a two-digit number: \d\d', inverted=True)
+    m = Matcher(r'Here is a two-digit number: \d\d', inverted=True)
     self.assertFalse(m.matches('Here is a two-digit number: 42'))
     self.assertTrue(m.matches('Here is a two-digit number: 4'))
 
@@ -53,7 +53,7 @@ class MultiMatcherTest(unittest.TestCase):
           """).lstrip()
         },
         'no_six': {
-          'pattern': "(?m)(^from six(\.\w+)* +import +)|(^import six\s*$)",
+          'pattern': r"(?m)(^from six(\.\w+)* +import +)|(^import six\s*$)",
           'inverted': True
         },
         'jvm_header': {

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -91,7 +91,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
 
 # The wheel METADATA file will contain a line like: `Version: 1.11.0.dev3+7951ec01`.
 # We don't parse the entire file because it's large (it contains the entire release notes history).
-_version_re = re.compile('Version: (?P<version>\S+)')
+_version_re = re.compile(r'Version: (?P<version>\S+)')
 
 
 def reversion(args):

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -121,8 +121,8 @@ class CheckstyleTest(NailgunTaskTestBase):
 
     suppression_file = self._create_suppression_file(
       [
-        '<suppress files=".*with_tab_1\.java" checks=".*" />',
-        '<suppress files=".*with_tab_2\.java" checks=".*" />',
+        '<suppress files=".*with_tab_1\\.java" checks=".*" />',
+        '<suppress files=".*with_tab_2\\.java" checks=".*" />',
       ])
 
     no_tab = self._create_target('no_tab', self._TEST_JAVA_SOURCE_WITH_NO_TAB)

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -160,7 +160,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
               "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
           <suppressions>
-            <suppress files=".*/bad-files/.*\.java" checks=".*"/>
+            <suppress files=".*/bad-files/.*\\.java" checks=".*"/>
           </suppressions>
           """).strip()
 
@@ -191,7 +191,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
                 "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
             <suppressions>
-              <suppress files=".*/bad-files/.*\.java" checks=".*"/>
+              <suppress files=".*/bad-files/.*\\.java" checks=".*"/>
             </suppressions>
           """).strip(),
           dedent("""
@@ -201,8 +201,8 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
                 "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
             <suppressions>
-              <suppress files=".*/bad-files/.*\.java" checks=".*"/>
-              <suppress files=".*/really-bad-files/.*\.java" checks=".*"/>
+              <suppress files=".*/bad-files/.*\\.java" checks=".*"/>
+              <suppress files=".*/really-bad-files/.*\\.java" checks=".*"/>
             </suppressions>
           """).strip(),
         ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
@@ -178,7 +178,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
 
   def _find_html_report(self, ivy_report_dir):
     html_report_file = None
-    pattern = re.compile('internal-.*-default\.html$')
+    pattern = re.compile(r'internal-.*-default\.html$')
     listdir = os.listdir(ivy_report_dir)
     for f in listdir:
       if os.path.isfile(os.path.join(ivy_report_dir, f)):


### PR DESCRIPTION
Problem

Python 3 interprets strings as unicode strings instead of literals. This
results	various escaped characters as being escaped unicode chars
instead of regex escapes.

Solution

Mark said strings as 'raw' strings or double escape slashes

Result

No warnings such as
```
22:12:19 00:03       [pythonstyle]
                     /Users/eax/svn/pantsbuild/pants/.pants.d/lint/pythonstyle/checker/6ef723da0ecff3d83671692c7a1c7959033193d6-DefaultFingerprintStrategy.9996ec0b06ff/CPython-3.7.6/.bootstrap/pex/pep425tags.py:274: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
                       import imp
                     src/python/pants/backend/project_info/rules/source_file_validator_test.py:19: DeprecationWarning: invalid escape sequence \d
                       m = Matcher('Here is a two-digit number: \d\d')
                     src/python/pants/backend/project_info/rules/source_file_validator_test.py:24: DeprecationWarning: invalid escape sequence \d
                       m = Matcher('Here is a two-digit number: \d\d', inverted=True)
                     src/python/pants/backend/project_info/rules/source_file_validator_test.py:56: DeprecationWarning: invalid escape sequence \.
                       'pattern': "(?m)(^from six(\.\w+)* +import +)|(^import six\s*$)",

```