### PR TITLE
Use absolute path when running interactive process in tempdir

### DIFF
--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -991,7 +991,7 @@ pub extern "C" fn run_local_interactive_process(
           command.current_dir(tempdir.path());
         }
 
-        let mut subprocess = command.spawn().map_err(|e| e.to_string())?;
+        let mut subprocess = command.spawn().map_err(|e| format!("Error executing interactive process: {}", e.to_string()))?;
         let exit_status = subprocess.wait().map_err(|e| e.to_string())?;
         let code = exit_status.code().unwrap_or(-1);
 


### PR DESCRIPTION
### Problem

When we run an interactive process in a tempdir, we set the current directory of the subprocess to that tempdir with https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir . According to the linked documentation, in this case it's unpredictable platform-specific behavior whether a relative path will be resolved relative to the directory we set or to the working directory of the parent process.

### Solution

Check and see if the interactive process was passed a relative path, and if so manually canonicalize it to the tempdir.