### PR TITLE
turn the Changed subsystem into v2 rules for target root calculation

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -290,3 +290,6 @@ class Specs:
 
   def __iter__(self) -> Iterator[Spec]:
     return iter(self.dependencies)
+
+  def __bool__(self):
+    return bool(self.dependencies)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -60,6 +60,7 @@ from pants.option.global_options import (
   GlobMatchErrorBehavior,
 )
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.scm.subsystems.changed import rules as changed_rules
 
 
 logger = logging.getLogger(__name__)
@@ -414,6 +415,7 @@ class EngineInitializer:
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       structs_rules() +
+      changed_rules() +
       rules
     )
 

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -13,10 +13,10 @@ from pants.base.target_roots import InvalidSpecConstraint, TargetRoots
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
 from pants.engine.scheduler import SchedulerSession
+from pants.engine.selectors import Params
 from pants.goal.workspace import ScmWorkspace
 from pants.option.options import Options
-from pants.scm.subsystems.changed import ChangedRequest
-
+from pants.scm.subsystems.changed import ChangedRequest, IncludeDependees, ScmWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +43,6 @@ class TargetRootsCalculator:
       tags=tags)
 
   @classmethod
-  def changed_files(cls, scm, changes_since=None, diffspec=None):
-    """Determines the files changed according to SCM/workspace and options."""
-    workspace = ScmWorkspace(scm)
-    if diffspec:
-      return workspace.changes_in(diffspec)
-
-    changes_since = changes_since or scm.current_rev_identifier()
-    return workspace.touched_files(changes_since)
-
-  @classmethod
   def create(
     cls,
     options: Options,
@@ -61,6 +51,11 @@ class TargetRootsCalculator:
     exclude_patterns: Optional[Iterable[str]] = None,
     tags: Optional[Iterable[str]] = None,
   ) -> TargetRoots:
+    """
+    :param Options options: An `Options` instance to use.
+    :param session: The Scheduler session
+    :param string build_root: The build root.
+    """
     # Determine the literal target roots.
     spec_roots = cls.parse_specs(
       target_specs=options.positional_args,
@@ -76,46 +71,52 @@ class TargetRootsCalculator:
     # Determine the `--owner-of=` arguments provided from the global options
     owned_files = options.for_global_scope().owner_of
 
-    logger.debug('spec_roots are: %s', spec_roots)
-    logger.debug('changed_request is: %s', changed_request)
-    logger.debug('owned_files are: %s', owned_files)
-    targets_specified = sum(1 for item
-                         in (changed_request.is_actionable(), owned_files, spec_roots.dependencies)
-                         if item)
+    logger.debug('spec_roots are: %s (%s)', spec_roots, bool(spec_roots))
+    logger.debug('changed_request is: %s (%s)', changed_request, bool(changed_request.is_actionable()))
+    logger.debug('owned_files are: %s (%s)', owned_files, bool(owned_files))
+    targets_specified = sum(
+      1 for item
+      in (changed_request.is_actionable(), owned_files, spec_roots)
+      if item)
 
     if targets_specified > 1:
       # We've been provided more than one of: a change request, an owner request, or spec roots.
       raise InvalidSpecConstraint(
         'Multiple target selection methods provided. Please use only one of '
-        '--changed-*, --owner-of, or target specs'
+        '--changed-*, --owner-of, or target specs.\n'
+        f'spec_roots: {spec_roots}\n'
+        f'changed_request: {changed_request}\n'
+        f'owned_files: {owned_files}'
       )
 
-    if changed_request.is_actionable():
+    def scm(entity):
       scm = get_scm()
       if not scm:
         raise InvalidSpecConstraint(
-          'The --changed-* options are not available without a recognized SCM (usually git).'
+          # TODO: centralize the error messaging for when an SCM is required, and describe what SCMs
+          # are supported!
+          '{} are not available without a recognized SCM (usually git).'
+          .format(entity)
         )
-      changed_files = cls.changed_files(
-          scm,
-          changes_since=changed_request.changes_since,
-          diffspec=changed_request.diffspec)
+      return scm
+
+    if changed_request.is_actionable():
       # We've been provided no spec roots (e.g. `./pants list`) AND a changed request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(changed_files),
-                              include_dependees=str(changed_request.include_dependees))
-      changed_addresses, = session.product_request(BuildFileAddresses, [request])
+      scm = scm('The --changed-* options')
+      changed_addresses, = session.product_request(
+        BuildFileAddresses,
+        [Params(ScmWrapper(scm), changed_request)])
       logger.debug('changed addresses: %s', changed_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses)
       return TargetRoots(Specs(dependencies=dependencies, exclude_patterns=exclude_patterns, tags=tags))
