### PR TITLE
Improve error messages for rule graph issues

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -156,6 +156,9 @@ def _make_rule(
     else:
       effective_name = name
 
+    # Set our own custom `__line_number__` dunder so that the engine may visualize the line number.
+    func.__line_number__ = func.__code__.co_firstlineno
+
     func.rule = TaskRule(
         return_type,
         tuple(parameter_types),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -253,6 +253,7 @@ class Scheduler:
                                                      self._to_type(product))
     self._raise_or_return(res)
 
+  @property
   def visualize_to_dir(self):
     return self._visualize_to_dir
 
@@ -411,10 +412,10 @@ class SchedulerSession:
     return self._scheduler.with_fork_context(func)
 
   def _maybe_visualize(self):
-    if self._scheduler.visualize_to_dir() is not None:
-      name = 'graph.{0:03d}.dot'.format(self._run_count)
+    if self._scheduler.visualize_to_dir is not None:
+      name = f'graph.{self._run_count:03d}.dot'
       self._run_count += 1
-      self.visualize_graph_to_file(os.path.join(self._scheduler.visualize_to_dir(), name))
+      self.visualize_graph_to_file(os.path.join(self._scheduler.visualize_to_dir, name))
 
   def execute(self, execution_request):
     """Invoke the engine for the given ExecutionRequest, returning Return and Throw states.
@@ -422,8 +423,12 @@ class SchedulerSession:
     :return: A tuple of (root, Return) tuples and (root, Throw) tuples.
     """
     start_time = time.time()
-    roots = list(zip(execution_request.roots,
-                     self._scheduler._run_and_return_roots(self._session, execution_request.native)))
+    roots = list(
+      zip(
+        execution_request.roots,
+        self._scheduler._run_and_return_roots(self._session, execution_request.native),
+      ),
+    )
 
     ExceptionSink.toggle_ignoring_sigint_v2_engine(False)
 

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -6,7 +6,6 @@ import inspect
 import re
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Optional, Type
-from unittest.mock import Mock
 
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
@@ -51,10 +50,8 @@ class OptionableFactory(ABC):
     snake_scope = cls.options_scope.replace('-', '_')
     partial_construct_optionable.__name__ = f'construct_scope_{snake_scope}'
     partial_construct_optionable.__module__ = cls.__module__
-    # It's a code smell to use unittest.mock in production, but this is a lightweight mechanism
-    # to get the engine to correctly display the class definition line.
     _, class_definition_lineno = inspect.getsourcelines(cls)
-    partial_construct_optionable.__code__ = Mock(co_firstlineno=class_definition_lineno)
+    partial_construct_optionable.__line_number__ = class_definition_lineno
 
     return dict(
         output_type=cls.optionable_cls,

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import functools
+import inspect
 import re
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Optional, Type
+from unittest.mock import Mock
 
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
@@ -41,9 +43,19 @@ class OptionableFactory(ABC):
 
     TODO: This indirection avoids a cycle between this module and the `rules` module.
     """
-    snake_scope = cls.options_scope.replace('-', '_')
     partial_construct_optionable = functools.partial(_construct_optionable, cls)
+
+    # NB: We must populate several dunder methods on the partial function because partial functions
+    # do not have these defined by default and the engine uses these values to visualize functions
+    # in error messages and the rule graph.
+    snake_scope = cls.options_scope.replace('-', '_')
     partial_construct_optionable.__name__ = f'construct_scope_{snake_scope}'
+    partial_construct_optionable.__module__ = cls.__module__
+    # It's a code smell to use unittest.mock in production, but this is a lightweight mechanism
+    # to get the engine to correctly display the class definition line.
+    _, class_definition_lineno = inspect.getsourcelines(cls)
+    partial_construct_optionable.__code__ = Mock(co_firstlineno=class_definition_lineno)
+
     return dict(
         output_type=cls.optionable_cls,
         input_selectors=tuple(),

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from io import StringIO
 from types import CoroutineType, GeneratorType
-from typing import Any, Callable, Optional, Sequence, Type
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, get_type_hints
 
 from colors import blue, green, red
 
@@ -201,3 +201,32 @@ class MockConsole:
 
   def red(self, text):
     return self._safe_color(text, red)
+
+
+def fmt_rust_function(func: Callable) -> str:
+  """Generate the str for a Rust Function, which is how Rust refers to `@rule`s.
+
+  This is useful when comparing strings against engine error messages. See
+  https://github.com/pantsbuild/pants/blob/5b97905443836b71dfa77cefc7cbc1735c7457cb/src/rust/engine/src/core.rs#L164.
+  """
+  return f"{func.__module__}:{func.__code__.co_firstlineno}:{func.__name__}"
+
+
+def fmt_rule(
+  rule: Callable, *, gets: Optional[List[Tuple[str, str]]] = None,
+) -> str:
+  """Generate the str that the engine will use for the rule.
+
+  This is useful when comparing strings against engine error messages.
+  """
+  type_hints = get_type_hints(rule)
+  product = type_hints.pop("return").__name__
+  params = ", ".join(t.__name__ for t in type_hints.values())
+  gets_str = ""
+  if gets:
+    get_members = ', '.join(
+      f"Get[{product_subject_pair[0]}]({product_subject_pair[1]})"
+      for product_subject_pair in gets
+    )
+    gets_str = f", gets=[{get_members}]"
+  return f"@rule({fmt_rust_function(rule)}({params}) -> {product}{gets_str})"

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -48,7 +48,7 @@ impl<R: Rule> UnreachableError<R> {
       rule,
       diagnostic: Diagnostic {
         params: ParamTypes::default(),
-        reason: "Was not usable by any other @rule.".to_string(),
+        reason: "Was not reachable, possibly because it was shadowed by another rule.".to_string(),
         details: vec![],
       },
     }
@@ -441,7 +441,7 @@ impl<'t, R: Rule> GraphMaker<'t, R> {
           params: params.clone(),
           reason: if params.is_empty() {
             format!(
-              "No rule was available to compute {}. Maybe declare it as a RootRule({})?",
+              "No rule was available to compute {}. Maybe declare RootRule({})?",
               dependency_key, product,
             )
           } else {

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -48,7 +48,7 @@ impl<R: Rule> UnreachableError<R> {
       rule,
       diagnostic: Diagnostic {
         params: ParamTypes::default(),
-        reason: "Was not reachable, possibly because it was shadowed by another rule.".to_string(),
+        reason: "Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.".to_string(),
         details: vec![],
       },
     }

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -48,7 +48,7 @@ impl<R: Rule> UnreachableError<R> {
       rule,
       diagnostic: Diagnostic {
         params: ParamTypes::default(),
-        reason: "Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.".to_string(),
+        reason: "Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.".to_string(),
         details: vec![],
       },
     }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -168,6 +168,8 @@ impl Function {
     let Function(key) = self;
     let module = externs::project_str(&externs::val_for(&key), "__module__");
     let name = externs::project_str(&externs::val_for(&key), "__name__");
+    // NB: this is a custom dunder method that Python code should populate before sending the
+    // function (e.g. an `@rule`) through FFI.
     let line_number = externs::project_str(&externs::val_for(&key), "__line_number__");
     format!("{}:{}:{}", module, line_number, name)
   }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -164,11 +164,15 @@ pub const ANY_TYPE: TypeId = TypeId(0);
 pub struct Function(pub Key);
 
 impl Function {
-  fn pretty_print(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+  pub fn name(&self) -> String {
     let Function(key) = self;
     let module = externs::project_str(&externs::val_for(&key), "__module__");
     let name = externs::project_str(&externs::val_for(&key), "__name__");
-    write!(f, "{}.{}()", module, name)
+    format!("{}.{}", module, name)
+  }
+
+  fn pretty_print(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}()", self.name())
   }
 }
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -166,8 +166,9 @@ pub struct Function(pub Key);
 impl Function {
   fn pretty_print(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let Function(key) = self;
+    let module = externs::project_str(&externs::val_for(&key), "__module__");
     let name = externs::project_str(&externs::val_for(&key), "__name__");
-    write!(f, "{}()", name)
+    write!(f, "{}.{}()", module, name)
   }
 }
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -101,7 +101,7 @@ impl Params {
       1 => params.pop().unwrap(),
       _ => {
         params.sort();
-        format!("({})", params.join("+"))
+        format!("({})", params.join(", "))
       }
     }
   }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -168,9 +168,8 @@ impl Function {
     let Function(key) = self;
     let module = externs::project_str(&externs::val_for(&key), "__module__");
     let name = externs::project_str(&externs::val_for(&key), "__name__");
-    let code = externs::project_ignoring_type(&externs::val_for(&key), "__code__");
-    let lineno = externs::project_str(&code, "co_firstlineno");
-    format!("{}:{}:{}", module, lineno, name)
+    let line_number = externs::project_str(&externs::val_for(&key), "__line_number__");
+    format!("{}:{}:{}", module, line_number, name)
   }
 }
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -168,7 +168,9 @@ impl Function {
     let Function(key) = self;
     let module = externs::project_str(&externs::val_for(&key), "__module__");
     let name = externs::project_str(&externs::val_for(&key), "__name__");
-    format!("{}.{}", module, name)
+    let code = externs::project_ignoring_type(&externs::val_for(&key), "__code__");
+    let lineno = externs::project_str(&code, "co_firstlineno");
+    format!("{}:{}:{}", module, lineno, name)
   }
 }
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -170,21 +170,17 @@ impl Function {
     let name = externs::project_str(&externs::val_for(&key), "__name__");
     format!("{}.{}", module, name)
   }
-
-  fn pretty_print(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}()", self.name())
-  }
 }
 
 impl fmt::Display for Function {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    self.pretty_print(f)
+    write!(f, "{}()", self.name())
   }
 }
 
 impl fmt::Debug for Function {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    self.pretty_print(f)
+    write!(f, "{}()", self.name())
   }
 }
 

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -15,7 +15,7 @@ pub struct Get {
 
 impl fmt::Display for Get {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-    write!(f, "Get(({}) -> {})", self.subject, self.product)
+    write!(f, "Get[{}]({})", self.product, self.subject)
   }
 }
 

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -15,7 +15,7 @@ pub struct Get {
 
 impl fmt::Display for Get {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-    write!(f, "Get({}, {})", self.product, self.subject)
+    write!(f, "Get(({}) -> {})", self.subject, self.product)
   }
 }
 

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -52,35 +52,36 @@ impl fmt::Display for Rule {
     match self {
       &Rule::Task(ref task) => {
         let product = format!("{}", task.product);
-        let mut clause_portion = task
+        let params = task
           .clause
           .iter()
           .map(|c| c.product.to_string())
           .collect::<Vec<_>>()
           .join(", ");
-        clause_portion = format!("[{}]", clause_portion);
-        let mut get_portion = task
-          .gets
-          .iter()
-          .map(::std::string::ToString::to_string)
-          .collect::<Vec<_>>()
-          .join(", ");
-        get_portion = if task.gets.is_empty() {
+        let get_portion = if task.gets.is_empty() {
           "".to_string()
         } else {
-          format!(", gets=[{}]", get_portion)
+          let get_members = task
+            .gets
+            .iter()
+            .map(::std::string::ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+          format!(", gets=[{}]", get_members)
         };
-
         write!(
           f,
-          "Rule(func={}, product={}, params={}{})",
-          task.func, product, clause_portion, get_portion,
+          "Rule({}({}) -> {}{})",
+          task.func.name(),
+          params,
+          product,
+          get_portion,
         )
       }
       &Rule::Intrinsic(ref intrinsic) => write!(
         f,
-        "Rule(product={}, params=[{}], <intrinsic>)",
-        intrinsic.product, intrinsic.input,
+        "Rule(<intrinsic>({}) -> {})",
+        intrinsic.input, intrinsic.product,
       ),
     }
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -68,18 +68,18 @@ impl fmt::Display for Rule {
         get_portion = if task.gets.is_empty() {
           "".to_string()
         } else {
-          format!("[{}], ", get_portion)
+          format!(", gets=[{}]", get_portion)
         };
 
         write!(
           f,
-          "({}, {}, {}{})",
-          product, clause_portion, get_portion, task.func,
+          "Rule(func={}, product={}, params={}{})",
+          task.func, product, clause_portion, get_portion,
         )
       }
       &Rule::Intrinsic(ref intrinsic) => write!(
         f,
-        "({}, [{}], <intrinsic>)",
+        "Rule(product={}, params=[{}], <intrinsic>)",
         intrinsic.product, intrinsic.input,
       ),
     }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -69,9 +69,15 @@ impl fmt::Display for Rule {
             .join(", ");
           format!(", gets=[{}]", get_members)
         };
+        let rule_type = if task.cacheable {
+          "rule".to_string()
+        } else {
+          "goal_rule".to_string()
+        };
         write!(
           f,
-          "Rule({}({}) -> {}{})",
+          "@{}({}({}) -> {}{})",
+          rule_type,
           task.func.name(),
           params,
           product,
@@ -80,7 +86,7 @@ impl fmt::Display for Rule {
       }
       &Rule::Intrinsic(ref intrinsic) => write!(
         f,
-        "Rule(<intrinsic>({}) -> {})",
+        "@rule(<intrinsic>({}) -> {})",
         intrinsic.input, intrinsic.product,
       ),
     }

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -111,6 +111,7 @@ python_tests(
   dependencies=[
     '3rdparty/python:dataclasses',
     ':scheduler_test_base',
+    ':rules',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:nodes',
@@ -196,6 +197,7 @@ python_tests(
   dependencies=[
     '3rdparty/python:dataclasses',
     ':util',
+    ':rules',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -111,7 +111,6 @@ python_tests(
   dependencies=[
     '3rdparty/python:dataclasses',
     ':scheduler_test_base',
-    ':rules',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:nodes',
@@ -184,6 +183,7 @@ python_tests(
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'tests/python/pants_test/engine/examples:parsers',
+    'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:test_base',
   ],
@@ -197,12 +197,12 @@ python_tests(
   dependencies=[
     '3rdparty/python:dataclasses',
     ':util',
-    ':rules',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/testutil:test_base',
+    'src/python/pants/testutil/engine:util',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -177,10 +177,10 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing(dedent('''
+    self.assert_equal_with_printing(dedent(f'''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
-        Computing Task(nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
+      Computing Select(<{__name__}.B object at 0xEEEEEEEEE>, A)
+        Computing Task({__name__}.nested_raise(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call
@@ -188,7 +188,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
               File LOCATION-INFO, in nested_raise
                 fn_raises(x)
               File LOCATION-INFO, in fn_raises
-                raise Exception(f'An exception for {type(x).__name__}')
+                raise Exception(f'An exception for {{type(x).__name__}}')
             Exception: An exception for B
       ''').lstrip()+'\n',
       remove_locations_from_traceback(str(cm.exception)))
@@ -229,11 +229,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing(dedent('''
+    self.assert_equal_with_printing(dedent(f'''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
-        Computing Task(a_from_c_and_d(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
-          Computing Task(d_from_b_nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D, true)
+      Computing Select(<{__name__}..B object at 0xEEEEEEEEE>, A)
+        Computing Task(a_from_c_and_d(), <{__name__}..B object at 0xEEEEEEEEE>, A, true)
+          Computing Task(d_from_b_nested_raise(), <{__name__}..B object at 0xEEEEEEEEE>, =D, true)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call
@@ -241,13 +241,13 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
                 File LOCATION-INFO, in d_from_b_nested_raise
                   fn_raises(b)
                 File LOCATION-INFO, in fn_raises
-                  raise Exception('An exception for {}'.format(type(x).__name__))
+                  raise Exception('An exception for {{}}'.format(type(x).__name__))
               Exception: An exception for B
 
 
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
-        Computing Task(a_from_c_and_d(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
-          Computing Task(c_from_b_nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C, true)
+      Computing Select(<{__name__}..B object at 0xEEEEEEEEE>, A)
+        Computing Task(a_from_c_and_d(), <{__name__}..B object at 0xEEEEEEEEE>, A, true)
+          Computing Task(c_from_b_nested_raise(), <{__name__}..B object at 0xEEEEEEEEE>, =C, true)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call
@@ -255,7 +255,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
                 File LOCATION-INFO, in c_from_b_nested_raise
                   fn_raises(b)
                 File LOCATION-INFO, in fn_raises
-                  raise Exception('An exception for {}'.format(type(x).__name__))
+                  raise Exception('An exception for {{}}'.format(type(x).__name__))
               Exception: An exception for B
       ''').lstrip()+'\n',
       remove_locations_from_traceback(str(cm.exception)))
@@ -281,9 +281,9 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(Exception) as cm:
       list(self.mk_scheduler(rules=rules, include_trace_on_error=False))
 
-    self.assert_equal_with_printing(dedent('''
+    self.assert_equal_with_printing(dedent(f'''
       Rules with errors: 1
-        Rule(func=upcast(), product=MyFloat, params=[MyInt]):
+        Rule(func={__name__}.upcast(), product=MyFloat, params=[MyInt]):
           No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
         ''').strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -12,6 +12,7 @@ from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
+from pants_test.engine.test_rules import fmt_rule, fmt_task_func
 
 
 class A:
@@ -180,7 +181,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     self.assert_equal_with_printing(dedent(f'''
       1 Exception encountered:
       Computing Select(<{__name__}.B object at 0xEEEEEEEEE>, A)
-        Computing Task({__name__}.nested_raise(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
+        Computing Task({fmt_task_func(nested_raise)}(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call
@@ -283,7 +284,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent(f'''
       Rules with errors: 1
-        Rule({__name__}.upcast(MyInt) -> MyFloat):
+        {fmt_rule(upcast)}:
           No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
         ''').strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -283,8 +283,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       Rules with errors: 1
-        (MyFloat, [MyInt], upcast()):
-          No rule was available to compute MyInt. Maybe declare it as a RootRule(MyInt)?
+        Rule(func=upcast(), product=MyFloat, params=[MyInt]):
+          No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
         ''').strip(),
       str(cm.exception)
     )

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -283,7 +283,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent(f'''
       Rules with errors: 1
-        Rule(func={__name__}.upcast(), product=MyFloat, params=[MyInt]):
+        Rule({__name__}.upcast(MyInt) -> MyFloat):
           No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
         ''').strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -10,9 +10,13 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
-from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
+from pants.testutil.engine.util import (
+  assert_equal_with_printing,
+  fmt_rule,
+  fmt_rust_function,
+  remove_locations_from_traceback,
+)
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
-from pants_test.engine.test_rules import fmt_rule, fmt_task_func
 
 
 class A:
@@ -181,7 +185,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     self.assert_equal_with_printing(dedent(f'''
       1 Exception encountered:
       Computing Select(<{__name__}.B object at 0xEEEEEEEEE>, A)
-        Computing Task({fmt_task_func(nested_raise)}(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
+        Computing Task({fmt_rust_function(nested_raise)}(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -253,9 +253,9 @@ class RuleGraphTest(TestBase):
         f"""\
         Rules with errors: 3
           {fmt_rule(a_from_b_and_c)}:
-            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
+            Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
           {fmt_rule(a_from_c_and_b)}:
-            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
+            Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
           {fmt_rule(d_from_a)}:
             Ambiguous rules to compute A with parameter types (B, C):
               {fmt_rule(a_from_b_and_c)} for (B, C)
@@ -383,7 +383,7 @@ class RuleGraphTest(TestBase):
         f"""\
         Rules with errors: 3
           {fmt_rule(a_from_c)}:
-            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
+            Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
           {fmt_rule(b_from_d)}:
             No rule was available to compute D with parameter type SubA
           {fmt_rule(d_from_a_and_suba, gets=[("A", "C")])}:
@@ -417,7 +417,7 @@ class RuleGraphTest(TestBase):
         f"""\
         Rules with errors: 1
           {fmt_rule(d_for_b)}:
-            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
+            Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
         """
       ).strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -221,11 +221,11 @@ def fmt_rule(
   gets_str = ""
   if gets:
     get_members = ', '.join(
-      f"Get(({product_subject_pair[1]}) -> {product_subject_pair[0]})"
+      f"Get[{product_subject_pair[0]}]({product_subject_pair[1]})"
       for product_subject_pair in gets
     )
     gets_str = f", gets=[{get_members}]"
-  return f"Rule({fmt_task_func(rule)}({params}) -> {product}{gets_str})"
+  return f"@rule({fmt_task_func(rule)}({params}) -> {product}{gets_str})"
 
 
 class RuleGraphTest(TestBase):
@@ -596,7 +596,7 @@ class RuleGraphTest(TestBase):
             "Select(A) for SubA" [color=blue]
             "Select(A) for SubA" -> {{"{fmt_rule(a_from_suba_and_b)} for SubA"}}
           // internal entries
-            "{fmt_rule(a_from_suba_and_b)} for SubA" -> {{"Param(SubA)" "{fmt_rule(b)} for ()"}}
+            "{fmt_rule(a_from_suba_and_b)} for SubA" -> {{"{fmt_rule(b)} for ()" "Param(SubA)"}}
             "{fmt_rule(b)} for ()" -> {{}}
         }}"""
       ).strip(),
@@ -638,7 +638,7 @@ class RuleGraphTest(TestBase):
                 "Select(A) for SubA" [color=blue]
                 "Select(A) for SubA" -> {{"{fmt_rule(a, gets=[("B", "C")])} for SubA"}}
               // internal entries
-                "{fmt_rule(a, gets=[("B", "C")])} for SubA" -> {{"Param(SubA)" "{fmt_rule(b_from_suba)} for C"}}
+                "{fmt_rule(a, gets=[("B", "C")])} for SubA" -> {{"{fmt_rule(b_from_suba)} for C" "Param(SubA)"}}
                 "{fmt_rule(b_from_suba)} for C" -> {{"{fmt_rule(suba_from_c)} for C"}}
                 "{fmt_rule(b_from_suba)} for SubA" -> {{"Param(SubA)"}}
                 "{fmt_rule(suba_from_c)} for C" -> {{"Param(C)"}}
@@ -776,7 +776,7 @@ class RuleGraphTest(TestBase):
             "Select(B) for (C, D)" -> {{"{fmt_rule(b_from_d_and_a)} for (C, D)"}}
           // internal entries
             "{fmt_rule(a_from_c)} for C" -> {{"Param(C)"}}
-            "{fmt_rule(b_from_d_and_a)} for (C, D)" -> {{"Param(D)" "{fmt_rule(a_from_c)} for C"}}
+            "{fmt_rule(b_from_d_and_a)} for (C, D)" -> {{"{fmt_rule(a_from_c)} for C" "Param(D)"}}
         }}"""
       ).strip(),
       fullgraph,
@@ -845,7 +845,7 @@ class RuleGraphTest(TestBase):
             "Select(A) for SubA" [color=blue]
             "Select(A) for SubA" -> {{"{fmt_rule(a_from_suba)} for SubA"}}
           // internal entries
-            "{fmt_rule(a_from_suba)} for SubA" -> {{"Param(SubA)" "{fmt_rule(b_singleton)} for ()"}}
+            "{fmt_rule(a_from_suba)} for SubA" -> {{"{fmt_rule(b_singleton)} for ()" "Param(SubA)"}}
             "{fmt_rule(b_singleton)} for ()" -> {{}}
         }}"""
       ).strip(),

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -251,9 +251,9 @@ class RuleGraphTest(TestBase):
         """\
         Rules with errors: 3
           Rule(func=a_from_b_and_c(), product=A, params=[B, C]):
-            Was not reachable, possibly because it was shadowed by another rule.
+            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
           Rule(func=a_from_c_and_b(), product=A, params=[C, B]):
-            Was not reachable, possibly because it was shadowed by another rule.
+            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
           Rule(func=d_from_a(), product=D, params=[A]):
             Ambiguous rules to compute A with parameter types (B, C):
               Rule(func=a_from_b_and_c(), product=A, params=[B, C]) for (B, C)
@@ -381,7 +381,7 @@ class RuleGraphTest(TestBase):
         """\
         Rules with errors: 3
           Rule(func=a_from_c(), product=A, params=[C]):
