### PR TITLE
Simplify `./pants test --debug` requesting one single address

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -16,7 +16,6 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.file_system_project_tree import FileSystemProjectTree
-from pants.base.specs import AddressSpecs
 from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -54,7 +53,7 @@ from pants.engine.parser import SymbolTable
 from pants.engine.platform import create_platform_rules
 from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.scheduler import Scheduler, SchedulerSession
-from pants.engine.selectors import Get, Params
+from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import (
   DEFAULT_EXECUTION_OPTIONS,
@@ -383,13 +382,13 @@ class EngineInitializer:
       return cast(BuildRoot, BuildRoot.instance)
 
     @rule
-    async def single_build_file_address(address_specs: AddressSpecs) -> BuildFileAddress:
-      build_file_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
+    async def single_build_file_address(
+      build_file_addresses: BuildFileAddresses,
+    ) -> BuildFileAddress:
       if len(build_file_addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
       if len(build_file_addresses.dependencies) > 1:
-        potential_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
-        targets = [bfa.to_address() for bfa in potential_addresses]
+        targets = [bfa.to_address() for bfa in build_file_addresses]
         output = '\n '.join(str(target) for target in targets)
 
         raise ResolveError(

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
-from pants.base.specs import AddressSpecs, SingleAddress
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import AddressProvenanceMap
@@ -67,8 +66,7 @@ class AddressAndDebugResult:
 @console_rule
 async def run_tests(console: Console, options: TestOptions, addresses: BuildFileAddresses) -> Test:
   if options.values.debug:
-    dependencies = tuple(SingleAddress(addr.spec_path, addr.target_name) for addr in addresses)
-    address = await Get[BuildFileAddress](AddressSpecs(dependencies=dependencies))
+    address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
     result = await Get[AddressAndDebugResult](Address, address.to_address())
     return Test(result.test_result.exit_code)
 

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 from pants.base.specs import AddressSpec, AddressSpecs, DescendantAddresses, SingleAddress
 from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import AddressProvenanceMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Snapshot
 from pants.engine.legacy.graph import HydratedTarget
@@ -37,7 +38,7 @@ class TestTest(TestBase):
     addr = self.make_build_target_address("some/target")
     res = run_rule(
       run_tests,
-      rule_args=[console, options, (addr,)],
+      rule_args=[console, options, BuildFileAddresses([addr])],
       mock_gets=[
         MockGet(
           product_type=AddressAndTestResult,
@@ -51,12 +52,8 @@ class TestTest(TestBase):
         ),
         MockGet(
           product_type=BuildFileAddress,
-          subject_type=AddressSpecs,
-          mock=lambda _: BuildFileAddress(
-            build_file=None,
-            target_name=addr.target_name,
-            rel_path=f'{addr.spec_path}/BUILD'
-          )
+          subject_type=BuildFileAddresses,
+          mock=lambda bfas: bfas.dependencies[0],
         ),
       ],
     )


### PR DESCRIPTION
Because the rule to get one single `BuildFileAddress` took `AddressSpecs` as its subject, we needed a little extra ceremony in `rules/core/test.py` to get a single `BuildFileAddress`. 

This was unnecessary, though. The rule `single_build_file_address` only ever needs `BuildFileAddresses` and never the additional information from `AddressSpecs`. Making the change to the rule signature allows us to thus simply pass `BuildFileAddresses` as the subject in `test.py`.