### PR TITLE
Add `deprecated.resolve_conflicting_options()` to facilitate moving options

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -4,7 +4,6 @@
 from pants.base.exceptions import TaskError
 from pants.task.lint_task_mixin import LintTaskMixin
 
-from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
@@ -13,7 +12,7 @@ class GoCheckstyle(LintTaskMixin, GoFmtTaskBase):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Gofmt.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="lint-go")
 
   def execute(self):
     with self.go_fmt_invalid_targets(['-d']) as output:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
@@ -3,7 +3,6 @@
 
 from pants.task.fmt_task_mixin import FmtTaskMixin
 
-from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
@@ -12,7 +11,7 @@ class GoFmt(FmtTaskMixin, GoFmtTaskBase):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Gofmt.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="fmt-go")
 
   def execute(self):
     with self.go_fmt_invalid_targets(['-w']) as output:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 from contextlib import contextmanager
 
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 
 from pants.contrib.go.subsystems.gofmt import Gofmt
@@ -14,6 +15,16 @@ from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 
 class GoFmtTaskBase(GoWorkspaceTask):
   """Base class for tasks that run gofmt."""
+
+  def _resolve_conflicting_skip(self, *, old_scope: str):
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope=old_scope,
+      new_scope="gofmt",
+      old_container=self.get_options(),
+      new_container=Gofmt.global_instance().options,
+    )
 
   @classmethod
   def is_checked(cls, target):

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
 from pants.task.fmt_task_mixin import FmtTaskMixin
@@ -13,6 +14,16 @@ from pants.contrib.googlejavaformat.subsystem import GoogleJavaFormat
 
 
 class GoogleJavaFormatBase(RewriteBase):
+
+  def _resolve_conflicting_skip(self, *, old_scope: str):
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope=old_scope,
+      new_scope="google-java-format",
+      old_container=self.get_options(),
+      new_container=GoogleJavaFormat.global_instance().options,
+    )
 
   @classmethod
   def register_options(cls, register):
@@ -68,7 +79,7 @@ class GoogleJavaFormatLintTask(LintTaskMixin, GoogleJavaFormatBase):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="fmt-google-java-format")
 
   def process_result(self, result):
     if result != 0:
@@ -84,7 +95,7 @@ class GoogleJavaFormatTask(FmtTaskMixin, GoogleJavaFormatBase):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or GoogleJavaFormat.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="lint-google-java-format")
 
   def process_result(self, result):
     if result != 0:

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -4,7 +4,7 @@
 import os
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable, List, Optional, Set, cast
+from typing import Iterable, List, Set
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.targets.python_binary import PythonBinary
@@ -15,7 +15,7 @@ from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.base import hash_utils
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
+from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
@@ -47,6 +47,16 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   _MYPY_COMPATIBLE_INTERPETER_CONSTRAINT = '>=3.5'
   _PYTHON_SOURCE_EXTENSION = '.py'
