### PR TITLE
Add ESLint subsystem and deprecate `node-distribution` ESLint options

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/eslint.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/eslint.py
@@ -1,0 +1,84 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import filecmp
+import logging
+import os.path
+import shutil
+from typing import Tuple
+
+from pants.option.custom_types import dir_option, file_option
+from pants.subsystem.subsystem import Subsystem
+from pants.util.dirutil import safe_mkdir, safe_rmtree
+
+
+logger = logging.getLogger(__name__)
+
+
+class ESLint(Subsystem):
+  options_scope = 'eslint'
+
+  required_files = ['yarn.lock', 'package.json']
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--version',  default='4.15.0', fingerprint=True, help='Use this ESLint version.')
+    register(
+      '--config', type=file_option, default=None,
+      help="Path to `.eslintrc` or alternative ESLint config file",
+    )
+    register(
+      '--setupdir', type=dir_option, fingerprint=True,
+      help='Find the package.json and yarn.lock under this dir for installing eslint and plugins.',
+    )
+    register(
+      '--ignore', type=file_option, fingerprint=True,
+      help='The path to the global eslint ignore path',
+    )
+
+  def configure(self, *, bootstrapped_support_path: str) -> None:
+    logger.debug(
+      f'Copying {self.options.setupdir} to bootstrapped dir: {bootstrapped_support_path}'
+    )
+    safe_rmtree(bootstrapped_support_path)
+    shutil.copytree(self.options.setupdir, bootstrapped_support_path)
+
+  def supportdir(self, *, task_workdir: str) -> Tuple[str, bool]:
+
+    """Returns the path where the ESLint is bootstrapped.
+
+    :param task_workdir: The task's working directory
+    :returns: The path where ESLint is bootstrapped and whether or not it is configured
+    """
+    bootstrapped_support_path = os.path.join(task_workdir, 'eslint')
+
+    # TODO(nsaechao): Should only have to check if the "eslint" dir exists in the task_workdir
+    # assuming fingerprinting works as intended.
+
+    # If the eslint_setupdir is not provided or missing required files, then
+    # clean up the directory so that Pants can install a pre-defined eslint version later on.
+    # Otherwise, if there is no configurations changes, rely on the cache.
+    # If there is a config change detected, use the new configuration.
+    if self.options.setupdir:
+      configured = all(
+        os.path.exists(os.path.join(self.options.setupdir, f)) for f in self.required_files
+      )
+    else:
+      configured = False
+    if not configured:
+      safe_mkdir(bootstrapped_support_path, clean=True)
+    else:
+      try:
+        installed = all(
+          filecmp.cmp(
+            os.path.join(self.options.setupdir, f),
+            os.path.join(bootstrapped_support_path, f)
+          ) for f in self.required_files
+        )
+      except OSError:
+        installed = False
+
+      if not installed:
+        self.configure(bootstrapped_support_path=bootstrapped_support_path)
+    return bootstrapped_support_path, configured

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -5,6 +5,7 @@ import filecmp
 import logging
 import os
 import shutil
+from typing import Tuple
 
 from pants.base.exceptions import TaskError
 from pants.binaries.binary_tool import NativeTool
@@ -65,14 +66,24 @@ class NodeDistribution(NativeTool):
              choices=VALID_PACKAGE_MANAGERS,
              help='Default package manager config for repo. Should be one of {}'.format(
                VALID_PACKAGE_MANAGERS))
+    # TODO: remove _configure_eslinter(), eslint_supportdir(), and _eslint_required_files when
+    # removing this option!
     register('--eslint-setupdir', advanced=True, type=dir_option, fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--eslint-setupdir` instead of `--node-distribution-eslint-setupdir`",
              help='Find the package.json and yarn.lock under this dir '
                   'for installing eslint and plugins.')
     register('--eslint-config', advanced=True, type=file_option, fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--eslint-config` instead of `--node-distribution-eslint-config`",
              help='The path to the global eslint configuration file specifying all the rules')
     register('--eslint-ignore', advanced=True, type=file_option, fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--eslint-ignore` instead of `--node-distribution-eslint-ignore`",
              help='The path to the global eslint ignore path')
     register('--eslint-version', default='4.15.0', fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--eslint-version` instead of `--node-distribution-eslint-version`",
              help='Use this ESLint version.')
     register('--node-scope', advanced=True, fingerprint=True,
              help='Default node scope for repo. Scope groups related packages together.')
@@ -162,22 +173,20 @@ class NodeDistribution(NativeTool):
     # `node` with no arguments is useful, it launches a REPL.
     return command_gen([self._install_node], 'node', args=args, node_paths=node_paths)
 
-  def _configure_eslinter(self, bootstrapped_support_path):
+  def _configure_eslinter(self, bootstrapped_support_path: str) -> None:
     logger.debug('Copying {setupdir} to bootstrapped dir: {support_path}'
                            .format(setupdir=self.eslint_setupdir,
                                    support_path=bootstrapped_support_path))
     safe_rmtree(bootstrapped_support_path)
     shutil.copytree(self.eslint_setupdir, bootstrapped_support_path)
-    return True
 
   _eslint_required_files = ['yarn.lock', 'package.json']
 
