### PR TITLE
update maven artifact url

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -74,7 +74,7 @@ class CoursierResolveTest(NailgunTaskTestBase):
   def test_resolve_with_remote_url(self):
     with self._temp_task_cache_dir():
       dep_with_url = JarDependency('a', 'b', 'c',
-                                   url='http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar')
+                                   url='https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar')
       dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
 
       compile_classpath = self.resolve([dep_with_url_lib])


### PR DESCRIPTION
Fixes `Central 501 HTTPS Required` per https://support.sonatype.com/hc/en-us/articles/360041287334
