### PR TITLE
Only compile non-module exports for `export-dep-as-jar` goal

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -472,7 +472,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       # The runtime classpath will always be a superset of the export_dep_as_jar_classpath
       # so however we compute runtime_classpath it will contain all the nescessary jars for
       # the export_dep_as_jar_classpath.export_dep_as_jar_classpath.
-      if self.context.products.is_required_data("export_dep_as_jar_classpath"):
+      if self.context.products.is_required_data('export_dep_as_jar_classpath'):
         self.context.products.get_data('export_dep_as_jar_classpath', classpath_product.copy)
 
   def _classpath_for_context(self, context):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -488,11 +488,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
     if self.context.products.is_required_data("export_dep_as_jar_classpath"):
       # filter modulized targets from invalid targets list.
-      print(f"filtering target root dependees from compile {invalid_targets}")
       target_root_addresses = [t.address for t in set(self.context.target_roots)]
       dependees_of_target_roots = self.context.build_graph.transitive_dependees_of_addresses(target_root_addresses)
       invalid_targets = list(set(invalid_targets) - dependees_of_target_roots)
-      print(f"invalid targets list is now {invalid_targets}")
 
     if self.execution_strategy == self.ExecutionStrategy.hermetic:
       self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -815,7 +815,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         self._default_work_for_vts,
         ivts,
         compile_context,
-        self._classpath_product_key,
+        'runtime_classpath',
         counter,
         all_compile_contexts,
         classpath_product),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -484,7 +484,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     compile_classpath = self.context.products.get_data('compile_classpath')
     classpath_product = self.context.products.get_data("runtime_classpath")
     if not classpath_product:
-      classpath_product = self.context.products.get_data("runtime_classpath", compile_classpath.copy)
+      classpath_product = self.context.products.get_data('runtime_classpath', compile_classpath.copy)
     else:
       classpath_product.update(compile_classpath)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -390,6 +390,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     self._worker_count = worker_count
 
     self._size_estimator = self.size_estimator_by_name(self.get_options().size_estimator)
+    self._classpath_product_key = "runtime_classpath"
 
   @memoized_property
   def _missing_deps_finder(self):
@@ -432,7 +433,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       return
 
     # Clone the compile_classpath to the runtime_classpath.
-    classpath_product = self.create_runtime_classpath()
+    classpath_product = self.create_classpath_product()
 
     fingerprint_strategy = DependencyContext.global_instance().create_fingerprint_strategy(
         classpath_product)
@@ -467,11 +468,13 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       return context.jar_file
     return context.classes_dir
 
-  def create_runtime_classpath(self):
+  def create_classpath_product(self):
+    if self.context.products.is_required_data("export_dep_as_jar_classpath"):
+      self._classpath_product_key = "export_dep_as_jar_classpath"
     compile_classpath = self.context.products.get_data('compile_classpath')
-    classpath_product = self.context.products.get_data('runtime_classpath')
+    classpath_product = self.context.products.get_data(self._classpath_product_key)
     if not classpath_product:
-      classpath_product = self.context.products.get_data('runtime_classpath', compile_classpath.copy)
+      classpath_product = self.context.products.get_data(self._classpath_product_key, compile_classpath.copy)
     else:
       classpath_product.update(compile_classpath)
 
@@ -482,6 +485,14 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
     invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
+
+    if self.context.products.is_required_data("export_dep_as_jar_classpath"):
+      # filter modulized targets from invalid targets list.
+      print(f"filtering target root dependees from compile {invalid_targets}")
+      target_root_addresses = [t.address for t in set(self.context.target_roots)]
+      dependees_of_target_roots = self.context.build_graph.transitive_dependees_of_addresses(target_root_addresses)
+      invalid_targets = list(set(invalid_targets) - dependees_of_target_roots)
+      print(f"invalid targets list is now {invalid_targets}")
 
     if self.execution_strategy == self.ExecutionStrategy.hermetic:
       self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
@@ -805,7 +816,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         self._default_work_for_vts,
         ivts,
         compile_context,
-        'runtime_classpath',
+        self._classpath_product_key,
         counter,
         all_compile_contexts,
         classpath_product),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -429,7 +429,10 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     relevant_targets = list(self.context.targets(predicate=self.select))
 
     # If we are only exporting jars then we can omit some targets from the runtime_classpath.
-    if self.context.products.is_required_data("export_dep_as_jar_classpath") and not self.context.products.is_required_data("runtime_classpath"):
+    if (
+        self.context.products.is_required_data("export_dep_as_jar_classpath") and
+        not self.context.products.is_required_data("runtime_classpath")
+    ):
       # Filter modulized targets from invalid targets list.
       target_root_addresses = [t.address for t in set(self.context.target_roots)]
       dependees_of_target_roots = self.context.build_graph.transitive_dependees_of_addresses(target_root_addresses)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -469,6 +469,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
             classpath_product.remove_for_target(cc.target, [(conf, cc.classes_dir)])
             classpath_product.add_for_target(cc.target, [(conf, cc.jar_file)])
 