-            Was not reachable, possibly because it was shadowed by another rule.
+            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
           Rule(func=b_from_d(), product=B, params=[D]):
             No rule was available to compute D with parameter type SubA
           Rule(func=d_from_a_and_suba(), product=D, params=[A, SubA], gets=[Get(A, C)]):
@@ -415,7 +415,7 @@ class RuleGraphTest(TestBase):
         """\
         Rules with errors: 1
           Rule(func=d_for_b(), product=D, params=[B]):
-            Was not reachable, possibly because it was shadowed by another rule.
+            Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
         """
       ).strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -384,7 +384,7 @@ class RuleGraphTest(TestBase):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
           Rule({__name__}.b_from_d(D) -> B):
             No rule was available to compute D with parameter type SubA
-          Rule({__name__}.d_from_a_and_suba(A, SubA) -> D, gets=[Get(A, C)]):
+          Rule({__name__}.d_from_a_and_suba(A, SubA) -> D, gets=[Get((C) -> A)]):
             No rule was available to compute A with parameter type SubA
         """
       ).strip(),
@@ -608,9 +608,9 @@ class RuleGraphTest(TestBase):
               // root subject types: SubA
               // root entries
                 "Select(A) for SubA" [color=blue]
-                "Select(A) for SubA" -> {{"Rule({__name__}.a(SubA) -> A, gets=[Get(B, C)]) for SubA"}}
+                "Select(A) for SubA" -> {{"Rule({__name__}.a(SubA) -> A, gets=[Get((C) -> B)]) for SubA"}}
               // internal entries
-                "Rule({__name__}.a(SubA) -> A, gets=[Get(B, C)]) for SubA" -> {{"Param(SubA)" "Rule({__name__}.b_from_suba(SubA) -> B) for C"}}
+                "Rule({__name__}.a(SubA) -> A, gets=[Get((C) -> B)]) for SubA" -> {{"Param(SubA)" "Rule({__name__}.b_from_suba(SubA) -> B) for C"}}
                 "Rule({__name__}.b_from_suba(SubA) -> B) for C" -> {{"Rule({__name__}.suba_from_c(C) -> SubA) for C"}}
                 "Rule({__name__}.b_from_suba(SubA) -> B) for SubA" -> {{"Param(SubA)"}}
                 "Rule({__name__}.suba_from_c(C) -> SubA) for C" -> {{"Param(C)"}}
@@ -926,9 +926,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A, gets=[Get(B, D)]) for ()"}}
+            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A, gets=[Get((D) -> B)]) for ()"}}
           // internal entries
-            "Rule({__name__}.a() -> A, gets=[Get(B, D)]) for ()" -> {{"Rule({__name__}.b_from_d(D) -> B) for D"}}
+            "Rule({__name__}.a() -> A, gets=[Get((D) -> B)]) for ()" -> {{"Rule({__name__}.b_from_d(D) -> B) for D"}}
             "Rule({__name__}.b_from_d(D) -> B) for D" -> {{"Param(D)"}}
         }}"""
       ).strip(),

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -216,7 +216,7 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 1
-          Rule(func={__name__}.a_from_b_noop(), product=A, params=[B]):
+          Rule({__name__}.a_from_b_noop(B) -> A):
             No rule was available to compute B with parameter type SubA
         """).strip(),
       str(cm.exception),
@@ -250,14 +250,14 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 3
-          Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]):
+          Rule({__name__}.a_from_b_and_c(B, C) -> A):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func={__name__}.a_from_c_and_b(), product=A, params=[C, B]):
+          Rule({__name__}.a_from_c_and_b(C, B) -> A):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func={__name__}.d_from_a(), product=D, params=[A]):
+          Rule({__name__}.d_from_a(A) -> D):
             Ambiguous rules to compute A with parameter types (B, C):
-              Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]) for (B, C)
-              Rule(func={__name__}.a_from_c_and_b(), product=A, params=[C, B]) for (B, C)
+              Rule({__name__}.a_from_b_and_c(B, C) -> A) for (B, C)
+              Rule({__name__}.a_from_c_and_b(C, B) -> A) for (B, C)
        """
       ).strip(),
       str(cm.exception),
