### PR TITLE
Rename public Target methods to use `address_spec` instead of `spec`

### DIFF
--- a/contrib/avro/src/python/pants/contrib/avro/tasks/avro_gen.py
+++ b/contrib/avro/src/python/pants/contrib/avro/tasks/avro_gen.py
@@ -30,7 +30,7 @@ class AvroJavaGenTask(SimpleCodegenTask, NailgunTask):
                           classpath=[JarDependency(org='org.apache.avro', name='avro-tools', rev=AVRO_REV)],)
     register('--runtime-deps', advanced=True, type=list, fingerprint=True,
              default=['//:avro-java-runtime'],
-             help='A list of specs pointing to dependencies of Avro generated code.')
+             help='A list of address specs pointing to dependencies of Avro generated code.')
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
@@ -34,9 +34,9 @@ class PythonAWSLambda(Target):
     return 'python_awslambda'
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
     target_representation = kwargs or payload.as_dict()
     binary = target_representation.get('binary')
     if binary:

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/meta_rename.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/meta_rename.py
@@ -75,7 +75,7 @@ class MetaRename(Task):
   def dependency_graph(self, scope=''):
     dependency_graph = defaultdict(set)
 
-    for address in self.context.build_graph.inject_specs_closure([DescendantAddresses(scope)]):
+    for address in self.context.build_graph.inject_address_specs_closure([DescendantAddresses(scope)]):
       target = self.context.build_graph.get_target(address)
 
       for dependency in target.dependencies:

--- a/contrib/node/src/python/pants/contrib/node/targets/node_bundle.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_bundle.py
@@ -35,14 +35,14 @@ class NodeBundle(NodePackage):
     super().__init__(address=address, payload=payload, **kwargs)
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
     target_representation = kwargs or payload.as_dict()
-    spec = target_representation.get('node_module')
-    if spec:
-      yield spec
+    address_spec = target_representation.get('node_module')
+    if address_spec:
+      yield address_spec
 
   @property
   def node_module(self):

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/scala_js_platform.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/scala_js_platform.py
@@ -53,7 +53,7 @@ class ScalaJSPlatform(InjectablesMixin, Subsystem, NodeResolverBase):
       json.dump(package, fp, indent=2)
 
   @property
-  def injectables_spec_mapping(self):
+  def injectables_address_spec_mapping(self):
     return {
       'runtime': self.get_options().runtime,
     }

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/scala_js_platform.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/scala_js_platform.py
@@ -24,7 +24,7 @@ class ScalaJSPlatform(InjectablesMixin, Subsystem, NodeResolverBase):
     # TODO: revisit after https://rbcommons.com/s/twitter/r/3225/
     register('--runtime', advanced=True, type=list, member_type=target_option,
              default=['//:scala-js-library'],
-             help='Target specs pointing to the scala-js runtime libraries.')
+             help='Address specs pointing to the scala-js runtime libraries.')
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_target.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_target.py
@@ -26,11 +26,11 @@ class ScalaJSTarget:
     super().__init__(address=address, payload=payload, **kwargs)
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
-    for spec in ScalaJSPlatform.global_instance().injectables_specs_for_key('runtime'):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
+    for address_spec in ScalaJSPlatform.global_instance().injectables_address_specs_for_key('runtime'):
+      yield address_spec
 
   @property
   def strict_deps(self):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -93,7 +93,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     return path
 
   def _resolve_deps(self, depmap):
-    """Given a map of gen-key=>target specs, resolves the target specs into references."""
+    """Given a map of gen-key=>address specs, resolves the address specs into references."""
     deps = defaultdict(lambda: OrderedSet())
     for category, depspecs in depmap.items():
       dependencies = deps[category]

