### PR TITLE
Use daemon thread

### DIFF
--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -48,7 +48,7 @@ class StreamingWorkunitHandler:
 
 class _InnerHandler(threading.Thread):
   def __init__(self, scheduler: Any, callbacks: Iterable[Callable], report_interval: float):
-    super(_InnerHandler, self).__init__()
+    super().__init__(daemon=True)
     self.scheduler = scheduler
     self.stop_request = threading.Event()
     self.report_interval = report_interval


### PR DESCRIPTION
## Problem

In the `session` contextmanager of `StreamingWorkunitHandler` we initialize a thread that periodically polls workunits from the engine. Currently, if pants raises an exception that isn't a child of `Exception` - for instance, the `KeyboardInterrupt` that is triggered when someone hits ctrl-c - this exception won't be explicitly caught. This causes the main thread to die without killing the child polling thread, which sticks around forever preventing pants from fully exiting.

## Solution

Use the `daemon=True` option that the Python stdlib `Threading` class provides on the polling thread spawned by `StreamingWorkunitHandler`. This has the effect of automatically terminating the polling thread once all non-daemon threads are terminated, which is exactly what we want in this case.

## Result

This makes it possible to quit pants by hitting Ctrl-C without leaving an orphaned thread polling forever.