### PR TITLE
Add `scrooge-linter` subsystem and deprecate `lint-thrift` options

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/register.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/register.py
@@ -4,9 +4,9 @@
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.scrooge.tasks.scrooge_gen import ScroogeGen
-from pants.contrib.scrooge.tasks.thrift_linter import ThriftLinter
+from pants.contrib.scrooge.tasks.thrift_linter_task import ThriftLinterTask
 
 
 def register_goals():
-  task(name='thrift', action=ThriftLinter).install('lint')
+  task(name='thrift', action=ThriftLinterTask).install('lint')
   task(name='scrooge', action=ScroogeGen).install('gen')

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies = [
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/option',
+  ],
+  tags = {"partially_type_checked"},
+)

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import multiprocessing
+from typing import Tuple
+
+from pants.option.option_util import flatten_shlexed_list
+from pants.subsystem.subsystem import Subsystem
+
+
+class ScroogeLinter(Subsystem):
+
+  options_scope = 'scrooge-linter'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--args', type=list, member_type=str, fingerprint=True,
+      help="Arguments to pass directly to the Scrooge Thrift linter, e.g. "
+           "`--scrooge-linter-args=\"--disable-rule Namespaces\"`",
+    )
+    register(
+      '--strict', type=bool, fingerprint=True,
+      help='Fail the goal if thrift linter errors are found. Overrides the `strict-default` option.'
+    )
+    register(
+      '--strict-default', default=False, advanced=True, type=bool, fingerprint=True,
+      help='Sets the default strictness for targets. The `strict` option overrides this value if '
+           'it is set.'
+    )
+    register(
+      '--worker-count', default=multiprocessing.cpu_count(), advanced=True, type=int,
+      help='Maximum number of workers to use for linter parallelization.',
+    )
+
+  def get_args(self) -> Tuple[str, ...]:
+    return flatten_shlexed_list(self.get_options().args)

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -34,9 +34,10 @@ python_library(
 
 python_library(
   name='thrift_linter',
-  sources=['thrift_linter.py'],
+  sources=['thrift_linter_task.py'],
   dependencies=[
     ':thrift_util',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/subsystems',
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -21,11 +21,12 @@ class ThriftLintError(Exception):
 class ThriftLinterTask(LintTaskMixin, NailgunTask):
   """Print lint warnings for thrift files."""
 
-  deprecation_template = (
-    "Conflicting options used. You used the new, preferred `--scrooge-linter-{option}`, but also "
-    "used the deprecated `--lint-thrift-{option}`\nPlease use only one of these "
-    "(preferably `--scrooge-linter-{option}`)."
-  )
+  def raise_conflicting_option(self, option: str) -> None:
+    raise ValueError(
+      f"Conflicting options used. You used the new, preferred `--scrooge-linter-{option}`, but also "
+      f"used the deprecated `--lint-thrift-{option}`\nPlease use only one of these "
+      f"(preferably `--scrooge-linter-{option}`)."
+    )
 
   @staticmethod
   def _is_thrift(target):
@@ -84,7 +85,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     task_strict_configured = not task_options.is_default('strict')
     subsystem_strict_configured = not subsystem_options.is_default('strict')
     if task_strict_configured and subsystem_strict_configured:
-      raise ValueError(self.deprecation_template.format(option="strict"))
+      self.raise_conflicting_option("strict")
     if subsystem_strict_configured:
       return self._to_bool(subsystem_options.strict)
     if task_strict_configured:
@@ -96,7 +97,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     task_strict_default_configured = not task_options.is_default('strict_default')
     subsystem_strict_default_configured = not subsystem_options.is_default('strict_default')
     if task_strict_default_configured and subsystem_strict_default_configured:
-      raise ValueError(self.deprecation_template.format(option="strict_default"))
+      self.raise_conflicting_option("strict_default")
     if task_strict_configured:
       return self._to_bool(task_options.strict_default)
     return self._to_bool(subsystem_options.strict_default)
@@ -144,7 +145,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     task_worker_count_configured = not self.get_options().is_default("worker_count")
     subsystem_worker_count_configured = not ScroogeLinter.global_instance().options.is_default("worker_count")
     if task_worker_count_configured and subsystem_worker_count_configured:
-      raise ValueError(self.deprecation_template.format(option="worker_count"))
+      self.raise_conflicting_option("worker_count")
     worker_count = (
       self.get_options().worker_count
       if task_worker_count_configured

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -8,9 +8,9 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work, WorkerPool
 from pants.base.workunit import WorkUnitLabel
-from pants.option.ranked_value import RankedValue
 from pants.task.lint_task_mixin import LintTaskMixin
 
+from pants.contrib.scrooge.subsystems.scrooge_linter import ScroogeLinter
 from pants.contrib.scrooge.tasks.thrift_util import calculate_include_paths
 
 
@@ -18,8 +18,14 @@ class ThriftLintError(Exception):
   """Raised on a lint failure."""
 
 
-class ThriftLinter(LintTaskMixin, NailgunTask):
+class ThriftLinterTask(LintTaskMixin, NailgunTask):
   """Print lint warnings for thrift files."""
+
+  deprecation_template = (
+    "Conflicting options used. You used the new, preferred `--scrooge-linter-{option}`, but also "
+    "used the deprecated `--lint-thrift-{option}`\nPlease use only one of these "
+    "(preferably `--scrooge-linter-{option}`)."
+  )
 
   @staticmethod
   def _is_thrift(target):
@@ -29,17 +35,29 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
   def register_options(cls, register):
     super().register_options(register)
     register('--strict', type=bool, fingerprint=True,
+             removal_hint="Use `--scrooge-linter-strict` instead",
              help='Fail the goal if thrift linter errors are found. Overrides the '
                   '`strict-default` option.')
     register('--strict-default', default=False, advanced=True, type=bool,
-             fingerprint=True,
+             fingerprint=True, removal_version="1.27.0.dev0",
+             removal_hint="Use `--scrooge-linter-strict-default` instead",
              help='Sets the default strictness for targets. The `strict` option overrides '
                   'this value if it is set.')
     register('--linter-args', default=[], advanced=True, type=list, fingerprint=True,
+             removal_version='1.27.0.dev0',
+             removal_hint='Use `--scrooge-linter-args` instead. Unlike this argument, you can pass '
+                          'all the arguments as one string, e.g. '
+                          '`--scrooge-linter-args="--disable-rule Namespaces".',
              help='Additional options passed to the linter.')
     register('--worker-count', default=multiprocessing.cpu_count(), advanced=True, type=int,
+             removal_version='1.27.0.dev0',
+             removal_hint="Use `--scrooge-linter-worker-count` instead.",
              help='Maximum number of workers to use for linter parallelization.')
     cls.register_jvm_tool(register, 'scrooge-linter')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (ScroogeLinter,)
 
   @classmethod
   def product_types(cls):
@@ -60,14 +78,28 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
     # 1. the option --[no-]strict, but only if explicitly set.
     # 2. java_thrift_library target in BUILD file, thrift_linter_strict = False,
     # 3. options, --[no-]strict-default
-    options = self.get_options()
-    if options.get_rank('strict') > RankedValue.HARDCODED:
-      return self._to_bool(self.get_options().strict)
+    task_options = self.get_options()
+    subsystem_options = ScroogeLinter.global_instance().options
+
+    task_strict_configured = not task_options.is_default('strict')
+    subsystem_strict_configured = not subsystem_options.is_default('strict')
+    if task_strict_configured and subsystem_strict_configured:
+      raise ValueError(self.deprecation_template.format(option="strict"))
+    if subsystem_strict_configured:
+      return self._to_bool(subsystem_options.strict)
+    if task_strict_configured:
+      return self._to_bool(task_options.strict)
 
     if target.thrift_linter_strict is not None:
       return self._to_bool(target.thrift_linter_strict)
 
-    return self._to_bool(self.get_options().strict_default)
+    task_strict_default_configured = not task_options.is_default('strict_default')
+    subsystem_strict_default_configured = not subsystem_options.is_default('strict_default')
+    if task_strict_default_configured and subsystem_strict_default_configured:
+      raise ValueError(self.deprecation_template.format(option="strict_default"))
+    if task_strict_configured:
+      return self._to_bool(task_options.strict_default)
+    return self._to_bool(subsystem_options.strict_default)
 
   def _lint(self, target, classpath):
     self.context.log.debug(f'Linting {target.address.spec}')
@@ -75,6 +107,7 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
     config_args = []
 
     config_args.extend(self.get_options().linter_args)
+    config_args.extend(ScroogeLinter.global_instance().get_args())
 
     # N.B. We always set --fatal-warnings to make sure errors like missing-namespace are at least printed.
     # If --no-strict is turned on, the return code will be 0 instead of 1, but the errors/warnings
@@ -107,6 +140,17 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
 
   def execute(self):
     thrift_targets = self.get_targets(self._is_thrift)
+
+    task_worker_count_configured = not self.get_options().is_default("worker_count")
+    subsystem_worker_count_configured = not ScroogeLinter.global_instance().options.is_default("worker_count")
+    if task_worker_count_configured and subsystem_worker_count_configured:
+      raise ValueError(self.deprecation_template.format(option="worker_count"))
+    worker_count = (
+      self.get_options().worker_count
+      if task_worker_count_configured
+      else ScroogeLinter.global_instance().options.worker_count
+    )
+
     with self.invalidated(thrift_targets) as invalidation_check:
       if not invalidation_check.invalid_vts:
         return
@@ -114,7 +158,7 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
       with self.context.new_workunit('parallel-thrift-linter') as workunit:
         worker_pool = WorkerPool(workunit.parent,
                                  self.context.run_tracker,
-                                 self.get_options().worker_count,
+                                 worker_count,
                                  workunit.name)
 
         scrooge_linter_classpath = self.tool_classpath('scrooge-linter')

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -29,7 +29,7 @@ class ThriftLinterTest(TaskTestBase):
   def task_type(cls):
     return ThriftLinterTask
 
-  @patch('pants.contrib.scrooge.tasks.thrift_linter.calculate_include_paths')
+  @patch('pants.contrib.scrooge.tasks.thrift_linter_task.calculate_include_paths')
   def test_lint(self, mock_calculate_include_paths):
 
     def get_default_jvm_options():
@@ -50,7 +50,7 @@ class ThriftLinterTest(TaskTestBase):
       jvm_options=get_default_jvm_options(),
       workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])
 
-  @patch('pants.contrib.scrooge.tasks.thrift_linter.calculate_include_paths')
+  @patch('pants.contrib.scrooge.tasks.thrift_linter_task.calculate_include_paths')
   def test_lint_direct_only(self, mock_calculate_include_paths):
     # Validate that we do lint only the direct sources of a target, rather than including the
     # sources of its transitive deps.

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -8,7 +8,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.testutil.task_test_base import TaskTestBase
 
-from pants.contrib.scrooge.tasks.thrift_linter import ThriftLinter
+from pants.contrib.scrooge.tasks.thrift_linter_task import ThriftLinterTask
 
 
 class ThriftLinterTest(TaskTestBase):
@@ -27,7 +27,7 @@ class ThriftLinterTest(TaskTestBase):
 
   @classmethod
   def task_type(cls):
-    return ThriftLinter
+    return ThriftLinterTask
 
   @patch('pants.contrib.scrooge.tasks.thrift_linter.calculate_include_paths')
   def test_lint(self, mock_calculate_include_paths):

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -87,7 +87,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   @rename_build_file
   def test_bad_default_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
-    cmd = ['lint.thrift', '--strict', self.thrift_test_target('bad-thrift-default')]
+    cmd = ['--scrooge-linter-strict', 'lint.thrift', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -98,8 +98,8 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     target_a = self.thrift_test_target('bad-thrift-strict')
     target_b = self.thrift_test_target('bad-thrift-strict2')
     cmd = ['-q',
+           '--scrooge-linter-strict',
            'lint.thrift',
-           '--strict',
            target_a,
            target_b,
            ]
@@ -113,7 +113,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   @rename_build_file
   def test_bad_strict_override(self):
     # thrift-linter passes with non-strict command line flag overriding the BUILD section.
-    cmd = ['lint.thrift', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
+    cmd = ['--no-scrooge-linter-strict', 'lint.thrift', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -121,7 +121,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   @rename_build_file
   def test_bad_non_strict_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
-    cmd = ['lint.thrift', '--strict', self.thrift_test_target('bad-thrift-non-strict')]
+    cmd = ['--scrooge-linter-strict', 'lint.thrift', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -130,7 +130,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def test_bad_pants_ini_strict(self):
     # thrift-linter fails if pants.ini has a thrift-linter:strict=True setting.
     cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-default')]
-    pants_ini_config = {'lint.thrift': {'strict': True}}
+    pants_ini_config = {'scrooge-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -139,8 +139,8 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def test_bad_pants_ini_strict_overridden(self):
     # thrift-linter passes if pants.ini has a thrift-linter:strict=True setting and
     # a command line non-strict flag is passed.
-    cmd = ['lint.thrift', '--no-strict', self.thrift_test_target('bad-thrift-default')]
-    pants_ini_config = {'lint.thrift': {'strict': True}}
+    cmd = ['--no-scrooge-linter-strict', 'lint.thrift', self.thrift_test_target('bad-thrift-default')]
+    pants_ini_config = {'scrooge-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)


### PR DESCRIPTION
This will allow us to deprecate `--lint-thrift-skip` in favor of `--scrooge-linter-skip`, per the V2 skip design doc: https://docs.google.com/document/d/13Qwb3JNgm3ogKeSgFz4QAiOs77jnrjfQqM6VqKWRyKM/edit