### PR TITLE
Deprecate defaulting to `--transitive`

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/filemap.py
+++ b/src/python/pants/backend/graph_info/tasks/filemap.py
@@ -7,6 +7,18 @@ from pants.task.console_task import ConsoleTask
 class Filemap(ConsoleTask):
   """Print a mapping from source file to the target that owns the source file."""
 
+  _register_console_transitivity_option = False
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `filemap`.",
+    )
+
   def console_output(self, _):
     visited = set()
     for target in self.determine_target_roots('filemap'):

--- a/src/python/pants/backend/graph_info/tasks/filter.py
+++ b/src/python/pants/backend/graph_info/tasks/filter.py
@@ -24,6 +24,8 @@ class Filter(TargetFilterTaskMixin, ConsoleTask):
   between them.
   """
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -37,6 +39,12 @@ class Filter(TargetFilterTaskMixin, ConsoleTask):
              help='Filter on target addresses matching these regexes.')
     register('--tag-regex', type=list, metavar='[+-]regex1,regex2,...',
              help='Filter on targets with tags matching these regexes.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `filter`.",
+    )
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/graph_info/tasks/minimal_cover.py
+++ b/src/python/pants/backend/graph_info/tasks/minimal_cover.py
@@ -12,6 +12,18 @@ class MinimalCover(ConsoleTask):
   the input targets without gaps.
   """
 
+  _register_console_transitivity_option = False
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `minimize`.",
+    )
+
   def console_output(self, _):
     internal_deps = self._collect_internal_deps(self.context.target_roots)
 

--- a/src/python/pants/backend/graph_info/tasks/paths.py
+++ b/src/python/pants/backend/graph_info/tasks/paths.py
@@ -47,6 +47,19 @@ def find_paths_breadth_first(from_target, to_target, log):
 
 
 class PathFinder(ConsoleTask):
+
+  _register_console_transitivity_option = False
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goals `path` and `paths`.",
+    )
+
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
     self.log = self.context.log

--- a/src/python/pants/backend/graph_info/tasks/sort_targets.py
+++ b/src/python/pants/backend/graph_info/tasks/sort_targets.py
@@ -8,11 +8,19 @@ from pants.task.console_task import ConsoleTask
 class SortTargets(ConsoleTask):
   """Topologically sort the targets."""
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--reverse', type=bool,
              help='Sort least-dependent to most-dependent.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `sort`.",
+    )
 
   def console_output(self, targets):
     sorted_targets = sort_targets(targets)

--- a/src/python/pants/backend/jvm/tasks/classmap.py
+++ b/src/python/pants/backend/jvm/tasks/classmap.py
@@ -9,10 +9,15 @@ from pants.task.console_task import ConsoleTask
 class ClassmapTask(ConsoleTask):
   """Print a mapping from class name to the owning target from target's runtime classpath."""
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-
+    register(
+      "--transitive", default=True, type=bool, fingerprint=True,
+      help="Include transitive dependencies in the classmap.",
+    )
     register('--internal-only', default=False, type=bool, fingerprint=True,
              help='Specifies that only class names of internal dependencies should be included.')
 

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -30,7 +30,7 @@ from pants.build_graph.build_graph import sort_targets
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy import Ivy
 from pants.task.scm_publish_mixin import Namedver, ScmPublishMixin, Semver
-from pants.task.target_restriction_mixins import HasTransitiveOptionMixin, TransitiveOptionRegistrar
+from pants.task.target_restriction_mixins import HasTransitiveOptionMixin
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree
 from pants.util.strutil import ensure_text
 
@@ -231,7 +231,7 @@ def target_internal_dependencies(target):
         yield childdep
 
 