+
+  def _resolve_conflicting_options(self, *, old_option: str, new_option: str):
+    return resolve_conflicting_options(
+      old_option=old_option,
+      new_option=new_option,
+      old_scope='lint-mypy',
+      new_scope='mypy',
+      old_container=self.get_options(),
+      new_container=self._mypy_subsystem.options,
+    )
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -87,7 +97,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or MyPy.global_instance().options.skip
+    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
 
   def find_mypy_interpreter(self):
     interpreters = self._interpreter_cache.setup(
@@ -169,21 +179,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
     return MyPy.global_instance()
 
   def _get_mypy_pex(self, py3_interpreter: PythonInterpreter, *extra_pexes: PEX) -> PEX:
-
-    def get_mypy_version() -> str:
-      task_version_configured = not self.get_options().is_default('version')
-      subsystem_version_configured = not self._mypy_subsystem.get_options().is_default('version')
-      if task_version_configured and subsystem_version_configured:
-        raise ValueError(
-          "Conflicting options for the MyPy version used. You used the new, preferred "
-          "`--mypy-version`, but also used the deprecated `--lint-mypy-version`.\nPlease use "
-          "only one of these (preferably `--mypy-version`)."
-        )
-      if task_version_configured:
-        return f"mypy=={self.get_options().version}"
-      return cast(str, self._mypy_subsystem.get_options().version)
-
-    mypy_version = get_mypy_version()
+    mypy_version = self._resolve_conflicting_options(old_option='version', new_option='version')
     extras_hash = hash_utils.hash_all(hash_utils.hash_dir(Path(extra_pex.path()))
                                       for extra_pex in extra_pexes)
 
@@ -262,18 +258,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
       # Construct the mypy command line.
       cmd = [f'--python-version={interpreter_for_targets.identity.python}']
 
-      def get_config() -> Optional[str]:
-        task_config = self.get_options().config_file
-        subsystem_config = self._mypy_subsystem.get_options().config
-        if task_config and subsystem_config:
-          raise ValueError(
-            "Conflicting options for the config file used. You used the new, preferred "
-            "`--mypy-config`, but also used the deprecated `--lint-mypy-config-file`.\nPlease use "
-            "only one of these (preferably `--mypy-config`)."
-          )
-        return subsystem_config or task_config or None
-
-      config = get_config()
+      config = self._resolve_conflicting_options(old_option='config_file', new_option='config')
       if config:
         cmd.append(f'--config-file={os.path.join(get_buildroot(), config)}')
       deprecated_conditional(

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -12,6 +12,7 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.build_environment import get_buildroot, pants_version
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_all
 from pants.base.workunit import WorkUnitLabel
@@ -85,7 +86,14 @@ class Checkstyle(LintTaskMixin, Task):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Pycheck.global_instance().options.skip
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope="lint-pythonstyle",
+      new_scope="pycheck",
+      old_container=self.get_options(),
+      new_container=Pycheck.global_instance().options,
+    )
 
   def _is_checked(self, target):
     return (not target.is_synthetic and isinstance(target, PythonTarget) and

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -13,7 +13,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
-from pants.base.deprecated import deprecated_conditional
+from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -51,8 +51,10 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @property
   def skip_execution(self):
+    task_options = self.get_options()
+    subsystem_options = PythonEvalSubystem.global_instance().options
     deprecated_conditional(
-      lambda: self.get_options().is_default("skip") and PythonEvalSubystem.global_instance().options.is_default("skip"),
+      lambda: task_options.is_default("skip") and subsystem_options.is_default("skip"),
       entity_description="`python-eval` defaulting to being used",
       removal_version="1.27.0.dev0",
       hint_message="`python-eval` is scheduled to be removed in Pants 1.29.0.dev0. The Python "
@@ -66,7 +68,14 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
                    "Pants 1.27.0.dev0, the default will change from `skip: False` to `skip: True`, "
                    "and in Pants 1.29.0.dev0, the module will be removed."
     )
-    return self.get_options().skip or PythonEvalSubystem.global_instance().options.skip
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope="lint-python-eval",
+      new_scope="python-eval",
+      old_container=task_options,
+      new_container=subsystem_options,
+    )
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -5,6 +5,7 @@ import multiprocessing
 
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work, WorkerPool
 from pants.base.workunit import WorkUnitLabel
@@ -21,11 +22,14 @@ class ThriftLintError(Exception):
 class ThriftLinterTask(LintTaskMixin, NailgunTask):
   """Print lint warnings for thrift files."""
 
-  def raise_conflicting_option(self, option: str) -> None:
-    raise ValueError(
-      f"Conflicting options used. You used the new, preferred `--scrooge-linter-{option}`, but also "
-      f"used the deprecated `--lint-thrift-{option}`\nPlease use only one of these "
-      f"(preferably `--scrooge-linter-{option}`)."
+  def _resolve_conflicting_options(self, *, old_option: str, new_option: str):
+    return resolve_conflicting_options(
+      old_option=old_option,
+      new_option=new_option,
+      old_scope='lint-thrift',
+      new_scope='scrooge-linter',
+      old_container=self.get_options(),
+      new_container=ScroogeLinter.global_instance().options,
     )
 
   @staticmethod
@@ -67,7 +71,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or ScroogeLinter.global_instance().options.skip
+    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
 
   @property
   def cache_target_dirs(self):
@@ -86,25 +90,19 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     task_options = self.get_options()
     subsystem_options = ScroogeLinter.global_instance().options
 
-    task_strict_configured = not task_options.is_default('strict')
-    subsystem_strict_configured = not subsystem_options.is_default('strict')
-    if task_strict_configured and subsystem_strict_configured:
-      self.raise_conflicting_option("strict")
-    if subsystem_strict_configured:
+    # NB: _resolve_conflicting_options() used to assert that both options aren't configured.
+    self._resolve_conflicting_options(old_option="strict", new_option="strict")
+    if not subsystem_options.is_default("strict"):
       return self._to_bool(subsystem_options.strict)
-    if task_strict_configured:
+    if not task_options.is_default("strict"):
       return self._to_bool(task_options.strict)
 
     if target.thrift_linter_strict is not None:
       return self._to_bool(target.thrift_linter_strict)
 
-    task_strict_default_configured = not task_options.is_default('strict_default')
-    subsystem_strict_default_configured = not subsystem_options.is_default('strict_default')
-    if task_strict_default_configured and subsystem_strict_default_configured:
-      self.raise_conflicting_option("strict_default")
-    if task_strict_configured:
-      return self._to_bool(task_options.strict_default)
-    return self._to_bool(subsystem_options.strict_default)
+    return self._to_bool(
+      self._resolve_conflicting_options(old_option="strict_default", new_option="strict_default"),
+    )
 
   def _lint(self, target, classpath):
     self.context.log.debug(f'Linting {target.address.spec}')
@@ -145,26 +143,17 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
 
   def execute(self):
     thrift_targets = self.get_targets(self._is_thrift)
-
-    task_worker_count_configured = not self.get_options().is_default("worker_count")
-    subsystem_worker_count_configured = not ScroogeLinter.global_instance().options.is_default("worker_count")
-    if task_worker_count_configured and subsystem_worker_count_configured:
-      self.raise_conflicting_option("worker_count")
-    worker_count = (
-      self.get_options().worker_count
-      if task_worker_count_configured
-      else ScroogeLinter.global_instance().options.worker_count
-    )
-
     with self.invalidated(thrift_targets) as invalidation_check:
       if not invalidation_check.invalid_vts:
         return
 
       with self.context.new_workunit('parallel-thrift-linter') as workunit:
-        worker_pool = WorkerPool(workunit.parent,
-                                 self.context.run_tracker,
-                                 worker_count,
-                                 workunit.name)
+        worker_pool = WorkerPool(
+          workunit.parent,
+          self.context.run_tracker,
+          self._resolve_conflicting_options(old_option="worker_count", new_option="worker_count"),
+          workunit.name,
+        )
 
         scrooge_linter_classpath = self.tool_classpath('scrooge-linter')
         results = []

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -8,6 +8,7 @@ from typing import List
 from pants.backend.jvm.subsystems.scalafix import Scalafix
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.target_scopes import Scopes
@@ -22,6 +23,26 @@ class ScalafixTask(RewriteBase):
   """Executes the scalafix tool."""
 
   _SCALAFIX_MAIN = 'scalafix.cli.Cli'
+
+  def _resolve_conflicting_options(self, *, old_option: str, new_option: str):
+    return resolve_conflicting_options(
+      old_option=old_option,
+      new_option=new_option,
+      old_scope='fmt-scalafix',
+      new_scope='scalafix',
+      old_container=self.get_options(),
+      new_container=Scalafix.global_instance().options,
+    )
+
+  def _resolve_conflicting_skip(self, *, old_scope: str):
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope=old_scope,
+      new_scope='scalafix',
+      old_container=self.get_options(),
+      new_container=Scalafix.global_instance().options,
+    )
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -102,15 +123,7 @@ class ScalafixTask(RewriteBase):
       args.append(f'--sourceroot={absolute_root}')
       args.append(f'--classpath={os.pathsep.join(classpath)}')
 
-    task_config = self.get_options().configuration
-    subsystem_config = Scalafix.global_instance().get_options().config
-    if task_config and subsystem_config:
-      raise ValueError(
-        "Conflicting options for the config file used. You used the new, preferred "
-        "`--scalafix-config`, but also used the deprecated `--fmt-scalafix-configuration`.\n"
-        "Please use only one of these (preferably `--scalafix-config`)."
-      )
-    config = task_config or subsystem_config or None
+    config = self._resolve_conflicting_options(old_option='configuration', new_option='config')
     if config:
       args.append(f'--config={config}')
 
@@ -149,7 +162,7 @@ class ScalaFixFix(FmtTaskMixin, ScalafixTask):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Scalafix.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="fmt-scalafix")
 
   def process_result(self, result):
     if result != 0:
