### PR TITLE
Move intrinsics code into new module

### DIFF
--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -1,15 +1,20 @@
-use crate::context::{Context};
-use futures::future::{self, Future};
+use crate::context::Context;
 use crate::core::{throw, Failure, /*Key, Params,*/ TypeId, Value};
-use crate::nodes::{NodeFuture, Snapshot, lift_digest, DownloadedFile};
-use crate::nodes::MultiPlatformExecuteProcess;
 use crate::externs;
-use hashing;
+use crate::nodes::MultiPlatformExecuteProcess;
+use crate::nodes::{lift_digest, DownloadedFile, NodeFuture, Snapshot};
 use boxfuture::{try_future, Boxable};
-use std::path::PathBuf;
 use bytes;
+use futures::future::{self, Future};
+use hashing;
+use std::path::PathBuf;
 
-pub fn run_intrinsic(input: TypeId, product: TypeId, context: Context, value: Value) -> NodeFuture<Value> {
+pub fn run_intrinsic(
+  input: TypeId,
+  product: TypeId,
+  context: Context,
+  value: Value,
+) -> NodeFuture<Value> {
   let types = &context.core.types;
   if product == types.process_result && input == types.multi_platform_process_request {
     multi_platform_process_request_to_process_result(context, value)
@@ -34,84 +39,84 @@ pub fn run_intrinsic(input: TypeId, product: TypeId, context: Context, value: Va
   }
 }
 
-fn multi_platform_process_request_to_process_result(context: Context, value: Value) -> NodeFuture<Value> {
+fn multi_platform_process_request_to_process_result(
+  context: Context,
+  value: Value,
+) -> NodeFuture<Value> {
   let core = context.core.clone();
   future::result(MultiPlatformExecuteProcess::lift(&value).map_err(|str| {
     throw(&format!(
-        "Error lifting MultiPlatformExecuteProcess: {}",
-        str
+      "Error lifting MultiPlatformExecuteProcess: {}",
+      str
     ))
-  })
-  )
-    .and_then(move |process_request| context.get(process_request))
-    .map(move |result| {
-      externs::unsafe_call(
-        &core.types.construct_process_result,
-        &[
+  }))
+  .and_then(move |process_request| context.get(process_request))
+  .map(move |result| {
+    externs::unsafe_call(
+      &core.types.construct_process_result,
+      &[
         externs::store_bytes(&result.0.stdout),
         externs::store_bytes(&result.0.stderr),
         externs::store_i64(result.0.exit_code.into()),
         Snapshot::store_directory(&core, &result.0.output_directory),
-        ],
-      )
-    })
+      ],
+    )
+  })
   .to_boxed()
 }
 