--- a/src/python/pants/backend/codegen/antlr/python/antlr_py_gen.py
+++ b/src/python/pants/backend/codegen/antlr/python/antlr_py_gen.py
@@ -40,7 +40,7 @@ class AntlrPyGen(SimpleCodegenTask, NailgunTask):
                           classpath_spec='//:antlr-{}'.format(_ANTLR3_REV))
     # The ANTLR runtime python deps.
     register('--antlr3-deps', advanced=True, type=list, member_type=target_option,
-             help='A list of specs pointing to dependencies of ANTLR3 generated code.')
+             help='A list of address specs pointing to dependencies of ANTLR3 generated code.')
 
   def find_sources(self, target, target_dir):
     # Ignore .tokens files.

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -42,9 +42,9 @@ class ApacheThriftGenBase(SimpleCodegenTask):
              default=cls.default_gen_options_map,
              help='Use these options for the {} generator.'.format(cls.thrift_generator))
     register('--deps', advanced=True, type=list, member_type=target_option,
-             help='A list of specs pointing to dependencies of thrift generated code.')
+             help='A list of address specs pointing to dependencies of thrift generated code.')
     register('--service-deps', advanced=True, type=list, member_type=target_option,
-             help='A list of specs pointing to dependencies of thrift generated service '
+             help='A list of address specs pointing to dependencies of thrift generated service '
                   'code.  If not supplied, then --deps will be used for service deps.')
 
   @classmethod

--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -86,7 +86,7 @@ class Page(Target):
     :param format: Page's format, ``md`` or ``rst``. By default, Pants infers from ``source`` file
        extension: ``.rst`` is ReStructured Text; anything else is Markdown.
     :param links: Other ``page`` targets that this `page` links to.
-    :type links: List of target specs
+    :type links: List of address specs
     :param provides: Optional "Addresses" at which this page is published.
        E.g., a wiki location.
     :type provides: List of ``wiki_artifact``s
@@ -116,13 +116,13 @@ class Page(Target):
     return list(self.payload.sources.source_paths)[0]
 
   @classmethod
-  def compute_injectable_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_injectable_specs(kwargs, payload):
-      yield spec
+  def compute_injectable_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_injectable_address_specs(kwargs, payload):
+      yield address_spec
 
     target_representation = kwargs or payload.as_dict()
-    for spec in target_representation.get('links', []):
-      yield spec
+    for address_spec in target_representation.get('links', []):
+      yield address_spec
 
   @property
   def provides(self):

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -35,7 +35,7 @@ class ReverseDepmap(ConsoleTask):
 
   def console_output(self, _):
     dependees_by_target = defaultdict(set)
-    for address in self.context.build_graph.inject_specs_closure([DescendantAddresses('')]):
+    for address in self.context.build_graph.inject_address_specs_closure([DescendantAddresses('')]):
       target = self.context.build_graph.get_target(address)
       # TODO(John Sirois): tighten up the notion of targets written down in a BUILD by a
       # user vs. targets created by pants at runtime.

--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -25,7 +25,7 @@ class Java(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem):
     super().register_options(register)
     # This target, if specified, serves as both a tool (for compiling java code) and a
     # dependency (for javac plugins).  See below for the different methods for accessing
-    # classpath entries (in the former case) or target specs (in the latter case).
+    # classpath entries (in the former case) or address specs (in the latter case).
     #
     # Javac plugins can access basically all of the compiler internals, so we don't shade anything.
     # Hence the unspecified main= argument. This tool is optional, hence the empty classpath list.

--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -51,7 +51,7 @@ class Java(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem):
       raise build_graph.ManualSyntheticTargetError(tools_jar_address)
 
   @property
-  def injectables_spec_mapping(self):
+  def injectables_address_spec_mapping(self):
     return {
       # Zinc directly accesses the javac tool.
       'javac': [self._javac_spec],

--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -57,7 +57,7 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
                                           scope='forced')
 
   @property
-  def injectables_spec_mapping(self):
+  def injectables_address_spec_mapping(self):
     return {
       'library': [self.get_options().junit_library]
     }

--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -49,7 +49,7 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
                           ])
 
   def injectables(self, build_graph):
