### PR TITLE
Mark certain types as "side-effecting"

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -15,7 +15,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent
-from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
+from pants.engine.interactive_runner import InteractiveProcessRequest
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
@@ -23,7 +23,7 @@ from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobalOptions
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
-from pants.rules.core.test import TestDebugResult, TestOptions, TestResult, TestTarget
+from pants.rules.core.test import TestDebugRequest, TestOptions, TestResult, TestTarget
 
 
 DEFAULT_COVERAGE_CONFIG = dedent(f"""
@@ -189,17 +189,14 @@ async def run_python_test(
 async def debug_python_test(
   test_target: PythonTestsAdaptor,
   test_setup: TestTargetSetup,
-  runner: InteractiveRunner
-) -> TestDebugResult:
+) -> TestDebugRequest:
 
   run_request = InteractiveProcessRequest(
     argv=(test_setup.requirements_pex.output_filename, *test_setup.args),
     run_in_workspace=False,
     input_files=test_setup.input_files_digest
   )
-
-  result = runner.run_local_interactive_process(run_request)
-  return TestDebugResult(result.process_exit_code)
+  return TestDebugRequest(run_request)
 
 
 def rules():

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -36,7 +36,7 @@ class NativeStdErr(NativeWriter):
 
 class Console:
   """Class responsible for writing text to the console while Pants is running. """
-  side_effecting = True
+  uncacheable = True
 
   def __init__(self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None):
     """`stdout` and `stderr` may be explicitly provided when Console is constructed. 

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -36,6 +36,7 @@ class NativeStdErr(NativeWriter):
 
 class Console:
   """Class responsible for writing text to the console while Pants is running. """
+  side_effecting = True
 
   def __init__(self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None):
     """`stdout` and `stderr` may be explicitly provided when Console is constructed. 

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -36,7 +36,7 @@ class NativeStdErr(NativeWriter):
 
 class Console:
   """Class responsible for writing text to the console while Pants is running. """
-  uncacheable = True
+  side_effecting = True
 
   def __init__(self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None):
     """`stdout` and `stderr` may be explicitly provided when Console is constructed. 

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from colors import blue, green, red
 
 from pants.engine.native import Native
+from pants.engine.rules import side_effecting
 
 
 #TODO this needs to be a file-like object/stream
@@ -34,6 +35,7 @@ class NativeStdErr(NativeWriter):
     self._native.write_stderr(self._session, payload)
 
 
+@side_effecting
 class Console:
   """Class responsible for writing text to the console while Pants is running. """
   side_effecting = True

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -209,8 +209,8 @@ class UrlToFetch:
   digest: Digest
 
 
-@dataclass(frozen=True)
 @side_effecting
+@dataclass(frozen=True)
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
   _scheduler: "SchedulerSession"

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple
 
 from pants.engine.objects import Collection
-from pants.engine.rules import RootRule
+from pants.engine.rules import RootRule, side_effecting
 from pants.option.custom_types import GlobExpansionConjunction as GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.dirutil import (
@@ -210,9 +210,9 @@ class UrlToFetch:
 
 
 @dataclass(frozen=True)
+@side_effecting
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
-  side_effecting = True
   _scheduler: "SchedulerSession"
 
   def materialize_directory(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -212,7 +212,7 @@ class UrlToFetch:
 @dataclass(frozen=True)
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
-  side_effecting = True
+  uncacheable = True
   _scheduler: "SchedulerSession"
 
   def materialize_directory(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -212,6 +212,7 @@ class UrlToFetch:
 @dataclass(frozen=True)
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
+  side_effecting = True
   _scheduler: "SchedulerSession"
 
   def materialize_directory(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -212,7 +212,7 @@ class UrlToFetch:
 @dataclass(frozen=True)
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
-  uncacheable = True
+  side_effecting = True
   _scheduler: "SchedulerSession"
 
   def materialize_directory(

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -30,8 +30,8 @@ class InteractiveProcessRequest:
       raise ValueError("InteractiveProessRequest should use the Workspace API to materialize any needed files when it runs in the workspace")
 
 
-@dataclass(frozen=True)
 @side_effecting
+@dataclass(frozen=True)
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
 

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -33,7 +33,7 @@ class InteractiveProcessRequest:
 @dataclass(frozen=True)
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
-  uncacheable = True
+  side_effecting = True
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -33,6 +33,7 @@ class InteractiveProcessRequest:
 @dataclass(frozen=True)
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
+  side_effecting = True
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Tuple
 
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
-from pants.engine.rules import RootRule
+from pants.engine.rules import RootRule, side_effecting
 
 
 if TYPE_CHECKING:
@@ -31,9 +31,9 @@ class InteractiveProcessRequest:
 
 
 @dataclass(frozen=True)
+@side_effecting
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
-  side_effecting = True
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -33,7 +33,7 @@ class InteractiveProcessRequest:
 @dataclass(frozen=True)
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
-  side_effecting = True
+  uncacheable = False
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -33,7 +33,7 @@ class InteractiveProcessRequest:
 @dataclass(frozen=True)
 class InteractiveRunner:
   _scheduler: 'SchedulerSession'
-  uncacheable = False
+  uncacheable = True
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -242,8 +242,8 @@ def rule_decorator(*args, **kwargs) -> Callable:
 def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool) -> None:
   if cacheable:
     for ty in parameter_types:
-      if getattr(ty, "uncacheable", False):
-        raise ValueError(f"Non-console `@rule` {func_id} has an uncacheable parameter: {ty}")
+      if getattr(ty, "side_effecting", False):
+        raise ValueError(f"Non-console `@rule` {func_id} has a side-effecting parameter: {ty}")
 
 
 def inner_rule(*args, **kwargs) -> Callable:

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -235,7 +235,15 @@ def rule_decorator(*args, **kwargs) -> Callable:
     )
     for name, parameter in signature.parameters.items()
   )
+  validate_parameter_types(func_id, parameter_types, cacheable)
   return _make_rule(return_type, parameter_types, cacheable=cacheable, name=name)(func)
+
+
+def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool):
+  if cacheable:
+    for ty in parameter_types:
+      if getattr(ty, "side_effecting", False):
+        raise ValueError(f"Non-console `@rule` {func_id} has a side-effecting parameter: {ty}")
 
 
 def inner_rule(*args, **kwargs) -> Callable:

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -22,6 +22,13 @@ from pants.util.memo import memoized
 from pants.util.meta import frozen_after_init
 
 
+def side_effecting(cls):
+  """Annotates a class to indicate that it is a side-effecting type, which needs
+  to be handled specially with respect to rule caching semantics."""
+  cls.__side_effecting = True
+  return cls
+
+
 class _RuleVisitor(ast.NodeVisitor):
   """Pull `Get` calls out of an @rule body."""
 
@@ -242,7 +249,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
 def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool) -> None:
   if cacheable:
     for ty in parameter_types:
-      if getattr(ty, "side_effecting", False):
+      if getattr(ty, "__side_effecting", False):
         raise ValueError(f"Non-console `@rule` {func_id} has a side-effecting parameter: {ty}")
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -239,7 +239,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
   return _make_rule(return_type, parameter_types, cacheable=cacheable, name=name)(func)
 
 
-def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool):
+def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool) -> None:
   if cacheable:
     for ty in parameter_types:
       if getattr(ty, "uncacheable", False):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -242,8 +242,8 @@ def rule_decorator(*args, **kwargs) -> Callable:
 def validate_parameter_types(func_id: str, parameter_types: Tuple[Type, ...], cacheable: bool):
   if cacheable:
     for ty in parameter_types:
