### PR TITLE
Deprecate `--fast` option

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -405,17 +405,12 @@ pytest_plugins: +[
 timeouts: true
 timeout_default: 60
 
-
 [test.junit]
-# TODO(#8649): Switch to --no-fast.
-fast: true
 timeouts: true
 timeout_default: 60
 
-
 [test.go]
-# TODO(#8649): Switch to --no-fast --chroot.
-fast: true
+# TODO(#8649): Switch to --chroot.
 chroot: false
 
 

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -397,6 +397,13 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
     # https://github.com/pantsbuild/pants/issues/5073
 
     register('--fast', type=bool, default=False, fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="This option is going away for better isolation of tests and in "
+                          "preparation for switching to the V2 test implementation, which provides "
+                          "much better caching and concurrency.\n\n"
+                          "We recommend running a full CI suite with `no-fast` (the default now) "
+                          "to see if any tests fail. If any fail, this likely signals shared state "
+                          "between your test targets.",
              help='Run all tests in a single invocation. If turned off, each test target '
                   'will run in its own invocation, which will be slower, but isolates '
                   'tests from process-wide state created by tests in other targets.')

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
@@ -4,7 +4,6 @@
 import os
 from collections import namedtuple
 from contextlib import contextmanager
-from unittest import expectedFailure
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
@@ -184,10 +183,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     ])
     self.assert_success(run)
 
-  @expectedFailure
   def test_unit_tests_with_different_sets_one_batch(self):
-    # NB(gmalmquist): Currently, junit_run isn't smart enough to partition the targets to run
-    # separately if they depend on jar_libraries which resolve using different managed dependencies.
     run = self.run_pants([
       'test',
       '--test-junit-batch-size=2',

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -57,8 +57,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants_with_workdir(
           ['test.junit',
            '--test=org.pantsbuild.example.hello.greet.GreetingTest',
-           'examples/tests/java/org/pantsbuild/example/hello/greet',
-           'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
+           'examples/tests/java/org/pantsbuild/example/hello/greet'],
           workdir)
       self.assert_success(pants_run)
       self._assert_output_for_class(workdir=workdir,
@@ -68,8 +67,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
-        '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)
 
@@ -77,8 +74,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
-        '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true',
         '--no-test-junit-chroot',
         '--test-junit-cwd=testprojects/src/java/org/pantsbuild/testproject/cwdexample/subdir'])
@@ -88,8 +83,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
-        '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)
 


### PR DESCRIPTION
This change is meant to give a nudge to users in the direction of the V2 test runner. By having them switch to `--no-fast` now, we lower the barrier to entry to the V2 test runner, which must run with `--no-fast`. 

This is meant to avoid a Python 2 vs. Python 3 situation where the cost to migrate from the V1 test runner to the V2 implementation is too costly such that users stick with V1 and the Pants community now bifurcates.