### PR TITLE
Add `--black-skip`, `--isort-skip`, and `--flake8-skip` 

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -66,6 +66,7 @@ class BlackIntegrationTest(TestBase):
     *,
     config: Optional[str] = None,
     passthrough_args: Optional[Sequence[str]] = None,
+    skip: bool = False,
   ) -> Tuple[LintResult, FmtResult]:
     if config is not None:
       self.create_file(relpath="pyproject.toml", contents=config)
@@ -81,6 +82,7 @@ class BlackIntegrationTest(TestBase):
       Black, options={Black.options_scope: {
         "config": "pyproject.toml" if config else None,
         "args": passthrough_args or [],
+        "skip": skip,
       }}
     )
     black_setup = self.request_single_product(
@@ -140,3 +142,8 @@ class BlackIntegrationTest(TestBase):
     assert "1 file would be left unchanged" in lint_result.stderr
     assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.digest == self.get_digest([self.needs_config_source])
+
+  def test_skip(self) -> None:
+    lint_result, fmt_result = self.run_black([self.bad_source], skip=True)
+    assert lint_result == LintResult.noop()
+    assert fmt_result == FmtResult.noop()

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -19,6 +19,10 @@ class Black(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--skip', type=bool, default=False,
+      help="Don't use Black when running `./pants fmt` and `./pants lint`"
+    )
+    register(
       '--args', type=list, member_type=str,
       help="Arguments to pass directly to Black, e.g. "
            "`--black-args=\"--target-version=py37 --quiet\"`",

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -29,8 +29,8 @@ class Flake8Target:
 
 def generate_args(wrapped_target: Flake8Target, flake8: Flake8) -> Tuple[str, ...]:
   args = []
-  if flake8.get_options().config is not None:
-    args.append(f"--config={flake8.get_options().config}")
+  if flake8.options.config is not None:
+    args.append(f"--config={flake8.options.config}")
   args.extend(flake8.get_args())
   args.extend(sorted(wrapped_target.target.sources.snapshot.files))
   return tuple(args)
@@ -43,6 +43,9 @@ async def lint(
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> LintResult:
+  if flake8.options.skip:
+    return LintResult.noop()
+
   target = wrapped_target.target
 
   # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
@@ -53,7 +56,7 @@ async def lint(
     python_setup=python_setup
   )
 
-  config_path: Optional[str] = flake8.get_options().config
+  config_path: Optional[str] = flake8.options.config
   config_snapshot = await Get[Snapshot](
     PathGlobs(include=tuple([config_path] if config_path else []))
   )

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -63,6 +63,7 @@ class Flake8IntegrationTest(TestBase):
     config: Optional[str] = None,
     passthrough_args: Optional[Sequence[str]] = None,
     interpreter_constraints: Optional[Sequence[str]] = None,
+    skip: bool = False,
   ) -> LintResult:
     if config is not None:
       self.create_file(relpath=".flake8", contents=config)
@@ -78,6 +79,7 @@ class Flake8IntegrationTest(TestBase):
       Flake8, options={Flake8.options_scope: {
         "config": ".flake8" if config else None,
         "args": passthrough_args or [],
+        "skip": skip,
       }}
     )
     return self.request_single_product(
@@ -125,3 +127,7 @@ class Flake8IntegrationTest(TestBase):
     result = self.run_flake8([self.bad_source], passthrough_args=["--ignore=F401"])
     assert result.exit_code == 0
     assert result.stdout.strip() == ""
+
+  def test_skip(self) -> None:
+    result = self.run_flake8([self.bad_source], skip=True)
+    assert result == LintResult.noop()

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -19,6 +19,10 @@ class Flake8(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--skip', type=bool, default=False,
+      help="Don't use Flake8 when running `./pants lint`"
+    )
+    register(
       '--args', type=list, member_type=str,
       help="Arguments to pass directly to Flake8, e.g. "
            "`--flake8-args=\"--ignore E123,W456 --enable-extensions H111\"`",

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -74,6 +74,7 @@ class IsortIntegrationTest(TestBase):
     *,
     config: Optional[str] = None,
     passthrough_args: Optional[Sequence[str]] = None,
+    skip: bool = False,
   ) -> Tuple[LintResult, FmtResult]:
     if config is not None:
       self.create_file(relpath=".isort.cfg", contents=config)
@@ -89,6 +90,7 @@ class IsortIntegrationTest(TestBase):
       Isort, options={Isort.options_scope: {
         "config": [".isort.cfg"] if config else None,
         "args": passthrough_args or [],
+        "skip": skip,
       }}
     )
     isort_setup = self.request_single_product(
@@ -153,3 +155,8 @@ class IsortIntegrationTest(TestBase):
     assert "Fixing" in fmt_result.stdout
     assert "test/config.py" in fmt_result.stdout
     assert fmt_result.digest == self.get_digest([self.fixed_needs_config_source])
+
+  def test_skip(self) -> None:
+    lint_result, fmt_result = self.run_isort([self.bad_source], skip=True)
+    assert lint_result == LintResult.noop()
+    assert fmt_result == FmtResult.noop()

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -18,6 +18,10 @@ class Isort(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--skip', type=bool, default=False, fingerprint=True,
+      help="Don't use isort when running `./pants fmt` and `./pants lint`"
+    )
+    register(
       '--args', type=list, member_type=str, fingerprint=True,
       help="Arguments to pass directly to isort, e.g. "
            "`--isort-args=\"--case-sensitive --trailing-comma\"`",

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import os
 
+from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
@@ -50,7 +51,7 @@ class IsortRun(FmtTaskMixin, Task):
         return
 
       isort = self.context.products.get_data(IsortPrep.tool_instance_cls)
-      isort_subsystem = IsortPrep.tool_subsystem_cls.global_instance()
+      isort_subsystem = Isort.global_instance()
       deprecated_conditional(
         lambda: self.get_passthru_args(),
         removal_version='1.26.0.dev3',
@@ -99,3 +100,7 @@ class IsortRun(FmtTaskMixin, Task):
   @classmethod
   def supports_passthru_args(cls):
     return True
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Isort.global_instance().options.skip

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.engine.console import Console
-from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
+from pants.engine.fs import (
+  EMPTY_DIRECTORY_DIGEST,
+  Digest,
+  DirectoriesToMerge,
+  DirectoryToMaterialize,
+  Workspace,
+)
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
@@ -20,6 +26,10 @@ class FmtResult:
   digest: Digest
   stdout: str
   stderr: str
+
+  @staticmethod
+  def noop() -> "FmtResult":
+    return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="")
 
   @staticmethod
   def from_execute_process_result(process_result: ExecuteProcessResult) -> "FmtResult":

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -20,6 +20,10 @@ class LintResult:
   stderr: str
 
   @staticmethod
+  def noop() -> "LintResult":
+    return LintResult(exit_code=0, stdout="", stderr="")
+
+  @staticmethod
   def from_fallible_execute_process_result(
     process_result: FallibleExecuteProcessResult
   ) -> "LintResult":


### PR DESCRIPTION
Per the [V2 skip design document](https://docs.google.com/document/d/13Qwb3JNgm3ogKeSgFz4QAiOs77jnrjfQqM6VqKWRyKM/edit#heading=h.v65cminz9qui), we have two problems:

1) We must remove `--fmt-skip` and `--lint-skip` to rename `fmt2` to `fmt` and `lint2` to `lint`.
2) We need a mechanism to **temporarily** turn off a linter in V2.

The solution was to move the `--skip` flag from tasks to their corresponding subsystem. This makes the change for isort, Black, and Flake8.

It does not yet deprecate `--fmt-isort-skip`, which will be done in a followup.