@@ -276,7 +276,7 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 1
-          Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]):
+          Rule({__name__}.a_from_b_and_c(B, C) -> A):
             No rule was available to compute B with parameter type SubA
             No rule was available to compute C with parameter type SubA
         """
@@ -313,9 +313,9 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 2
-          Rule(func={__name__}.a_from_b(), product=A, params=[B]):
+          Rule({__name__}.a_from_b(B) -> A):
             No rule was available to compute B with parameter type C
-          Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]):
+          Rule({__name__}.b_from_suba(SubA) -> B):
             No rule was available to compute SubA with parameter type C
         """
       ).strip(),
@@ -345,7 +345,7 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 1
-          Rule(func={__name__}.d_from_c(), product=D, params=[C]):
+          Rule({__name__}.d_from_c(C) -> D):
             No rule was available to compute C with parameter type A
         """).strip(),
         str(cm.exception),
@@ -380,11 +380,11 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 3
-          Rule(func={__name__}.a_from_c(), product=A, params=[C]):
+          Rule({__name__}.a_from_c(C) -> A):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func={__name__}.b_from_d(), product=B, params=[D]):
+          Rule({__name__}.b_from_d(D) -> B):
             No rule was available to compute D with parameter type SubA
-          Rule(func={__name__}.d_from_a_and_suba(), product=D, params=[A, SubA], gets=[Get(A, C)]):
+          Rule({__name__}.d_from_a_and_suba(A, SubA) -> D, gets=[Get(A, C)]):
             No rule was available to compute A with parameter type SubA
         """
       ).strip(),
