### PR TITLE
ipex in v2

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -7,6 +7,7 @@ from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
     download_pex_bin,
     inject_init,
+    ipex,
     pex,
     pex_from_target_closure,
     prepare_chrooted_python_sources,
@@ -110,6 +111,7 @@ def rules():
     return (
         *download_pex_bin.rules(),
         *inject_init.rules(),
+        *ipex.rules(),
         *prepare_chrooted_python_sources.rules(),
         *pex.rules(),
         *pex_from_target_closure.rules(),

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -21,6 +21,7 @@ python_library(
     'src/python/pants/rules/core',
     'src/python/pants/source:source',
     'src/python/pants/util:logging',
+    'src/python/pants/util:pkg_util',
   ],
   tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/python/rules/ipex.py
+++ b/src/python/pants/backend/python/rules/ipex.py
@@ -1,0 +1,138 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import dataclasses
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from pex.pex_info import PexInfo
+from pex.version import __version__ as pex_version
+
+import pants.backend.python.subsystems.pex_bootstrap
+from pants.backend.python.rules.pex import CreatePex, Pex, PexRequirements
+from pants.backend.python.subsystems.pex_bootstrap._ipex_launcher import APP_CODE_PREFIX
+from pants.backend.python.subsystems.python_repos import PythonRepos
+from pants.engine.fs import (
+    EMPTY_DIRECTORY_DIGEST,
+    Digest,
+    DirectoriesToMerge,
+    DirectoryWithPrefixToAdd,
+    FileContent,
+    InputFilesContent,
+    Snapshot,
+)
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.rules import RootRule, rule, subsystem_rule
+from pants.engine.selectors import Get
+from pants.util.pkg_util import get_resource_bytes
+
+
+@dataclass(frozen=True)
+class IpexRequest:
+    underlying_request: CreatePex
+
+
+@rule
+async def create_ipex(request: IpexRequest, python_repos: PythonRepos) -> Pex:
+    # 1. Create the original pex as-is *without* input files, in order to get the
+    #    transitively-resolved requirements from its PEX-INFO.
+    orig_request = request.underlying_request
+
+    # Removing the entry point and input files digest means this process execution will be cached even
+    # if the source files change! This is useful because resolving large deps such as tensorflow can
+    # take multiple minutes when uncached.
+    requirements_only_request = dataclasses.replace(
+        orig_request,
+        entry_point=None,
+        input_files_digest=None,
+    )
+    requirements_only_pex = await Get[Pex](CreatePex, requirements_only_request)
+
+    # 2. Extract its requirements.
+    requirements_only_unzipped_info = await Get[ExecuteProcessResult](ExecuteProcessRequest(
+        # TODO: make a "hacky local execute process request" type which automatically adds the PATH to
+        # the subprocess `env`!
+        argv=('unzip', '-p', requirements_only_pex.output_filename, 'PEX-INFO',),
+        env={'PATH': os.environ['PATH']},
+        input_files=requirements_only_pex.directory_digest,
+        description=f'Unzip {requirements_only_pex.output_filename} to extract its PEX-INFO!',
+    ))
+
+    # 3. Add the original source files in a subdirectory.
+    subdir_sources = await Get[Snapshot](DirectoryWithPrefixToAdd(
+        directory_digest=(orig_request.input_files_digest or EMPTY_DIRECTORY_DIGEST),
+        prefix=APP_CODE_PREFIX))
+
+    # 4. Create IPEX-INFO, BOOTSTRAP-PEX-INFO, and ipex.py.
+
+    # IPEX-INFO: A json mapping interpreted in _ipex_launcher.py:
+    # {
+    #   "code": [<which source files to add to the "hydrated" pex when bootstrapped>],
+    #   "resolver_settings": {<which indices to search for requirements from when bootstrapping>},
+    # }
+    resolver_settings = dict(
+        indexes=list(python_repos.indexes),
+        # TODO: get self._all_find_links!!!
+        find_links=[],
+    )
+    prefixed_code_paths = subdir_sources.files
+    ipex_info = dict(
+        code=prefixed_code_paths,
+        resolver_settings=resolver_settings,
+    )
+    ipex_info_file = FileContent(
+        path='IPEX-INFO',
+        content=json.dumps(ipex_info).encode(),
+    )
+
+    # BOOTSTRAP-PEX-INFO: The original PEX-INFO, which should be the PEX-INFO in the hydrated .pex
+    #                     file that is generated when the .ipex is first executed.
+    requirements_only_pex_info = PexInfo.from_json(requirements_only_unzipped_info.stdout)
+    requirements_only_pex_info.entry_point = orig_request.entry_point
+    bootstrap_pex_info_file = FileContent(
+        path='BOOTSTRAP-PEX-INFO',
+        content=requirements_only_pex_info.dump().encode(),
+    )
+
+    # ipex.py: The special bootstrap script to hydrate the .ipex with the fully resolved
+    #          requirements when it is first executed.
+    ipex_launcher_file = FileContent(
+        path='ipex.py',
+        content=get_resource_bytes(pants.backend.python.subsystems.pex_bootstrap,
+                                                             Path('_ipex_launcher.py')),
+    )
+
+    # 5. Merge all the new injected files, along with the subdirectory of source files, into the new
+    # CreatePex input.
+    injected_files = await Get[Digest](InputFilesContent([
+        ipex_info_file,
+        bootstrap_pex_info_file,
+        ipex_launcher_file,
+    ]))
+    merged_input_files = await Get[Digest](DirectoriesToMerge((
+        subdir_sources.directory_digest,
+        injected_files,
+    )))
+
+    # The PEX-INFO we generate shouldn't have any requirements (except pex itself), or they will
+    # fail to bootstrap because they were unable to find those distributions. Instead, the .pex file
+    # produced when the .ipex is first executed will read and resolve all those requirements from
+    # the BOOTSTRAP-PEX-INFO.
+    modified_request = dataclasses.replace(
+        orig_request,
+        requirements=PexRequirements((f'pex=={pex_version}',)),
+        entry_point='ipex',
+        input_files_digest=merged_input_files,
+    )
+
+    return await Get[Pex](CreatePex, modified_request)
+
+
+def rules():
+    return [
+        RootRule(IpexRequest),
+        subsystem_rule(PythonRepos),
+        create_ipex,
+    ]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -29,6 +29,7 @@ from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
@@ -221,6 +222,7 @@ class PexDebug:
 async def create_pex(
     request: CreatePex,
     pex_bin: DownloadedPexBin,
+    python_repos: PythonRepos,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
     pex_build_environment: PexBuildEnvironment,
@@ -239,6 +241,12 @@ async def create_pex(
 
     pex_debug = PexDebug(log_level)
     argv.extend(pex_debug.iter_pex_args())
+
+    argv.extend([
+        '--no-pypi',
+        *(f'--index={url}' for url in python_repos.indexes),
+        *(f'--find-links={url}' for url in python_repos.repos),
+    ])
 
     if python_setup.resolver_jobs:
         argv.extend(["--jobs", python_setup.resolver_jobs])

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from pants.backend.python.rules.ipex import IpexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -37,7 +36,7 @@ class CreatePexFromTargetClosure:
 @rule(name="Create PEX from targets")
 async def create_pex_from_target_closure(
     request: CreatePexFromTargetClosure, python_setup: PythonSetup
-) -> Pex:
+) -> CreatePex:
     transitive_hydrated_targets = await Get[TransitiveHydratedTargets](Addresses, request.addresses)
     all_targets = transitive_hydrated_targets.closure
 
@@ -66,7 +65,7 @@ async def create_pex_from_target_closure(
         adaptors=all_target_adaptors, additional_requirements=request.additional_requirements
     )
 
-    create_pex_request = CreatePex(
+    return CreatePex(
         output_filename=request.output_filename,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
@@ -74,12 +73,6 @@ async def create_pex_from_target_closure(
         input_files_digest=merged_input_digest,
         additional_args=request.additional_args,
     )
-
-  if request.generate_ipex:
-    pex = await Get[Pex](IpexRequest(create_pex_request))
-  else:
-    pex = await Get[Pex](CreatePex, create_pex_request)
-  return pex
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from pants.backend.python.rules.ipex import IpexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -74,8 +75,11 @@ async def create_pex_from_target_closure(
         additional_args=request.additional_args,
     )
 
+  if request.generate_ipex:
+    pex = await Get[Pex](IpexRequest(create_pex_request))
+  else:
     pex = await Get[Pex](CreatePex, create_pex_request)
-    return pex
+  return pex
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -2,19 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
 
-from pants.backend.python.rules.pex import Pex
+from pants.backend.python.rules.ipex import IpexRequest, IpexResult
+from pants.backend.python.rules.pex import CreatePex, Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.rules.targets import EntryPoint, PythonBinarySources
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
-from pants.engine.rules import UnionRule, rule
+from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.engine.target import Target
 from pants.rules.core.binary import BinaryImplementation, CreatedBinary
 from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.subsystem.subsystem import Subsystem
 
 
 @dataclass(frozen=True)
@@ -35,8 +37,29 @@ class PythonBinaryImplementation(BinaryImplementation):
         return cls(tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint])
 
 
+class PexCreationOptions(Subsystem):
+    options_scope = 'pex-creation'
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register('--generate-ipex', type=bool, default=False, fingerprint=True,
+                 help='Whether to generate a .ipex file, which will "hydrate" its dependencies '
+                      'when it is executed, rather than at build time (the normal pex behavior). '
+                      'This option can reduce the size of a shipped pex file by over 100x for '
+                      'common deps such as tensorflow, but it does require access to a pypi-esque '
+                      'index when executed.')
+
+    @property
+    def generate_ipex(self) -> bool:
+        return cast(bool, self.get_options().generate_ipex)
+
+
 @rule
-async def create_python_binary(implementation: PythonBinaryImplementation) -> CreatedBinary:
+async def create_python_binary(
+    options: PexCreationOptions,
+    implementation: PythonBinaryImplementation,
+) -> CreatedBinary:
     entry_point: Optional[str]
     if implementation.entry_point.value is not None:
         entry_point = implementation.entry_point.value
@@ -51,15 +74,22 @@ async def create_python_binary(implementation: PythonBinaryImplementation) -> Cr
         else:
             entry_point = None
 
-    request = CreatePexFromTargetClosure(
+    request = await Get[CreatePex](CreatePexFromTargetClosure(
         addresses=Addresses([implementation.address]),
         entry_point=entry_point,
         output_filename=f"{implementation.address.target_name}.pex",
-    )
+    ))
+    if options.generate_ipex:
+        request = ((await Get[IpexResult](IpexRequest(request)))
+                   .underlying_request)
 
-    pex = await Get[Pex](CreatePexFromTargetClosure, request)
+    pex = await Get[Pex](CreatePex, request)
     return CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
 
 
 def rules():
-    return [create_python_binary, UnionRule(BinaryImplementation, PythonBinaryImplementation)]
+    return [
+        subsystem_rule(PexCreationOptions),
+        create_python_binary,
+        UnionRule(BinaryImplementation, PythonBinaryImplementation),
+    ]

--- a/src/python/pants/backend/python/subsystems/ipex/BUILD
+++ b/src/python/pants/backend/python/subsystems/ipex/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# NB: This target is written into an .ipex file as the main script, and should not have any
+# NB: This target is written into a .ipex file as the main script, and should not have any
 # dependencies on another python code! .ipex files should always contain pex and setuptools
 # requirements in order to run the main script!
 python_library()


### PR DESCRIPTION
### Problem

The PR is based on top of #8793. This PR recreates the same feature set, but using v2 rules. One benefit of this is that it avoids the need for complex manual caching logic such as in #8800.

### Solution

- Create a set of v2 rules in `ipex.py` which can create a `Pex` from an `IpexRequest`.
- Add the `PexCreationOptions` subsystem to cover the `--generate-ipex` flag.
- Rework the integration test to use v2 python binary now.