-    junit_addr = Address.parse(self.injectables_spec_for_key('library'))
+    junit_addr = Address.parse(self.injectables_address_spec_for_key('library'))
     if not build_graph.contains_address(junit_addr):
       build_graph.inject_synthetic_target(junit_addr,
                                           JarLibrary,

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -198,7 +198,7 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
         raise build_graph.ManualSyntheticTargetError(target_address)
 
   @property
-  def injectables_spec_mapping(self):
+  def injectables_address_spec_mapping(self):
     maybe_suffix = '' if self.version == 'custom' else '-synthetic'
     return {
       # Target spec for the scala compiler library.

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -186,8 +186,8 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
     ]
 
     for spec_key, create_jardep_func in specs_to_create:
-      spec = self.injectables_spec_for_key(spec_key)
-      target_address = Address.parse(spec)
+      address_spec = self.injectables_address_spec_for_key(spec_key)
+      target_address = Address.parse(address_spec)
       if not build_graph.contains_address(target_address):
         jars = [create_jardep_func(self.version)]
         build_graph.inject_synthetic_target(target_address,

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -64,7 +64,7 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
         raise build_graph.ManualSyntheticTargetError(target_address)
 
   @property
-  def injectables_spec_mapping(self):
+  def injectables_address_spec_mapping(self):
     return {
       # Target spec for scoverage plugin.
       'scoverage': [f"//:scoverage"],

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -51,8 +51,8 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
     ]
 
     for spec_key, create_jardep_func in specs_to_create:
-      spec = self.injectables_spec_for_key(spec_key)
-      target_address = Address.parse(spec)
+      address_spec = self.injectables_address_spec_for_key(spec_key)
+      target_address = Address.parse(address_spec)
       if not build_graph.contains_address(target_address):
         target_jars = create_jardep_func()
         jars = target_jars if isinstance(target_jars, list) else [target_jars]

--- a/src/python/pants/backend/jvm/targets/javac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/javac_plugin.py
@@ -25,8 +25,8 @@ class JavacPlugin(JavaLibrary):
     self.classname = classname
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
-    yield Java.global_instance().injectables_spec_for_key('tools.jar')
+    yield Java.global_instance().injectables_address_spec_for_key('tools.jar')

--- a/src/python/pants/backend/jvm/targets/junit_tests.py
+++ b/src/python/pants/backend/jvm/targets/junit_tests.py
@@ -91,12 +91,12 @@ class JUnitTests(JvmTarget):
                                       + repr(self.VALID_CONCURRENCY_OPTS) + " got: " + concurrency)
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
-    for spec in JUnit.global_instance().injectables_specs_for_key('library'):
-      yield spec
+    for address_spec in JUnit.global_instance().injectables_address_specs_for_key('library'):
+      yield address_spec
 
   @property
   def test_platform(self):

--- a/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
+++ b/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
@@ -32,17 +32,17 @@ class ManagedJarDependencies(Target):
 
   @classmethod
   def compute_injectable_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_injectable_specs(kwargs, payload):
-      yield spec
+    for address_spec in super().compute_injectable_address_specs(kwargs, payload):
+      yield address_spec
 
     if kwargs:
-      _, specs = cls._split_jars_and_specs(kwargs.get('artifacts', ()))
-      for spec in specs:
-        yield spec
+      _, address_specs = cls._split_jars_and_specs(kwargs.get('artifacts', ()))
+      for address_spec in address_specs:
+        yield address_spec
     elif payload:
       payload_dict = payload.as_dict()
-      for spec in payload_dict.get('library_specs', ()):
-        yield spec
+      for address_spec in payload_dict.get('library_specs', ()):
+        yield address_spec
 
   @memoized_property
   def library_specs(self):

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -48,7 +48,7 @@ class ScalaLibrary(ExportableJvmLibrary):
       forced by splitting interdependent java and scala into multiple targets,
       don't use this at all.
       Prefer using ``dependencies`` to express non-circular dependencies.
-    :type java_sources: target spec or list of target specs
+    :type java_sources: address spec or list of address specs
     :param resources: An optional list of paths (DEPRECATED) or ``resources``
       targets containing resources that belong on this library's classpath.
     """
@@ -81,9 +81,9 @@ class ScalaLibrary(ExportableJvmLibrary):
       **kwargs)
 
   @classmethod
-  def compute_injectable_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_injectable_specs(kwargs, payload):
-      yield spec
+  def compute_injectable_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_injectable_address_specs(kwargs, payload):
+      yield address_spec
 
     target_representation = kwargs or payload.as_dict()
     java_sources_specs = target_representation.get('java_sources', None) or []
@@ -91,16 +91,16 @@ class ScalaLibrary(ExportableJvmLibrary):
       yield java_source_spec
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
-    for spec in ScalaPlatform.global_instance().injectables_specs_for_key('scala-library'):
-      yield spec
+    for address_spec in ScalaPlatform.global_instance().injectables_address_specs_for_key('scala-library'):
+      yield address_spec
 
     if ScoveragePlatform.global_instance().get_options().enable_scoverage:
-      for spec in ScoveragePlatform.global_instance().injectables_specs_for_key('scoverage'):
-        yield spec
+      for address_spec in ScoveragePlatform.global_instance().injectables_address_specs_for_key('scoverage'):
+        yield address_spec
 
   def get_jar_dependencies(self):
     for jar in super().get_jar_dependencies():

--- a/src/python/pants/backend/jvm/targets/scalac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/scalac_plugin.py
@@ -24,9 +24,9 @@ class ScalacPlugin(ScalaLibrary):
     self.classname = classname
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
-    for spec in ScalaPlatform.global_instance().injectables_specs_for_key('scalac'):
-      yield spec
+    for address_spec in ScalaPlatform.global_instance().injectables_address_specs_for_key('scalac'):
+      yield address_spec

--- a/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
@@ -154,7 +154,7 @@ class Jacoco(CoverageEngine):
   def _get_jacoco_coverage_targets(self, targets):
     coverage_targets = {t for t in targets if (self.is_coverage_target(t) and self._include_target(t))}
     if len(coverage_targets) == 0:
-      raise TaskError(f"No coverage target specs matched jacoco report filters ({self._target_filters})")
+      raise TaskError(f"No coverage address specs matched jacoco report filters ({self._target_filters})")
     return coverage_targets
 
   def _get_target_classpaths(self):

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -71,15 +71,15 @@ class PythonTarget(Target):
         raise TargetDefinitionException(self, str(e))
 
   @classmethod
-  def compute_injectable_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_injectable_specs(kwargs, payload):
-      yield spec
+  def compute_injectable_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_injectable_address_specs(kwargs, payload):
+      yield address_spec
 
     target_representation = kwargs or payload.as_dict()
     provides = target_representation.get('provides', None) or []
     if provides:
-      for spec in provides._binaries.values():
-        yield spec
+      for address_spec in provides._binaries.values():
+        yield address_spec
 
   @property
   def provides(self):

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -73,7 +73,7 @@ class TargetAncestorIterator:
     def iter_targets_in_spec_path(spec_path):
       try:
         siblings = SiblingAddresses(spec_path)
-        for address in self._build_graph.inject_specs_closure([siblings]):
+        for address in self._build_graph.inject_address_specs_closure([siblings]):
           yield self._build_graph.get_target(address)
       except AddressLookupError:
         # A spec path may not have any addresses registered under it and that's ok.

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -268,9 +268,9 @@ class AppBase(Target):
     raise NotImplementedError('Must implement in subclass (e.g.: `return PythonBinary`)')
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
     target_representation = kwargs or payload.as_dict()
     binary = target_representation.get('binary')

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -10,6 +10,7 @@ from typing import Iterable
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.deprecated import warn_or_error
 from pants.base.specs import AddressSpec
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -604,6 +605,17 @@ class BuildGraph(ABC):
     """
 
   @abstractmethod
+  def inject_address_specs_closure(self, address_specs: Iterable[AddressSpec], fail_fast=None):
+    """Resolves, constructs and injects Targets and their transitive closures of dependencies.
+
+    :API: public
+
+    :param address_specs: An iterable of AddressSpec objects to resolve and inject.
+    :param fail_fast: Whether to fail quickly for the first error, or to complete all
+      possible injections before failing.
+    :returns: Yields a sequence of resolved Address objects.
+    """
+
   def inject_specs_closure(self, specs: Iterable[AddressSpec], fail_fast=None):
     """Resolves, constructs and injects Targets and their transitive closures of dependencies.
 
@@ -614,6 +626,13 @@ class BuildGraph(ABC):
       possible injections before failing.
     :returns: Yields a sequence of resolved Address objects.
     """
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="inject_specs_closure()",
+      hint="Use `inject_address_specs_closure()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
 
   def resolve(self, spec):
     """Returns an iterator over the target(s) the given address points to."""

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -101,11 +101,11 @@ class ImportRemoteSourcesMixin(Target, metaclass=ABCMeta):
     return libs
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
     """Tack imported_target_specs onto the traversable_specs generator for this target."""
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
     imported_target_specs = cls.imported_target_specs(kwargs=kwargs, payload=payload)
-    for spec in imported_target_specs:
-      yield spec
+    for address_spec in imported_target_specs:
+      yield address_spec

--- a/src/python/pants/build_graph/injectables_mixin.py
+++ b/src/python/pants/build_graph/injectables_mixin.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
+from pants.base.deprecated import warn_or_error
 from pants.build_graph.address import Address
 
 
@@ -27,8 +27,8 @@ class InjectablesMixin:
     """
 
   @property
-  def injectables_spec_mapping(self):
-    """A mapping of {key: spec} that is used for locating injectable specs.
+  def injectables_address_spec_mapping(self):
+    """A mapping of {key: address_spec} that is used for locating injectable address specs.
 
     This should be overridden by subclasses who wish to define an injectables mapping.
 
@@ -36,31 +36,77 @@ class InjectablesMixin:
     """
     return {}
 
+  def injectables_address_specs_for_key(self, key):
+    """Given a key, yield all relevant injectable address specs.
+
+    :API: public
+    """
+    mapping = self.injectables_address_spec_mapping
+    if key not in mapping:
+      raise self.NoMappingForKey(key)
+    address_specs = mapping[key]
+    assert isinstance(address_specs, list), (
+      'invalid `injectables_address_spec_mapping` on {!r} for key "{}". '
+      'expected a `list` but instead found a `{}`: {}'
+    ).format(self, key, type(address_specs), address_specs)
+    return [Address.parse(s).spec for s in address_specs]
+
+  def injectables_address_spec_for_key(self, key):
+    """Given a key, yield a singular address spec representing that key.
+
+    :API: public
+    """
+    address_specs = self.injectables_address_specs_for_key(key)
+    specs_len = len(address_specs)
+    if specs_len == 0:
+      return None
+    if specs_len != 1:
+      raise self.TooManySpecsForKey(
+        f'injectables address spec mapping for key included {specs_len} elements, expected 1'
+      )
+    return address_specs[0]
+
+  @property
+  def injectables_spec_mapping(self):
+    """A mapping of {key: spec} that is used for locating injectable specs.
+
+    This should be overridden by subclasses who wish to define an injectables mapping.
+
+    :API: public
+    """
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="injectables_spec_mapping()",
+      hint="Use `injectables_address_spec_mapping()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
+    return self.injectables_address_spec_mapping
+
   def injectables_specs_for_key(self, key):
     """Given a key, yield all relevant injectable spec addresses.
 
     :API: public
     """
-    mapping = self.injectables_spec_mapping
-    if key not in mapping:
-      raise self.NoMappingForKey(key)
-    specs = mapping[key]
-    assert isinstance(specs, list), (
-      'invalid `injectables_spec_mapping` on {!r} for key "{}". '
-      'expected a `list` but instead found a `{}`: {}'
-    ).format(self, key, type(specs), specs)
-    return [Address.parse(s).spec for s in specs]
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="injectables_specs_for_key()",
+      hint="Use `injectables_specs_for_key()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
+    return self.injectables_address_specs_for_key(key)
 
   def injectables_spec_for_key(self, key):
     """Given a key, yield a singular spec representing that key.
 
     :API: public
     """
-    specs = self.injectables_specs_for_key(key)
-    specs_len = len(specs)
-    if specs_len == 0:
-      return None
-    if specs_len != 1:
-      raise self.TooManySpecsForKey('injectables spec mapping for key included {} elements, '
-                                    'expected 1'.format(specs_len))
-    return specs[0]
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="injectables_spec_for_key()",
+      hint="Use `injectables_spec_for_key()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
+    return self.injectables_address_spec_for_key(key)

--- a/src/python/pants/build_graph/remote_sources.py
+++ b/src/python/pants/build_graph/remote_sources.py
@@ -55,9 +55,9 @@ class RemoteSources(Target):
     return Address.parse(sources_target, relative_to=address.spec_path).spec
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    for spec in super().compute_dependency_specs(kwargs, payload):
-      yield spec
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
+    for address_spec in super().compute_dependency_address_specs(kwargs, payload):
+      yield address_spec
 
     if kwargs:
       address = kwargs.get('address')

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -10,6 +10,7 @@ from typing import Optional, Sequence, Union
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
@@ -606,9 +607,9 @@ class Target(AbstractTarget):
     )
 
   @classmethod
