### PR TITLE
Tweak options parser to allow globs in specs

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -211,7 +211,7 @@ class ArgSplitter:
     An arg is a spec if it looks like an AddressSpec or a FilesystemSpec.
     In the future we can expand this heuristic to support other kinds of specs, such as URLs.
     """
-    return os.path.sep in arg or ':' in arg or Path(arg).exists()
+    return os.path.sep in arg or ':' in arg or '*' in arg or Path(arg).exists()
 
   def _consume_scope(self) -> Tuple[Optional[str], List[str]]:
     """Returns a pair (scope, list of flags encountered in that scope).

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -92,6 +92,10 @@ class ArgSplitterTest(unittest.TestCase):
       'a/',
       './a.txt',
       '.',
+      '*',
+      'a/b/*.txt',
+      'a/b/test*',
+      'a/**/*',
     ]
     for s in unambiguous_specs:
       assert_spec(s)
@@ -168,6 +172,9 @@ class ArgSplitterTest(unittest.TestCase):
     assert_test_goal_split('./pants test test/test.txt', expected_specs=['test/test.txt'])
     assert_test_goal_split('./pants test test/test', expected_specs=['test/test'])
     assert_test_goal_split('./pants test .', expected_specs=['.'])
+    assert_test_goal_split('./pants test *', expected_specs=['*'])
+    assert_test_goal_split('./pants test test/*.txt', expected_specs=['test/*.txt'])
+    assert_test_goal_split('./pants test test/**/*', expected_specs=['test/**/*'])
 
     # An argument that looks like a file, but is a known scope, should be interpreted as a goal.
     self.assert_valid_split(


### PR DESCRIPTION
### Problem
Originally, we stated that we do _not_ want to add support for globs in filesystem specs because it would be too difficult to support. Instead, users should rely on their shell's builtin glob expansion.

However, `PathGlobs`—which is how we'll implement filesystem specs—has built-in support for globs. So, it is valid for a user to specify `./pants cloc2 'src/python/**/*.py'` (note the quotes around the spec). In fact, it would be difficult for us to restrict users from using `./pants cloc2 'src/python/**/*.py'` because we would need to proactively validate that they aren't using globs, even though the engine does support them.

### Solution
Our `ArgSplitter` heuristic already supported globs, outside of the top-level `*` spec. This fixes that edge case and adds testing to ensure globs work at the `ArgSplitter` level.