### PR TITLE
Skip hanging Pantsd integration test

### DIFF
--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -602,6 +602,7 @@ Interrupted by user over pailgun client!
       # NB: Make the timeout very small to ensure the warning message will reliably occur in CI!
       quit_timeout=1e-6)
 
+  @unittest.skip(reason="This started consistently hanging on Jan. 13, 2020 for some unknown reason.")
   def test_sigint_kills_request_waiting_for_lock(self):
     """
     Test that, when a pailgun request is blocked waiting for another one to end,


### PR DESCRIPTION
This started hanging consistently around 11 AM PST on the master branch and several PR builds. 

The first failure was for https://travis-ci.org/pantsbuild/pants/builds/636504715, which only adds f-strings and is highly unlikely to be causing the hang. 

A PR to run each test method as an individual target isolated the issue to `test_sigint_kills_request_waiting_for_lock()`. We skip this for now to stabilize CI.