### PR TITLE
Add `shell_str` type to improve `--args` option support

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
@@ -1,11 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
-
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.option.custom_types import file_option
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import file_option, shell_str
 
 
 class MyPy(PythonToolBase):
@@ -18,7 +15,7 @@ class MyPy(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str, fingerprint=True,
+      '--args', type=list, member_type=shell_str, fingerprint=True,
       help="Arguments to pass directly to mypy, e.g. "
            "`--mypy-args=\"--python-version 3.7 --disallow-any-expr\"`",
     )
@@ -30,6 +27,3 @@ class MyPy(PythonToolBase):
       '--skip', type=bool, default=False,
       help="Don't use MyPy when running `./pants lint`."
     )
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -290,7 +290,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
                      "V2 implementation, which only supports `--mypy-args`.",
       )
       cmd.extend(self.get_passthru_args())
-      cmd.extend(self._mypy_subsystem.get_args())
+      cmd.extend(self._mypy_subsystem.options.args)
       cmd.append(f'@{sources_list_path}')
 
       with self.context.new_workunit(name='create_mypy_pex', labels=[WorkUnitLabel.PREP]):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/subsystems/scrooge_linter.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import multiprocessing
-from typing import Tuple
 
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import shell_str
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -16,7 +15,7 @@ class ScroogeLinter(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str, fingerprint=True,
+      '--args', type=list, member_type=shell_str, fingerprint=True,
       help="Arguments to pass directly to the Scrooge Thrift linter, e.g. "
            "`--scrooge-linter-args=\"--disable-rule Namespaces\"`.",
     )
@@ -37,6 +36,3 @@ class ScroogeLinter(Subsystem):
       '--worker-count', default=multiprocessing.cpu_count(), advanced=True, type=int,
       help='Maximum number of workers to use for linter parallelization.',
     )
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -112,7 +112,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
     config_args = []
 
     config_args.extend(self.get_options().linter_args)
-    config_args.extend(ScroogeLinter.global_instance().get_args())
+    config_args.extend(ScroogeLinter.global_instance().options.args)
 
     # N.B. We always set --fatal-warnings to make sure errors like missing-namespace are at least printed.
     # If --no-strict is turned on, the return code will be 0 instead of 1, but the errors/warnings

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -63,7 +63,7 @@ async def setup_black(black: Black) -> BlackSetup:
   return BlackSetup(
     requirements_pex=requirements_pex,
     config_snapshot=config_snapshot,
-    passthrough_args=black.get_args(),
+    passthrough_args=tuple(black.options.args),
     skip=black.options.skip,
   )
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -1,11 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
-
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.option.custom_types import file_option
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import file_option, shell_str
 
 
 class Black(PythonToolBase):
@@ -23,7 +20,7 @@ class Black(PythonToolBase):
       help="Don't use Black when running `./pants fmt` and `./pants lint`"
     )
     register(
-      '--args', type=list, member_type=str,
+      '--args', type=list, member_type=shell_str,
       help="Arguments to pass directly to Black, e.g. "
            "`--black-args=\"--target-version=py37 --quiet\"`",
     )
@@ -31,6 +28,3 @@ class Black(PythonToolBase):
       '--config', type=file_option, default=None, advanced=True,
       help="Path to Black's pyproject.toml config file"
     )
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -31,7 +31,7 @@ def generate_args(wrapped_target: Flake8Target, flake8: Flake8) -> Tuple[str, ..
   args = []
   if flake8.options.config is not None:
     args.append(f"--config={flake8.options.config}")
-  args.extend(flake8.get_args())
+  args.extend(flake8.options.args)
   args.extend(sorted(wrapped_target.target.sources.snapshot.files))
   return tuple(args)
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -1,11 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
-
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.option.custom_types import file_option
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import file_option, shell_str
 
 
 class Flake8(PythonToolBase):
@@ -23,7 +20,7 @@ class Flake8(PythonToolBase):
       help="Don't use Flake8 when running `./pants lint`"
     )
     register(
-      '--args', type=list, member_type=str,
+      '--args', type=list, member_type=shell_str,
       help="Arguments to pass directly to Flake8, e.g. "
            "`--flake8-args=\"--ignore E123,W456 --enable-extensions H111\"`",
     )
@@ -31,6 +28,3 @@ class Flake8(PythonToolBase):
       '--config', type=file_option, default=None, advanced=True,
       help="Path to `.flake8` or alternative Flake8 config file"
     )
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -59,7 +59,7 @@ async def setup_isort(isort: Isort) -> IsortSetup:
   return IsortSetup(
     requirements_pex=requirements_pex,
     config_snapshot=config_snapshot,
-    passthrough_args=isort.get_args(),
+    passthrough_args=tuple(isort.options.args),
     skip=isort.options.skip,
   )
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -1,11 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
-
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.option.custom_types import file_option
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import file_option, shell_str
 
 
 class Isort(PythonToolBase):
