### PR TITLE
Add `checkstyle` subsystem and deprecate `--lint-checkstyle-configuration`

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -246,6 +246,9 @@ no_warning_args: [
     '-Xlint:none',
   ]
 
+[checkstyle]
+config: %(pants_supportdir)s/checkstyle/coding_style.xml
+
 [node-distribution]
 eslint_setupdir: %(pants_supportdir)s/eslint
 eslint_config: %(pants_supportdir)s/eslint/.eslintrc
@@ -259,9 +262,6 @@ config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
 
 [lint]
 transitive: False
-
-[lint.checkstyle]
-configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
 [lint.google-java-format]
 skip: True

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -2,6 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
+  name = 'checkstyle',
+  sources = ['checkstyle.py'],
+  dependencies = [
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+  ],
+  tags = {"partially_type_checked"},
+)
+
+python_library(
   name = 'dependency_context',
   sources = ['dependency_context.py'],
   dependencies = [

--- a/src/python/pants/backend/jvm/subsystems/checkstyle.py
+++ b/src/python/pants/backend/jvm/subsystems/checkstyle.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.option.custom_types import file_option
+from pants.subsystem.subsystem import Subsystem
+
+
+class Checkstyle(Subsystem):
+
+  options_scope = 'checkstyle'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--config', type=file_option, default=None, fingerprint=True,
+      help="Path to Checkstyle config file."
+    )

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -160,6 +160,7 @@ python_library(
     ':nailgun_task',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/java/jar',
+    'src/python/pants/backend/jvm/subsystems:checkstyle',
     'src/python/pants/backend/jvm/subsystems:shader',
     'src/python/pants/base:exceptions',
     'src/python/pants/option',

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -5,6 +5,7 @@ import os
 
 from twitter.common.collections import OrderedSet
 
+from pants.backend.jvm.subsystems.checkstyle import Checkstyle as CheckstyleSubsystem
 from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
@@ -31,6 +32,8 @@ class Checkstyle(LintTaskMixin, NailgunTask):
   def register_options(cls, register):
     super().register_options(register)
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
+             removal_version='1.27.0.dev0',
+             removal_hint='Use `--checkstyle-config` instead of `--lint-checkstyle-configuration`.',
              help='Path to the checkstyle configuration file.')
     register('--properties', advanced=True, type=dict_with_files_option, default={},
              fingerprint=True,
@@ -59,6 +62,10 @@ class Checkstyle(LintTaskMixin, NailgunTask):
                               Shader.exclude_package('com.puppycrawl.tools.checkstyle',
                                                      recursive=True),
                           ])
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (CheckstyleSubsystem,)
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -100,12 +107,22 @@ class Checkstyle(LintTaskMixin, NailgunTask):
         union_classpath.update(jar for conf, jar in runtime_classpath
                                if conf in self.get_options().confs)
 
-    configuration_file = self.get_options().configuration
-    if not configuration_file:
-      raise TaskError('No checkstyle configuration file provided.')
+    task_config = self.get_options().configuration
+    subsystem_config = CheckstyleSubsystem.global_instance().options.config
+    if task_config and subsystem_config:
+      raise ValueError(
+        "Conflicting options for the config file used. You used the new, preferred "
+        "`--checkstyle-config`, but also used the deprecated `--lint-checkstyle-configuration`.\n"
+        "Please use only one of these (preferably `--checkstyle-config`)."
+      )
+    config = task_config or subsystem_config
+    if not config:
+      raise TaskError(
+        'No checkstyle configuration file configured. Configure with `--checkstyle-config`.'
+      )
 
     args = [
-      '-c', configuration_file,
+      '-c', config,
       '-f', 'plain'
     ]
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -4,6 +4,7 @@
 import os
 from textwrap import dedent
 
+from pants.backend.jvm.subsystems.checkstyle import Checkstyle as CheckstyleSubsystem
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.checkstyle import Checkstyle
 from pants.base.exceptions import TaskError
@@ -50,9 +51,11 @@ class CheckstyleTest(NailgunTaskTestBase):
       options={
         self.options_scope: {
           'bootstrap_tools': ['//:checkstyle'],
-          'configuration': self._create_config_file(rules_xml),
           'properties': properties or {},
-        }
+        },
+        CheckstyleSubsystem.options_scope: {
+          'config': self._create_config_file(rules_xml),
+        },
       },
       target_roots=target_roots)
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -49,10 +49,10 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
           self._create_config_file(config_file, config)
           args = [
             'clean-all',
+            f'--checkstyle-config={config_file}',
             'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
-            f'--lint-checkstyle-configuration={config_file}'
           ]
           pants_run = self.run_pants_with_workdir(args, workdir)
           self.assert_success(pants_run)
@@ -73,10 +73,10 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
           config_file = os.path.join(tmp, config_name)
           self._create_config_file(config_file, config)
           args = [
+            f'--checkstyle-config={config_file}',
             'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
-            f'--lint-checkstyle-configuration={config_file}'
           ]
           pants_run = self.run_pants_with_workdir(args, workdir)
           self.assert_success(pants_run)
@@ -140,10 +140,10 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
         previous_names.add(config_file)
         self._create_config_file(config_file, config)
         args = [
+          f'--checkstyle-config={config_file}',
           'lint.checkstyle',
           cache_args,
           'examples/src/java/org/pantsbuild/example/hello/simple',
-          f'--lint-checkstyle-configuration={config_file}',
         ]
         pants_run = self.run_pants_with_workdir(args, workdir)
         self.assert_success(pants_run)


### PR DESCRIPTION
This will allow us to deprecate `--lint-checkstyle-skip` in favor of `--checkstyle-skip`, per the V2 skip design doc: https://docs.google.com/document/d/13Qwb3JNgm3ogKeSgFz4QAiOs77jnrjfQqM6VqKWRyKM/edit

Note that we name the subsystem `checkstyle`, rather than something like `java-checkstyle`. Even though `checkstyle` is a valuable namespace, search engine results show that the Checkstyle tool does not compete with any other similarly named tools. Given its age (2001) and popularity, we stick with `checkstyle` because this name is more predictable to users than something like `java-checkstyle`.