### PR TITLE
Fix Outputting mixin for V2 goals

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -9,6 +9,16 @@ page(
 # TODO: Get rid of all these microtargets. The entire package should be one target,
 # or be split into multiple packages.
 
+python_tests(
+  name = 'tests',
+  dependencies = [
+    ':console',
+    ':goal',
+    ':rules',
+    'src/python/pants/testutil/engine:util',
+  ],
+)
+
 python_library(
   name = 'legacy_engine',
   sources = ['legacy_engine.py', 'round_engine.py', 'round_manager.py'],

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -131,7 +131,7 @@ class Outputting:
 
     The passed options instance will generally be the `Goal.Options` of an `Outputting` `Goal`.
     """
-    with self.output_sink(self, console) as output_sink:
+    with self.output_sink(console) as output_sink:
       yield lambda msg: output_sink.write(msg)
 
   @contextmanager

--- a/src/python/pants/engine/goal_test.py
+++ b/src/python/pants/engine/goal_test.py
@@ -1,14 +1,40 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.goal import Outputting
-from pants.testutil.engine.util import MockConsole
+from unittest.mock import Mock
+
+import pytest
+
+from pants.engine.console import Console
+from pants.engine.goal import Goal, GoalSubsystem, LineOriented
+from pants.engine.rules import goal_rule
+from pants.testutil.engine.util import MockConsole, run_rule
 
 
-def test_outputting_goal():
-  class DummyGoal(Outputting):
-    pass
+@pytest.mark.skip(
+  reason="Figure out how to create a GoalSubsystem for tests. We can't call global_instance()"
+)
+def test_line_oriented_goal() -> None:
 
-  console = MockConsole()
-  with DummyGoal.output(None, console) as output:
-    pass
+  class OutputtingGoalOptions(LineOriented, GoalSubsystem):
+    name = "dummy"
+
+  class OutputtingGoal(Goal):
+    subsystem_cls = OutputtingGoalOptions
+
+  @goal_rule
+  def output_rule(console: Console, options: OutputtingGoalOptions) -> OutputtingGoal:
+    with options.output(console) as write_stdout:
+      write_stdout("output...")
+    with options.line_oriented(console) as print_stdout:
+      print_stdout("line oriented")
+    return OutputtingGoal(0)
+
+  mock_console = MockConsole()
+  # TODO: how should we mock `GoalSubsystem`s passed to `run_rule`?
+  mock_options = Mock()
+  mock_options.output = OutputtingGoalOptions.output
+  mock_options.line_oriented = OutputtingGoalOptions.line_oriented
+  result: OutputtingGoal = run_rule(output_rule, rule_args=[mock_console, mock_options])
+  assert result.exit_code == 0
+  assert mock_console.stdout.getvalue() == "output...line oriented"


### PR DESCRIPTION
`GoalSubsystem`s that extend `Outputting`, rather than `LineOriented`, fail when calling `output()` due to too many positional args being passed to `output_sink()`.

This was not detected because every `GoalSubsystem` in Pants uses `LineOriented` instead of `Outputting` and the original tests never had an owning target so didn't ever run.