@@ -414,7 +414,7 @@ class RuleGraphTest(TestBase):
       dedent(
         f"""\
         Rules with errors: 1
-          Rule(func={__name__}.d_for_b(), product=D, params=[B]):
+          Rule({__name__}.d_for_b(B) -> D):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
         """
       ).strip(),
@@ -439,9 +439,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.a_from_suba(SubA) -> A) for SubA" -> {{"Param(SubA)"}}
         }}"""
       ).strip(),
       fullgraph,
@@ -503,15 +503,15 @@ class RuleGraphTest(TestBase):
             "Select(A) for A" [color=blue]
             "Select(A) for A" -> {{"Param(A)"}}
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
             "Select(B) for A" [color=blue]
-            "Select(B) for A" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for A"}}
+            "Select(B) for A" -> {{"Rule({__name__}.b_from_a(A) -> B) for A"}}
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
+            "Select(B) for SubA" -> {{"Rule({__name__}.b_from_a(A) -> B) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
-            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for A" -> {{"Param(A)"}}
-            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Rule({__name__}.a_from_suba(SubA) -> A) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.b_from_a(A) -> B) for A" -> {{"Param(A)"}}
+            "Rule({__name__}.b_from_a(A) -> B) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
         }}"""
       ).strip(),
       fullgraph,
@@ -535,9 +535,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.a_from_suba(SubA) -> A) for SubA" -> {{"Param(SubA)"}}
         }}"""
       ).strip(),
       subgraph,
@@ -566,10 +566,10 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba_and_b(SubA, B) -> A) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b(), product=B, params=[]) for ()"}}
-            "Rule(func={__name__}.b(), product=B, params=[]) for ()" -> {{}}
+            "Rule({__name__}.a_from_suba_and_b(SubA, B) -> A) for SubA" -> {{"Param(SubA)" "Rule({__name__}.b() -> B) for ()"}}
+            "Rule({__name__}.b() -> B) for ()" -> {{}}
         }}"""
       ).strip(),
       subgraph,
@@ -608,12 +608,12 @@ class RuleGraphTest(TestBase):
               // root subject types: SubA
               // root entries
                 "Select(A) for SubA" [color=blue]
-                "Select(A) for SubA" -> {{"Rule(func={__name__}.a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA"}}
+                "Select(A) for SubA" -> {{"Rule({__name__}.a(SubA) -> A, gets=[Get(B, C)]) for SubA"}}
               // internal entries