-
-    if owned_files:
+    elif owned_files:
       # We've been provided no spec roots (e.g. `./pants list`) AND a owner request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(owned_files), include_dependees=str('none'))
+      request = OwnersRequest(sources=tuple(owned_files), include_dependees=IncludeDependees.none)
       owner_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('owner addresses: %s', owner_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)
       return TargetRoots(Specs(dependencies=dependencies, exclude_patterns=exclude_patterns, tags=tags))
-
-    return TargetRoots(spec_roots)
+    else:
+      return TargetRoots(spec_roots)

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -1,10 +1,20 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from enum import Enum
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Tuple
 
+from pants.engine.rules import RootRule, rule
+from pants.goal.workspace import ScmWorkspace
+from pants.scm.scm import Scm
 from pants.subsystem.subsystem import Subsystem
+
+
+class IncludeDependees(Enum):
+  none = 'none'
+  direct = 'direct'
+  transitive = 'transitive'
 
 
 @dataclass(frozen=True)
@@ -12,8 +22,8 @@ class ChangedRequest:
   """Parameters required to compute a changed file/target set."""
   changes_since: Any
   diffspec: Any
-  include_dependees: Any
-  fast: Any
+  include_dependees: IncludeDependees
+  fast: bool
 
   @classmethod
   def from_options(cls, options):
@@ -21,7 +31,7 @@ class ChangedRequest:
     return cls(options.changes_since,
                options.diffspec,
                options.include_dependees,
-               options.fast)
+               options.fast or False)
 
   def is_actionable(self):
     return bool(self.changes_since or self.diffspec)
@@ -42,7 +52,41 @@ class Changed(Subsystem):
              help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
     register('--diffspec',
              help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
-    register('--include-dependees', choices=['none', 'direct', 'transitive'], default='none',
+    register('--include-dependees', type=IncludeDependees, default=IncludeDependees.none,
              help='Include direct or transitive dependees of changed targets.')
     register('--fast', type=bool,
              help='Stop searching for owners once a source is mapped to at least one owning target.')
+
+
+@dataclass(frozen=True)
+class ScmWrapper:
+  scm: Scm
+
+
+@dataclass(frozen=True)
+class ChangedFilesResult:
+  changed_files: Tuple[str, ...]
+
+
+# TODO: ensure this rule isn't ever cached with an @ensure_daemon integration test!
+@rule
+def get_changed(scm: ScmWrapper, changed_request: ChangedRequest) -> ChangedFilesResult:
+  scm = scm.scm
+  workspace = ScmWorkspace(scm)
+  diffspec = changed_request.diffspec
+  if diffspec:
+    # TODO: this does a synchronous process invocation to git under the hood -- rewrite!
+    result = workspace.changes_in(diffspec)
+  else:
+    # .current_rev_identifier() is just a static string for git right now (not slow to access).
+    changes_since = changed_request.changes_since or scm.current_rev_identifier()
+    result = workspace.touched_files(changes_since)
+  return ChangedFilesResult(changed_files=result)
+
+
+def rules():
+  return [
+    RootRule(ChangedRequest),
+    RootRule(ScmWrapper),
+    get_changed,
+  ]


### PR DESCRIPTION
### Problem

It would be cool to convert some command-line processing that currently occurs synchronously into v2 rules. This is pre-work for #7350!

### Solution

- Convert the output of the `Changed` subsystem into an `OwnersRequest`.
- Invoke the scheduler in `target_roots_calculator.py`.