### PR TITLE
Bump up deprecations for the 1.26 series to earlier in the 1.26 dev series

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -263,7 +263,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
         cmd.append(f'--config-file={os.path.join(get_buildroot(), config)}')
       deprecated_conditional(
         lambda: self.get_passthru_args(),
-        removal_version='1.26.0.dev3',
+        removal_version='1.26.0.dev1',
         entity_description='Using the old style of passthrough args for MyPy',
         hint_message="You passed arguments to MyPy through either the "
                      "`--lint-mypy-passthrough-args` option or the style "

--- a/src/docs/deprecation_policy.md
+++ b/src/docs/deprecation_policy.md
@@ -3,7 +3,7 @@ Pants Deprecation Policy
 
 Deprecations should live for one entire `dev` series and stable release branch (at the minimum) before their code is removed. This ensures that there is always at least one stable release containing a deprecation, and allows users upgrading their copy of pants to consume only stable releases in order to observe all deprecations.
 
-As an example: if a feature is deprecated during the `1.0.0.dev` series, it should remain available but deprecated for the entire `1.1.0.dev` series, and can be removed when master bumps to `1.2.0.dev0`.
+As an example: if a feature is deprecated in `1.0.0.dev2`, it should remain available but deprecated for the entire `1.1.0.dev` series, and can be removed when master bumps to `1.2.0.dev0`.
 
 API Definition
 --------------

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -30,7 +30,7 @@ class Dependencies(ConsoleTask):
       '--external-only',
       type=bool,
       help='Specifies that only external dependencies should be included in the graph output (only external jars).',
-      removal_version="1.26.0.dev1",
+      removal_version="1.26.0.dev0",
       removal_hint="This feature is being removed. If you depend on this functionality, please let us know in the "
                    "#general channel on Slack at https://pantsbuild.slack.com/. \nYou can join the pants slack here: "
                    "https://pantsslack.herokuapp.com/ ",
@@ -47,7 +47,7 @@ class Dependencies(ConsoleTask):
   def console_output(self, unused_method_argument):
     deprecated_conditional(
       lambda: not self.is_external_only and not self.is_internal_only,
-      removal_version="1.26.0.dev1",
+      removal_version="1.26.0.dev0",
       entity_description="The default dependencies output including external dependencies",
       hint_message="Pants will soon default to `--internal-only`, and remove the `--external-only` option. "
                     "Currently, Pants defaults to include both internal and external dependencies, which means this "

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -36,7 +36,7 @@ class PythonToolBase(Subsystem):
     register('--requirements', type=list, advanced=True, fingerprint=True,
              default=cls.default_requirements,
              help='Python requirement strings for the tool.',
-             removal_version='1.26.0.dev2',
+             removal_version='1.26.0.dev1',
              removal_hint="Instead of `--requirements`, use `--version` and, optionally, "
                           "`--extra-requirements`.")
     register('--entry-point', type=str, advanced=True, fingerprint=True,
@@ -52,7 +52,7 @@ class PythonToolBase(Subsystem):
 
     deprecated_conditional(
       lambda: defined_default_deprecated_options,
-      removal_version="1.26.0.dev2",
+      removal_version="1.26.0.dev1",
       entity_description="Defining `default_requirements` for a subclass of `PythonToolBase`",
       hint_message="Instead of defining `default_requirements`, define `default_version` and, "
                    "optionally, `default_extra_requirements`."

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -54,7 +54,7 @@ class IsortRun(FmtTaskMixin, Task):
       isort_subsystem = Isort.global_instance()
       deprecated_conditional(
         lambda: self.get_passthru_args(),
-        removal_version='1.26.0.dev3',
+        removal_version='1.26.0.dev1',
         entity_description='Using the old style of passthrough args for isort',
         hint_message="You passed arguments to isort through either the "
                      "`--fmt-isort-passthrough-args` option or the style "

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -660,7 +660,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
 
       deprecated_conditional(
         lambda: self.get_passthru_args(),
-        removal_version='1.26.0.dev3',
+        removal_version='1.26.0.dev1',
         entity_description='Using the old style of passthrough args for Pytest',
         hint_message="You passed arguments to Pytest through either the "
                      "`--test-pytest-passthrough-args` option or the style "

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -43,7 +43,7 @@ class Login(ConsoleTask):
 
     deprecated_conditional(
       lambda: self.get_passthru_args(),
-      removal_version='1.26.0.dev3',
+      removal_version='1.26.0.dev1',
       entity_description='Using passthrough args with `./pants login`',
       hint_message="Instead of passing the provider through `--login-passthrough-args` or the "
                    "style `./pants login -- prod`, use the option `--login-to`, such as "

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -506,7 +506,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help=f'The maximum number of times to loop when `{loop_flag}` is specified.')
 
     register('-t', '--timeout', advanced=True, type=int, metavar='<seconds>',
-            removal_version="1.26.0.dev2",
+            removal_version="1.26.0.dev1",
             removal_hint="This option is not used and may be removed with no change in behavior. ",
             help='Number of seconds to wait for http connections.')
     # TODO: After moving to the new options system these abstraction leaks can go away.

--- a/tests/python/pants_test/deprecated_testinfra.py
+++ b/tests/python/pants_test/deprecated_testinfra.py
@@ -19,7 +19,7 @@ def deprecated_testinfra_module(instead=None):
     instead = f'pants.testutil.{caller_module_name.lstrip("pants_test.")}'
 
   deprecated_module(
-    removal_version='1.26.0.dev2',
+    removal_version='1.26.0.dev1',
     hint_message=f'Import {instead} from the pantsbuild.pants.testutil distribution instead.',
     stacklevel=4
   )


### PR DESCRIPTION
_**This has no impact on stable releases.**_

Our deprecation policy never required two full cycles for deprecations, but, due to a misunderstanding, we were doing this in some cases. For example, if we deprecated something in 1.0.0.dev2, we were waiting until 1.2.0.dev2, rather than 1.2.0.dev0, to remove the code.

This misunderstanding was slowing down deprecations necessary for incrementally migrating from V1 to V2. Here, we slightly bump up those deprecations planned for the `1.26.0.dev` series to happen earlier in that series.

We also update the docs to better clarify how the policy works.

