### PR TITLE
Add --fmt-only flag

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 from contextlib import contextmanager
 
-from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 
 from pants.contrib.go.subsystems.gofmt import Gofmt

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -17,13 +17,10 @@ class GoFmtTaskBase(GoWorkspaceTask):
   """Base class for tasks that run gofmt."""
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope=old_scope,
       new_scope="gofmt",
-      old_container=self.get_options(),
-      new_container=Gofmt.global_instance().options,
+      subsystem=Gofmt.global_instance(),
     )
 
   @classmethod

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -16,7 +16,9 @@ class GoFmtTaskBase(GoWorkspaceTask):
   """Base class for tasks that run gofmt."""
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return self.resolve_conflicting_skip_options(
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    return self.resolve_conflicting_skip_options( # type: ignore
       old_scope=old_scope,
       new_scope="gofmt",
       subsystem=Gofmt.global_instance(),

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -4,7 +4,6 @@
 from abc import abstractmethod
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
-from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
 from pants.task.fmt_task_mixin import FmtTaskMixin

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -15,7 +15,9 @@ from pants.contrib.googlejavaformat.subsystem import GoogleJavaFormat
 class GoogleJavaFormatBase(RewriteBase):
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return self.resolve_conflicting_skip_options(
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    return self.resolve_conflicting_skip_options( # type: ignore
       old_scope=old_scope,
       new_scope="google-java-format",
       subsystem=GoogleJavaFormat.global_instance(),

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -16,13 +16,10 @@ from pants.contrib.googlejavaformat.subsystem import GoogleJavaFormat
 class GoogleJavaFormatBase(RewriteBase):
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope=old_scope,
       new_scope="google-java-format",
-      old_container=self.get_options(),
-      new_container=GoogleJavaFormat.global_instance().options,
+      subsystem=GoogleJavaFormat.global_instance(),
     )
 
   @classmethod

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -97,7 +97,11 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @property
   def skip_execution(self):
-    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
+    return self.resolve_conflicting_skip_options(
+      old_scope="lint-mypy",
+      new_scope="mypy",
+      subsystem=self._mypy_subsystem,
+    )
 
   def find_mypy_interpreter(self):
     interpreters = self._interpreter_cache.setup(

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -40,7 +40,9 @@ class JavascriptStyleBase(NodeTask):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return self.resolve_conflicting_skip_options(
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    return self.resolve_conflicting_skip_options( # type: ignore
       old_scope=old_scope,
       new_scope='eslint',
       subsystem=ESLint.global_instance(),

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -40,13 +40,10 @@ class JavascriptStyleBase(NodeTask):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope=old_scope,
       new_scope='eslint',
-      old_container=self.get_options(),
-      new_container=ESLint.global_instance().options,
+      subsystem=ESLint.global_instance(),
     )
 
   @classmethod

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -86,13 +86,10 @@ class Checkstyle(LintTaskMixin, Task):
 
   @property
   def skip_execution(self):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope="lint-pythonstyle",
       new_scope="pycheck",
-      old_container=self.get_options(),
-      new_container=Pycheck.global_instance().options,
+      subsystem=Pycheck.global_instance(),
     )
 
   def _is_checked(self, target):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -12,7 +12,6 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.build_environment import get_buildroot, pants_version
-from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_all
 from pants.base.workunit import WorkUnitLabel

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -13,7 +13,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
-from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -68,13 +68,10 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
                    "Pants 1.27.0.dev0, the default will change from `skip: False` to `skip: True`, "
                    "and in Pants 1.29.0.dev0, the module will be removed."
     )
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope="lint-python-eval",
       new_scope="python-eval",
-      old_container=task_options,
-      new_container=subsystem_options,
+      subsystem=PythonEvalSubystem.global_instance(),
     )
 
   @classmethod

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -71,7 +71,11 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
 
   @property
   def skip_execution(self):
-    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
+    return self.resolve_conflicting_skip_options(
+      old_scope="thrift-linter",
+      new_scope="scrooge-linter",
+      subsystem=ScroogeLinter.global_instance(),
+    )
 
   @property
   def cache_target_dirs(self):

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -80,7 +80,11 @@ class Checkstyle(LintTaskMixin, NailgunTask):
 
   @property
   def skip_execution(self):
-    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
+    return self.resolve_conflicting_skip_options(
+      old_scope="lint-checkstyle",
+      new_scope="checkstyle",
+      subsystem=CheckstyleSubsystem.global_instance(),
+    )
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -35,13 +35,10 @@ class ScalafixTask(RewriteBase):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope=old_scope,
       new_scope='scalafix',
-      old_container=self.get_options(),
-      new_container=Scalafix.global_instance().options,
+      subsystem=Scalafix.global_instance(),
     )
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -35,7 +35,9 @@ class ScalafixTask(RewriteBase):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return self.resolve_conflicting_skip_options(
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    return self.resolve_conflicting_skip_options( # type: ignore
       old_scope=old_scope,
       new_scope='scalafix',
       subsystem=Scalafix.global_instance(),

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -31,13 +31,10 @@ class ScalafmtTask(RewriteBase):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope=old_scope,
       new_scope='scalafmt',
-      old_container=self.get_options(),
-      new_container=Scalafmt.global_instance().options,
+      subsystem=Scalafmt.global_instance(),
     )
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -31,7 +31,9 @@ class ScalafmtTask(RewriteBase):
     )
 
   def _resolve_conflicting_skip(self, *, old_scope: str):
-    return self.resolve_conflicting_skip_options(
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    return self.resolve_conflicting_skip_options( # type: ignore
       old_scope=old_scope,
       new_scope='scalafmt',
       subsystem=Scalafmt.global_instance(),

--- a/src/python/pants/backend/jvm/tasks/scalastyle_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle_task.py
@@ -111,7 +111,11 @@ class ScalastyleTask(LintTaskMixin, NailgunTask):
 
   @property
   def skip_execution(self):
-    return self._resolve_conflicting_options(old_option="skip", new_option="skip")
+    return self.resolve_conflicting_skip_options(
+      old_scope="lint-scalastyle",
+      new_scope="scalastyle",
+      subsystem=Scalastyle.global_instance(),
+    )
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -103,11 +103,8 @@ class IsortRun(FmtTaskMixin, Task):
 
   @property
   def skip_execution(self):
-    return resolve_conflicting_options(
-      old_option="skip",
-      new_option="skip",
+    return self.resolve_conflicting_skip_options(
       old_scope="fmt-isort",
       new_scope="isort",
-      old_container=self.get_options(),
-      new_container=Isort.global_instance().options,
+      subsystem=Isort.global_instance(),
     )

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -11,7 +11,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.fmt_task_mixin import FmtTaskMixin

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -7,7 +7,16 @@ from pants.task.target_restriction_mixins import (
 )
 
 
+class FmtGoalRegistrar(DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar):
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register("--only", type=str, default=None, fingerprint=True,
+             help="Only run the specified formatter. Currently the only accepted values are "
+                  "scalafix, or not setting any value.")
+
+
 class FmtTaskMixin(HasSkipAndDeprecatedTransitiveGoalOptionsMixin):
   """A mixin to combine with code formatting tasks."""
-  goal_options_registrar_cls = DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
+  goal_options_registrar_cls = FmtGoalRegistrar
   target_filtering_enabled = True

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -11,9 +11,9 @@ class FmtGoalRegistrar(DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register("--only", type=str, default=None, fingerprint=True,
+    register("--only", type=str, default=None, fingerprint=True, advanced=True,
              help="Only run the specified formatter. Currently the only accepted values are "
-                  "scalafix, or not setting any value.")
+                  "`scalafix` or not setting any value.")
 
 
 class FmtTaskMixin(HasSkipAndDeprecatedTransitiveGoalOptionsMixin):

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -77,7 +77,7 @@ class HasSkipOptionMixin:
         return only_resolved_as_skip
       else:
         raise ValueError("Invalid value for flag --only - must be scalafix or not set at all")
-    return False
+    return skip
 
   def resolve_conflicting_skip_options(self, old_scope: str, new_scope: str, subsystem: Subsystem):
     skip = resolve_conflicting_options(

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -64,8 +64,12 @@ class HasSkipOptionMixin:
     # When the v2 goal is renamed from fmt2 to fmt, this option should be moved to that Goal, and
     # its implementation broadened to support all v2 formatters, as well as any v1 formatters we
     # fancy while we keep them around.
-    if hasattr(self.get_options(), "only"):
-      only = self.get_options().only
+    #
+    # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+    # properly.
+    options = self.get_options() # type: ignore
+    if hasattr(options, "only"):
+      only = options.only
       if only is None:
         return skip
       elif only == "scalafix":
@@ -85,7 +89,9 @@ class HasSkipOptionMixin:
       new_option="skip",
       old_scope=old_scope,
       new_scope=new_scope,
-      old_container=self.get_options(),
+      # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
+      # properly.
+      old_container=self.get_options(), # type: ignore
       new_container=subsystem.options,
     )
     return self.resolve_only_as_skip(skip)

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -67,7 +67,7 @@ class HasSkipOptionMixin:
     if hasattr(self.get_options(), "only"):
       only = self.get_options().only
       if only is None:
-        return False
+        return skip
       elif only == "scalafix":
         only_resolved_as_skip = not self.__class__.__name__.startswith("ScalaFix")
         if skip and not only_resolved_as_skip:


### PR DESCRIPTION
This is a hacky one-off implementation to help Twitter deal with the
fact that they have a custom Goal called scalafix, which does the
equivalent of `fmt --fmt-only=scalafix`, as it provides them with a
forward-compatible way of migrating people off of their scalafix goal.

When the v2 goal is renamed from fmt2 to fmt, this option should be
moved to that Goal, and its implementation broadened to support all v2
formatters, as well as any v1 formatters we fancy while we keep them
around.