### PR TITLE
Use Python 3.6+ by default for Python users

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -393,17 +393,14 @@ verify_commit: False
 
 
 [python-setup]
-interpreter_constraints: ["CPython>=3.6"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 
-
 [pytest]
-version: pytest>=5.2.4
 pytest_plugins: +[
     # TODO(8528): implement a generic retry mechanism for the V2 test runner instead of using this
     #  plugin.
-    "pytest-rerunfailures>=8.0",
+    "pytest-rerunfailures",
     # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
     #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
     "setuptools==40.6.3",

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -3,7 +3,6 @@
 
 from typing import Tuple
 
-from pants.base.deprecated import deprecated_conditional
 from pants.option.custom_types import shell_str
 from pants.subsystem.subsystem import Subsystem
 
@@ -19,19 +18,14 @@ class PyTest(Subsystem):
       help="Arguments to pass directly to Pytest, e.g. `--pytest-args=\"-k test_foo --quiet\"`",
     )
     register(
-      '--version', default='pytest>=4.6.6,<4.7', fingerprint=True,
+      '--version', default='pytest', fingerprint=True,
       help="Requirement string for Pytest.",
     )
     register(
       '--pytest-plugins',
       type=list,
       fingerprint=True,
-      default=[
-        'pytest-timeout>=1.3.3,<1.4',
-        'pytest-cov>=2.8.1,<3',
-        "unittest2>=1.1.0 ; python_version<'3'",
-        "more-itertools<6.0.0 ; python_version<'3'",
-      ],
+      default=['pytest-timeout', 'pytest-cov'],
       help="Requirement strings for any plugins or additional requirements you'd like to use.",
     )
     register(
@@ -39,9 +33,9 @@ class PyTest(Subsystem):
       type=bool,
       default=True,
       help='Enable test target timeouts. If timeouts are enabled then test targets with a '
-          'timeout= parameter set on their target will time out after the given number of '
-          'seconds if not completed. If no timeout is set, then either the default timeout '
-          'is used or no timeout is configured.',
+           'timeout= parameter set on their target will time out after the given number of '
+           'seconds if not completed. If no timeout is set, then either the default timeout '
+           'is used or no timeout is configured.',
     )
     register(
       '--timeout-default',
@@ -58,16 +52,4 @@ class PyTest(Subsystem):
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""
-    deprecated_conditional(
-      lambda: self.options.is_default("version"),
-      removal_version="1.25.0.dev2",
-      entity_description="Pants defaulting to a Python 2-compatible Pytest version",
-      hint_message="Pants will soon start defaulting to Pytest 5.x, which no longer supports "
-                   "running tests with Python 2. In preparation for this change, you should "
-                   "explicitly set what version of Pytest to use in your `pants.ini` under the "
-                   "section `pytest`.\n\nIf you need to keep running tests with Python 2, set "
-                   "`version` to `pytest>=4.6.6,<4.7` (the current default). If you don't have any "
-                   "tests with Python 2 and want the newest Pytest, set `version` to "
-                   "`pytest>=5.2.4`."
-    )
     return (self.options.version, *self.options.pytest_plugins)

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -4,10 +4,10 @@
 import logging
 import os
 import subprocess
+from typing import Tuple
 
 from pex.variables import Variables
 
-from pants.base.deprecated import deprecated_conditional
 from pants.option.custom_types import UnsetBool
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
@@ -24,7 +24,7 @@ class PythonSetup(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register('--interpreter-constraints', advanced=True, fingerprint=True, type=list,
-             default=['CPython>=2.7,<3', 'CPython>=3.6'],
+             default=['CPython>=3.6'],
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
                   "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
@@ -65,21 +65,7 @@ class PythonSetup(Subsystem):
                   'platforms.')
 
   @property
-  def interpreter_constraints(self):
-    deprecated_conditional(
-      lambda: self.get_options().is_default("interpreter_constraints"),
-      removal_version="1.25.0.dev2",
-      entity_description="Pants defaulting to Python 2.7+ for --python-setup-interpreter-constraints",
-      hint_message="Pants will soon default to using Python 3.6+ for Python commands like "
-                   "`./pants test` and `./pants repl`, whereas now it defaults to Python 2.7 or "
-                   "Python 3.6+. In preparation for this change, you should explicitly mark what "
-                   "Python version(s) your project uses in your `pants.ini` under the section "
-                   "`python-setup`.\n\nFor example, if you need to still support Python 2, set "
-                   "`interpreter_constraints` to `['CPython>=2.7,<3', 'CPython>=3.6']`. "
-                   "Otherwise, set the value to something like `['CPython>=3.6']`. See "
-                   "https://www.pantsbuild.org/python_readme.html#configure-the-python-version "
-                   "for more information on setting interpreter constraints."
-    )
+  def interpreter_constraints(self) -> Tuple[str, ...]:
     return tuple(self.get_options().interpreter_constraints)
 
   @memoized_property

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -43,7 +43,7 @@ class PythonReplTest(PythonTaskTestBase):
   def setUp(self):
     super().setUp()
     self.six = self.create_python_requirement_library('3rdparty/python/six', 'six',
-                                                      requirements=['six==1.9.0'])
+                                                      requirements=['six==1.13.0'])
     self.requests = self.create_python_requirement_library('3rdparty/python/requests', 'requests',
                                                            requirements=['requests==2.6.0'])
 
@@ -132,7 +132,7 @@ class PythonReplTest(PythonTaskTestBase):
 
   def test_requirement(self):
     self.do_test_repl(code=['import six',
-                            'six._print("Hello there")'],
+                            'six.print_("Hello there")'],
                       expected=['Hello there'],
                       targets=[self.six])
 
@@ -142,7 +142,7 @@ class PythonReplTest(PythonTaskTestBase):
                             'from lib.lib import go',
                             'print("teapot response code is: {}".format(requests.codes.teapot))',
                             'go()',
-                            'six._print("Hello there")'],
+                            'six.print_("Hello there")'],
                       expected=['teapot response code is: 418',
                                 'gogogo!',
                                 'Hello there'],


### PR DESCRIPTION
Users of the Python backend will now default to Python 3.6+ for their interpreter constraints, which impacts for example which interpreter is used for `./pants test`. Before, we defaulted to Python 2.7 _or_ Python 3.6+.

To go back to the original, users should set `['CPython>=2.7,<3', 'CPython>=3.6']` under `python-setup` in their `pants.ini`.

This also updates the default Pytest to use Pytest 5, which only works with Python 3 tests.