### PR TITLE
Deprecate running `python-eval` by default

### DIFF
--- a/contrib/mypy/README.md
+++ b/contrib/mypy/README.md
@@ -13,19 +13,19 @@ its own copy of `mypy`.
 
 ## Usage
 
-Just invoke the `mypy` task against any Python target(s). For example, if you had `python_library`
+Invoke the `lint` task against any Python target(s). For example, if you had `python_library`
 target identified by `src/python/foo/bar:baz`, run this command:
 
 ```
-./pants mypy src/python/foo/bar:baz
+./pants lint src/python/foo/bar:baz
 ```
 
-The `mypy` task will pass through any extra command-line arguments directly to `mypy`. For example,
+To pass through any extra command-line arguments directly to `mypy`, use `--mypy-args`. For example,
 if you want to pass `--follow-imports=silent` to `mypy` for the same python_library target, run
 this command:
 
 ```
-./pants mypy src/python/foo/bar:baz -- --follow-imports=silent
+./pants lint src/python/foo/bar:baz --mypy-args='--follow-imports=silent'
 ```
 
 See `mypy`'s usage screen for more information.

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -13,6 +13,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -31,7 +32,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
     def __init__(self, *args, **kwargs):
       compiled = kwargs.pop('compiled')
       failed = kwargs.pop('failed')
-      super(PythonEval.Error, self).__init__(*args, **kwargs)
+      super().__init__(*args, **kwargs)
       self.compiled = compiled
       self.failed = failed
 
@@ -44,6 +45,25 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
       PexBuilderWrapper.Factory,
       PythonInterpreterCache
     )
+
+  @property
+  def skip_execution(self):
+    deprecated_conditional(
+      lambda: self.get_options().is_default("skip"),
+      entity_description="`python-eval` defaulting to being used",
+      removal_version="1.27.0.dev0",
+      hint_message="`python-eval` is scheduled to be removed in Pants 1.29.0.dev0. The Python "
+                   "linter landscape has changed since we first created this tool - there are now "
+                   "popular linters that dramatically improve upon this one, such as MyPy and "
+                   "Pylint. Pants currently provides a wrapper around MyPy and will soon add "
+                   "Pylint. (To install MyPy, add "
+                   "`pantsbuild.pants.contrib.mypy==%(pants_version)s` to your `plugins` list.)"
+                   "\n\nTo prepare, set `skip: True` in your `pants.ini` under the section "
+                   "`python-eval`. If you still need to use this tool, set `skip: False`. In "
+                   "Pants 1.27.0.dev0, the default will change from `skip: False` to `skip: True`, "
+                   "and in Pants 1.29.0.dev0, the module will be removed."
+    )
+    return self.get_options().skip
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/pants.ini
+++ b/pants.ini
@@ -267,8 +267,6 @@ configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 skip: True
 
 [lint.python-eval]
-# After we fix the cycles from the engine refactor we should re-enable this.
-# https://github.com/pantsbuild/pants/issues/4601
 skip: True
 
 [lint.scalafmt]


### PR DESCRIPTION
https://github.com/pantsbuild/pants/issues/7444#issuecomment-569821230 proposed deprecating `python-eval` now that Pylint and MyPy provide similar functionality of checking transitive dependencies, e.g. checking for undefined imports. 

These alternatives are much more popular and provide better functionality. At the same time, maintaining `python-eval` adds a burden to the project, especially as we work to migrate the entire Python pipeline to V2.

To be able to remove `python-eval`, we first deprecate using it by default. In a followup, we will deprecate the module entirely.