### PR TITLE
Fix rule type hint validation to work with `from __future__ import annotations`

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,7 +9,7 @@ import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, get_type_hints
 
 from twitter.common.collections import OrderedSet
 
@@ -191,14 +191,15 @@ class MissingParameterTypeAnnotation(InvalidTypeAnnotation):
 
 
 def _ensure_type_annotation(
-  annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
-) -> type:
-  if annotation == empty_value:
+  *, type_annotation: Optional[Type], name: str, raise_type: Type[InvalidTypeAnnotation],
+) -> Type:
+  if type_annotation is None:
     raise raise_type(f'{name} is missing a type annotation.')
-  if not isinstance(annotation, type):
-    raise raise_type(f'The annotation for {name} must be a type, '
-                     f'got {annotation} of type {type(annotation)}.')
-  return annotation
+  if not isinstance(type_annotation, type):
+    raise raise_type(
+      f'The annotation for {name} must be a type, got {type_annotation} of type {type(type_annotation)}.'
+    )
+  return type_annotation
 
 
 PUBLIC_RULE_DECORATOR_ARGUMENTS = {'name'}
@@ -225,22 +226,20 @@ def rule_decorator(*args, **kwargs) -> Callable:
   cacheable: bool = kwargs['cacheable']
   name: Optional[str] = kwargs.get('name')
 
-  signature = inspect.signature(func)
   func_id = f'@rule {func.__module__}:{func.__name__}'
+  type_hints = get_type_hints(func)
   return_type = _ensure_type_annotation(
-    annotation=signature.return_annotation,
+    type_annotation=type_hints.get("return"),
     name=f'{func_id} return',
-    empty_value=inspect.Signature.empty,
-    raise_type=MissingReturnTypeAnnotation
+    raise_type=MissingReturnTypeAnnotation,
   )
   parameter_types = tuple(
     _ensure_type_annotation(
-      annotation=parameter.annotation,
-      name=f'{func_id} parameter {name}',
-      empty_value=inspect.Parameter.empty,
-      raise_type=MissingParameterTypeAnnotation
+      type_annotation=type_hints.get(parameter),
+      name=f'{func_id} parameter {parameter}',
+      raise_type=MissingParameterTypeAnnotation,
     )
-    for name, parameter in signature.parameters.items()
+    for parameter in inspect.signature(func).parameters
   )
   validate_parameter_types(func_id, parameter_types, cacheable)
   return _make_rule(return_type, parameter_types, cacheable=cacheable, name=name)(func)


### PR DESCRIPTION
`from __future__ import annotations` causes type annotations to be treated as strings at runtime. This means that activating `from __future__ import annotations` in any file with an `@rule` will cause Pants to fail to resolve the rule's types, complaining that the annotations are all strings.

Per [PEP 563](https://www.python.org/dev/peps/pep-0563/), the solution is to use `typing.get_type_hints()`, which returns an ordered dictionary of the annotations like `{"arg1": int, "arg2": str, "return": Foo}`.