### PR TITLE
Deprecate `option.custom_types.dict_option` and `list_option`

### DIFF
--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -6,6 +6,7 @@ import re
 from enum import Enum
 from typing import Dict, Iterable, List, Pattern, Sequence
 
+from pants.base.deprecated import warn_or_error
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method
@@ -32,6 +33,11 @@ def dict_option(s: str) -> "DictValueComponent":
 
   :API: public
   """
+  warn_or_error(
+    removal_version="1.27.0.dev0",
+    deprecated_entity_description="pants.option.custom_types.dict_option",
+    hint="Instead of setting an option's type as `type=dict_option`, set `type=dict`."
+  )
   return DictValueComponent.create(s)
 
 
@@ -48,6 +54,11 @@ def list_option(s: str) -> "ListValueComponent":
 
   :API: public
   """
+  warn_or_error(
+    removal_version="1.27.0.dev0",
+    deprecated_entity_description="pants.option.custom_types.list_option",
+    hint="Instead of setting an option's type as `type=list_option`, set `type=list`."
+  )
   return ListValueComponent.create(s)
 
 
@@ -61,8 +72,6 @@ def target_option(s: str) -> str:
   return s
 
 
-# TODO: Replace target_list_option with type=list, member_type=target_option.
-# Then we'll get all the goodies from list_option (e.g., appending) free.
 def target_list_option(s):
   """Same type as 'list_option', but indicates list contents are target specs.
 
@@ -70,6 +79,12 @@ def target_list_option(s):
 
   TODO(stuhood): Eagerly convert these to Addresses: see https://rbcommons.com/s/twitter/r/2937/
   """
+  warn_or_error(
+    removal_version="1.27.0.dev0",
+    deprecated_entity_description="pants.option.custom_types.target_list_option",
+    hint="Instead of setting an option's type as `type=target_list_option`, set "
+         "`type=list, member_type=target_option`."
+  )
   return _convert(s, (list, tuple))
 
 
@@ -110,7 +125,7 @@ def dict_with_files_option(s):
 
   :API: public
   """
-  return dict_option(s)
+  return DictValueComponent.create(s)
 
 
 def _convert(val, acceptable_types):

--- a/src/python/pants/option/options_fingerprinter_test.py
+++ b/src/python/pants/option/options_fingerprinter_test.py
@@ -6,12 +6,12 @@ import os
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.option.custom_types import (
+  DictValueComponent,
+  ListValueComponent,
   UnsetBool,
-  dict_option,
   dict_with_files_option,
   dir_option,
   file_option,
-  list_option,
   target_option,
 )
 from pants.option.options_fingerprinter import OptionsFingerprinter
@@ -29,20 +29,20 @@ class OptionsFingerprinterTest(TestBase):
     d1 = {'b': 1, 'a': 2}
     d2 = {'a': 2, 'b': 1}
     d3 = {'a': 1, 'b': 2}
-    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(dict_option, d)
+    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(DictValueComponent.create, d)
                      for d in (d1, d2, d3))
     self.assertEqual(fp1, fp2)
     self.assertNotEqual(fp1, fp3)
 
   def test_fingerprint_dict_with_non_string_keys(self) -> None:
     d = {('a', 2): (3, 4)}
-    fp = self.options_fingerprinter.fingerprint(dict_option, d)
+    fp = self.options_fingerprinter.fingerprint(DictValueComponent.create, d)
     self.assertEqual(fp, '3852a094612ce1c22c08ee2ddcdc03d09e87ad97')
 
   def test_fingerprint_list(self) -> None:
     l1 = [1, 2, 3]
     l2 = [1, 3, 2]
-    fp1, fp2 = (self.options_fingerprinter.fingerprint(list_option, l)
+    fp1, fp2 = (self.options_fingerprinter.fingerprint(ListValueComponent.create, l)
                      for l in (l1, l2))
     self.assertNotEqual(fp1, fp2)
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -564,15 +564,15 @@ class Parser:
   @staticmethod
   def _wrap_type(t):
     if t == list:
-      return list_option
+      return ListValueComponent.create
     if t == dict:
-      return dict_option
+      return DictValueComponent.create
     return t
 
   @staticmethod
   def _convert_member_type(t, x):
     if t == dict:
-      return dict_option(x).val
+      return DictValueComponent.create(x).val
     return t(x)
 
   def _compute_value(self, dest, kwargs, flag_val_strs):


### PR DESCRIPTION
These were intended to be removed several years ago, but we never properly initiated a deprecation cycle. 