### PR TITLE
Rename `Spec` to `AddressSpec`

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/filter.py
+++ b/src/python/pants/backend/graph_info/tasks/filter.py
@@ -45,8 +45,8 @@ class Filter(TargetFilterTaskMixin, ConsoleTask):
     def _get_targets(spec_str):
       spec_parser = CmdLineSpecParser(get_buildroot())
       try:
-        spec = spec_parser.parse_spec(spec_str)
-        addresses = self.context.address_mapper.scan_specs([spec])
+        address_spec = spec_parser.parse_address_spec(spec_str)
+        addresses = self.context.address_mapper.scan_address_specs([address_spec])
       except AddressLookupError as e:
         raise TaskError('Failed to parse address selector: {spec_str}\n {message}'.format(spec_str=spec_str, message=e))
       # filter specs may not have been parsed as part of the context: force parsing

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -3,7 +3,7 @@
 
 from typing import Set
 
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
@@ -31,18 +31,18 @@ class Dependencies(Goal):
 
 @console_rule
 async def dependencies(
-  console: Console, specs: Specs, options: DependenciesOptions
+  console: Console, address_specs: AddressSpecs, options: DependenciesOptions,
 ) -> Dependencies:
   addresses: Set[str] = set()
   if options.values.transitive:
-    transitive_targets = await Get[TransitiveHydratedTargets](Specs, specs)
+    transitive_targets = await Get[TransitiveHydratedTargets](AddressSpecs, address_specs)
     addresses.update(hydrated_target.address.spec for hydrated_target in transitive_targets.closure)
     # transitive_targets.closure includes the initial target. To keep the behavior consistent with intransitive
     # dependencies, we remove the initial target from the set of addresses.
-    for single_address in specs.dependencies:
-      addresses.discard(single_address.to_spec_string())
+    for address_spec in address_specs.dependencies:
+      addresses.discard(address_spec.to_spec_string())
   else:
