### PR TITLE
Use color in v2 pytest

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -17,6 +17,7 @@ from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.rules.core.core_test_model import TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
@@ -48,7 +49,8 @@ async def run_python_test(
   test_target: PythonTestsAdaptor,
   pytest: PyTest,
   python_setup: PythonSetup,
-  subprocess_encoding_environment: SubprocessEncodingEnvironment
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+  options_bootstrapper: OptionsBootstrapper
 ) -> TestResult:
   """Runs pytest for one target."""
 
@@ -92,6 +94,11 @@ async def run_python_test(
     timeout_default=pytest.options.timeout_default,
     timeout_maximum=pytest.options.timeout_maximum,
   )
+
+  global_options = options_bootstrapper.bootstrap_options.for_global_scope()
+  colors = global_options.colors
+  env = {"PYTEST_ADDOPTS": f"--color={'yes' if colors else 'no'}"}
+
   request = resolved_requirements_pex.create_execute_request(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
@@ -99,7 +106,8 @@ async def run_python_test(
     pex_args=(*pytest.options.args, *test_target_sources_file_names),
     input_files=merged_input_files,
     description=f'Run Pytest for {test_target.address.reference()}',
-    timeout_seconds=timeout_seconds if timeout_seconds is not None else 9999
+    timeout_seconds=timeout_seconds if timeout_seconds is not None else 9999,
+    env=env
   )
   result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
   return TestResult.from_fallible_execute_process_result(result)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -17,7 +17,7 @@ from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
-from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.global_options import GlobalOptionValueContainer
 from pants.rules.core.core_test_model import TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
@@ -50,7 +50,7 @@ async def run_python_test(
   pytest: PyTest,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
-  options_bootstrapper: OptionsBootstrapper
+  global_options_values: GlobalOptionValueContainer,
 ) -> TestResult:
   """Runs pytest for one target."""
 
@@ -95,8 +95,8 @@ async def run_python_test(
     timeout_maximum=pytest.options.timeout_maximum,
   )
 
-  global_options = options_bootstrapper.bootstrap_options.for_global_scope()
-  colors = global_options.colors
+  #global_options = global_options_values.inner
+  colors = global_options_values.colors
   env = {"PYTEST_ADDOPTS": f"--color={'yes' if colors else 'no'}"}
 
   request = resolved_requirements_pex.create_execute_request(

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -17,7 +17,7 @@ from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
-from pants.option.global_options import GlobalOptionValueContainer
+from pants.option.global_options import GlobalOptions
 from pants.rules.core.core_test_model import TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
@@ -50,7 +50,7 @@ async def run_python_test(
   pytest: PyTest,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
-  global_options_values: GlobalOptionValueContainer,
+  global_options: GlobalOptions,
 ) -> TestResult:
   """Runs pytest for one target."""
 
@@ -95,8 +95,7 @@ async def run_python_test(
     timeout_maximum=pytest.options.timeout_maximum,
   )
 
-  #global_options = global_options_values.inner
-  colors = global_options_values.colors
+  colors = global_options.colors
   env = {"PYTEST_ADDOPTS": f"--color={'yes' if colors else 'no'}"}
 
   request = resolved_requirements_pex.create_execute_request(

--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from pants.engine.rules import RootRule, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -30,10 +31,17 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
   return ScopedOptions(scope, options.options.for_scope(scope.scope))
 
 
+@rule
+def global_options(options_bootstrapper: OptionsBootstrapper) -> GlobalOptions:
+  global_options = options_bootstrapper.bootstrap_options.for_global_scope()
+  return GlobalOptions(_inner=global_options)
+
+
 def create_options_parsing_rules():
   return [
     scope_options,
     parse_options,
+    global_options,
     RootRule(Scope),
     RootRule(OptionsBootstrapper),
   ]

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -59,7 +59,6 @@ from pants.init.options_initializer import BuildConfigInitializer, OptionsInitia
 from pants.option.global_options import (
   DEFAULT_EXECUTION_OPTIONS,
   ExecutionOptions,
-  GlobalOptionValueContainer,
   GlobMatchErrorBehavior,
 )
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -219,11 +218,10 @@ class LegacyGraphSession:
     )
     workspace = Workspace(self.scheduler_session)
     interactive_runner = InteractiveRunner(self.scheduler_session)
-    global_options_values = GlobalOptionValueContainer(_inner=global_options)
 
     for goal in goals:
       goal_product = self.goal_map[goal]
-      params = Params(subject, options_bootstrapper, console, workspace, interactive_runner, global_options_values)
+      params = Params(subject, options_bootstrapper, console, workspace, interactive_runner)
       logger.debug(f'requesting {goal_product} to satisfy execution of `{goal}` goal')
       try:
         exit_code = self.scheduler_session.run_console_rule(goal_product, params)
@@ -405,7 +403,6 @@ class EngineInitializer:
     rules = (
       [
         RootRule(Console),
-        RootRule(GlobalOptionValueContainer),
         glob_match_error_behavior_singleton,
         build_configuration_singleton,
         symbol_table_singleton,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -59,6 +59,7 @@ from pants.init.options_initializer import BuildConfigInitializer, OptionsInitia
 from pants.option.global_options import (
   DEFAULT_EXECUTION_OPTIONS,
   ExecutionOptions,
+  GlobalOptionValueContainer,
   GlobMatchErrorBehavior,
 )
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -218,10 +219,11 @@ class LegacyGraphSession:
     )
     workspace = Workspace(self.scheduler_session)
     interactive_runner = InteractiveRunner(self.scheduler_session)
+    global_options_values = GlobalOptionValueContainer(_inner=global_options)
 
     for goal in goals:
       goal_product = self.goal_map[goal]
-      params = Params(subject, options_bootstrapper, console, workspace, interactive_runner)
+      params = Params(subject, options_bootstrapper, console, workspace, interactive_runner, global_options_values)
       logger.debug(f'requesting {goal_product} to satisfy execution of `{goal}` goal')
       try:
         exit_code = self.scheduler_session.run_console_rule(goal_product, params)
@@ -403,6 +405,7 @@ class EngineInitializer:
     rules = (
       [
         RootRule(Console),
+        RootRule(GlobalOptionValueContainer),
         glob_match_error_behavior_singleton,
         build_configuration_singleton,
         symbol_table_singleton,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -24,7 +24,7 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 
 @dataclass(frozen=True)
-class GlobalOptionValueContainer:
+class GlobalOptions:
   _inner: OptionValueContainer
 
   def __getattr__(self, key):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -17,9 +17,18 @@ from pants.base.build_environment import (
 )
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
+
+
+@dataclass(frozen=True)
+class GlobalOptionValueContainer:
+  _inner: OptionValueContainer
+
+  def __getattr__(self, key):
+    return self._inner.__getattr__(key)
 
 
 class GlobMatchErrorBehavior(Enum):


### PR DESCRIPTION
### Problem

When we run python tests in V2, we run a pex that invokes pytest as a python library to actually do the testing, using the ExecuteProcessRequest abstraction. When run this way, pytest detects that it's not being run in a terminal and so doesn't normally display color.

### Solution

Add the environment variable PYTEST_ADDOPTS, setting it to `--color=yes` if the global color option is set, or to `--color=no` if it's not. This forces (or unforces) pytest to output color regardless of the state of the terminal.


### Result

This results in V2 python testing displaying color output in the same way it did in V1.