### PR TITLE
Describe the origin of failure when globs do not match

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -19,6 +19,7 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.rules.core.lint import LintResult
 
 
@@ -58,7 +59,11 @@ async def lint(
 
   config_path: Optional[str] = bandit.options.config
   config_snapshot = await Get[Snapshot](
-    PathGlobs(include=tuple([config_path] if config_path else []))
+    PathGlobs(
+      include=tuple([config_path] if config_path else []),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      description_of_origin="the option `--bandit-config`",
+    )
   )
   requirements_pex = await Get[Pex](
     CreatePex(

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -26,6 +26,7 @@ from pants.engine.isolated_process import (
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
 
@@ -48,7 +49,11 @@ class BlackSetup:
 async def setup_black(black: Black) -> BlackSetup:
   config_path: Optional[str] = black.options.config
   config_snapshot = await Get[Snapshot](
-    PathGlobs(include=tuple([config_path] if config_path else []))
+    PathGlobs(
+      include=tuple([config_path] if config_path else []),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      description_of_origin="the option `--black-config`",
+    )
   )
   requirements_pex = await Get[Pex](
     CreatePex(

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -19,6 +19,7 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.rules.core.lint import LintResult
 
 
@@ -58,7 +59,11 @@ async def lint(
 
   config_path: Optional[str] = flake8.options.config
   config_snapshot = await Get[Snapshot](
-    PathGlobs(include=tuple([config_path] if config_path else []))
+    PathGlobs(
+      include=tuple([config_path] if config_path else []),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      description_of_origin="the option `--flake8-config`",
+    )
   )
   requirements_pex = await Get[Pex](
     CreatePex(

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -24,6 +24,8 @@ from pants.engine.isolated_process import (
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
+from pants.option.custom_types import GlobExpansionConjunction
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
 
@@ -45,7 +47,14 @@ class IsortSetup:
 @rule
 async def setup_isort(isort: Isort) -> IsortSetup:
   config_path: Optional[List[str]] = isort.options.config
-  config_snapshot = await Get[Snapshot](PathGlobs(include=config_path or ()))
+  config_snapshot = await Get[Snapshot](
+    PathGlobs(
+      include=config_path or (),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      conjunction=GlobExpansionConjunction.all_match,
+      description_of_origin="the option `--isort-config`",
+    )
+  )
   requirements_pex = await Get[Pex](
     CreatePex(
       output_filename="isort.pex",

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -91,11 +91,21 @@ class PathGlobs:
     self.__post_init__()
 
   def __post_init__(self) -> None:
-    if not self.description_of_origin and self.glob_match_error_behavior != GlobMatchErrorBehavior.ignore:
-      raise ValueError(
-        "Please provide a `description_of_origin` so that the error message is more helpful to "
-        "users when their globs fail to match."
-      )
+    if self.glob_match_error_behavior == GlobMatchErrorBehavior.ignore:
+      if self.description_of_origin:
+        raise ValueError(
+          "You provided a `description_of_origin` value when `glob_match_error_behavior` is set to "
+          "`ignore`. The `ignore` value means that the engine will never generate an error when "
+          "the globs are generated, so `description_of_origin` won't end up ever being used. "
+          "Please either change `glob_match_error_behavior` to `warn` or `error`, or remove "
+          "`description_of_origin`."
+        )
+    else:
+      if not self.description_of_origin:
+        raise ValueError(
+          "Please provide a `description_of_origin` so that the error message is more helpful to "
+          "users when their globs fail to match."
+        )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -63,18 +63,31 @@ class PathGlobs:
   exclude: Tuple[str, ...]
   glob_match_error_behavior: GlobMatchErrorBehavior
   conjunction: GlobExpansionConjunction
+  description_of_origin: str
 
   def __init__(
     self,
     include: Iterable[str],
     exclude: Iterable[str] = (),
     glob_match_error_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.ignore,
-    conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match
+    conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match,
+    description_of_origin: Optional[str] = None,
   ) -> None:
+    """
+    :param include: globs to match, e.g. "foo.txt" or "**/*.txt"
+    :param exclude: globs to exclude, in the same style as the args to `include`
+    :param glob_match_error_behavior: whether to warn or error upon match failures
+    :param conjunction: whether all `include`s must match or only at least one must match
+    :param description_of_origin: a human-friendly description of where this PathGlobs request is
+                                  coming from, used to improve the error message for unmatched
+                                  globs. For example, this might be
+                                  "src/python/pants/util:strutil (line 84)".
+    """
     self.include = tuple(include)
     self.exclude = tuple(exclude)
     self.glob_match_error_behavior = glob_match_error_behavior
     self.conjunction = conjunction
+    self.description_of_origin = description_of_origin or ""
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -81,7 +81,7 @@ class PathGlobs:
     :param description_of_origin: a human-friendly description of where this PathGlobs request is
                                   coming from, used to improve the error message for unmatched
                                   globs. For example, this might be
-                                  "src/python/pants/util:strutil (line 84)".
+                                  "the option `--isort-config`".
     """
     self.include = tuple(include)
     self.exclude = tuple(exclude)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -88,6 +88,14 @@ class PathGlobs:
     self.glob_match_error_behavior = glob_match_error_behavior
     self.conjunction = conjunction
     self.description_of_origin = description_of_origin or ""
+    self.__post_init__()
+
+  def __post_init__(self) -> None:
+    if not self.description_of_origin and self.glob_match_error_behavior != GlobMatchErrorBehavior.ignore:
+      raise ValueError(
+        "Please provide a `description_of_origin` so that the error message is more helpful to "
+        "users when their globs fail to match."
+      )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -727,7 +727,7 @@ async def sources_snapshots_from_filesystem_specs(
       glob_match_error_behavior=glob_match_error_behavior,
       # We validate that _every_ filesystem spec is valid.
       conjunction=GlobExpansionConjunction.all_match,
-      description_of_origin="file specs",
+      description_of_origin="file arguments",
     )
   )
   return SourcesSnapshots([SourcesSnapshot(snapshot)])

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -632,16 +632,20 @@ async def hydrate_sources(
 ) -> HydratedField:
   """Given a SourcesField, request a Snapshot for its path_globs and create an EagerFilesetWithSpec.
   """
-  # TODO(#5864): merge the target's selection of --glob-expansion-failure (which doesn't exist yet)
-  # with the global default!
+  address = sources_field.address
   path_globs = dataclasses.replace(
-    sources_field.path_globs, glob_match_error_behavior=glob_match_error_behavior
+    sources_field.path_globs,
+    glob_match_error_behavior=glob_match_error_behavior,
+    # TODO(#9012): add line number referring to the sources field.
+    description_of_origin=(
+      f"{address.rel_path} for target {address.relative_spec}'s `{sources_field.arg}` field"
+    ),
   )
   snapshot = await Get[Snapshot](PathGlobs, path_globs)
   fileset_with_spec = _eager_fileset_with_spec(
-    sources_field.address.spec_path,
-    sources_field.filespecs,
-    snapshot,
+    spec_path=address.spec_path,
+    filespec=sources_field.filespecs,
+    snapshot=snapshot,
   )
   sources_field.validate_fn(fileset_with_spec)
   return HydratedField(sources_field.arg, fileset_with_spec)
@@ -652,20 +656,26 @@ async def hydrate_bundles(
   bundles_field: BundlesField, glob_match_error_behavior: GlobMatchErrorBehavior,
 ) -> HydratedField:
   """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
+  address = bundles_field.address
   path_globs_with_match_errors = [
-    dataclasses.replace(pg, glob_match_error_behavior=glob_match_error_behavior)
+    dataclasses.replace(
+      pg,
+      glob_match_error_behavior=glob_match_error_behavior,
+      # TODO(#9012): add line number referring to the bundles field.
+      description_of_origin=f"{address.rel_path} for target {address.relative_spec}'s `bundles` field",
+    )
     for pg in bundles_field.path_globs_list
   ]
-  snapshot_list = await MultiGet(Get[Snapshot](PathGlobs, pg) for pg in path_globs_with_match_errors)
-
-  spec_path = bundles_field.address.spec_path
+  snapshot_list = await MultiGet(
+    Get[Snapshot](PathGlobs, pg) for pg in path_globs_with_match_errors
+  )
 
   bundles = []
   zipped = zip(bundles_field.bundles,
                bundles_field.filespecs_list,
                snapshot_list)
   for bundle, filespecs, snapshot in zipped:
-    rel_spec_path = getattr(bundle, 'rel_path', spec_path)
+    rel_spec_path = getattr(bundle, 'rel_path', address.spec_path)
     kwargs = bundle.kwargs()
     # NB: We `include_dirs=True` because bundle filesets frequently specify directories in order
     # to trigger a (deprecated) default inclusion of their recursive contents. See the related
@@ -717,6 +727,7 @@ async def sources_snapshots_from_filesystem_specs(
       glob_match_error_behavior=glob_match_error_behavior,
       # We validate that _every_ filesystem spec is valid.
       conjunction=GlobExpansionConjunction.all_match,
+      description_of_origin="file specs",
     )
   )
   return SourcesSnapshots([SourcesSnapshot(snapshot)])

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -17,7 +17,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
 from pants.base.specs import AddressSpec, AddressSpecs, FilesystemSpecs, Specs
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
@@ -265,7 +265,9 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     self, package_relative_path_globs: List[str], package_dir: str = '',
   ) -> EagerFilesetWithSpec:
     sources_field = SourcesField(
-      address=Address.parse(f'{package_dir}:_bogus_target_for_test'),
+      address=BuildFileAddress(
+        rel_path=os.path.join(package_dir, "BUILD"), target_name="_bogus_target_for_test",
+      ),
       arg='sources',
       filespecs={'globs': package_relative_path_globs},
       base_globs=None,

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -457,6 +457,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
               // something here, or we don't care. Is that a valid assumption?
               fs::StrictGlobMatching::Ignore,
               fs::GlobExpansionConjunction::AllMatch,
+              "".to_string(),
             )?)
             .map_err(|e| format!("Error expanding globs: {:?}", e))
             .and_then(move |paths| {

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -453,11 +453,10 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
                 .map(str::to_string)
                 .collect::<Vec<String>>(),
               &[],
-              // By using `Ignore`, we assume all elements of the globs will definitely expand to
-              // something here, or we don't care. Is that a valid assumption?
+              // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
+              // that a valid assumption?
               fs::StrictGlobMatching::Ignore,
               fs::GlobExpansionConjunction::AllMatch,
-              "".to_string(),
             )?)
             .map_err(|e| format!("Error expanding globs: {:?}", e))
             .and_then(move |paths| {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -453,6 +453,7 @@ pub struct PathGlobs {
   exclude: Arc<GitignoreStyleExcludes>,
   strict_match_behavior: StrictGlobMatching,
   conjunction: GlobExpansionConjunction,
+  description_of_origin: String,
 }
 
 impl PathGlobs {
@@ -461,9 +462,16 @@ impl PathGlobs {
     exclude: &[String],
     strict_match_behavior: StrictGlobMatching,
     conjunction: GlobExpansionConjunction,
+    description_of_origin: String,
   ) -> Result<PathGlobs, String> {
     let include = PathGlob::spread_filespecs(include)?;
-    Self::create_with_globs_and_match_behavior(include, exclude, strict_match_behavior, conjunction)
+    Self::create_with_globs_and_match_behavior(
+      include,
+      exclude,
+      strict_match_behavior,
+      conjunction,
+      description_of_origin,
+    )
   }
 
   fn create_with_globs_and_match_behavior(
@@ -471,6 +479,7 @@ impl PathGlobs {
     exclude: &[String],
     strict_match_behavior: StrictGlobMatching,
     conjunction: GlobExpansionConjunction,
+    description_of_origin: String,
   ) -> Result<PathGlobs, String> {
     let gitignore_excludes = GitignoreStyleExcludes::create(exclude)?;
     Ok(PathGlobs {
@@ -478,10 +487,14 @@ impl PathGlobs {
       exclude: gitignore_excludes,
       strict_match_behavior,
       conjunction,
+      description_of_origin,
     })
   }
 
-  pub fn from_globs(include: Vec<PathGlob>) -> Result<PathGlobs, String> {
+  pub fn from_globs(
+    include: Vec<PathGlob>,
+    description_of_origin: String,
+  ) -> Result<PathGlobs, String> {
     let include = include
       .into_iter()
       .map(|glob| PathGlobIncludeEntry {
@@ -495,6 +508,7 @@ impl PathGlobs {
       &[],
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
+      description_of_origin,
     )
   }
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -432,7 +432,7 @@ impl StrictGlobMatching {
 
   pub fn should_throw_on_error(&self) -> bool {
     match self {
-      StrictGlobMatching::Error(_) => true,
+      &StrictGlobMatching::Error(_) => true,
       _ => false,
     }
   }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -80,6 +80,7 @@ impl CommandRunner {
       &[],
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
+      "".to_string(),
     ));
 
     posix_fs

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -75,12 +75,12 @@ impl CommandRunner {
       })
       .collect();
 
+    // TODO: should we error when globs fail?
     let output_globs = try_future!(PathGlobs::create(
       &try_future!(output_paths),
       &[],
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
-      "".to_string(),
     ));
 
     posix_fs

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -465,7 +465,7 @@ impl Snapshot {
     // and store::Snapshot::from_path_stats tracking dependencies for file digests.
     context
       .expand(path_globs)
-      .map_err(|e| format!("PathGlobs expansion failed: {}", e))
+      .map_err(|e| format!("{}", e))
       .and_then(move |path_stats| {
         store::Snapshot::from_path_stats(
           context.core.store(),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -483,25 +483,24 @@ impl Snapshot {
     let include = externs::project_multi_strs(item, "include");
     let exclude = externs::project_multi_strs(item, "exclude");
 
+    let origin = externs::project_str(item, "description_of_origin");
+    let description_of_origin = if origin.is_empty() {
+      None
+    } else {
+      Some(origin)
+    };
+
     let glob_match_error_behavior =
       externs::project_ignoring_type(item, "glob_match_error_behavior");
     let failure_behavior = externs::project_str(&glob_match_error_behavior, "value");
-    let strict_glob_matching = StrictGlobMatching::create(failure_behavior.as_str())?;
+    let strict_glob_matching =
+      StrictGlobMatching::create(failure_behavior.as_str(), description_of_origin)?;
 
     let conjunction_obj = externs::project_ignoring_type(item, "conjunction");
     let conjunction_string = externs::project_str(&conjunction_obj, "value");
     let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
 
-    let description_of_origin = externs::project_str(item, "description_of_origin");
-
-    PathGlobs::create(
-      &include,
-      &exclude,
-      strict_glob_matching,
-      conjunction,
-      description_of_origin,
-    )
-    .map_err(|e| {
+    PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {
       format!(
         "Failed to parse PathGlobs for include({:?}), exclude({:?}): {}",
         include, exclude, e

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -492,7 +492,16 @@ impl Snapshot {
     let conjunction_string = externs::project_str(&conjunction_obj, "value");
     let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
 
-    PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {
+    let description_of_origin = externs::project_str(item, "description_of_origin");
+
+    PathGlobs::create(
+      &include,
+      &exclude,
+      strict_glob_matching,
+      conjunction,
+      description_of_origin,
+    )
+    .map_err(|e| {
       format!(
         "Failed to parse PathGlobs for include({:?}), exclude({:?}): {}",
         include, exclude, e

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -33,12 +33,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
       "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.txt\', \'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
-      'Unmatched glob: "testprojects/src/python/sources/*.rs"',
+      'Unmatched glob from testprojects/src/python/sources/BUILD for target :some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
       "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.scala\',), exclude=(\'testprojects/src/python/sources/*Test.scala\', \'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
-      'Unmatched glob: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
+      'Unmatched glob from testprojects/src/python/sources/BUILD for target :missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
       "['a/b/file1.txt']",
@@ -47,7 +47,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
       "Snapshot(PathGlobs(include=(\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
-      'Unmatched glob: "testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"',
+      'Unmatched glob from testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD for target :missing-bundle-fileset\'s `bundles` field:: "testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"',
     ]
   }
 
@@ -123,6 +123,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       'missing-zglobs': ['**/*.a'],
       'missing-literal-files': ['another_nonexistent_file.txt', 'nonexistent_test_file.txt'],
     }
+    build_path = os.path.join(self._SOURCES_TARGET_BASE, "BUILD")
     with self.setup_sources_targets():
       for target in target_to_unmatched_globs:
         target_full = f'{self._SOURCES_TARGET_BASE}:{target}'
@@ -137,10 +138,11 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
           f'"{os.path.join(self._SOURCES_TARGET_BASE, glob)}"'
           for glob in unmatched_globs
         )
+        error_origin = f"from {build_path} for target :{target}'s `sources` field"
         if len(unmatched_globs) == 1:
-          assert f"[WARN] Unmatched glob: {formatted_globs}" in pants_run.stderr_data
+          assert f"[WARN] Unmatched glob {error_origin}: {formatted_globs}" in pants_run.stderr_data
         else:
-          assert f"[WARN] Unmatched globs: [{formatted_globs}]" in pants_run.stderr_data
+          assert f"[WARN] Unmatched globs {error_origin}: [{formatted_globs}]" in pants_run.stderr_data
 
   def test_existing_sources(self):
     target_full = f'{self._SOURCES_TARGET_BASE}:text'
@@ -150,10 +152,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(pants_run)
-    assert "[WARN] Unmatched glob:" not in pants_run.stderr_data
+    assert "[WARN] Unmatched glob" not in pants_run.stderr_data
 
   def test_missing_bundles_warnings(self):
     target_full = f'{self._BUNDLE_TARGET_BASE}:missing-bundle-fileset'
+    build_path = os.path.join(self._BUNDLE_TARGET_BASE, "BUILD")
+    error_origin = f"from {build_path} for target :missing-bundle-fileset's `bundles` field"
     with self.setup_bundle_target():
       pants_run = self.run_pants(['filedeps', target_full], config={
         GLOBAL_SCOPE_CONFIG_SECTION: {
@@ -164,12 +168,13 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     unmatched_glob = ["*.aaaa", "**/*.abab"]
     unmatched_globs = [["**/*.aaaa", "**/*.bbbb"], ["file1.aaaa", "file2.aaaa"]]
     for glob in unmatched_glob:
-      assert f'[WARN] Unmatched glob: "{os.path.join(self._BUNDLE_TARGET_BASE, glob)}"' in pants_run.stderr_data
+      formatted_glob = f'"{os.path.join(self._BUNDLE_TARGET_BASE, glob)}"'
+      assert f"[WARN] Unmatched glob {error_origin}: {formatted_glob}" in pants_run.stderr_data
     for globs in unmatched_globs:
       formatted_globs = ', '.join(
         f'"{os.path.join(self._BUNDLE_TARGET_BASE, glob)}"' for glob in globs
       )
-      assert f"[WARN] Unmatched globs: [{formatted_globs}]" in pants_run.stderr_data
+      assert f"[WARN] Unmatched globs {error_origin}: [{formatted_globs}]" in pants_run.stderr_data
 
   def test_existing_bundles(self):
     target_full = f'{self._BUNDLE_TARGET_BASE}:mapper'
@@ -179,7 +184,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(pants_run)
-    self.assertNotIn("Globs", pants_run.stderr_data)
+    self.assertNotIn("[WARN] Unmatched glob", pants_run.stderr_data)
 
   def test_existing_directory_with_no_build_files_fails(self):
     pants_run = self.run_pants(['list', f"{self._NO_BUILD_FILE_TARGET_BASE}::"])

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -477,34 +477,40 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       self.request_single_product(Snapshot, digest)
 
   def test_glob_match_error(self):
+    test_name = f"{__name__}.{self.test_glob_match_error.__name__}()"
     with self.assertRaises(ValueError) as cm:
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[],
         glob_match_error_behavior=GlobMatchErrorBehavior.error,
+        description_of_origin=test_name,
       ), [])
-    assert 'Unmatched glob: "not-a-file.txt"' in str(cm.exception)
+    assert f'Unmatched glob from {test_name}: "not-a-file.txt"' in str(cm.exception)
 
   def test_glob_match_error_with_exclude(self):
+    test_name = f"{__name__}.{self.test_glob_match_error_with_exclude.__name__}()"
     with self.assertRaises(ValueError) as cm:
       self.assert_walk_files(PathGlobs(
         include=['*.txt'],
         exclude=['4.txt'],
         glob_match_error_behavior=GlobMatchErrorBehavior.error,
+        description_of_origin=test_name,
       ), [])
-    assert 'Unmatched glob: "*.txt", exclude: "4.txt"' in str(cm.exception)
+    assert f'Unmatched glob from {test_name}: "*.txt", exclude: "4.txt"' in str(cm.exception)
 
   @unittest.skip('Skipped to expedite landing #5769: see #5863')
   def test_glob_match_warn_logging(self):
+    test_name = f"{__name__}.{self.test_glob_match_warn_logging.__name__}()"
     with self.captured_logging(logging.WARNING) as captured:
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[''],
         glob_match_error_behavior=GlobMatchErrorBehavior.warn,
+        description_of_origin=test_name,
       ), [])
       all_warnings = captured.warnings()
       assert len(all_warnings) == 1
-      assert 'Unmatched glob: "not-a-file.txt"' == str(all_warnings[0])
+      assert f'Unmatched glob from {test_name}: "not-a-file.txt"' == str(all_warnings[0])
 
   def test_glob_match_ignore_logging(self):
     with self.captured_logging(logging.WARNING) as captured:


### PR DESCRIPTION
### Before
```
▶ ./pants fmt2 ::
18:54:50 [WARN] Unmatched glob: "testprojects/src/java/org/pantsbuild/testproject/bundle/a/bad/*"
18:54:51 [WARN] Unmatched glob: "src/python/pants/util/fake.py"
```
(Also note, this does not complain about a bad `--isort-config='fake.cfg'` I added to `pants.ini` - we end up with a weird runtime exception from isort not being able to find `fake.cfg` in the chroot.)

### After
```
▶ ./pants fmt2 ::
18:57:08 [WARN] Unmatched glob from testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD for target :mapper's `bundles` field: "testprojects/src/java/org/pantsbuild/testproject/bundle/a/bad/*"
18:57:08 [WARN] Unmatched glob from src/python/pants/util/BUILD for target :strutil's `sources` field: "src/python/pants/util/fake.py"

ERROR: Unmatched glob from the option `--isort-config`: "fake.cfg"
```

```
▶ ./pants cloc2 src/fake.txt
18:57:49 [WARN] Unmatched glob from file arguments: "src/fake.txt"
```