### PR TITLE
Have python_test_runner generate coverage.

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -81,6 +81,9 @@ def get_packages_to_cover(
   coverage: str,
   source_root_stripped_file_paths: List[str],
 ) -> Set[str]:
+  """Coverage may be a comma separated string of source root stripped files or packages or the special value 'auto'
+    for which we will attempt to figure out which packages we should produce coverage reports for.
+  """
   if coverage == 'auto':
     if hasattr(test_target, 'coverage'):
       return set(test_target.coverage)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -128,7 +128,7 @@ async def setup_pytest_for_target(test_target: PythonTestsAdaptor, pytest: PyTes
   )
   test_target_sources_file_names = source_root_stripped_test_target_sources.snapshot.files
   coverage_args = []
-  if test_options.values.coverage:
+  if test_options.values.run_coverage:
     packages_to_cover = get_packages_to_cover(
       test_target,
       source_root_stripped_file_paths=test_target_sources_file_names,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import List, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
@@ -79,7 +78,7 @@ class TestTargetSetup:
 def get_packages_to_cover(
   test_target: PythonTestsAdaptor,
   coverage: str,
-  source_root_stripped_file_paths: List[str],
+  source_root_stripped_file_paths: Tuple[str, ...],
 ) -> Set[str]:
   """Coverage may be a comma separated string of source root stripped files or packages or the special value 'auto'
     for which we will attempt to figure out which packages we should produce coverage reports for.

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -55,12 +55,6 @@ class PyTest(Subsystem):
       advanced=True,
       help='The maximum timeout (in seconds) that can be set on a test target.',
     )
-    register(
-      '--coverage',
-      help='Emit coverage information for specified packages or directories (these should be provided as source root '
-          'stripped paths). The special value "auto" indicates that Pants should attempt to deduce which packages to '
-          'emit coverage for.',
-    )
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -55,6 +55,12 @@ class PyTest(Subsystem):
       advanced=True,
       help='The maximum timeout (in seconds) that can be set on a test target.',
     )
+    register(
+      '--coverage',
+      help='Emit coverage information for specified packages or directories (these should be provided as source root '
+          'stripped paths). The special value "auto" indicates that Pants should attempt to deduce which packages to '
+          'emit coverage for.',
+    )
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -79,9 +79,19 @@ class TestOptions(GoalSubsystem):
   @classmethod
   def register_options(cls, register) -> None:
     super().register_options(register)
-    register('--debug', type=bool, default=False,
-             help='Run a single test target in an interactive process. This is '
-                  'necessary, for example, when you add breakpoints in your code.')
+    register(
+      '--debug',
+      type=bool,
+      default=False,
+      help='Run a single test target in an interactive process. This is necessary, for example, when you add '
+           'breakpoints in your code.'
+    )
+    register(
+      '--run-coverage',
+      type=bool,
+      default=False,
+      help='Generate a coverage report for this test run.',
+    )
 
 
 class Test(Goal):


### PR DESCRIPTION
### Problem

For parity with V1 we need to generate coverage reports.

### Solution

Have the run_python_test rule optionally run coverage.

### Result

This is part one of several in getting coverage reports in V2. I've broken it up here to keep it reviewable. 

At this point if you run 
```
./pants --no-process-execution-cleanup-local-dirs --v2 --no-v1 test --test-run-coverage src/python/pants/base:tests 
```
You'll see that it produces a `.coverage` file in `<chroot>/.coverage` This is accessable via TestResult. _python_sqlite_coverage_file` (see #8915 for ways we might improve on that. )

### Upcoming changes:
- A rule for merging coverage data, and its product `MergedCoverageData`
- A rule for generating coverage reports, and its product `CoverageReport`
- A subsystem for all the coverage options (include test sources, coverage report format (html or xml), and coverage output dir.)

You can see the design doc for this at #8915