-class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublishMixin, JarTask):
+class JarPublish(HasTransitiveOptionMixin, ScmPublishMixin, JarTask):
   """Publish jars to a maven repository.
 
   At a high-level, pants uses `Apache Ivy <http://ant.apache.org/ivy/>`_ to
@@ -349,6 +349,8 @@ class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublish
                   'artifact published')
     register('--prompt', default=True, type=bool,
              help='Interactively prompt user before publishing each artifact.')
+    register('--transitive', default=True, type=bool,
+             help='Publish the specified targets and all their internal dependencies transitively.')
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -61,6 +61,22 @@ class Dependencies(ConsoleTask):
       else:
         self.dependency_type = DependencyType.SOURCE_AND_THIRD_PARTY
 
+  @property
+  def act_transitively(self):
+    # NB: Stop overriding this property once the deprecation is complete.
+    deprecated_conditional(
+      lambda: self.get_options().is_default("transitive"),
+      entity_description=f"Pants defaulting to `--dependencies-transitive`",
+      removal_version="1.28.0.dev0",
+      hint_message="Currently, Pants defaults to `--dependencies-transitive`, which means that it "
+                   "will find all transitive dependencies for the target, rather than only direct "
+                   "dependencies. This is a useful feature, but surprising to be the default."
+                   "\n\nTo prepare for this change to the default value, set in `pants.ini` under "
+                   "the section `dependencies` the value `transitive: False`. In Pants 1.28.0, "
+                   "you can safely remove the setting."
+    )
+    return self.get_options().transitive
+
   def console_output(self, unused_method_argument):
     opts = self.get_options()
     deprecated_conditional(

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -22,6 +22,8 @@ class Depmap(ConsoleTask):
     RESOURCE = 'RESOURCE'  # Resource belonging to Source Target
     TEST_RESOURCE = 'TEST_RESOURCE'  # Resource belonging to Test Target
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -44,6 +46,12 @@ class Depmap(ConsoleTask):
     register('--separator', default='-',
              help='Specifies the separator to use between the org/name/rev components of a '
                   'dependency\'s fully qualified name.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `depmap`.",
+    )
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -418,6 +418,24 @@ class Export(ExportTask, ConsoleTask):  # type: ignore[misc]
   Intended for exporting project information for IDE, such as the IntelliJ Pants plugin.
   """
 
+  _register_console_transitivity_option = False
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="`export` should always act transitively, which is the default. This option "
+                   "will be going away to ensure that Pants always does the right thing.",
+    )
+
+  @property
+  def act_transitively(self):
+    # NB: `export` should always act transitively
+    return self.get_options().transitive
+
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
 

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -32,6 +32,8 @@ class ExportDepAsJar(ConsoleTask):
   jvm dependencies instead of sources.
   """
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (DependencyContext,)
@@ -43,6 +45,19 @@ class ExportDepAsJar(ConsoleTask):
       help='Causes output to be a single line of JSON.')
     register('--sources', type=bool,
       help='Causes the sources of dependencies to be zipped and included in the project.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="`export-dep-as-jar` should always act transitively, which is the default. "
+                   "This option will be going away to ensure that Pants always does the right "
+                   "thing.",
+    )
+
+  @property
+  def act_transitively(self):
+    # NB: `export-dep-as-jar` should always act transitively
+    return self.get_options().transitive
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -6,6 +6,7 @@ import os
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.task.console_task import ConsoleTask
 
 
@@ -23,6 +24,22 @@ class FileDeps(ConsoleTask):
              help='Instead of outputting filenames, output globs (ignoring excludes)')
     register('--absolute', type=bool, default=True,
              help='If True output with absolute path, else output with path relative to the build root')
+
+  @property
+  def act_transitively(self):
+    # NB: Stop overriding this property once the deprecation is complete.
+    deprecated_conditional(
+      lambda: self.get_options().is_default("transitive"),
+      entity_description=f"Pants defaulting to `--filedeps-transitive`",
+      removal_version="1.28.0.dev0",
+      hint_message="Currently, Pants defaults to `--filedeps-transitive`, which means that it "
+                   "will find all transitive files used by the target, rather than only direct "
+                   "file dependencies. This is a useful feature, but surprising to be the default."
+                   "\n\nTo prepare for this change to the default value, set in `pants.ini` under "
+                   "the section `filedeps` the value `transitive: False`. In Pants 1.28.0, "
+                   "you can safely remove the setting."
+    )
+    return self.get_options().transitive
 
   def _file_path(self, path):
     return os.path.join(get_buildroot(), path) if self.get_options().absolute else path

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -52,6 +52,8 @@ class IdeaPluginGen(ConsoleTask):
 
   PROJECT_NAME_LIMIT = 200
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -75,6 +77,18 @@ class IdeaPluginGen(ConsoleTask):
                   'jdk name for the --java-language-level is used')
     register('--java-language-level', type=int, default=8,
              help='Sets the java language and jdk used to compile the project\'s java sources.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="`idea-plugin` should always act transitively, which is the default. This option "
+                   "will be going away to ensure that Pants always does the right thing.",
+    )
+
+  @property
+  def act_transitively(self):
+    # NB: `idea-plugin` should always act transitively
+    return self.get_options().transitive
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/core_tasks/bash_completion.py
+++ b/src/python/pants/core_tasks/bash_completion.py
@@ -18,6 +18,18 @@ from pants.task.task import TaskBase
 class BashCompletion(ConsoleTask):
   """Generate a Bash shell script that teaches Bash how to autocomplete pants command lines."""
 
+  _register_console_transitivity_option = False
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `bash-completion`.",
+    )
+
   @staticmethod
   def _get_all_cmd_line_scopes():
     """Return all scopes that may be explicitly specified on the cmd line, in no particular order.

