### PR TITLE
Snapshot subset intrinsic

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -185,6 +185,13 @@ class Snapshot:
     return self == EMPTY_SNAPSHOT
 
 
+class SnapshotSubset:
+  """A request to create a subset of a snapshot."""
+  directory_digest: Digest
+  include_files: Tuple[str, ...]
+  include_dirs: Tuple[str, ...]
+
+
 @dataclass(frozen=True)
 class DirectoriesToMerge:
   directories: Tuple[Digest, ...]

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -190,8 +190,6 @@ class SnapshotSubset:
   """A request to create a subset of a snapshot."""
   directory_digest: Digest
   includes: PathGlobs
-  include_files: Tuple[str, ...]
-  include_dirs: Tuple[str, ...]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -189,6 +189,7 @@ class Snapshot:
 class SnapshotSubset:
   """A request to create a subset of a snapshot."""
   directory_digest: Digest
+  includes: PathGlobs
   include_files: Tuple[str, ...]
   include_dirs: Tuple[str, ...]
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -189,7 +189,7 @@ class Snapshot:
 class SnapshotSubset:
   """A request to create a subset of a snapshot."""
   directory_digest: Digest
-  includes: PathGlobs
+  globs: PathGlobs
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -185,6 +185,7 @@ class Snapshot:
     return self == EMPTY_SNAPSHOT
 
 
+@dataclass(frozen=True)
 class SnapshotSubset:
   """A request to create a subset of a snapshot."""
   directory_digest: Digest
@@ -324,4 +325,5 @@ def create_fs_rules():
     RootRule(DirectoryWithPrefixToStrip),
     RootRule(DirectoryWithPrefixToAdd),
     RootRule(UrlToFetch),
+    RootRule(SnapshotSubset),
   ]

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -30,6 +30,7 @@ from pants.engine.fs import (
   MaterializeDirectoryResult,
   PathGlobs,
   Snapshot,
+  SnapshotSubset,
   UrlToFetch,
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
@@ -580,6 +581,7 @@ class EngineTypes(NamedTuple):
   construct_interactive_process_result: Function
   interactive_process_request: TypeId
   interactive_process_result: TypeId
+  snapshot_subset: TypeId
 
 
 class PyResult(NamedTuple):
@@ -943,6 +945,7 @@ class Native(metaclass=SingletonMetaclass):
         construct_interactive_process_result=func(InteractiveProcessResult),
         interactive_process_request=ti(InteractiveProcessRequest),
         interactive_process_result=ti(InteractiveProcessResult),
+        snapshot_subset=ti(SnapshotSubset),
     )
 
     scheduler_result = self.lib.scheduler_create(

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -830,7 +830,7 @@ pub extern "C" fn match_path_globs(path_globs: Handle, paths_buf: BufferBuffer) 
     .into_iter()
     .map(PathBuf::from)
     .collect::<Vec<_>>();
-  path_globs.matches(&paths).map(externs::store_bool).into()
+  externs::store_bool(path_globs.matches(&paths)).into()
 }
 
 #[no_mangle]

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -113,6 +113,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
       exclude,
       strict_match_behavior,
       conjunction,
+      ..
     } = path_globs;
 
     if include.is_empty() {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -548,20 +548,6 @@ impl PathGlobs {
     pattern.matches_path_with(path, &PATTERN_MATCH_OPTIONS)
       && !self.exclude.is_ignored_path(path, false)
   }
-
-  pub fn filter(&self, paths: Vec<PathBuf>) -> Result<Vec<PathBuf>, String> {
-    let mut output = vec![];
-    for path in paths.into_iter() {
-      match self.matches(&[path.clone()]) {
-        Ok(true) => {
-          output.push(path);
-        }
-        Ok(false) => (),
-        Err(e) => return Err(e),
-      }
-    }
-    Ok(output)
-  }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -514,7 +514,6 @@ impl PathGlobs {
   /// traversal in expand is (currently) too expensive to use for that in-memory matching (such as
   /// via MemFS).
   ///
-  //TODO I think this can be &[&PathBuf]
   pub fn matches(&self, paths: &[PathBuf]) -> Result<bool, String> {
     let patterns = self
       .include
@@ -541,9 +540,9 @@ impl PathGlobs {
       match self.matches(&[path.clone()]) {
         Ok(true) => {
           output.push(path);
-        },
+        }
         Ok(false) => (),
-        Err(e) => return Err(e)
+        Err(e) => return Err(e),
       }
     }
     Ok(output)

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -514,6 +514,7 @@ impl PathGlobs {
   /// traversal in expand is (currently) too expensive to use for that in-memory matching (such as
   /// via MemFS).
   ///
+  //TODO I think this can be &[&PathBuf]
   pub fn matches(&self, paths: &[PathBuf]) -> Result<bool, String> {
     let patterns = self
       .include
@@ -532,6 +533,20 @@ impl PathGlobs {
           && !self.exclude.is_ignored_path(path, false)
       })
     }))