-      if getattr(ty, "side_effecting", False):
-        raise ValueError(f"Non-console `@rule` {func_id} has a side-effecting parameter: {ty}")
+      if getattr(ty, "uncacheable", False):
+        raise ValueError(f"Non-console `@rule` {func_id} has an uncacheable parameter: {ty}")
 
 
 def inner_rule(*args, **kwargs) -> Callable:

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -13,6 +13,7 @@ from pants.engine.build_files import AddressProvenanceMap
 from pants.engine.console import Console
 from pants.engine.fs import Digest
 from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.objects import union
@@ -54,8 +55,8 @@ class TestResult:
 
 
 @dataclass(frozen=True)
-class TestDebugResult:
-  exit_code: int
+class TestDebugRequest:
+  ipr: InteractiveProcessRequest
 
 
 @union
@@ -119,17 +120,19 @@ class AddressAndTestResult:
 
 
 @dataclass(frozen=True)
-class AddressAndDebugResult:
+class AddressAndDebugRequest:
   address: BuildFileAddress
-  test_result: TestDebugResult
+  request: TestDebugRequest
 
 
 @goal_rule
-async def run_tests(console: Console, options: TestOptions, addresses: BuildFileAddresses) -> Test:
+async def run_tests(console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses) -> Test:
   if options.values.debug:
     address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
