### PR TITLE
Don't show core goals like `binary` and `test` when they have no implementation

### DIFF
--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -20,6 +20,7 @@ class DependencyType(Enum):
 
 # TODO(#8762) Get this rule to feature parity with the dependencies task.
 class DependenciesOptions(LineOriented, GoalSubsystem):
+  """Print the target's dependencies."""
   name = 'dependencies2'
 
   @classmethod

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -15,6 +15,7 @@ from pants.base.workunit import WorkUnit
 from pants.bin.goal_runner import GoalRunner
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.native import Native
+from pants.engine.rules import UnionMembership
 from pants.engine.scheduler import SchedulerSession
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_printer import HelpPrinter
@@ -129,7 +130,12 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
       # of the same engine functionality, but for now is separate to avoid
       # breaking functionality associated with zipkin tracing while iterating on streaming workunit reporting.
       stream_workunits = len(options.for_global_scope().streaming_workunits_handlers) != 0
-      graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits=stream_workunits)
+      graph_session = graph_scheduler_helper.new_session(
+        zipkin_trace_v2,
+        RunTracker.global_instance().run_id,
+        v2_ui,
+        should_report_workunits=stream_workunits,
+      )
     return graph_session, graph_session.scheduler_session
 
   @staticmethod
@@ -189,6 +195,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     if global_options.verify_config:
       options_bootstrapper.verify_configs_against_options(options)
 
