### PR TITLE
Add `--skip` option to every linter/formatter subsystem

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/gofmt.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/gofmt.py
@@ -1,22 +1,17 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.custom_types import file_option
 from pants.subsystem.subsystem import Subsystem
 
 
-class Checkstyle(Subsystem):
+class Gofmt(Subsystem):
 
-  options_scope = 'checkstyle'
+  options_scope = 'gofmt'
 
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--config', type=file_option, default=None, fingerprint=True,
-      help="Path to Checkstyle config file."
-    )
-    register(
       '--skip', type=bool, default=False,
-      help="Don't use Checkstyle when running `./pants lint`."
+      help="Don't use Gofmt when running `./pants fmt` and `./pants lint`."
     )

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -4,11 +4,16 @@
 from pants.base.exceptions import TaskError
 from pants.task.lint_task_mixin import LintTaskMixin
 
+from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
 class GoCheckstyle(LintTaskMixin, GoFmtTaskBase):
   """Checks Go code matches gofmt style."""
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Gofmt.global_instance().options.skip
 
   def execute(self):
     with self.go_fmt_invalid_targets(['-d']) as output:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
@@ -3,11 +3,16 @@
 
 from pants.task.fmt_task_mixin import FmtTaskMixin
 
+from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
 class GoFmt(FmtTaskMixin, GoFmtTaskBase):
   """Format Go code using gofmt."""
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Gofmt.global_instance().options.skip
 
   def execute(self):
     with self.go_fmt_invalid_targets(['-w']) as output:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -31,10 +31,6 @@ class GoFmtTaskBase(GoWorkspaceTask):
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (Gofmt,)
 
-  @property
-  def skip_execution(self):
-    return self.get_options().skip or Gofmt.global_instance().options.skip
-
   @contextmanager
   def go_fmt_invalid_targets(self, flags):
     targets = self.get_targets(self.is_checked)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 
 from pants.base.exceptions import TaskError
 
+from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.targets.go_local_source import GoLocalSource
 from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 
@@ -25,6 +26,14 @@ class GoFmtTaskBase(GoWorkspaceTask):
       sources.update(source for source in target.sources_relative_to_buildroot()
                      if GoLocalSource.is_go_source(source))
     return sources
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (Gofmt,)
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Gofmt.global_instance().options.skip
 
   @contextmanager
   def go_fmt_invalid_targets(self, flags):

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=['googlejavaformat.py'],
+  sources=['googlejavaformat.py', 'subsystem.py'],
   tags = {'partially_type_checked'},
 )
 

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -9,6 +9,8 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
 
+from pants.contrib.googlejavaformat.subsystem import GoogleJavaFormat
+
 
 class GoogleJavaFormatBase(RewriteBase):
 
@@ -28,12 +30,20 @@ class GoogleJavaFormatBase(RewriteBase):
     return super().implementation_version() + [('GoogleJavaFormatBase', 1)]
 
   @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (GoogleJavaFormat,)
+
+  @classmethod
   def target_types(cls):
     return ['java_library', 'junit_tests']
 
   @classmethod
   def source_extension(cls):
     return '.java'
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
 
   def invoke_tool(self, _, target_sources):
     args = list(self.additional_args)
@@ -50,7 +60,7 @@ class GoogleJavaFormatBase(RewriteBase):
     """List of additional args to supply on the tool command-line."""
 
 
