### PR TITLE
Rename `optionable_rule` to `subsystem_rule`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -18,7 +18,7 @@ from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.legacy.structs import PythonAWSLambdaAdaptor
-from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 
 
@@ -83,4 +83,4 @@ async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
 def rules():
   return [create_python_awslambda,
           UnionRule(AWSLambdaTarget, PythonAWSLambdaAdaptor),
-          setup_lambdex, optionable_rule(Lambdex)]
+          setup_lambdex, subsystem_rule(Lambdex)]

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -13,7 +13,7 @@ from pants.engine.fs import Digest, FilesContent
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.objects import Collection
-from pants.engine.rules import console_rule, optionable_rule, rule
+from pants.engine.rules import console_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -274,5 +274,5 @@ def rules():
   return [
     validate,
     match_regexes_for_one_target,
-    optionable_rule(SourceFileValidation),
+    subsystem_rule(SourceFileValidation),
   ]

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -24,7 +24,7 @@ from pants.engine.isolated_process import (
   FallibleExecuteProcessResult,
 )
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
@@ -150,7 +150,7 @@ def rules():
     create_black_request,
     fmt,
     lint,
-    optionable_rule(Black),
+    subsystem_rule(Black),
     UnionRule(PythonFormatTarget, BlackTarget),
     UnionRule(PythonLintTarget, BlackTarget),
   ]

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
-from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.rules.core.lint import LintResult
 
@@ -91,4 +91,4 @@ async def lint(
 
 
 def rules():
-  return [lint, optionable_rule(Flake8), UnionRule(PythonLintTarget, Flake8Target)]
+  return [lint, subsystem_rule(Flake8), UnionRule(PythonLintTarget, Flake8Target)]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -22,7 +22,7 @@ from pants.engine.isolated_process import (
   FallibleExecuteProcessResult,
 )
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
@@ -140,7 +140,7 @@ def rules():
     create_isort_request,
     fmt,
     lint,
-    optionable_rule(Isort),
+    subsystem_rule(Isort),
     UnionRule(PythonFormatTarget, IsortTarget),
     UnionRule(PythonLintTarget, IsortTarget),
   ]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -18,7 +18,7 @@ from pants.engine.fs import (
 from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import optionable_rule, rule
+from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
 
 
@@ -144,5 +144,5 @@ async def create_pex(
 def rules():
   return [
     create_pex,
-    optionable_rule(PythonSetup),
+    subsystem_rule(PythonSetup),
   ]

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -15,7 +15,7 @@ from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
-from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.rules.core.core_test_model import TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
@@ -109,6 +109,6 @@ def rules():
   return [
     run_python_test,
     UnionRule(TestTarget, PythonTestsAdaptor),
-    optionable_rule(PyTest),
-    optionable_rule(PythonSetup),
+    subsystem_rule(PyTest),
+    subsystem_rule(PythonSetup),
   ]

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -15,7 +15,7 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.binaries.executable_pex_tool import ExecutablePexTool
-from pants.engine.rules import optionable_rule, rule
+from pants.engine.rules import rule, subsystem_rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.objects import SubclassesOf
@@ -167,6 +167,6 @@ def create_pex_native_build_environment(python_native_code: PythonNativeCode) ->
 
 def rules():
   return [
-    optionable_rule(PythonNativeCode),
+    subsystem_rule(PythonNativeCode),
     create_pex_native_build_environment,
   ]

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from pants.engine.rules import optionable_rule, rule
+from pants.engine.rules import rule, subsystem_rule
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -52,6 +52,6 @@ def create_subprocess_encoding_environment(
 
 def rules():
   return [
-    optionable_rule(SubprocessEnvironment),
+    subsystem_rule(SubprocessEnvironment),
     create_subprocess_encoding_environment,
   ]

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -16,6 +16,7 @@ from twitter.common.collections import OrderedSet
 from pants.engine.goal import Goal
 from pants.engine.objects import union
 from pants.engine.selectors import Get
+from pants.option.optionable import OptionableFactory
 from pants.util.collections import assert_single_element
 from pants.util.memo import memoized
 from pants.util.meta import frozen_after_init
@@ -54,8 +55,8 @@ class _RuleVisitor(ast.NodeVisitor):
 
 
 @memoized
-def optionable_rule(optionable_factory):
-  """Returns a TaskRule that constructs an instance of the Optionable for the given OptionableFactory.
+def subsystem_rule(optionable_factory: Type[OptionableFactory]) -> "TaskRule":
+  """Returns a TaskRule that constructs an instance of the subsystem.
 
   TODO: This API is slightly awkward for two reasons:
     1) We should consider whether Subsystems/Optionables should be constructed explicitly using
@@ -137,7 +138,7 @@ def _make_rule(
       for p, s in rule_visitor.gets)
 
     # Register dependencies for @console_rule/Goal.
-    dependency_rules = (optionable_rule(return_type.subsystem_cls),) if is_goal_cls else None
+    dependency_rules = (subsystem_rule(return_type.subsystem_cls),) if is_goal_cls else None
 
     # Set a default name for Goal classes if one is not explicitly provided
     if is_goal_cls and name is None:

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -6,7 +6,7 @@ from typing import Set
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import console_rule, optionable_rule, rule
+from pants.engine.rules import console_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.source.source_root import AllSourceRoots, SourceRoot, SourceRootConfig
 
@@ -59,7 +59,7 @@ async def list_roots(console: Console, options: RootsOptions, all_roots: AllSour
 
 def rules():
   return [
-      optionable_rule(SourceRootConfig),
+      subsystem_rule(SourceRootConfig),
       all_roots,
       list_roots,
     ]

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.build_graph.files import Files
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot
 from pants.engine.legacy.graph import HydratedTarget
-from pants.engine.rules import optionable_rule, rule
+from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.source.source_root import SourceRootConfig
 
@@ -51,4 +51,4 @@ async def strip_source_root(
 
 
 def rules():
-  return [strip_source_root, optionable_rule(SourceRootConfig)]
+  return [strip_source_root, subsystem_rule(SourceRootConfig)]


### PR DESCRIPTION
### Rationale

This rename is meant to make rule authoring more familiar for Pants rule authors. 

`Subsystem`s are a concept used frequently in both V1 and V2 which most plugin authors are familiar with. It is also a concrete concept. In V2, developers exclusively use `GoalSubsystem`s and `Subsystem`s to consume options, so the name `subsystem` is familiar.

In contrast, `Optionable` is an interface that most developers never use, unless they go under-the-hood to see how subsystems work. Likewise, `Optionable` may be easily confused for `Optional`.

### Possible future need for flexibility

There could possibly be a future where we have some new type of `Optionable` that is not a `Subsystem` or `GoalSubsystem`. Were that to happen, then `subsystem_rule` name would not work because it's not as flexible as the current `optionable_rule`.

Rather than this being a reason to stick with the status quo, however, we could instead introduce in this future a new rule name that explicitly describes that concept, including possibly reusing `optionable_rule` to co-exist with `subsystem_rule`. 

Until this possible future, only having `subsystem_rule` makes the concept more concrete and leverages the prior knowledge of Pants devs. 