### PR TITLE
Add helpful error message to rule authors when merging non-digests

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -139,7 +139,7 @@ async def setup_pytest_for_target(
     for package in packages_to_cover:
       coverage_args.extend(['--cov', package])
 
-  merged_input_files: Digest = await Get[Digest](DirectoriesToMerge(directories=tuple(directories_to_merge)))
+  merged_input_files = await Get[Digest](DirectoriesToMerge(directories=tuple(directories_to_merge)))
 
   return TestTargetSetup(
     requirements_pex=resolved_requirements_pex,

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -161,6 +161,12 @@ class Snapshot:
 class DirectoriesToMerge:
   directories: Tuple[Digest, ...]
 
+  def __post_init__(self) -> None:
+    non_digests = [v for v in self.directories if not isinstance(v, Digest)]  # type: ignore[misc]
+    if non_digests:
+      formatted_non_digests = '\n'.join(f"* {v}" for v in non_digests)
+      raise ValueError(f"Not all arguments are digests:\n\n{formatted_non_digests}")
+
 
 @dataclass(frozen=True)
 class DirectoryWithPrefixToStrip:


### PR DESCRIPTION
### Problem
Several different times, rule authors have encountered issues where they try merging a non-digest with `DirectoriesToMerge`. This is especially common because we often try to merge digests coming from wrapper types like `InitInjectedDigest` and we forgot to unwrap the underlying digest. When this happens, the error message is particularly unhelpful:

```
Exception message: Internal logic error in scheduler: expected elements in `self._native._peek_cffi_extern_method_runtime_exceptions()`
```

While MyPy does catch most these issues now that our rule code is fully typed, there's sometimes a chicken-and-the-egg problem that the issue in the rule results in `./pants lint` not working to even be able to run MyPy. Also, most devs try running `./pants their-new-command` before running MyPy and this will help to eagerly catch the issue.

### Result
Now, we print an error message like this:

>             ValueError: Not all arguments are digests:
>
>            * ChrootedPythonSources(digest=Digest(fingerprint='7ec62cce797eaa13f80faef681089bda5dc6b0d9608c0a0ad974db97761b75f1', serialized_bytes_length=165))
>            * Pex(directory_digest=Digest(fingerprint='7d8f3a805c82c34b513c976beabaa2a50f10c47e15ed0885677e1fe05693ff28', serialized_bytes_length=107), output_filename='pytest-with-requirements.pex')

Closes https://github.com/pantsbuild/pants/issues/8907.