@@ -165,7 +178,7 @@ class ScalaFixCheck(LintTaskMixin, ScalafixTask):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Scalafix.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="lint-scalafix")
 
   def process_result(self, result):
     if result != 0:

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 
 from pants.backend.jvm.subsystems.scalafmt import Scalafmt
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
@@ -18,6 +19,26 @@ class ScalafmtTask(RewriteBase):
   Classes that inherit from this should override additional_args and
   process_result to run different scalafmt commands.
   """
+
+  def _resolve_conflicting_options(self, *, old_option: str, new_option: str):
+    return resolve_conflicting_options(
+      old_option=old_option,
+      new_option=new_option,
+      old_scope='fmt-scalafmt',
+      new_scope='scalafmt',
+      old_container=self.get_options(),
+      new_container=Scalafmt.global_instance().options,
+    )
+
+  def _resolve_conflicting_skip(self, *, old_scope: str):
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope=old_scope,
+      new_scope='scalafmt',
+      old_container=self.get_options(),
+      new_container=Scalafmt.global_instance().options,
+    )
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -51,16 +72,8 @@ class ScalafmtTask(RewriteBase):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
   def invoke_tool(self, absolute_root, target_sources):
-    task_config = self.get_options().configuration
-    subsystem_config = Scalafmt.global_instance().get_options().config
-    if task_config and subsystem_config:
-      raise ValueError(
-        "Conflicting options for the config file used. You used the new, preferred "
-        "`--scalafmt-config`, but also used the deprecated `--fmt-scalafmt-configuration`.\n"
-        "Please use only one of these (preferably `--scalafmt-config`)."
-      )
-    config = task_config or subsystem_config or None
     args = list(self.additional_args)
+    config = self._resolve_conflicting_options(old_option="configuration", new_option="config")
     if config is not None:
       args.extend(['--config', config])
     args.extend([source for _target, source in target_sources])
@@ -97,7 +110,7 @@ class ScalaFmtCheckFormat(LintTaskMixin, ScalafmtTask):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Scalafmt.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="lint-scalafmt")
 
   def process_result(self, result):
     if result != 0:
@@ -120,7 +133,7 @@ class ScalaFmtFormat(FmtTaskMixin, ScalafmtTask):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Scalafmt.global_instance().options.skip
+    return super()._resolve_conflicting_skip(old_scope="fmt-scalafmt")
 
   def process_result(self, result):
     # Processes the results of running the scalafmt command.

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -11,7 +11,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
+from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.fmt_task_mixin import FmtTaskMixin
@@ -103,4 +103,11 @@ class IsortRun(FmtTaskMixin, Task):
 
   @property
   def skip_execution(self):
-    return self.get_options().skip or Isort.global_instance().options.skip
+    return resolve_conflicting_options(
+      old_option="skip",
+      new_option="skip",
+      old_scope="fmt-isort",
+      new_scope="isort",
+      old_container=self.get_options(),
+      new_container=Isort.global_instance().options,
+    )


### PR DESCRIPTION
Recently, we've moved many options from tasks to subsystems. In the past, we've also moved options from one subsystem to another or renamed options within a subsystem. These use cases are certain to continue, especially in the pursuit of an incremental migration for V2.

We started using a pattern to robustly handle two conflicting options living at the same time during the deprecation. For example, this pattern will provide a friendly error if users try to specify both options at the same time. It will also default to reading from the new option.

However, this pattern was inlined everywhere it was used with the idea that "this is temporary code, so not worth spending too much time deduplicating." This rationale does not stand. While any particular call site may indeed be short-lived, we are going to continue making this type of deprecation in the future. 

Generalizing this functionality ensures that future deprecations are handled robustly and lowers the barrier to entry for deprecating something, thus encouraging an incremental migration for V2.