### PR TITLE
Restore support for `dependencies` outputting 3rdparty deps through new enum option

### DIFF
--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -13,9 +13,9 @@ from pants.engine.selectors import Get
 
 
 class DependencyType(Enum):
-  INTERNAL = "internal"
-  EXTERNAL = "external"
-  INTERNAL_AND_EXTERNAL = "internal-and-external"
+  SOURCE = "source"
+  THIRD_PARTY = "3rdparty"
+  SOURCE_AND_THIRD_PARTY = "source-and-3rdparty"
 
 
 # TODO(#8762) Get this rule to feature parity with the dependencies task.
@@ -33,9 +33,9 @@ class DependenciesOptions(LineOriented, GoalSubsystem):
     )
     # TODO(#8762): Wire this up. Currently we only support `internal`.
     register(
-      '--type', type=DependencyType, default=DependencyType.INTERNAL,
-      help="Which types of dependencies to find, where `internal` means source code dependencies "
-           "and `external` means 3rd party requirements and JARs."
+      '--type', type=DependencyType, default=DependencyType.SOURCE,
+      help="Which types of dependencies to find, where `source` means source code dependencies "
+           "and `3rdparty` means third-party requirements and JARs."
     )
 
 

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from enum import Enum
 from typing import Set
 
 from pants.engine.addressable import BuildFileAddresses
@@ -9,6 +10,12 @@ from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
+
+
+class DependencyType(Enum):
+  INTERNAL = "internal"
+  EXTERNAL = "external"
+  INTERNAL_AND_EXTERNAL = "internal-and-external"
 
 
 # TODO(#8762) Get this rule to feature parity with the dependencies task.
@@ -20,9 +27,15 @@ class DependenciesOptions(LineOriented, GoalSubsystem):
     super().register_options(register)
     register(
       '--transitive',
-      default=True,
+      default=False,
       type=bool,
       help='Run dependencies against transitive dependencies of targets specified on the command line.',
+    )
+    # TODO(#8762): Wire this up. Currently we only support `internal`.
+    register(
+      '--type', type=DependencyType, default=DependencyType.INTERNAL,
+      help="Which types of dependencies to find, where `internal` means source code dependencies "
+           "and `external` means 3rd party requirements and JARs."
     )
 
 

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -40,7 +40,7 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
     env = {
       'PANTS_BACKEND_PACKAGES2': 'pants.backend.project_info'
     }
-    args = ['--no-transitive'] if not transitive else []
+    args = ['--transitive'] if transitive else []
     self.assert_console_output(*expected, args=[*args, target], env=env)
 
   def test_no_target(self):

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -1,12 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.backend.project_info.rules.dependencies import DependencyType
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.payload_field import JarsField, PythonRequirementsField
@@ -23,39 +23,53 @@ class Dependencies(ConsoleTask):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--internal-only', type=bool,
-             help='Specifies that only internal dependencies should be included in the graph '
-                  'output (no external jars).')
+    register(
+      '--type', type=DependencyType, default=DependencyType.INTERNAL,
+      help="Which types of dependencies to find, where `internal` means source code dependencies "
+           "and `external` means 3rd party requirements and JARs."
+    )
+    register(
+      '--internal-only', type=bool,
+      help='Specifies that only internal dependencies should be included in the graph output '
+           '(no external jars).',
+      removal_version="1.27.0.dev0",
+      removal_hint="Use `--dependencies-type=internal` instead.",
+    )
     register(
       '--external-only',
       type=bool,
-      help='Specifies that only external dependencies should be included in the graph output (only external jars).',
-      removal_version="1.26.0.dev0",
-      removal_hint="This feature is being removed. If you depend on this functionality, please let us know in the "
-                   "#general channel on Slack at https://pantsbuild.slack.com/. \nYou can join the pants slack here: "
-                   "https://pantsslack.herokuapp.com/ ",
+      help='Specifies that only external dependencies should be included in the graph output '
+           '(only external jars).',
+      removal_version="1.27.0.dev0",
+      removal_hint="Use `--dependencies-type=external` instead.",
     )
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
-
-    self.is_internal_only = self.get_options().internal_only
-    self.is_external_only = self.get_options().external_only
-    if self.is_internal_only and self.is_external_only:
-      raise TaskError('At most one of --internal-only or --external-only can be selected.')
+    opts = self.get_options()
+    type_configured = not opts.is_default("type")
+    if type_configured:
+      self.dependency_type = opts.type
+      return
+    else:
+      if opts.internal_only and opts.external_only:
+        raise TaskError('At most one of --internal-only or --external-only can be selected.')
+      if opts.internal_only:
+        self.dependency_type = DependencyType.INTERNAL
+      elif opts.external_only:
+        self.dependency_type = DependencyType.EXTERNAL
+      else:
+        self.dependency_type = DependencyType.INTERNAL_AND_EXTERNAL
 
   def console_output(self, unused_method_argument):
+    opts = self.get_options()
     deprecated_conditional(
-      lambda: not self.is_external_only and not self.is_internal_only,
-      removal_version="1.26.0.dev0",
+      lambda: opts.is_default("type") and not opts.internal_only and not opts.external_only,
+      removal_version="1.27.0.dev0",
       entity_description="The default dependencies output including external dependencies",
-      hint_message="Pants will soon default to `--internal-only`, and remove the `--external-only` option. "
-                    "Currently, Pants defaults to include both internal and external dependencies, which means this "
-                    "task returns a mix of both target addresses and requirement strings."
-                    "\n\nTo prepare, you can run this task with the `--internal-only` option. "
-                    "If you need still need support for including external dependencies in the output, please let us "
-                    "know in the #general channel on Slack at https://pantsbuild.slack.com/."
-                    "\nYou can join the pants slack here: https://pantsslack.herokuapp.com/",
+      hint_message="Pants will soon default to `--dependencies-type=internal`, rather than "
+                   "`--dependencies-type=internal-and-external`. To prepare, run this task with"
+                   " `--dependencies-type=internal`.",
     )
     ordered_closure = OrderedSet()
     for target in self.context.target_roots:
@@ -65,9 +79,9 @@ class Dependencies(ConsoleTask):
         ordered_closure.update(target.dependencies)
 
     for tgt in ordered_closure:
-      if not self.is_external_only:
+      if self.dependency_type in [DependencyType.INTERNAL, DependencyType.INTERNAL_AND_EXTERNAL]:
         yield tgt.address.spec
-      if not self.is_internal_only:
+      if self.dependency_type in [DependencyType.EXTERNAL, DependencyType.INTERNAL_AND_EXTERNAL]:
         # TODO(John Sirois): We need an external payload abstraction at which point knowledge
         # of jar and requirement payloads can go and this hairball will be untangled.
         if isinstance(tgt.payload.get_field('requirements'), PythonRequirementsField):


### PR DESCRIPTION
Turns out, there is a use case for `./pants dependencies --external-only`, such as scripts using it to determine the exact version strings of Python requirements used by Pants targets.

However, the option names are not ideal, such as having to enforce that they're mutually exclusive at runtime. It's also a bit confusing to default to `internal and external`. Ideally, we'd default to `sources` (aka `internal`) and only include `3rdparty` (aka `external`) when requested.

We can make both improvements through a new enum option, which wasn't available when we first wrote this due to Python 2 not having enums.

![help message for the dependencies2 goal](https://user-images.githubusercontent.com/14852634/72855006-54cf5180-3c73-11ea-9351-29d7e880384a.png)