-  def compute_injectable_specs(cls, kwargs=None, payload=None):
+  def compute_injectable_address_specs(cls, kwargs=None, payload=None):
     """Given either pre-Target.__init__() kwargs or a post-Target.__init__() payload, compute the
-    specs to inject as non-dependencies in the same vein as the prior `traversable_specs`.
+    address specs to inject as non-dependencies (in the same vein as the prior `traversable_specs`).
 
     :API: public
 
@@ -623,9 +624,10 @@ class Target(AbstractTarget):
     yield  # type: ignore[misc] # MyPy doesn't understand this pattern; complains that code is unreachable
 
   @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
+  def compute_dependency_address_specs(cls, kwargs=None, payload=None):
     """Given either pre-Target.__init__() kwargs or a post-Target.__init__() payload, compute the
-    full set of dependency specs in the same vein as the prior `traversable_dependency_specs`.
+    full set of dependency address specs (in the same vein as the prior
+    `traversable_dependency_specs`).
 
     N.B. This is a temporary bridge to span the gap between v2 "Fields" products vs v1 `BuildGraph`
     `Target` object representations. See:
@@ -644,6 +646,52 @@ class Target(AbstractTarget):
     # subclassing.
     return
     yield  # type: ignore[misc] # MyPy doesn't understand this pattern; complains that code is unreachable
