### PR TITLE
Add type hints to `specs.py`

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -3,7 +3,7 @@
 
 import os
 
-from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
+from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress, Spec
 
 
 class CmdLineSpecParser:
@@ -28,10 +28,10 @@ class CmdLineSpecParser:
   class BadSpecError(Exception):
     """Indicates an unparseable command line address selector."""
 
-  def __init__(self, root_dir):
+  def __init__(self, root_dir: str) -> None:
     self._root_dir = os.path.realpath(root_dir)
 
-  def _normalize_spec_path(self, path):
+  def _normalize_spec_path(self, path: str) -> str:
     is_abs = not path.startswith('//') and os.path.isabs(path)
     if is_abs:
       path = os.path.realpath(path)
@@ -48,11 +48,9 @@ class CmdLineSpecParser:
       normalized = ''
     return normalized
 
-  def parse_spec(self, spec):
-    """Parse the given spec into a `specs.Spec` object.
+  def parse_spec(self, spec: str) -> Spec:
+    """Parse the given spec into a `Spec` object.
 
-    :param spec: a single spec string.
-    :return: a single specs.Specs object.
     :raises: CmdLineSpecParser.BadSpecError if the address selector could not be parsed.
     """
 

--- a/src/python/pants/base/target_roots.py
+++ b/src/python/pants/base/target_roots.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any
+
+from pants.base.specs import Specs
 
 
 class InvalidSpecConstraint(Exception):
@@ -12,4 +13,4 @@ class InvalidSpecConstraint(Exception):
 @dataclass(frozen=True)
 class TargetRoots:
   """Determines the target roots for a given pants run."""
-  specs: Any
+  specs: Specs

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -62,7 +62,7 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
   return AddressFamily.create(directory.path, address_maps)
 
 
-def _raise_did_you_mean(address_family, name, source=None):
+def _raise_did_you_mean(address_family: AddressFamily, name: str, source=None) -> None:
   names = [a.target_name for a in address_family.addressables]
   possibilities = "\n  ".join(":{}".format(target_name) for target_name in sorted(names))
 
@@ -73,8 +73,7 @@ def _raise_did_you_mean(address_family, name, source=None):
 
   if source:
     raise resolve_error from source
-  else:
-    raise resolve_error
+  raise resolve_error
 
 
 @rule
@@ -199,7 +198,7 @@ def _hydrate(item_type, spec_path, **kwargs):
 
 @rule
 async def provenanced_addresses_from_address_families(
-    address_mapper: AddressMapper, specs: Specs
+  address_mapper: AddressMapper, specs: Specs,
 ) -> ProvenancedBuildFileAddresses:
   """Given an AddressMapper and list of Specs, return matching ProvenancedBuildFileAddresses.
 
@@ -275,7 +274,7 @@ def address_provenance_map(pbfas: ProvenancedBuildFileAddresses) -> AddressProve
   )
 
 
-def _spec_to_globs(address_mapper, specs):
+def _spec_to_globs(address_mapper: AddressMapper, specs: Specs) -> PathGlobs:
   """Given a Specs object, return a PathGlobs object for the build files that it matches."""
   patterns = set()
   for spec in specs:
@@ -284,11 +283,7 @@ def _spec_to_globs(address_mapper, specs):
 
 
 def create_graph_rules(address_mapper: AddressMapper):
-  """Creates tasks used to parse Structs from BUILD files.
-
-:param address_mapper_key: The subject key for an AddressMapper instance.
-:param symbol_table: A SymbolTable instance to provide symbols for Address lookups.
-"""
+  """Creates tasks used to parse Structs from BUILD files."""
 
   @rule
   def address_mapper_singleton() -> AddressMapper:

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -529,7 +529,7 @@ def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):
 
 @rule
 async def hydrate_sources(
-  sources_field: SourcesField, glob_match_error_behavior: GlobMatchErrorBehavior
+  sources_field: SourcesField, glob_match_error_behavior: GlobMatchErrorBehavior,
 ) -> HydratedField:
   """Given a SourcesField, request a Snapshot for its path_globs and create an EagerFilesetWithSpec.
   """
