### PR TITLE
make "canonical" symlinks to cache materializing popular files in local hermetic process executions

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -40,6 +40,7 @@ class ExecuteProcessRequest:
   unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: Digest
   jdk_home: Optional[str]
   is_nailgunnable: bool
+  require_real_files: bool
 
   def __init__(
     self,
@@ -55,6 +56,7 @@ class ExecuteProcessRequest:
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: Digest = EMPTY_DIRECTORY_DIGEST,
     jdk_home: Optional[str] = None,
     is_nailgunnable: bool = False,
+    require_real_files: bool = False,
   ) -> None:
     self.argv = argv
     self.input_files = input_files
@@ -67,6 +69,7 @@ class ExecuteProcessRequest:
     self.unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule = unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule
     self.jdk_home = jdk_home
     self.is_nailgunnable = is_nailgunnable
+    self.require_real_files = require_real_files
 
 
 @frozen_after_init

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -976,6 +976,8 @@ class Native(metaclass=SingletonMetaclass):
         execution_options.process_execution_use_local_cache,
         self.context.utf8_dict(execution_options.remote_execution_headers),
         execution_options.process_execution_local_enable_nailgun,
+        execution_options.process_execution_local_symlink_optimization_threshold,
+        execution_options.process_execution_local_symlink_ttl,
       )
     if scheduler_result.is_throw:
       value = self.context.from_value(scheduler_result.throw_handle)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -61,6 +61,8 @@ class ExecutionOptions:
   remote_execution_extra_platform_properties: Any
   remote_execution_headers: Any
   process_execution_local_enable_nailgun: bool
+  process_execution_local_symlink_optimization_threshold: int
+  process_execution_local_symlink_ttl: float
 
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
@@ -86,6 +88,8 @@ class ExecutionOptions:
       remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
       remote_execution_headers=bootstrap_options.remote_execution_headers,
       process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
+      process_execution_local_symlink_optimization_threshold=bootstrap_options.process_execution_local_symlink_optimization_threshold,
+      process_execution_local_symlink_ttl=bootstrap_options.process_execution_local_symlink_ttl,
     )
 
 
@@ -111,6 +115,10 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     process_execution_local_enable_nailgun=False,
+    process_execution_local_symlink_optimization_threshold=100,
+    # The default is set to clean up cached materializations if they have not been accessed for 2
+    # days.
+    process_execution_local_symlink_ttl=172800.0,
   )
 
 
@@ -471,6 +479,13 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-local-enable-nailgun', type=bool, default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_enable_nailgun,
              help='Whether or not to use nailgun to run the requests that are marked as nailgunnable.',
              advanced=True)
+    register('--process-execution-local-symlink-optimization-threshold', type=int, default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_symlink_optimization_threshold,
+             help='The number of times to materialize a file before using a symlink instead '
+                  'for applicable local process executions. A value of 0 disables this feature.')
+    register('--process-execution-local-symlink-ttl', type=float, default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_symlink_ttl,
+             help='The time (in seconds) to retain symlink file materialization cache entries. '
+                  'All entries older than this will be deleted when Pants exits. '
+                  'The default is 2 days.')
 
   @classmethod
   def register_options(cls, register):

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serverset 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sharded_lmdb 0.0.1",

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -26,7 +26,9 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use serde_derive::Serialize;
+use serde_derive::{Deserialize, Serialize};
+
+use std::default::Default;
 
 /// A concrete data representation of a duration.
 /// Unlike std::time::Duration, it doesn't hide how the time is stored as the purpose of this
@@ -39,12 +41,18 @@ use serde_derive::Serialize;
 ///
 /// It can be used to represent a timestamp (as a duration since the unix epoch) or simply a
 /// duration between two arbitrary timestamps.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Duration {
   /// How many seconds did this `Duration` last?
   pub secs: u64,
   /// How many sub-second nanoseconds did this `Duration` last?
   pub nanos: u32,
