### PR TITLE
Ensure that every filesystem spec is valid

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -710,13 +710,16 @@ async def sources_snapshots_from_filesystem_specs(
   filesystem_specs: FilesystemSpecs, glob_match_error_behavior: GlobMatchErrorBehavior,
 ) -> SourcesSnapshots:
   """Resolve the snapshot associated with the provided filesystem specs."""
-  snapshot = await Get[Snapshot](
-    PathGlobs(
-      include=(fs_spec.glob for fs_spec in filesystem_specs),
-      glob_match_error_behavior=glob_match_error_behavior,
+  snapshots = await MultiGet(
+    Get[Snapshot](
+      PathGlobs(
+        include=(fs_spec.glob,),
+        glob_match_error_behavior=glob_match_error_behavior,
+      )
     )
+    for fs_spec in filesystem_specs
   )
-  return SourcesSnapshots([SourcesSnapshot(snapshot)])
+  return SourcesSnapshots(SourcesSnapshot(snapshot) for snapshot in snapshots)
 
 
 def create_legacy_graph_tasks():

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -42,6 +42,7 @@ from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
+from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.scm.subsystems.changed import IncludeDependeesOption
 from pants.source.filespec import any_matches_filespec
@@ -714,6 +715,8 @@ async def sources_snapshots_from_filesystem_specs(
     PathGlobs(
       include=(fs_spec.glob for fs_spec in filesystem_specs),
       glob_match_error_behavior=glob_match_error_behavior,
+      # We validate that _every_ filesystem spec is valid.
+      conjunction=GlobExpansionConjunction.all_match,
     )
   )
   return SourcesSnapshots([SourcesSnapshot(snapshot)])

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -710,16 +710,13 @@ async def sources_snapshots_from_filesystem_specs(
   filesystem_specs: FilesystemSpecs, glob_match_error_behavior: GlobMatchErrorBehavior,
 ) -> SourcesSnapshots:
   """Resolve the snapshot associated with the provided filesystem specs."""
-  snapshots = await MultiGet(
-    Get[Snapshot](
-      PathGlobs(
-        include=(fs_spec.glob,),
-        glob_match_error_behavior=glob_match_error_behavior,
-      )
+  snapshot = await Get[Snapshot](
+    PathGlobs(
+      include=(fs_spec.glob for fs_spec in filesystem_specs),
+      glob_match_error_behavior=glob_match_error_behavior,
     )
-    for fs_spec in filesystem_specs
   )
-  return SourcesSnapshots(SourcesSnapshot(snapshot) for snapshot in snapshots)
+  return SourcesSnapshots([SourcesSnapshot(snapshot)])
 
 
 def create_legacy_graph_tasks():


### PR DESCRIPTION
### Problem
Previously, these nonexistant filesystem specs would correctly warn:

```
./pants cloc2 src/fake.txt 'src/lies*.txt'
19:05:43 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["src/fake.txt", "src/lies*.txt"].
```

But, adding one valid spec meant that the warning would no longer trigger:

```
$ ./pants cloc2 src/fake.txt 'src/lies*.txt' src/python/pants/util/strutil.py
...cloc output...
```

This is unlike the `sources` field, where one invalid glob among many valid globs would still trigger a warning.

### Solution
Use `GlobExpansionConjunction.all_match` for the engine to validate this for us.

### Result

```
$ ./pants cloc2 src/fake.txt 'src/lies*.txt' src/python/pants/util/strutil.py
18:49:48 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["src/fake.txt", "src/lies*.txt"].
...cloc output...
```