@@ -549,7 +549,7 @@ async def hydrate_sources(
 
 @rule
 async def hydrate_bundles(
-  bundles_field: BundlesField, glob_match_error_behavior: GlobMatchErrorBehavior
+  bundles_field: BundlesField, glob_match_error_behavior: GlobMatchErrorBehavior,
 ) -> HydratedField:
   """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
   path_globs_with_match_errors = [

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -7,13 +7,14 @@ from collections import defaultdict, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from os.path import dirname
-from typing import Any, Tuple
+from typing import Any, Iterable, Tuple
 
 from twitter.common.collections import OrderedSet
 
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.parse_context import ParseContext
-from pants.base.specs import AscendantAddresses, DescendantAddresses, SingleAddress, Specs
+from pants.base.specs import AscendantAddresses, DescendantAddresses, SingleAddress, Spec, Specs
+from pants.base.target_roots import TargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
@@ -186,17 +187,17 @@ class LegacyBuildGraph(BuildGraph):
     addresses = set(addresses) - set(self._target_by_address.keys())
     if not addresses:
       return
-    dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in addresses)
-    for _ in self._inject_specs(Specs(dependencies=tuple(dependencies))):
+    dependencies = (SingleAddress(directory=a.spec_path, name=a.target_name) for a in addresses)
+    for _ in self._inject_specs(Specs(dependencies)):
       pass
 
-  def inject_roots_closure(self, target_roots, fail_fast=None):
+  def inject_roots_closure(self, target_roots: TargetRoots, fail_fast=None):
     for address in self._inject_specs(target_roots.specs):
       yield address
 
-  def inject_specs_closure(self, specs, fail_fast=None):
+  def inject_specs_closure(self, specs: Iterable[Spec], fail_fast=None):
     # Request loading of these specs.
-    for address in self._inject_specs(Specs(dependencies=tuple(specs))):
+    for address in self._inject_specs(Specs(specs)):
       yield address
 
   def resolve_address(self, address):
@@ -232,7 +233,7 @@ class LegacyBuildGraph(BuildGraph):
         yielded_addresses.add(address)
         yield address
 
-  def _inject_specs(self, specs):
+  def _inject_specs(self, specs: Specs):
     """Injects targets into the graph for the given `Specs` object.
 
     Yields the resulting addresses.
@@ -251,7 +252,7 @@ class LegacyBuildGraph(BuildGraph):
       yield hydrated_target.address
 
 
-class _DependentGraph(object):
+class _DependentGraph:
   """A graph for walking dependent addresses of TargetAdaptor objects.
 
   This avoids/imitates constructing a v1 BuildGraph object, because that codepath results

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from typing import Iterable, Optional
 
 from twitter.common.collections import OrderedSet
 
@@ -11,7 +12,9 @@ from pants.base.specs import SingleAddress, Specs
 from pants.base.target_roots import TargetRoots
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
+from pants.engine.scheduler import SchedulerSession
 from pants.goal.workspace import ScmWorkspace
+from pants.option.options import Options
 from pants.scm.subsystems.changed import ChangedRequest
 
 
@@ -26,13 +29,14 @@ class TargetRootsCalculator:
   """Determines the target roots for a given pants run."""
 
   @classmethod
-  def parse_specs(cls, target_specs, build_root=None, exclude_patterns=None, tags=None):
-    """Parse string specs into unique `Spec` objects.
-
-    :param iterable target_specs: An iterable of string specs.
-    :param string build_root: The path to the build root.
-    :returns: A `Specs` object.
-    """
+  def parse_specs(
+    cls,
+    target_specs: Iterable[str],
+    build_root: Optional[str] = None,
+    exclude_patterns: Optional[Iterable[str]] = None,
+    tags: Optional[Iterable[str]] = None,
+  ) -> Specs:
+    """Parse string specs into unique `Spec` objects."""
     build_root = build_root or get_buildroot()
     spec_parser = CmdLineSpecParser(build_root)
 
@@ -53,12 +57,14 @@ class TargetRootsCalculator:
     return workspace.touched_files(changes_since)
 
   @classmethod
-  def create(cls, options, session, build_root=None, exclude_patterns=None, tags=None):
-    """
-    :param Options options: An `Options` instance to use.
-    :param session: The Scheduler session
-    :param string build_root: The build root.
-    """
+  def create(
+    cls,
+    options: Options,
+    session: SchedulerSession,
+    build_root: Optional[str] = None,
+    exclude_patterns: Optional[Iterable[str]] = None,
+    tags: Optional[Iterable[str]] = None,
+  ) -> TargetRoots:
     # Determine the literal target roots.
     spec_roots = cls.parse_specs(
       target_specs=options.positional_args,

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -9,7 +9,7 @@ from twitter.common.collections import OrderedSet
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.specs import SingleAddress, Specs
-from pants.base.target_roots import TargetRoots
+from pants.base.target_roots import InvalidSpecConstraint, TargetRoots
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
 from pants.engine.scheduler import SchedulerSession
@@ -19,10 +19,6 @@ from pants.scm.subsystems.changed import ChangedRequest
 
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidSpecConstraint(Exception):
-  """Raised when invalid constraints are given via target specs and arguments like --changed*."""
 
 
 class TargetRootsCalculator:

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -110,7 +110,7 @@ class SubsystemClientMixin:
       message = 'Cycle detected:\n\t{}'.format(' ->\n\t'.join(
         '{} scope: {}'.format(optionable_cls, optionable_cls.options_scope)
         for optionable_cls in cycle))
-      super(SubsystemClientMixin.CycleException, self).__init__(message)
+      super().__init__(message)
 
   @classmethod
   def known_scope_infos(cls):

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -16,6 +16,7 @@ from typing import Any, Optional, Type, TypeVar, Union, cast
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
+from pants.base.specs import Specs
 from pants.base.target_roots import TargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -400,7 +401,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     ).new_session(zipkin_trace_v2=False, build_id="buildid_for_test")
     self._scheduler = graph_session.scheduler_session
     self._build_graph, self._address_mapper = graph_session.create_build_graph(
-        TargetRoots([]), self._build_root()
+        TargetRoots(Specs([])), self._build_root()
       )
 
   @property

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -9,7 +9,7 @@ from typing import Type, cast
 from pants.base.project_tree import Dir
 from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
-from pants.engine.addressable import addressable, addressable_dict
+from pants.engine.addressable import BuildFileAddresses, addressable, addressable_dict
 from pants.engine.build_files import (
   ResolvedTypeMismatchError,
   create_graph_rules,
@@ -66,7 +66,13 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
   def _snapshot(self) -> Snapshot:
     return Snapshot(Digest('xx', 2), ('root/BUILD',), ())
 
-  def _resolve_build_file_addresses(self, specs, address_family, snapshot, address_mapper):
+  def _resolve_build_file_addresses(
+    self,
+    specs: Specs,
+    address_family: AddressFamily,
+    snapshot: Snapshot,
+    address_mapper: AddressMapper,
+  ) -> BuildFileAddresses:
     pbfas = run_rule(
       provenanced_addresses_from_address_families,
       rule_args=[address_mapper, specs],
@@ -83,7 +89,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         ),
       ],
     )
-    return run_rule(remove_provenance, rule_args=[pbfas])
+    return cast(BuildFileAddresses, run_rule(remove_provenance, rule_args=[pbfas]))
 
   def test_duplicated(self) -> None:
     """Test that matching the same Spec twice succeeds."""

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -4,6 +4,7 @@
 import os
 import re
 import unittest
+from typing import Type, cast
 
 from pants.base.project_tree import Dir
 from pants.base.specs import SiblingAddresses, SingleAddress, Specs
@@ -22,6 +23,7 @@ from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
 from pants.engine.nodes import Return, Throw
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
+from pants.engine.scheduler import SchedulerSession
 from pants.engine.struct import Struct, StructWithDeps
 from pants.testutil.engine.util import MockGet, Target, run_rule
 from pants.util.objects import Exactly
@@ -34,7 +36,7 @@ from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
 
 class ParseAddressFamilyTest(unittest.TestCase):
-  def test_empty(self):
+  def test_empty(self) -> None:
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
     address_mapper = AddressMapper(JsonParser(TEST_TABLE))
     af = run_rule(
@@ -58,10 +60,10 @@ class ParseAddressFamilyTest(unittest.TestCase):
 
 class AddressesFromAddressFamiliesTest(unittest.TestCase):
 
-  def _address_mapper(self):
+  def _address_mapper(self) -> AddressMapper:
     return AddressMapper(JsonParser(TEST_TABLE))
 
-  def _snapshot(self):
+  def _snapshot(self) -> Snapshot:
     return Snapshot(Digest('xx', 2), ('root/BUILD',), ())
 
   def _resolve_build_file_addresses(self, specs, address_family, snapshot, address_mapper):
@@ -83,7 +85,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     )
     return run_rule(remove_provenance, rule_args=[pbfas])
 
-  def test_duplicated(self):
+  def test_duplicated(self) -> None:
     """Test that matching the same Spec twice succeeds."""
     address = SingleAddress('a', 'a')
     snapshot = Snapshot(Digest('xx', 2), ('a/BUILD',), ())
@@ -96,7 +98,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     self.assertEqual(len(bfas.dependencies), 1)
     self.assertEqual(bfas.dependencies[0].spec, 'a:a')
 
-  def test_tag_filter(self):
+  def test_tag_filter(self) -> None:
     """Test that targets are filtered based on `tags`."""
     specs = Specs([SiblingAddresses('root')], tags=['+integration'])
     address_family = AddressFamily('root',
@@ -112,7 +114,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:b')
 
-  def test_fails_on_nonexistent_specs(self):
+  def test_fails_on_nonexistent_specs(self) -> None:
     """Test that specs referring to nonexistent targets raise a ResolveError."""
     address_family = AddressFamily('root', {'a': ('root/BUILD', TargetAdaptor())})
     specs = Specs([SingleAddress('root', 'b'), SingleAddress('root', 'a')])
@@ -130,7 +132,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       self._resolve_build_file_addresses(
         specs, address_family, self._snapshot(), self._address_mapper())
 
-  def test_exclude_pattern(self):
+  def test_exclude_pattern(self) -> None:
     """Test that targets are filtered based on exclude patterns."""
     specs = Specs([SiblingAddresses('root')], exclude_patterns=tuple(['.exclude*']))
     address_family = AddressFamily('root',
@@ -145,7 +147,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
-  def test_exclude_pattern_with_single_address(self):
+  def test_exclude_pattern_with_single_address(self) -> None:
     """Test that single address targets are filtered based on exclude patterns."""
     specs = Specs([SingleAddress('root', 'not_me')], exclude_patterns=tuple(['root.*']))
     address_family = AddressFamily('root',
@@ -208,7 +210,7 @@ TEST_TABLE = SymbolTable({
 
 
 class GraphTestBase(unittest.TestCase, SchedulerTestBase):
-  def create(self, build_patterns=None, parser=None):
+  def create(self, build_patterns=None, parser=None) -> SchedulerSession:
     address_mapper = AddressMapper(build_patterns=build_patterns,
                                    parser=parser)
 
@@ -217,10 +219,9 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
       return TEST_TABLE
     rules = create_fs_rules() + create_graph_rules(address_mapper) + [symbol_table_singleton]
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples'))
-    scheduler = self.mk_scheduler(rules=rules, project_tree=project_tree)
-    return scheduler
+    return cast(SchedulerSession, self.mk_scheduler(rules=rules, project_tree=project_tree))
 
-  def create_json(self):
+  def create_json(self) -> SchedulerSession:
     return self.create(build_patterns=('*.BUILD.json',), parser=JsonParser(TEST_TABLE))
 
   def _populate(self, scheduler, address):
@@ -285,21 +286,21 @@ class InlinedGraphTest(GraphTestBase):
 
     self.assertEqual(expected_java1.configurations, resolved_java1.configurations)
 
-  def test_json(self):
+  def test_json(self) -> None:
     scheduler = self.create_json()
     self.do_test_codegen_simple(scheduler)
 
-  def test_python(self):
+  def test_python(self) -> None:
     scheduler = self.create(build_patterns=('*.BUILD.python',),
                             parser=PythonAssignmentsParser(TEST_TABLE))
     self.do_test_codegen_simple(scheduler)
 
-  def test_python_classic(self):
+  def test_python_classic(self) -> None:
     scheduler = self.create(build_patterns=('*.BUILD',),
                             parser=PythonCallbacksParser(TEST_TABLE))
     self.do_test_codegen_simple(scheduler)
 
-  def test_resolve_cache(self):
+  def test_resolve_cache(self) -> None:
     scheduler = self.create_json()
 
     nonstrict_address = Address.parse('graph_test:nonstrict')
@@ -313,7 +314,7 @@ class InlinedGraphTest(GraphTestBase):
 
     self.assertEqual(java1, self.resolve(scheduler, java1_address))
 
-  def do_test_trace_message(self, scheduler, parsed_address, expected_regex=None):
+  def do_test_trace_message(self, scheduler, parsed_address, expected_regex=None) -> None:
     # Confirm that the root failed, and that a cycle occurred deeper in the graph.
     request, state = self._populate(scheduler, parsed_address)
     self.assertEqual(type(state), Throw)
@@ -324,7 +325,7 @@ class InlinedGraphTest(GraphTestBase):
       print(trace_message)
       self.assertRegex(trace_message, expected_regex)
 
-  def do_test_cycle(self, address_str, cyclic_address_str):
+  def do_test_cycle(self, address_str, cyclic_address_str) -> None:
     scheduler = self.create_json()
     parsed_address = Address.parse(address_str)
     self.do_test_trace_message(
@@ -333,11 +334,11 @@ class InlinedGraphTest(GraphTestBase):
         f'(?ms)Dep graph contained a cycle:.*{cyclic_address_str}.* <-.*{cyclic_address_str}.* <-'
       )
 
-  def assert_throws_are_leaves(self, error_msg, throw_name):
-    def indent_of(s):
+  def assert_throws_are_leaves(self, error_msg, throw_name) -> None:
+    def indent_of(s: str) -> int:
       return len(s) - len(s.lstrip())
 
-    def assert_equal_or_more_indentation(more_indented_line, less_indented_line):
+    def assert_equal_or_more_indentation(more_indented_line: str, less_indented_line: str) -> None:
       self.assertTrue(indent_of(more_indented_line) >= indent_of(less_indented_line),
                       '\n"{}"\nshould have more equal or more indentation than\n"{}"\n{}'.format(more_indented_line,
                                                                                              less_indented_line, error_msg))
@@ -348,38 +349,38 @@ class InlinedGraphTest(GraphTestBase):
       # Make sure lines with Throw have more or equal indentation than its neighbors.
       current_line = lines[idx]
       line_above = lines[max(0, idx - 1)]
-
       assert_equal_or_more_indentation(current_line, line_above)
 
-  def test_cycle_self(self):
+  def test_cycle_self(self) -> None:
     self.do_test_cycle('graph_test:self_cycle', 'graph_test:self_cycle')
 
-  def test_cycle_direct(self):
+  def test_cycle_direct(self) -> None:
     self.do_test_cycle('graph_test:direct_cycle', 'graph_test:direct_cycle')
 
-  def test_cycle_indirect(self):
+  def test_cycle_indirect(self) -> None:
     self.do_test_cycle('graph_test:indirect_cycle', 'graph_test:one')
 
-  def test_type_mismatch_error(self):
+  def test_type_mismatch_error(self) -> None:
     scheduler = self.create_json()
     mismatch = Address.parse('graph_test:type_mismatch')
     self.assert_resolve_failure_type(ResolvedTypeMismatchError, mismatch, scheduler)
     self.do_test_trace_message(scheduler, mismatch)
 
-  def test_not_found_but_family_exists(self):
+  def test_not_found_but_family_exists(self) -> None:
     scheduler = self.create_json()
     dne = Address.parse('graph_test:this_addressable_does_not_exist')
     self.assert_resolve_failure_type(ResolveError, dne, scheduler)
     self.do_test_trace_message(scheduler, dne)
 
-  def test_not_found_and_family_does_not_exist(self):
+  def test_not_found_and_family_does_not_exist(self) -> None:
     scheduler = self.create_json()
     dne = Address.parse('this/dir/does/not/exist')
     self.assert_resolve_failure_type(ResolveError, dne, scheduler)
     self.do_test_trace_message(scheduler, dne)
 
-  def assert_resolve_failure_type(self, expected_type, mismatch, scheduler):
-
+  def assert_resolve_failure_type(
+    self, expected_type: Type[Exception], mismatch: Address, scheduler: SchedulerSession
+  ) -> None:
     failure = self.resolve_failure(scheduler, mismatch)
     self.assertEqual(type(failure),
                       expected_type,

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -6,7 +6,7 @@ import unittest
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.base.specs import SingleAddress, Specs
+from pants.base.specs import SingleAddress, Spec, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import create_graph_rules
@@ -54,7 +54,7 @@ class AddressMapTest(unittest.TestCase):
     self.assertEqual(path, address_map.path)
     yield address_map
 
-  def test_parse(self):
+  def test_parse(self) -> None:
     with self.parse_address_map(dedent("""
       {
         "type_alias": "thing",
@@ -71,17 +71,17 @@ class AddressMapTest(unittest.TestCase):
       self.assertEqual({'one': Thing(name='one', age=42), 'two': Thing(name='two', age=37)},
                        address_map.objects_by_name)
 
-  def test_not_serializable(self):
+  def test_not_serializable(self) -> None:
     with self.assertRaises(UnaddressableObjectError):
       with self.parse_address_map('{}'):
         self.fail()
 
-  def test_not_named(self):
+  def test_not_named(self) -> None:
     with self.assertRaises(UnaddressableObjectError):
       with self.parse_address_map('{"type_alias": "thing"}'):
         self.fail()
 
-  def test_duplicate_names(self):
+  def test_duplicate_names(self) -> None:
     with self.assertRaises(DuplicateNameError):
       with self.parse_address_map('{"type_alias": "thing", "name": "one"}'
                                   '{"type_alias": "thing", "name": "one"}'):
@@ -89,7 +89,7 @@ class AddressMapTest(unittest.TestCase):
 
 
 class AddressFamilyTest(unittest.TestCase):
-  def test_create_single(self):
+  def test_create_single(self) -> None:
     address_family = AddressFamily.create('',
                                           [AddressMap('0', {
                                             'one': Thing(name='one', age=42),
@@ -100,7 +100,7 @@ class AddressFamilyTest(unittest.TestCase):
                       Address.parse('//:two'): Thing(name='two', age=37)},
                      address_family.addressables)
 
-  def test_create_multiple(self):
+  def test_create_multiple(self) -> None:
     address_family = AddressFamily.create('name/space',
                                           [AddressMap('name/space/0',
                                                       {'one': Thing(name='one', age=42)}),
@@ -112,18 +112,18 @@ class AddressFamilyTest(unittest.TestCase):
                       Address.parse('name/space:two'): Thing(name='two', age=37)},
                      address_family.addressables)
 
-  def test_create_empty(self):
+  def test_create_empty(self) -> None:
     # Case where directory exists but is empty.
     address_family = AddressFamily.create('name/space', [])
     self.assertEqual(dict(), address_family.addressables)
 
-  def test_mismatching_paths(self):
+  def test_mismatching_paths(self) -> None:
     with self.assertRaises(DifferingFamiliesError):
       AddressFamily.create('one',
                            [AddressMap('/dev/null/one/0', {}),
                             AddressMap('/dev/null/two/0', {})])
 
-  def test_duplicate_names(self):
+  def test_duplicate_names(self) -> None:
     with self.assertRaises(DuplicateNameError):
       AddressFamily.create('name/space',
                            [AddressMap('name/space/0',
@@ -142,7 +142,7 @@ async def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> Hydrat
 
 
 class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
-  def setUp(self):
+  def setUp(self) -> None:
     # Set up a scheduler that supports address mapping.
     address_mapper = AddressMapper(parser=JsonParser(TARGET_TABLE),
                                    build_patterns=('*.BUILD.json',))
@@ -162,11 +162,11 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              configurations=['//a/d/e', Struct(embedded='yes')],
                              type_alias='target')
 
-  def resolve(self, spec):
-    tacs, = self.scheduler.product_request(HydratedStructs, [Specs(tuple([spec]))])
+  def resolve(self, spec: Spec):
+    tacs, = self.scheduler.product_request(HydratedStructs, [Specs([spec])])
     return [tac.value for tac in tacs]
 
-  def test_no_address_no_family(self):
+  def test_no_address_no_family(self) -> None:
     spec = SingleAddress('a/c', 'c')
 
     # Does not exist.
@@ -188,7 +188,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
     self.assertEqual(1, len(resolved))
     self.assertEqual([Struct(address=Address.parse('a/c'), type_alias='struct')], resolved)
 
-  def test_resolve(self):
+  def test_resolve(self) -> None:
     resolved = self.resolve(SingleAddress('a/b', 'b'))
     self.assertEqual(1, len(resolved))
     self.assertEqual(self.a_b, resolved[0].address)


### PR DESCRIPTION
We'll be making lots of changes to this code soon in preparation for supporting non-target specs, namely `FileSpecs`. 

Before we make any such changes, these type hints will help to ensure we don't break things and adding type hints helps to better understand what's going on.