-class GoogleJavaFormatCheckFormat(LintTaskMixin, GoogleJavaFormatBase):
+class GoogleJavaFormatLintTask(LintTaskMixin, GoogleJavaFormatBase):
   """Check if Java source code complies with Google Java Style.
 
   If the files are not formatted correctly an error is raised
@@ -66,7 +76,7 @@ class GoogleJavaFormatCheckFormat(LintTaskMixin, GoogleJavaFormatBase):
                       '`./pants fmt <targets>`'.format(result), exit_code=result)
 
 
-class GoogleJavaFormat(FmtTaskMixin, GoogleJavaFormatBase):
+class GoogleJavaFormatTask(FmtTaskMixin, GoogleJavaFormatBase):
   """Reformat Java source code to comply with Google Java Style."""
 
   sideeffecting = True

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -41,10 +41,6 @@ class GoogleJavaFormatBase(RewriteBase):
   def source_extension(cls):
     return '.java'
 
-  @property
-  def skip_execution(self):
-    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
-
   def invoke_tool(self, _, target_sources):
     args = list(self.additional_args)
     args.extend([source for target, source in target_sources])
@@ -70,6 +66,10 @@ class GoogleJavaFormatLintTask(LintTaskMixin, GoogleJavaFormatBase):
   sideeffecting = False
   additional_args = ['--set-exit-if-changed']
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
+
   def process_result(self, result):
     if result != 0:
       raise TaskError('google-java-format failed with exit code {}; to fix run: '
@@ -81,6 +81,10 @@ class GoogleJavaFormatTask(FmtTaskMixin, GoogleJavaFormatBase):
 
   sideeffecting = True
   additional_args = ['-i']
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
 
   def process_result(self, result):
     if result != 0:

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/register.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/register.py
@@ -3,10 +3,10 @@
 
 from pants.goal.task_registrar import TaskRegistrar as task
 
-from pants.contrib.googlejavaformat.googlejavaformat import (GoogleJavaFormat,
-                                                             GoogleJavaFormatCheckFormat)
+from pants.contrib.googlejavaformat.googlejavaformat import (GoogleJavaFormatLintTask,
+                                                             GoogleJavaFormatTask)
 
 
 def register_goals():
-  task(name='google-java-format', action=GoogleJavaFormat).install('fmt')
-  task(name='google-java-format', action=GoogleJavaFormatCheckFormat).install('lint')
+  task(name='google-java-format', action=GoogleJavaFormatTask).install('fmt')
+  task(name='google-java-format', action=GoogleJavaFormatLintTask).install('lint')

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/subsystem.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/subsystem.py
@@ -1,22 +1,17 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.custom_types import file_option
 from pants.subsystem.subsystem import Subsystem
 
 
-class Checkstyle(Subsystem):
+class GoogleJavaFormat(Subsystem):
 
-  options_scope = 'checkstyle'
+  options_scope = 'google-java-format'
 
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--config', type=file_option, default=None, fingerprint=True,
-      help="Path to Checkstyle config file."
-    )
-    register(
       '--skip', type=bool, default=False,
-      help="Don't use Checkstyle when running `./pants lint`."
+      help="Don't use `google-java-format` when running `./pants fmt` and `./pants lint`."
     )

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
@@ -9,8 +9,8 @@ from pants.base.exceptions import TaskError
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
-from pants.contrib.googlejavaformat.googlejavaformat import (GoogleJavaFormat,
-                                                             GoogleJavaFormatCheckFormat)
+from pants.contrib.googlejavaformat.googlejavaformat import (GoogleJavaFormatLintTask,
+                                                             GoogleJavaFormatTask)
 
 
 class TestBase(NailgunTaskTestBase):
@@ -45,7 +45,7 @@ class GoogleJavaFormatTests(TestBase):
 
   @classmethod
   def task_type(cls):
-    return GoogleJavaFormat
+    return GoogleJavaFormatTask
 
   def test_googlejavaformat(self):
     javafile = self.create_file(
@@ -67,7 +67,7 @@ class GoogleJavaFormatCheckFormatTests(TestBase):
 
   @classmethod
   def task_type(cls):
-    return GoogleJavaFormatCheckFormat
+    return GoogleJavaFormatLintTask
 
   def test_lint_badformat(self):
     self.create_file(

--- a/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
@@ -26,6 +26,10 @@ class MyPy(PythonToolBase):
       '--config', type=file_option, fingerprint=True,
       help="Path to `mypy.ini` or alternative MyPy config file"
     )
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use MyPy when running `./pants lint`."
+    )
 
   def get_args(self) -> Tuple[str, ...]:
     return flatten_shlexed_list(self.get_options().args)

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -85,6 +85,10 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (PythonInterpreterCache, MyPy)
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or MyPy.global_instance().options.skip
+
   def find_mypy_interpreter(self):
     interpreters = self._interpreter_cache.setup(
       filters=[self._MYPY_COMPATIBLE_INTERPETER_CONSTRAINT]

--- a/contrib/node/src/python/pants/contrib/node/subsystems/eslint.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/eslint.py
@@ -29,6 +29,10 @@ class ESLint(Subsystem):
       help="Path to `.eslintrc` or alternative ESLint config file",
     )
     register(
+      '--skip', type=bool, default=False,
+      help="Don't use ESLint when running `./pants fmt` and `./pants lint`"
+    )
+    register(
       '--setupdir', type=dir_option, fingerprint=True,
       help='Find the package.json and yarn.lock under this dir for installing eslint and plugins.',
     )
@@ -45,7 +49,6 @@ class ESLint(Subsystem):
     shutil.copytree(self.options.setupdir, bootstrapped_support_path)
 
   def supportdir(self, *, task_workdir: str) -> Tuple[str, bool]:
-
     """Returns the path where the ESLint is bootstrapped.
 
     :param task_workdir: The task's working directory

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -39,10 +39,6 @@ class JavascriptStyleBase(NodeTask):
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (ESLint,)
 
