### PR TITLE
Avoid exiting in streaming workunit reporter session

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -257,7 +257,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     if self._options.help_request:
       help_printer = HelpPrinter(self._options)
       result = help_printer.print_help()
-      self._exiter(result)
+      return result
 
   def _maybe_run_v1(self):
     v1_goals, ambiguous_goals, _ = self._options.goals_by_version
@@ -325,23 +325,28 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
     streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callbacks=callbacks)
 
+    help_output = self._maybe_handle_help()
+    if help_output is not None:
+      self._exiter.exit(help_output)
+
     with streaming_reporter.session():
       try:
-        self._maybe_handle_help()
         engine_result = self._maybe_run_v2()
         goal_runner_result = self._maybe_run_v1()
       finally:
-        try:
-          self._update_stats()
-          run_tracker_result = self._run_tracker.end()
-        except ValueError as e:
-          # Calling .end() sometimes writes to a closed file, so we return a dummy result here.
-          logger.exception(e)
-          run_tracker_result = PANTS_SUCCEEDED_EXIT_CODE
-
+        run_tracker_result = self._finish_run()
     final_exit_code = self._compute_final_exit_code(
       engine_result,
       goal_runner_result,
       run_tracker_result
     )
     self._exiter.exit(final_exit_code)
+
+  def _finish_run(self):
+    try:
+      self._update_stats()
+      return self._run_tracker.end()
+    except ValueError as e:
+      # Calling .end() sometimes writes to a closed file, so we return a dummy result here.
+      logger.exception(e)
+      return PANTS_SUCCEEDED_EXIT_CODE


### PR DESCRIPTION
### Problem

We were previously calling `_maybe_handle_help` within the `with` context provided by the streaming workunit handler. `_maybe_handle_help` checks to see if the user is trying to invoke `./pants goals` and if so prints top-level goal help and calls `_exiter`, which calls `sys.exit`. This means that we were exiting the program within the `with`-context when the user ran `./pants goals`, which meant that the `with`-context wasn't doing its job of shutting down the thread that polled for workunit information. So, if the user ran `./pants goals` the program wouldn't cleanly exit but the workunit polling thread would stick around looping forever.

### Solution

Have `_maybe_handle_help` return a signal value rather than directly calling the exit function, and check for that signal value outside the `with`-context to determine if we even need to enter it. Also refactor some of the code that was in the `with`-context to make debugging a bit easier in the future.