--- a/src/python/pants/core_tasks/explain_options_task.py
+++ b/src/python/pants/core_tasks/explain_options_task.py
@@ -21,6 +21,8 @@ class ExplainOptionsTask(ConsoleTask):
   value and then a cli FLAG value).
   """
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -36,6 +38,12 @@ class ExplainOptionsTask(ConsoleTask):
              help='Do not show inherited options, unless their values differ from their parents.')
     register('--output-format', choices=['text', 'json'], default='text',
              help='Specify the format options will be printed.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      help='If True, use all targets in the build graph, else use only target roots.',
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `options`.",
+    )
 
   def _scope_filter(self, scope):
     pattern = self.get_options().scope

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -17,6 +17,8 @@ class Login(ConsoleTask):
   :API: public
   """
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (BasicAuth,)
@@ -35,6 +37,11 @@ class Login(ConsoleTask):
            'points to the URL `https://app.pantsbuild.org/auth`, then you '
            'could here use the option `--login-to=prod` to login at '
            '`https://app.pantsbuild.org/auth`.'
+    )
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `login`.",
     )
 
   def console_output(self, targets):

--- a/src/python/pants/core_tasks/targets_help.py
+++ b/src/python/pants/core_tasks/targets_help.py
@@ -11,10 +11,17 @@ from pants.task.console_task import ConsoleTask
 class TargetsHelp(ConsoleTask):
   """List available target types."""
 
+  _register_console_transitivity_option = False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--details', help='Show details about this target type.')
+    register(
+      '--transitive', type=bool, default=True, fingerprint=True,
+      removal_version="1.27.0.dev0",
+      removal_hint="This option has no impact on the goal `targets`.",
+    )
 
   def console_output(self, targets):
     buildfile_aliases = self.context.build_configuration.registered_aliases()

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -5,6 +5,7 @@ import errno
 import os
 from contextlib import contextmanager
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.task.target_restriction_mixins import HasTransitiveOptionMixin
 from pants.task.task import QuietTaskMixin, Task
@@ -34,6 +35,22 @@ class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
     if cls._register_console_transitivity_option:
       register('--transitive', type=bool, default=True, fingerprint=True,
                help='If True, use all targets in the build graph, else use only target roots.')
+
+  @property
+  def act_transitively(self):
+    deprecated_conditional(
+      lambda: self.get_options().is_default("transitive"),
+      entity_description=f"Pants defaulting to `--transitive` for `{self.options_scope}`",
+      removal_version="1.27.0.dev0",
+      hint_message="Currently, Pants defaults to `--transitive`, which means that it "
+                   "will run against transitive dependencies for the targets you specify on the "
+                   "command line, rather than only the targets you specify. This is often useful, "
+                   "such as running `./pants dependencies --transitive`, but it is surprising "
+                   "to have this behavior by default.\n\nTo prepare for this change to the default "
+                   f"value, set in `pants.ini` under the section `{self.options_scope}` the value "
+                   "`transitive: False`. In Pants 1.27.0, you can safely remove the setting."
+    )
+    return self.get_options().transitive
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)


### PR DESCRIPTION
Currently, `ConsoleTasks` default to having an option `--transitive` with a default value of True. 

Per this audit https://docs.google.com/spreadsheets/d/1gKfyiCES8zzXX1yeDnOWrhRTYL2zVjMiqsKdBVIKiMM/edit#gid=0, we currently have 11 tasks where this option does not have impact. 

For the vast majority of the other tasks, the option should default to False instead of True to be less surprising to users. For example, one would expect `./pants test tests/pants_test/util/test_strutil.py` to only run over 1 file, but it will by default run over 2 files.

As documented in the audit https://docs.google.com/spreadsheets/d/1gKfyiCES8zzXX1yeDnOWrhRTYL2zVjMiqsKdBVIKiMM/edit#gid=0, this PR makes these changes:

* Deprecates `--transitive` for 11 tasks which currently no-op
* Keeps 3 tasks defaulting as `--no-transitive`
* Keeps 3 tasks defaulting as `--transitive`
* Deprecates `--transitive` for 3 tasks which should always act transitively
* Deprecates relying on the default `--transitive` for 6 tasks so that we can switch the default to `--no-transitive`