-  def eslint_supportdir(self, task_workdir):
-    """ Returns the path where the ESLint is bootstrapped.
+  def eslint_supportdir(self, task_workdir: str) -> Tuple[str, bool]:
+    """Returns the path where the ESLint is bootstrapped.
 
-    :param string task_workdir: The task's working directory
+    :param task_workdir: The task's working directory
     :returns: The path where ESLint is bootstrapped and whether or not it is configured
-    :rtype: (string, bool)
     """
     bootstrapped_support_path = os.path.join(task_workdir, 'eslint')
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -11,6 +11,7 @@ from pants.task.lint_task_mixin import LintTaskMixin
 from pants.util.contextutil import pushd
 from pants.util.memo import memoized_method
 
+from pants.contrib.node.subsystems.eslint import ESLint
 from pants.contrib.node.subsystems.package_managers import (PACKAGE_MANAGER_YARNPKG,
                                                             PackageInstallationVersionOption)
 from pants.contrib.node.targets.node_module import NodeModule
@@ -33,6 +34,31 @@ class JavascriptStyleBase(NodeTask):
     register('--fail-slow', type=bool,
              help='Check all targets and present the full list of errors.')
     register('--color', type=bool, default=True, help='Enable or disable color.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (ESLint,)
+
+  def _get_eslint_option(self, option: str, *, default_provided: bool = False):
+    """Temporary utility to help with the migration from node-distribution -> eslint."""
+    old_option = f"eslint_{option}"
+    node_distribution_val = getattr(self.node_distribution.get_options(), old_option)
+    eslint_val = getattr(ESLint.global_instance().options, option)
+
+    both_defined = node_distribution_val and eslint_val
+    both_not_default = (
+      not self.node_distribution.get_options().is_default(old_option) and
+      not ESLint.global_instance().options.is_default(option)
+    )
+    both_configured = both_not_default if default_provided else both_defined
+    if both_configured:
+      raise ValueError(
+        f"Conflicting options used. You used the new, preferred `--eslint-{option}`, but also "
+        f"used the deprecated `--node-distribution-eslint-{option}`.\n"
+        f"Please use only one of these (preferably `--eslint-{option}`)."
+      )
+
+    return eslint_val or node_distribution_val
 
   @property
   def fix(self):
@@ -71,7 +97,7 @@ class JavascriptStyleBase(NodeTask):
   @memoized_method
   def _bootstrap_eslinter(self, bootstrap_dir):
     with pushd(bootstrap_dir):
-      eslint_version = self.node_distribution.eslint_version
+      eslint_version = self._get_eslint_option("version", default_provided=True)
       eslint = f'eslint@{eslint_version}'
       self.context.log.debug(f'Installing {eslint}...')
       result, add_command = self.add_package(
@@ -140,7 +166,11 @@ class JavascriptStyleBase(NodeTask):
     if not targets:
       return
     failed_targets = []
-    bootstrap_dir, is_preconfigured = self.node_distribution.eslint_supportdir(self.workdir)
+    bootstrap_dir, is_preconfigured = (
+      ESLint.global_instance().supportdir(task_workdir=self.workdir)
+      if ESLint.global_instance().options.setupdir else
+      self.node_distribution.eslint_supportdir(self.workdir)
+    )
     if not is_preconfigured:
       self.context.log.debug('ESLint is not pre-configured, bootstrapping with defaults.')
       self._bootstrap_eslinter(bootstrap_dir)
@@ -149,11 +179,13 @@ class JavascriptStyleBase(NodeTask):
     for target in targets:
       files = self.get_javascript_sources(target)
       if files:
-        result_code, command = self._run_javascriptstyle(target,
-                                                         bootstrap_dir,
-                                                         files,
-                                                         config=self.node_distribution.eslint_config,
-                                                         ignore_path=self.node_distribution.eslint_ignore)
+        result_code, command = self._run_javascriptstyle(
+          target,
+          bootstrap_dir,
+          files,
+          config=self._get_eslint_option("config"),
+          ignore_path=self._get_eslint_option("ignore"),
+        )
         if result_code != 0:
           if self.get_options().fail_slow:
             raise TaskError('Javascript style failed: \n'

--- a/pants.ini
+++ b/pants.ini
@@ -249,10 +249,10 @@ no_warning_args: [
 [checkstyle]
 config: %(pants_supportdir)s/checkstyle/coding_style.xml
 
-[node-distribution]
-eslint_setupdir: %(pants_supportdir)s/eslint
-eslint_config: %(pants_supportdir)s/eslint/.eslintrc
-eslint_ignore: %(pants_supportdir)s/eslint/.eslintignore
+[eslint]
+setupdir: %(pants_supportdir)s/eslint
+config: %(pants_supportdir)s/eslint/.eslintrc
+ignore: %(pants_supportdir)s/eslint/.eslintignore
 
 [isort]
 config: [".isort.cfg", "contrib/.isort.cfg", "examples/.isort.cfg"]


### PR DESCRIPTION
This will allow us to deprecate `--{fmt,lint}-javascriptstyle-skip` in favor of `--eslint-skip`, per the V2 skip design doc: https://docs.google.com/document/d/13Qwb3JNgm3ogKeSgFz4QAiOs77jnrjfQqM6VqKWRyKM/edit

`--eslint-x` is also less verbose than `--node-distribution-eslint-x`.