### PR TITLE
Change distribution lookup for JvmTask subclasses to call into JvmTask

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -68,7 +68,7 @@ class JvmPlatform(Subsystem):
                                name=name)
 
   @classmethod
-  def preferred_jvm_distribution(cls, platforms, strict=False):
+  def preferred_jvm_distribution(cls, platforms, strict=False, jdk=False):
     """Returns a jvm Distribution with a version that should work for all the platforms.
 
     Any one of those distributions whose version is >= all requested platforms' versions
@@ -78,13 +78,17 @@ class JvmPlatform(Subsystem):
     :param bool strict: If true, only distribution whose version matches the minimum
       required version can be returned, i.e, the max target_level of all the requested
       platforms.
+    :param bool jdk: If true, the distribution must be a JDK.
     :returns: Distribution one of the selected distributions.
     """
     if not platforms:
-      return DistributionLocator.cached()
+      return DistributionLocator.cached(jdk=jdk)
     min_version = max(platform.target_level for platform in platforms)
     max_version = Revision(*(min_version.components + [9999])) if strict else None
-    return DistributionLocator.cached(minimum_version=min_version, maximum_version=max_version)
+    return DistributionLocator.cached(
+      minimum_version=min_version,
+      maximum_version=max_version,
+      jdk=jdk)
 
   @memoized_property
   def platforms_by_name(self):

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -87,7 +87,7 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
     # Collect a transitive classpath for the benchmark targets.
     classpath = self.classpath(targets, benchmark_tools_classpath)
 
-    java_executor = SubprocessExecutor(DistributionLocator.cached())
+    java_executor = SubprocessExecutor(self.preferred_jvm_distribution_for_targets(targets))
     exit_code = execute_java(classpath=classpath,
                              main=self._CALIPER_MAIN,
                              jvm_options=self.jvm_options,

--- a/src/python/pants/backend/jvm/tasks/javadoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/javadoc_gen.py
@@ -38,7 +38,7 @@ class JavadocGen(JvmdocGen):
       return None
 
     # Without a JDK/tools.jar we have no javadoc tool and cannot proceed, so check/acquire early.
-    jdk = DistributionLocator.cached(jdk=True)
+    jdk = self.preferred_jvm_distribution_for_targets(targets, jdk=True)
     tool_classpath = jdk.find_libs(['tools.jar'])
 
     args = ['-quiet',

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -77,9 +77,9 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                   'If cwd is set on a target, it will supersede this option. It is an error to '
                   'use this option in combination with `--chroot`')
     register('--strict-jvm-version', type=bool, advanced=True, fingerprint=True,
-      help='If true, will strictly require running jvms with the same version of Java as '
-           'the platform -target level. Otherwise, the platform -target level will be '
-           'treated as the minimum jvm to run.')
+             help='If true, will strictly require running junits with the same version of java as '
+                  'the platform -target level. Otherwise, the platform -target level will be '
+                  'treated as the minimum jvm to run.')
     register('--failure-summary', type=bool, default=True,
              help='If true, includes a summary of which test-cases failed at the end of a failed '
                   'junit run.')

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -9,7 +9,6 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.fs.fs import expand_path
-from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import CommandLineGrabber
 from pants.util.dirutil import safe_open
 
@@ -37,10 +36,6 @@ class JvmRun(JvmTask):
              help='Set the working directory. If no argument is passed, use the target path.')
     register('--main', metavar='<main class>',
              help='Invoke this class (overrides "main"" attribute in jvm_binary targets)')
-
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super().subsystem_dependencies() + (DistributionLocator,)
 
   @classmethod
   def supports_passthru_args(cls):
@@ -87,7 +82,7 @@ class JvmRun(JvmTask):
     # python_binary, in which case we have to no-op and let python_run do its thing.
     # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
     if isinstance(binary, JvmBinary):
-      jvm = DistributionLocator.cached()
+      jvm = self.preferred_jvm_distribution_for_targets([binary])
       executor = CommandLineGrabber(jvm) if self.only_write_cmd_line else None
       self.context.release_lock()
       with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -33,10 +33,6 @@ class JvmTask(Task):
     super().register_options(register)
     register('--confs', type=list, default=['default'],
              help='Use only these Ivy configurations of external deps.')