-    hydrated_targets = await Get[HydratedTargets](Specs, specs)
+    hydrated_targets = await Get[HydratedTargets](AddressSpecs, address_specs)
     addresses.update(
       dep.spec
       for hydrated_target in hydrated_targets

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -3,7 +3,7 @@
 
 import os
 
-from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress, Spec
+from pants.base.specs import AddressSpec, DescendantAddresses, SiblingAddresses, SingleAddress
 
 
 class CmdLineSpecParser:
@@ -48,8 +48,8 @@ class CmdLineSpecParser:
       normalized = ''
     return normalized
 
-  def parse_spec(self, spec: str) -> Spec:
-    """Parse the given spec into a `Spec` object.
+  def parse_address_spec(self, spec: str) -> AddressSpec:
+    """Parse the given spec into an `AddressSpec` object.
 
     :raises: CmdLineSpecParser.BadSpecError if the address selector could not be parsed.
     """

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
   from pants.engine.mapper import AddressFamily, AddressMapper
 
 
-class Spec(ABC):
+class AddressSpec(ABC):
   """Represents address selectors as passed from the command line.
 
   Supports `Single` target addresses as well as `Sibling` (:) and `Descendant` (::) selector forms.
@@ -30,7 +30,7 @@ class Spec(ABC):
 
   @abstractmethod
   def to_spec_string(self) -> str:
-    """Returns the normalized string representation of this spec."""
+    """Returns the normalized string representation of this address spec."""
 
   class AddressFamilyResolutionError(Exception):
     pass
@@ -39,16 +39,18 @@ class Spec(ABC):
   def matching_address_families(
     self, address_families_dict: Dict[str, "AddressFamily"],
   ) -> List["AddressFamily"]:
-    """Given a dict of (namespace path) -> AddressFamily, return the values matching this spec.
+    """Given a dict of (namespace path) -> AddressFamily, return the values matching this address
+    spec.
 
-    :raises: :class:`Spec.AddressFamilyResolutionError` if no address families matched this spec.
+    :raises: :class:`AddressSpec.AddressFamilyResolutionError` if no address families matched this spec.
     """
 
   @classmethod
   def address_families_for_dir(
     cls, address_families_dict: Dict[str, "AddressFamily"], spec_dir_path: str
   ) -> List["AddressFamily"]:
-    """Implementation of `matching_address_families()` for specs matching at most one directory."""
+    """Implementation of `matching_address_families()` for address specs matching at most
+    one directory."""
     maybe_af = address_families_dict.get(spec_dir_path, None)
     if maybe_af is None:
       raise cls.AddressFamilyResolutionError(
@@ -61,12 +63,12 @@ class Spec(ABC):
 
   @abstractmethod
   def address_target_pairs_from_address_families(self, address_families: List["AddressFamily"]):
-    """Given a list of AddressFamily, return (address, target) pairs matching this spec.
+    """Given a list of AddressFamily, return (address, target) pairs matching this address spec.
 
     :raises: :class:`SingleAddress._SingleAddressResolutionError` for resolution errors with a
              :class:`SingleAddress` instance.
-    :raises: :class:`Spec.AddressResolutionError` if no targets could be found otherwise, if the
-             spec type requires a non-empty set of targets.
+    :raises: :class:`AddressSpec.AddressResolutionError` if no targets could be found otherwise, if
+             the address spec type requires a non-empty set of targets.
     :return: list of (Address, Target) pairs.
     """
 
@@ -80,7 +82,7 @@ class Spec(ABC):
 
   @abstractmethod
   def make_glob_patterns(self, address_mapper: "AddressMapper") -> List[str]:
-    """Generate glob patterns matching exactly all the BUILD files this spec covers."""
+    """Generate glob patterns matching exactly all the BUILD files this address spec covers."""
 
   @classmethod
   def globs_in_single_dir(cls, spec_dir_path: str, address_mapper: "AddressMapper") -> List[str]:
@@ -89,8 +91,8 @@ class Spec(ABC):
 
 
 @dataclass(frozen=True)
-class SingleAddress(Spec):
-  """A Spec for a single address."""
+class SingleAddress(AddressSpec):
+  """An AddressSpec for a single address."""
   directory: str
   name: str
 
@@ -137,8 +139,8 @@ class SingleAddress(Spec):
 
 
 @dataclass(frozen=True)
-class SiblingAddresses(Spec):
-  """A Spec representing all addresses located directly within the given directory."""
+class SiblingAddresses(AddressSpec):
+  """An AddressSpec representing all addresses located directly within the given directory."""
   directory: str
 
   def to_spec_string(self) -> str:
@@ -157,8 +159,8 @@ class SiblingAddresses(Spec):
 
 
 @dataclass(frozen=True)
-class DescendantAddresses(Spec):
-  """A Spec representing all addresses located recursively under the given directory."""
+class DescendantAddresses(AddressSpec):
+  """An AddressSpec representing all addresses located recursively under the given directory."""
   directory: str
 
   def to_spec_string(self) -> str:
@@ -175,7 +177,7 @@ class DescendantAddresses(Spec):
   def address_target_pairs_from_address_families(self, address_families: Sequence["AddressFamily"]):
     addr_tgt_pairs = self.all_address_target_pairs(address_families)
     if len(addr_tgt_pairs) == 0:
-      raise self.AddressResolutionError('Spec {} does not match any targets.'.format(self))
+      raise self.AddressResolutionError('AddressSpec {} does not match any targets.'.format(self))
     return addr_tgt_pairs
 
   def make_glob_patterns(self, address_mapper: "AddressMapper") -> List[str]:
@@ -183,8 +185,8 @@ class DescendantAddresses(Spec):
 
 
 @dataclass(frozen=True)
-class AscendantAddresses(Spec):
-  """A Spec representing all addresses located recursively _above_ the given directory."""
+class AscendantAddresses(AddressSpec):
+  """An AddressSpec representing all addresses located recursively _above_ the given directory."""
   directory: str
 
   def to_spec_string(self) -> str:
@@ -218,27 +220,32 @@ _specificity = {
 }
 
 
-def more_specific(spec1: Optional[Spec], spec2: Optional[Spec]) -> Spec:
+def more_specific(
+  address_spec1: Optional[AddressSpec], address_spec2: Optional[AddressSpec]
+) -> AddressSpec:
   """Returns which of the two specs is more specific.
 
   This is useful when a target matches multiple specs, and we want to associate it with
   the "most specific" one, which will make the most intuitive sense to the user.
   """
   # Note that if either of spec1 or spec2 is None, the other will be returned.
-  if spec1 is None and spec2 is None:
+  if address_spec1 is None and address_spec2 is None:
     raise ValueError('internal error: both specs provided to more_specific() were None')
-  return cast(Spec, spec1 if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2)
+  return cast(
+    AddressSpec,
+    address_spec1 if _specificity[type(address_spec1)] < _specificity[type(address_spec2)] else address_spec2
+  )
 
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class AddressSpecsMatcher:
-  """Contains filters for the output of a Specs match.
+  """Contains filters for the output of a AddressSpecs match.
 
-  This class is separated out from `Specs` to allow for both stuctural equality of the `tags` and
+  This class is separated out from `AddressSpecs` to allow for both stuctural equality of the `tags` and
   `exclude_patterns`, and for caching of their compiled forms using `@memoized_property` (which uses
-  the hash of the class instance in its key, and results in a very large key when used with `Specs`
-  directly).
+  the hash of the class instance in its key, and results in a very large key when used with
+  `AddressSpecs` directly).
   """
   tags: Tuple[str, ...]
   exclude_patterns: Tuple[str, ...]
@@ -274,20 +281,20 @@ class AddressSpecsMatcher:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class Specs:
+class AddressSpecs:
   """A collection of `AddressSpec`s representing AddressSpec subclasses, and a AddressSpecsMatcher
   to filter results."""
-  dependencies: Tuple[Spec, ...]
+  dependencies: Tuple[AddressSpec, ...]
   matcher: AddressSpecsMatcher
 
   def __init__(
     self,
-    dependencies: Iterable[Spec],
+    dependencies: Iterable[AddressSpec],
     tags: Optional[Iterable[str]] = None,
     exclude_patterns: Optional[Iterable[str]] = None,
   ) -> None:
     self.dependencies = tuple(dependencies)
     self.matcher = AddressSpecsMatcher(tags=tags, exclude_patterns=exclude_patterns)
 
-  def __iter__(self) -> Iterator[Spec]:
+  def __iter__(self) -> Iterator[AddressSpec]:
     return iter(self.dependencies)

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -232,7 +232,7 @@ def more_specific(spec1: Optional[Spec], spec2: Optional[Spec]) -> Spec:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class SpecsMatcher:
+class AddressSpecsMatcher:
   """Contains filters for the output of a Specs match.
 
   This class is separated out from `Specs` to allow for both stuctural equality of the `tags` and