-  @property
-  def skip_execution(self):
-    return self.get_options().skip or ESLint.global_instance().options.skip
-
   def _get_eslint_option(self, option: str, *, default_provided: bool = False):
     """Temporary utility to help with the migration from node-distribution -> eslint."""
     old_option = f"eslint_{option}"
@@ -212,6 +208,10 @@ class JavascriptStyleLint(LintTaskMixin, JavascriptStyleBase):
   """
   fix = False
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or ESLint.global_instance().options.skip
+
 
 class JavascriptStyleFmt(FmtTaskMixin, JavascriptStyleBase):
   """Check and fix source files to ensure they follow the style guidelines.
@@ -219,3 +219,7 @@ class JavascriptStyleFmt(FmtTaskMixin, JavascriptStyleBase):
   :API: public
   """
   fix = True
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or ESLint.global_instance().options.skip

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -39,6 +39,10 @@ class JavascriptStyleBase(NodeTask):
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (ESLint,)
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or ESLint.global_instance().options.skip
+
   def _get_eslint_option(self, option: str, *, default_provided: bool = False):
     """Temporary utility to help with the migration from node-distribution -> eslint."""
     old_option = f"eslint_{option}"

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
@@ -13,6 +13,7 @@ python_library(
     'src/python/pants/base:generator',
     'src/python/pants/base:workunit',
     'src/python/pants/task',
+    'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -31,6 +31,7 @@ from pkg_resources import DistributionNotFound, Environment, Requirement, Workin
 from pants.contrib.python.checks.checker import checker
 from pants.contrib.python.checks.tasks.checkstyle.plugin_subsystem_base import \
   default_subsystem_for_plugin
+from pants.contrib.python.checks.tasks.checkstyle.pycheck_subsystem import Pycheck
 from pants.contrib.python.checks.tasks.checkstyle.pycodestyle_subsystem import PyCodeStyleSubsystem
 from pants.contrib.python.checks.tasks.checkstyle.pyflakes_subsystem import FlakeCheckSubsystem
 
@@ -53,6 +54,7 @@ class Checkstyle(LintTaskMixin, Task):
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + cls.plugin_subsystems + (
+      Pycheck,
       PexBuilderWrapper.Factory,
       PythonInterpreterCache,
       PythonSetup,
@@ -80,6 +82,10 @@ class Checkstyle(LintTaskMixin, Task):
                   '(either from defaults or pants.ini). If the user supplies an empty list, '
                   'Pants will lint all targets in the target set, irrespective of the working '
                   'set of compatibility constraints.')
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Pycheck.global_instance().options.skip
 
   def _is_checked(self, target):
     return (not target.is_synthetic and isinstance(target, PythonTarget) and

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycheck_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycheck_subsystem.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.subsystem.subsystem import Subsystem
+
+
+class Pycheck(Subsystem):
+
+  options_scope = 'pycheck'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use the `pythonstyle` lints when running `./pants lint`. Note that you may get "
+           "more granular than this by turning off specific lints, e.g. `--pycheck-newlines-skip` "
+           "and `--pycheck-class-factoring-skip`. Run `./pants options | grep pycheck` to see all "
+           "the possible lints to skip."
+    )

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -24,6 +24,8 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
+from pants.contrib.python.checks.tasks.python_eval_subsystem import PythonEval as PythonEvalSubystem
+
 
 class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
   class Error(TaskError):
@@ -42,6 +44,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (
+      PythonEvalSubystem,
       PexBuilderWrapper.Factory,
       PythonInterpreterCache
     )
@@ -49,7 +52,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
   @property
   def skip_execution(self):
     deprecated_conditional(
-      lambda: self.get_options().is_default("skip"),
+      lambda: self.get_options().is_default("skip") and PythonEvalSubystem.global_instance().options.is_default("skip"),
       entity_description="`python-eval` defaulting to being used",
       removal_version="1.27.0.dev0",
       hint_message="`python-eval` is scheduled to be removed in Pants 1.29.0.dev0. The Python "
@@ -63,7 +66,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
                    "Pants 1.27.0.dev0, the default will change from `skip: False` to `skip: True`, "
                    "and in Pants 1.29.0.dev0, the module will be removed."
     )
-    return self.get_options().skip
+    return self.get_options().skip or PythonEvalSubystem.global_instance().options.skip
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval_subsystem.py
@@ -1,22 +1,17 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.custom_types import file_option
 from pants.subsystem.subsystem import Subsystem
 
 
-class Checkstyle(Subsystem):
+class PythonEval(Subsystem):
 
-  options_scope = 'checkstyle'
+  options_scope = 'python-eval'
 
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--config', type=file_option, default=None, fingerprint=True,
-      help="Path to Checkstyle config file."
-    )
-    register(
       '--skip', type=bool, default=False,
-      help="Don't use Checkstyle when running `./pants lint`."
+      help="Don't use `python-eval` when running `./pants lint`.",
     )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
@@ -18,7 +18,11 @@ class ScroogeLinter(Subsystem):
     register(
       '--args', type=list, member_type=str, fingerprint=True,
       help="Arguments to pass directly to the Scrooge Thrift linter, e.g. "
-           "`--scrooge-linter-args=\"--disable-rule Namespaces\"`",
+           "`--scrooge-linter-args=\"--disable-rule Namespaces\"`.",
+    )
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use the Scrooge Thrift linter when running `./pants lint`."
     )
     register(
       '--strict', type=bool, fingerprint=True,

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -66,6 +66,10 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     return ['thrift-linter']
 
   @property
+  def skip_execution(self):
+    return self.get_options().skip or ScroogeLinter.global_instance().options.skip
+
+  @property
   def cache_target_dirs(self):
     return True
 

--- a/pants.ini
+++ b/pants.ini
@@ -254,8 +254,20 @@ setupdir: %(pants_supportdir)s/eslint
 config: %(pants_supportdir)s/eslint/.eslintrc
 ignore: %(pants_supportdir)s/eslint/.eslintignore
 
+[google-java-format]
+skip: True
+
 [isort]
 config: [".isort.cfg", "contrib/.isort.cfg", "examples/.isort.cfg"]
+
+[python-eval]
+skip: True
+
+[scalafmt]
+skip: True
+
+[scalafix]
+skip: True
 
 [scalastyle]
 config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
@@ -263,32 +275,11 @@ config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
 [lint]
 transitive: False
 
-[lint.google-java-format]
-skip: True
-
-[lint.python-eval]
-skip: True
-
-[lint.scalafmt]
-skip: True
-
-[lint.scalafix]
-skip: True
-
 [lint.scalastyle]
 excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
 
 [fmt]
 transitive: False
-
-[fmt.google-java-format]
-skip: True
-
-[fmt.scalafmt]
-skip: True
-
-[fmt.scalafix]
-skip: True
 
 [protoc.gen.go-protobuf]
 version=3.4.1

--- a/src/python/pants/backend/jvm/subsystems/scalafix.py
+++ b/src/python/pants/backend/jvm/subsystems/scalafix.py
@@ -16,3 +16,7 @@ class Scalafix(Subsystem):
       '--config', type=file_option, default=None, fingerprint=True,
       help="Path to `.scalafix.conf` or an alternative Scalafix config file."
     )
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use Scalafix when running `./pants fmt` and `./pants lint`."
+    )

--- a/src/python/pants/backend/jvm/subsystems/scalafmt.py
+++ b/src/python/pants/backend/jvm/subsystems/scalafmt.py
@@ -16,3 +16,7 @@ class Scalafmt(Subsystem):
       '--config', type=file_option, default=None, fingerprint=True,
       help="Path to `.scalafmt.conf` or an alternative Scalafmt config file."
     )
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use Scalafmt when running `./pants fmt` and `./pants lint`."
+    )

--- a/src/python/pants/backend/jvm/subsystems/scalastyle.py
+++ b/src/python/pants/backend/jvm/subsystems/scalastyle.py
@@ -16,3 +16,7 @@ class Scalastyle(Subsystem):
       '--config', type=file_option, default=None, fingerprint=True,
       help="Path to `scalastyle_config.xml` or alternative an Scalastyle config file."
     )
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use Scalastyle when running `./pants lint`."
+    )

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -67,6 +67,10 @@ class Checkstyle(LintTaskMixin, NailgunTask):
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (CheckstyleSubsystem,)
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or CheckstyleSubsystem.global_instance().options.skip
+
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -55,6 +55,10 @@ class ScalafixTask(RewriteBase):
   def source_extension(cls):
     return '.scala'
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafix.global_instance().options.skip
+
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -55,10 +55,6 @@ class ScalafixTask(RewriteBase):
   def source_extension(cls):
     return '.scala'
 
-  @property
-  def skip_execution(self):
-    return self.get_options().skip or Scalafix.global_instance().options.skip
-
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)
@@ -151,6 +147,10 @@ class ScalaFixFix(FmtTaskMixin, ScalafixTask):
   sideeffecting = True
   additional_args: List[str] = []
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafix.global_instance().options.skip
+
   def process_result(self, result):
     if result != 0:
       raise TaskError(
@@ -162,6 +162,10 @@ class ScalaFixCheck(LintTaskMixin, ScalafixTask):
 
   sideeffecting = False
   additional_args = ['--test']
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafix.global_instance().options.skip
 
   def process_result(self, result):
     if result != 0:

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -50,6 +50,10 @@ class ScalafmtTask(RewriteBase):
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafmt.global_instance().options.skip
+
   def invoke_tool(self, absolute_root, target_sources):
     task_config = self.get_options().configuration
     subsystem_config = Scalafmt.global_instance().get_options().config

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -50,10 +50,6 @@ class ScalafmtTask(RewriteBase):
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
-  @property
-  def skip_execution(self):
-    return self.get_options().skip or Scalafmt.global_instance().options.skip
-
   def invoke_tool(self, absolute_root, target_sources):
     task_config = self.get_options().configuration
     subsystem_config = Scalafmt.global_instance().get_options().config
@@ -99,6 +95,10 @@ class ScalaFmtCheckFormat(LintTaskMixin, ScalafmtTask):
   sideeffecting = False
   additional_args = ['--test']
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafmt.global_instance().options.skip
+
   def process_result(self, result):
     if result != 0:
       raise TaskError('Scalafmt failed with exit code {}; to fix run: '
@@ -117,6 +117,10 @@ class ScalaFmtFormat(FmtTaskMixin, ScalafmtTask):
 
   sideeffecting = True
   additional_args = ['-i']
+
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalafmt.global_instance().options.skip
 
   def process_result(self, result):
     # Processes the results of running the scalafmt command.

--- a/src/python/pants/backend/jvm/tasks/scalastyle_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle_task.py
@@ -98,6 +98,10 @@ class ScalastyleTask(LintTaskMixin, NailgunTask):
 
     return scala_sources
 
+  @property
+  def skip_execution(self):
+    return self.get_options().skip or Scalastyle.global_instance().options.skip
+
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
 

--- a/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
@@ -37,7 +37,7 @@ class CustomScalaTest(NailgunTaskTestBase):
     # If config is not specified, then we override pants.ini scalastyle such that
     # we have a default scalastyle config xml but with empty excludes.
     self.set_options_for_scope(Scalastyle.options_scope, config=scalastyle_config)
-    self.set_options(skip=False, excludes=excludes)
+    self.set_options(excludes=excludes)
     return self.context(target_roots=target_roots)
 
   def _create_scalastyle_config_file(self, rules=None):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -22,7 +22,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     options = {
       'lint.scalafix': rules,
       'fmt.scalafix': rules,
-      'lint.scalastyle': {'skip': True}
+      'scalastyle': {'skip': True}
     }
 
     target = f'{TEST_DIR}/procedure_syntax'
@@ -36,7 +36,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     options = {
       'lint.scalafix': rules,
       'fmt.scalafix': rules,
-      'lint.scalastyle': {'skip': True}
+      'scalastyle': {'skip': True}
     }
 
     # take a snapshot of the file which we can write out
@@ -67,7 +67,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
       'compile.rsc': {'args': '+["-S-Ywarn-unused"]'},
       'lint.scalafix': rules,
       'fmt.scalafix': rules,
-      'lint.scalastyle': {'skip': True}
+      'scalastyle': {'skip': True}
     }
 
     test_file_name = f'{TEST_DIR}/rsc_compat/RscCompat.scala'
@@ -83,7 +83,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(test_fix)
 
   def test_rsccompat_fmt(self):
-    options =  {
+    options = {
       'scala': {
         'scalac_plugin_dep': f'{TEST_DIR}/rsc_compat:semanticdb-scalac',
         'scalac_plugins': '+["semanticdb"]'
@@ -94,8 +94,6 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
         'transitive': True,
         'scalafix_tool_classpath': f'{TEST_DIR}/rsc_compat:rsc-compat',
       },
-      'lint.scalafix': {'skip': True},
-      'lint.scalastyle': {'skip': True},
     }
     
     test_file_name = f'{TEST_DIR}/rsc_compat/RscCompat.scala'

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -94,25 +94,22 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
     return ScalaFmtCheckFormat
 
   def test_scalafmt_fail_default_config(self):
-    self.set_options(skip=False)
     context = self.context(target_roots=self.library)
     with self.assertRaises(TaskError):
       self.execute(context)
 
   def test_scalafmt_fail(self):
     self.set_options_for_scope(Scalafmt.options_scope, config=self.config)
-    self.set_options(skip=False)
     context = self.context(target_roots=self.library)
     with self.assertRaises(TaskError):
       self.execute(context)
 
   def test_scalafmt_disabled(self):
-    self.set_options(skip=True)
+    self.set_options_for_scope(Scalafmt.options_scope, skip=True)
     self.execute(self.context(target_roots=self.library))
 
   def test_scalafmt_ignore_resources(self):
     self.set_options_for_scope(Scalafmt.options_scope, config=self.config)
-    self.set_options(skip=False)
     context = self.context(target_roots=self.as_resources)
     self.execute(context)
 
@@ -124,11 +121,11 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
     return ScalaFmtFormat
 
   def test_scalafmt_format_default_config(self):
-    self.format_file_and_verify_fmt(skip=False)
+    self.format_file_and_verify_fmt()
 
   def test_scalafmt_format(self):
     self.set_options_for_scope(Scalafmt.options_scope, config=self.config)
-    self.format_file_and_verify_fmt(skip=False)
+    self.format_file_and_verify_fmt()
 
   def format_file_and_verify_fmt(self, **options):
     self.set_options(**options)
@@ -151,7 +148,7 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
 
   def test_output_dir(self):
     with temporary_dir() as output_dir:
-      self.set_options(skip=False, output_dir=output_dir)
+      self.set_options(output_dir=output_dir)
 
       lint_options_scope = 'sfcf'
       check_fmt_task_type = self.synthesize_task_subtype(ScalaFmtCheckFormat, lint_options_scope)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -57,7 +57,7 @@ class ScalastyleTest(NailgunTaskTestBase):
     # If config is not specified, then we override pants.ini scalastyle such that
     # we have a default scalastyle config xml but with empty excludes.
     self.set_options_for_scope(Scalastyle.options_scope, config=scalastyle_config)
-    self.set_options(skip=False, excludes=excludes)
+    self.set_options(excludes=excludes)
     return self.context(target_roots=target_roots)
 
   def _create_scalastyle_task(self, scalastyle_config):


### PR DESCRIPTION
This allows skipping via either the task option or subsystem option. A followup will deprecate the task option per the V2 skip design doc https://docs.google.com/document/d/13Qwb3JNgm3ogKeSgFz4QAiOs77jnrjfQqM6VqKWRyKM/edit.