### PR TITLE
Refactor `config.py` to allow supporting possible future config file formats

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -260,7 +260,7 @@ class _EmptyConfig(Config):
     return None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class _SingleFileConfig(Config):
   """Config read from a single file."""
   config_path: str

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -247,19 +247,19 @@ class OptionsBootstrapperTest(unittest.TestCase):
                                                                ScopeInfo('foo', ScopeInfo.TASK)])
       opts2 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo('foo', ScopeInfo.TASK),
                                                                ScopeInfo('', ScopeInfo.GLOBAL)])
-      self.assertIs(opts1, opts2)
+      assert opts1 is opts2
 
       opts3 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo('', ScopeInfo.GLOBAL),
                                                                ScopeInfo('foo', ScopeInfo.TASK),
                                                                ScopeInfo('', ScopeInfo.GLOBAL)])
-      self.assertIs(opts1, opts3)
+      assert opts1 is opts3
 
       opts4 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo('', ScopeInfo.GLOBAL)])
-      self.assertIsNot(opts1, opts4)
+      assert opts1 is not opts4
 
       opts5 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo('', ScopeInfo.GLOBAL)])
-      self.assertIs(opts4, opts5)
-      self.assertIsNot(opts1, opts5)
+      assert opts4 is opts5
+      assert opts1 is not opts5
 
   def test_bootstrap_short_options(self) -> None:
     def parse_options(*args: str) -> OptionValueContainer:


### PR DESCRIPTION
We already were going out of our way to encapsulate our config abstraction and decouple from `configparser`. Our `Config` API is very similar to `configparser`, but encapsulates the library and provides a limited API rather than allowing direct access to `configparser`.

The only place this encapsulation broke through was in `_SingleFileConfig`, where `options_bootstrapper.py` was directly calling methods on a `configparser.ConfigParser` instance, rather than relying on an interface provided by Pants.

This PR extends the prior encapsulation so that `config.py` is the only file ever interacting with the `configparser` module. Beyond better encapsulation, this gives us the possibility to add support for other config formats like TOML in the future.