-                "Rule(func={__name__}.a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for C"}}
-                "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for C" -> {{"Rule(func={__name__}.suba_from_c(), product=SubA, params=[C]) for C"}}
-                "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
-                "Rule(func={__name__}.suba_from_c(), product=SubA, params=[C]) for C" -> {{"Param(C)"}}
+                "Rule({__name__}.a(SubA) -> A, gets=[Get(B, C)]) for SubA" -> {{"Param(SubA)" "Rule({__name__}.b_from_suba(SubA) -> B) for C"}}
+                "Rule({__name__}.b_from_suba(SubA) -> B) for C" -> {{"Rule({__name__}.suba_from_c(C) -> SubA) for C"}}
+                "Rule({__name__}.b_from_suba(SubA) -> B) for SubA" -> {{"Param(SubA)"}}
+                "Rule({__name__}.suba_from_c(C) -> SubA) for C" -> {{"Param(C)"}}
             }}
         """).strip(),
         subgraph,
@@ -642,10 +642,10 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_b(), product=A, params=[B]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_b(B) -> A) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_b(), product=A, params=[B]) for SubA" -> {{"Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA"}}
-            "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.a_from_b(B) -> A) for SubA" -> {{"Rule({__name__}.b_from_suba(SubA) -> B) for SubA"}}
+            "Rule({__name__}.b_from_suba(SubA) -> B) for SubA" -> {{"Param(SubA)"}}
         }}"""
       ).strip(),
       subgraph,
@@ -679,9 +679,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
+            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A) for ()"}}
           // internal entries
-            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+            "Rule({__name__}.a() -> A) for ()" -> {{}}
         }}"""
       ).strip(),
       subgraph,
@@ -710,9 +710,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
+            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A) for ()"}}
           // internal entries
-            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+            "Rule({__name__}.a() -> A) for ()" -> {{}}
         }}"""
       ).strip(),
       fullgraph,
@@ -743,12 +743,12 @@ class RuleGraphTest(TestBase):
           // root subject types: C, D
           // root entries
             "Select(A) for C" [color=blue]
-            "Select(A) for C" -> {{"Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C"}}
+            "Select(A) for C" -> {{"Rule({__name__}.a_from_c(C) -> A) for C"}}
             "Select(B) for (C, D)" [color=blue]
-            "Select(B) for (C, D)" -> {{"Rule(func={__name__}.b_from_d_and_a(), product=B, params=[D, A]) for (C, D)"}}
+            "Select(B) for (C, D)" -> {{"Rule({__name__}.b_from_d_and_a(D, A) -> B) for (C, D)"}}
           // internal entries
-            "Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C" -> {{"Param(C)"}}
-            "Rule(func={__name__}.b_from_d_and_a(), product=B, params=[D, A]) for (C, D)" -> {{"Param(D)" "Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C"}}
+            "Rule({__name__}.a_from_c(C) -> A) for C" -> {{"Param(C)"}}
+            "Rule({__name__}.b_from_d_and_a(D, A) -> B) for (C, D)" -> {{"Param(D)" "Rule({__name__}.a_from_c(C) -> A) for C"}}
         }}"""
       ).strip(),
       fullgraph,
@@ -784,9 +784,9 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
+            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A) for ()"}}
           // internal entries
-            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+            "Rule({__name__}.a() -> A) for ()" -> {{}}
         }}"""
       ).strip(),
       subgraph,
@@ -815,10 +815,10 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA, B]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA, B) -> A) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA, B]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b_singleton(), product=B, params=[]) for ()"}}
-            "Rule(func={__name__}.b_singleton(), product=B, params=[]) for ()" -> {{}}
+            "Rule({__name__}.a_from_suba(SubA, B) -> A) for SubA" -> {{"Param(SubA)" "Rule({__name__}.b_singleton() -> B) for ()"}}
+            "Rule({__name__}.b_singleton() -> B) for ()" -> {{}}
         }}"""
       ).strip(),
       subgraph,
@@ -852,10 +852,10 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
+            "Select(B) for SubA" -> {{"Rule({__name__}.b_from_a(A) -> B) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
-            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Rule({__name__}.a_from_suba(SubA) -> A) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.b_from_a(A) -> B) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
         }}"""
       ).strip(),
       subgraph,
@@ -889,15 +889,15 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Select(A) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
+            "Select(B) for SubA" -> {{"Rule({__name__}.b_from_a(A) -> B) for SubA"}}
             "Select(C) for SubA" [color=blue]
-            "Select(C) for SubA" -> {{"Rule(func={__name__}.c_from_a(), product=C, params=[A]) for SubA"}}
+            "Select(C) for SubA" -> {{"Rule({__name__}.c_from_a(A) -> C) for SubA"}}
           // internal entries
-            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
-            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
-            "Rule(func={__name__}.c_from_a(), product=C, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Rule({__name__}.a_from_suba(SubA) -> A) for SubA" -> {{"Param(SubA)"}}
+            "Rule({__name__}.b_from_a(A) -> B) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
+            "Rule({__name__}.c_from_a(A) -> C) for SubA" -> {{"Rule({__name__}.a_from_suba(SubA) -> A) for SubA"}}
         }}"""
       ).strip(),
       subgraph,
@@ -926,10 +926,10 @@ class RuleGraphTest(TestBase):
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[], gets=[Get(B, D)]) for ()"}}
+            "Select(A) for ()" -> {{"Rule({__name__}.a() -> A, gets=[Get(B, D)]) for ()"}}
           // internal entries
-            "Rule(func={__name__}.a(), product=A, params=[], gets=[Get(B, D)]) for ()" -> {{"Rule(func={__name__}.b_from_d(), product=B, params=[D]) for D"}}
-            "Rule(func={__name__}.b_from_d(), product=B, params=[D]) for D" -> {{"Param(D)"}}
+            "Rule({__name__}.a() -> A, gets=[Get(B, D)]) for ()" -> {{"Rule({__name__}.b_from_d(D) -> B) for D"}}
+            "Rule({__name__}.b_from_d(D) -> B) for D" -> {{"Param(D)"}}
         }}"""
       ).strip(),
       subgraph,

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -214,9 +214,9 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 1
-          Rule(func=a_from_b_noop(), product=A, params=[B]):
+          Rule(func={__name__}.a_from_b_noop(), product=A, params=[B]):
             No rule was available to compute B with parameter type SubA
         """).strip(),
       str(cm.exception),
@@ -248,16 +248,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 3
-          Rule(func=a_from_b_and_c(), product=A, params=[B, C]):
+          Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func=a_from_c_and_b(), product=A, params=[C, B]):
+          Rule(func={__name__}.a_from_c_and_b(), product=A, params=[C, B]):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func=d_from_a(), product=D, params=[A]):
+          Rule(func={__name__}.d_from_a(), product=D, params=[A]):
             Ambiguous rules to compute A with parameter types (B, C):
-              Rule(func=a_from_b_and_c(), product=A, params=[B, C]) for (B, C)
-              Rule(func=a_from_c_and_b(), product=A, params=[C, B]) for (B, C)
+              Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]) for (B, C)
+              Rule(func={__name__}.a_from_c_and_b(), product=A, params=[C, B]) for (B, C)
        """
       ).strip(),
       str(cm.exception),
@@ -274,9 +274,9 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 1
-          Rule(func=a_from_b_and_c(), product=A, params=[B, C]):
+          Rule(func={__name__}.a_from_b_and_c(), product=A, params=[B, C]):
             No rule was available to compute B with parameter type SubA
             No rule was available to compute C with parameter type SubA
         """
@@ -311,11 +311,11 @@ class RuleGraphTest(TestBase):
       create_scheduler(rules)
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 2
-          Rule(func=a_from_b(), product=A, params=[B]):
+          Rule(func={__name__}.a_from_b(), product=A, params=[B]):
             No rule was available to compute B with parameter type C
-          Rule(func=b_from_suba(), product=B, params=[SubA]):
+          Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]):
             No rule was available to compute SubA with parameter type C
         """
       ).strip(),