-    register('--strict-jvm-version', type=bool, advanced=True, fingerprint=True,
-         help='If true, will strictly require running jvms with the same version of Java as '
-              'the platform -target level. Otherwise, the platform -target level will be '
-              'treated as the minimum jvm to run.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -49,7 +45,6 @@ class JvmTask(Task):
     self.args = self.jvm.get_program_args()
     self.confs = self.get_options().confs
     self.synthetic_classpath = self.jvm.get_options().synthetic_classpath
-    self._strict_jvm_version = self.get_options().strict_jvm_version
 
   def classpath(self, targets, classpath_prefix=None, classpath_product=None, exclude_scopes=None,
                 include_scopes=None):
@@ -77,13 +72,13 @@ class JvmTask(Task):
     classpath.extend(classpath_for_targets)
     return classpath
 
-  def preferred_jvm_distribution_for_targets(self, targets, jdk=False):
+  def preferred_jvm_distribution_for_targets(self, targets, jdk=False, strict=False):
     """Find the preferred jvm distribution for running code from the given targets."""
     return self.preferred_jvm_distribution(self._jvm_platforms_from_targets(targets),
-                                           jdk=jdk)
+                                           jdk=jdk, strict=strict)
 
-  def preferred_jvm_distribution(self, platforms, jdk=False):
-    return JvmPlatform.preferred_jvm_distribution(platforms, self._strict_jvm_version, jdk=jdk)
+  def preferred_jvm_distribution(self, platforms, jdk=False, strict=False):
+    return JvmPlatform.preferred_jvm_distribution(platforms, jdk=jdk, strict=strict)
 
   def _jvm_platforms_from_targets(self, targets):
     # Override this to change platform lookup.

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -3,16 +3,15 @@
 
 from typing import Optional
 
-from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
+from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.java.executor import SubprocessExecutor
-from pants.task.task import Task
 
 
-class RunJvmPrepCommandBase(Task):
+class RunJvmPrepCommandBase(JvmTask):
   """Base class to enable running JVM binaries before executing a goal.
 
   This command will use the 'runtime_classpath' product and compile dependent JVM code
@@ -50,7 +49,6 @@ class RunJvmPrepCommandBase(Task):
     """
     :API: public
     """
-    super().prepare(options, round_manager)
     round_manager.require_data('compile_classpath')
     if not cls.classpath_product_only:
       round_manager.require_data('runtime_classpath')
@@ -71,7 +69,7 @@ class RunJvmPrepCommandBase(Task):
 
     with self.context.new_workunit(name='jvm_prep_command', labels=[WorkUnitLabel.PREP]) as workunit:
       for target in targets:
-        distribution = JvmPlatform.preferred_jvm_distribution([target.platform])
+        distribution = self.preferred_jvm_distribution_for_targets([target])
         executor = SubprocessExecutor(distribution)
 
         mainclass = target.payload.get_field_value('mainclass')

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -3,15 +3,16 @@
 
 from typing import Optional
 
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
-from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.java.executor import SubprocessExecutor
+from pants.task.task import Task
 
 
-class RunJvmPrepCommandBase(JvmTask):
+class RunJvmPrepCommandBase(Task):
   """Base class to enable running JVM binaries before executing a goal.
 
   This command will use the 'runtime_classpath' product and compile dependent JVM code
@@ -49,6 +50,7 @@ class RunJvmPrepCommandBase(JvmTask):
     """
     :API: public
     """
+    super().prepare(options, round_manager)
     round_manager.require_data('compile_classpath')
     if not cls.classpath_product_only:
       round_manager.require_data('runtime_classpath')
@@ -69,7 +71,7 @@ class RunJvmPrepCommandBase(JvmTask):
 
     with self.context.new_workunit(name='jvm_prep_command', labels=[WorkUnitLabel.PREP]) as workunit:
       for target in targets:
-        distribution = self.preferred_jvm_distribution_for_targets([target])
+        distribution = JvmPlatform.preferred_jvm_distribution([target.platform])
         executor = SubprocessExecutor(distribution)
 
         mainclass = target.payload.get_field_value('mainclass')

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -42,9 +42,10 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
     repl_name = ScalaPlatform.global_instance().repl
     return (self.tool_classpath('pants-runner') +
             self.tool_classpath(repl_name, scope=ScalaPlatform.options_scope) +
-            self.classpath(targets))
+            self.classpath(targets),
+            self.preferred_jvm_distribution_for_targets(targets))
 
-  def launch_repl(self, classpath):
+  def launch_repl(self, classpath, distribution):
     # The scala repl requires -Dscala.usejavacp=true since Scala 2.8 when launching in the way
     # we do here (not passing -classpath as a program arg to scala.tools.nsc.MainGenericRunner).
     jvm_options = self.jvm_options
@@ -55,9 +56,9 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
     #
     # NOTE: Using PantsRunner class because the classLoader used by REPL
     # does not load Class-Path from manifest.
