### PR TITLE
Add IPython subsystem and deprecate `--repl-py` options

### DIFF
--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+
+
+class IPython(PythonToolBase):
+  options_scope = 'ipython'
+  default_version = 'ipython==5.8.0'
+  default_extra_requirements: List[str] = []
+  default_entry_point = 'IPython:start_ipython'
+  default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--enabled', type=bool, default=False, fingerprint=True,
+      help="Use IPython instead of the standard Python REPL.",
+    )

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -12,11 +12,3 @@ class IPython(PythonToolBase):
   default_extra_requirements: List[str] = []
   default_entry_point = 'IPython:start_ipython'
   default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
-
-  @classmethod
-  def register_options(cls, register):
-    super().register_options(register)
-    register(
-      '--enabled', type=bool, default=False, fingerprint=True,
-      help="Use IPython instead of the standard Python REPL.",
-    )

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -3,9 +3,11 @@
 
 from pex.pex_info import PexInfo
 
+from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exception_sink import ExceptionSink
 from pants.task.repl_task_mixin import ReplTaskMixin
 
@@ -13,31 +15,60 @@ from pants.task.repl_task_mixin import ReplTaskMixin
 class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
   """Launch an interactive Python interpreter session."""
 
+  def _resolve_conflicting_options(self, *, old_option: str, new_option: str):
+    return resolve_conflicting_options(
+      old_option=old_option,
+      new_option=new_option,
+      old_scope='repl-py',
+      new_scope='ipython',
+      old_container=self.get_options(),
+      new_container=IPython.global_instance().options,
+    )
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    # TODO: Create a python equivalent of register_jvm_tool, and use that instead of these
-    # ad-hoc options.
-    register('--ipython', type=bool,
+    register('--ipython', type=bool, fingerprint=True,
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--ipython-enabled` instead of `--repl-py-ipython`.",
              help='Run an IPython REPL instead of the standard python one.')
     register('--ipython-entry-point', advanced=True, default='IPython:start_ipython',
-             help='The IPython REPL entry point.')
-    register('--ipython-requirements', advanced=True, type=list, default=['ipython==1.0.0'],
-             help='The IPython interpreter version to use.')
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--ipython-entry-point` instead of `--repl-py-ipython-entry-point`.",
+             fingerprint=True, help='The IPython REPL entry point.')
+    register('--ipython-requirements', advanced=True, type=list, default=['ipython==5.8.0'],
+             removal_version="1.27.0.dev0",
+             removal_hint="Use `--ipython-version` and `--ipython-extra-requirements` instead of "
+                          "`--repl-py-ipython-requirements`.",
+             fingerprint=True, help='The IPython interpreter version to use.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (IPython,)
 
   @classmethod
   def select_targets(cls, target):
     return isinstance(target, (PythonTarget, PythonRequirementLibrary))
 
   def extra_requirements(self):
-    if self.get_options().ipython:
-      return self.get_options().ipython_requirements
-    else:
+    if not self.get_options().ipython and not IPython.global_instance().options.enabled:
       return []
+    ipython_version = self._resolve_conflicting_options(
+      old_option="ipython_requirements", new_option="version",
+    )
+    ipython_extra_requirements = self._resolve_conflicting_options(
+      old_option="ipython_requirements", new_option="extra_requirements",
+    )
+    if isinstance(ipython_version, list):
+      return self.get_options().ipython_requirements
+    return [ipython_version, *ipython_extra_requirements]
 
   def setup_repl_session(self, targets):
-    if self.get_options().ipython:
-      entry_point = self.get_options().ipython_entry_point
+    ipython_enabled = self._resolve_conflicting_options(old_option="ipython", new_option="enabled")
+    if ipython_enabled:
+      entry_point = self._resolve_conflicting_options(
+        old_option="ipython_entry_point", new_option="entry_point",
+      )
     else:
       entry_point = 'code:interact'
     pex_info = PexInfo.default()

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -29,8 +29,6 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
   def register_options(cls, register):
     super().register_options(register)
     register('--ipython', type=bool, fingerprint=True,
-             removal_version="1.27.0.dev0",
-             removal_hint="Use `--ipython-enabled` instead of `--repl-py-ipython`.",
              help='Run an IPython REPL instead of the standard python one.')
     register('--ipython-entry-point', advanced=True, default='IPython:start_ipython',
              removal_version="1.27.0.dev0",
@@ -51,7 +49,7 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
     return isinstance(target, (PythonTarget, PythonRequirementLibrary))
 
   def extra_requirements(self):
-    if not self.get_options().ipython and not IPython.global_instance().options.enabled:
+    if not self.get_options().ipython:
       return []
     ipython_version = self._resolve_conflicting_options(
       old_option="ipython_requirements", new_option="version",
@@ -64,8 +62,7 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
     return [ipython_version, *ipython_extra_requirements]
 
   def setup_repl_session(self, targets):
-    ipython_enabled = self._resolve_conflicting_options(old_option="ipython", new_option="enabled")
-    if ipython_enabled:
+    if self.get_options().ipython:
       entry_point = self._resolve_conflicting_options(
         old_option="ipython_entry_point", new_option="entry_point",
       )

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -5,6 +5,7 @@ import os
 from contextlib import contextmanager
 from textwrap import dedent
 
+from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
@@ -14,6 +15,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.testutil.subsystem.util import init_subsystem
 from pants.util.contextutil import environment_as, stdio_as, temporary_dir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
@@ -42,6 +44,7 @@ class PythonReplTest(PythonTaskTestBase):
 
   def setUp(self):
     super().setUp()
+    init_subsystem(IPython)
     self.six = self.create_python_requirement_library('3rdparty/python/six', 'six',
                                                       requirements=['six==1.13.0'])
     self.requests = self.create_python_requirement_library('3rdparty/python/requests', 'requests',
@@ -76,9 +79,7 @@ class PythonReplTest(PythonTaskTestBase):
         with stdio_as(stdin_fd=inp.fileno(), stdout_fd=out.fileno(), stderr_fd=err.fileno()):
           yield (stdin, stdout, stderr)
 
-  def do_test_repl(self, code, expected, targets, options=None):
-    if options:
-      self.set_options(**options)
+  def do_test_repl(self, code, expected, targets):
 
     class JvmRepl(ReplTaskMixin):
       options_scope = 'test_scope_jvm_repl'
@@ -171,7 +172,7 @@ class PythonReplTest(PythonTaskTestBase):
     # the head of this very file.
     with open(__file__, 'r') as fp:
       me = fp.readline()
+      self.set_options_for_scope(IPython.options_scope, enabled=True)
       self.do_test_repl(code=[f'!head -1 {__file__}'],
                         expected=[me],
-                        targets=[self.six],  # Just to get the repl to pop up.
-                        options={'ipython': True})
+                        targets=[self.six])  # Just to get the repl to pop up.

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -170,9 +170,9 @@ class PythonReplTest(PythonTaskTestBase):
   def test_ipython(self):
     # IPython supports shelling out with a leading !, so indirectly test its presence by reading
     # the head of this very file.
+    self.set_options(ipython=True)
     with open(__file__, 'r') as fp:
       me = fp.readline()
-      self.set_options_for_scope(IPython.options_scope, enabled=True)
       self.do_test_repl(code=[f'!head -1 {__file__}'],
                         expected=[me],
                         targets=[self.six])  # Just to get the repl to pop up.


### PR DESCRIPTION
This is prework for a V2 implementation of `repl`.

This also fixes a bug that we forgot to set `fingerprint=True` on the `repl-py` options, so disabling and enabling IPython wouldn't actually do anything until running `clean-all`.