+      # The runtime classpath will always be a superset of the export_dep_as_jar_classpath
+      # so however we compute runtime_classpath it will contain all the nescessary jars for
+      # the export_dep_as_jar_classpath.export_dep_as_jar_classpath.
       if self.context.products.is_required_data("export_dep_as_jar_classpath"):
         self.context.products.get_data('export_dep_as_jar_classpath', classpath_product.copy)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -717,7 +717,7 @@ class ZincCompile(BaseZincCompile):
 
   @classmethod
   def product_types(cls):
-    return ['runtime_classpath', 'zinc_analysis', 'zinc_args']
+    return ['runtime_classpath', 'export_dep_as_jar_classpath', 'zinc_analysis', 'zinc_args']
 
   def select(self, target):
     # Require that targets are marked for JVM compilation, to differentiate from

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -356,7 +356,7 @@ class ExportDepAsJar(ConsoleTask):
   def console_output(self, targets):
     runtime_classpath = self.context.products.get_data('export_dep_as_jar_classpath')
     if runtime_classpath is None:
-      raise TaskError("There was an error compiling the targets - There is no runtime classpath")
+      raise TaskError("There was an error compiling the targets - There is no export_dep_as_jar classpath")
     graph_info = self.generate_targets_map(targets, runtime_classpath=runtime_classpath)
     if self.get_options().formatted:
       return json.dumps(graph_info, indent=4, separators=(',', ': ')).splitlines()

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -47,7 +47,7 @@ class ExportDepAsJar(ConsoleTask):
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)
-    round_manager.require_data('runtime_classpath')
+    round_manager.require_data('export_dep_as_jar_classpath')
 
   @property
   def _output_folder(self):
@@ -354,7 +354,7 @@ class ExportDepAsJar(ConsoleTask):
     return graph_info
 
   def console_output(self, targets):
-    runtime_classpath = self.context.products.get_data('runtime_classpath')
+    runtime_classpath = self.context.products.get_data('export_dep_as_jar_classpath')
     if runtime_classpath is None:
       raise TaskError("There was an error compiling the targets - There is no runtime classpath")
     graph_info = self.generate_targets_map(targets, runtime_classpath=runtime_classpath)

--- a/src/python/pants/testutil/task_test_base.py
+++ b/src/python/pants/testutil/task_test_base.py
@@ -165,6 +165,19 @@ class TaskTestBase(TestBase):
       else:
         self.assertEqual(num_artifacts, expected_num_artifacts)
 
+  def make_linear_graph(self, names, **additional_target_args):
+    # A build graph where a -(depends on)-> b -> ... -> e
+    graph = {}
+    last_target = None
+    for name in reversed(names):
+      last_target = self.make_target(
+        f'project_info:{name}',
+        dependencies=[] if last_target is None else [last_target],
+        **additional_target_args,
+      )
+      graph[name] = last_target
+    return graph
+
 
 class ConsoleTaskTestBase(TaskTestBase):
   """A base class useful for testing ConsoleTasks.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -20,7 +20,9 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm/tasks/jvm_compile',
     'src/python/pants/backend/jvm/tasks:classpath_products',
+    'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
+    'src/python/pants/testutil/subsystem',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
@@ -42,7 +42,7 @@ class JvmCompileTest(NailgunTaskTestBase):
     runtime_classpath.add_for_targets([target], [('default', pre_init_runtime_entry)])
 
     task = self.create_task(context)
-    resulting_classpath = task.create_runtime_classpath()
+    resulting_classpath = task.create_classpath_product()
     self.assertEqual([('default', pre_init_runtime_entry), ('default', compile_entry)],
       resulting_classpath.get_for_target(target))
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -247,21 +247,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       sources=[],
     )
 
-    def _make_linear_graph(names, **additional_target_args):
-      # A build graph where a -(depends on)-> b -> ... -> e
-      graph = {}
-      last_target = None
-      for name in reversed(names):
-        last_target = self.make_target(
-          f'project_info:{name}',
-          target_type=ScalaLibrary,
-          dependencies=[] if last_target is None else [last_target],
-          **additional_target_args,
-        )
-        graph[name] = last_target
-      return graph
-
-    self.linear_build_graph = _make_linear_graph(['a', 'b', 'c', 'd', 'e'])
+    self.linear_build_graph = self.make_linear_graph(['a', 'b', 'c', 'd', 'e'], target_type=ScalaLibrary)
 
   def create_runtime_classpath_for_targets(self, target):
     def path_to_zjar_with_workdir(address: Address):

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -295,7 +295,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
                            for_task_types=[BootstrapJvmTools])
 
     runtime_classpath = self.create_runtime_classpath_for_targets(self.scala_with_source_dep)
-    context.products.safe_create_data('runtime_classpath',
+    context.products.safe_create_data('export_dep_as_jar_classpath',
                                       init_func=lambda: runtime_classpath)
 
     bootstrap_task = BootstrapJvmTools(context, self.pants_workdir)


### PR DESCRIPTION
### Problem

When running the `export-dep-as-jar` Goal we compile all targets in the build context. This is unnecessary and can be problematic if any of the target roots have compile errors in them, because the export will fail. It is unnecessary because the target roots are being exported as source modules #8812 

### Solution

We exclude target_roots, and their dependees from the compile context.

### Result

Only targets in the build context that are not being exported as sources are compiled.