### PR TITLE
Rename `@console_rule` to `@goal_rule`

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -4,7 +4,7 @@
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 
 
 class ListAndDieForTestingOptions(GoalSubsystem):
@@ -16,7 +16,7 @@ class ListAndDieForTesting(Goal):
   subsystem_cls = ListAndDieForTestingOptions
 
 
-@console_rule
+@goal_rule
 def fast_list_and_die_for_testing(
   console: Console, addresses: BuildFileAddresses
 ) -> ListAndDieForTesting:

--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -10,7 +10,7 @@ from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, 
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.objects import union
-from pants.engine.rules import console_rule, rule
+from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.distdir import DistDir
 
@@ -39,7 +39,7 @@ class AWSLambdaGoal(Goal):
   subsystem_cls = AWSLambdaOptions
 
 
-@console_rule
+@goal_rule
 async def create_awslambda(
     addresses: BuildFileAddresses,
     console: Console,

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -20,7 +20,7 @@ python_tests(
   name='tests',
   dependencies=[
     ':rules',
-    'src/python/pants/testutil:console_rule_test_base',
+    'src/python/pants/testutil:goal_rule_test_base',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -7,7 +7,7 @@ from pants.base.specs import AddressSpecs
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 
 
@@ -29,7 +29,7 @@ class DependenciesOptions(LineOriented, GoalSubsystem):
 class Dependencies(Goal):
   subsystem_cls = DependenciesOptions
 
-@console_rule
+@goal_rule
 async def dependencies(
   console: Console, address_specs: AddressSpecs, options: DependenciesOptions,
 ) -> Dependencies:

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -6,10 +6,10 @@ from typing import List, Optional
 from pants.backend.project_info.rules import dependencies
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class FastDependenciesTest(ConsoleRuleTestBase):
+class FastDependenciesTest(GoalRuleTestBase):
   goal_cls = dependencies.Dependencies
 
   @classmethod

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -13,7 +13,7 @@ from pants.engine.fs import Digest, FilesContent
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.objects import Collection
-from pants.engine.rules import console_rule, rule, subsystem_rule
+from pants.engine.rules import goal_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -217,7 +217,7 @@ class MultiMatcher:
 
 # TODO: Switch this to `lint` once we figure out a good way for v1 tasks and v2 rules
 # to share goal names.
-@console_rule
+@goal_rule
 async def validate(
   console: Console, hydrated_targets: HydratedTargets, validate_options: ValidateOptions
 ) -> Validate:

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -44,7 +44,7 @@ from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessR
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonBinaryAdaptor, PythonTargetAdaptor, ResourcesAdaptor
 from pants.engine.objects import Collection
-from pants.engine.rules import console_rule, rule, subsystem_rule
+from pants.engine.rules import goal_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import shell_str
 from pants.rules.core.distdir import DistDir
@@ -228,7 +228,7 @@ def validate_args(args: Tuple[str, ...]):
     raise InvalidSetupPyArgs('Cannot use the `upload` or `register` setup.py commands')
 
 
-@console_rule
+@goal_rule
 async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, console: Console,
                         provenance_map: AddressProvenanceMap,
                         distdir: DistDir, workspace: Workspace) -> SetupPy:

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -123,7 +123,7 @@ class GoalRunnerFactory:
 class GoalRunner:
   """Lists installed goals or else executes a named goal.
 
-  NB: GoalRunner represents a v1-only codepath. v2 goals are registered via `@console_rule` and
+  NB: GoalRunner represents a v1-only codepath. v2 goals are registered via `@goal_rule` and
   the `pants.engine.goal.Goal` class.
   """
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -283,18 +283,18 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     ).create().run()
 
   def _maybe_run_v2(self):
-    # N.B. For daemon runs, @console_rules are invoked pre-fork -
+    # N.B. For daemon runs, @goal_rules are invoked pre-fork -
     # so this path only serves the non-daemon run mode.
     if self._is_daemon:
       return PANTS_SUCCEEDED_EXIT_CODE
 
     _, ambiguous_goals, v2_goals = self._options.goals_by_version
     goals = v2_goals + (ambiguous_goals if self._global_options.v2 else tuple())
-    self._run_tracker.set_v2_console_rule_names(goals)
+    self._run_tracker.set_v2_goal_rule_names(goals)
     if not goals:
       return PANTS_SUCCEEDED_EXIT_CODE
 
-    return self._graph_session.run_console_rules(
+    return self._graph_session.run_goal_rules(
       self._options_bootstrapper,
       self._options,
       goals,

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -86,7 +86,7 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
 
 @dataclass(frozen=True)
 class Goal:
-  """The named product of a `@console_rule`.
+  """The named product of a `@goal_rule`.
 
   This class should be subclassed and linked to a corresponding `GoalSubsystem`:
 
@@ -99,8 +99,8 @@ class Goal:
     subsystem_cls = ListOptions
   ```
 
-  Since `@console_rules` always run in order to produce side effects (generally: console output),
-  they are not cacheable, and the `Goal` product of a `@console_rule` contains only a exit_code
+  Since `@goal_rules` always run in order to produce side effects (generally: console output),
+  they are not cacheable, and the `Goal` product of a `@goal_rule` contains only a exit_code
   value to indicate whether the rule exited cleanly.
   """
   exit_code: int

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -95,14 +95,9 @@ def _make_rule(
 
   has_goal_return_type = issubclass(return_type, Goal)
   if cacheable and has_goal_return_type:
-    raise TypeError(
-      'An `@rule` that returns a `Goal` must be declared with `@console_rule` in order to signal '
-      'that it is not cacheable.'
-    )
+    raise TypeError("An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`.")
   if not cacheable and not has_goal_return_type:
-    raise TypeError(
-      'An `@console_rule` must return a subclass of `engine.goal.Goal`.'
-    )
+    raise TypeError("An `@goal_rule` must return a subclass of `engine.goal.Goal`.")
   is_goal_cls = has_goal_return_type
 
   def wrapper(func):
@@ -145,7 +140,7 @@ def _make_rule(
       Get.create_statically_for_rule_graph(resolve_type(p), resolve_type(s))
       for p, s in rule_visitor.gets)
 
-    # Register dependencies for @console_rule/Goal.
+    # Register dependencies for @goal_rule/Goal.
     dependency_rules = (subsystem_rule(return_type.subsystem_cls),) if is_goal_cls else None
 
     # Set a default name for Goal classes if one is not explicitly provided
@@ -201,7 +196,7 @@ def _ensure_type_annotation(
 
 PUBLIC_RULE_DECORATOR_ARGUMENTS = {'name'}
 # We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
-# set it implicitly based on whether the rule annotation is @rule or @console_rule.
+# set it implicitly based on whether the rule annotation is @rule or @goal_rule.
 # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
 IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {'cacheable'}
 
@@ -215,7 +210,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
 
   if len(set(kwargs) - PUBLIC_RULE_DECORATOR_ARGUMENTS - IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS) != 0:
     raise UnrecognizedRuleArgument(
-      f"`@rule`s and `@console_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
+      f"`@rule`s and `@goal_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
     )
 
   func = args[0]
@@ -256,7 +251,7 @@ def rule(*args, **kwargs) -> Callable:
   return inner_rule(*args, **kwargs, cacheable=True)
 
 
-def console_rule(*args, **kwargs) -> Callable:
+def goal_rule(*args, **kwargs) -> Callable:
   return inner_rule(*args, **kwargs, cacheable=False)
 
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -456,7 +456,7 @@ class SchedulerSession:
         unique_exceptions
       )
 
-  def run_console_rule(self, product, subject):
+  def run_goal_rule(self, product, subject):
     """
     :param product: A Goal subtype.
     :param subject: subject for the request.

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -15,7 +15,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
-    'src/python/pants/testutil:console_rule_test_base',
+    'src/python/pants/testutil:goal_rule_test_base',
     'src/python/pants/testutil/engine:util',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -112,7 +112,7 @@ class RunTracker(Subsystem):
     self._run_timestamp = time.time()
     self._cmd_line = ' '.join(['pants'] + sys.argv[1:])
     self._sorted_goal_infos = tuple()
-    self._v2_console_rule_names = tuple()
+    self._v2_goal_rule_names = tuple()
 
     self.run_uuid = uuid.uuid4().hex
     # Select a globally unique ID for the run, that sorts by time.
@@ -184,8 +184,8 @@ class RunTracker(Subsystem):
   def set_sorted_goal_infos(self, sorted_goal_infos):
     self._sorted_goal_infos = sorted_goal_infos
 
-  def set_v2_console_rule_names(self, v2_console_rule_names):
-    self._v2_console_rule_names = v2_console_rule_names
+  def set_v2_goal_rule_names(self, v2_goal_rule_names):
+    self._v2_goal_rule_names = v2_goal_rule_names
 
   def register_thread(self, parent_workunit):
     """Register the parent workunit for all work in the calling thread.
@@ -527,7 +527,7 @@ class RunTracker(Subsystem):
     if self._sorted_goal_infos and self.run_info.get_info("computed_goals") is None:
       self.run_info.add_info(
         "computed_goals",
-        self._v2_console_rule_names + tuple(goal.goal.name for goal in self._sorted_goal_infos),
+        self._v2_goal_rule_names + tuple(goal.goal.name for goal in self._sorted_goal_infos),
         stringify=False,
         # If the goal is clean-all then the run info dir no longer exists, so ignore that error.
         ignore_errors=True,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -191,14 +191,13 @@ class LegacyGraphSession:
     """Raised when invalid v2 goals are passed in a v2-only mode."""
 
     def __init__(self, invalid_goals):
-      super(LegacyGraphSession.InvalidGoals, self).__init__(
-        'could not satisfy the following goals with @console_rules: {}'
-        .format(', '.join(invalid_goals))
+      super().__init__(
+        f"could not satisfy the following goals with @goal_rules: {', '.join(invalid_goals)}"
       )
       self.invalid_goals = invalid_goals
 
-  def run_console_rules(self, options_bootstrapper, options, goals, target_roots):
-    """Runs @console_rules sequentially and interactively by requesting their implicit Goal products.
+  def run_goal_rules(self, options_bootstrapper, options, goals, target_roots):
+    """Runs @goal_rules sequentially and interactively by requesting their implicit Goal products.
 
     For retryable failures, raises scheduler.ExecutionError.
 
@@ -223,7 +222,7 @@ class LegacyGraphSession:
       params = Params(subject, options_bootstrapper, console, workspace, interactive_runner)
       logger.debug(f'requesting {goal_product} to satisfy execution of `{goal}` goal')
       try:
-        exit_code = self.scheduler_session.run_console_rule(goal_product, params)
+        exit_code = self.scheduler_session.run_goal_rule(goal_product, params)
       finally:
         console.flush()
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -511,14 +511,14 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--v1', advanced=True, type=bool, default=True,
              help='Enables execution of v1 Tasks.')
     register('--v2', advanced=True, type=bool, default=False,
-             help='Enables execution of v2 @console_rules.')
+             help='Enables execution of v2 @goal_rules.')
     register('--v2-ui', default=False, type=bool, daemon=False,
              help='Whether to show v2 engine execution progress. '
                   'This requires the --v2 flag to take effect.')
 
     loop_flag = '--loop'
     register(loop_flag, type=bool,
-             help='Run v2 @console_rules continuously as file changes are detected. Requires '
+             help='Run v2 @goal_rules continuously as file changes are detected. Requires '
                   '`--v2`, and is best utilized with `--v2 --no-v1`.')
     register('--loop-max', type=int, default=2**32, advanced=True,
              help=f'The maximum number of times to loop when `{loop_flag}` is specified.')
@@ -562,7 +562,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     Raises pants.option.errors.OptionsError on validation failure.
     """
     if opts.loop and (not opts.v2 or opts.v1):
-      raise OptionsError('The `--loop` option only works with @console_rules, and thus requires '
+      raise OptionsError('The `--loop` option only works with @goal_rules, and thus requires '
                          '`--v2 --no-v1` to function as expected.')
     if opts.loop and not opts.enable_pantsd:
       raise OptionsError('The `--loop` option requires `--enable-pantsd`, in order to watch files.')

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -226,8 +226,8 @@ class SchedulerService(PantsService):
     if v2_goals or (ambiguous_goals and global_options.v2):
       goals = v2_goals + (ambiguous_goals if global_options.v2 else tuple())
 
-      # N.B. @console_rules run pre-fork in order to cache the products they request during execution.
-      exit_code = session.run_console_rules(
+      # N.B. @goal_rules run pre-fork in order to cache the products they request during execution.
+      exit_code = session.run_goal_rules(
           options_bootstrapper,
           options,
           goals,

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -36,7 +36,7 @@ python_tests(
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/engine/legacy:structs',
     'src/python/pants/testutil:test_base',
-    'src/python/pants/testutil:console_rule_test_base',
+    'src/python/pants/testutil:goal_rule_test_base',
     'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil/subsystem',
   ],

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -10,7 +10,7 @@ from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, 
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.objects import union
-from pants.engine.rules import console_rule, rule
+from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.distdir import DistDir
 
@@ -36,7 +36,7 @@ class CreatedBinary:
   binary_name: str
 
 
-@console_rule
+@goal_rule
 async def create_binary(
     addresses: BuildFileAddresses,
     console: Console,

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -19,7 +19,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
-from pants.engine.rules import console_rule, rule
+from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get
 
 
@@ -65,7 +65,7 @@ class CountLinesOfCode(Goal):
   subsystem_cls = CountLinesOfCodeOptions
 
 
-@console_rule
+@goal_rule
 async def run_cloc(
   console: Console,
   options: CountLinesOfCodeOptions,

--- a/src/python/pants/rules/core/cloc_test.py
+++ b/src/python/pants/rules/core/cloc_test.py
@@ -6,10 +6,10 @@ from typing import Sequence
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.rules.core import cloc
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class ClocTest(ConsoleRuleTestBase):
+class ClocTest(GoalRuleTestBase):
   goal_cls = cloc.CountLinesOfCode
 
   @classmethod

--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -8,7 +8,7 @@ from pants.base.build_root import BuildRoot
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import TransitiveHydratedTargets
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 
 
 class FiledepsOptions(LineOriented, GoalSubsystem):
@@ -36,7 +36,7 @@ class Filedeps(Goal):
   subsystem_cls = FiledepsOptions
 
 
-@console_rule
+@goal_rule
 def file_deps(
   console: Console,
   filedeps_options: FiledepsOptions,

--- a/src/python/pants/rules/core/filedeps_test.py
+++ b/src/python/pants/rules/core/filedeps_test.py
@@ -14,10 +14,10 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.rules.core import filedeps
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class FileDepsTest(ConsoleRuleTestBase):
+class FileDepsTest(GoalRuleTestBase):
 
   goal_cls = filedeps.Filedeps
 

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -17,7 +17,7 @@ from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.objects import union
-from pants.engine.rules import UnionMembership, console_rule
+from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get, MultiGet
 
 
@@ -81,7 +81,7 @@ class Fmt(Goal):
   subsystem_cls = FmtOptions
 
 
-@console_rule
+@goal_rule
 async def fmt(
   console: Console,
   targets: HydratedTargets,

--- a/src/python/pants/rules/core/generate_pants_ini.py
+++ b/src/python/pants/rules/core/generate_pants_ini.py
@@ -14,7 +14,7 @@ from pants.engine.fs import (
   Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.version import VERSION as pants_version
 
@@ -28,7 +28,7 @@ class GeneratePantsIni(Goal):
   subsystem_cls = GeneratePantsIniOptions
 
 
-@console_rule
+@goal_rule
 async def generate_pants_ini(console: Console, workspace: Workspace) -> GeneratePantsIni:
   pants_ini_content = dedent(f"""\
     [GLOBAL]

--- a/src/python/pants/rules/core/generate_pants_ini_test.py
+++ b/src/python/pants/rules/core/generate_pants_ini_test.py
@@ -6,11 +6,11 @@ from pathlib import Path
 
 from pants.rules.core.generate_pants_ini import GeneratePantsIni
 from pants.rules.core.generate_pants_ini import rules as generate_pants_ini_rules
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 from pants.version import VERSION
 
 
-class GeneratePantsIniTest(ConsoleRuleTestBase):
+class GeneratePantsIniTest(GoalRuleTestBase):
 
   goal_cls = GeneratePantsIni
 

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -9,7 +9,7 @@ from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.objects import Collection, union
-from pants.engine.rules import UnionMembership, console_rule
+from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get, MultiGet
 
 
@@ -67,7 +67,7 @@ class Lint(Goal):
   subsystem_cls = LintOptions
 
 
-@console_rule
+@goal_rule
 async def lint(console: Console, targets: HydratedTargets, union_membership: UnionMembership) -> Lint:
   nested_results = await MultiGet(
     Get[LintResults](LintTarget, target.adaptor)

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -6,7 +6,7 @@ from typing import Set
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import console_rule, rule, subsystem_rule
+from pants.engine.rules import goal_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.source.source_root import AllSourceRoots, SourceRoot, SourceRootConfig
 
@@ -48,7 +48,7 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
   return AllSourceRoots(all_source_roots)
 
 
-@console_rule
+@goal_rule
 async def list_roots(console: Console, options: RootsOptions, all_roots: AllSourceRoots) -> Roots:
   with options.line_oriented(console) as print_stdout:
     for src_root in sorted(all_roots, key=lambda x: x.path):

--- a/src/python/pants/rules/core/list_roots_test.py
+++ b/src/python/pants/rules/core/list_roots_test.py
@@ -6,8 +6,8 @@ import json
 from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.rules.core import list_roots
 from pants.source.source_root import SourceRoot, SourceRootCategories, SourceRootConfig
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
 from pants.testutil.engine.util import MockGet, run_rule
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 from pants.testutil.test_base import TestBase
 
 
@@ -77,7 +77,7 @@ class AllRootsTest(TestBase):
                       set(output))
 
 
-class RootsTest(ConsoleRuleTestBase):
+class RootsTest(GoalRuleTestBase):
   goal_cls = list_roots.Roots
 
   @classmethod

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -8,7 +8,7 @@ from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTargets
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 
 
@@ -33,7 +33,7 @@ class List(Goal):
   subsystem_cls = ListOptions
 
 
-@console_rule
+@goal_rule
 async def list_targets(
   console: Console, list_options: ListOptions, address_specs: AddressSpecs,
 ) -> List:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -9,7 +9,7 @@ from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.engine.rules import console_rule
+from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.rules.core.binary import CreatedBinary
 from pants.util.contextutil import temporary_dir
@@ -24,7 +24,7 @@ class Run(Goal):
   subsystem_cls = RunOptions
 
 
-@console_rule
+@goal_rule
 async def run(
   console: Console,
   workspace: Workspace,

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -7,11 +7,11 @@ from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.rules.core import run
 from pants.rules.core.binary import CreatedBinary
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class RunTest(ConsoleRuleTestBase):
+class RunTest(GoalRuleTestBase):
   goal_cls = run.Run
 
   def create_mock_binary(self, program_text: bytes) -> CreatedBinary:

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -16,7 +16,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.objects import union
-from pants.engine.rules import UnionMembership, console_rule, rule
+from pants.engine.rules import UnionMembership, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 
 
@@ -124,7 +124,7 @@ class AddressAndDebugResult:
   test_result: TestDebugResult
 
 
-@console_rule
+@goal_rule
 async def run_tests(console: Console, options: TestOptions, addresses: BuildFileAddresses) -> Test:
   if options.values.debug:
     address = await Get[BuildFileAddress](BuildFileAddresses, addresses)

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -91,8 +91,8 @@ python_library(
 )
 
 python_library(
-  name = 'console_rule_test_base',
-  sources = ['console_rule_test_base.py'],
+  name = 'goal_rule_test_base',
+  sources = ['goal_rule_test_base.py'],
   dependencies = [
     ':test_base',
     'src/python/pants/bin',

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -15,8 +15,8 @@ from pants.testutil.test_base import TestBase
 from pants.util.meta import classproperty
 
 
-class ConsoleRuleTestBase(TestBase):
-  """A baseclass useful for testing a Goal defined as a @console_rule.
+class GoalRuleTestBase(TestBase):
+  """A baseclass useful for testing a Goal defined as a @goal_rule.
 
   :API: public
   """
@@ -38,7 +38,7 @@ class ConsoleRuleTestBase(TestBase):
       raise AssertionError('goal_cls() must return a Goal subclass, got {}'.format(self.goal_cls))
 
   def execute_rule(self, args=tuple(), env=tuple(), exit_code=0, additional_params: Iterable[Any]=tuple()):
-    """Executes the @console_rule for this test class.
+    """Executes the @goal_rule for this test class.
 
     :API: public
 
@@ -58,7 +58,7 @@ class ConsoleRuleTestBase(TestBase):
     # Run for the target specs parsed from the args.
     address_specs = TargetRootsCalculator.parse_address_specs(full_options.specs, self.build_root)
     params = Params(address_specs, console, options_bootstrapper, workspace, *additional_params)
-    actual_exit_code = self.scheduler.run_console_rule(self.goal_cls, params)
+    actual_exit_code = self.scheduler.run_goal_rule(self.goal_cls, params)
 
     # Flush and capture console output.
     console.flush()

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -357,7 +357,7 @@ impl<N: Node> Entry<N> {
           // cause it to re-run if the dep_generations mismatch).
           // Note that if the node is uncacheable, we avoid storing a previous result, which will
           // transitively invalidate every node that depends on us. This works because, in practice,
-          // the only uncacheable nodes are Select nodes and @console_rule Task nodes. See #6146 and #6598
+          // the only uncacheable nodes are Select nodes and @goal_rule Task nodes. See #6146 and #6598
           Self::run(
             context,
             &self.node,

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -69,7 +69,7 @@ python_library(
   sources = ['console_rule_test_base.py'],
   dependencies = [
     ':deprecated_testinfra',
-    'src/python/pants/testutil:console_rule_test_base',
+    'src/python/pants/testutil:goal_rule_test_base',
   ],
   tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -80,7 +80,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/backend/python/targets',
     'src/python/pants/testutil/subsystem',
-    'src/python/pants/testutil:console_rule_test_base',
+    'src/python/pants/testutil:goal_rule_test_base',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
@@ -14,10 +14,10 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.rules.core import list_targets
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class ListTargetsTest(ConsoleRuleTestBase):
+class ListTargetsTest(GoalRuleTestBase):
   goal_cls = list_targets.List
 
   @classmethod

--- a/tests/python/pants_test/console_rule_test_base.py
+++ b/tests/python/pants_test/console_rule_test_base.py
@@ -1,8 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.console_rule_test_base import ConsoleRuleTestBase as ConsoleRuleTestBase  # noqa
+from pants.testutil.goal_rule_test_base import GoalRuleTestBase as ConsoleRuleTestBase  # noqa
 from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_testinfra_module()
+deprecated_testinfra_module(instead="pants.testutil.goal_rule_test_base")

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -71,8 +71,8 @@ python_tests(
 )
 
 python_tests(
-  name = 'console_rule_integration',
-  sources = [ 'test_console_rule_integration.py' ],
+  name = 'goal_rule_integration',
+  sources = [ 'test_goal_rule_integration.py' ],
   dependencies = [
     'tests/python/pants_test/pantsd:pantsd_integration_test_base',
     'examples/src/scala/org/pantsbuild/example:hello_directory',

--- a/tests/python/pants_test/engine/legacy/test_goal_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_goal_rule_integration.py
@@ -11,7 +11,7 @@ from pants.util.dirutil import fast_relpath, safe_file_dump
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
-class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
+class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
 
   list_target = 'examples/src/java/org/pantsbuild/example/hello::'
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -15,7 +15,7 @@ from pants.engine.rules import (
   RootRule,
   RuleIndex,
   UnrecognizedRuleArgument,
-  console_rule,
+  goal_rule,
   rule,
 )
 from pants.engine.selectors import Get
@@ -79,17 +79,17 @@ class Example(Goal):
   subsystem_cls = ExampleOptions
 
 
-@console_rule
-async def a_console_rule_generator(console: Console) -> Example:
+@goal_rule
+async def a_goal_rule_generator(console: Console) -> Example:
   a = await Get[A](str('a str!'))
   console.print_stdout(str(a))
   return Example(exit_code=0)
 
 
 class RuleTest(unittest.TestCase):
-  def test_run_rule_console_rule_generator(self):
+  def test_run_rule_goal_rule_generator(self):
     res = run_rule(
-      a_console_rule_generator,
+      a_goal_rule_generator,
       rule_args=[Console()],
       mock_gets=[MockGet(product_type=A, subject_type=str, mock=lambda _: A())],
     )
@@ -120,19 +120,19 @@ class RuleArgumentAnnotationTest(unittest.TestCase):
       def named_rule(a: int, b: str) -> bool:
         return False
 
-  def test_console_rule_automatically_gets_name_from_goal(self):
-    @console_rule
-    def some_console_rule(console: Console) -> Example:
+  def test_goal_rule_automatically_gets_name_from_goal(self):
+    @goal_rule
+    def some_goal_rule() -> Example:
       return Example(exit_code=0)
 
-    self.assertEqual(some_console_rule.rule.name, "example")
+    self.assertEqual(some_goal_rule.rule.name, "example")
 
-  def test_can_override_console_rule_name(self):
-    @console_rule(name='example but **COOLER**')
-    def some_console_rule(console: Console) -> Example:
+  def test_can_override_goal_rule_name(self):
+    @goal_rule(name='example but **COOLER**')
+    def some_goal_rule() -> Example:
       return Example(exit_code=0)
 
-    self.assertEqual(some_console_rule.rule.name, "example but **COOLER**")
+    self.assertEqual(some_goal_rule.rule.name, "example but **COOLER**")
 
 
 class RuleTypeAnnotationTest(unittest.TestCase):
@@ -167,24 +167,23 @@ class RuleTypeAnnotationTest(unittest.TestCase):
         return False
 
 
-class ConsoleRuleValidation(TestBase):
+class GoalRuleValidation(TestBase):
 
-  def test_not_properly_marked_console_rule(self) -> None:
+  def test_not_properly_marked_goal_rule(self) -> None:
     with self.assertRaisesWithMessage(
       TypeError,
-      "An `@rule` that returns a `Goal` must be declared with `@console_rule` in order to signal "
-      "that it is not cacheable."
+      "An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`."
     ):
       @rule
       def normal_rule_trying_to_return_a_goal() -> Example:
         return Example(0)
 
-  def test_console_rule_not_returning_a_goal(self) -> None:
+  def test_goal_rule_not_returning_a_goal(self) -> None:
     with self.assertRaisesWithMessage(
-      TypeError, "An `@console_rule` must return a subclass of `engine.goal.Goal`."
+      TypeError, "An `@goal_rule` must return a subclass of `engine.goal.Goal`."
     ):
-      @console_rule
-      def console_rule_returning_a_non_goal() -> int:
+      @goal_rule
+      def goal_rule_returning_a_non_goal() -> int:
         return 0
 
 


### PR DESCRIPTION
Any time that you add a new top-level goal in V2—that is a "verb" for Pants like `test`, `fmt`, `setup-py`, and `dependencies`—you must define the same three basic things:

```
Goal, GoalSubsystem, @console_rule
```

One of those does not fit with the other two. In contrast, these three all belong:

```
Goal, GoalSubsystem, @goal_rule
```

### What is an `@console_rule`?

There are (at least) 3 ways of conceptualizing what an `@console_rule` means:

1. A rule that has exclusive access to the `Console`.
    * Only `@console_rules` can write to stdout and stderr.
    * This property is represented in the name `@console_rule`.
2. A rule that is not cached.
    * This is an important property of `@console_rules` and contrasts with normal `@rules`.
    * Per the conversation in https://github.com/pantsbuild/pants/pull/8931#issuecomment-572752105, this idea on uncachability is the main mental model for some.
3. A rule that maps 1-1 with a top-level goal / returns an `engine.goal.Goal`.

All three of these properties are true and important components of an `@console_rule`. However, I argue that #3 is the most important: _fundamentally, an `@console_rule` is a special rule that hooks up to a Pants goal_.

Right now, the name `@console_rule` optimizes for property #1. In contrast, `@goal_rule` focuses on property #3. 

(NB: all three of these properties will continue applying regardless of the name)

### Leveraging prior Pants knowledge

Most Pants users are familiar with the idea of a goal. It's the [very first concept introduced in our docs](https://www.pantsbuild.org/first_concepts.html) and every single Pants run involves invoking goals, regardless of V1 vs. V2.

In contrast, fewer users are familiar with the `Console` abstraction, which is never mentioned in our docs and is more of an implementation detail for how V2 Pants works.

We do expect users to soon write their own rules in plugins. The name `@goal_rule` will allow them to leverage their prior knowledge, just as `subsystem_rule` leverages prior knowledge better than `optionable_rule` did.