-    result = await Get[AddressAndDebugResult](Address, address.to_address())
-    return Test(result.test_result.exit_code)
+    addr_debug_request = await Get[AddressAndDebugRequest](Address, address.to_address())
+    result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
+    return Test(result.process_exit_code)
+
   results = await MultiGet(Get[AddressAndTestResult](Address, addr.to_address()) for addr in addresses)
   did_any_fail = False
   filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
@@ -186,10 +189,10 @@ async def coordinator_of_tests(
 
 
 @rule
-async def coordinator_of_debug_tests(target: HydratedTarget) -> AddressAndDebugResult:
+async def coordinator_of_debug_tests(target: HydratedTarget) -> AddressAndDebugRequest:
   logger.info(f"Starting tests in debug mode: {target.address.reference()}")
-  result = await Get[TestDebugResult](TestTarget, target.adaptor)
-  return AddressAndDebugResult(target.address, result)
+  request = await Get[TestDebugRequest](TestTarget, target.adaptor)
+  return AddressAndDebugRequest(target.address, request)
 
 
 def rules():

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -87,7 +87,7 @@ async def a_goal_rule_generator(console: Console) -> Example:
 
 
 class RuleTest(TestBase):
-  def test_run_rule_console_rule_generator(self):
+  def test_run_rule_goal_rule_generator(self):
     res = run_rule(
       a_goal_rule_generator,
       rule_args=[Console()],
@@ -95,8 +95,8 @@ class RuleTest(TestBase):
     )
     self.assertEquals(res, Example(0))
 
-  def test_uncacheable_inputs(self) -> None:
-    @console_rule
+  def test_side_effecting_inputs(self) -> None:
+    @goal_rule
     def valid_rule(console: Console, b: str) -> Example:
       return Example(exit_code=0)
 
@@ -106,7 +106,7 @@ class RuleTest(TestBase):
         return False
 
     error_str = str(cm.exception)
-    assert "invalid_rule has an uncacheable parameter" in error_str
+    assert "invalid_rule has a side-effecting parameter" in error_str
     assert "pants.engine.console.Console" in error_str
 
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -86,14 +86,28 @@ async def a_goal_rule_generator(console: Console) -> Example:
   return Example(exit_code=0)
 
 
-class RuleTest(unittest.TestCase):
-  def test_run_rule_goal_rule_generator(self):
+class RuleTest(TestBase):
+  def test_run_rule_console_rule_generator(self):
     res = run_rule(
       a_goal_rule_generator,
       rule_args=[Console()],
       mock_gets=[MockGet(product_type=A, subject_type=str, mock=lambda _: A())],
     )
     self.assertEquals(res, Example(0))
+
+  def test_side_effecting_inputs(self) -> None:
+    @console_rule
+    def valid_rule(console: Console, b: str) -> Example:
+      return Example(exit_code=0)
+
+    with self.assertRaises(ValueError) as cm:
+      @rule
+      def invalid_rule(console: Console, b: str) -> bool:
+        return False
+
+    error_str = str(cm.exception)
+    assert "invalid_rule has a side-effecting parameter" in error_str
+    assert "pants.engine.console.Console" in error_str
 
 
 class RuleIndexTest(TestBase):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -95,7 +95,7 @@ class RuleTest(TestBase):
     )
     self.assertEquals(res, Example(0))
 
-  def test_side_effecting_inputs(self) -> None:
+  def test_uncacheable_inputs(self) -> None:
     @console_rule
     def valid_rule(console: Console, b: str) -> Example:
       return Example(exit_code=0)
@@ -106,7 +106,7 @@ class RuleTest(TestBase):
         return False
 
     error_str = str(cm.exception)
-    assert "invalid_rule has a side-effecting parameter" in error_str
+    assert "invalid_rule has an uncacheable parameter" in error_str
     assert "pants.engine.console.Console" in error_str
 
 


### PR DESCRIPTION
### Problem

Pants occasionally needs to perform some side-effecting operation that do not work well with the normal caching semantics provided by `@rule`s. For instance, writing build artifacts to disk, or running a binary locally and interactively.

Over the course of discussing how to go about implementing these kinds of side-effecting operations, we've created a pattern: create a new python type that implements one of these side-effecting operations, and request it as the input to a `@goal_rule`. Right now, `@goal_rule`s are top-level rules associated with a pants goal that also have the property of being marked as non-cacheable, so it is okay for side-effecting behavior to happen in this subset of rules.

### Solution

This commit formalizes the notion of an side-effecting rule input type by giving the category a name - "side-effecting" - and establishing a check at rule registration time that only non-cacheable `@rule`s are trying to request these types. Right now, the only type of `@rule` that is non-cacheable is a rule declared as a `@goal_rule`, but this might change in the future (and would require a corresponding update to the logic of this check).