@@ -343,9 +343,9 @@ class RuleGraphTest(TestBase):
     # This error message could note near matches like the singleton.
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 1
-          Rule(func=d_from_c(), product=D, params=[C]):
+          Rule(func={__name__}.d_from_c(), product=D, params=[C]):
             No rule was available to compute C with parameter type A
         """).strip(),
         str(cm.exception),
@@ -378,13 +378,13 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 3
-          Rule(func=a_from_c(), product=A, params=[C]):
+          Rule(func={__name__}.a_from_c(), product=A, params=[C]):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
-          Rule(func=b_from_d(), product=B, params=[D]):
+          Rule(func={__name__}.b_from_d(), product=B, params=[D]):
             No rule was available to compute D with parameter type SubA
-          Rule(func=d_from_a_and_suba(), product=D, params=[A, SubA], gets=[Get(A, C)]):
+          Rule(func={__name__}.d_from_a_and_suba(), product=D, params=[A, SubA], gets=[Get(A, C)]):
             No rule was available to compute A with parameter type SubA
         """
       ).strip(),
@@ -412,9 +412,9 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
+        f"""\
         Rules with errors: 1
-          Rule(func=d_for_b(), product=D, params=[B]):
+          Rule(func={__name__}.d_for_b(), product=D, params=[B]):
             Was not reachable, either because no rules can produce the params or it was shadowed by another @rule.
         """
       ).strip(),
@@ -434,15 +434,15 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA" -> {"Param(SubA)"}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+        }}"""
       ).strip(),
       fullgraph,
     )
@@ -496,23 +496,23 @@ class RuleGraphTest(TestBase):
     fullgraph = self.create_full_graph(rules)
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: A, SubA
           // root entries
             "Select(A) for A" [color=blue]
-            "Select(A) for A" -> {"Param(A)"}
+            "Select(A) for A" -> {{"Param(A)"}}
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
             "Select(B) for A" [color=blue]
-            "Select(B) for A" -> {"Rule(func=b_from_a(), product=B, params=[A]) for A"}
+            "Select(B) for A" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for A"}}
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {"Rule(func=b_from_a(), product=B, params=[A]) for SubA"}
+            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA" -> {"Param(SubA)"}
-            "Rule(func=b_from_a(), product=B, params=[A]) for A" -> {"Param(A)"}
-            "Rule(func=b_from_a(), product=B, params=[A]) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for A" -> {{"Param(A)"}}
+            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+        }}"""
       ).strip(),
       fullgraph,
     )
@@ -530,15 +530,15 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA" -> {"Param(SubA)"}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -561,16 +561,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA" -> {"Param(SubA)" "Rule(func=b(), product=B, params=[]) for ()"}
-            "Rule(func=b(), product=B, params=[]) for ()" -> {}
-        }"""
+            "Rule(func={__name__}.a_from_suba_and_b(), product=A, params=[SubA, B]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b(), product=B, params=[]) for ()"}}
+            "Rule(func={__name__}.b(), product=B, params=[]) for ()" -> {{}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -603,18 +603,18 @@ class RuleGraphTest(TestBase):
 
     subgraph = self.create_subgraph(A, rules, SubA())
     self.assert_equal_with_printing(
-        dedent("""\
-            digraph {
+        dedent(f"""\
+            digraph {{
               // root subject types: SubA
               // root entries
                 "Select(A) for SubA" [color=blue]
-                "Select(A) for SubA" -> {"Rule(func=a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA"}
+                "Select(A) for SubA" -> {{"Rule(func={__name__}.a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA"}}
               // internal entries
-                "Rule(func=a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA" -> {"Param(SubA)" "Rule(func=b_from_suba(), product=B, params=[SubA]) for C"}
-                "Rule(func=b_from_suba(), product=B, params=[SubA]) for C" -> {"Rule(func=suba_from_c(), product=SubA, params=[C]) for C"}
-                "Rule(func=b_from_suba(), product=B, params=[SubA]) for SubA" -> {"Param(SubA)"}
-                "Rule(func=suba_from_c(), product=SubA, params=[C]) for C" -> {"Param(C)"}
-            }
+                "Rule(func={__name__}.a(), product=A, params=[SubA], gets=[Get(B, C)]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for C"}}
+                "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for C" -> {{"Rule(func={__name__}.suba_from_c(), product=SubA, params=[C]) for C"}}
+                "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+                "Rule(func={__name__}.suba_from_c(), product=SubA, params=[C]) for C" -> {{"Param(C)"}}
+            }}
         """).strip(),
         subgraph,
       )
@@ -637,16 +637,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_b(), product=A, params=[B]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_b(), product=A, params=[B]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_b(), product=A, params=[B]) for SubA" -> {"Rule(func=b_from_suba(), product=B, params=[SubA]) for SubA"}
-            "Rule(func=b_from_suba(), product=B, params=[SubA]) for SubA" -> {"Param(SubA)"}
-        }"""
+            "Rule(func={__name__}.a_from_b(), product=A, params=[B]) for SubA" -> {{"Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA"}}
+            "Rule(func={__name__}.b_from_suba(), product=B, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -674,15 +674,15 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {"Rule(func=a(), product=A, params=[]) for ()"}
+            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
           // internal entries
-            "Rule(func=a(), product=A, params=[]) for ()" -> {}
-        }"""
+            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -705,15 +705,15 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {"Rule(func=a(), product=A, params=[]) for ()"}
+            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
           // internal entries
-            "Rule(func=a(), product=A, params=[]) for ()" -> {}
-        }"""
+            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+        }}"""
       ).strip(),
       fullgraph,
     )
@@ -738,18 +738,18 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: C, D
           // root entries
             "Select(A) for C" [color=blue]
-            "Select(A) for C" -> {"Rule(func=a_from_c(), product=A, params=[C]) for C"}
+            "Select(A) for C" -> {{"Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C"}}
             "Select(B) for (C, D)" [color=blue]
-            "Select(B) for (C, D)" -> {"Rule(func=b_from_d_and_a(), product=B, params=[D, A]) for (C, D)"}
+            "Select(B) for (C, D)" -> {{"Rule(func={__name__}.b_from_d_and_a(), product=B, params=[D, A]) for (C, D)"}}
           // internal entries
-            "Rule(func=a_from_c(), product=A, params=[C]) for C" -> {"Param(C)"}
-            "Rule(func=b_from_d_and_a(), product=B, params=[D, A]) for (C, D)" -> {"Param(D)" "Rule(func=a_from_c(), product=A, params=[C]) for C"}
-        }"""
+            "Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C" -> {{"Param(C)"}}
+            "Rule(func={__name__}.b_from_d_and_a(), product=B, params=[D, A]) for (C, D)" -> {{"Param(D)" "Rule(func={__name__}.a_from_c(), product=A, params=[C]) for C"}}
+        }}"""
       ).strip(),
       fullgraph,
     )
@@ -779,15 +779,15 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {"Rule(func=a(), product=A, params=[]) for ()"}
+            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[]) for ()"}}
           // internal entries
-            "Rule(func=a(), product=A, params=[]) for ()" -> {}
-        }"""
+            "Rule(func={__name__}.a(), product=A, params=[]) for ()" -> {{}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -810,16 +810,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA, B]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA, B]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA, B]) for SubA" -> {"Param(SubA)" "Rule(func=b_singleton(), product=B, params=[]) for ()"}
-            "Rule(func=b_singleton(), product=B, params=[]) for ()" -> {}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA, B]) for SubA" -> {{"Param(SubA)" "Rule(func={__name__}.b_singleton(), product=B, params=[]) for ()"}}
+            "Rule(func={__name__}.b_singleton(), product=B, params=[]) for ()" -> {{}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -847,16 +847,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {"Rule(func=b_from_a(), product=B, params=[A]) for SubA"}
+            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA" -> {"Param(SubA)"}
-            "Rule(func=b_from_a(), product=B, params=[A]) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -884,21 +884,21 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for SubA" [color=blue]
-            "Select(A) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
+            "Select(A) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
             "Select(B) for SubA" [color=blue]
-            "Select(B) for SubA" -> {"Rule(func=b_from_a(), product=B, params=[A]) for SubA"}
+            "Select(B) for SubA" -> {{"Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA"}}
             "Select(C) for SubA" [color=blue]
-            "Select(C) for SubA" -> {"Rule(func=c_from_a(), product=C, params=[A]) for SubA"}
+            "Select(C) for SubA" -> {{"Rule(func={__name__}.c_from_a(), product=C, params=[A]) for SubA"}}
           // internal entries
-            "Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA" -> {"Param(SubA)"}
-            "Rule(func=b_from_a(), product=B, params=[A]) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
-            "Rule(func=c_from_a(), product=C, params=[A]) for SubA" -> {"Rule(func=a_from_suba(), product=A, params=[SubA]) for SubA"}
-        }"""
+            "Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA" -> {{"Param(SubA)"}}
+            "Rule(func={__name__}.b_from_a(), product=B, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+            "Rule(func={__name__}.c_from_a(), product=C, params=[A]) for SubA" -> {{"Rule(func={__name__}.a_from_suba(), product=A, params=[SubA]) for SubA"}}
+        }}"""
       ).strip(),
       subgraph,
     )
