### PR TITLE
Deprecate `--fmt-skip` and `--lint-skip`

### DIFF
--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.task.target_restriction_mixins import (
-  HasSkipAndTransitiveGoalOptionsMixin,
-  SkipAndTransitiveGoalOptionsRegistrar,
+  DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar,
+  HasSkipAndDeprecatedTransitiveGoalOptionsMixin,
 )
 
 
-class FmtTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
+class FmtTaskMixin(HasSkipAndDeprecatedTransitiveGoalOptionsMixin):
   """A mixin to combine with code formatting tasks."""
-  goal_options_registrar_cls = SkipAndTransitiveGoalOptionsRegistrar
+  goal_options_registrar_cls = DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
   target_filtering_enabled = True

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.task.target_restriction_mixins import (
-  HasSkipAndTransitiveGoalOptionsMixin,
-  SkipAndTransitiveGoalOptionsRegistrar,
+  DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar,
+  HasSkipAndDeprecatedTransitiveGoalOptionsMixin,
 )
 
 
-class LintTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
+class LintTaskMixin(HasSkipAndDeprecatedTransitiveGoalOptionsMixin):
   """A mixin to combine with lint tasks."""
-  goal_options_registrar_cls = SkipAndTransitiveGoalOptionsRegistrar
+  goal_options_registrar_cls = DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
   target_filtering_enabled = True

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -64,10 +64,24 @@ class SkipOptionRegistrar:
 
 class HasSkipAndTransitiveOptionsMixin(HasSkipOptionMixin, HasTransitiveOptionMixin):
   """A mixin for tasks that have a --transitive and a --skip option."""
-  pass
 
 
 class HasSkipAndTransitiveGoalOptionsMixin(GoalOptionsMixin, HasSkipAndTransitiveOptionsMixin):
+  """A mixin for tasks that have a --transitive and a --skip option registered at the goal level."""
+
+
+class SkipAndTransitiveOptionsRegistrar(SkipOptionRegistrar, TransitiveOptionRegistrar):
+  """Registrar of --skip and --transitive."""
+
+
+class SkipAndTransitiveGoalOptionsRegistrar(SkipAndTransitiveOptionsRegistrar,
+                                            GoalOptionsRegistrar):
+  """Registrar of --skip and --transitive at the goal level."""
+
+
+# TODO: delete this class once we change the default of `--fmt-transitive` and `--lint-transitive`
+# to False. Go back to using HasSkipAndTransitiveOptionsMixin.
+class HasSkipAndDeprecatedTransitiveGoalOptionsMixin(GoalOptionsMixin, HasSkipAndTransitiveOptionsMixin):
   """A mixin for tasks that have a --transitive and a --skip option registered at the goal level."""
 
   @property
@@ -89,12 +103,48 @@ class HasSkipAndTransitiveGoalOptionsMixin(GoalOptionsMixin, HasSkipAndTransitiv
     return self.get_options().transitive
 
 
-class SkipAndTransitiveOptionsRegistrar(SkipOptionRegistrar, TransitiveOptionRegistrar):
-  """Registrar of --skip and --transitive."""
-  pass
+class DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar(GoalOptionsRegistrar):
 
-
-class SkipAndTransitiveGoalOptionsRegistrar(SkipAndTransitiveOptionsRegistrar,
-                                            GoalOptionsRegistrar):
-  """Registrar of --skip and --transitive at the goal level."""
-  pass
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    # TODO: deprecate this option once the default for `--fmt-transitive` and `--lint-transitive`
+    # changes.
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True, recursive=True,
+      help="If false, act only on the targets directly specified on the command line. "
+           "If true, act on the transitive dependency closure of those targets.",
+    )
+    deprecated_skip_mapping = {
+      'lint-checkstyle': 'checkstyle',
+      'fmt-javascriptstyle': 'eslint',
+      'lint-javascriptstyle': 'eslint',
+      'fmt-go': 'gofmt',
+      'lint-go': 'gofmt',
+      'fmt-google-java-format': 'google-java-format',
+      'lint-google-java-format': 'google-java-format',
+      'fmt-isort': 'isort',
+      'lint-mypy': 'mypy',
+      'lint-python-eval': 'python-eval',
+      'fmt-scalafix': 'scalafix',
+      'lint-scalafix': 'scalafix',
+      'fmt-scalafmt': 'scalafmt',
+      'lint-scalafmt': 'scalafmt',
+      'lint-scalastyle': 'scalastyle',
+      'lint-thrift': 'scrooge-linter',
+    }
+    deprecated_skip_mapping_str = '\n'.join(
+      f'* --{old}-skip -> --{new}-skip' for old, new in sorted(deprecated_skip_mapping.items())
+    )
+    skip_deprecation_message = (
+      "`--fmt-skip` and `--lint-skip` are being replaced by options on the linters and formatters "
+      "themselves. For example, `--fmt-isort-skip` is now `--isort-skip`.\n\nPlease use these new "
+      f"options instead:\n\n{deprecated_skip_mapping_str}\n\nThere is no alternative for the "
+      f"top-level `--fmt-skip` and `--lint-skip`. Instead, don't run "
+      f"`./pants fmt` and `./pants lint`."
+    )
+    register(
+      '--skip', type=bool, default=False, fingerprint=True, recursive=True,
+      removal_version='1.27.0.dev0', removal_hint=skip_deprecation_message,
+      help='Skip task.',
+    )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/8346. This is necessary to rename `fmt2` to `fmt` and `lint2` to `lint`.

For the deprecation message, we cannot customize the message based on which task is run. Ideally, given `--fmt-isort-skip`, we could say `Use --isort-skip instead`, but this does not work as the option only gets registered at the root `lint` and `fmt` goals and then gets applied recursively to tasks.

Instead, we print this:
```
▶ ./pants fmt.isort --skip
Scrubbed PYTHONPATH=/Users/eric/DocsLocal/code/projects/pants/src/python: from the environment.
21:55:47 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/bin/pants_loader.py:85: DeprecationWarning: DEPRECATED: option 'skip' in scope 'fmt.isort' will be removed in version 1.27.0.dev0.
  `--fmt-skip` and `--lint-skip` are being replaced by options on the linters and formatters themselves. For example, `--fmt-isort-skip` is now `--isort-skip`.

Please use these new options instead:

* --fmt-go-skip -> --gofmt-skip
* --fmt-google-java-format-skip -> --google-java-format-skip
* --fmt-isort-skip -> --isort-skip
* --fmt-javascriptstyle-skip -> --eslint-skip
* --fmt-scalafix-skip -> --scalafix-skip
* --fmt-scalafmt-skip -> --scalafmt-skip
* --lint-checkstyle-skip -> --checkstyle-skip
* --lint-go-skip -> --gofmt-skip
* --lint-google-java-format-skip -> --google-java-format-skip
* --lint-javascriptstyle-skip -> --eslint-skip
* --lint-mypy-skip -> --mypy-skip
* --lint-python-eval-skip -> --python-eval-skip
* --lint-scalafix-skip -> --scalafix-skip
* --lint-scalafmt-skip -> --scalafmt-skip
* --lint-scalastyle-skip -> --scalastyle-skip
* --lint-thrift-skip -> --scrooge-linter-skip

There is no alternative for the top-level `--fmt-skip` and `--lint-skip`. Instead, don't run `./pants fmt` and `./pants lint`.
```