+
+  @classmethod
+  def compute_injectable_specs(cls, kwargs=None, payload=None):
+    """Given either pre-Target.__init__() kwargs or a post-Target.__init__() payload, compute the
+    specs to inject as non-dependencies in the same vein as the prior `traversable_specs`.
+
+    :API: public
+
+    :param dict kwargs: The pre-Target.__init__() kwargs dict.
+    :param Payload payload: The post-Target.__init__() Payload object.
+    :yields: AddressSpec strings representing dependencies of this target.
+    """
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="Target.compute_injectable_specs()",
+      hint="Use `Target.compute_injectable_address_specs()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
+    cls.compute_injectable_address_specs(kwargs=kwargs, payload=payload)
+
+  @classmethod
+  def compute_dependency_specs(cls, kwargs=None, payload=None):
+    """Given either pre-Target.__init__() kwargs or a post-Target.__init__() payload, compute the
+    full set of dependency specs in the same vein as the prior `traversable_dependency_specs`.
+
+    N.B. This is a temporary bridge to span the gap between v2 "Fields" products vs v1 `BuildGraph`
+    `Target` object representations. See:
+
+      https://github.com/pantsbuild/pants/issues/3560
+      https://github.com/pantsbuild/pants/issues/3561
+
+    :API: public
+
+    :param dict kwargs: The pre-Target.__init__() kwargs dict.
+    :param Payload payload: The post-Target.__init__() Payload object.
+    :yields: AddressSpec strings representing dependencies of this target.
+    """
+    warn_or_error(
+      removal_version="1.27.0.dev0",
+      deprecated_entity_description="Target.compute_dependency_specs()",
+      hint="Use `Target.compute_dependency_address_specs()` instead. The API is the same as "
+           "before. This change is to prepare for Pants eventually supporting file system specs, "
+           "e.g. `./pants cloc foo.py`. In preparation, we renamed `Spec` to `AddressSpec`."
+    )
+    cls.compute_dependency_address_specs(kwargs=kwargs, payload=payload)
 
   @property
   def dependencies(self):

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -32,7 +32,7 @@ class JvmAppTest(TestBase):
     self.assertEqual('foo-app', app_target.payload.basename)
     self.assertEqual('foo-app', app_target.basename)
     self.assertEqual(binary_target, app_target.binary)
