### PR TITLE
Refactor `--changed-include-dependees` to use an Enum option

### DIFF
--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -82,6 +82,7 @@ python_library(
     'src/python/pants/engine:parser',
     'src/python/pants/engine:selectors',
     'src/python/pants/option',
+    'src/python/pants/scm/subsystems:changed',
     'src/python/pants/source',
     'src/python/pants/util:dirutil',
   ],

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -15,7 +15,7 @@ from pants.engine.legacy.graph import OwnersRequest
 from pants.engine.scheduler import SchedulerSession
 from pants.goal.workspace import ScmWorkspace
 from pants.option.options import Options
-from pants.scm.subsystems.changed import ChangedRequest
+from pants.scm.subsystems.changed import ChangedRequest, IncludeDependeesOption
 
 
 logger = logging.getLogger(__name__)
@@ -102,8 +102,9 @@ class TargetRootsCalculator:
           diffspec=changed_request.diffspec)
       # We've been provided no spec roots (e.g. `./pants list`) AND a changed request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(changed_files),
-                              include_dependees=changed_request.include_dependees)
+      request = OwnersRequest(
+        sources=tuple(changed_files), include_dependees=changed_request.include_dependees,
+      )
       changed_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('changed addresses: %s', changed_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses)
@@ -114,7 +115,9 @@ class TargetRootsCalculator:
     if owned_files:
       # We've been provided no spec roots (e.g. `./pants list`) AND a owner request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(owned_files), include_dependees='none')
+      request = OwnersRequest(
+        sources=tuple(owned_files), include_dependees=IncludeDependeesOption.NONE,
+      )
       owner_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('owner addresses: %s', owner_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -2,9 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from pants.subsystem.subsystem import Subsystem
+
+
+class IncludeDependeesOption(Enum):
+  NONE = "none"
+  DIRECT = "direct"
+  TRANSITIVE = "transitive"
 
 
 @dataclass(frozen=True)
@@ -12,11 +19,11 @@ class ChangedRequest:
   """Parameters required to compute a changed file/target set."""
   changes_since: Any
   diffspec: Any
-  include_dependees: Any
+  include_dependees: IncludeDependeesOption
   fast: Any
 
   @classmethod
-  def from_options(cls, options):
+  def from_options(cls, options) -> "ChangedRequest":
     """Given an `Options` object, produce a `ChangedRequest`."""
     return cls(options.changes_since,
                options.diffspec,
@@ -42,7 +49,7 @@ class Changed(Subsystem):
              help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
     register('--diffspec',
              help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
-    register('--include-dependees', choices=['none', 'direct', 'transitive'], default='none',
+    register('--include-dependees', type=IncludeDependeesOption, default=IncludeDependeesOption.NONE,
              help='Include direct or transitive dependees of changed targets.')
     register('--fast', type=bool,
              help='Stop searching for owners once a source is mapped to at least one owning target.')

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -8,6 +8,7 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
+from pants.scm.subsystems.changed import IncludeDependeesOption
 from pants.testutil.test_base import TestBase
 
 
@@ -21,7 +22,7 @@ class SourceMapperTest(TestBase):
     )
 
   def owner(self, owner, f):
-    request = OwnersRequest(sources=(f,), include_dependees='none')
+    request = OwnersRequest(sources=(f,), include_dependees=IncludeDependeesOption.NONE)
     addresses = self.request_single_product(BuildFileAddresses, request)
     self.assertEqual(set(owner), {i.spec for i in addresses})
 


### PR DESCRIPTION
This was a long-standing TODO noticed while hooking up filesystem specs to `OwnersRequest`.

Thanks to @herman5's work on https://github.com/pantsbuild/pants/pull/8853, the output for `./pants help` will be nearly identical to users:

<img width="681" alt="screen shot of help message" src="https://user-images.githubusercontent.com/14852634/72843955-cea61180-3c58-11ea-9e6d-94f697834a62.png">
