### PR TITLE
Stop requesting AddressSpecs in `@goal_rules`

### DIFF
--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -9,7 +9,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
-class FastDependenciesTest(GoalRuleTestBase):
+class DependenciesIntegrationTest(GoalRuleTestBase):
   goal_cls = dependencies.Dependencies
 
   @classmethod

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -103,7 +103,7 @@ class TargetRootsCalculator:
       # We've been provided no spec roots (e.g. `./pants list`) AND a changed request. Compute
       # alternate target roots.
       request = OwnersRequest(sources=tuple(changed_files),
-                              include_dependees=str(changed_request.include_dependees))
+                              include_dependees=changed_request.include_dependees)
       changed_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('changed addresses: %s', changed_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses)
@@ -114,7 +114,7 @@ class TargetRootsCalculator:
     if owned_files:
       # We've been provided no spec roots (e.g. `./pants list`) AND a owner request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(owned_files), include_dependees=str('none'))
+      request = OwnersRequest(sources=tuple(owned_files), include_dependees='none')
       owner_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('owner addresses: %s', owner_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -3,7 +3,6 @@
 
 from typing import Union
 
-from pants.base.specs import AddressSpecs
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -35,7 +34,7 @@ class List(Goal):
 
 @goal_rule
 async def list_targets(
-  console: Console, list_options: ListOptions, address_specs: AddressSpecs,
+  console: Console, list_options: ListOptions, build_file_addresses: BuildFileAddresses,
 ) -> List:
   provides = list_options.values.provides
   provides_columns = list_options.values.provides_columns
@@ -43,7 +42,7 @@ async def list_targets(
   collection: Union[HydratedTargets, BuildFileAddresses]
   if provides or documented:
     # To get provides clauses or documentation, we need hydrated targets.
-    collection = await Get[HydratedTargets](AddressSpecs, address_specs)
+    collection = await Get[HydratedTargets](BuildFileAddresses, build_file_addresses)
     if provides:
       extractors = dict(
           address=lambda target: target.address.spec,
@@ -73,7 +72,7 @@ async def list_targets(
       print_fn = print_documented
   else:
     # Otherwise, we can use only addresses.
-    collection = await Get[BuildFileAddresses](AddressSpecs, address_specs)
+    collection = build_file_addresses
     print_fn = lambda address: address.spec
 
   with list_options.line_oriented(console) as print_stdout:

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from typing import Dict, Optional
 from unittest.mock import Mock
 
-from pants.base.specs import AddressSpec, AddressSpecs, DescendantAddresses, SingleAddress
+from pants.base.specs import AddressSpec, DescendantAddresses, SingleAddress
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import AddressProvenanceMap
@@ -144,11 +144,9 @@ class TestTest(TestBase):
         MockGet(product_type=AddressAndDebugRequest, subject_type=Address, mock=make_debug_request),
         MockGet(
           product_type=BuildFileAddress,
-          subject_type=AddressSpecs,
+          subject_type=BuildFileAddresses,
           mock=lambda tgt: BuildFileAddress(
-            build_file=None,
-            target_name=tgt.target_name,
-            rel_path=f'{tgt.spec_path}/BUILD'
+            rel_path=f'{tgt.spec_path}/BUILD', target_name=tgt.target_name,
           )
         ),
       ],
@@ -254,7 +252,7 @@ class TestTest(TestBase):
     assert result == AddressAndTestResult(addr, None)
 
   def test_coordinator_globbed_test_target(self):
-    bfaddr = BuildFileAddress(None, 'tests', 'some/dir')
+    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
       bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')}
@@ -264,7 +262,7 @@ class TestTest(TestBase):
     )
 
   def test_coordinator_globbed_non_test_target(self):
-    bfaddr = BuildFileAddress(None, 'bin', 'some/dir')
+    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
       bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')},

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -21,7 +21,7 @@ class SourceMapperTest(TestBase):
     )
 
   def owner(self, owner, f):
-    request = OwnersRequest(sources=(f,), include_dependees=str('none'))
+    request = OwnersRequest(sources=(f,), include_dependees='none')
     addresses = self.request_single_product(BuildFileAddresses, request)
     self.assertEqual(set(owner), {i.spec for i in addresses})
 


### PR DESCRIPTION
Per the file system design doc https://docs.google.com/document/d/15xphZcFnowytF0Qu2sO1PG7wHAWoyLof7hK0jVa5T8E/edit#, we want users to be able to specify _either_ file system specs or address specs and for the engine to do the right thing, with semantics depending on the type of goal.

This means that `@goal_rules` should no longer request `AddressSpecs` in their signature because then they would not automatically have support for file system specs. There is no way to go from `AddressSpecs <-> FilesystemSpecs` nor would it make sense for there to be this conversion. 

Instead, `@goal_rules` should request a type associated with the minimal information they need to operate. (These types are still being worked out, but are currently proposed to be `SourcesSnapshot`, `BuildFileAddresses`, or `TargetsWithSources`).

--

Note that rules may still use AddressSpecs, such as the below. This only impacts what `@goal_rule`s should request in their signature. https://github.com/pantsbuild/pants/blob/f93cbf500e43f8160832e2fe966abe468b3d0cfe/src/python/pants/backend/python/rules/run_setup_py.py#L535-L538