-    self.assertEqual([':foo-binary'], list(app_target.compute_dependency_specs(payload=app_target.payload)))
+    self.assertEqual([':foo-binary'], list(app_target.compute_dependency_address_specs(payload=app_target.payload)))
 
   def test_jvmapp_bundle_payload_fields(self):
     app_target = self.make_target(':foo_payload',

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -31,7 +31,7 @@ class UnpackedJarsTest(TestBase):
     target = self.make_target(':foo', UnpackedJars, libraries=[':import_jars'])
 
     self.assertIsInstance(target, UnpackedJars)
-    dependency_specs = [spec for spec in target.compute_dependency_specs(payload=target.payload)]
+    dependency_specs = [spec for spec in target.compute_dependency_address_specs(payload=target.payload)]
     self.assertSequenceEqual([':import_jars'], dependency_specs)
     self.assertEqual(1, len(target.all_imported_jar_deps))
     import_jar_dep = target.all_imported_jar_deps[0]

--- a/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
+++ b/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
@@ -11,7 +11,7 @@ class ResolveJarsTestMixin:
   """Mixin for evaluating tasks which resolve their own source and javadoc jars (such as Export)."""
 
   def evaluate_subtask(self, targets, workdir, load_extra_confs, extra_args, expected_jars):
-    """Evaluate the underlying task with the given target specs.
+    """Evaluate the underlying task with the given address specs.
 
     :param targets: the list of targets.
     :param string workdir: the working directory to execute in.

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -42,8 +42,8 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
 
     self.assertEqual('targets', actual_properties[0].getAttribute('name'))
     actual_targets = json.loads(actual_properties[0].getAttribute('value'))
-    abs_expected_target_specs = [os.path.join(get_buildroot(), relative_spec) for relative_spec in expected_targets]
-    self.assertEqual(abs_expected_target_specs, actual_targets)
+    abs_expected_address_specs = [os.path.join(get_buildroot(), relative_spec) for relative_spec in expected_targets]
+    self.assertEqual(abs_expected_address_specs, actual_targets)
 
     self.assertEqual('project_path', actual_properties[1].getAttribute('name'))
     actual_project_path = actual_properties[1].getAttribute('value')
@@ -65,19 +65,19 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
     with open(output_file, 'r') as result:
       return result.readlines()[0].strip()
 
-  def _run_and_check(self, target_specs, incremental_import=None):
+  def _run_and_check(self, address_specs, incremental_import=None):
     """
     Invoke idea-plugin goal and check for target specs and project in the
     generated project and workspace file.
 
-    :param target_specs: list of target specs
+    :param address_specs: list of address specs
     :return: n/a
     """
-    self.assertTrue(target_specs, "targets are empty")
+    self.assertTrue(address_specs, "targets are empty")
     spec_parser = CmdLineSpecParser(get_buildroot())
     # project_path is always the directory of the first target,
     # which is where intellij is going to zoom in under project view.
-    project_path = spec_parser.parse_address_spec(target_specs[0]).directory
+    project_path = spec_parser.parse_address_spec(address_specs[0]).directory
 
     with self.temporary_workdir() as workdir:
       with temporary_file(root_dir=workdir, cleanup=True) as output_file:
@@ -88,12 +88,12 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
           ]
         if incremental_import is not None:
           args.append(f'--incremental-import={incremental_import}')