-fn directory_digest_to_files_content(context: Context, directory_digest_val: Value) -> NodeFuture<Value> {
+fn directory_digest_to_files_content(
+  context: Context,
+  directory_digest_val: Value,
+) -> NodeFuture<Value> {
   let workunit_store = context.session.workunit_store();
   future::result(lift_digest(&directory_digest_val).map_err(|str| throw(&str)))
-  .and_then(move |digest| {
-    context
-      .core
-      .store()
-      .contents_for_directory(digest, workunit_store)
-      .map_err(|str| throw(&str))
-      .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
-  })
-  .to_boxed()
+    .and_then(move |digest| {
+      context
+        .core
+        .store()
+        .contents_for_directory(digest, workunit_store)
+        .map_err(|str| throw(&str))
+        .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
+    })
+    .to_boxed()
 }
 
 fn directory_with_prefix_to_strip_to_digest(context: Context, request: Value) -> NodeFuture<Value> {
   let core = context.core.clone();
   let workunit_store = context.session.workunit_store();
 
-  future::result(lift_digest(&externs::project_ignoring_type(
-        &request,
-        "directory_digest",
-  )).map_err(|str| throw(&str))
+  future::result(
+    lift_digest(&externs::project_ignoring_type(
+      &request,
+      "directory_digest",
+    ))
+    .map_err(|str| throw(&str)),
   )
-    .and_then(move |digest| {
-      let prefix = externs::project_str(&request, "prefix");
-      store::Snapshot::strip_prefix(
-        core.store(),
-        digest,
-        PathBuf::from(prefix),
-        workunit_store,
-      )
-        .map_err(|err| throw(&err))
-        .map(move |digest| Snapshot::store_directory(&core, &digest))
-    })
+  .and_then(move |digest| {
+    let prefix = externs::project_str(&request, "prefix");
+    store::Snapshot::strip_prefix(core.store(), digest, PathBuf::from(prefix), workunit_store)
+      .map_err(|err| throw(&err))
+      .map(move |digest| Snapshot::store_directory(&core, &digest))
+  })
   .to_boxed()
 }
 
 fn directory_with_prefix_to_add_to_digest(context: Context, request: Value) -> NodeFuture<Value> {
   let core = context.core.clone();
-  future::result(lift_digest(&externs::project_ignoring_type(
-        &request,
-        "directory_digest",
-  )).map_err(|str| throw(&str))
+  future::result(
+    lift_digest(&externs::project_ignoring_type(
+      &request,
+      "directory_digest",
+    ))
+    .map_err(|str| throw(&str)),
   )
-    .and_then(move |digest| {
-      let prefix = externs::project_str(&request, "prefix");
-      store::Snapshot::add_prefix(
-        core.store(),
-        digest,
-        PathBuf::from(prefix),
-      )
-        .map_err(|err| throw(&err))
-        .map(move |digest| Snapshot::store_directory(&core, &digest))
-    })
+  .and_then(move |digest| {
+    let prefix = externs::project_str(&request, "prefix");
+    store::Snapshot::add_prefix(core.store(), digest, PathBuf::from(prefix))
+      .map_err(|err| throw(&err))
+      .map(move |digest| Snapshot::store_directory(&core, &digest))
+  })
   .to_boxed()
 }
 
@@ -120,10 +125,10 @@ fn digest_to_snapshot(context: Context, directory_digest_val: Value) -> NodeFutu
   let core = context.core.clone();
   let store = context.core.store();
   future::result(lift_digest(&directory_digest_val).map_err(|str| throw(&str)))
-  .and_then(move |digest| {
-    store::Snapshot::from_digest(store, digest, workunit_store).map_err(|str| throw(&str))
-  })
-  .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
+    .and_then(move |digest| {
+      store::Snapshot::from_digest(store, digest, workunit_store).map_err(|str| throw(&str))
+    })
+    .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
     .to_boxed()
 }
 
@@ -132,26 +137,27 @@ fn directories_to_merge_to_digest(context: Context, request: Value) -> NodeFutur
   let core = context.core.clone();
   let digests: Result<Vec<hashing::Digest>, Failure> =
     externs::project_multi(&request, "directories")
-    .into_iter()
-    .map(|val| lift_digest(&val).map_err(|str| throw(&str)))
-    .collect();
+      .into_iter()
+      .map(|val| lift_digest(&val).map_err(|str| throw(&str)))
+      .collect();
   store::Snapshot::merge_directories(core.store(), try_future!(digests), workunit_store)
     .map_err(|err| throw(&err))
     .map(move |digest| Snapshot::store_directory(&core, &digest))
     .to_boxed()
-
 }
 
 fn url_to_fetch_to_snapshot(context: Context, val: Value) -> NodeFuture<Value> {
   let core = context.core.clone();
-  context.get(DownloadedFile(externs::key_for(val)))
+  context
+    .get(DownloadedFile(externs::key_for(val)))
     .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
     .to_boxed()
 }
 
 fn path_globs_to_snapshot(context: Context, val: Value) -> NodeFuture<Value> {
   let core = context.core.clone();
-  context.get(Snapshot(externs::key_for(val)))
+  context
+    .get(Snapshot(externs::key_for(val)))
     .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
     .to_boxed()
 }
@@ -175,14 +181,12 @@ fn input_files_content_to_digest(context: Context, files_content: Value) -> Node
         .map_err(|err| throw(&err))
         .to_boxed()
     })
-  .collect();
+    .collect();
   futures::future::join_all(digests)
     .and_then(|digests| {
       store::Snapshot::merge_directories(context.core.store(), digests, workunit_store)
         .map_err(|err| throw(&err))
-        .map(move |digest: hashing::Digest| {
-          Snapshot::store_directory(&context.core, &digest)
-        })
+        .map(move |digest: hashing::Digest| Snapshot::store_directory(&context.core, &digest))
     })