+  }
+
+  pub fn filter(&self, paths: Vec<PathBuf>) -> Result<Vec<PathBuf>, String> {
+    let mut output = vec![];
+    for path in paths.into_iter() {
+      match self.matches(&[path.clone()]) {
+        Ok(true) => {
+          output.push(path);
+        },
+        Ok(false) => (),
+        Err(e) => return Err(e)
+      }
+    }
+    Ok(output)
   }
 }
 

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -559,6 +559,24 @@ impl Snapshot {
       })
       .to_boxed()
   }
+
+  pub fn get_snapshot_subset(
+    _store: Store,
+    _digest: Digest,
+    _include_files: Vec<String>,
+    _include_dirs: Vec<String>,
+  ) -> BoxFuture<Digest, String> {
+
+    future::ok(EMPTY_DIGEST).to_boxed()
+      /*
+         let directory = store.load_directory(original_digest, workunit_store)
+         .and_then(move |maybe_directory| {
+
+         .map(|(dir, _metadata)| dir)
+         .ok_or_else(|| format!("Digest {:?} did not exist in the Store.", digest))
+         })
+         */
+  }
 }
 
 impl fmt::Debug for Snapshot {

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -11,6 +11,7 @@ use hashing::{Digest, EMPTY_DIGEST};
 use indexmap::{self, IndexMap};
 use itertools::Itertools;
 use protobuf;
+use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fmt;
 use std::iter::Iterator;
@@ -561,21 +562,42 @@ impl Snapshot {
   }
 
   pub fn get_snapshot_subset(
-    _store: Store,
-    _digest: Digest,
-    _include_files: Vec<String>,
-    _include_dirs: Vec<String>,
+    store: Store,
+    digest: Digest,
+    include_files: BTreeSet<String>,
+    include_dirs: BTreeSet<String>,
+    workunit_store: WorkUnitStore,
   ) -> BoxFuture<Digest, String> {
+    use bazel_protos::remote_execution::{Directory, DirectoryNode, FileNode};
+    use protobuf::RepeatedField;
 
-    future::ok(EMPTY_DIGEST).to_boxed()
-      /*
-         let directory = store.load_directory(original_digest, workunit_store)
-         .and_then(move |maybe_directory| {
+    let directory = store
+      .load_directory(digest, workunit_store)
+      .and_then(move |maybe_directory| {
+        maybe_directory
+          .map(|(dir, _metadata)| dir)
+          .ok_or_else(|| format!("Digest {:?} did not exist in the Store.", digest))
+      });
+    directory
+      .and_then(move |mut directory: Directory| {
+        let mut out_dir = Directory::new();
+        let file_nodes: RepeatedField<FileNode> = directory.take_files();
+        let subset_file_nodes = file_nodes
+          .into_iter()
+          .filter(|orig_file: &FileNode| include_files.contains(orig_file.get_name()))
+          .collect();
+        out_dir.set_files(subset_file_nodes);
 
-         .map(|(dir, _metadata)| dir)
-         .ok_or_else(|| format!("Digest {:?} did not exist in the Store.", digest))
-         })
-         */
+        let directory_nodes: RepeatedField<DirectoryNode> = directory.take_directories();
+        let subset_dir_nodes = directory_nodes
+          .into_iter()
+          .filter(|orig_dir: &DirectoryNode| include_dirs.contains(orig_dir.get_name()))
+          .collect();
+
+        out_dir.set_directories(subset_dir_nodes);
+        store.record_directory(&out_dir, true)
+      })
+      .to_boxed()
   }
 }
 

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -1,7 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::HashMap;
 use crate::Store;
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
@@ -12,6 +11,7 @@ use hashing::{Digest, EMPTY_DIGEST};
 use indexmap::{self, IndexMap};
 use itertools::Itertools;
 use protobuf;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt;
 use std::iter::Iterator;
