### PR TITLE
Catch BaseException in StreamingWorkunitHandler

### DIFF
--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -40,7 +40,7 @@ class StreamingWorkunitHandler:
       self.start()
       yield
       self.end()
-    except Exception as e:
+    except BaseException as e:
       if self._thread_runner:
         self._thread_runner.join()
       raise e


### PR DESCRIPTION
### Problem

In the `session` contextmanager of `StreamingWorkunitHandler` we have a try-except block that catches all `Exception`s, shuts down the thread polling for workunits, then re-raises the exception. However, certain exceptions we care about - like the `KeyboardInterrupt` raised when the user hits Ctrl-C - are not subclasses of `Exception`, so they aren't handled by this check. This means that right now if the user hits Ctrl-C to shut down pants, nothing will shut down the polling thread and it will stick around forever (or until someone kills it manually with `kill -9`).

### Solution

Catch `BaseException` instead of `Exception` here.

## Result

This makes it possible to quit pants by hitting Ctrl-C without leaving an orphaned thread polling forever.