### PR TITLE
Extract rule for preparing python sources

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -17,6 +17,9 @@ from pants.backend.python.rules.download_pex_bin import download_pex_bin
 from pants.backend.python.rules.inject_init import inject_init
 from pants.backend.python.rules.pex import create_pex
 from pants.backend.python.rules.pex_from_target_closure import create_pex_from_target_closure
+from pants.backend.python.rules.prepare_chrooted_python_sources import (
+  prepare_chrooted_python_sources,
+)
 from pants.backend.python.subsystems.python_native_code import (
   PythonNativeCode,
   create_pex_native_build_environment,
@@ -53,6 +56,7 @@ class TestPythonAWSLambdaCreation(TestBase):
       strip_source_root,
       download_pex_bin,
       inject_init,
+      prepare_chrooted_python_sources,
       create_pex_from_target_closure,
       RootRule(Digest),
       RootRule(SourceRootConfig),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -10,6 +10,7 @@ from pants.backend.python.rules import (
   inject_init,
   pex,
   pex_from_target_closure,
+  prepare_chrooted_python_sources,
   python_create_binary,
   python_test_runner,
 )
@@ -95,6 +96,7 @@ def rules():
   return (
     *download_pex_bin.rules(),
     *inject_init.rules(),
+    *prepare_chrooted_python_sources.rules(),
     *pex.rules(),
     *pex_from_target_closure.rules(),
     *python_test_runner.rules(),

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -4,20 +4,19 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
 )
+from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSourcesRequest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants.engine.fs import Digest
+from pants.engine.legacy.graph import TransitiveHydratedTargets
 from pants.engine.rules import rule
-from pants.engine.selectors import Get, MultiGet
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.engine.selectors import Get
 
 
 @dataclass(frozen=True)
@@ -43,20 +42,9 @@ async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
     python_setup=python_setup
   )
 
-  merged_input_files: Optional[Digest] = None
+  sources_digest: Optional[Digest] = None
   if request.include_source_files:
-    source_root_stripped_sources = await MultiGet(
-      Get[SourceRootStrippedSources](HydratedTarget, target_adaptor)
-      for target_adaptor in all_targets
-    )
-
-    stripped_sources_digests = [stripped_sources.snapshot.directory_digest
-                                for stripped_sources in source_root_stripped_sources]
-    sources_digest = await Get[Digest](DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
-    inits_digest = await Get[InjectedInitDigest](Digest, sources_digest)
-    all_input_digests = [sources_digest, inits_digest.directory_digest]
-    merged_input_files = await Get[Digest](DirectoriesToMerge,
-                                          DirectoriesToMerge(directories=tuple(all_input_digests)))
+    sources_digest = await Get[Digest](ChrootedPythonSourcesRequest(hydrated_targets=all_targets))
 
   requirements = PexRequirements.create_from_adaptors(
     adaptors=all_target_adaptors,
@@ -68,7 +56,7 @@ async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
     requirements=requirements,
     interpreter_constraints=interpreter_constraints,
     entry_point=request.entry_point,
-    input_files_digest=merged_input_files,
+    input_files_digest=sources_digest,
   )
 
   pex = await Get[Pex](CreatePex, create_pex_request)

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -42,7 +42,7 @@ async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
   )
 
   if request.include_source_files:
-    chrooted_sources = await Get[ChrootedPythonSources](HydratedTargets, all_targets)
+    chrooted_sources = await Get[ChrootedPythonSources](HydratedTargets(all_targets))
 
   requirements = PexRequirements.create_from_adaptors(
     adaptors=all_target_adaptors,

--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.backend.python.rules.inject_init import InjectedInitDigest
+from pants.engine.fs import Digest, DirectoriesToMerge
+from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
+from pants.engine.rules import rule
+from pants.engine.selectors import Get, MultiGet
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
+
+
+@dataclass(frozen=True)
+class ChrootedPythonSourcesRequest:
+  hydrated_targets: HydratedTargets
+
+
+@rule
+async def prepare_chrooted_python_sources(request: ChrootedPythonSourcesRequest) -> Digest:
+  source_root_stripped_sources = await MultiGet(
+    Get[SourceRootStrippedSources](HydratedTarget, target_adaptor)
+    for target_adaptor in request.hydrated_targets
+  )
+
+  stripped_sources_digests = [stripped_sources.snapshot.directory_digest
+                              for stripped_sources in source_root_stripped_sources]
+  sources_digest = await Get[Digest](DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
+  inits_digest = await Get[InjectedInitDigest](Digest, sources_digest)
+  all_input_digests = (sources_digest, inits_digest.directory_digest)
+  merged_input_files = await Get[Digest](DirectoriesToMerge(directories=all_input_digests))
+  return merged_input_files
+
+
+def rules():
+  return [
+    prepare_chrooted_python_sources,
+  ]

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -3,9 +3,9 @@
 
 from typing import Optional
 
-from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
+from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSourcesRequest
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -13,10 +13,10 @@ from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
-from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants.engine.legacy.graph import TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, optionable_rule, rule
-from pants.engine.selectors import Get, MultiGet
+from pants.engine.selectors import Get
 from pants.rules.core.core_test_model import TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
@@ -77,24 +77,11 @@ async def run_python_test(
     Address, test_target.address.to_address()
   )
 
-  source_root_stripped_sources = await MultiGet(
-    Get[SourceRootStrippedSources](HydratedTarget, hydrated_target)
-    for hydrated_target in all_targets
-  )
-
-  stripped_sources_digests = tuple(
-    stripped_sources.snapshot.directory_digest for stripped_sources in source_root_stripped_sources
-  )
-  sources_digest = await Get[Digest](DirectoriesToMerge(directories=stripped_sources_digests))
-  inits_digest = await Get[InjectedInitDigest](Digest, sources_digest)
+  sources_digest = await Get[Digest](ChrootedPythonSourcesRequest(hydrated_targets=all_targets))
 
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
-      directories=(
-        sources_digest,
-        inits_digest.directory_digest,
-        resolved_requirements_pex.directory_digest,
-      )
+      directories=(sources_digest, resolved_requirements_pex.directory_digest)
     ),
   )
 

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
-from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSourcesRequest
+from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -13,7 +13,7 @@ from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
-from pants.engine.legacy.graph import TransitiveHydratedTargets
+from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, optionable_rule, rule
 from pants.engine.selectors import Get
@@ -77,11 +77,11 @@ async def run_python_test(
     Address, test_target.address.to_address()
   )
 
-  sources_digest = await Get[Digest](ChrootedPythonSourcesRequest(hydrated_targets=all_targets))
+  chrooted_sources = await Get[ChrootedPythonSources](HydratedTargets, all_targets)
 
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
-      directories=(sources_digest, resolved_requirements_pex.directory_digest)
+      directories=(chrooted_sources.digest, resolved_requirements_pex.directory_digest)
     ),
   )
 

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -77,7 +77,7 @@ async def run_python_test(
     Address, test_target.address.to_address()
   )
 
-  chrooted_sources = await Get[ChrootedPythonSources](HydratedTargets, all_targets)
+  chrooted_sources = await Get[ChrootedPythonSources](HydratedTargets(all_targets))
 
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(


### PR DESCRIPTION
📝 Followup to https://github.com/pantsbuild/pants/pull/8852#pullrequestreview-337803648

### Problem

We duplicate several actions (stripping source roots, injecting inits, merging files) in multiple rules.

### Solution

Consolidate preparing python sources to a rule that can be reused elsewhere (done here for `pex_from_target_closure` and `python_test_runner`)

### Result

More reusable rules for working with python files.