### PR TITLE
Set V2 Pytest pex files as `--not-zip-safe` to fix occasional hanging

### DIFF
--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 from pants.backend.python.rules.pex import (
   CreatePex,
@@ -24,8 +24,9 @@ class CreatePexFromTargetClosure:
   build_file_addresses: BuildFileAddresses
   output_filename: str
   entry_point: Optional[str] = None
-  additional_requirements: tuple = ()
+  additional_requirements: Tuple[str, ...] = ()
   include_source_files: bool = True
+  additional_args: Tuple[str, ...] = ()
 
 
 @rule(name="Create PEX from targets")
@@ -55,6 +56,7 @@ async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
     interpreter_constraints=interpreter_constraints,
     entry_point=request.entry_point,
     input_files_digest=chrooted_sources.digest if request.include_source_files else None,
+    additional_args=request.additional_args,
   )
 
   pex = await Get[Pex](CreatePex, create_pex_request)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -107,6 +107,9 @@ async def setup_pytest_for_target(
       # NB: We set `--not-zip-safe` because Pytest plugin discovery, which uses
       # `importlib_metadata` and thus `zipp`, does not play nicely when doing import magic directly
       # from zip files. `zipp` has pathologically bad behavior with large zipfiles.
+      # TODO: this does have a performance cost as the pex must now be expanded to disk. Long term,
+      # it would be better to fix Zipp (whose fix would then need to be used by importlib_metadata
+      # and then by Pytest). See https://github.com/jaraco/zipp/pull/26.
       additional_args=("--not-zip-safe",),
       include_source_files=False,
     )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -104,7 +104,11 @@ async def setup_pytest_for_target(
       output_filename='pytest-with-requirements.pex',
       entry_point="pytest:main",
       additional_requirements=pytest.get_requirement_strings(),
-      include_source_files=False
+      # NB: We set `--not-zip-safe` because Pytest plugin discovery, which uses
+      # `importlib_metadata` and thus `zipp`, does not play nicely when doing import magic directly
+      # from zip files. `zipp` has pathologically bad behavior with large zipfiles.
+      additional_args=("--not-zip-safe",),
+      include_source_files=False,
     )
   )
 
@@ -186,11 +190,7 @@ async def run_python_test(
 
 
 @rule(name="Run pytest in an interactive process")
-async def debug_python_test(
-  test_target: PythonTestsAdaptor,
-  test_setup: TestTargetSetup,
-) -> TestDebugRequest:
-
+async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
   run_request = InteractiveProcessRequest(
     argv=(test_setup.requirements_pex.output_filename, *test_setup.args),
     run_in_workspace=False,


### PR DESCRIPTION
### Problem

Toolchain tests—which run via local V2 execution—started frequently hanging recently. For the past two months, they've frequently timed out, which we assumed was due to too high of concurrency, but it now seems likely that those tests were actually hanging.

We identified that the issue is from Pex marking the Pytest requirements pexes as `--zip-safe` (the default). Pytest plugin discovery, which uses `importlib_metadata` and thus `zipp`, does not play nicely when doing import magic directly from zip files. `zipp` has pathologically bad behavior with large zipfiles.

### Solution

Set Pytest requirement pexes as `--not-zip-safe`, which requires tweaking our core V2 pex abstraction to allow rules to pass through additional args to Pex.

### Result

Running a Toolchain test from Pants sources no longer hangs when using V2.