@@ -22,7 +19,7 @@ class Isort(PythonToolBase):
       help="Don't use isort when running `./pants fmt` and `./pants lint`"
     )
     register(
-      '--args', type=list, member_type=str, fingerprint=True,
+      '--args', type=list, member_type=shell_str, fingerprint=True,
       help="Arguments to pass directly to isort, e.g. "
            "`--isort-args=\"--case-sensitive --trailing-comma\"`",
     )
@@ -30,6 +27,3 @@ class Isort(PythonToolBase):
       '--config', type=list, member_type=file_option, fingerprint=True,
       help="Path to `isort.cfg` or alternative isort config file(s)"
     )
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -109,7 +109,7 @@ async def run_python_test(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path=f'./{output_pytest_requirements_pex_filename}',
-    pex_args=(*pytest.get_args(), *test_target_sources_file_names),
+    pex_args=(*pytest.options.args, *test_target_sources_file_names),
     input_files=merged_input_files,
     description=f'Run Pytest for {test_target.address.reference()}',
     timeout_seconds=timeout_seconds if timeout_seconds is not None else 9999

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -4,7 +4,7 @@
 from typing import Tuple
 
 from pants.base.deprecated import deprecated_conditional
-from pants.option.option_util import flatten_shlexed_list
+from pants.option.custom_types import shell_str
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -15,7 +15,7 @@ class PyTest(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str, fingerprint=True,
+      '--args', type=list, member_type=shell_str, fingerprint=True,
       help="Arguments to pass directly to Pytest, e.g. `--pytest-args=\"-k test_foo --quiet\"`",
     )
     register(
@@ -58,10 +58,8 @@ class PyTest(Subsystem):
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""
-    opts = self.get_options()
-
     deprecated_conditional(
-      lambda: opts.is_default("version"),
+      lambda: self.options.is_default("version"),
       removal_version="1.25.0.dev2",
       entity_description="Pants defaulting to a Python 2-compatible Pytest version",
       hint_message="Pants will soon start defaulting to Pytest 5.x, which no longer supports "
@@ -72,8 +70,4 @@ class PyTest(Subsystem):
                    "tests with Python 2 and want the newest Pytest, set `version` to "
                    "`pytest>=5.2.4`."
     )
-
-    return (opts.version, *opts.pytest_plugins)
-
-  def get_args(self) -> Tuple[str, ...]:
-    return flatten_shlexed_list(self.get_options().args)
+    return (self.options.version, *self.options.pytest_plugins)

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -66,7 +66,7 @@ class IsortRun(FmtTaskMixin, Task):
                      "V2 implementation, which only supports `--isort-args`.",
       )
       args = [
-        *self.get_passthru_args(), *isort_subsystem.get_args(), '--filter-files', *sources
+        *self.get_passthru_args(), *isort_subsystem.options.args, '--filter-files', *sources,
       ]
 
       # NB: We execute isort out of process to avoid unwanted side-effects from importing it:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -637,7 +637,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                                                                     pytest_rootdir):
       # Validate that the user didn't provide any passthru args that conflict
       # with those we must set ourselves.
-      for arg in (*self.get_passthru_args(), *PyTest.global_instance().get_args()):
+      for arg in (*self.get_passthru_args(), *PyTest.global_instance().options.args):
         if arg.startswith('--junitxml') or arg.startswith('--confcutdir'):
           raise TaskError(f'Cannot pass this arg through to pytest: {arg}')
 
@@ -670,7 +670,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                      "passthrough args and to prepare for Pytest eventually exclusively using the "
                      "V2 implementation, which only supports `--pytest-args`.",
       )
-      args.extend([*self.get_passthru_args(), *PyTest.global_instance().get_args()])
+      args.extend([*self.get_passthru_args(), *PyTest.global_instance().options.args])
 
       args.extend(test_args)
       args.extend(sources_map.keys())

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -128,6 +128,17 @@ def dict_with_files_option(s):
   return DictValueComponent.create(s)
 
 
