### PR TITLE
Allow for deprecation of child scopes

### DIFF
--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -28,10 +28,6 @@ class BooleanOptionNameWithNo(RegistrationError):
   """"Boolean option names cannot start with --no."""
 
 
-class FrozenRegistration(RegistrationError):
-  """Cannot register an option on a scope after registering on any of its inner scopes."""
-
-
 class ImplicitValIsNone(RegistrationError):
   """Implicit value cannot be None."""
 

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -22,7 +22,6 @@ from pants.option.errors import (
   BooleanConversionError,
   BooleanOptionNameWithNo,
   FromfileError,
-  FrozenRegistration,
   ImplicitValIsNone,
   InvalidKwarg,
   InvalidMemberType,
@@ -726,13 +725,6 @@ class OptionsTest(TestBase):
     assertError(InvalidMemberType, '--foo', type=list, member_type=list)
     assertError(InvalidMemberType, '--foo', type=list, member_type=list)
 
-  def test_frozen_registration(self) -> None:
-    options = Options.create(args=[], env={}, config=self._create_config(),
-                             known_scope_infos=[task('foo')])
-    options.register('foo', '--arg1')
-    with self.assertRaises(FrozenRegistration):
-      options.register(GLOBAL_SCOPE, '--arg2')
-
   def test_implicit_value(self) -> None:
     def check(*, flag: str = "", expected: str) -> None:
       options = self._parse(flags=flag)
@@ -754,6 +746,7 @@ class OptionsTest(TestBase):
       with self.assertRaises(Shadowing):
         options.register(scope, *args)
 
+    assert_raises_shadowing(scope='', args=['--opt2'])
     assert_raises_shadowing(scope='bar', args=['--opt1'])
     assert_raises_shadowing(scope='foo.bar', args=['--opt1'])
     assert_raises_shadowing(scope='foo.bar', args=['--opt2'])
@@ -1523,6 +1516,48 @@ class OptionsTest(TestBase):
 
     # Check values.
     self.assertEqual('uu', vals2.qux)
+
+  def test_scope_deprecation_parent(self) -> None:
+    # Note: This test demonstrates that a scope can mark itself as deprecating a subscope of
+    # another scope.
+    class DummyOptionable1(Optionable):
+      options_scope = 'test'
+      options_scope_category = ScopeInfo.SUBSYSTEM
+
+      @classmethod
+      def register_options(cls, register):
+        super().register_options(register)
+        register('--bar')
+
+    class DummyOptionable2(Optionable):
+      options_scope = 'lint'
+      options_scope_category = ScopeInfo.SUBSYSTEM
+      deprecated_options_scope = 'test.a-bit-linty'
+      deprecated_options_scope_removal_version = '9999.9.9.dev0'
+
+      @classmethod
+      def register_options(cls, register):
+        super().register_options(register)
+        register('--foo')
+
+    known_scope_infos = list(DummyOptionable1.known_scope_infos()) +list(DummyOptionable2.known_scope_infos())
+
+    options = Options.create(env={},
+                             config=self._create_config(),
+                             known_scope_infos=known_scope_infos,
+                             args=shlex.split('./pants --test-a-bit-linty-foo=vv'))
+
+    # NB: Order matters here, because Optionables are typically registered in sorted order.
+    DummyOptionable2.register_options_on_scope(options)
+    DummyOptionable1.register_options_on_scope(options)
+
+    with self.warnings_catcher() as w:
+      vals = options.for_scope(DummyOptionable2.options_scope)
+
+    # Check that we got a warning, but also the correct value.
+    single_warning_dummy1 = assert_single_element(w)
+    self.assertEqual(single_warning_dummy1.category, DeprecationWarning)
+    self.assertEqual('vv', vals.foo)
 
   def test_scope_deprecation_defaults(self) -> None:
     # Confirms that a DEFAULT option does not trigger deprecation warnings for a deprecated scope.


### PR DESCRIPTION
### Problem

Currently an attempt to deprecate a scope below another scope (eg: deprecating the `test.mytask` scope in favor of `mytask`) will fail 50% of the time based on registration order due to the requirement that scopes are registered in alphabetical order, and governed by a requirement that parent scopes are frozen before children.

These requirements mean that if the new scope for a deprecation sorts before the old scope, the deprecated sub scope will already have options registered in it by the time the parent is visited, triggering a `FrozenRegistration` error.

### Solution

This form of deprecation is very useful (the "`test`" example above is real-ish, and triggered by welcome v2 changes in the `test` scope). The parser freezing case appeared to be in service of an optimization, but removing it and replacing it with eager lookups to possibly shadowed options 1) is clearer, 2) has equivalent performance.

### Result

Nested option scopes may be deprecated. Fixes #8984.