@@ -921,16 +921,16 @@ class RuleGraphTest(TestBase):
 
     self.assert_equal_with_printing(
       dedent(
-        """\
-        digraph {
+        f"""\
+        digraph {{
           // root subject types: SubA
           // root entries
             "Select(A) for ()" [color=blue]
-            "Select(A) for ()" -> {"Rule(func=a(), product=A, params=[], gets=[Get(B, D)]) for ()"}
+            "Select(A) for ()" -> {{"Rule(func={__name__}.a(), product=A, params=[], gets=[Get(B, D)]) for ()"}}
           // internal entries
-            "Rule(func=a(), product=A, params=[], gets=[Get(B, D)]) for ()" -> {"Rule(func=b_from_d(), product=B, params=[D]) for D"}
-            "Rule(func=b_from_d(), product=B, params=[D]) for D" -> {"Param(D)"}
-        }"""
+            "Rule(func={__name__}.a(), product=A, params=[], gets=[Get(B, D)]) for ()" -> {{"Rule(func={__name__}.b_from_d(), product=B, params=[D]) for D"}}
+            "Rule(func={__name__}.b_from_d(), product=B, params=[D]) for D" -> {{"Param(D)"}}
+        }}"""
       ).strip(),
       subgraph,
     )

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -212,12 +212,15 @@ class RuleGraphTest(TestBase):
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
-    self.assert_equal_with_printing(dedent("""
-                     Rules with errors: 1
-                       (A, [B], a_from_b_noop()):
-                         No rule was available to compute B with parameter type SubA
-                     """).strip(),
-                                    str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 1
+         (A, [B], a_from_b_noop()):
+           No rule was available to compute B with parameter type SubA
+        """).strip(),
+      str(cm.exception),
+    )
 
   def test_ruleset_with_ambiguity(self):
     @rule
@@ -232,7 +235,6 @@ class RuleGraphTest(TestBase):
     def d_from_a(a: A) -> D:
       pass
 
-
     rules = [
         a_from_c_and_b,
         a_from_b_and_c,
@@ -244,18 +246,22 @@ class RuleGraphTest(TestBase):
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
-    self.assert_equal_with_printing(dedent("""
-                     Rules with errors: 3
-                       (A, [B, C], a_from_b_and_c()):
-                         Was not usable by any other @rule.
-                       (A, [C, B], a_from_c_and_b()):
-                         Was not usable by any other @rule.
-                       (D, [A], d_from_a()):
-                         Ambiguous rules to compute A with parameter types (B+C):
-                           (A, [B, C], a_from_b_and_c()) for (B+C)
-                           (A, [C, B], a_from_c_and_b()) for (B+C)
-                     """).strip(),
-      str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 3
+          (A, [B, C], a_from_b_and_c()):
+            Was not usable by any other @rule.
+          (A, [C, B], a_from_c_and_b()):
+            Was not usable by any other @rule.
+          (D, [A], d_from_a()):
+            Ambiguous rules to compute A with parameter types (B+C):
+              (A, [B, C], a_from_b_and_c()) for (B+C)
+              (A, [C, B], a_from_c_and_b()) for (B+C)
+        """
+      ).strip(),
+      str(cm.exception),
+    )
 
   def test_ruleset_with_rule_with_two_missing_selects(self):
     @rule
@@ -266,13 +272,17 @@ class RuleGraphTest(TestBase):
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
-    self.assert_equal_with_printing(dedent("""
-                     Rules with errors: 1
-                       (A, [B, C], a_from_b_and_c()):
-                         No rule was available to compute B with parameter type SubA
-                         No rule was available to compute C with parameter type SubA
-                     """).strip(),
-      str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 1
+          (A, [B, C], a_from_b_and_c()):
+            No rule was available to compute B with parameter type SubA
+            No rule was available to compute C with parameter type SubA
+        """
+      ).strip(),
+      str(cm.exception),
+    )
 
   def test_ruleset_with_selector_only_provided_as_root_subject(self):
     @rule
@@ -299,14 +309,18 @@ class RuleGraphTest(TestBase):
 
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
-    self.assert_equal_with_printing(dedent("""
-                                      Rules with errors: 2
-                                        (A, [B], a_from_b()):
-                                          No rule was available to compute B with parameter type C
-                                        (B, [SubA], b_from_suba()):
-                                          No rule was available to compute SubA with parameter type C
-                                      """).strip(),
-                                    str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 2
+          (A, [B], a_from_b()):
+            No rule was available to compute B with parameter type C
+          (B, [SubA], b_from_suba()):
+            No rule was available to compute SubA with parameter type C
+        """
+      ).strip(),
+      str(cm.exception),
+    )
 
   def test_ruleset_with_failure_due_to_incompatible_subject_for_singleton(self):
     @rule
@@ -327,12 +341,15 @@ class RuleGraphTest(TestBase):
       create_scheduler(rules)
 
     # This error message could note near matches like the singleton.