-    DistributionLocator.cached().execute_java(classpath=classpath,
-                                              main=ScalaRepl._RUNNER_MAIN,
-                                              jvm_options=jvm_options,
-                                              args=[self.get_options().main] + self.args,
-                                              create_synthetic_jar=True,
-                                              stdin=sys.stdin)
+    distribution.execute_java(classpath=classpath,
+                              main=ScalaRepl._RUNNER_MAIN,
+                              jvm_options=jvm_options,
+                              args=[self.get_options().main] + self.args,
+                              create_synthetic_jar=True,
+                              stdin=sys.stdin)

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -45,9 +45,10 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
             self.classpath(targets),
             self.preferred_jvm_distribution_for_targets(targets))
 
-  def launch_repl(self, classpath, distribution):
+  def launch_repl(self, session_setup):
     # The scala repl requires -Dscala.usejavacp=true since Scala 2.8 when launching in the way
     # we do here (not passing -classpath as a program arg to scala.tools.nsc.MainGenericRunner).
+    classpath, distribution = session_setup
     jvm_options = self.jvm_options
     if not any(opt.startswith('-Dscala.usejavacp=') for opt in jvm_options):
       jvm_options.append('-Dscala.usejavacp=true')

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -57,7 +57,7 @@ class ScaladocGen(JvmdocGen):
 
     args.extend(sources)
 
-    java_executor = SubprocessExecutor(DistributionLocator.cached())
+    java_executor = SubprocessExecutor(self.preferred_jvm_distribution_for_targets(targets))
     runner = java_executor.runner(jvm_options=self.jvm_options,
                                   classpath=tool_classpath,
                                   main='scala.tools.nsc.ScalaDoc',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import unittest.mock
 
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform, JvmPlatformSettings
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.testutil.jvm.jvm_task_test_base import JvmTaskTestBase
@@ -46,3 +49,28 @@ class JvmTaskTest(JvmTaskTestBase):
 
   def test_classpath_custom_product(self):
     self.assertEqual([], self.task.classpath([self.t1], classpath_product=ClasspathProducts(self.pants_workdir)))
+
+  def test_distribution_from_jvm_platform_passed_through(self):
+    fake_dist = "a dist"
+    platforms = [JvmPlatformSettings('8', '8', [])]
+    with unittest.mock.patch.object(JvmPlatform, 'preferred_jvm_distribution') as plat_mock:
+      plat_mock.return_value = fake_dist
+      dist = self.task.preferred_jvm_distribution(platforms)
+
+      plat_mock.assert_called_once()
+      self.assertEqual(fake_dist, dist)
+
+  def test_distribution_from_targets_passes_through_platforms(self):
+    fake_dist = "a dist"
+    java8_platform = JvmPlatformSettings('8', '8', [])
+    targets = [self.make_target('platformed_target', JvmTarget, platform='java8')]
+    with unittest.mock.patch.object(JvmPlatform, 'preferred_jvm_distribution') as plat_mock:
+      with unittest.mock.patch.object(JvmPlatform.global_instance(), 'get_platform_for_target') as \
+        target_plat_mock:
+        target_plat_mock.return_value = java8_platform
+
+        plat_mock.return_value = fake_dist
+        dist = self.task.preferred_jvm_distribution_for_targets(targets)
+
+        plat_mock.assert_called_once_with([java8_platform], False, jdk=False)
+        self.assertEqual(fake_dist, dist)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
@@ -72,5 +72,5 @@ class JvmTaskTest(JvmTaskTestBase):
         plat_mock.return_value = fake_dist
         dist = self.task.preferred_jvm_distribution_for_targets(targets)
 
-        plat_mock.assert_called_once_with([java8_platform], False, jdk=False)
+        plat_mock.assert_called_once_with([java8_platform], strict=False, jdk=False)
         self.assertEqual(fake_dist, dist)


### PR DESCRIPTION
### Problem
A number of tasks ought to use JVM versions based on what a target requires via it's kwargs. Compile and test tasks both explicitly use target declared JVM platforms, but there are a number of other tasks that should depend on them as well. Compile is a special case and wasn't modified here.

I'm working on making it possible to declare runtime platforms separately from compile platforms so that you can, for example, migrate the runtime version separately from the compile version of the JDK.

### Solution

This patch consolidates the platform lookups for JvmTask subclasses so that platform lookups all happen through one set of code paths. This makes it a lot simpler to introduce a new concept of a `runtime_platform` to JVM targets.

Specifically it does the following
    - Change all DistributionLocator usages in JvmTask subclasses with calls into preferred_jvm_distribution_for_targets
    - Add a cut out so that junit_run can use test_platform
    - Pass JDK through to JvmPlatform calls so that javadoc can be covered, though javadoc invokes won't work with version of the JDK > 8 (#8937)

### Result

JvmTasks use a JVM that matches the platform declared on targets, and all of them use a common code path to look up those platforms.
