### PR TITLE
Introduce `SourcesSnapshot` for `@goal_rule`s that only need source files to operate

### DIFF
--- a/src/python/pants/rules/core/cloc_test.py
+++ b/src/python/pants/rules/core/cloc_test.py
@@ -56,3 +56,9 @@ class ClocTest(GoalRuleTestBase):
     output = self.execute_rule(args=[py_dir, '--cloc2-ignored'])
     assert "Ignored the following files:" in output
     assert "empty.py: zero sized file" in output
+
+  def test_no_sources_exits_gracefully(self) -> None:
+    py_dir = 'src/py/foo'
+    self.add_to_build_file(py_dir, 'python_library()')
+    output = self.execute_rule(args=[py_dir])
+    assert output.strip() == ""


### PR DESCRIPTION
Per the [filesystem design doc](https://docs.google.com/document/d/15xphZcFnowytF0Qu2sO1PG7wHAWoyLof7hK0jVa5T8E/edit#), there are 4 types of goals in terms of how they consume target information. 

One type of goal only ever needs access to source files and can ignore any information about the target. This is true for `cloc` and `validate`, and certain rules for `fmt`/`lint` (although these aren't considered in this PR because those goals are more complex).

This PR introduces `SourcesSnapshots` as a new type for `@goal_rule`s to request when they only need source files. When given address specs, the engine will do the minimum amount of hydration possible to get a `SourcesSnapshot` for each target:

![sources snapshot hydration DAG](https://user-images.githubusercontent.com/14852634/72579178-8a4ff580-3895-11ea-897f-bfe43273d85e.png)

A followup will implement the filesystem specs portion of the DAG to allow filesystem specs to work with `cloc2` and `validate`.