### PR TITLE
Add side-effecting HttpRequester type

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -75,6 +75,16 @@ python_library(
 )
 
 python_library(
+  name='http',
+  sources=['http.py'],
+  dependencies=[
+    '3rdparty/python:dataclasses',
+    '3rdparty/python:requests',
+  ],
+  tags = {'partially_type_checked'},
+)
+
+python_library(
   name='build_files',
   sources=['build_files.py'],
   dependencies=[
@@ -253,4 +263,15 @@ python_library(
 resources(
   name='native_engine_shared_library',
   sources=['native_engine.so']
+)
+
+python_tests(
+  name = "tests",
+  sources = ["http_test.py"],
+  dependencies = [
+    ':http',
+    'src/python/pants/testutil:test_base',
+    'tests/python/pants_test:console_rule_test_base',
+    'tests/python/pants_test/engine:util'
+  ]
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -273,5 +273,6 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'tests/python/pants_test:console_rule_test_base',
     'tests/python/pants_test/engine:util'
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -21,12 +21,12 @@ class HttpGetResponse:
 @dataclass(frozen=True)
 class HttpRequester:
 
-  def get_request(self, url: str, *, headers: Dict[str, str] = {}) -> HttpGetResponse:
-    r = requests.get(url, headers)
-    header_list = [(str(item), r.headers[item]) for item in r.headers]
+  def get_request(self, url: str, *, headers: Optional[Dict[str, str]] = None) -> HttpGetResponse:
+    r = requests.get(url, headers=headers)
+    header_list = tuple((str(item), r.headers[item]) for item in r.headers)
     return HttpGetResponse(
       url=r.url,
-      headers=tuple(header_list),
+      headers=header_list,
       status_code=r.status_code,
       output_bytes=r.content,
     )

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from pants.engine.rules import side_effecting
+
+
+@dataclass(frozen=True)
+class HttpGetResponse:
+  url: str
+  status_code: Optional[int]
+  output_bytes: Optional[bytes]
+  headers: Tuple[Tuple[str, str], ...]
+
+
+@side_effecting
+class HttpRequester:
+
+  def get_request(self, url: str, headers: Dict[str, str] = {}) -> HttpGetResponse:
+    r = requests.get(url, headers)
+    header_list = [ (str(item), r.headers[item]) for item in r.headers ]
+    return HttpGetResponse(
+      url = r.url,
+      headers = tuple(header_list),
+      status_code = r.status_code,
+      output_bytes = r.content,
+    )

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -23,10 +23,10 @@ class HttpRequester:
 
   def get_request(self, url: str, *, headers: Dict[str, str] = {}) -> HttpGetResponse:
     r = requests.get(url, headers)
-    header_list = [ (str(item), r.headers[item]) for item in r.headers ]
+    header_list = [(str(item), r.headers[item]) for item in r.headers]
     return HttpGetResponse(
-      url = r.url,
-      headers = tuple(header_list),
-      status_code = r.status_code,
-      output_bytes = r.content,
+      url=r.url,
+      headers=tuple(header_list),
+      status_code=r.status_code,
+      output_bytes=r.content,
     )

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -18,6 +18,7 @@ class HttpGetResponse:
 
 
 @side_effecting
+@dataclass(frozen=True)
 class HttpRequester:
 
   def get_request(self, url: str, headers: Dict[str, str] = {}) -> HttpGetResponse:

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -21,7 +21,7 @@ class HttpGetResponse:
 @dataclass(frozen=True)
 class HttpRequester:
 
-  def get_request(self, url: str, headers: Dict[str, str] = {}) -> HttpGetResponse:
+  def get_request(self, url: str, *, headers: Dict[str, str] = {}) -> HttpGetResponse:
     r = requests.get(url, headers)
     header_list = [ (str(item), r.headers[item]) for item in r.headers ]
     return HttpGetResponse(

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -3,7 +3,7 @@
 
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Tuple
 from urllib.parse import parse_qs, urlparse
 
 from pants.engine.http import HttpGetResponse, HttpRequester
@@ -49,62 +49,44 @@ class HttpHandlerForTests(BaseHTTPRequestHandler):
     self.end_headers()
 
 
-class CachingTestHandler(BaseHTTPRequestHandler):
-  count = 0
-
-  def do_GET(self):
-    self.send_response(200)
-    self.end_headers()
-    count = CachingTestHandler.count
-    output = f"Your path: {self.path} count: {count}"
-    CachingTestHandler.count += 1
-    self.wfile.write(output.encode())
-
-
 class HttpIntrinsicTest(TestBase):
-  #
-  #@classmethod
-  #def rules(cls):
-  #  return super().rules() + [
-  #    RootRule(MakeHttpRequest),
-  #  ]
 
   @contextmanager
-  def make_request_to_path(self, path: str, headers: Dict[str, str] = ()) -> Iterator[HttpGetResponse]:
+  def make_request_to_path(self, path: str, headers: Dict[str, str] = {}) -> Iterator[Tuple[HttpGetResponse, int]]:
     with http_server(HttpHandlerForTests) as port:
       url = f'http://localhost:{port}/{path}'
       requester = HttpRequester()
       output = requester.get_request(url=url, headers=headers)
       yield (output, port)
 
-  def test_200(self):
+  def test_200(self) -> None:
     with self.make_request_to_path("valid-url") as (response, port):
       assert response.status_code == 200
       assert response.output_bytes == b"A valid HTTP response!"
       assert response.url == f'http://localhost:{port}/valid-url'
       assert ('Content-Type', 'text/utf-8') in response.headers
 
-  def test_302(self):
+  def test_302(self) -> None:
     with self.make_request_to_path("redirect") as (response, port):
       assert response.url == f"http://localhost:{port}/valid-url"
 
-  def test_404(self):
+  def test_404(self) -> None:
     with self.make_request_to_path("nothingtheserverknowsabout") as (response, port):
       assert response.status_code == 404
       assert response.output_bytes == b"Custom 404 page"
       assert response.url == f'http://localhost:{port}/nothingtheserverknowsabout'
 
-  def test_500(self):
+  def test_500(self) -> None:
     with self.make_request_to_path("deliberate500") as (response, port):
       assert response.status_code == 500
       assert response.output_bytes == b"500 internal server error"
       assert response.url == f'http://localhost:{port}/deliberate500'
 
-  def test_custom_headers(self):
+  def test_custom_headers(self) -> None:
     headers = {"X-My-Custom-Header": "custom-info", "X-Other-Header": "more-info"}
     with self.make_request_to_path("test-headers", headers=headers) as (response, port):
-      print(f"RESP: {response}")
       assert response.status_code == 200
+      assert response.output_bytes is not None
       output = response.output_bytes.decode()
       assert "X-My-Custom-Header" in output
       assert "custom-info" in output

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -1,0 +1,112 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler
+from typing import Dict, Iterator
+from urllib.parse import parse_qs, urlparse
+
+from pants.engine.http import HttpGetResponse, HttpRequester
+from pants.testutil.test_base import TestBase
+from pants.util.contextutil import http_server
+
+
+class HttpHandlerForTests(BaseHTTPRequestHandler):
+  response_text = b"A valid HTTP response!"
+  not_found_text = b"Custom 404 page"
+  server_failure_text = b"500 internal server error"
+
+  def do_GET(self):
+    self.send_headers()
+    if self.path == "/valid-url":
+      self.wfile.write(self.response_text)
+    elif self.path == "/deliberate500":
+      self.wfile.write(self.server_failure_text)
+    elif "test-headers" in self.path:
+      output = str(parse_qs(urlparse(self.path).query))
+      self.wfile.write(output.encode())
+    elif self.path == "/redirect":
+      self.wfile.write(b"")
+    else:
+      self.wfile.write(self.not_found_text)
+
+  def send_headers(self):
+    if self.path == "/valid-url" or "/test-headers" in self.path:
+      code = 200
+    elif self.path == "/deliberate500":
+      code = 500
+    elif self.path == "/redirect":
+      code = 302
+    else:
+      code = 404
+    self.send_response(code)
+
+    if self.path == "/redirect":
+      self.send_header("Location", "/valid-url")
+
+    self.send_header("Content-Type", "text/utf-8")
+
+    self.end_headers()
+
+
+class CachingTestHandler(BaseHTTPRequestHandler):
+  count = 0
+
+  def do_GET(self):
+    self.send_response(200)
+    self.end_headers()
+    count = CachingTestHandler.count
+    output = f"Your path: {self.path} count: {count}"
+    CachingTestHandler.count += 1
+    self.wfile.write(output.encode())
+
+
+class HttpIntrinsicTest(TestBase):
+  #
+  #@classmethod
+  #def rules(cls):
+  #  return super().rules() + [
+  #    RootRule(MakeHttpRequest),
+  #  ]
+
+  @contextmanager
+  def make_request_to_path(self, path: str, headers: Dict[str, str] = ()) -> Iterator[HttpGetResponse]:
+    with http_server(HttpHandlerForTests) as port:
+      url = f'http://localhost:{port}/{path}'
+      requester = HttpRequester()
+      output = requester.get_request(url=url, headers=headers)
+      yield (output, port)
+
+  def test_200(self):
+    with self.make_request_to_path("valid-url") as (response, port):
+      assert response.status_code == 200
+      assert response.output_bytes == b"A valid HTTP response!"
+      assert response.url == f'http://localhost:{port}/valid-url'
+      assert ('Content-Type', 'text/utf-8') in response.headers
+
+  def test_302(self):
+    with self.make_request_to_path("redirect") as (response, port):
+      assert response.url == f"http://localhost:{port}/valid-url"
+
+  def test_404(self):
+    with self.make_request_to_path("nothingtheserverknowsabout") as (response, port):
+      assert response.status_code == 404
+      assert response.output_bytes == b"Custom 404 page"
+      assert response.url == f'http://localhost:{port}/nothingtheserverknowsabout'
+
+  def test_500(self):
+    with self.make_request_to_path("deliberate500") as (response, port):
+      assert response.status_code == 500
+      assert response.output_bytes == b"500 internal server error"
+      assert response.url == f'http://localhost:{port}/deliberate500'
+
+  def test_custom_headers(self):
+    headers = {"X-My-Custom-Header": "custom-info", "X-Other-Header": "more-info"}
+    with self.make_request_to_path("test-headers", headers=headers) as (response, port):
+      print(f"RESP: {response}")
+      assert response.status_code == 200
+      output = response.output_bytes.decode()
+      assert "X-My-Custom-Header" in output
+      assert "custom-info" in output
+      assert "X-Other-Header" in output
+      assert "more-info" in output


### PR DESCRIPTION
### Problem

We would like to add the functionality for `@rule`s to make HTTP requests. 

### Solution

There are several ways we could in principle go about doing this. One way was discussed in the design document here: https://docs.google.com/document/d/1CdlGMXWxdwpGqet7-k6DFIbg90IqR75cFg8SkRu06H8/edit?usp=sharing , that is, creating engine intrinsics that could be requested from within a rule. This proved to be problematic for a couple of reasons, discussed more thoroughly in that document. In brief, some types of HTTP requests (i.e. POST requests) have inherently side-effecting semantics that don't make sense in the context of cacheable rules; and even other types of HTTP requests (i.e. successful GET requests) that can be cached have failure/retry cases that are hard to fit into the rule model as well.

In lieu of that model, this commit adds a new type `HttpRequester` as a marked side-effecting type (so it can only be requested within a `@goal_rule`). Rules that need to make HTTP requests will call methods provided by this type to actually fire off any kind of HTTP request. This commit only implements a `get_request` method, since that's the first piece of HTTP functionality we need - but it should be easy to add additional HTTP methods and more HTTP functionality to `HttpRequester`, as we need it.

Methods on `HttpRequester` currently effectively wrap the Python `requests` library, but none of its functionality is dependent on that specific library. We can swap out `requests` for another HTTP library if and when we need to. 