### PR TITLE
Make streaming workunits report interval a configurable option

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -321,9 +321,12 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     engine_result = PANTS_FAILED_EXIT_CODE
     goal_runner_result = PANTS_FAILED_EXIT_CODE
 
-    streaming_handlers = self._options.for_global_scope().streaming_workunits_handlers
+    global_options = self._options.for_global_scope()
+
+    streaming_handlers = global_options.streaming_workunits_handlers
+    report_interval = global_options.streaming_workunits_report_interval
     callbacks = Subsystem.get_streaming_workunit_callbacks(streaming_handlers)
-    streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callbacks=callbacks)
+    streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callbacks=callbacks, report_interval_seconds=report_interval)
 
     with streaming_reporter.session():
       try:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -544,7 +544,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--lock', advanced=True, type=bool, default=True,
              help='Use a global lock to exclude other versions of pants from running during '
                   'critical operations.')
-    register('--streaming-workunits-report-interval', type=float, default=10,
+    register('--streaming-workunits-report-interval', type=float, default=10, advanced=True,
         help="Interval in seconds between when streaming workunit event receivers will be polled."
     )
     register('--streaming-workunits-handlers', type=list, member_type=str, default=[],

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -544,6 +544,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--lock', advanced=True, type=bool, default=True,
              help='Use a global lock to exclude other versions of pants from running during '
                   'critical operations.')
+    register('--streaming-workunits-report-interval', type=float, default=10,
+        help="Interval in seconds between when streaming workunit event receivers will be polled."
+    )
     register('--streaming-workunits-handlers', type=list, member_type=str, default=[],
         advanced=True,
         help="Use this option to name Subsystems which will receive streaming workunit events. "

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -6,9 +6,6 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterable, Iterator, Optional
 
 
-DEFAULT_REPORT_INTERVAL_SECONDS = 10
-
-
 class StreamingWorkunitHandler:
   """StreamingWorkunitHandler's job is to periodically call each registered callback function with the
   following kwargs:
@@ -16,7 +13,7 @@ class StreamingWorkunitHandler:
     finished: bool - this will be set to True when the last chunk of workunit data is reported to the callback
   """
 
-  def __init__(self, scheduler: Any, callbacks: Iterable[Callable] = (), report_interval_seconds: float = DEFAULT_REPORT_INTERVAL_SECONDS):
+  def __init__(self, scheduler: Any, callbacks: Iterable[Callable], report_interval_seconds: float):
     self.scheduler = scheduler
     self.report_interval = report_interval_seconds
     self.callbacks = callbacks


### PR DESCRIPTION
### Problem

We hard-coded a streaming workunit report interval of 10 seconds, but this value actually should be configurable by pants administrators, since different administrators with different sets of plugins will need a different minimum interval.

### Solution

Expose this report interval as a configurable global option (moving the default of 10 seconds to an option default).