### PR TITLE
Hotfix MyPy not working on macOS due to type alias

### DIFF
--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -131,9 +131,7 @@ class Parser:
     self._known_args: Set[str] = set()
 
     # List of (args, kwargs) registration pairs, exactly as captured at registration time.
-    OptionNames = Tuple[str, ...]
-    OptionKwargs = Dict[str, Any]
-    self._option_registrations: List[Tuple[OptionNames, OptionKwargs]] = []
+    self._option_registrations: List[Tuple[Tuple[str, ...], Dict[str, Any]]] = []
 
     self._parent_parser = parent_parser
     self._child_parsers: List["Parser"] = []


### PR DESCRIPTION
Likely due to some bug in MyPy, running MyPy on macOS locally was resulting in this error. This didn't fail in CI (which uses Linux), however.

MyPy should be supporting the local type alias, but we don't care much about that particular type alias so we revert it here and hope that a future MyPy release fixes this bug.

> Traceback (most recent call last):
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 397, in execute
    exit_code = self._wrap_coverage(self._wrap_profiling, self._execute)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 329, in _wrap_coverage
    return runner(*args)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 360, in _wrap_profiling
    return runner(*args)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 442, in _execute
    return self.execute_entry(self._pex_info.entry_point)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 540, in execute_entry
    return runner(entry_point)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/.bootstrap/pex/pex.py", line 547, in execute_module
    runpy.run_module(module_name, run_name='__main__')
  File "/Users/eric/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 208, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/Users/eric/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761-da39a3ee5e6b4b0d3255bfef95601890afd80709/pants_mypy_launcher.py", line 10, in <module>
    runpy.run_module('mypy', run_name='__main__')
  File "/Users/eric/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 208, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/Users/eric/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/eric/DocsLocal/code/projects/pants/.pants.d/lint/mypy/CPython-3.6.8/mypy==0.761/.deps/mypy-0.761-cp36-cp36m-macosx_10_6_x86_64.whl/mypy/__main__.py", line 12, in <module>
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 89, in main
  File "mypy/build.py", line 166, in build
  File "mypy/build.py", line 235, in _build
  File "mypy/build.py", line 2611, in dispatch
  File "mypy/build.py", line 2911, in process_graph
  File "mypy/build.py", line 2989, in process_fresh_modules
  File "mypy/build.py", line 1919, in fix_cross_refs
  File "mypy/fixup.py", line 25, in fixup_module
  File "mypy/fixup.py", line 89, in visit_symbol_table
  File "mypy/fixup.py", line 45, in visit_type_info
  File "mypy/fixup.py", line 91, in visit_symbol_table
  File "mypy/nodes.py", line 874, in accept
  File "mypy/fixup.py", line 136, in visit_var
  File "mypy/types.py", line 794, in accept
  File "mypy/fixup.py", line 160, in visit_instance
  File "mypy/types.py", line 1347, in accept
  File "mypy/fixup.py", line 217, in visit_tuple_type
  File "mypy/types.py", line 234, in accept
    co.co_stacksize,
  File "mypy/fixup.py", line 169, in visit_type_alias_type
  File "mypy/fixup.py", line 276, in lookup_qualified_alias
  File "mypy/fixup.py", line 290, in lookup_qualified
  File "mypy/fixup.py", line 299, in lookup_qualified_stnode
  File "mypy/lookup.py", line 47, in lookup_fully_qualified
AssertionError: Cannot find component 'OptionNames' for 'pants.option.parser.Parser.OptionNames'
>
> FAILURE: mypy failed: code=1
>
>
>               Waiting for background workers to finish.
> 08:56:19 00:11   [complete]
>               FAILURE
> Please fix the above errors and run again.