+}
+
+impl Default for Duration {
+  fn default() -> Self {
+    Duration { secs: 0, nanos: 0 }
+  }
 }
 
 impl Duration {
@@ -70,7 +78,7 @@ impl Into<std::time::Duration> for Duration {
 }
 
 /// A timespan
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TimeSpan {
   /// Duration since the UNIX_EPOCH
   pub start: Duration,
@@ -79,6 +87,13 @@ pub struct TimeSpan {
 }
 
 impl TimeSpan {
+  pub fn now() -> Self {
+    TimeSpan {
+      start: Self::since_epoch(&std::time::SystemTime::now()).into(),
+      duration: Duration::default(),
+    }
+  }
+
   fn since_epoch(time: &std::time::SystemTime) -> std::time::Duration {
     time
       .duration_since(std::time::UNIX_EPOCH)

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -720,8 +720,9 @@ fn main() {
       .expect("Error making BackoffConfig"),
       1,
       1,
+      None,
     ),
-    None => Store::local_only(runtime.clone(), &store_path),
+    None => Store::local_only(runtime.clone(), &store_path, None),
   }
   .expect("Error making store");
 

--- a/src/rust/engine/fs/brfs/src/syscall_tests.rs
+++ b/src/rust/engine/fs/brfs/src/syscall_tests.rs
@@ -16,7 +16,7 @@ fn read_file_by_digest_exact_bytes() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
 

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -16,7 +16,7 @@ fn missing_digest() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
   assert!(!&mount_dir
@@ -32,7 +32,7 @@ fn read_file_by_digest() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
 
@@ -55,7 +55,7 @@ fn list_directory() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
   let test_directory = TestDirectory::containing_roland();
@@ -81,7 +81,7 @@ fn read_file_from_directory() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
   let test_directory = TestDirectory::containing_roland();
@@ -109,7 +109,7 @@ fn list_recursive_directory() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
   let treat_bytes = TestData::catnip();
@@ -144,7 +144,7 @@ fn read_file_from_recursive_directory() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
   let treat_bytes = TestData::catnip();
@@ -184,7 +184,7 @@ fn files_are_correctly_executable() {
   let runtime = task_executor::Executor::new();
 
   let store =
-    Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
+    Store::local_only(runtime.clone(), store_dir.path(), None).expect("Error creating local store");
 
   let treat_bytes = TestData::catnip();
   let directory = TestDirectory::with_mixed_executable_files();

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -25,6 +25,7 @@ serverset = { path = "../../serverset" }
 sha2 = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3"

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -3,6 +3,7 @@ use crate::tests::block_on;
 use crate::{EntryType, ShrinkBehavior};
 use bytes::{BufMut, Bytes, BytesMut};
 use hashing::{Digest, Fingerprint};
+use std::convert::From;
 use std::path::Path;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
@@ -426,7 +427,7 @@ pub fn all_digests() {
 }
 
 pub fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
-  ByteStore::new(task_executor::Executor::new(), dir).unwrap()
+  ByteStore::new(task_executor::Executor::new(), dir, None).unwrap()
 }
 
 pub fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {

--- a/src/rust/engine/fs/store/src/materialization_cache.rs
+++ b/src/rust/engine/fs/store/src/materialization_cache.rs
@@ -1,0 +1,318 @@
+use concrete_time::Duration;
+use hashing::Digest;
+
+use serde_derive::{Deserialize, Serialize};
+use serde_json;
+
+use std::collections::{HashMap, HashSet};
+use std::default::Default;
+use std::fs;
+use std::io::Write;
+use std::ops::Drop;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+// NB: This is always going to refer to a *file*, never a *directory*!
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FileMaterializationInput {
+  pub digest: Digest,
+  pub is_executable: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CachedFileToMaterialize {
+  pub input: FileMaterializationInput,
+  pub canonical_materialized_location: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CanonicalFileMaterializationRequest {
+  pub input: FileMaterializationInput,
+  // NB: This directory is the *base* directory to materialize files into -- this is *not* a path
+  // pointing to the canonical materialization location! The recipient of this struct is expected to
+  // create the canonical materialization location and provide a `CachedFileToMaterialize` to
+  // `LocalFileMaterializationCache::register_newly_materialized_file()!
+  pub materialize_into_dir: PathBuf,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct MaterializationCacheEntry {
+  pub last_accessed: SystemTime,
+  pub num_occurrences: u64,
+  pub canonical_location: Option<PathBuf>,
+}
+
+impl Default for MaterializationCacheEntry {
+  fn default() -> Self {
+    MaterializationCacheEntry {
+      last_accessed: SystemTime::now(),
+      num_occurrences: 0,
+      canonical_location: None,
+    }
+  }
+}
+
+///
+/// We attempt to create a "secretly" mutable cache of files we have materialized on disk. We
+/// want to use this to create symlinks when materializing files which are materialized to disk
+/// *extremely* often.
+///
+#[derive(Debug)]
+pub struct LocalFileMaterializationCache {
+  // TODO: Determine whether u64 is sufficiently large to avoid wrapping back over to 0! This should
+  // be an easy question with an easy answer!
+  all_materializations: HashMap<FileMaterializationInput, MaterializationCacheEntry>,
+  // If a file is materialized this many times, create a "canonical file materialization", and
+  // henceforth create a symlink to that file when materializing files locally!
+  canonical_file_materialization_threshold: u64,
+  ttl: Duration,
+  // The directory where we store what we call "canonical file materializations" (note that
+  // "canonical" is used in many different ways in this codebase!). "Canonical file
+  // materializations" here are files we materialize within this
+  // directory.
+  materialize_into_dir: PathBuf,
+  // Path to the file which contains persisted cache information that is re-read in
+  // `LocalFileMaterializationCache::new()`. A json blob is written to this file path on Drop.
+  cache_info_file_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CachedFileMaterializationState {
+  AlreadyCanonicallyMaterialized(CachedFileToMaterialize),
+  RequiresCanonicalMaterialization(CanonicalFileMaterializationRequest),
+  HasNoCanonicalMaterialization,
+}
+
+impl LocalFileMaterializationCache {
+  pub fn new<P: AsRef<Path>>(
+    materialize_into_dir: P,
+    canonical_file_materialization_threshold: u64,
+    ttl: Duration,
+  ) -> Result<Self, String> {
+    let materialize_into_dir = materialize_into_dir.as_ref().to_path_buf();
+    if !materialize_into_dir.is_dir() {
+      return Err(format!(
+        "the specified directory for the file materialization cache at {:?} is not a directory!",
+        &materialize_into_dir
+      ));
+    }
+
+    let cache_info_file_path = materialize_into_dir.join("cache-info.json");
+    let persisted_state = match fs::read_to_string(&cache_info_file_path) {
+      Err(_) => PersistedFileMaterializationState::default(),
+      Ok(file_contents) => serde_json::from_str(&file_contents).map_err(|e| format!("{}", e))?,
+    };
+
+    let PersistedFileMaterializationState {
+      all_materializations,
+    } = persisted_state;
+
+    Ok(LocalFileMaterializationCache {
+      all_materializations: all_materializations.into_iter().collect(),
+      canonical_file_materialization_threshold,
+      materialize_into_dir,
+      cache_info_file_path,
+      ttl,
+    })
+  }
+
+  ///
+  /// This method will register the `digest` as an "attempted materialization", and if this method
+  /// is called with the same `digest` enough times, it will eventually return a
+  /// RequiresCanonicalMaterialization!
+  ///
+  pub fn determine_materialization_state_for_file(
+    &mut self,
+    input: FileMaterializationInput,
+  ) -> CachedFileMaterializationState {
+    let (num_occurrences, maybe_cached_materialization) = {
+      let entry = self.all_materializations.entry(input).or_default();
+      // Update the last access time to now.
+      (*entry).last_accessed = SystemTime::now();
+      // Increment the number of occurrences for the given `input`.
+      (*entry).num_occurrences += 1;
+      ((*entry).num_occurrences, &(*entry).canonical_location)
+    };
+
+    if let &Some(ref cached_materialization) = maybe_cached_materialization {
+      CachedFileMaterializationState::AlreadyCanonicallyMaterialized(CachedFileToMaterialize {
+        input,
+        canonical_materialized_location: cached_materialization.clone(),
+      })
+    } else if num_occurrences >= self.canonical_file_materialization_threshold {
+      CachedFileMaterializationState::RequiresCanonicalMaterialization(
+        CanonicalFileMaterializationRequest {
+          input,
+          materialize_into_dir: self.materialize_into_dir.clone(),
+        },
+      )
+    } else {
+      CachedFileMaterializationState::HasNoCanonicalMaterialization
+    }
+  }
+
+  ///
+  /// If the caller previously received a
+  /// `CachedFileMaterializationState::RequiresCanonicalMaterialization`, they should call this
+  /// method so that subsequent invocations of `self.determine_materialization_state_for_file()`
+  /// will return a `CachedFileMaterializationState::AlreadyCanonicallyMaterialized`!
+  ///
+  pub fn register_newly_materialized_file(
+    &mut self,
+    newly_materialized_file: CachedFileToMaterialize,
+  ) -> Result<(), String> {
+    let CachedFileToMaterialize {
+      input,
+      canonical_materialized_location,
+    } = newly_materialized_file;
+
+    let mut entry = self.all_materializations.get_mut(&input)
+      .ok_or_else(|| format!("input {:?} attempted to be registered as a canonical file materialization at {:?}, but the canonical file materialization cache has never seen this input!",
+                             &input, &canonical_materialized_location,
+      ))?;
+
+    if entry.canonical_location.is_some() {
+      Ok(())
+    } else if entry.num_occurrences < self.canonical_file_materialization_threshold {
+      Err(format!("input {:?} was registered as a canonical file materialization at {:?}, but was only seen {:?} times, less than the threshold of {:?}!",
+                  &input, &canonical_materialized_location, &entry.num_occurrences, self.canonical_file_materialization_threshold))
+    } else {
+      // We have encountered a valid, newly-registered canonical file materialization!
+      entry.canonical_location = Some(canonical_materialized_location);
+      Ok(())
+    }
+  }
+
+  fn write_persisted_state(&self) -> Result<(), String> {
+    let persisted_state = PersistedFileMaterializationState::extract(&self);
+    let mut file = fs::File::create(&self.cache_info_file_path).map_err(|e| {
+      format!(
+        "{:?} could not be created: {}",
+        &self.cache_info_file_path, e
+      )
+    })?;
+    let json_payload = serde_json::to_string_pretty(&persisted_state).map_err(|e| {
+      format!(
+        "persisted state {:?} could not be converted to json: {:?}",
+        &persisted_state, e
+      )
+    })?;
+    file.write_all(json_payload.as_bytes()).map_err(|e| {
+      format!(
+        "error writing json payload {:?} to file {:?}: {}",
+        json_payload, file, e
+      )
+    })?;
+    Ok(())
+  }
+
+  fn get_old_entries(
+    &mut self,
+  ) -> Vec<(&FileMaterializationInput, &mut MaterializationCacheEntry)> {
+    let now = std::time::SystemTime::now();
+    let ttl = self.ttl;
+    self
+      .all_materializations
+      .iter_mut()
+      .filter(
+        move |(
+          _,
+          MaterializationCacheEntry {
+            last_accessed,
+            canonical_location,
+            ..
+          },
+        )| {
+          let diff: Duration = now
+            .duration_since(*last_accessed)
+            .map(|d| d.into())
+            .unwrap_or_default();
+          diff > ttl && canonical_location.is_some()
+        },
+      )
+      .collect()
+  }
+
+  fn cleanup_old_entries(&mut self) -> Result<(), String> {
+    // Remove files belonging to any cache entries older than the ttl.
+    for (ref input, ref mut entry) in self.get_old_entries().into_iter() {
+      let location = entry.canonical_location.clone().unwrap();
+      fs::remove_file(&location).map_err(|e| {
+        format!(
+          "failed to clean up old entry {:?} for input {:?}: {}",
+          &input, &entry, e
+        )
+      })?;
+      entry.canonical_location = None;
+    }
+
+    // Cleanup any files in the cache directory that aren't recognized by the current set of
+    // entries.
+    let mut unrecognized_files: HashSet<_> = fs::read_dir(&self.materialize_into_dir)
+      .map_err(|e| {
+        format!(
+          "reading file materialization cache dir {:?} failed: {}",
+          self.materialize_into_dir, e
+        )
+      })?
+      .map(|dir_entry| dir_entry.map(|d| d.path()))
+      .collect::<Result<HashSet<_>, _>>()
+      .map_err(|e| {
+        format!(
+          "reading file materialization cache dir {:?} failed: {}",
+          self.materialize_into_dir, e
+        )
+      })?;
+    // Avoid deleting the cache info file.
+    unrecognized_files.remove(&self.cache_info_file_path);
+    // Unmark all files that did survive the ttl-based cache purge.
+    for canonical_location in self.all_materializations.iter().flat_map(
+      |(
+        _,
+        MaterializationCacheEntry {
+          ref canonical_location,
+          ..
+        },
+      )| canonical_location,
+    ) {
+      assert!(unrecognized_files.remove(canonical_location));
+    }
+    for file in unrecognized_files.into_iter() {
+      fs::remove_file(&file)
+        .map_err(|e| format!("failed to remove unrecognized file {:?}: {}", file, e))?;
+    }
+
+    Ok(())
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+struct PersistedFileMaterializationState {
+  pub all_materializations: Vec<(FileMaterializationInput, MaterializationCacheEntry)>,
+}
+
+impl PersistedFileMaterializationState {
+  fn extract(cache: &LocalFileMaterializationCache) -> Self {
+    let &LocalFileMaterializationCache {
+      ref all_materializations,
+      ..
+    } = cache;
+    PersistedFileMaterializationState {
+      all_materializations: all_materializations
+        .iter()
+        .map(|(input, entry)| (*input, entry.clone()))
+        .collect(),
+    }
+  }
+}
+
+impl Drop for LocalFileMaterializationCache {
+  fn drop(&mut self) {
+    self
+      .cleanup_old_entries()
+      .unwrap_or_else(|e| panic!("error cleaning up old entries: {}", e));
+    self
+      .write_persisted_state()
+      .unwrap_or_else(|e| panic!("error writing persisted materialization cache info: {}", e));
+  }
+}

--- a/src/rust/engine/fs/store/src/materialization_cache_tests.rs
+++ b/src/rust/engine/fs/store/src/materialization_cache_tests.rs
@@ -1,0 +1,162 @@
+use crate::local::ByteStore;
+use crate::materialization_cache::{
+  CachedFileMaterializationState, CanonicalFileMaterializationRequest, FileMaterializationInput,
+  LocalFileMaterializationCache, CachedFileToMaterialize,
+};
+use crate::tests::{block_on, is_executable};
+use crate::{FileMaterializationBehavior, Store};
+
+use concrete_time::Duration;
+use hashing::EMPTY_DIGEST;
+use tempfile::TempDir;
+use testutil::data::TestData;
+use workunit_store::WorkUnitStore;
+
+use std::convert::From;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+struct Error(String);
+
+impl From<io::Error> for Error {
+  fn from(e: io::Error) -> Error {
+    Error(format!("{}", e))
+  }
+}
+
+impl From<String> for Error {
+  fn from(e: String) -> Error {
+    Error(e)
+  }
+}
+
+#[test]
+fn file_materialization_cache() -> Result<(), Error> {
+  // Create a file materialization cache which will start creating symlinks after 2 materialization
+  // attempts.
+  let cache_dir = TempDir::new()?;
+  let cache = LocalFileMaterializationCache::new(cache_dir.path(), 2, Duration::default())?;
+
+  let store_dir = TempDir::new()?;
+  let store = Store {
+    local: ByteStore::new(
+      task_executor::Executor::new(),
+      store_dir.path(),
+      Some(cache),
+    )?,
+    remote: None,
+  };
+
+  let materialize_dir = TempDir::new()?;
+  let file = materialize_dir.path().join("file");
+  let testdata = TestData::roland();
+  block_on(store.store_file_bytes(testdata.bytes(), false))?;
+
+  let materialize_file = |file: &PathBuf, testdata: &TestData, is_executable: bool| {
+    store.materialize_file(
+      file.clone(),
+      testdata.digest(),
+      is_executable,
+      FileMaterializationBehavior::AllowSymlinkOptimization,
+      WorkUnitStore::new(),
+    )
+  };
+
+  block_on(materialize_file(&file, &testdata, false))?;
+  assert!(fs::symlink_metadata(&file)?.is_file());
+
+  // Check that attempting to create a symlink at an existing file location produces an Err.
+  assert!(block_on(materialize_file(&file, &testdata, false)).is_err());
+  fs::remove_file(&file)?;
+
+  // Create the file a second time, which should produce a symlink now.
+  block_on(materialize_file(&file, &testdata, false))?;
+  assert!(fs::symlink_metadata(&file)?.file_type().is_symlink());
+  assert!(!is_executable(&file));
+
+  // Check that materializing with is_executable=true modifies the cache key.
+  block_on(materialize_file(&file, &testdata, true))?;
+  assert!(fs::symlink_metadata(&file)?.is_file());
+  fs::remove_file(&file)?;
+  block_on(materialize_file(&file, &testdata, true))?;
+  assert!(fs::symlink_metadata(&file)?.file_type().is_symlink());
+  // Check that the underlying file is correctly marked as executable!
+  assert!(is_executable(&file));
+
+  Ok(())
+}
+
+#[test]
+fn cache_serde_on_new_and_drop() -> Result<(), Error> {
+  let tmp_dir = TempDir::new()?;
+  let cache_dir = tmp_dir.path();
+  let empty_input = FileMaterializationInput {
+    digest: EMPTY_DIGEST,
+    is_executable: false,
+  };
+  let cache_file_path = cache_dir.join("idk.txt");
+  let cache_info_file_path = cache_dir.join("cache-info.json");
+
+  // Create new file materialization cache.
+  assert!(!cache_info_file_path.exists());
+  {
+    // Large enough to be longer than the duration of this test running.
+    let duration = Duration::new(100, 0);
+    let mut cache = LocalFileMaterializationCache::new(cache_dir, 2, duration)?;
+    // First use should signal no caching needs to be done.
+    assert_eq!(
+      cache.determine_materialization_state_for_file(empty_input),
+      CachedFileMaterializationState::HasNoCanonicalMaterialization
+    );
+    let to_materialize = match cache.determine_materialization_state_for_file(empty_input) {
+      CachedFileMaterializationState::RequiresCanonicalMaterialization(
+        CanonicalFileMaterializationRequest {
+          input, materialize_into_dir,
+        }
+      ) => {
+        assert_eq!(input, empty_input);
+        assert_eq!(materialize_into_dir, cache_dir);
+        fs::File::create(&cache_file_path)?.write_all(b"")?;
+        let to_materialize = CachedFileToMaterialize {
+          input,
+          canonical_materialized_location: cache_file_path.clone(),
+        };
+        cache.register_newly_materialized_file(to_materialize.clone())?;
+        to_materialize
+      },
+      _ => unreachable!(),
+    };
+    assert_eq!(cache.determine_materialization_state_for_file(empty_input),
+               CachedFileMaterializationState::AlreadyCanonicallyMaterialized(to_materialize));
+  }
+  // After `cache` is `drop()`ed, the info file should be populated.
+  assert!(cache_info_file_path.exists());
+
+  // Create another `cache`, with a much shorter (0) ttl.
+  {
+    let duration = Duration::default();
+    let mut cache = LocalFileMaterializationCache::new(cache_dir, 2, duration)?;
+
+    // The previous entry should already exist in a materialized state.
+    match cache.determine_materialization_state_for_file(empty_input) {
+      CachedFileMaterializationState::AlreadyCanonicallyMaterialized(CachedFileToMaterialize {
+        input,
+        canonical_materialized_location,
+      }) => {
+        assert_eq!(input, empty_input);
+        assert_eq!(canonical_materialized_location, cache_file_path.clone());
+      },
+      _ => unreachable!(),
+    }
+
+    assert!(cache_file_path.exists());
+  }
+  // After the `drop()` from a cache with a 0 ttl, the single entry should be wiped.
+  assert!(!cache_file_path.exists());
+  // The cache info file should still exist.
+  assert!(cache_info_file_path.exists());
+
+  Ok(())
+}

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -32,6 +32,7 @@ fn setup() -> (
       .prefix("lmdb_store")
       .tempdir()
       .unwrap(),
+    None,
   )
   .unwrap();
   let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -22,7 +22,7 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   let runtime = task_executor::Executor::new();
   let work_dir = TempDir::new().unwrap();
   let store_dir = TempDir::new().unwrap();
-  let store = Store::local_only(runtime.clone(), store_dir.path()).unwrap();
+  let store = Store::local_only(runtime.clone(), store_dir.path(), None).unwrap();
   let local = crate::local::CommandRunner::new(
     store.clone(),
     runtime.clone(),

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -211,6 +211,8 @@ pub struct ExecuteProcessRequest {
   pub target_platform: Platform,
 
   pub is_nailgunnable: bool,
+
+  pub require_real_files: bool,
 }
 
 impl TryFrom<MultiPlatformExecuteProcessRequest> for ExecuteProcessRequest {

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -627,7 +627,7 @@ fn output_empty_dir() {
 fn local_only_scratch_files_materialized() {
   let store_dir = TempDir::new().unwrap();
   let executor = task_executor::Executor::new();
-  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
+  let store = Store::local_only(executor.clone(), store_dir.path(), None).unwrap();
 
   // Prepare the store to contain roland, because the EPR needs to materialize it
   let roland_directory_digest = TestDirectory::containing_roland().digest();
@@ -705,7 +705,7 @@ fn timeout() {
 fn working_directory() {
   let store_dir = TempDir::new().unwrap();
   let executor = task_executor::Executor::new();
-  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
+  let store = Store::local_only(executor.clone(), store_dir.path(), None).unwrap();
 
   // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
   // from the ./cats directory.
@@ -775,7 +775,7 @@ fn run_command_locally_in_dir(
   let store_dir = TempDir::new().unwrap();
   let executor = executor.unwrap_or_else(task_executor::Executor::new);
   let store =
-    store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
+    store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path(), None).unwrap());
   let runner = crate::local::CommandRunner::new(store, executor.clone(), dir, cleanup);
   executor.block_on(runner.run(req.into(), Context::default()))
 }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -65,6 +65,7 @@ fn construct_nailgun_server_request(
     jdk_home: Some(jdk),
     target_platform: platform,
     is_nailgunnable: true,
+    require_real_files: true,
   }
 }
 
@@ -86,6 +87,7 @@ fn construct_nailgun_client_request(
     jdk_home: _jdk_home,
     target_platform,
     is_nailgunnable,
+    require_real_files,
   } = original_req;
   client_args.insert(0, client_main_class);
   ExecuteProcessRequest {
@@ -101,6 +103,7 @@ fn construct_nailgun_client_request(
     jdk_home: None,
     target_platform,
     is_nailgunnable,
+    require_real_files,
   }
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -22,7 +22,7 @@ use lazy_static::lazy_static;
 use crate::ExecuteProcessRequest;
 use digest::Digest as DigestTrait;
 use sha2::Sha256;
-use store::Store;
+use store::{FileMaterializationBehavior, Store};
 use workunit_store::WorkUnitStore;
 
 lazy_static! {
@@ -57,7 +57,7 @@ impl NailgunPool {
     let workdir_for_server2 = workdir_for_server.clone();
 
     // TODO(#8481) This materializes the input files in the client req, which is a superset of the files we need (we only need the classpath, not the input files)
-    store.materialize_directory(workdir_for_server.clone(), input_files, workunit_store)
+    store.materialize_directory(workdir_for_server.clone(), input_files, FileMaterializationBehavior::RequireRealFiles, workunit_store)
     .and_then(move |_metadata| {
       let jdk_home_in_workdir = &workdir_for_server.clone().join(".jdk");
       let jdk_home_in_workdir2 = jdk_home_in_workdir.clone();

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -11,7 +11,7 @@ use workunit_store::WorkUnitStore;
 fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
   let store_dir = TempDir::new().unwrap();
   let executor = task_executor::Executor::new();
-  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
+  let store = Store::local_only(executor.clone(), store_dir.path(), None).unwrap();
   let local_runner =
     crate::local::CommandRunner::new(store, executor.clone(), std::env::temp_dir(), true);
   let metadata = ExecuteProcessRequestMetadata {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -763,6 +763,7 @@ pub fn sends_headers() {
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store");
 
@@ -929,6 +930,7 @@ fn ensure_inline_stdio_is_stored() {
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store");
 
@@ -961,7 +963,7 @@ fn ensure_inline_stdio_is_stored() {
   );
 
   let local_store =
-    Store::local_only(runtime.clone(), &store_dir_path).expect("Error creating local store");
+    Store::local_only(runtime.clone(), &store_dir_path, None).expect("Error creating local store");
   {
     assert_eq!(
       runtime
@@ -1462,6 +1464,7 @@ fn execute_missing_file_uploads_if_known() {
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store");
   runtime
@@ -1570,6 +1573,7 @@ fn execute_missing_file_uploads_if_known_status() {
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store");
   store
@@ -1654,6 +1658,7 @@ fn execute_missing_file_errors_if_unknown() {
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store");
 
@@ -2515,6 +2520,7 @@ fn make_store(store_dir: &Path, cas: &mock::StubCAS, executor: task_executor::Ex
     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
     1,
     1,
+    None,
   )
   .expect("Failed to make store")
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -454,6 +454,7 @@ impl MultiPlatformExecuteProcess {
     };
 
     let is_nailgunnable = externs::project_bool(&value, "is_nailgunnable");
+    let require_real_files = externs::project_bool(&value, "require_real_files");
 
     let unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule =
       lift_digest(&externs::project_ignoring_type(
@@ -475,6 +476,7 @@ impl MultiPlatformExecuteProcess {
       jdk_home,
       target_platform,
       is_nailgunnable,
+      require_real_files,
     })
   }
 


### PR DESCRIPTION
### Problem

We create temp dirs willy-nilly when running hermetic process executions locally. Because it appears most operating systems do garbage collection of `/tmp` only on restart, developing on pants will occasionally bring up a "disk out of space" error that is only resolved by restarting (is there a ticket for this?). While we would like the operating system to do this job for us, there may also be some benefit in terms of performance if we an avoid writing out so many files from LMDB to a temp dir while pants runs locally.

### Solution

- Add a field `require_real_files: bool = False` to `ExecuteProcessRequest`, which preserves the existing behavior when `True`.
  - When `False`, and when `--process-execution-local-symlink-optimization-threshold` is nonzero, begin to start producing symlinks for files which have been materialized more times than the value of that threshold, when creating the sandbox in `/tmp` for a local hermetic process execution.
- Create `LocalFileMaterializationCache` in `materialization_cache.rs` to accomplish the above, by writing "canonical" file materializations into `~/.cache/pants/lmdb_cache/file_materialization_cache`, and writing symlinks pointing to files in that directory.
- Have the file materialization cache persist across pants executions by writing its info to a `cache-info.json` file when `Drop`ed.

### Result

This will hopefully help to reduce the incidence of disk out of space errors when developing on pants locally. This is expected to improve the performance of local v2 process executions, but we don't currently invoke any of those en masse in parallel yet. The native or jvm backends might be good things to convert to v2 next to perhaps take advantage of this optimization.