-    self.assert_equal_with_printing(dedent("""
-                                      Rules with errors: 1
-                                        (D, [C], d_from_c()):
-                                          No rule was available to compute C with parameter type A
-                                      """).strip(),
-                                    str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 1
+          (D, [C], d_from_c()):
+            No rule was available to compute C with parameter type A
+        """).strip(),
+        str(cm.exception),
+    )
 
   def test_not_fulfillable_duplicated_dependency(self):
     # If a rule depends on another rule+subject in two ways, and one of them is unfulfillable
@@ -359,16 +376,20 @@ class RuleGraphTest(TestBase):
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
-    self.assert_equal_with_printing(dedent("""
-                      Rules with errors: 3
-                        (A, [C], a_from_c()):
-                          Was not usable by any other @rule.
-                        (B, [D], b_from_d()):
-                          No rule was available to compute D with parameter type SubA
-                        (D, [A, SubA], [Get(A, C)], d_from_a_and_suba()):
-                          No rule was available to compute A with parameter type SubA
-                      """).strip(),
-        str(cm.exception))
+    self.assert_equal_with_printing(
+      dedent(
+        """\
+        Rules with errors: 3
+          (A, [C], a_from_c()):
+            Was not usable by any other @rule.
+          (B, [D], b_from_d()):
+            No rule was available to compute D with parameter type SubA
+          (D, [A, SubA], [Get(A, C)], d_from_a_and_suba()):
+            No rule was available to compute A with parameter type SubA
+        """
+      ).strip(),
+      str(cm.exception),
+    )
 
   def test_unreachable_rule(self):
     """Test that when one rule "shadows" another, we get an error."""
@@ -389,13 +410,16 @@ class RuleGraphTest(TestBase):
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
-    self.assert_equal_with_printing(dedent("""
+    self.assert_equal_with_printing(
+      dedent(
+        """\
         Rules with errors: 1
           (D, [B], d_for_b()):
             Was not usable by any other @rule.
-        """).strip(),
-        str(cm.exception)
-      )
+        """
+      ).strip(),
+      str(cm.exception)
+    )
 
   def test_smallest_full_test(self):
     @rule
@@ -860,16 +884,21 @@ class RuleGraphTest(TestBase):
                                     subgraph)
 
   def test_invalid_get_arguments(self):
-    with self.assertRaisesWithMessage(ValueError, """\
-Could not resolve type `XXX` in top level of module pants_test.engine.test_rules"""):
+    with self.assertRaisesWithMessage(
+      ValueError,
+      "Could not resolve type `XXX` in top level of module pants_test.engine.test_rules",
+    ):
       class XXX: pass
+
       @rule
       async def f() -> A:
-        return await Get(A, XXX, 3)
+        return await Get[A](XXX, 3)
 
     # This fails because the argument is defined in this file's module, but it is not a type.
-    with self.assertRaisesWithMessage(ValueError, """\
-Expected a `type` constructor for `_this_is_not_a_type`, but got: 3 (type `int`)"""):
+    with self.assertRaisesWithMessage(
+      ValueError,
+      "Expected a `type` constructor for `_this_is_not_a_type`, but got: 3 (type `int`)"
+    ):
       @rule
       async def g() -> A:
         return await Get(A, _this_is_not_a_type, 3)

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -3,7 +3,6 @@
 
 import unittest
 from textwrap import dedent
-from typing import Callable, List, Optional, Tuple, get_type_hints
 
 from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
@@ -25,6 +24,7 @@ from pants.testutil.engine.util import (
   MockGet,
   assert_equal_with_printing,
   create_scheduler,
+  fmt_rule,
   run_rule,
 )
 from pants.testutil.test_base import TestBase
@@ -200,32 +200,6 @@ class GoalRuleValidation(TestBase):
       @goal_rule
       def goal_rule_returning_a_non_goal() -> int:
         return 0
-
-
-def fmt_task_func(func: Callable) -> str:
-  """Generate the str for a Rust Func, which is how Rust refers to `@rule`s."""
-  return f"{func.__module__}:{func.__code__.co_firstlineno}:{func.__name__}"
-
-
-def fmt_rule(
-  rule: Callable, *, gets: Optional[List[Tuple[str, str]]] = None,
-) -> str:
-  """Generate the str that the engine will use for the rule.
-
-  This is very tightly coupled with the engine - any changes to Rust's display of rules will
-  impact these tests. But, this function allows us to at least isolate that coupling to one helper
-  function, rather than hardcoding the formatting in every test."""
-  type_hints = get_type_hints(rule)
-  product = type_hints.pop("return").__name__
-  params = ", ".join(t.__name__ for t in type_hints.values())
-  gets_str = ""
-  if gets:
-    get_members = ', '.join(
-      f"Get[{product_subject_pair[0]}]({product_subject_pair[1]})"
-      for product_subject_pair in gets
-    )
-    gets_str = f", gets=[{get_members}]"
-  return f"@rule({fmt_task_func(rule)}({params}) -> {product}{gets_str})"
 
 
 class RuleGraphTest(TestBase):

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -259,9 +259,12 @@ class SchedulerWithNestedRaiseTest(TestBase):
   #TODO(#8675) - This test (and others like it) that rely on matching a specific string repr of a complex python object is fragile.
   def test_get_type_match_failure(self):
     """Test that Get(...)s are now type-checked during rule execution, to allow for union types."""
-    expected_msg = """\
-Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, subject: B }], func: a_typecheck_fail_test(), cacheable: true, display_info: None }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
-"""
+    expected_msg = (
+      "Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { "
+      "product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, "
+      f"subject: B }}], func: {__name__}.a_typecheck_fail_test(), cacheable: true, display_info: "
+      "None }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })"
+    )
     with assert_execution_error(self, expected_msg):
       # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
       self.request_single_product(A, Params(TypeCheckFailWrapper(A())))
@@ -342,9 +345,9 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
     self.scheduler.execute(request)
 
     trace = remove_locations_from_traceback('\n'.join(self.scheduler.trace(request)))
-    assert_equal_with_printing(self, dedent('''
+    assert_equal_with_printing(self, dedent(f'''
                      Computing Select(B(), A)
-                       Computing Task(nested_raise(), B(), A, true)
+                       Computing Task({__name__}.nested_raise(), B(), A, true)
                          Throw(An exception for B)
                            Traceback (most recent call last):
                              File LOCATION-INFO, in call
@@ -352,6 +355,6 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
                              File LOCATION-INFO, in nested_raise
                                fn_raises(x)
                              File LOCATION-INFO, in fn_raises
-                               raise Exception(f'An exception for {type(x).__name__}')
+                               raise Exception(f'An exception for {{type(x).__name__}}')
                            Exception: An exception for B''').lstrip() + '\n\n',  # Traces include two empty lines after.
                                trace)

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -234,15 +234,11 @@ class SchedulerTest(TestBase):
     a = self.request_single_product(A, Params(UnionWrapper(UnionB())))
     self.assertTrue(isinstance(a, A))
     # Fails due to no union relationship from A -> UnionBase.
-    expected_msg = """\
-Type A is not a member of the UnionBase @union
-"""
-    with self._assert_execution_error(expected_msg):
+    with self._assert_execution_error("Type A is not a member of the UnionBase @union"):
       self.request_single_product(A, Params(UnionWrapper(A())))
 
   def test_union_rules_no_docstring(self):
-    expected_msg = "specific error message for UnionA instance"
-    with self._assert_execution_error(expected_msg):
+    with self._assert_execution_error("specific error message for UnionA instance"):
       self.request_single_product(UnionX, Params(UnionWrapper(UnionA())))
 
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -14,9 +14,12 @@ from pants.engine.objects import union
 from pants.engine.rules import RootRule, UnionRule, rule
 from pants.engine.scheduler import ExecutionError, SchedulerSession
 from pants.engine.selectors import Get, Params
-from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
+from pants.testutil.engine.util import (
+  assert_equal_with_printing,
+  fmt_rust_function,
+  remove_locations_from_traceback,
+)
 from pants.testutil.test_base import TestBase
-from pants_test.engine.test_rules import fmt_task_func
 
 
 @dataclass(frozen=True)
@@ -263,7 +266,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
     expected_msg = (
       "Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { "
       "product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, "
-      f"subject: B }}], func: {fmt_task_func(a_typecheck_fail_test)}(), cacheable: true, display_info: "
+      f"subject: B }}], func: {fmt_rust_function(a_typecheck_fail_test)}(), cacheable: true, display_info: "
       "None }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })"
     )
     with assert_execution_error(self, expected_msg):
@@ -351,7 +354,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
       dedent(
         f'''\
         Computing Select(B(), A)
-          Computing Task({fmt_task_func(nested_raise)}(), B(), A, true)
+          Computing Task({fmt_rust_function(nested_raise)}(), B(), A, true)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call


### PR DESCRIPTION
This closes https://github.com/pantsbuild/pants/issues/7509 to improve graph error messages and the graph visualization.

This makes the following improvements:

* Represent rules as Python 3 type signatures: `foo(A, B) -> C`
    * Intrinsics: `<intrinsic>(A) -> B`
* Represent `Get`s  as `Get[A](B)`
* Prefix the `Rule` str with `@rule` or `@goal_rule`.
   * This allows us to group the `gets=` kwarg with the rule signature. We could stop outputting `gets`, but this is often a very useful thing to display when debugging graph issues.
* Use the full module name for the rule function.
   * Better grepping for the rule.
   * Disambiguates between `isort.fmt` and `black.fmt`.
* Includes the line number for rules.
   * Allows us to jump to line.
   * Mirrors other tools like Pytest.
* Use `, ` to join Params, rather than `+`.
    * We use `, ` everywhere else.
    * Easier on the eye because more whitespace.
* Reword `"Was not usable by any other @rule."`
    * This message suggests that no rules consume the rule, which isn't the issue.
    * Instead, the issue is that the rule is not _reachable_.
    * Point out that this happens when the rule is shadowed or no rules can produce the params.

### Before
```
(A, [B], [Get(X, Y)], a_from_b_noop())
```

### After

```
@rule(pants_test.engine.rules:84:a_from_b_noop(B) -> A, gets=[Get[X](Y)])
```

There are still some possible followups, tracked by https://github.com/pantsbuild/pants/issues/7509#issuecomment-577445094.