### PR TITLE
Set workunit parent IDs correctly (fixes #7969)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workunit_store 0.0.1",
 ]
 
 [[package]]

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1219,10 +1219,7 @@ impl Node for NodeKey {
   type Error = Failure;
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
-    let handle_workunits =
-      context.session.should_report_workunits() || context.session.should_record_zipkin_spans();
-
-    let (node_workunit_params, maybe_span_id) = if handle_workunits {
+    let (node_workunit_params, maybe_span_id) = if context.session.should_handle_workunits() {
       let span_id = generate_random_64bit_string();
       let node_workunit_params = match self.user_facing_name() {
         Some(ref node_name) => {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1221,17 +1221,23 @@ impl Node for NodeKey {
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
     let (maybe_started_workunit, maybe_span_id) = if context.session.should_handle_workunits() {
+      let user_facing_name = self.user_facing_name();
       let span_id = generate_random_64bit_string();
       let parent_id = workunit_store::get_parent_id();
-      let maybe_started_workunit = self
-        .user_facing_name()
+      let maybe_started_workunit = user_facing_name
+        .as_ref()
         .map(|ref node_name| StartedWorkUnit {
-          name: node_name.clone(),
+          name: node_name.to_string(),
           start_time: std::time::SystemTime::now(),
           span_id: span_id.clone(),
           parent_id,
         });
-      (maybe_started_workunit, Some(span_id))
+      let maybe_span_id = if user_facing_name.is_some() {
+        Some(span_id)
+      } else {
+        None
+      };
+      (maybe_started_workunit, maybe_span_id)
     } else {
       (None, None)
     };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{self, fmt};
 
-use concrete_time::TimeSpan;
 use futures::future::{self, Future};
 use futures::Stream;
 use url::Url;
@@ -34,7 +33,9 @@ use rule_graph;
 
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 use store::{self, StoreFileByDigest};
-use workunit_store::{generate_random_64bit_string, set_parent_id, WorkUnit, WorkUnitStore};
+use workunit_store::{
+  generate_random_64bit_string, set_parent_id, StartedWorkUnit, WorkUnit, WorkUnitStore,
+};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 
@@ -1219,16 +1220,18 @@ impl Node for NodeKey {
   type Error = Failure;
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
-    let (node_workunit_params, maybe_span_id) = if context.session.should_handle_workunits() {
+    let (maybe_started_workunit, maybe_span_id) = if context.session.should_handle_workunits() {
       let span_id = generate_random_64bit_string();
-      let node_workunit_params = match self.user_facing_name() {
-        Some(ref node_name) => {
-          let start_time = std::time::SystemTime::now();
-          Some((node_name.clone(), start_time, span_id.clone()))
-        }
-        _ => None,
-      };
-      (node_workunit_params, Some(span_id))
+      let parent_id = workunit_store::get_parent_id();
+      let maybe_started_workunit = self
+        .user_facing_name()
+        .map(|ref node_name| StartedWorkUnit {
+          name: node_name.clone(),
+          start_time: std::time::SystemTime::now(),
+          span_id: span_id.clone(),
+          parent_id,
+        });
+      (maybe_started_workunit, Some(span_id))
     } else {
       (None, None)
     };
@@ -1250,16 +1253,10 @@ impl Node for NodeKey {
       }
     })
     .inspect(move |_: &NodeResult| {
-      if let Some((name, start_time, span_id)) = node_workunit_params {
-        let workunit = WorkUnit {
-          name,
-          time_span: TimeSpan::since(&start_time),
-          span_id,
-          // TODO: set parent_id with the proper value, issue #7969
-          parent_id: None,
-        };
+      if let Some(started_workunit) = maybe_started_workunit {
+        let workunit: WorkUnit = started_workunit.finish();
         context2.session.workunit_store().add_workunit(workunit)
-      };
+      }
     })
     .to_boxed()
   }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -140,6 +140,10 @@ impl Session {
       f()
     }
   }
+
+  pub fn should_handle_workunits(&self) -> bool {
+    self.should_report_workunits() || self.should_record_zipkin_spans()
+  }
 }
 
 pub struct ExecutionRequest {

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -10,3 +10,4 @@ futures = "0.1"
 futures-cpupool = "0.1"
 logging = { path = "../logging" }
 tokio = "0.1"
+workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -63,7 +63,7 @@ impl Executor {
     self
       .runtime
       .executor()
-      .spawn(Self::future_with_correct_logging_context(future))
+      .spawn(Self::future_with_correct_context(future))
   }
 
   ///
@@ -95,7 +95,7 @@ impl Executor {
     future: F,
   ) -> impl Future<Item = Item, Error = Error> {
     futures::sync::oneshot::spawn(
-      Self::future_with_correct_logging_context(future),
+      Self::future_with_correct_context(future),
       &self.runtime.executor(),
     )
   }
@@ -124,7 +124,7 @@ impl Executor {
     // for a user-facing thread).
     Runtime::new()
       .unwrap()
-      .block_on(Self::future_with_correct_logging_context(future))
+      .block_on(Self::future_with_correct_context(future))
   }
 
   ///
@@ -146,21 +146,25 @@ impl Executor {
   ) -> impl Future<Item = Item, Error = Error> {
     self
       .io_pool
-      .spawn(Self::future_with_correct_logging_context(future))
+      .spawn(Self::future_with_correct_context(future))
   }
 
   ///
-  /// Copy our (thread-local or task-local) logging destination into the task.
+  /// Copy our (thread-local or task-local) logging destination and current workunit parent into
+  /// the task. The former ensures that when a pantsd thread kicks off a future, any logging done
+  /// by it ends up in the pantsd log as we expect. The latter ensures that when a new workunit
+  /// is created it has an accurate handle to its parent.
   ///
-  /// This helps us to ensure that when a pantsd thread kicks off a future, any logging done by it
-  /// ends up in the pantsd log as we expect.
-  ///
-  fn future_with_correct_logging_context<Item, Error, F: Future<Item = Item, Error = Error>>(
+  fn future_with_correct_context<Item, Error, F: Future<Item = Item, Error = Error>>(
     future: F,
   ) -> impl Future<Item = Item, Error = Error> {
     let logging_destination = logging::get_destination();
+    let workunit_parent_id = workunit_store::get_parent_id();
     futures::lazy(move || {
       logging::set_destination(logging_destination);
+      if let Some(parent_id) = workunit_parent_id {
+        workunit_store::set_parent_id(parent_id);
+      }
       future
     })
   }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -41,6 +41,24 @@ pub struct WorkUnit {
   pub parent_id: Option<String>,
 }
 
+pub struct StartedWorkUnit {
+  pub name: String,
+  pub start_time: std::time::SystemTime,
+  pub span_id: String,
+  pub parent_id: Option<String>,
+}
+
+impl StartedWorkUnit {
+  pub fn finish(self) -> WorkUnit {
+    WorkUnit {
+      name: self.name,
+      time_span: TimeSpan::since(&self.start_time),
+      span_id: self.span_id,
+      parent_id: self.parent_id,
+    }
+  }
+}
+
 impl WorkUnit {
   pub fn new(name: String, time_span: TimeSpan, parent_id: Option<String>) -> WorkUnit {
     let span_id = generate_random_64bit_string();
@@ -113,16 +131,22 @@ task_local! {
 }
 
 pub fn set_parent_id(parent_id: String) {
-  TASK_PARENT_ID.with(|task_parent_id| {
-    *task_parent_id.lock() = Some(parent_id);
-  })
+  if futures::task::is_in_task() {
+    TASK_PARENT_ID.with(|task_parent_id| {
+      *task_parent_id.lock() = Some(parent_id);
+    })
+  }
 }
 
 pub fn get_parent_id() -> Option<String> {
-  TASK_PARENT_ID.with(|task_parent_id| {
-    let task_parent_id = task_parent_id.lock();
-    (*task_parent_id).clone()
-  })
+  if futures::task::is_in_task() {
+    TASK_PARENT_ID.with(|task_parent_id| {
+      let task_parent_id = task_parent_id.lock();
+      (*task_parent_id).clone()
+    })
+  } else {
+    None
+  }
 }
 
 #[cfg(test)]

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -91,7 +91,8 @@ class Omega:
 
 @rule(name="rule_one")
 async def rule_one(i: Input) -> Beta:
-  """This rule should be the first one executed by the engine."""
+  """This rule should be the first one executed by the engine, and
+  thus have no parent."""
   a = Alpha()
   o = await Get[Omega](Alpha, a)
   b = await Get[Beta](Omega, o)
@@ -337,7 +338,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     r3 = next(item for item in tracker.workunits if item['name'] == 'rule_three')
     r4 = next(item for item in tracker.workunits if item['name'] == 'rule_four')
 
+    assert r1.get('parent_id', None) is None
     assert r2['parent_id'] == r1['span_id']
     assert r3['parent_id'] == r1['span_id']
     assert r4['parent_id'] == r2['span_id']
-

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -66,6 +66,57 @@ class MyFloat:
 def upcast(n: MyInt) -> MyFloat:
   return MyFloat(float(n.val))
 
+# This set of dummy types and the following `@rule`s are intended to test that workunits are
+# being generated correctly and with the correct parent-child relationships.
+
+class Input:
+  pass
+
+
+class Alpha:
+  pass
+
+
+class Beta:
+  pass
+
+
+class Gamma:
+  pass
+
+
+class Omega:
+  pass
+
+
+@rule(name="rule_one")
+async def rule_one(i: Input) -> Beta:
+  """This rule should be the first one executed by the engine."""
+  a = Alpha()
+  o = await Get[Omega](Alpha, a)
+  b = await Get[Beta](Omega, o)
+  return b
+
+@rule(name="rule_two")
+async def rule_two(a: Alpha) -> Omega:
+  """This rule should be invoked in the body of `rule_one` and
+  therefore its workunit should be a child of `rule_one`'s workunit."""
+  await Get[Gamma](Alpha, a)
+  return Omega()
+
+@rule(name="rule_three")
+async def rule_three(o: Omega) -> Beta:
+  """This rule should be invoked in the body of `rule_one` and
+  therefore its workunit should be a child of `rule_one`'s workunit."""
+  return Beta()
+
+
+@rule(name="rule_four")
+def rule_four(a: Alpha) -> Gamma:
+  """This rule should be invoked in the body of `rule_two` and
+  therefore its workunit should be a child of `rule_two`'s workunit."""
+  return Gamma()
+
 
 class EngineTest(unittest.TestCase, SchedulerTestBase):
 
@@ -237,33 +288,56 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
       str(cm.exception)
     )
 
-  def test_async_reporting(self):
+
+  @dataclass
+  class WorkunitTracker:
+    workunits: List[dict] = field(default_factory=list)
+    finished: bool = False
+
+    def add(self, workunits, **kwargs) -> None:
+      if kwargs['finished'] == True:
+        self.finished = True
+      self.workunits.extend(workunits)
+
+  def test_streaming_workunits_reporting(self):
     rules = [ fib, RootRule(int)]
     scheduler = self.mk_scheduler(rules, include_trace_on_error=False, should_report_workunits=True)
 
-    @dataclass
-    class Tracker:
-      workunits: List[dict] = field(default_factory=list)
-      finished: bool = False
-
-      def add(self, workunits, **kwargs) -> None:
-        if kwargs['finished'] == True:
-          self.finished = True
-        self.workunits.extend(workunits)
-
-    tracker = Tracker()
-    async_reporter = StreamingWorkunitHandler(scheduler, callbacks=[tracker.add], report_interval_seconds=0.01)
-    with async_reporter.session():
+    tracker = self.WorkunitTracker()
+    handler = StreamingWorkunitHandler(scheduler, callbacks=[tracker.add], report_interval_seconds=0.01)
+    with handler.session():
       scheduler.product_request(Fib, subjects=[0])
 
     # The execution of the single named @rule "fib" should be providing this one workunit.
     self.assertEquals(len(tracker.workunits), 1)
 
     tracker.workunits = []
-    with async_reporter.session():
+    with handler.session():
       scheduler.product_request(Fib, subjects=[10])
 
     # Requesting a bigger fibonacci number will result in more rule executions and thus more reported workunits.
     # In this case, we expect 10 invocations of the `fib` rule.
     assert len(tracker.workunits) ==  10
     assert tracker.finished
+
+  def test_streaming_workunits_parent_id(self):
+    rules = [RootRule(Input), rule_one, rule_two, rule_three, rule_four]
+    scheduler = self.mk_scheduler(rules, include_trace_on_error=False, should_report_workunits=True)
+    tracker = self.WorkunitTracker()
+    handler = StreamingWorkunitHandler(scheduler, callbacks=[tracker.add], report_interval_seconds=0.01)
+
+    with handler.session():
+      i = Input()
+      scheduler.product_request(Beta, subjects=[i])
+
+    assert tracker.finished
+
+    r1 = next(item for item in tracker.workunits if item['name'] == 'rule_one')
+    r2 = next(item for item in tracker.workunits if item['name'] == 'rule_two')
+    r3 = next(item for item in tracker.workunits if item['name'] == 'rule_three')
+    r4 = next(item for item in tracker.workunits if item['name'] == 'rule_four')
+
+    assert r2['parent_id'] == r1['span_id']
+    assert r3['parent_id'] == r1['span_id']
+    assert r4['parent_id'] == r2['span_id']
+


### PR DESCRIPTION
### Problem

Cf. https://github.com/pantsbuild/pants/issues/7969 , we weren't previously setting a workunit's parent ID correctly.

### Solution

The solution turned out to be to make sure that we call `workunit_store::[get|set]_parent_id` in `task_executor`, to make sure that the task-local notion of what the most current parent ID for a workunit is gets propagated to newly-spawned tasks. It also makes sure that at least one workunit is the first one to start and set the parent id, which ensures that that workunit itself will have a `None` `parent_id` in Python.