@@ -275,9 +275,10 @@ class SpecsMatcher:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class Specs:
-  """A collection of Specs representing Spec subclasses, and a SpecsMatcher to filter results."""
+  """A collection of `AddressSpec`s representing AddressSpec subclasses, and a AddressSpecsMatcher
+  to filter results."""
   dependencies: Tuple[Spec, ...]
-  matcher: SpecsMatcher
+  matcher: AddressSpecsMatcher
 
   def __init__(
     self,
@@ -286,7 +287,7 @@ class Specs:
     exclude_patterns: Optional[Iterable[str]] = None,
   ) -> None:
     self.dependencies = tuple(dependencies)
-    self.matcher = SpecsMatcher(tags=tags, exclude_patterns=exclude_patterns)
+    self.matcher = AddressSpecsMatcher(tags=tags, exclude_patterns=exclude_patterns)
 
   def __iter__(self) -> Iterator[Spec]:
     return iter(self.dependencies)

--- a/src/python/pants/base/target_roots.py
+++ b/src/python/pants/base/target_roots.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 
 
 class InvalidSpecConstraint(Exception):
@@ -13,4 +13,4 @@ class InvalidSpecConstraint(Exception):
 @dataclass(frozen=True)
 class TargetRoots:
   """Determines the target roots for a given pants run."""
-  specs: Specs
+  specs: AddressSpecs

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -54,7 +54,7 @@ class GoalRunnerFactory:
     spec_parser = CmdLineSpecParser(self._root_dir)
 
     for goal in requested_goals:
-      if address_mapper.is_valid_single_address(spec_parser.parse_spec(goal)):
+      if address_mapper.is_valid_single_address(spec_parser.parse_address_spec(goal)):
         logger.warning("Command-line argument '{0}' is ambiguous and was assumed to be "
                        "a goal. If this is incorrect, disambiguate it with ./{0}.".format(goal))
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -236,7 +236,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
     spec_parser = CmdLineSpecParser(get_buildroot())
     target_specs = [
-      spec_parser.parse_spec(spec).to_spec_string()
+      spec_parser.parse_address_spec(spec).to_spec_string()
       for spec in self._options.positional_args
     ]
     # Note: This will not include values from `--owner-of` or `--changed-*` flags.

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -145,19 +145,19 @@ class Address:
     normpath = os.path.normpath(path)
     components = normpath.split(os.sep)
     if components[0] in ('.', '..') or normpath != path:
-      raise InvalidSpecPath("Spec has un-normalized path part '{path}'".format(path=path))
+      raise InvalidSpecPath("Address spec has un-normalized path part '{path}'".format(path=path))
     if components[-1].startswith('BUILD'):
-      raise InvalidSpecPath('Spec path {path} has {trailing} as the last path part and BUILD is '
+      raise InvalidSpecPath('Address spec path {path} has {trailing} as the last path part and BUILD is '
                             'reserved files'.format(path=path, trailing=components[-1]))
     if os.path.isabs(path):
-      raise InvalidSpecPath('Spec has absolute path {path}; expected a path relative '
+      raise InvalidSpecPath('Address spec has absolute path {path}; expected a path relative '
                             'to the build root.'.format(path=path))
     return normpath if normpath != '.' else ''
 
   @classmethod
   def check_target_name(cls, spec_path, name):
     if not name:
-      raise InvalidTargetName('Spec {spec}:{name} has no name part'
+      raise InvalidTargetName('Address spec {spec}:{name} has no name part'
                                  .format(spec=spec_path, name=name))
 
     banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(name)

--- a/src/python/pants/build_graph/address_mapper.py
+++ b/src/python/pants/build_graph/address_mapper.py
@@ -3,8 +3,9 @@
 
 import logging
 from abc import ABC, abstractmethod
+from typing import Iterable
 
-from pants.base.specs import SingleAddress
+from pants.base.specs import AddressSpec, SingleAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 
 
@@ -50,8 +51,8 @@ class AddressMapper(ABC):
     """
 
   @abstractmethod
-  def scan_specs(self, specs, fail_fast=True):
-    """Execute a collection of `specs.Spec` objects and return a set of Addresses."""
+  def scan_address_specs(self, address_specs: Iterable[AddressSpec], fail_fast=True):
+    """Execute a collection of `specs.AddressSpec` objects and return a set of Addresses."""
 
   def is_valid_single_address(self, single_address):
     """Check if a potentially ambiguous single address spec really exists.
@@ -65,7 +66,7 @@ class AddressMapper(ABC):
           single_address, type(single_address), SingleAddress))
 
     try:
-      return bool(self.scan_specs([single_address]))
+      return bool(self.scan_address_specs([single_address]))
     except AddressLookupError:
       return False
 

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -6,9 +6,11 @@ import logging
 import weakref
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict, deque
+from typing import Iterable
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.specs import AddressSpec
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.injectables_mixin import InjectablesMixin
@@ -602,12 +604,12 @@ class BuildGraph(ABC):
     """
 
   @abstractmethod
-  def inject_specs_closure(self, specs, fail_fast=None):
+  def inject_specs_closure(self, specs: Iterable[AddressSpec], fail_fast=None):
     """Resolves, constructs and injects Targets and their transitive closures of dependencies.
 
     :API: public
 
-    :param specs: A list of base.specs.Spec objects to resolve and inject.
+    :param specs: An iterable of AddressSpec objects to resolve and inject.
     :param fail_fast: Whether to fail quickly for the first error, or to complete all
       possible injections before failing.
     :returns: Yields a sequence of resolved Address objects.

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -614,7 +614,7 @@ class Target(AbstractTarget):
 
     :param dict kwargs: The pre-Target.__init__() kwargs dict.
     :param Payload payload: The post-Target.__init__() Payload object.
-    :yields: Spec strings representing dependencies of this target.
+    :yields: AddressSpec strings representing dependencies of this target.
     """
     cls._validate_target_representation_args(kwargs, payload)
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for
@@ -637,7 +637,7 @@ class Target(AbstractTarget):
 
     :param dict kwargs: The pre-Target.__init__() kwargs dict.
     :param Payload payload: The post-Target.__init__() Payload object.
-    :yields: Spec strings representing dependencies of this target.
+    :yields: AddressSpec strings representing dependencies of this target.
     """
     cls._validate_target_representation_args(kwargs, payload)
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from functools import update_wrapper
 from typing import Any, Set, Tuple, Type
 
-from pants.base.specs import Spec
+from pants.base.specs import AddressSpec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
@@ -21,7 +21,7 @@ class Addresses(Collection[Address]):
 class ProvenancedBuildFileAddress:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
   build_file_address: BuildFileAddress
-  provenance: Spec
+  provenance: AddressSpec
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -9,7 +9,7 @@ from typing import Dict
 from twitter.common.collections import OrderedSet
 
 from pants.base.project_tree import Dir
-from pants.base.specs import SingleAddress, Spec, Specs, more_specific
+from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress, more_specific
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import (
@@ -198,41 +198,42 @@ def _hydrate(item_type, spec_path, **kwargs):
 
 @rule
 async def provenanced_addresses_from_address_families(
-  address_mapper: AddressMapper, specs: Specs,
+  address_mapper: AddressMapper, address_specs: AddressSpecs,
 ) -> ProvenancedBuildFileAddresses:
-  """Given an AddressMapper and list of Specs, return matching ProvenancedBuildFileAddresses.
+  """Given an AddressMapper and list of AddressSpecs, return matching ProvenancedBuildFileAddresses.
 
   :raises: :class:`ResolveError` if:
      - there were no matching AddressFamilies, or
-     - the Spec matches no addresses for SingleAddresses.
+     - the AddressSpec matches no addresses for SingleAddresses.
   :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
   """
-  # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
+  # Capture a Snapshot covering all paths for these AddressSpecs, then group by directory.
+  snapshot = await Get[Snapshot](PathGlobs, _address_spec_to_globs(address_mapper, address_specs))
   dirnames = {dirname(f) for f in snapshot.files}
   address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}
 
   matched_addresses = OrderedSet()
-  addr_to_provenance: Dict[BuildFileAddress, Spec] = {}
+  addr_to_provenance: Dict[BuildFileAddress, AddressSpec] = {}
 
-  for spec in specs:
-    # NB: if a spec is provided which expands to some number of targets, but those targets match
-    # --exclude-target-regexp, we do NOT fail! This is why we wait to apply the tag and exclude
-    # patterns until we gather all the targets the spec would have matched without them.
+  for address_spec in address_specs:
+    # NB: if an address spec is provided which expands to some number of targets, but those targets
+    # match --exclude-target-regexp, we do NOT fail! This is why we wait to apply the tag and
+    # exclude patterns until we gather all the targets the address spec would have matched
+    # without them.
     try:
-      addr_families_for_spec = spec.matching_address_families(address_family_by_directory)
-    except Spec.AddressFamilyResolutionError as e:
+      addr_families_for_spec = address_spec.matching_address_families(address_family_by_directory)
+    except AddressSpec.AddressFamilyResolutionError as e:
       raise ResolveError(e) from e
 
     try:
-      all_addr_tgt_pairs = spec.address_target_pairs_from_address_families(
+      all_addr_tgt_pairs = address_spec.address_target_pairs_from_address_families(
         addr_families_for_spec
       )
       for addr, _ in all_addr_tgt_pairs:
         # A target might be covered by multiple specs, so we take the most specific one.
-        addr_to_provenance[addr] = more_specific(addr_to_provenance.get(addr), spec)
-    except Spec.AddressResolutionError as e:
+        addr_to_provenance[addr] = more_specific(addr_to_provenance.get(addr), address_spec)
+    except AddressSpec.AddressResolutionError as e:
       raise AddressLookupError(e) from e
     except SingleAddress._SingleAddressResolutionError as e:
       _raise_did_you_mean(e.single_address_family, e.name, source=e)
@@ -240,7 +241,7 @@ async def provenanced_addresses_from_address_families(
     matched_addresses.update(
       addr
       for (addr, tgt) in all_addr_tgt_pairs
-      if specs.matcher.matches_target_address_pair(addr, tgt)
+      if address_specs.matcher.matches_target_address_pair(addr, tgt)
     )
 
   # NB: This may be empty, as the result of filtering by tag and exclude patterns!
@@ -261,24 +262,24 @@ def remove_provenance(pbfas: ProvenancedBuildFileAddresses) -> BuildFileAddresse
 
 @dataclass(frozen=True)
 class AddressProvenanceMap:
-  bfaddr_to_spec: Dict[BuildFileAddress, Spec]
+  bfaddr_to_address_spec: Dict[BuildFileAddress, AddressSpec]
 
   def is_single_address(self, address: BuildFileAddress):
-    return isinstance(self.bfaddr_to_spec.get(address), SingleAddress)
+    return isinstance(self.bfaddr_to_address_spec.get(address), SingleAddress)
 
 
 @rule
 def address_provenance_map(pbfas: ProvenancedBuildFileAddresses) -> AddressProvenanceMap:
   return AddressProvenanceMap(
-    bfaddr_to_spec={pbfa.build_file_address: pbfa.provenance for pbfa in pbfas.dependencies}
+    bfaddr_to_address_spec={pbfa.build_file_address: pbfa.provenance for pbfa in pbfas.dependencies}
   )
 
 
-def _spec_to_globs(address_mapper: AddressMapper, specs: Specs) -> PathGlobs:
-  """Given a Specs object, return a PathGlobs object for the build files that it matches."""
+def _address_spec_to_globs(address_mapper: AddressMapper, address_specs: AddressSpecs) -> PathGlobs:
+  """Given an AddressSpecs object, return a PathGlobs object for the build files that it matches."""
   patterns = set()
-  for spec in specs:
-    patterns.update(spec.make_glob_patterns(address_mapper))
+  for address_spec in address_specs:
+    patterns.update(address_spec.make_glob_patterns(address_mapper))
   return PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
 
 
@@ -294,7 +295,7 @@ def create_graph_rules(address_mapper: AddressMapper):
     # BUILD file parsing.
     hydrate_struct,
     parse_address_family,
-    # Spec handling: locate directories that contain build files, and request
+    # AddressSpec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
     provenanced_addresses_from_address_families,
     remove_provenance,
@@ -303,5 +304,5 @@ def create_graph_rules(address_mapper: AddressMapper):
     RootRule(Address),
     RootRule(BuildFileAddress),
     RootRule(BuildFileAddresses),
-    RootRule(Specs),
+    RootRule(AddressSpecs),
   ]

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -376,8 +376,8 @@ class SchedulerSession:
 
     :param products: A list of product types to request for the roots.
     :type products: list of types
-    :param subjects: A list of Spec and/or PathGlobs objects.
-    :type subject: list of :class:`pants.base.specs.Spec`, `pants.build_graph.Address`, and/or
+    :param subjects: A list of AddressSpec and/or PathGlobs objects.
+    :type subject: list of :class:`pants.base.specs.AddressSpec`, `pants.build_graph.Address`, and/or
       :class:`pants.engine.fs.PathGlobs` objects.
     :returns: An ExecutionRequest for the given products and subjects.
     """

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -16,7 +16,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.file_system_project_tree import FileSystemProjectTree
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -379,12 +379,12 @@ class EngineInitializer:
       return cast(BuildRoot, BuildRoot.instance)
 
     @rule
-    async def single_build_file_address(specs: Specs) -> BuildFileAddress:
-      build_file_addresses = await Get[BuildFileAddresses](Specs, specs)
+    async def single_build_file_address(address_specs: AddressSpecs) -> BuildFileAddress:
+      build_file_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
       if len(build_file_addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
       if len(build_file_addresses.dependencies) > 1:
-        potential_addresses = await Get[BuildFileAddresses](Specs, specs)
+        potential_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
         targets = [bfa.to_address() for bfa in potential_addresses]
         output = '\n '.join(str(target) for target in targets)
 

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Set
 
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 from pants.engine.console import Console
 from pants.engine.fs import (
   Digest,
@@ -67,7 +67,10 @@ class CountLinesOfCode(Goal):
 
 @console_rule
 async def run_cloc(
-  console: Console, options: CountLinesOfCodeOptions, cloc_script: DownloadedClocScript, specs: Specs
+  console: Console,
+  options: CountLinesOfCodeOptions,
+  cloc_script: DownloadedClocScript,
+  address_specs: AddressSpecs,
 ) -> CountLinesOfCode:
   """Runs the cloc perl script in an isolated process"""
 
@@ -75,10 +78,10 @@ async def run_cloc(
   ignored = options.values.ignored
 
   if transitive:
-    transitive_hydrated_targets = await Get[TransitiveHydratedTargets](Specs, specs)
+    transitive_hydrated_targets = await Get[TransitiveHydratedTargets](AddressSpecs, address_specs)
     all_target_adaptors = {ht.adaptor for ht in transitive_hydrated_targets.closure}
   else:
-    hydrated_targets = await Get[HydratedTargets](Specs, specs)
+    hydrated_targets = await Get[HydratedTargets](AddressSpecs, address_specs)
     all_target_adaptors = {ht.adaptor for ht in hydrated_targets}
 
   digests_to_merge = []

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -3,7 +3,7 @@
 
 from typing import Union
 
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -34,14 +34,16 @@ class List(Goal):
 
 
 @console_rule
-async def list_targets(console: Console, list_options: ListOptions, specs: Specs) -> List:
+async def list_targets(
+  console: Console, list_options: ListOptions, address_specs: AddressSpecs,
+) -> List:
   provides = list_options.values.provides
   provides_columns = list_options.values.provides_columns
   documented = list_options.values.documented
   collection: Union[HydratedTargets, BuildFileAddresses]
   if provides or documented:
     # To get provides clauses or documentation, we need hydrated targets.
-    collection = await Get[HydratedTargets](Specs, specs)
+    collection = await Get[HydratedTargets](AddressSpecs, address_specs)
     if provides:
       extractors = dict(
           address=lambda target: target.address.spec,
@@ -71,7 +73,7 @@ async def list_targets(console: Console, list_options: ListOptions, specs: Specs
       print_fn = print_documented
   else:
     # Otherwise, we can use only addresses.
-    collection = await Get[BuildFileAddresses](Specs, specs)
+    collection = await Get[BuildFileAddresses](AddressSpecs, address_specs)
     print_fn = lambda address: address.spec
 
   with list_options.line_oriented(console) as print_stdout:

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -5,7 +5,7 @@ import logging
 from textwrap import dedent
 from typing import Dict, Optional
 
-from pants.base.specs import DescendantAddresses, SingleAddress, Spec
+from pants.base.specs import AddressSpec, DescendantAddresses, SingleAddress
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.build_files import AddressProvenanceMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Snapshot
@@ -120,7 +120,7 @@ class TestTest(TestBase):
     self,
     *,
     address: Address,
-    bfaddr_to_spec: Optional[Dict[BuildFileAddress, Spec]] = None,
+    bfaddr_to_address_spec: Optional[Dict[BuildFileAddress, AddressSpec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
   ) -> AddressAndTestResult:
@@ -146,7 +146,7 @@ class TestTest(TestBase):
         rule_args=[
           HydratedTarget(address, target_adaptor, ()),
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
-          AddressProvenanceMap(bfaddr_to_spec=bfaddr_to_spec or {}),
+          AddressProvenanceMap(bfaddr_to_address_spec=bfaddr_to_address_spec or {}),
         ],
         mock_gets=[
           MockGet(
@@ -173,7 +173,7 @@ class TestTest(TestBase):
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
         address=bfaddr.to_address(),
-        bfaddr_to_spec={bfaddr: SingleAddress(directory='some/dir', name='bin')},
+        bfaddr_to_address_spec={bfaddr: SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
@@ -186,7 +186,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(None, 'tests', 'some/dir')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')}
+      bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
       bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
@@ -196,7 +196,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(None, 'bin', 'some/dir')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')},
+      bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
     assert result == AddressAndTestResult(bfaddr.to_address(), None)

--- a/src/python/pants/testutil/console_rule_test_base.py
+++ b/src/python/pants/testutil/console_rule_test_base.py
@@ -56,8 +56,8 @@ class ConsoleRuleTestBase(TestBase):
     workspace = Workspace(scheduler)
 
     # Run for the target specs parsed from the args.
-    specs = TargetRootsCalculator.parse_specs(full_options.positional_args, self.build_root)
-    params = Params(specs, console, options_bootstrapper, workspace, *additional_params)
+    address_specs = TargetRootsCalculator.parse_address_specs(full_options.positional_args, self.build_root)
+    params = Params(address_specs, console, options_bootstrapper, workspace, *additional_params)
     actual_exit_code = self.scheduler.run_console_rule(self.goal_cls, params)
 
     # Flush and capture console output.

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -16,7 +16,7 @@ from typing import Any, Optional, Type, TypeVar, Union, cast
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
-from pants.base.specs import Specs
+from pants.base.specs import AddressSpecs
 from pants.base.target_roots import TargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -401,7 +401,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     ).new_session(zipkin_trace_v2=False, build_id="buildid_for_test")
     self._scheduler = graph_session.scheduler_session
     self._build_graph, self._address_mapper = graph_session.create_build_graph(
-        TargetRoots(Specs([])), self._build_root()
+        TargetRoots(AddressSpecs([])), self._build_root()
       )
 
   @property
@@ -565,7 +565,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     Returns the set of all Targets found.
     """
 
-    spec = CmdLineSpecParser(self.build_root).parse_spec(spec)
+    spec = CmdLineSpecParser(self.build_root).parse_address_spec(spec)
     targets = []
     for address in self.build_graph.inject_specs_closure([spec]):
       targets.append(self.build_graph.get_target(address))

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -77,7 +77,7 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
     spec_parser = CmdLineSpecParser(get_buildroot())
     # project_path is always the directory of the first target,
     # which is where intellij is going to zoom in under project view.
-    project_path = spec_parser.parse_spec(target_specs[0]).directory
+    project_path = spec_parser.parse_address_spec(target_specs[0]).directory
 
     with self.temporary_workdir() as workdir:
       with temporary_file(root_dir=workdir, cleanup=True) as output_file:

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -2,22 +2,23 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import Optional
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
-from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
+from pants.base.specs import AddressSpec, DescendantAddresses, SiblingAddresses, SingleAddress
 from pants.testutil.test_base import TestBase
 
 
-def single(directory, name=None):
+def single(directory: str, name: Optional[str] = None) -> SingleAddress:
   name = name if name is not None else os.path.basename(directory)
   return SingleAddress(directory, name)
 
 
-def desc(directory):
+def desc(directory: str) -> DescendantAddresses:
   return DescendantAddresses(directory)
 
 
-def sib(directory):
+def sib(directory: str) -> SiblingAddresses:
   return SiblingAddresses(directory)
 
 
@@ -89,5 +90,5 @@ class CmdLineSpecParserTest(TestBase):
     self.assert_parsed('./a/b/:b', single('a/b', 'b'))
     self.assert_parsed(os.path.join(self.build_root, './a/b/:b'), single('a/b', 'b'))
 
-  def assert_parsed(self, spec_str, expected_spec):
-    self.assertEqual(self._spec_parser.parse_spec(spec_str), expected_spec)
+  def assert_parsed(self, spec_str: str, expected_address_spec: AddressSpec) -> None:
+    self.assertEqual(self._spec_parser.parse_address_spec(spec_str), expected_address_spec)

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -116,18 +116,18 @@ class LegacyAddressMapperTest(TestBase):
       mapper.addresses_in_spec_path('foo')
     self.assertIn('does not match any targets.', str(cm.exception))
 
-  def test_scan_specs(self):
+  def test_scan_address_specs(self):
     self.create_build_files()
     mapper = self.address_mapper
-    addresses = mapper.scan_specs([SingleAddress('dir_a', 'a'), SiblingAddresses('')])
+    addresses = mapper.scan_address_specs([SingleAddress('dir_a', 'a'), SiblingAddresses('')])
     self.assertEqual(addresses,
                       {Address('', 'a'), Address('', 'b'), Address('', 'c'), Address('dir_a', 'a')})
 
-  def test_scan_specs_bad_spec(self):
+  def test_scan_address_specs_bad_spec(self):
     self.create_build_files()
     mapper = self.address_mapper
     with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
-      mapper.scan_specs([SingleAddress('dir_a', 'd')])
+      mapper.scan_address_specs([SingleAddress('dir_a', 'd')])
     self.assertIn('does not match any targets.', str(cm.exception))
 
   def test_scan_addresses(self):

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -6,7 +6,7 @@ import unittest
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.base.specs import SingleAddress, Spec, Specs
+from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import create_graph_rules
@@ -162,8 +162,8 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              configurations=['//a/d/e', Struct(embedded='yes')],
                              type_alias='target')
 
-  def resolve(self, spec: Spec):
-    tacs, = self.scheduler.product_request(HydratedStructs, [Specs([spec])])
+  def resolve(self, address_spec: AddressSpec):
+    tacs, = self.scheduler.product_request(HydratedStructs, [AddressSpecs([address_spec])])
     return [tac.value for tac in tacs]
 
   def test_no_address_no_family(self) -> None:


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/8593 to support non-target specs, e.g. file system specs.

## Rationale
We don’t want to expand the current definition of `Spec` to include files - it’s a useful abstraction as is, e.g. that we have logic for `SingleAddress`.

At the same time, “specs” is a useful namespace to describe your _specifications_ for what you want to run against. We want to be able to use `Specs` to describe an abstraction `specification` and then have `AddressSpec` and `FilesystemSpec` describe the concrete specifications, e.g.:

![hierarchy tree for Spec](https://user-images.githubusercontent.com/14852634/71929478-f2e0f900-3156-11ea-92dd-50c9e8d41f28.png)

(Note that the design for `FilesystemSpec` will likely change - this is a first draft.)

### Rejected alternative: `PositionalArg`
`PositionalArg` is an implementation detail - the real fundamental idea of this object is that this is a specification for something to run against.

## Re: deprecation policy
This is safe to change without a deprecation cycle because `Spec` is not marked as a public API and its only direct usage is in rules, which are experimental.

We do not rename functions that are public to reflect this name change. Namely, we keep `Target.compute_dependency_specs()` as the same name rather than `Target.compute_dependency_address_specs()`.