-  .to_boxed()
+    .to_boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -1,0 +1,40 @@
+use crate::context::{Context};
+use futures::future::{self, Future};
+use crate::core::{throw,/* Failure, Key, Params,*/ TypeId, Value};
+use crate::nodes::{NodeFuture, Snapshot};
+use crate::nodes::MultiPlatformExecuteProcess;
+use crate::externs;
+use boxfuture::Boxable;
+
+pub fn run_intrinsic(input: TypeId, product: TypeId, context: Context, value: Value) -> NodeFuture<Value> {
+  let types = &context.core.types;
+  if product == types.process_result && input == types.multi_platform_process_request {
+    multi_platform_process_request_to_process_result(context, value)
+  } else {
+    panic!("Unrecognized intrinsic: {:?} -> {:?}", input, product)
+  }
+}
+
+fn multi_platform_process_request_to_process_result(context: Context, value: Value) -> NodeFuture<Value> {
+  let core = context.core.clone();
+  future::result(MultiPlatformExecuteProcess::lift(&value).map_err(|str| {
+    throw(&format!(
+        "Error lifting MultiPlatformExecuteProcess: {}",
+        str
+    ))
+  })
+  )
+    .and_then(move |process_request| context.get(process_request))
+    .map(move |result| {
+      externs::unsafe_call(
+        &core.types.construct_process_result,
+        &[
+        externs::store_bytes(&result.0.stdout),
+        externs::store_bytes(&result.0.stderr),
+        externs::store_i64(result.0.exit_code.into()),
+        Snapshot::store_directory(&core, &result.0.output_directory),
+        ],
+      )
+    })
+  .to_boxed()
+}

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -24,6 +24,8 @@ pub fn run_intrinsic(input: TypeId, product: TypeId, context: Context, value: Va
     directories_to_merge_to_digest(context, value)
   } else if product == types.snapshot && input == types.url_to_fetch {
     url_to_fetch_to_snapshot(context, value)
+  } else if product == types.snapshot && input == types.path_globs {
+    path_globs_to_snapshot(context, value)
   } else {
     panic!("Unrecognized intrinsic: {:?} -> {:?}", input, product)
   }
