### PR TITLE
Have handle_workunits callback use kwargs

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -320,24 +320,24 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   def _run(self):
     engine_result = PANTS_FAILED_EXIT_CODE
     goal_runner_result = PANTS_FAILED_EXIT_CODE
-    try:
-      self._maybe_handle_help()
 
-      streaming_handlers = self._options.for_global_scope().streaming_workunits_handlers
-      callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
-      streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callbacks=callbacks)
-      with streaming_reporter.session():
-        engine_result = self._maybe_run_v2()
+    streaming_handlers = self._options.for_global_scope().streaming_workunits_handlers
+    callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
+    streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callbacks=callbacks)
 
-      goal_runner_result = self._maybe_run_v1()
-    finally:
+    with streaming_reporter.session():
       try:
-        self._update_stats()
-        run_tracker_result = self._run_tracker.end()
-      except ValueError as e:
-        # Calling .end() sometimes writes to a closed file, so we return a dummy result here.
-        logger.exception(e)
-        run_tracker_result = PANTS_SUCCEEDED_EXIT_CODE
+        self._maybe_handle_help()
+        engine_result = self._maybe_run_v2()
+        goal_runner_result = self._maybe_run_v1()
+      finally:
+        try:
+          self._update_stats()
+          run_tracker_result = self._run_tracker.end()
+        except ValueError as e:
+          # Calling .end() sometimes writes to a closed file, so we return a dummy result here.
+          logger.exception(e)
+          run_tracker_result = PANTS_SUCCEEDED_EXIT_CODE
 
     final_exit_code = self._compute_final_exit_code(
       engine_result,

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -183,9 +183,8 @@ class Subsystem(SubsystemClientMixin, Optionable):
     intended to be passed to StreamingWorkunitHandler. The caller provides a
     collection of strings representing a Python import path to a class that
     implements the `Subsystem` class. It will then inspect these classes for
-    the presence of a special method called `handle_workunits`, which expects a
-    single non-self argument - namely, a tuple of Python dictionaries
-    representing workunits.
+    the presence of a special method called `handle_workunits`, which will
+    be called with a set of kwargs - see the docstring for StreamingWorkunitHandler. 
 
     For instance, you might invoke this method with something like:
 

--- a/src/python/pants/subsystem/subsystem_test.py
+++ b/src/python/pants/subsystem/subsystem_test.py
@@ -13,7 +13,7 @@ from pants.testutil.test_base import TestBase
 class WorkunitSubscriptableSubsystem(Subsystem):
   options_scope = "dummy scope"
 
-  def handle_workunits(self, workunits):
+  def handle_workunits(self, **kwargs):
     pass
 
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -244,8 +244,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     @dataclass
     class Tracker:
       workunits: List[dict] = field(default_factory=list)
+      finished: bool = False
 
-      def add(self, workunits) -> None:
+      def add(self, workunits, **kwargs) -> None:
+        if kwargs['finished'] == True:
+          self.finished = True
         self.workunits.extend(workunits)
 
     tracker = Tracker()
@@ -262,4 +265,5 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     # Requesting a bigger fibonacci number will result in more rule executions and thus more reported workunits.
     # In this case, we expect 10 invocations of the `fib` rule.
-    self.assertEquals(len(tracker.workunits), 10)
+    assert len(tracker.workunits) ==  10
+    assert tracker.finished


### PR DESCRIPTION
### Problem

We want the streaming workunits abstraction to be able to signal that the last batch of workunits is going to be sent, which requires a change to the signature of the `handle_workunits` callback that we expect Subsystems to provide. More generally we want any further changes to the contract that StreamingWorkunitsHandler makes with the callback to not affect existing Subsystems that make use of that functionality.

### Solution

Change the streaming workunit subsystem to always call the `handle_workunits` callback with a set of kwargs, and document exactly what those kwargs are. 

As an additional change, modify the scope of the streaming workunits `session()` context, so that the try-finally block that shuts down run_tracker is within the scope. This makes sure that the last workunits message sent from the streaming workunit handler happens after RunTracker shuts down.

### Result

This will require a one-time change in any client Subsystems making use of the streaming workunits functionality, but afterwards pants will be able to add additional kwargs to this callback without requiring any change to client Subsystems.