@@ -574,7 +574,6 @@ impl Snapshot {
                           _: Digest,
                           directory: &Directory|
           -> BoxFuture<(Vec<PathStat>, StoreManyFileDigests), String> {
-
       let subdir_paths: Vec<PathBuf> = directory
         .get_directories()
         .iter()
@@ -585,7 +584,13 @@ impl Snapshot {
       let file_paths: Vec<(PathBuf, Result<Digest, String>, bool)> = directory
         .get_files()
         .iter()
-        .map(|node: &FileNode| (path_so_far.join(node.get_name()), node.get_digest().into(), node.is_executable))
+        .map(|node: &FileNode| {
+          (
+            path_so_far.join(node.get_name()),
+            node.get_digest().into(),
+            node.is_executable,
+          )
+        })
         .filter(|(path, _, _)| path_globs.matches(&[path.clone()]))
         .collect();
 
@@ -598,33 +603,37 @@ impl Snapshot {
       for (path, maybe_digest, is_executable) in file_paths.into_iter() {
         let digest = match maybe_digest {
           Ok(d) => d,
-          Err(err) => return future::err(err).to_boxed()
+          Err(err) => return future::err(err).to_boxed(),
         };
         hash.insert(path.clone(), digest);
         path_stats.push(PathStat::file(
-            path.clone(),
-            File { path, is_executable },
+          path.clone(),
+          File {
+            path,
+            is_executable,
+          },
         ));
       }
 
-      future::ok((path_stats, StoreManyFileDigests { hash }))
-      .to_boxed()
+      future::ok((path_stats, StoreManyFileDigests { hash })).to_boxed()
     };
 
     store
       .walk(digest, traverser, workunit_store.clone())
-      .and_then(move |path_stats_and_stores_per_directory: Vec<(Vec<PathStat>, StoreManyFileDigests)>| {
+      .and_then(
+        move |path_stats_and_stores_per_directory: Vec<(Vec<PathStat>, StoreManyFileDigests)>| {
+          let mut final_store = StoreManyFileDigests::new();
+          let mut path_stats: Vec<PathStat> = vec![];
+          for (per_dir_path_stats, per_dir_store) in path_stats_and_stores_per_directory.into_iter()
+          {
+            final_store.merge(per_dir_store);
+            path_stats.extend(per_dir_path_stats.into_iter());
+          }
 
-        let mut final_store = StoreManyFileDigests::new();
-        let mut path_stats: Vec<PathStat> = vec![];
-        for (per_dir_path_stats, per_dir_store) in path_stats_and_stores_per_directory.into_iter() {
-          final_store.merge(per_dir_store);
-          path_stats.extend(per_dir_path_stats.into_iter());
-        }
-
-        path_stats.sort_by(|l, r| l.path().cmp(&r.path()));
-        Snapshot::from_path_stats(store, &final_store, path_stats, workunit_store)
-      })
+          path_stats.sort_by(|l, r| l.path().cmp(&r.path()));
+          Snapshot::from_path_stats(store, &final_store, path_stats, workunit_store)
+        },
+      )
       .to_boxed()
   }
 }
@@ -709,12 +718,14 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
 
 #[derive(Clone)]
 struct StoreManyFileDigests {
-  pub hash: HashMap<PathBuf, Digest>
+  pub hash: HashMap<PathBuf, Digest>,
 }
 
 impl StoreManyFileDigests {
   fn new() -> StoreManyFileDigests {
-    StoreManyFileDigests { hash: HashMap::new() }
+    StoreManyFileDigests {
+      hash: HashMap::new(),
+    }
   }
 
   fn merge(&mut self, other: StoreManyFileDigests) {
@@ -724,15 +735,12 @@ impl StoreManyFileDigests {
 
 impl StoreFileByDigest<String> for StoreManyFileDigests {
   fn store_by_digest(&self, file: File, _: WorkUnitStore) -> BoxFuture<Digest, String> {
-    future::result(self
-      .hash
-      .get(&file.path)
-      .map(|digest| digest.clone())
-      .ok_or(format!("Could not find file {} when storing file by digest", file.path.display()))
-    )
-      .to_boxed()
+    future::result(self.hash.get(&file.path).copied().ok_or_else(|| {
+      format!(
+        "Could not find file {} when storing file by digest",
+        file.path.display()
+      )
+    }))
+    .to_boxed()
   }
 }
-
-
-

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -445,13 +445,19 @@ impl PyResult {
   }
 }
 
+impl From<Value> for PyResult {
+  fn from(val: Value) -> Self {
+    PyResult {
+      is_throw: false,
+      handle: val.into(),
+    }
+  }
+}
+
 impl From<Result<Value, Failure>> for PyResult {
   fn from(result: Result<Value, Failure>) -> Self {
     match result {
-      Ok(val) => PyResult {
-        is_throw: false,
-        handle: val.into(),
-      },
+      Ok(val) => val.into(),
       Err(f) => {
         let val = match f {
           f @ Failure::Invalidated => create_exception(&format!("{}", f)),

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -196,10 +196,10 @@ fn input_files_content_to_digest(context: Context, files_content: Value) -> Node
 
 fn snapshot_subset_to_snapshot(context: Context, value: Value) -> NodeFuture<Value> {
   let workunit_store = context.session.workunit_store();
-  let includes = externs::project_ignoring_type(&value, "includes");
+  let globs = externs::project_ignoring_type(&value, "globs");
   let store = context.core.store();
 
-  let path_globs = future::result(Snapshot::lift_path_globs(&includes));
+  let path_globs = future::result(Snapshot::lift_path_globs(&globs));
   let original_digest = future::result(lift_digest(&externs::project_ignoring_type(
     &value,
     "directory_digest",

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -174,6 +174,10 @@ impl Tasks {
         product: types.process_result,
         input: types.multi_platform_process_request,
       },
+      Intrinsic {
+        product: types.directory_digest,
+        input: types.snapshot_subset,
+      },
     ];
 
     for intrinsic in intrinsics {

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -175,7 +175,7 @@ impl Tasks {
         input: types.multi_platform_process_request,
       },
       Intrinsic {
-        product: types.directory_digest,
+        product: types.snapshot,
         input: types.snapshot_subset,
       },
     ];

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -32,4 +32,5 @@ pub struct Types {
   pub construct_interactive_process_result: Function,
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
+  pub snapshot_subset: TypeId,
 }

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -611,8 +611,6 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
   def test_empty_snapshot_subset(self) -> None:
     ss = SnapshotSubset(directory_digest=self.generate_original_digest(),
         includes = PathGlobs((), ()),
-        include_files=(),
-        include_dirs=(),
     )
     subset_snapshot = self.request_single_product(Snapshot, ss)
     assert subset_snapshot.directory_digest == EMPTY_DIRECTORY_DIGEST
@@ -622,8 +620,6 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
   def test_snapshot_subset_files_dirs(self) -> None:
     ss1 = SnapshotSubset(directory_digest=self.generate_original_digest(),
         includes=PathGlobs(("a.txt", "c.txt", "subdir2/**"), ()),
-        include_files=("a.txt", "c.txt"),
-        include_dirs=('subdir2',),
     )
 
     subset_snapshot = self.request_single_product(Snapshot, ss1)
@@ -631,14 +627,10 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
     ss2 = SnapshotSubset(directory_digest=self.generate_original_digest(),
         includes=PathGlobs(("a.txt", "c.txt", "subdir2/*"), ()),
-        include_files=("a.txt", "c.txt"),
-        include_dirs=('subdir2',),
     )
 
     subset_snapshot = self.request_single_product(Snapshot, ss2)
     assert set(subset_snapshot.files) == {'a.txt', 'c.txt', 'subdir2/a.txt'} 
-
-
 
 
 class StubHandler(BaseHTTPRequestHandler):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -620,12 +620,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         include_files=("a.txt", "c.txt"),
         include_dirs=('subdir2',),
     )
-    subset_digest = self.request_single_product(Digest, ss)
-    result_files = self.request_single_product(FilesContent, subset_digest)
-    assert len(result_files.dependencies) == 3
-    assert any(fc.path == 'a.txt' for fc in result_files.dependencies)
-    assert any(fc.path == 'c.txt' for fc in result_files.dependencies)
-    assert any(fc.path == 'subdir2/a.txt' for fc in result_files.dependencies)
+    subset_snapshot = self.request_single_product(Snapshot, ss)
+    assert set(subset_snapshot.files) == {'a.txt', 'c.txt', 'subdir2/a.txt'}
 
 
 class StubHandler(BaseHTTPRequestHandler):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 
-from pants.engine.fs import (  # SnapshotSubset,
+from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
   Digest,
   DirectoriesToMerge,
@@ -24,6 +24,7 @@ from pants.engine.fs import (  # SnapshotSubset,
   PathGlobs,
   PathGlobsAndRoot,
   Snapshot,
+  SnapshotSubset,
   UrlToFetch,
   create_fs_rules,
 )
@@ -594,7 +595,29 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         ))
 
   def test_snapshot_subset(self):
-    pass
+
+    content = b'dummy content'
+    input_files_content = InputFilesContent((
+      FileContent(path='a.txt', content=content),
+      FileContent(path='b.txt', content=content),
+      FileContent(path='c.txt', content=content),
+      FileContent(path='subdir/a.txt', content=content),
+      FileContent(path='subdir/b.txt', content=content),
+      FileContent(path='subdir2/a.txt', content=content),
+    ))
+
+    digest = self.request_single_product(Digest, input_files_content)
+
+    ss = SnapshotSubset(directory_digest=digest,
+        include_files=(),
+        include_dirs=(),
+    )
+
+    subset_digest = self.request_single_product(Digest, ss)
+    print(f"Subset digest: {subset_digest}")
+
+    assert 1 == 2
+
 
 
 class StubHandler(BaseHTTPRequestHandler):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -24,6 +24,7 @@ from pants.engine.fs import (
   PathGlobs,
   PathGlobsAndRoot,
   Snapshot,
+  SnapshotSubset,
   UrlToFetch,
   create_fs_rules,
 )
@@ -593,6 +594,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
           82
         ))
 
+  def test_snapshot_subset(self):
+    pass
 
 class StubHandler(BaseHTTPRequestHandler):
   response_text = b"www.pantsbuild.org"

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 
-from pants.engine.fs import (
+from pants.engine.fs import (  # SnapshotSubset,
   EMPTY_DIRECTORY_DIGEST,
   Digest,
   DirectoriesToMerge,
@@ -24,7 +24,6 @@ from pants.engine.fs import (
   PathGlobs,
   PathGlobsAndRoot,
   Snapshot,
-  SnapshotSubset,
   UrlToFetch,
   create_fs_rules,
 )
@@ -596,6 +595,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
   def test_snapshot_subset(self):
     pass
+
 
 class StubHandler(BaseHTTPRequestHandler):
   response_text = b"www.pantsbuild.org"


### PR DESCRIPTION
### Problem

This is prework for https://github.com/pantsbuild/pants/pull/8956 . We want to be able to request a Digest that contains a subset of the files and directories from another Snapshot.

### Solution

Create a new root type SnapshotSubset, which wraps a Digest and a list of files/dirs from that Digest to be put into a new Digest. Then create an engine intrinsic that will filter stored file information to that subset and output a new Digest.