-        pants_run = self.run_pants_with_workdir(args + target_specs, workdir)
+        pants_run = self.run_pants_with_workdir(args + address_specs, workdir)
         self.assert_success(pants_run)
 
         project_dir = self._get_project_dir(output_file.name)
         self.assertTrue(os.path.exists(project_dir), f"{project_dir} does not exist")
-        self._do_check(project_dir, project_path, target_specs, incremental_import=incremental_import)
+        self._do_check(project_dir, project_path, address_specs, incremental_import=incremental_import)
 
   def test_idea_plugin_single_target(self):
     target = 'examples/src/scala/org/pantsbuild/example/hello:hello'

--- a/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
+++ b/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
@@ -34,7 +34,7 @@ class UnpackedWheelsTest(TestBase):
     target = self.make_target(':foo', UnpackedWheels, libraries=[':import_whls'], module_name='foo')
 
     self.assertIsInstance(target, UnpackedWheels)
-    dependency_specs = [spec for spec in target.compute_dependency_specs(payload=target.payload)]
+    dependency_specs = [spec for spec in target.compute_dependency_address_specs(payload=target.payload)]
     self.assertSequenceEqual([':import_whls'], dependency_specs)
     import_whl_dep = assert_single_element(target.all_imported_requirements)
     self.assertIsInstance(import_whl_dep, PythonRequirement)

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -71,7 +71,7 @@ class TargetTest(TestBase):
 
   def test_empty_traversable_properties(self):
     target = self.make_target(':foo', Target)
-    self.assertSequenceEqual([], list(target.compute_dependency_specs(payload=target.payload)))
+    self.assertSequenceEqual([], list(target.compute_dependency_address_specs(payload=target.payload)))
 
   def test_validate_target_representation_args_invalid_exactly_one(self):
     with self.assertRaises(AssertionError):


### PR DESCRIPTION
We left this for a followup from https://github.com/pantsbuild/pants/pull/8916 because these changes require a deprecation cycle.

It's unlikely we'll end up introducing equivalent V1 methods to iterate over filesystem specs, but this  PR still has some benefit because it completes the rename so that there's no ambiguity what a `spec` refers to.

This also updates some references to `target specs` to instead `address specs` for consistent language.