+    union_membership = UnionMembership(build_config.union_rules())
+
     # If we're running with the daemon, we'll be handed a session from the
     # resident graph helper - otherwise initialize a new one here.
     graph_session, scheduler_session = cls._maybe_init_graph_session(
@@ -208,15 +216,16 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     profile_path = env.get('PANTS_PROFILE')
 
     return cls(
-      build_root,
-      options,
-      options_bootstrapper,
-      build_config,
-      specs,
-      graph_session,
-      scheduler_session,
-      daemon_graph_session is not None,
-      profile_path
+      build_root=build_root,
+      options=options,
+      options_bootstrapper=options_bootstrapper,
+      build_config=build_config,
+      specs=specs,
+      graph_session=graph_session,
+      scheduler_session=scheduler_session,
+      union_membership=union_membership,
+      is_daemon=daemon_graph_session is not None,
+      profile_path=profile_path,
     )
 
   def __init__(
@@ -228,6 +237,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     specs: Specs,
     graph_session: LegacyGraphSession,
     scheduler_session: SchedulerSession,
+    union_membership: UnionMembership,
     is_daemon: bool,
     profile_path: Optional[str],
   ) -> None:
@@ -248,6 +258,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     self._specs = specs
     self._graph_session = graph_session
     self._scheduler_session = scheduler_session
+    self._union_membership = union_membership
     self._is_daemon = is_daemon
     self._profile_path = profile_path
 
@@ -296,7 +307,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   def _maybe_handle_help(self):
     """Handle requests for `help` information."""
     if self._options.help_request:
-      help_printer = HelpPrinter(self._options)
+      help_printer = HelpPrinter(options=self._options, union_membership=self._union_membership)
       result = help_printer.print_help()
       return result
 
@@ -304,7 +315,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     v1_goals, ambiguous_goals, _ = self._options.goals_by_version
     if not self._global_options.v1:
       if v1_goals:
-        HelpPrinter(self._options, help_request=UnknownGoalHelp(v1_goals)).print_help()
+        HelpPrinter(
+          options=self._options,
+          help_request=UnknownGoalHelp(v1_goals),
+          union_membership=self._union_membership,
+        ).print_help()
         return PANTS_FAILED_EXIT_CODE
       return PANTS_SUCCEEDED_EXIT_CODE
 

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from collections.abc import Iterable
 
 from twitter.common.collections import OrderedSet
@@ -34,7 +34,7 @@ class BuildConfiguration:
     self._exposed_context_aware_object_factory_by_alias = {}
     self._optionables = OrderedSet()
     self._rules = OrderedSet()
-    self._union_rules = {}
+    self._union_rules = OrderedDict()
 
   def registered_aliases(self):
     """Return the registered aliases exposed in BUILD files.
@@ -175,7 +175,10 @@ class BuildConfiguration:
     return list(self._rules)
 
   def union_rules(self):
-    """Returns a mapping of registered union base types -> [OrderedSet of union member types]."""
+    """Returns a mapping of registered union base types -> [OrderedSet of union member types].
+
+    :rtype: OrderedDict
+    """
     return self._union_rules
 
   @memoized_method

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from collections.abc import Iterable
 
 from twitter.common.collections import OrderedSet
@@ -34,7 +34,7 @@ class BuildConfiguration:
     self._exposed_context_aware_object_factory_by_alias = {}
     self._optionables = OrderedSet()
     self._rules = OrderedSet()
-    self._union_rules = OrderedDict()
+    self._union_rules = {}
 
   def registered_aliases(self):
     """Return the registered aliases exposed in BUILD files.
@@ -175,10 +175,7 @@ class BuildConfiguration:
     return list(self._rules)
 
   def union_rules(self):
-    """Returns a mapping of registered union base types -> [OrderedSet of union member types].
-
-    :rtype: OrderedDict
-    """
+    """Returns a mapping of registered union base types -> [OrderedSet of union member types]."""
     return self._union_rules
 
   @memoized_method

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -4,7 +4,7 @@
 from abc import abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import ClassVar, List, Type
+from typing import ClassVar, Tuple, Type
 
 from pants.cache.cache_setup import CacheSetup
 from pants.option.optionable import Optionable
@@ -35,7 +35,7 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
 
   # If the goal requires downstream implementations to work properly, such as `test` and `run`,
   # it should declare the union types that must have members.
-  required_union_implementations: List[Type] = []
+  required_union_implementations: Tuple[Type, ...] = ()
 
   @classproperty
   @abstractmethod

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -4,13 +4,17 @@
 from abc import abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import ClassVar, Type
+from typing import TYPE_CHECKING, ClassVar, Type
 
 from pants.cache.cache_setup import CacheSetup
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.meta import classproperty
+
+
+if TYPE_CHECKING:
+  from pants.engine.rules import UnionMembership
 
 
 class GoalSubsystem(SubsystemClientMixin, Optionable):
@@ -30,6 +34,8 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
     ...
   ```
   """
+
+  options_scope_category = ScopeInfo.GOAL
 
   @classproperty
   @abstractmethod
@@ -70,7 +76,17 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
       return dep,
     return tuple()
 
-  options_scope_category = ScopeInfo.GOAL
+  @classmethod
+  def is_implemented(cls, *, union_membership: "UnionMembership") -> bool:
+    """Whether the goal has an actual implementation, such that `./pants $goal` may do something
+    useful.
+
+    Some core goals like `fmt`, `lint`, and `test` depend upon downstream rules providing concrete
+    implementations - they do not work properly when no implementations are registered, so should
+    not show up in `./pants goals`, for example. Those core rules should override this method
+    and inspect the UnionMemership to see if any rules provide an implementation.
+    """
+    return True
 
   def __init__(self, scope, scoped_options):
     # NB: This constructor is shaped to meet the contract of `Optionable(Factory).signature`.

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
+    'src/python/pants/engine:rules',
     'src/python/pants/goal',
     'src/python/pants/option',
     'src/python/pants/subsystem',

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, cast
 from typing_extensions import Literal
 
 from pants.base.build_environment import pants_release, pants_version
+from pants.engine.goal import GoalSubsystem
 from pants.engine.rules import UnionMembership
 from pants.goal.goal import Goal
 from pants.help.help_formatter import HelpFormatter
@@ -71,7 +72,8 @@ class HelpPrinter:
       goal_scope_infos = [
         scope_info
         for scope_info in self._options.known_scope_to_info.values()
-        if scope_info.category == ScopeInfo.GOAL
+        if scope_info.optionable_cls is not None
+        and issubclass(scope_info.optionable_cls, GoalSubsystem)
         and scope_info.optionable_cls.is_implemented(union_membership=self._union_membership)
       ]
       for scope_info in goal_scope_infos:

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -72,11 +72,17 @@ class HelpPrinter:
       goal_scope_infos = [
         scope_info
         for scope_info in self._options.known_scope_to_info.values()
-        if scope_info.optionable_cls is not None
-        and issubclass(scope_info.optionable_cls, GoalSubsystem)
-        and scope_info.optionable_cls.is_implemented(union_membership=self._union_membership)
+        if scope_info.category == ScopeInfo.GOAL
       ]
       for scope_info in goal_scope_infos:
+        if scope_info.optionable_cls is None or not issubclass(scope_info.optionable_cls, GoalSubsystem):
+          continue
+        is_unimplemented = any(
+          self._union_membership.union_rules.get(union_type) is None
+          for union_type in scope_info.optionable_cls.required_union_implementations
+        )
+        if is_unimplemented:
+          continue
         description = scope_info.description or "<no description>"
         goal_descriptions[scope_info.scope] = description
     if global_options.v1:

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
-from typing import Optional, cast
+from typing import Dict, Optional, cast
 
 from typing_extensions import Literal
 
 from pants.base.build_environment import pants_release, pants_version
+from pants.engine.rules import UnionMembership
 from pants.goal.goal import Goal
 from pants.help.help_formatter import HelpFormatter
 from pants.help.scope_info_iterator import ScopeInfoIterator
@@ -25,9 +26,16 @@ from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 class HelpPrinter:
   """Prints help to the console."""
 
-  def __init__(self, options: Options, *, help_request: Optional[HelpRequest] = None) -> None:
+  def __init__(
+    self,
+    *,
+    options: Options,
+    help_request: Optional[HelpRequest] = None,
+    union_membership: UnionMembership,
+  ) -> None:
     self._options = options
     self._help_request = help_request or self._options.help_request
+    self._union_membership = union_membership
 
   @property
   def bin_name(self) -> str:
@@ -55,15 +63,20 @@ class HelpPrinter:
       return 1
     return 0
 
-  def _print_goals_help(self):
+  def _print_goals_help(self) -> None:
     print(f'\nUse `{self.bin_name} help $goal` to get help for a particular goal.\n')
     global_options = self._options.for_global_scope()
-    goal_descriptions = {}
+    goal_descriptions: Dict[str, str] = {}
     if global_options.v2:
-      for scope_info in self._options.known_scope_to_info.values():
-        if scope_info.category == ScopeInfo.GOAL:
-          description = scope_info.description or "<no description>"
-          goal_descriptions[scope_info.scope] = description
+      goal_scope_infos = [
+        scope_info
+        for scope_info in self._options.known_scope_to_info.values()
+        if scope_info.category == ScopeInfo.GOAL
+        and scope_info.optionable_cls.is_implemented(union_membership=self._union_membership)
+      ]
+      for scope_info in goal_scope_infos:
+        description = scope_info.description or "<no description>"
+        goal_descriptions[scope_info.scope] = description
     if global_options.v1:
       goal_descriptions.update({goal.name: goal.description_first_line
                                 for goal in Goal.all()
@@ -71,7 +84,7 @@ class HelpPrinter:
 
     max_width = max(len(name) for name in goal_descriptions.keys()) if goal_descriptions else 0
     for name, description in sorted(goal_descriptions.items()):
-      print('  {}: {}'.format(name.rjust(max_width), description))
+      print(f'  {name.rjust(max_width)}: {description}')
     print()
 
   def _print_options_help(self):

--- a/src/python/pants/help/list_goals_integration_test.py
+++ b/src/python/pants/help/list_goals_integration_test.py
@@ -5,19 +5,36 @@ from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class TestListGoalsIntegration(PantsRunIntegrationTest):
-  def test_goals(self):
-    command = ['--v2', 'goals']
+  def test_goals(self) -> None:
+    command = ['--v1', '--v2', 'goals']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn('to get help for a particular goal', pants_run.stdout_data)
+    assert 'to get help for a particular goal' in pants_run.stdout_data
     # Spot check a few core goals.
-    self.assertIn('list:', pants_run.stdout_data)
-    self.assertIn('test:', pants_run.stdout_data)
-    self.assertIn(' fmt:', pants_run.stdout_data)
+    for goal in ['filedeps', 'list', 'roots', 'validate']:
+      assert goal in pants_run.stdout_data
 
-  def test_ignored_args(self):
+  def test_only_show_implemented_goals(self) -> None:
+    # Some core goals, such as `./pants test`, require downstream implementations to work
+    # properly. We should only show those goals when an implementation is provided.
+    goals_that_need_implementation = ["binary", "fmt2", "lint2", "run", "test"]
+    command = ["--pants-config-files=[]", "--no-v1", "--v2", "goals"]
+
+    not_implemented_run = self.run_pants(command)
+    self.assert_success(not_implemented_run)
+    for goal in goals_that_need_implementation:
+      assert goal not in not_implemented_run.stdout_data
+
+    implemented_run = self.run_pants([
+      "--backend-packages2=['pants.backend.python', 'pants.backend.python.lint.isort']", *command],
+    )
+    self.assert_success(implemented_run)
+    for goal in goals_that_need_implementation:
+      assert goal in implemented_run.stdout_data
+
+  def test_ignored_args(self) -> None:
     # Test that arguments (some of which used to be relevant) are ignored.
     command = ['goals', '--all', '--graphviz', '--llama']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn('to get help for a particular goal', pants_run.stdout_data)
+    assert 'to get help for a particular goal' in pants_run.stdout_data

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -10,7 +10,7 @@ from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, 
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.objects import union
-from pants.engine.rules import UnionMembership, goal_rule, rule
+from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.distdir import DistDir
 
@@ -31,9 +31,7 @@ class BinaryOptions(LineOriented, GoalSubsystem):
   """Create a runnable binary."""
   name = 'binary'
 
-  @classmethod
-  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
-    return union_membership.union_rules.get(BinaryTarget) is not None
+  required_union_implementations = [BinaryTarget]
 
 
 class Binary(Goal):

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -31,7 +31,7 @@ class BinaryOptions(LineOriented, GoalSubsystem):
   """Create a runnable binary."""
   name = 'binary'
 
-  required_union_implementations = [BinaryTarget]
+  required_union_implementations = (BinaryTarget,)
 
 
 class Binary(Goal):

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -76,9 +76,7 @@ class FmtOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'fmt2'
 
-  @classmethod
-  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
-    return union_membership.union_rules.get(FormatTarget) is not None
+  required_union_implementations = [FormatTarget]
 
 
 class Fmt(Goal):

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -76,7 +76,7 @@ class FmtOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'fmt2'
 
-  required_union_implementations = [FormatTarget]
+  required_union_implementations = (FormatTarget,)
 
 
 class Fmt(Goal):

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -76,6 +76,10 @@ class FmtOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'fmt2'
 
+  @classmethod
+  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
+    return union_membership.union_rules.get(FormatTarget) is not None
+
 
 class Fmt(Goal):
   subsystem_cls = FmtOptions

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -62,9 +62,7 @@ class LintOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'lint2'
 
-  @classmethod
-  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
-    return union_membership.union_rules.get(LintTarget) is not None
+  required_union_implementations = [LintTarget]
 
 
 class Lint(Goal):

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -62,7 +62,7 @@ class LintOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'lint2'
 
-  required_union_implementations = [LintTarget]
+  required_union_implementations = (LintTarget,)
 
 
 class Lint(Goal):

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -62,6 +62,10 @@ class LintOptions(GoalSubsystem):
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
   name = 'lint2'
 
+  @classmethod
+  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
+    return union_membership.union_rules.get(LintTarget) is not None
+
 
 class Lint(Goal):
   subsystem_cls = LintOptions

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -20,7 +20,7 @@ class RunOptions(GoalSubsystem):
   name = 'run'
 
   # NB: To be runnable, you must be a BinaryTarget.
-  required_union_implementations = [BinaryTarget]
+  required_union_implementations = (BinaryTarget,)
 
 
 class Run(Goal):

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -9,15 +9,20 @@ from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.engine.rules import goal_rule
+from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get
-from pants.rules.core.binary import CreatedBinary
+from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
 
 class RunOptions(GoalSubsystem):
   """Runs a runnable target."""
   name = 'run'
+
+  @classmethod
+  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
+    # NB: To be runnable, you must be a BinaryTarget.
+    return union_membership.union_rules.get(BinaryTarget) is not None
 
 
 class Run(Goal):

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -9,7 +9,7 @@ from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.engine.rules import UnionMembership, goal_rule
+from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.util.contextutil import temporary_dir
@@ -19,10 +19,8 @@ class RunOptions(GoalSubsystem):
   """Runs a runnable target."""
   name = 'run'
 
-  @classmethod
-  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
-    # NB: To be runnable, you must be a BinaryTarget.
-    return union_membership.union_rules.get(BinaryTarget) is not None
+  # NB: To be runnable, you must be a BinaryTarget.
+  required_union_implementations = [BinaryTarget]
 
 
 class Run(Goal):

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -80,7 +80,7 @@ class TestOptions(GoalSubsystem):
   """Runs tests."""
   name = "test"
 
-  required_union_implementations = [TestTarget]
+  required_union_implementations = (TestTarget,)
 
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -80,6 +80,8 @@ class TestOptions(GoalSubsystem):
   """Runs tests."""
   name = "test"
 
+  required_union_implementations = [TestTarget]
+
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False
 
@@ -99,10 +101,6 @@ class TestOptions(GoalSubsystem):
       default=False,
       help='Generate a coverage report for this test run.',
     )
-
-  @classmethod
-  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
-    return union_membership.union_rules.get(TestTarget) is not None
 
 
 class Test(Goal):

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -100,6 +100,10 @@ class TestOptions(GoalSubsystem):
       help='Generate a coverage report for this test run.',
     )
 
+  @classmethod
+  def is_implemented(cls, *, union_membership: UnionMembership) -> bool:
+    return union_membership.union_rules.get(TestTarget) is not None
+
 
 class Test(Goal):
   subsystem_cls = TestOptions
@@ -132,7 +136,9 @@ class AddressAndDebugRequest:
 
 
 @goal_rule
-async def run_tests(console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses) -> Test:
+async def run_tests(
+  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses,
+) -> Test:
   if options.values.debug:
     address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
     addr_debug_request = await Get[AddressAndDebugRequest](Address, address.to_address())


### PR DESCRIPTION
Certain goals like `test` and `binary` require implementations to actually work. Without any backends registered, for example, users would encounter this error:

```
$ ./v2 --pants-config-files='[]' fmt2 src/python/pants/util:strutil

ERROR: Not a registered union type: <class 'pants.util.meta.FormatTarget'>
```

So, it does not make sense to output those goals in `./pants goals` when they have no implementation. 

A followup could improve upon this to instead explicitly warn users that these goals are unimplemented and direct them to which backends they might want to register.