### PR TITLE
Add type hints to `options.py`, `options_bootstrapper.py`, and `config.py`

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Tuple
+from typing import List, Mapping, Optional, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -97,7 +97,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   @staticmethod
   def parse_options(
     args: List[str],
-    env: Dict[str, str],
+    env: Mapping[str, str],
     options_bootstrapper: Optional[OptionsBootstrapper] = None,
   ) -> Tuple[Options, BuildConfiguration, OptionsBootstrapper]:
     options_bootstrapper = options_bootstrapper or OptionsBootstrapper.create(args=args, env=env)
@@ -155,7 +155,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   def create(
     cls,
     args: List[str],
-    env: Dict[str, str],
+    env: Mapping[str, str],
     specs: Optional[Specs] = None,
     daemon_graph_session: Optional[LegacyGraphSession] = None,
     options_bootstrapper: Optional[OptionsBootstrapper] = None,

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -5,11 +5,13 @@ import logging
 import os
 import sys
 import warnings
+from typing import List, Mapping, Optional
 
 from pants.base.exception_sink import ExceptionSink
 from pants.bin.remote_pants_runner import RemotePantsRunner
 from pants.init.logging import init_rust_logger, setup_logging_to_stderr
 from pants.init.util import init_workdir
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
@@ -19,10 +21,15 @@ logger = logging.getLogger(__name__)
 class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   """A higher-level runner that delegates runs to either a LocalPantsRunner or RemotePantsRunner."""
 
-  def __init__(self, args=None, env=None, start_time=None):
+  def __init__(
+    self,
+    args: Optional[List[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    start_time: Optional[float] = None,
+  ) -> None:
     """
-    :param list args: The arguments (sys.argv) for this run. (Optional, default: sys.argv)
-    :param dict env: The environment for this run. (Optional, default: os.environ)
+    :param args: The arguments (sys.argv) for this run. (Optional, default: sys.argv)
+    :param env: The environment for this run. (Optional, default: os.environ)
     """
     self._args = args or sys.argv
     self._env = env or os.environ
@@ -33,15 +40,15 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   # should be able to avoid needing to kill it at all.
   _DAEMON_KILLING_GOALS = frozenset(['kill-pantsd', 'clean-all'])
 
-  def will_terminate_pantsd(self):
+  def will_terminate_pantsd(self) -> bool:
     return not frozenset(self._args).isdisjoint(self._DAEMON_KILLING_GOALS)
 
-  def _enable_rust_logging(self, global_bootstrap_options):
+  def _enable_rust_logging(self, global_bootstrap_options: OptionValueContainer) -> None:
     levelname = global_bootstrap_options.level.upper()
     init_rust_logger(levelname, global_bootstrap_options.log_show_rust_3rdparty)
     setup_logging_to_stderr(logging.getLogger(None), levelname)
 
-  def _should_run_with_pantsd(self, global_bootstrap_options):
+  def _should_run_with_pantsd(self, global_bootstrap_options: OptionValueContainer) -> bool:
     # The parent_build_id option is set only for pants commands (inner runs)
     # that were called by other pants command.
     # Inner runs should never be run with pantsd.
@@ -49,13 +56,15 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     is_inner_run = global_bootstrap_options.parent_build_id is not None
 
     # If we want concurrent pants runs, we can't have pantsd enabled.
-    return global_bootstrap_options.enable_pantsd and \
-           not self.will_terminate_pantsd() and \
-           not global_bootstrap_options.concurrent and \
-           not is_inner_run
+    return (
+      global_bootstrap_options.enable_pantsd
+      and not self.will_terminate_pantsd()
+      and not global_bootstrap_options.concurrent
+      and not is_inner_run
+    )
 
   @staticmethod
-  def scrub_pythonpath():
+  def scrub_pythonpath() -> None:
     # If PYTHONPATH was used to set up the Pants runtime environment, its entries are now on our
     # `sys.path` allowing us to run. Do not propagate any of these Pants-specific sys.path entries
     # forward to our subprocesses.

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -5,11 +5,13 @@ import logging
 import sys
 import time
 from contextlib import contextmanager
+from typing import List, Mapping
 
 from pants.base.exception_sink import ExceptionSink, SignalHandler
 from pants.console.stty_utils import STTYSettings
 from pants.java.nailgun_client import NailgunClient
 from pants.java.nailgun_protocol import NailgunProtocol
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.util.dirutil import maybe_read_file
 
@@ -65,12 +67,21 @@ class RemotePantsRunner:
     NailgunClient.NailgunExecutionError
   )
 
-  def __init__(self, exiter, args, env, options_bootstrapper, stdin=None, stdout=None, stderr=None):
+  def __init__(
+    self,
+    exiter,
+    args: List[str],
+    env: Mapping[str, str],
+    options_bootstrapper: OptionsBootstrapper,
+    stdin=None,
+    stdout=None,
+    stderr=None
+  ) -> None:
     """
     :param Exiter exiter: The Exiter instance to use for this run.
-    :param list args: The arguments (e.g. sys.argv) for this run.
-    :param dict env: The environment (e.g. os.environ) for this run.
-    :param OptionsBootstrapper options_bootstrapper: The bootstrap options.
+    :param args: The arguments (e.g. sys.argv) for this run.
+    :param env: The environment (e.g. os.environ) for this run.
+    :param options_bootstrapper: The bootstrap options.
     :param file stdin: The stream representing stdin.
     :param file stdout: The stream representing stdout.
     :param file stderr: The stream representing stderr.

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -6,7 +6,7 @@ import sys
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from twitter.common.collections import OrderedSet
 
@@ -128,7 +128,7 @@ class ArgSplitter:
         self._help_request = OptionsHelp(advanced=advanced, all_scopes=all_scopes)
     return True
 
-  def split_args(self, args: Optional[List[str]] = None) -> SplitArgs:
+  def split_args(self, args: Optional[Sequence[str]] = None) -> SplitArgs:
     """Split the specified arg list (or sys.argv if unspecified).
 
     args[0] is ignored.

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -5,10 +5,11 @@ import copy
 import re
 import sys
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
 from pants.base.deprecated import warn_or_error
-from pants.option.arg_splitter import ArgSplitter
+from pants.option.arg_splitter import ArgSplitter, HelpRequest
+from pants.option.config import Config
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_list_option
@@ -18,17 +19,6 @@ from pants.option.parser_hierarchy import ParserHierarchy, all_enclosing_scopes,
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import frozen_after_init
-
-
-def make_flag_regex(long_name, short_name=None):
-  long_esc = re.escape(long_name)
-  if short_name:
-    short_esc = re.escape(short_name)
-    rx_str = r"\A(?:\-({short_esc})|\-\-(?:(no)\-)?({long_esc})(?:=(.*))?)\Z".format(
-      short_esc=short_esc, long_esc=long_esc)
-  else:
-    rx_str = r"\A\-\-(?:(no)\-)?({long_esc})(?:=(.*))?\Z".format(long_esc=long_esc)
-  return re.compile(rx_str)
 
 
 class Options:
@@ -83,7 +73,7 @@ class Options:
     """More than one registration occurred for the same scope."""
 
   @classmethod
-  def complete_scopes(cls, scope_infos):
+  def complete_scopes(cls, scope_infos: Iterable[ScopeInfo]) -> Set[ScopeInfo]:
     """Expand a set of scopes to include all enclosing scopes.
 
     E.g., if the set contains `foo.bar.baz`, ensure that it also contains `foo.bar` and `foo`.
@@ -91,7 +81,7 @@ class Options:
     Also adds any deprecated scopes.
     """
     ret = {GlobalOptionsRegistrar.get_scope_info()}
-    original_scopes = dict()
+    original_scopes: Dict[str, ScopeInfo] = {}
     for si in scope_infos:
       ret.add(si)
       if si.scope in original_scopes:
@@ -113,11 +103,18 @@ class Options:
     return ret
 
   @classmethod
-  def create(cls, env, config, known_scope_infos, args=None, bootstrap_option_values=None):
+  def create(
+    cls,
+    env: Mapping[str, str],
+    config: Config,
+    known_scope_infos: Iterable[ScopeInfo],
+    args: Optional[Sequence[str]] = None,
+    bootstrap_option_values: Optional[OptionValueContainer] = None,
+  ) -> "Options":
     """Create an Options instance.
 
     :param env: a dict of environment variables.
-    :param :class:`pants.option.config.Config` config: data from a config file.
+    :param config: data from a config file.
     :param known_scope_infos: ScopeInfos for all scopes that may be encountered.
     :param args: a list of cmd-line args; defaults to `sys.argv` if None is supplied.
     :param bootstrap_option_values: An optional namespace containing the values of bootstrap
@@ -144,14 +141,34 @@ class Options:
     parser_hierarchy = ParserHierarchy(env, config, complete_known_scope_infos, option_tracker)
     bootstrap_option_values = bootstrap_option_values
     known_scope_to_info = {s.scope: s for s in complete_known_scope_infos}
-    return cls(split_args.goals, split_args.scope_to_flags, split_args.specs,
-               split_args.passthru, split_args.passthru_owner, help_request,
-               parser_hierarchy, bootstrap_option_values, known_scope_to_info,
-               option_tracker, split_args.unknown_scopes)
+    return cls(
+      goals=split_args.goals,
+      scope_to_flags=split_args.scope_to_flags,
+      specs=split_args.specs,
+      passthru=split_args.passthru,
+      passthru_owner=split_args.passthru_owner,
+      help_request=help_request,
+      parser_hierarchy=parser_hierarchy,
+      bootstrap_option_values=bootstrap_option_values,
+      known_scope_to_info=known_scope_to_info,
+      option_tracker=option_tracker,
+      unknown_scopes=split_args.unknown_scopes,
+    )
 
-  def __init__(self, goals, scope_to_flags, specs: List[str], passthru, passthru_owner, help_request,
-               parser_hierarchy, bootstrap_option_values, known_scope_to_info,
-               option_tracker, unknown_scopes) -> None:
+  def __init__(
+    self,
+    goals: List[str],
+    scope_to_flags: Dict[str, List[str]],
+    specs: List[str],
+    passthru: List[str],
+    passthru_owner: Optional[str],
+    help_request: Optional[HelpRequest],
+    parser_hierarchy: ParserHierarchy,
+    bootstrap_option_values: Optional[OptionValueContainer],
+    known_scope_to_info: Dict[str, ScopeInfo],
+    option_tracker: OptionTracker,
+    unknown_scopes: List[str],
+  ) -> None:
     """The low-level constructor for an Options instance.
 
     Dependees should use `Options.create` instead.
@@ -171,16 +188,16 @@ class Options:
 
   # TODO: Eliminate this in favor of a builder/factory.
   @property
-  def frozen(self):
+  def frozen(self) -> bool:
     """Whether or not this Options object is frozen from writes."""
     return self._frozen
 
   @property
-  def tracker(self):
+  def tracker(self) -> OptionTracker:
     return self._option_tracker
 
   @property
-  def help_request(self):
+  def help_request(self) -> Optional[HelpRequest]:
     """
     :API: public
     """
@@ -223,7 +240,7 @@ class Options:
     return self._specs
 
   @property
-  def goals(self):
+  def goals(self) -> List[str]:
     """The requested goals, in the order specified on the cmd line.
 
     :API: public
@@ -231,7 +248,7 @@ class Options:
     return self._goals
 
   @memoized_property
-  def goals_by_version(self):
+  def goals_by_version(self) -> Tuple[Tuple[str, ...], Tuple[str, ...], Tuple[str, ...]]:
     """Goals organized into three tuples by whether they are v1, ambiguous, or v2 goals (respectively).
 
     It's possible for a goal to be implemented with both v1 and v2, in which case a consumer
@@ -254,18 +271,18 @@ class Options:
     return tuple(v1), tuple(ambiguous), tuple(v2)
 
   @property
-  def known_scope_to_info(self):
+  def known_scope_to_info(self) -> Dict[str, ScopeInfo]:
     return self._known_scope_to_info
 
   @property
-  def scope_to_flags(self):
+  def scope_to_flags(self) -> Dict[str, List[str]]:
     return self._scope_to_flags
 
-  def freeze(self):
+  def freeze(self) -> None:
     """Freezes this Options instance."""
     self._frozen = True
 
-  def drop_flag_values(self):
+  def drop_flag_values(self) -> "Options":
     """Returns a copy of these options that ignores values specified via flags.
 
     Any pre-cached option values are cleared and only option values that come from option defaults,
@@ -273,27 +290,29 @@ class Options:
     """
     # An empty scope_to_flags to force all values to come via the config -> env hierarchy alone
     # and empty values in case we already cached some from flags.
-    no_flags = {}
-    return Options(self._goals,
-                   no_flags,
-                   self._specs,
-                   self._passthru,
-                   self._passthru_owner,
-                   self._help_request,
-                   self._parser_hierarchy,
-                   self._bootstrap_option_values,
-                   self._known_scope_to_info,
-                   self._option_tracker,
-                   self._unknown_scopes)
+    no_flags: Dict[str, List[str]] = {}
+    return Options(
+      goals=self._goals,
+      scope_to_flags=no_flags,
+      specs=self._specs,
+      passthru=self._passthru,
+      passthru_owner=self._passthru_owner,
+      help_request=self._help_request,
+      parser_hierarchy=self._parser_hierarchy,
+      bootstrap_option_values=self._bootstrap_option_values,
+      known_scope_to_info=self._known_scope_to_info,
+      option_tracker=self._option_tracker,
+      unknown_scopes=self._unknown_scopes,
+    )
 
-  def is_known_scope(self, scope):
+  def is_known_scope(self, scope: str) -> bool:
     """Whether the given scope is known by this instance.
 
     :API: public
     """
     return scope in self._known_scope_to_info
 
-  def passthru_args_for_scope(self, scope):
+  def passthru_args_for_scope(self, scope: str) -> List[str]:
     # Passthru args "belong" to the last scope mentioned on the command-line.
 
     # Note: If that last scope is a goal, we allow all tasks in that goal to access the passthru
@@ -311,14 +330,13 @@ class Options:
     if (scope and self._passthru_owner and scope.startswith(self._passthru_owner) and
           (len(scope) == len(self._passthru_owner) or scope[len(self._passthru_owner)] == '.')):
       return self._passthru
-    else:
-      return []
+    return []
 
-  def _assert_not_frozen(self):
+  def _assert_not_frozen(self) -> None:
     if self._frozen:
       raise self.FrozenOptionsError(f'cannot mutate frozen Options instance {self!r}.')
 
-  def register(self, scope, *args, **kwargs):
+  def register(self, scope: str, *args, **kwargs) -> None:
     """Register an option in the given scope."""
     self._assert_not_frozen()
     self.get_parser(scope).register(*args, **kwargs)
@@ -340,7 +358,7 @@ class Options:
     register.scope = optionable_class.options_scope
     return register
 
-  def get_parser(self, scope):
+  def get_parser(self, scope: str) -> Parser:
     """Returns the parser for the given scope, so code can register on it directly."""
     self._assert_not_frozen()
     return self._parser_hierarchy.get_parser_by_scope(scope)
@@ -463,7 +481,9 @@ class Options:
 
   # TODO: Eagerly precompute backing data for this?
   @memoized_method
-  def for_scope(self, scope, inherit_from_enclosing_scope=True):
+  def for_scope(
+    self, scope: str, inherit_from_enclosing_scope: bool = True,
+  ) -> OptionValueContainer:
     """Return the option values for the given scope.
 
     Values are attributes of the returned object, e.g., options.foo.
@@ -540,12 +560,12 @@ class Options:
         pairs.append((val_type, val))
     return pairs
 
-  def __getitem__(self, scope):
+  def __getitem__(self, scope: str) -> OptionValueContainer:
     # TODO(John Sirois): Mainly supports use of dict<str, dict<str, str>> for mock options in tests,
     # Consider killing if tests consolidate on using TestOptions instead of the raw dicts.
     return self.for_scope(scope)
 
-  def bootstrap_option_values(self):
+  def bootstrap_option_values(self) -> Optional[OptionValueContainer]:
     """Return the option values for bootstrap options.
 
     General code can also access these values in the global scope.  But option registration code
@@ -553,7 +573,7 @@ class Options:
     """
     return self._bootstrap_option_values
 
-  def for_global_scope(self):
+  def for_global_scope(self) -> OptionValueContainer:
     """Return the option values for the global scope.
 
     :API: public

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -7,15 +7,16 @@ import os
 import stat
 import sys
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type
 
 from pants.base.build_environment import get_default_pants_config_file
 from pants.engine.fs import FileContent
 from pants.option.config import Config
 from pants.option.custom_types import ListValueComponent
 from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.optionable import Optionable
 from pants.option.options import Options
-from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
+from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
 from pants.util.dirutil import read_file
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.strutil import ensure_text
@@ -28,13 +29,13 @@ logger = logging.getLogger(__name__)
 class OptionsBootstrapper:
   """Holds the result of the first stage of options parsing, and assists with parsing full
   options."""
-  env_tuples: Tuple
-  bootstrap_args: Tuple
-  args: Tuple
+  env_tuples: Tuple[Tuple[str, str], ...]
+  bootstrap_args: Tuple[str, ...]
+  args: Tuple[str, ...]
   config: Config
 
   @staticmethod
-  def get_config_file_paths(env, args):
+  def get_config_file_paths(env, args) -> List[str]:
     """Get the location of the config files.
 
     The locations are specified by the --pants-config-files option.  However we need to load the
@@ -69,7 +70,7 @@ class OptionsBootstrapper:
     return ListValueComponent.merge(path_list_values).val
 
   @staticmethod
-  def parse_bootstrap_options(env, args, config):
+  def parse_bootstrap_options(env: Mapping[str, str], args: Sequence[str], config: Config) -> Options:
     bootstrap_options = Options.create(
       env=env,
       config=config,
@@ -85,11 +86,9 @@ class OptionsBootstrapper:
     return bootstrap_options
 
   @classmethod
-  def from_options_parse_request(cls, parse_request):
-    return cls.create(env=dict(parse_request.env), args=parse_request.args)
-
-  @classmethod
-  def create(cls, env=None, args=None):
+  def create(
+    cls, env: Optional[Mapping[str, str]] = None, args: Optional[Sequence[str]] = None,
+  ) -> "OptionsBootstrapper":
     """Parses the minimum amount of configuration necessary to create an OptionsBootstrapper.
 
     :param env: An environment dictionary, or None to use `os.environ`.
@@ -103,7 +102,7 @@ class OptionsBootstrapper:
     short_flags = set()
 
     # TODO: This codepath probably shouldn't be using FileContent, which is a very v2 engine thing.
-    def filecontent_for(path):
+    def filecontent_for(path: str) -> FileContent:
       is_executable = os.stat(path).st_mode & stat.S_IXUSR == stat.S_IXUSR
       return FileContent(
         ensure_text(path),
@@ -111,7 +110,7 @@ class OptionsBootstrapper:
         is_executable=is_executable,
       )
 
-    def capture_the_flags(*args, **kwargs):
+    def capture_the_flags(*args: str, **kwargs) -> None:
       for arg in args:
         flags.add(arg)
         if len(arg) == 2:
@@ -121,7 +120,7 @@ class OptionsBootstrapper:
 
     GlobalOptionsRegistrar.register_bootstrap_options(capture_the_flags)
 
-    def is_bootstrap_option(arg):
+    def is_bootstrap_option(arg: str) -> bool:
       components = arg.split('=', 1)
       if components[0] in flags:
         return True
@@ -153,18 +152,18 @@ class OptionsBootstrapper:
     full_config_files_products = [filecontent_for(p) for p in full_configpaths]
     post_bootstrap_config = Config.load_file_contents(
       full_config_files_products,
-      seed_values=bootstrap_option_values
+      seed_values=bootstrap_option_values.as_dict(),
     )
 
     env_tuples = tuple(sorted(env.items(), key=lambda x: x[0]))
     return cls(env_tuples=env_tuples, bootstrap_args=bargs, args=args, config=post_bootstrap_config)
 
   @memoized_property
-  def env(self):
+  def env(self) -> Dict[str, str]:
     return dict(self.env_tuples)
 
   @memoized_property
-  def bootstrap_options(self):
+  def bootstrap_options(self) -> Options:
     """The post-bootstrap options, computed from the env, args, and fully discovered Config.
 
     Re-computing options after Config has been fully expanded allows us to pick up bootstrap values
@@ -175,14 +174,12 @@ class OptionsBootstrapper:
     """
     return self.parse_bootstrap_options(self.env, self.bootstrap_args, self.config)
 
-  def get_bootstrap_options(self):
-    """:returns: an Options instance that only knows about the bootstrap options.
-    :rtype: :class:`Options`
-    """
+  def get_bootstrap_options(self) -> Options:
+    """Returns an Options instance that only knows about the bootstrap options."""
     return self.bootstrap_options
 
   @memoized_method
-  def _full_options(self, known_scope_infos):
+  def _full_options(self, known_scope_infos: Tuple[ScopeInfo, ...]) -> Options:
     bootstrap_option_values = self.get_bootstrap_options().for_global_scope()
     options = Options.create(self.env,
                              self.config,
@@ -190,7 +187,7 @@ class OptionsBootstrapper:
                              args=self.args,
                              bootstrap_option_values=bootstrap_option_values)
 
-    distinct_optionable_classes = set()
+    distinct_optionable_classes: Set[Type[Optionable]] = set()
     for ksi in sorted(known_scope_infos, key=lambda si: si.scope):
       if not ksi.optionable_cls or ksi.optionable_cls in distinct_optionable_classes:
         continue
@@ -199,21 +196,19 @@ class OptionsBootstrapper:
 
     return options
 
-  def get_full_options(self, known_scope_infos):
+  def get_full_options(self, known_scope_infos: Iterable[ScopeInfo]) -> Options:
     """Get the full Options instance bootstrapped by this object for the given known scopes.
 
     :param known_scope_infos: ScopeInfos for all scopes that may be encountered.
     :returns: A bootrapped Options instance that also carries options for all the supplied known
               scopes.
-    :rtype: :class:`Options`
     """
-    return self._full_options(tuple(sorted(set(known_scope_infos))))
+    return self._full_options(tuple(set(known_scope_infos)))
 
-  def verify_configs_against_options(self, options):
+  def verify_configs_against_options(self, options: Options) -> None:
     """Verify all loaded configs have correct scopes and options.
 
     :param options: Fully bootstrapped valid options.
-    :return: None.
     """
     error_log = []
     for config in self.config.configs():

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -3,29 +3,32 @@
 
 import os
 import unittest
+from functools import partial
 from textwrap import dedent
+from typing import Dict, List, Optional
 
 from pants.base.build_environment import get_buildroot
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import ScopeInfo
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 
 
-class BootstrapOptionsTest(unittest.TestCase):
+class OptionsBootstrapperTest(unittest.TestCase):
 
-  def _do_test(self, expected_vals, config, env, args):
-    self._test_bootstrap_options(config, env, args,
-                                 pants_workdir=expected_vals[0],
-                                 pants_supportdir=expected_vals[1],
-                                 pants_distdir=expected_vals[2])
-
-  def _config_path(self, path):
+  def _config_path(self, path: Optional[str]) -> List[str]:
     if path is None:
       return ["--pants-config-files=[]"]
-    else:
-      return [f"--pants-config-files=['{path}']"]
+    return [f"--pants-config-files=['{path}']"]
 
-  def _test_bootstrap_options(self, config, env, args, **expected_entries):
+  def assert_bootstrap_options(
+    self,
+    *,
+    config: Optional[Dict[str, str]] = None,
+    env: Optional[Dict[str, str]] = None,
+    args: Optional[List[str]] = None,
+    **expected_entries,
+  ) -> None:
     with temporary_file(binary_mode=False) as fp:
       fp.write('[DEFAULT]\n')
       if config:
@@ -33,73 +36,90 @@ class BootstrapOptionsTest(unittest.TestCase):
           fp.write(f'{k}: {v}\n')
       fp.close()
 
-      args = args + self._config_path(fp.name)
-      bootstrapper = OptionsBootstrapper.create(env=env, args=args)
+      args = [*self._config_path(fp.name), *(args or [])]
+      bootstrapper = OptionsBootstrapper.create(env=env or {}, args=args)
       vals = bootstrapper.get_bootstrap_options().for_global_scope()
 
-      vals_dict = {k: getattr(vals, k) for k in expected_entries}
-      self.assertEqual(expected_entries, vals_dict)
+    vals_dict = {k: getattr(vals, k) for k in expected_entries}
+    self.assertEqual(expected_entries, vals_dict)
 
-  def test_bootstrap_option_values(self):
-    # Check all defaults.
-    buildroot = get_buildroot()
+  def test_bootstrap_seed_values(self) -> None:
+    def assert_seed_values(
+      *,
+      config: Optional[Dict[str, str]] = None,
+      env: Optional[Dict[str, str]] = None,
+      args: Optional[List[str]] = None,
+      workdir: Optional[str] = None,
+      supportdir: Optional[str] = None,
+      distdir: Optional[str] = None,
+    ) -> None:
+      self.assert_bootstrap_options(
+        config=config,
+        env=env,
+        args=args,
+        pants_workdir=workdir or os.path.join(get_buildroot(), '.pants.d'),
+        pants_supportdir=supportdir or os.path.join(get_buildroot(), 'build-support'),
+        pants_distdir=distdir or os.path.join(get_buildroot(), 'dist'),
+      )
 
-    def br(path):
-      # Returns the full path of the given path under the buildroot.
-      return os.path.join(buildroot, path)
-
-    self._do_test([br('.pants.d'), br('build-support'), br('dist')],
-                  config=None, env={}, args=[])
+    # Check for valid default seed values
+    assert_seed_values()
 
     # Check getting values from config, env and args.
-    self._do_test(['/from_config/.pants.d', br('build-support'), br('dist')],
-                  config={'pants_workdir': '/from_config/.pants.d'}, env={}, args=[])
-    self._do_test([br('.pants.d'), '/from_env/build-support', br('dist')],
-                  config=None,
-                  env={'PANTS_SUPPORTDIR': '/from_env/build-support'}, args=[])
-    self._do_test([br('.pants.d'), br('build-support'), '/from_args/dist'],
-                  config={}, env={}, args=['--pants-distdir=/from_args/dist'])
+    assert_seed_values(
+      config={'pants_workdir': '/from_config/.pants.d'}, workdir='/from_config/.pants.d',
+    )
+    assert_seed_values(
+      env={'PANTS_SUPPORTDIR': '/from_env/build-support'}, supportdir='/from_env/build-support',
+    )
+    assert_seed_values(args=['--pants-distdir=/from_args/dist'], distdir='/from_args/dist')
 
     # Check that args > env > config.
-    self._do_test(['/from_config/.pants.d', '/from_env/build-support', '/from_args/dist'],
-                  config={
-                    'pants_workdir': '/from_config/.pants.d',
-                    'pants_supportdir': '/from_config/build-support',
-                    'pants_distdir': '/from_config/dist'
-                  },
-                  env={
-                    'PANTS_SUPPORTDIR': '/from_env/build-support',
-                    'PANTS_DISTDIR': '/from_env/dist'
-                  },
-                  args=['--pants-distdir=/from_args/dist'])
+    assert_seed_values(
+      config={
+        'pants_workdir': '/from_config/.pants.d',
+        'pants_supportdir': '/from_config/build-support',
+        'pants_distdir': '/from_config/dist',
+      },
+      env={
+        'PANTS_SUPPORTDIR': '/from_env/build-support',
+        'PANTS_DISTDIR': '/from_env/dist',
+      },
+      args=['--pants-distdir=/from_args/dist'],
+      workdir='/from_config/.pants.d',
+      supportdir='/from_env/build-support',
+      distdir='/from_args/dist',
+    )
 
     # Check that unrelated args and config don't confuse us.
-    self._do_test(['/from_config/.pants.d', '/from_env/build-support', '/from_args/dist'],
-                  config={
-                    'pants_workdir': '/from_config/.pants.d',
-                    'pants_supportdir': '/from_config/build-support',
-                    'pants_distdir': '/from_config/dist',
-                    'unrelated': 'foo'
-                  },
-                  env={
-                    'PANTS_SUPPORTDIR': '/from_env/build-support',
-                    'PANTS_DISTDIR': '/from_env/dist'
-                  },
-                  args=['--pants-distdir=/from_args/dist', '--foo=bar', '--baz'])
+    assert_seed_values(
+      config={
+        'pants_workdir': '/from_config/.pants.d',
+        'pants_supportdir': '/from_config/build-support',
+        'pants_distdir': '/from_config/dist',
+        'unrelated': 'foo',
+      },
+      env={
+        'PANTS_SUPPORTDIR': '/from_env/build-support',
+        'PANTS_DISTDIR': '/from_env/dist',
+        'PANTS_NO_RELATIONSHIP': 'foo',
+      },
+      args=['--pants-distdir=/from_args/dist', '--foo=bar', '--baz'],
+      workdir='/from_config/.pants.d',
+      supportdir='/from_env/build-support',
+      distdir='/from_args/dist',
+    )
 
-  def test_bootstrap_bool_option_values(self):
+  def test_bootstrap_bool_option_values(self) -> None:
     # Check the default.
-    self._test_bootstrap_options(config=None, env={}, args=[], pantsrc=True)
+    self.assert_bootstrap_options(pantsrc=True)
 
-    # Check an override via flag - currently bools (for store_true and store_false actions) cannot
-    # be inverted from the default via env vars or the config.
-    self._test_bootstrap_options(config={}, env={}, args=['--no-pantsrc'], pantsrc=False)
+    assert_pantsrc_is_false = partial(self.assert_bootstrap_options, pantsrc=False)
+    assert_pantsrc_is_false(args=['--no-pantsrc'])
+    assert_pantsrc_is_false(config={'pantsrc': False})
+    assert_pantsrc_is_false(env={'PANTS_PANTSRC': 'False'})
 
-    self._test_bootstrap_options(config={'pantsrc': False}, env={}, args=[], pantsrc=False)
-
-    self._test_bootstrap_options(config={}, env={'PANTS_PANTSRC': 'False'}, args=[], pantsrc=False)
-
-  def test_create_bootstrapped_options(self):
+  def test_create_bootstrapped_options(self) -> None:
     # Check that we can set a bootstrap option from a cmd-line flag and have that interpolate
     # correctly into regular config.
     with temporary_file(binary_mode=False) as fp:
@@ -130,7 +150,7 @@ class BootstrapOptionsTest(unittest.TestCase):
     self.assertEqual('/qux/baz', opts.for_scope('foo').bar)
     self.assertEqual('/pear/banana', opts.for_scope('fruit').apple)
 
-  def test_bootstrapped_options_ignore_irrelevant_env(self):
+  def test_bootstrapped_options_ignore_irrelevant_env(self) -> None:
     included = 'PANTS_SUPPORTDIR'
     excluded = 'NON_PANTS_ENV'
     bootstrapper = OptionsBootstrapper.create(
@@ -142,67 +162,66 @@ class BootstrapOptionsTest(unittest.TestCase):
     self.assertIn(included, bootstrapper.env)
     self.assertNotIn(excluded, bootstrapper.env)
 
-  def do_test_create_bootstrapped_multiple_config(self, create_options_bootstrapper):
-    # check with multiple config files, the latest values always get taken
-    # in this case worker_count will be overwritten, while fruit stays the same
-    with temporary_file(binary_mode=False) as fp:
-      fp.write(dedent("""
-      [compile.apt]
-      worker_count: 1
-
-      [fruit]
-      apple: red
-      """))
-      fp.close()
-
-      bootstrapper_single_config = create_options_bootstrapper(fp.name)
-
-      opts_single_config = bootstrapper_single_config.get_full_options(known_scope_infos=[
-          ScopeInfo('', ScopeInfo.GLOBAL),
-          ScopeInfo('compile.apt', ScopeInfo.TASK),
-          ScopeInfo('fruit', ScopeInfo.TASK),
-      ])
-      # So we don't choke on these on the cmd line.
-      opts_single_config.register('', '--pants-config-files', type=list)
-      opts_single_config.register('', '--config-override', type=list)
-
-      opts_single_config.register('compile.apt', '--worker-count')
-      opts_single_config.register('fruit', '--apple')
-
-      self.assertEqual('1', opts_single_config.for_scope('compile.apt').worker_count)
-      self.assertEqual('red', opts_single_config.for_scope('fruit').apple)
-
-      with temporary_file(binary_mode=False) as fp2:
-        fp2.write(dedent("""
-        [compile.apt]
-        worker_count: 2
-        """))
-        fp2.close()
-
-        bootstrapper_double_config = create_options_bootstrapper(fp.name, fp2.name)
-
-        opts_double_config = bootstrapper_double_config.get_full_options(known_scope_infos=[
-          ScopeInfo('', ScopeInfo.GLOBAL),
-          ScopeInfo('compile.apt', ScopeInfo.TASK),
-          ScopeInfo('fruit', ScopeInfo.TASK),
-        ])
-        # So we don't choke on these on the cmd line.
-        opts_double_config.register('', '--pants-config-files', type=list)
-        opts_double_config.register('', '--config-override', type=list)
-        opts_double_config.register('compile.apt', '--worker-count')
-        opts_double_config.register('fruit', '--apple')
-
-        self.assertEqual('2', opts_double_config.for_scope('compile.apt').worker_count)
-        self.assertEqual('red', opts_double_config.for_scope('fruit').apple)
-
-  def test_create_bootstrapped_multiple_pants_config_files(self):
-    def create_options_bootstrapper(*config_paths):
+  def test_create_bootstrapped_multiple_pants_config_files(self) -> None:
+    """When given multiple config files, the later files should take precedence when options
+    conflict."""
+    def create_options_bootstrapper(*config_paths: str) -> OptionsBootstrapper:
       return OptionsBootstrapper.create(args=[f'--pants-config-files={cp}' for cp in config_paths])
 
-    self.do_test_create_bootstrapped_multiple_config(create_options_bootstrapper)
+    def assert_config_read_correctly(
+      options_bootstrapper: OptionsBootstrapper, *, expected_worker_count: int,
+    ) -> None:
+      options = options_bootstrapper.get_full_options(
+        known_scope_infos=[
+          ScopeInfo('', ScopeInfo.GLOBAL),
+          ScopeInfo('compile.apt', ScopeInfo.TASK),
+          ScopeInfo('fruit', ScopeInfo.TASK),
+        ],
+      )
+      # So we don't choke on these on the cmd line.
+      options.register('', '--pants-config-files', type=list)
+      options.register('', '--config-override', type=list)
+      options.register('compile.apt', '--worker-count')
+      options.register('fruit', '--apple')
 
-  def test_options_pantsrc_files(self):
-    def create_options_bootstrapper(*config_paths):
+      self.assertEqual(str(expected_worker_count), options.for_scope('compile.apt').worker_count)
+      self.assertEqual('red', options.for_scope('fruit').apple)
+
+    with temporary_file(binary_mode=False) as fp1, temporary_file(binary_mode=False) as fp2:
+      fp1.write(
+        dedent(
+          """\
+         [compile.apt]
+         worker_count: 1
+  
+         [fruit]
+         apple: red
+         """
+        )
+      )
+      fp2.write(
+        dedent(
+          """\
+          [compile.apt]
+          worker_count: 2
+          """
+        )
+      )
+      fp1.close()
+      fp2.close()
+
+      assert_config_read_correctly(
+        create_options_bootstrapper(fp1.name), expected_worker_count=1,
+      )
+      assert_config_read_correctly(
+        create_options_bootstrapper(fp1.name, fp2.name), expected_worker_count=2,
+      )
+      assert_config_read_correctly(
+        create_options_bootstrapper(fp2.name, fp1.name), expected_worker_count=1,
+      )
+
+  def test_options_pantsrc_files(self) -> None:
+    def create_options_bootstrapper(*config_paths: str) -> OptionsBootstrapper:
       return OptionsBootstrapper.create(args=[f'--pantsrc-files={cp}' for cp in config_paths])
     with temporary_file(binary_mode=False) as fp:
       fp.write(dedent("""
@@ -219,7 +238,7 @@ class BootstrapOptionsTest(unittest.TestCase):
       opts_single_config.register('resolver', '--resolver')
       self.assertEqual('coursier', opts_single_config.for_scope('resolver').resolver)
 
-  def test_full_options_caching(self):
+  def test_full_options_caching(self) -> None:
     with temporary_file_path() as config:
       args = self._config_path(config)
       bootstrapper = OptionsBootstrapper.create(env={}, args=args)
@@ -242,9 +261,9 @@ class BootstrapOptionsTest(unittest.TestCase):
       self.assertIs(opts4, opts5)
       self.assertIsNot(opts1, opts5)
 
-  def test_bootstrap_short_options(self):
-    def parse_options(*args):
-      full_args = list(args) + self._config_path(None)
+  def test_bootstrap_short_options(self) -> None:
+    def parse_options(*args: str) -> OptionValueContainer:
+      full_args = [*args, *self._config_path(None)]
       return OptionsBootstrapper.create(args=full_args).get_bootstrap_options().for_global_scope()
 
     # No short options passed - defaults presented.
@@ -261,9 +280,9 @@ class BootstrapOptionsTest(unittest.TestCase):
     self.assertEqual('/tmp/logs', vals.logdir)
     self.assertEqual('debug', vals.level)
 
-  def test_bootstrap_options_passthrough_dup_ignored(self):
-    def parse_options(*args):
-      full_args = list(args) + self._config_path(None)
+  def test_bootstrap_options_passthrough_dup_ignored(self) -> None:
+    def parse_options(*args: str) -> OptionValueContainer:
+      full_args = [*args, *self._config_path(None)]
       return OptionsBootstrapper.create(args=full_args).get_bootstrap_options().for_global_scope()
 
     vals = parse_options('main', 'args', '-d/tmp/frogs', '--', '-d/tmp/logs')
@@ -272,7 +291,7 @@ class BootstrapOptionsTest(unittest.TestCase):
     vals = parse_options('main', 'args', '--', '-d/tmp/logs')
     self.assertIsNone(vals.logdir)
 
-  def test_bootstrap_options_explicit_config_path(self):
+  def test_bootstrap_options_explicit_config_path(self) -> None:
     def config_path(*args, **env):
       return OptionsBootstrapper.get_config_file_paths(env, args)
 
@@ -301,7 +320,7 @@ class BootstrapOptionsTest(unittest.TestCase):
                      config_path('main', 'args', '-x', "--pants-config-files=['/from/flag']",
                                  'goal', '--other-flag', PANTS_CONFIG_FILES="+['/from/env']"))
 
-  def test_setting_pants_config_in_config(self):
+  def test_setting_pants_config_in_config(self) -> None:
     # Test that setting pants_config in the config file has no effect.
     with temporary_dir() as tmpdir:
       config1 = os.path.join(tmpdir, 'config1')

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -96,7 +96,7 @@ class OptionsTest(TestBase):
       bootstrap_option_values=bootstrap_option_values,
     )
     self._register(options)
-    return cast(Options, options)
+    return options
 
   _known_scope_infos = [intermediate('compile'),
                         task('compile.java'),
@@ -738,7 +738,7 @@ class OptionsTest(TestBase):
     options = Options.create(env={},
                              config=self._create_config(),
                              known_scope_infos=[task('bar'), intermediate('foo'), task('foo.bar')],
-                             args='./pants')
+                             args=['./pants'])
     options.register('', '--opt1')
     options.register('foo', '-o', '--opt2')
 
@@ -770,7 +770,7 @@ class OptionsTest(TestBase):
     options = Options.create(env={},
                              config=self._create_config(),
                              known_scope_infos=[subsystem('foo')],
-                             args='./pants')
+                             args=['./pants'])
     # All subsystem options are implicitly recursive (a subscope of subsystem scope represents
     # a separate instance of the subsystem, so it needs all the options).
     # We disallow explicit specification of recursive (even if set to True), to avoid confusion.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -17,6 +17,7 @@ from typing import (
   Dict,
   Iterable,
   List,
+  Mapping,
   Optional,
   Set,
   Tuple,
@@ -110,7 +111,7 @@ class Parser:
 
   def __init__(
     self,
-    env: Dict[str, str],
+    env: Mapping[str, str],
     config: Config,
     scope_info: ScopeInfo,
     parent_parser: Optional["Parser"],
@@ -624,8 +625,10 @@ class Parser:
     config_section = GLOBAL_SCOPE_CONFIG_SECTION if self._scope == GLOBAL_SCOPE else self._scope
     config_default_val_or_str = expand(self._config.get(Config.DEFAULT_SECTION, dest, default=None))
     config_val_or_str = expand(self._config.get(config_section, dest, default=None))
-    config_source_file = (self._config.get_source_for_option(config_section, dest) or
-        self._config.get_source_for_option(Config.DEFAULT_SECTION, dest))
+    config_source_file = (
+      self._config.get_source_for_option(config_section, dest) or
+      self._config.get_source_for_option(Config.DEFAULT_SECTION, dest)
+    )
     if config_source_file is not None:
       config_source_file = os.path.relpath(config_source_file)
       config_details = f'in {config_source_file}'

--- a/src/python/pants/testutil/option/util.py
+++ b/src/python/pants/testutil/option/util.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Dict, Iterable, Optional, cast
+from typing import Dict, Iterable, Optional
 
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -9,7 +9,6 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 def create_options_bootstrapper(
   *, args: Optional[Iterable[str]] = None, env: Optional[Dict[str, str]] = None,
 ) -> OptionsBootstrapper:
-  return cast(
-    OptionsBootstrapper,
-    OptionsBootstrapper.create(args=("--pants-config-files=[]", *(args or [])), env=env or {}),
+  return OptionsBootstrapper.create(
+    args=("--pants-config-files=[]", *(args or [])), env=env or {},
   )

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -42,13 +42,15 @@ def parse_expression(
   try:
     parsed_value = eval(val)
   except Exception as e:
-    raise raise_type(dedent("""\
-      The {name} cannot be evaluated as a literal expression: {error}
-      Given raw value:
-      {value}
-      """.format(name=get_name(),
-                 error=e,
-                 value=format_raw_value())))
+    raise raise_type(
+      dedent(
+        f"""\
+        The {get_name()} cannot be evaluated as a literal expression: {e!r}
+        Given raw value:
+        {format_raw_value()}
+        """
+      )
+    )
 
   if not isinstance(parsed_value, acceptable_types):
     def iter_types(types):
@@ -59,15 +61,18 @@ def parse_expression(
           for typ in iter_types(item):
             yield typ
       else:
-        raise ValueError('The given acceptable_types is not a valid type (tuple): {}'
-                         .format(acceptable_types))
+        raise ValueError(
+          f'The given acceptable_types is not a valid type (tuple): {acceptable_types}'
+        )
 
-    raise raise_type(dedent("""\
-      The {name} is not of the expected type(s): {types}:
-      Given the following raw value that evaluated to type {type}:
-      {value}
-      """.format(name=get_name(),
-                 types=', '.join(format_type(t) for t in iter_types(acceptable_types)),
-                 type=format_type(type(parsed_value)),
-                 value=format_raw_value())))
+    expected_types = ', '.join(format_type(t) for t in iter_types(acceptable_types))
+    raise raise_type(
+      dedent(
+        f"""\
+        The {get_name()} is not of the expected type(s): {expected_types}:
+        Given the following raw value that evaluated to type {format_type(type(parsed_value))}:
+        {format_raw_value()}
+        """
+      )
+    )
   return parsed_value


### PR DESCRIPTION
This is prework for an experiment to add support for TOML config files, like `pants.toml`.