@@ -140,6 +142,13 @@ fn directories_to_merge_to_digest(context: Context, request: Value) -> NodeFutur
 fn url_to_fetch_to_snapshot(context: Context, val: Value) -> NodeFuture<Value> {
   let core = context.core.clone();
   context.get(DownloadedFile(externs::key_for(val)))
+    .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
+    .to_boxed()
+}
+
+fn path_globs_to_snapshot(context: Context, val: Value) -> NodeFuture<Value> {
+  let core = context.core.clone();
+  context.get(Snapshot(externs::key_for(val)))
     .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
     .to_boxed()
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -35,6 +35,7 @@ mod core;
 pub mod externs;
 mod handles;
 mod interning;
+mod intrinsics;
 pub mod nodes;
 mod scheduler;
 mod selectors;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -219,17 +219,6 @@ impl WrappedNode for Select {
             .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.snapshot && input == types.url_to_fetch =>
-        {
-          let context = context.clone();
-          let core = context.core.clone();
-          self
-            .select_product(&context, types.url_to_fetch, "intrinsic")
-            .and_then(move |val| context.get(DownloadedFile(externs::key_for(val))))
-            .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {
@@ -643,7 +632,7 @@ impl From<Snapshot> for NodeKey {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct DownloadedFile(Key);
+pub struct DownloadedFile(pub Key);
 
 impl DownloadedFile {
   fn load_or_download(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -265,57 +265,6 @@ impl WrappedNode for Select {
             .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.directory_digest && input == types.directory_with_prefix_to_add =>
-        {
-          let request =
-            self.select_product(&context, types.directory_with_prefix_to_add, "intrinsic");
-          let core = context.core.clone();
-          request
-            .and_then(move |request| {
-              let digest = lift_digest(&externs::project_ignoring_type(
-                &request,
-                "directory_digest",
-              ))
-              .map_err(|str| throw(&str))?;
-              let prefix = externs::project_str(&request, "prefix");
-              Ok((digest, prefix))
-            })
-            .and_then(|(digest, prefix)| {
-              store::Snapshot::add_prefix(core.store(), digest, PathBuf::from(prefix))
-                .map_err(|err| throw(&err))
-                .map(move |digest| Snapshot::store_directory(&core, &digest))
-            })
-            .to_boxed()
-        }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.directory_digest && input == types.directory_with_prefix_to_strip =>
-        {
-          let request =
-            self.select_product(&context, types.directory_with_prefix_to_strip, "intrinsic");
-          let core = context.core.clone();
-          request
-            .and_then(move |request| {
-              let digest = lift_digest(&externs::project_ignoring_type(
-                &request,
-                "directory_digest",
-              ))
-              .map_err(|str| throw(&str))?;
-              let prefix = externs::project_str(&request, "prefix");
-              Ok((digest, prefix))
-            })
-            .and_then(|(digest, prefix)| {
-              store::Snapshot::strip_prefix(
-                core.store(),
-                digest,
-                PathBuf::from(prefix),
-                workunit_store,
-              )
-              .map_err(|err| throw(&err))
-              .map(move |digest| Snapshot::store_directory(&core, &digest))
-            })
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -249,22 +249,6 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.snapshot && input == types.directory_digest =>
-        {
-          let core = context.core.clone();
-          let store = context.core.store();
-          self
-            .select_product(&context, types.directory_digest, "intrinsic")
-            .and_then(|directory_digest_val| {
-              lift_digest(&directory_digest_val).map_err(|str| throw(&str))
-            })
-            .and_then(move |digest| {
-              store::Snapshot::from_digest(store, digest, workunit_store).map_err(|str| throw(&str))
-            })
-            .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -230,25 +230,6 @@ impl WrappedNode for Select {
             .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.directory_digest && input == types.directories_to_merge =>
-        {
-          let request = self.select_product(&context, types.directories_to_merge, "intrinsic");
-          let core = context.core.clone();
-          request
-            .and_then(move |request| {
-              let digests: Result<Vec<hashing::Digest>, Failure> =
-                externs::project_multi(&request, "directories")
-                  .into_iter()
-                  .map(|val| lift_digest(&val).map_err(|str| throw(&str)))
-                  .collect();
-              store::Snapshot::merge_directories(core.store(), try_future!(digests), workunit_store)
-                .map_err(|err| throw(&err))
-                .map(move |digest| Snapshot::store_directory(&core, &digest))
-                .to_boxed()
-            })
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -316,25 +316,6 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.files_content && input == types.directory_digest =>
-        {
-          let context = context.clone();
-          self
-            .select_product(&context, types.directory_digest, "intrinsic")
-            .and_then(|directory_digest_val| {
-              lift_digest(&directory_digest_val).map_err(|str| throw(&str))
-            })
-            .and_then(move |digest| {
-              context
-                .core
-                .store()
-                .contents_for_directory(digest, workunit_store)
-                .map_err(|str| throw(&str))
-                .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
-            })
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {
@@ -716,7 +697,7 @@ impl Snapshot {
     )
   }
 
-  fn store_files_content(context: &Context, item: &[FileContent]) -> Value {
+  pub fn store_files_content(context: &Context, item: &[FileContent]) -> Value {
     let entries: Vec<_> = item
       .iter()
       .map(|e| Self::store_file_content(context, e))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -208,17 +208,6 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &Rule::Intrinsic(Intrinsic { product, input })
-          if product == types.snapshot && input == types.path_globs =>
-        {
-          let context = context.clone();
-          let core = context.core.clone();
-          self
-            .select_product(&context, types.path_globs, "intrinsic")
-            .and_then(move |val| context.get(Snapshot(externs::key_for(val))))
-            .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
-            .to_boxed()
-        }
         &Rule::Intrinsic(Intrinsic { product, input }) =>
           self.select_product(&context, input, "intrinsic")
           .and_then(move |value| {
@@ -508,7 +497,7 @@ impl From<Scandir> for NodeKey {
 /// A Node that captures an store::Snapshot for a PathGlobs subject.
 ///
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Snapshot(Key);
+pub struct Snapshot(pub Key);
 
 impl Snapshot {
   fn create(context: Context, path_globs: PathGlobs) -> NodeFuture<store::Snapshot> {


### PR DESCRIPTION
### Problem

The implementation of `WrappedNode::run()` on `Select` was getting gigantic and unwieldy because it had a giant `match` statement, every arm of which implemented an engine intrinsic.

### Solution

Create a new top-level module-file `intrinsics.rs`, move the intrinsic-implementing code into a bunch of self-contained functions defined there, and make the `WrappedNode::run` implementation call into that.

### Result

This is a pure refactoring change that should have no user-visible effect, and should make it easier for pants developers to reason about existing intrinsics and add new ones.