+def shell_str(s: str) -> str:
+  """A member_type for strings that should be split upon parsing through `shlex.split()`.
+
+  For example, the option value `--foo --bar=val` would be split into `['--foo', '--bar=val']`,
+  and then the parser will safely merge this expanded list with any other values defined for the
+  option.
+
+  :API: public"""
+  return s
+
+
 def _convert(val, acceptable_types):
   """Ensure that val is one of the acceptable types, converting it if needed.
 

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import shlex
-from typing import Sequence, Tuple, cast
+from typing import List, Sequence, cast
 
 from pants.option.custom_types import dict_with_files_option, list_option
 
@@ -15,13 +15,9 @@ def is_dict_option(kwargs) -> bool:
   return kwargs.get('type') in (dict, dict_with_files_option)
 
 
-# TODO: consider moving this directly into the option system, e.g. allowing registration of an
-#  option with `type=flattened_list, member_type=shlexed`.
-def flatten_shlexed_list(shlexed_args: Sequence[str]) -> Tuple[str, ...]:
+def flatten_shlexed_list(shlexed_args: Sequence[str]) -> List[str]:
   """Convert a list of shlexed args into a flattened list of individual args.
 
    For example, ['arg1 arg2=foo', '--arg3'] would be converted to ['arg1', 'arg2=foo', '--arg3'].
    """
-  return tuple(
-    arg for shlexed_arg in shlexed_args for arg in shlex.split(shlexed_arg)
-  )
+  return [arg for shlexed_arg in shlexed_args for arg in shlex.split(shlexed_arg)]

--- a/src/python/pants/option/option_util_test.py
+++ b/src/python/pants/option/option_util_test.py
@@ -9,7 +9,7 @@ from pants.option.option_util import flatten_shlexed_list
 class OptionUtilTest(TestCase):
 
   def test_flatten_shlexed_list(self) -> None:
-    assert flatten_shlexed_list(["arg1", "arg2"]) == ("arg1", "arg2")
-    assert flatten_shlexed_list(["arg1 arg2"]) == ("arg1", "arg2")
-    assert flatten_shlexed_list(["arg1 arg2=foo", "--arg3"]) == ("arg1", "arg2=foo", "--arg3")
-    assert flatten_shlexed_list(["arg1='foo bar'", "arg2='baz'"]) == ("arg1=foo bar", "arg2=baz")
+    assert flatten_shlexed_list(["arg1", "arg2"]) == ["arg1", "arg2"]
+    assert flatten_shlexed_list(["arg1 arg2"]) == ["arg1", "arg2"]
+    assert flatten_shlexed_list(["arg1 arg2=foo", "--arg3"]) == ["arg1", "arg2=foo", "--arg3"]
+    assert flatten_shlexed_list(["arg1='foo bar'", "arg2='baz'"]) == ["arg1=foo bar", "arg2=baz"]

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -37,6 +37,7 @@ from pants.option.custom_types import (
   dir_option,
   file_option,
   list_option,
+  shell_str,
   target_option,
 )
 from pants.option.errors import (
@@ -60,7 +61,7 @@ from pants.option.errors import (
   Shadowing,
 )
 from pants.option.option_tracker import OptionTracker
-from pants.option.option_util import is_dict_option, is_list_option
+from pants.option.option_util import flatten_shlexed_list, is_dict_option, is_list_option
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
@@ -490,7 +491,7 @@ class Parser:
 
   # TODO: Remove dict_option from here after deprecation is complete.
   _allowed_member_types = {
-    str, int, float, dict, dir_option, dict_option, file_option, target_option
+    str, int, float, dict, dir_option, dict_option, file_option, target_option, shell_str
   }
 
   def _validate(self, args, kwargs) -> None:
@@ -732,6 +733,8 @@ class Parser:
       # TODO: run `check()` for all elements of a list option too!!!
       merged_val = [self._convert_member_type(kwargs.get('member_type', str), x)
                     for x in merged_val]
+      if kwargs.get('member_type') == shell_str:
+        merged_val = flatten_shlexed_list(merged_val)
       for val in merged_val:
         check(val)
       ret = RankedValue(merged_rank, merged_val)


### PR DESCRIPTION
### Problem

We now use [V2 style passthrough args](https://docs.google.com/document/d/18-WFAYiktq3DAfOQPrnU5yaycT6V1K27yrnFPoGgTIA/edit) (i.e. `--args` defined on the goal or subsystem) in several places. 

The current approach was a temporary way to land this feature and is not robust. It suffers from these problems:

1) It's easy to accidentally call `my_subsystem.options.args` without realizing that you need to call `my_subystem.get_args()` for the option to work properly.
   * It's also easy for subsystem authors to miss that they need to define `get_args()`.
1) The `help` message doesn't express any information to the end-user that this is a special option type.
   * Normally, when `member_type=str`, users would expect to pass every "word" as a distinct entry in a list. That will work but is not ergonomic, and we want to express that there's some sugar.
1) It won't work cleanly for backporting goal-level `--args` to V1 tasks. For example, the V1 task `--run-py` won't have a way to call `RunOptions.get_args()` because V1 tasks don't have a reference to `RunOptions` (which is an `engine.GoalSubystem)`.
    * Instead, each task would need to call `flatten_shlexed_list`, which is a leaky abstraction.

### Solution

Add a `shell_str` `member_type`. When `type=list, member_type=shell_str`, the parser will know to call `flatten_shlexed_list` for the option. 

#### Rejected solution: `type=flattened_list` 
https://github.com/pantsbuild/pants/pull/8728/files#r351511571 proposed introducing `type=flattened_list, member_type=shell_str` to reduce the magic in this solution.

Trying to implement the proposal proved more complex than anticipated, in part due to the machinery that would need to be added for a new top-level `type` and in part due to unclear semantics. 

Were we to allow `type=flattend_list, member_type=shell_str`, then presumably we'd also allow `type=flattened_list, member_type=int` (or `type=flattened_list, member_type=List[int]`?). There is no current use case for this. By introducing `type=flattened_list`, we'd be introducing a new permutation for every `member_type`, when really we only care about one of those permutatoins (`member_type=shell_str`). Given how complex the parser already is, we want to avoid adding this complexity for as long as possible.