### PR TITLE
Stop using hacky `ExecuteProcessRequest` to inject missing __init__.py files

### DIFF
--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -4,8 +4,7 @@
 from dataclasses import dataclass
 
 from pants.backend.python.subsystems.pex_build_util import identify_missing_init_files
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, Snapshot
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, Snapshot, InputFilesContent, FileContent
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
 
@@ -21,24 +20,14 @@ async def inject_init(snapshot: Snapshot) -> InjectedInitDigest:
   """Ensure that every package has an __init__.py file in it."""
   missing_init_files = tuple(sorted(identify_missing_init_files(snapshot.files)))
   if not missing_init_files:
-    new_init_files_digest = EMPTY_DIRECTORY_DIGEST
-  else:
-    # TODO(7718): add a builtin rule for FilesContent->Snapshot, so that we can avoid using touch
-    # and the absolute path and have the engine build the files for us.
-    touch_init_request = ExecuteProcessRequest(
-      argv=("/usr/bin/touch",) + missing_init_files,
-      output_files=missing_init_files,
-      description="Inject missing __init__.py files: {}".format(", ".join(missing_init_files)),
-      input_files=snapshot.directory_digest,
-    )
-    touch_init_result = await Get[ExecuteProcessResult](ExecuteProcessRequest, touch_init_request)
-    new_init_files_digest = touch_init_result.output_directory_digest
-  # TODO(#7710): Once this gets fixed, merge the original source digest and the new init digest
-  # into one unified digest.
-  return InjectedInitDigest(directory_digest=new_init_files_digest)
+    return InjectedInitDigest(EMPTY_DIRECTORY_DIGEST)
+  digest = await Get[Digest](
+    InputFilesContent([FileContent(path=fp, content=b"") for fp in missing_init_files])
+  )
+  return InjectedInitDigest(digest)
 
 
 def rules():
   return [
-      inject_init,
-    ]
+    inject_init,
+  ]

--- a/src/python/pants/backend/python/rules/inject_init_test.py
+++ b/src/python/pants/backend/python/rules/inject_init_test.py
@@ -7,15 +7,15 @@ from pants.engine.rules import RootRule
 from pants.testutil.test_base import TestBase
 
 
-class TestInjectInit(TestBase):
+class InjectIniTest(TestBase):
 
   @classmethod
   def rules(cls):
     return super().rules() + [inject_init, RootRule(Snapshot)]
 
-  def assert_result(self, input_snapshot, expected_digest):
+  def assert_result(self, *, input_snapshot, expected_digest):
     injected_digest = self.request_single_product(InjectedInitDigest, input_snapshot)
-    self.assertEqual(injected_digest.directory_digest, expected_digest)
+    assert injected_digest.directory_digest == expected_digest
 
   def test_noops_when_empty_snapshot(self):
     self.assert_result(input_snapshot=EMPTY_SNAPSHOT, expected_digest=EMPTY_DIRECTORY_DIGEST)


### PR DESCRIPTION
Beyond readability, this improves caching and performance.