### PR TITLE
Add type hints to `Address`, `Struct`, `TargetAdaptor`, `Parser`, and `HydratedTarget`

### DIFF
--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -90,7 +90,7 @@ class BuildFile(ABC):
     return OrderedSet(sorted((BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
                              key=lambda build_file: build_file.full_path))
 
-  def __init__(self, project_tree: ProjectTree, relpath: str):
+  def __init__(self, project_tree: ProjectTree, relpath: str) -> None:
     """Creates a BuildFile object representing the BUILD file family at the specified path.
 
     :param project_tree: Project tree the BUILD file exist in.

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -159,10 +159,7 @@ python_library(
   sources=['parser.py'],
   dependencies=[
     '3rdparty/python:dataclasses',
-    ':addressable',
-    ':objects',
-    'src/python/pants/build_graph',
-    'src/python/pants/util:memo',
+    ':struct',
   ],
   tags = {"partially_type_checked"},
 )

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,7 +5,7 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from functools import update_wrapper
-from typing import Any, Set, Tuple, Type
+from typing import Any, List, Set, Tuple, Type
 
 from pants.base.specs import AddressSpec
 from pants.build_graph.address import Address, BuildFileAddress
@@ -26,7 +26,7 @@ class ProvenancedBuildFileAddress:
 
 class BuildFileAddresses(Collection[BuildFileAddress]):
   @property
-  def addresses(self):
+  def addresses(self) -> List[Address]:
     """Converts the BuildFileAddress objects in this collection to Address objects."""
     return [bfa.to_address() for bfa in self]
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -86,7 +86,10 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
 
   address_family = await Get[AddressFamily](Dir(address.spec_path))
 
-  struct = address_family.addressables.get(address)
+  # NB: `address_family.addressables` is a dictionary of `BuildFileAddress`es and we look it up
+  # with an `Address`. This works because `BuildFileAddress` is a subclass, but MyPy warns that it
+  # could be a bug.
+  struct = address_family.addressables.get(address)  # type: ignore[call-overload]
   addresses = address_family.addressables
   if not struct or address not in addresses:
     _raise_did_you_mean(address_family, address.target_name)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -7,7 +7,7 @@ from collections import defaultdict, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from os.path import dirname
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple, cast
 
 from twitter.common.collections import OrderedSet
 
@@ -30,7 +30,13 @@ from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
-from pants.engine.legacy.structs import BundleAdaptor, BundlesField, HydrateableField, SourcesField
+from pants.engine.legacy.structs import (
+  BundleAdaptor,
+  BundlesField,
+  HydrateableField,
+  SourcesField,
+  TargetAdaptor,
+)
 from pants.engine.mapper import AddressMapper
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
@@ -358,35 +364,33 @@ class HydratedTarget:
   of hashing: we implement eq/hash via direct usage of an Address field to speed that up.
   """
   address: Any
-  adaptor: Any
-  dependencies: Any
+  adaptor: TargetAdaptor
+  dependencies: Tuple
 
   @property
-  def addresses(self):
+  def addresses(self) -> Tuple:
     return self.dependencies
 
   def __hash__(self):
     return hash(self.address)
 
 
-# TODO: add type-checking to datatype fields in this file! Tuple fields such as 'dependencies' need
-# some groundwork to be more ergonomic -- see #6936 for one possible implementation.
+class HydratedTargets(Collection[HydratedTarget]):
+  """An intransitive set of HydratedTarget objects."""
+
+
 @dataclass(frozen=True)
 class TransitiveHydratedTarget:
   """A recursive structure wrapping a HydratedTarget root and TransitiveHydratedTarget deps."""
   root: HydratedTarget
-  dependencies: Any
+  dependencies: Tuple["TransitiveHydratedTarget", ...]
 
 
 @dataclass(frozen=True)
 class TransitiveHydratedTargets:
   """A set of HydratedTarget roots, and their transitive, flattened, de-duped closure."""
-  roots: Any
-  closure: Any
-
-
-class HydratedTargets(Collection[HydratedTarget]):
-  """An intransitive set of HydratedTarget objects."""
+  roots: Tuple[HydratedTarget, ...]
+  closure: OrderedSet  # TODO: this is an OrderedSet[HydratedTarget]
 
 
 @dataclass(frozen=True)
@@ -548,8 +552,8 @@ class HydratedField:
 
 @rule
 async def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
-  target_adaptor = hydrated_struct.value
   """Construct a HydratedTarget from a TargetAdaptor and hydrated versions of its adapted fields."""
+  target_adaptor = cast(TargetAdaptor, hydrated_struct.value)
   # Hydrate the fields of the adaptor and re-construct it.
   hydrated_fields = await MultiGet(Get[HydratedField](HydrateableField, fa)
                                    for fa in target_adaptor.field_adaptors)

--- a/src/python/pants/engine/legacy/graph_test.py
+++ b/src/python/pants/engine/legacy/graph_test.py
@@ -7,6 +7,7 @@ from typing import Dict, Tuple
 import pytest
 
 from pants.engine.legacy.graph import HydratedTarget, topo_sort
+from pants.engine.legacy.structs import TargetAdaptor
 
 
 def make_graph(name_to_deps: Dict[str, Tuple[str, ...]]) -> Dict[str, HydratedTarget]:
@@ -15,7 +16,7 @@ def make_graph(name_to_deps: Dict[str, Tuple[str, ...]]) -> Dict[str, HydratedTa
   def make_ht(nm: str) -> HydratedTarget:
     if nm not in name_to_ht:
       dep_hts = tuple(make_ht(dep) for dep in name_to_deps[nm])
-      name_to_ht[nm] = HydratedTarget(address=nm, adaptor=None, dependencies=dep_hts)
+      name_to_ht[nm] = HydratedTarget(address=nm, adaptor=TargetAdaptor(), dependencies=dep_hts)
     return name_to_ht[nm]
 
   for name in name_to_deps:

--- a/src/python/pants/engine/nodes.py
+++ b/src/python/pants/engine/nodes.py
@@ -52,21 +52,3 @@ class Return(State):
 class Throw(State):
   """Indicates that a Node should have been able to return a value, but failed."""
   exc: Any
-
-
-@dataclass(frozen=True)
-class Runnable(State):
-  """Indicates that the Node is ready to run with the given closure.
-
-  The return value of the Runnable will become the final state of the Node.
-  """
-  func: Any
-  args: Any
-  cacheable: Any
-
-  @classmethod
-  def _from_components(cls, components):
-    return cls(components[0], components[2:], components[1])
-
-  def _to_components(self):
-    return (self.func, self.cacheable) + self.args

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -3,7 +3,9 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Dict, Type
+
+from pants.engine.struct import Struct
 
 
 class ParseError(Exception):
@@ -13,7 +15,7 @@ class ParseError(Exception):
 @dataclass(frozen=True)
 class SymbolTable:
   """A symbol table dict mapping symbol name to implementation class."""
-  table: Dict
+  table: Dict[str, Type]
 
 
 @dataclass(frozen=True)
@@ -23,17 +25,17 @@ class HydratedStruct:
   This exists so that the rule graph can statically provide a struct for a target, and rules can depend on this
   without needing to depend on having a concrete instance of SymbolTable to register their input selectors.
   """
-  value: Any
+  value: Struct
 
 
 class Parser(ABC):
 
   @abstractmethod
-  def parse(self, filepath, filecontent):
+  def parse(self, filepath: str, filecontent: bytes):
     """
-    :param string filepath: The name of the file being parsed. The parser should not assume
-                            that the path is accessible, and should consume the filecontent.
-    :param bytes filecontent: The raw byte content to parse.
+    :param filepath: The name of the file being parsed. The parser should not assume that the path
+                     is accessible, and should consume the filecontent.
+    :param filecontent: The raw byte content to parse.
     :returns: A list of decoded addressable, Serializable objects. The callable will
               raise :class:`ParseError` if there were any problems encountered parsing the filecontent.
     :rtype: :class:`collections.Callable`

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -1,18 +1,20 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import cast
+
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.rules.core import run
 from pants.rules.core.binary import CreatedBinary
+from pants.rules.core.run import Run, run
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
 class RunTest(GoalRuleTestBase):
-  goal_cls = run.Run
+  goal_cls = Run
 
   def create_mock_binary(self, program_text: bytes) -> CreatedBinary:
     input_files_content = InputFilesContent((
@@ -24,10 +26,12 @@ class RunTest(GoalRuleTestBase):
       digest=digest,
     )
 
-  def single_target_run(self, *, console: MockConsole, program_text: bytes, spec: str):
+  def single_target_run(
+    self, *, console: MockConsole, program_text: bytes, address_spec: str,
+  ) -> Run:
     workspace = Workspace(self.scheduler)
     interactive_runner = InteractiveRunner(self.scheduler)
-    address = Address.parse(spec)
+    address = Address.parse(address_spec)
     bfa = BuildFileAddress(
       build_file=None,
       target_name=address.target_name,
@@ -35,7 +39,7 @@ class RunTest(GoalRuleTestBase):
     )
     BuildRoot().path = self.build_root
     res = run_rule(
-      run.run,
+      run,
       rule_args=[console, workspace, interactive_runner, BuildRoot(), bfa],
       mock_gets=[
         MockGet(
@@ -45,7 +49,7 @@ class RunTest(GoalRuleTestBase):
         ),
       ],
     )
-    return res
+    return cast(Run, res)
 
   def test_normal_run(self) -> None:
     console = MockConsole(use_colors=False)
@@ -53,7 +57,7 @@ class RunTest(GoalRuleTestBase):
     res = self.single_target_run(
       console=console,
       program_text=program_text,
-      spec='some/addr'
+      address_spec='some/addr',
     )
     self.assertEqual(res.exit_code, 0)
     self.assertEquals(console.stdout.getvalue(), "Running target: some/addr:addr\nsome/addr:addr ran successfully.\n")
@@ -87,7 +91,7 @@ class RunTest(GoalRuleTestBase):
     res = self.single_target_run(
       console=console,
       program_text=program_text,
-      spec='some/addr'
+      address_spec='some/addr'
     )
     self.assertEqual(res.exit_code, 1)
     self.assertEquals(console.stdout.getvalue(), "Running target: some/addr:addr\n")

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -20,7 +20,7 @@ from pants.util.dirutil import touch
 
 
 class ParseSpecTest(unittest.TestCase):
-  def test_parse_spec(self):
+  def test_parse_spec(self) -> None:
     spec_path, target_name = parse_spec('a/b/c')
     self.assertEqual(spec_path, 'a/b/c')
     self.assertEqual(target_name, 'c')
@@ -33,7 +33,7 @@ class ParseSpecTest(unittest.TestCase):
     self.assertEqual(spec_path, 'a/b/c')
     self.assertEqual(target_name, 'c')
 
-  def test_parse_local_spec(self):
+  def test_parse_local_spec(self) -> None:
     spec_path, target_name = parse_spec(':c')
     self.assertEqual(spec_path, '')
     self.assertEqual(target_name, 'c')
@@ -42,7 +42,7 @@ class ParseSpecTest(unittest.TestCase):
     self.assertEqual(spec_path, 'here')
     self.assertEqual(target_name, 'c')
 
-  def test_parse_absolute_spec(self):
+  def test_parse_absolute_spec(self) -> None:
     spec_path, target_name = parse_spec('//a/b/c')
     self.assertEqual(spec_path, 'a/b/c')
     self.assertEqual(target_name, 'c')
@@ -55,7 +55,7 @@ class ParseSpecTest(unittest.TestCase):
     self.assertEqual(spec_path, '')
     self.assertEqual(target_name, 'c')
 
-  def test_parse_bad_spec_non_normalized(self):
+  def test_parse_bad_spec_non_normalized(self) -> None:
     self.do_test_bad_spec_path('..')
     self.do_test_bad_spec_path('.')
 
@@ -70,16 +70,16 @@ class ParseSpecTest(unittest.TestCase):
     self.do_test_bad_spec_path('a/')
     self.do_test_bad_spec_path('a/b/')
 
-  def test_parse_bad_spec_bad_path(self):
+  def test_parse_bad_spec_bad_path(self) -> None:
     self.do_test_bad_spec_path('/a')
     self.do_test_bad_spec_path('///a')
 
-  def test_parse_bad_spec_bad_name(self):
+  def test_parse_bad_spec_bad_name(self) -> None:
     self.do_test_bad_target_name('a:')
     self.do_test_bad_target_name('a::')
     self.do_test_bad_target_name('//')
 
-  def test_parse_bad_spec_build_trailing_path_component(self):
+  def test_parse_bad_spec_build_trailing_path_component(self) -> None:
     self.do_test_bad_spec_path('BUILD')
     self.do_test_bad_spec_path('BUILD.suffix')
     self.do_test_bad_spec_path('//BUILD')
@@ -93,19 +93,19 @@ class ParseSpecTest(unittest.TestCase):
     self.do_test_bad_spec_path('//a/BUILD:b')
     self.do_test_bad_spec_path('//a/BUILD.suffix:b')
 
-  def test_banned_chars_in_target_name(self):
+  def test_banned_chars_in_target_name(self) -> None:
     with self.assertRaises(InvalidTargetName):
       Address(*parse_spec('a/b:c@d'))
 
-  def do_test_bad_spec_path(self, spec):
+  def do_test_bad_spec_path(self, spec: str) -> None:
     with self.assertRaises(InvalidSpecPath):
       Address(*parse_spec(spec))
 
-  def do_test_bad_target_name(self, spec):
+  def do_test_bad_target_name(self, spec: str) -> None:
     with self.assertRaises(InvalidTargetName):
       Address(*parse_spec(spec))
 
-  def test_subproject_spec(self):
+  def test_subproject_spec(self) -> None:
     # Ensure that a spec referring to a subproject gets assigned to that subproject properly.
     def parse(spec, relative_to):
       return parse_spec(spec,
@@ -165,20 +165,20 @@ class BaseAddressTest(unittest.TestCase):
             touch(os.path.join(root_dir, buildfile))
           yield os.path.realpath(root_dir)
 
-  def assert_address(self, spec_path, target_name, address):
+  def assert_address(self, spec_path: str, target_name: str, address: Address) -> None:
     self.assertEqual(spec_path, address.spec_path)
     self.assertEqual(target_name, address.target_name)
 
 
 class AddressTest(BaseAddressTest):
-  def test_equivalence(self):
+  def test_equivalence(self) -> None:
     self.assertNotEqual("Not really an address", Address('a/b', 'c'))
 
     self.assertEqual(Address('a/b', 'c'), Address('a/b', 'c'))
     self.assertEqual(Address('a/b', 'c'), Address.parse('a/b:c'))
     self.assertEqual(Address.parse('a/b:c'), Address.parse('a/b:c'))
 
-  def test_parse(self):
+  def test_parse(self) -> None:
     self.assert_address('a/b', 'target', Address.parse('a/b:target'))
     self.assert_address('a/b', 'target', Address.parse('//a/b:target'))
     self.assert_address('a/b', 'b', Address.parse('a/b'))
@@ -190,7 +190,7 @@ class AddressTest(BaseAddressTest):
 
 
 class BuildFileAddressTest(BaseAddressTest):
-  def test_build_file_forms(self):
+  def test_build_file_forms(self) -> None:
     with self.workspace('a/b/c/BUILD') as root_dir:
       build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='a/b/c/BUILD')
       self.assert_address('a/b/c', 'c', BuildFileAddress(build_file=build_file))

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -16,7 +16,7 @@ from pants.util.dirutil import safe_file_dump, safe_mkdir
 
 class LegacyAddressMapperTest(TestBase):
 
-  def create_build_files(self):
+  def create_build_files(self) -> None:
     # Create BUILD files
     # build_root:
     #   BUILD
@@ -45,7 +45,7 @@ class LegacyAddressMapperTest(TestBase):
 
     safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
 
-  def test_is_valid_single_address(self):
+  def test_is_valid_single_address(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
 
@@ -54,7 +54,7 @@ class LegacyAddressMapperTest(TestBase):
     with self.assertRaises(TypeError):
       mapper.is_valid_single_address('foo')
 
-  def test_scan_build_files(self):
+  def test_scan_build_files(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
 
@@ -67,7 +67,7 @@ class LegacyAddressMapperTest(TestBase):
     build_files = mapper.scan_build_files('dir_a/subdir')
     self.assertEqual(build_files, {'dir_a/subdir/BUILD'})
 
-  def test_scan_build_files_edge_cases(self):
+  def test_scan_build_files_edge_cases(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
 
@@ -80,7 +80,7 @@ class LegacyAddressMapperTest(TestBase):
     build_files = mapper.scan_build_files('empty')
     self.assertEqual(build_files, set())
 
-  def test_is_declaring_file(self):
+  def test_is_declaring_file(self) -> None:
     scheduler = unittest.mock.Mock()
     mapper = LegacyAddressMapper(scheduler, '')
     self.assertTrue(mapper.is_declaring_file(Address('path', 'name'), 'path/BUILD'))
@@ -94,21 +94,21 @@ class LegacyAddressMapperTest(TestBase):
       BuildFileAddress(target_name='name', rel_path='path/BUILD'),
       'path/BUILD'))
 
-  def test_addresses_in_spec_path(self):
+  def test_addresses_in_spec_path(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     addresses = mapper.addresses_in_spec_path('dir_a')
     self.assertEqual(addresses,
                       {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c')})
 
-  def test_addresses_in_spec_path_no_dir(self):
+  def test_addresses_in_spec_path_no_dir(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
       mapper.addresses_in_spec_path('foo')
     self.assertIn('does not match any targets.', str(cm.exception))
 
-  def test_addresses_in_spec_path_no_build_files(self):
+  def test_addresses_in_spec_path_no_build_files(self) -> None:
     self.create_build_files()
     safe_mkdir(os.path.join(self.build_root, 'foo'))
     mapper = self.address_mapper
@@ -116,21 +116,21 @@ class LegacyAddressMapperTest(TestBase):
       mapper.addresses_in_spec_path('foo')
     self.assertIn('does not match any targets.', str(cm.exception))
 
-  def test_scan_address_specs(self):
+  def test_scan_address_specs(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     addresses = mapper.scan_address_specs([SingleAddress('dir_a', 'a'), SiblingAddresses('')])
     self.assertEqual(addresses,
                       {Address('', 'a'), Address('', 'b'), Address('', 'c'), Address('dir_a', 'a')})
 
-  def test_scan_address_specs_bad_spec(self):
+  def test_scan_address_specs_bad_spec(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
       mapper.scan_address_specs([SingleAddress('dir_a', 'd')])
     self.assertIn('does not match any targets.', str(cm.exception))
 
-  def test_scan_addresses(self):
+  def test_scan_addresses(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     addresses = mapper.scan_addresses()
@@ -139,7 +139,7 @@ class LegacyAddressMapperTest(TestBase):
                       Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
                       Address('dir_b', 'a'), Address('dir_a/subdir', 'a')})
 
-  def test_scan_addresses_with_root_specified(self):
+  def test_scan_addresses_with_root_specified(self) -> None:
     self.create_build_files()
     mapper = self.address_mapper
     addresses = mapper.scan_addresses(os.path.join(self.build_root, 'dir_a'))
@@ -147,14 +147,14 @@ class LegacyAddressMapperTest(TestBase):
                       {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
                       Address('dir_a/subdir', 'a')})
 
-  def test_scan_addresses_bad_dir(self):
+  def test_scan_addresses_bad_dir(self) -> None:
     # scan_addresses() should not raise an error.
     self.create_build_files()
     mapper = self.address_mapper
     addresses = mapper.scan_addresses(os.path.join(self.build_root, 'foo'))
     self.assertEqual(addresses, set())
 
-  def test_other_throw_is_fail(self):
+  def test_other_throw_is_fail(self) -> None:
     # scan_addresses() should raise an error if the scheduler returns an error it can't ignore.
     class ThrowReturningScheduler:
       def execution_request(self, *args):

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -3,6 +3,7 @@
 
 import functools
 import os
+from typing import cast
 
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
@@ -22,14 +23,14 @@ class GraphTest(TestBase):
   _TAG = 'tag_added_by_macro'
 
   @classmethod
-  def alias_groups(cls):
-    return super().alias_groups().merge(
+  def alias_groups(cls) -> BuildFileAliases:
+    return cast(BuildFileAliases, super().alias_groups().merge(
       BuildFileAliases(targets={
           'files': Files,
           'tagged_files': TargetMacro.Factory.wrap(functools.partial(macro, Files, cls._TAG), Files),
-        }))
+        })))
 
-  def test_with_missing_target_in_existing_build_file(self):
+  def test_with_missing_target_in_existing_build_file(self) -> None:
     self.create_library('3rdparty/python', 'target', 'Markdown')
     self.create_library('3rdparty/python', 'target', 'Pygments')
     # When a target is missing,
@@ -42,21 +43,21 @@ class GraphTest(TestBase):
     with self.assertRaisesRegex(AddressLookupError, expected_message):
       self.targets('3rdparty/python:rutabaga')
 
-  def test_with_missing_directory_fails(self):
+  def test_with_missing_directory_fails(self) -> None:
     with self.assertRaises(AddressLookupError) as cm:
       self.targets('no-such-path:')
 
     self.assertIn('Path "no-such-path" does not contain any BUILD files',
                   str(cm.exception))
 
-  def test_invalidate_fsnode(self):
+  def test_invalidate_fsnode(self) -> None:
     # NB: Invalidation is now more directly tested in unit tests in the `graph` crate.
     self.create_library('src/example', 'target', 'things')
     self.targets('src/example::')
     invalidated_count = self.invalidate_for('src/example/BUILD')
     self.assertGreater(invalidated_count, 0)
 
-  def test_sources_ordering(self):
+  def test_sources_ordering(self) -> None:
     input_sources = ['p', 'a', 'n', 't', 's', 'b', 'u', 'i', 'l', 'd']
     expected_sources = sorted(input_sources)
     self.create_library('src/example', 'files', 'things', sources=input_sources)
@@ -65,7 +66,7 @@ class GraphTest(TestBase):
     sources = [os.path.basename(s) for s in target.sources_relative_to_buildroot()]
     self.assertEqual(expected_sources, sources)
 
-  def test_target_macro_override(self):
+  def test_target_macro_override(self) -> None:
     """Tests that we can "wrap" an existing target type with additional functionality.
 
     Installs an additional TargetMacro that wraps `target` aliases to add a tag to all definitions.

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -10,7 +10,7 @@ from pants.engine.parser import SymbolTable
 
 class LegacyPythonCallbacksParserTest(unittest.TestCase):
 
-  def test_no_import_sideeffects(self):
+  def test_no_import_sideeffects(self) -> None:
     # A parser with no symbols registered.
     parser = LegacyPythonCallbacksParser(SymbolTable({}), BuildFileAliases(), build_file_imports_behavior='allow')
     # Call to import a module should succeed.

--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -8,13 +8,13 @@ from pants.engine.legacy.structs import Files
 
 class StructTest(unittest.TestCase):
 
-  def test_filespec_with_excludes(self):
+  def test_filespec_with_excludes(self) -> None:
     files = Files(spec_path='')
     self.assertEqual({'globs': []}, files.filespecs)
     files = Files(exclude=['*.md'], spec_path='')
     self.assertEqual({'exclude': [{'globs': ['*.md']}], 'globs': []}, files.filespecs)
 
-  def test_excludes_of_wrong_type(self):
+  def test_excludes_of_wrong_type(self) -> None:
     with self.assertRaises(ValueError) as cm:
       Files(exclude='*.md', spec_path='')
     self.assertEqual('Excludes of type `str` are not supported: got "*.md"',

--- a/tests/python/pants_test/engine/test_struct.py
+++ b/tests/python/pants_test/engine/test_struct.py
@@ -10,7 +10,7 @@ from pants.engine.struct import Struct
 
 class StructTest(unittest.TestCase):
 
-  def test_attribute_error_raised_in_property(self):
+  def test_attribute_error_raised_in_property(self) -> None:
     """This tests that Struct#__getattr__ doesn't prevent correct attribution of AttributeErrors."""
     class StructWithProperty(Struct):
       @property
@@ -22,15 +22,15 @@ class StructTest(unittest.TestCase):
     self.assertEqual("'StructWithProperty' object has no attribute 'missing_attribute'",
                      str(cm.exception))
 
-  def test_address_no_name(self):
+  def test_address_no_name(self) -> None:
     config = Struct(address=Address.parse('a:b'))
     self.assertEqual('b', config.name)
 
-  def test_address_name_conflict(self):
+  def test_address_name_conflict(self) -> None:
     with self.assertRaises(ValidationError):
       Struct(name='a', address=Address.parse('a:b'))
 
-  def test_type_alias(self):
+  def test_type_alias(self) -> None:
     self.assertEqual('Struct', Struct().type_alias)
     self.assertEqual('aliased', Struct(type_alias='aliased').type_alias)
 
@@ -40,7 +40,7 @@ class StructTest(unittest.TestCase):
     self.assertEqual('Subclass', Subclass().type_alias)
     self.assertEqual('aliased_subclass', Subclass(type_alias='aliased_subclass').type_alias)
 
-  def test_extend(self):
+  def test_extend(self) -> None:
     extends = Struct(age=32, label='green', items=[],
                             extends=Struct(age=42, other=True, items=[1, 2]))
 
@@ -50,7 +50,7 @@ class StructTest(unittest.TestCase):
     # But we do pick it up now.
     self.assertEqual(Struct(age=32, label='green', items=[], other=True), extends.create())
 
-  def test_merge(self):
+  def test_merge(self) -> None:
     merges = Struct(age=32, items=[3], knobs={'b': False},
                            merges=[Struct(age=42,
                                           other=True,
@@ -71,7 +71,7 @@ class StructTest(unittest.TestCase):
                             other=True),
                      merges.create())
 
-  def test_extend_and_merge(self):
+  def test_extend_and_merge(self) -> None:
     extends_and_merges = Struct(age=32, label='green', items=[5],
                                 extends=Struct(age=42,
                                                other=True,
@@ -89,7 +89,7 @@ class StructTest(unittest.TestCase):
                             knobs={'a': False, 'b': True}),
                      extends_and_merges.create())
 
-  def test_validate_concrete(self):
+  def test_validate_concrete(self) -> None:
     class Subclass(Struct):
       def validate_concrete(self):
         if self.name != 'jake':


### PR DESCRIPTION
These are all used in the journey from raw address specs -> `AddressSpec` -> `TargetRoots` being saved to the global context -> `Address` -> `HydratedStruct` -> `HydratedTarget`.