### PR TITLE
Fix non-deterministic ConsolidateClasspath

### DIFF
--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -6,7 +6,9 @@ from collections import defaultdict
 
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_binary_task import JvmBinaryTask
+from pants.base.hash_utils import hash_all
 from pants.build_graph.target_scopes import Scopes
+from pants.util.dirutil import fast_relpath
 
 
 class ConsolidateClasspath(JvmBinaryTask):
@@ -17,7 +19,7 @@ class ConsolidateClasspath(JvmBinaryTask):
 
   @classmethod
   def implementation_version(cls):
-    return super().implementation_version() + [('ConsolidateClasspath', 1)]
+    return super().implementation_version() + [('ConsolidateClasspath', 2)]
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -56,9 +58,11 @@ class ConsolidateClasspath(JvmBinaryTask):
     with self.invalidated(targets=targets, invalidate_dependents=True) as invalidation:
       for vt in invalidation.all_vts:
         entries = entries_map.get(vt.target, [])
-        for index, (conf, entry) in enumerate(entries):
+        for conf, entry in entries:
+          relpath = fast_relpath(entry.path, self.get_options().pants_workdir)
+          suffix = hash_all([relpath])[:6]
           if ClasspathUtil.is_dir(entry.path):
-            jarpath = os.path.join(vt.results_dir, f'output-{index}.jar')
+            jarpath = os.path.join(vt.results_dir, f'output-{suffix}.jar')
 
             # Regenerate artifact for invalid vts.
             if not vt.valid:

--- a/src/python/pants/engine/round_manager.py
+++ b/src/python/pants/engine/round_manager.py
@@ -3,6 +3,8 @@
 
 from collections import defaultdict, namedtuple
 
+from twitter.common.collections import OrderedSet
+
 from pants.goal.goal import Goal
 
 
@@ -20,7 +22,7 @@ class RoundManager:
 
   @staticmethod
   def _index_products():
-    producer_info_by_product_type = defaultdict(set)
+    producer_info_by_product_type = defaultdict(OrderedSet)
     for goal in Goal.all():
       for task_type in goal.task_types():
         for product_type in task_type.product_types():
@@ -29,8 +31,8 @@ class RoundManager:
     return producer_info_by_product_type
 
   def __init__(self, context):
-    self._dependencies = set()
-    self._optional_dependencies = set()
+    self._dependencies = OrderedSet()
+    self._optional_dependencies = OrderedSet()
     self._context = context
     self._producer_infos_by_product_type = None
 
@@ -80,7 +82,7 @@ class RoundManager:
 
   def get_dependencies(self):
     """Returns the set of data dependencies as producer infos corresponding to data requirements."""
-    producer_infos = set()
+    producer_infos = OrderedSet()
     for product_type in self._dependencies:
       producer_infos.update(self._get_producer_infos_by_product_type(product_type))
     return producer_infos


### PR DESCRIPTION
Fixes #8941

This fixes two root causes:
1. ConsolidateClasspath uses a hash of the ClasspathEntry path, rather
   than the order it was added to the ClasspathEntries, in its output
   naming. This is important because nothing guarantees that
   ClasspathEntries will be added in consistent orderings (e.g. some
   tasks remove and re-add ClasspathEntries without preserving order).
2. Make Goals run in more deterministic orders. Right now, dependencies
   are added, and thus traversed, via sets, which changes their order.
   Another reason that ClasspathEntries are added in inconsistent orders
   is because unrelated Goals may run in random orders compared to each
   other (specifically, in this case, compile and resources inverting
   order). By not randomising tie-breaks in Goal ordering, we can avoid
   this - this isn't a proper fix (the proper fix is to avoid depending
   on order where it's not specified), but being consistent makes bugs
   less likely.

I tried for a while to add a test, but couldn't reproduce the bug I was
seeing in a reduced test case even 1% of the time, so sadly gave up.