### PR TITLE
Dirty the dependents of uncacheable nodes

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -118,9 +118,9 @@ class Scheduler:
   def _root_type_ids(self):
     return self._to_ids_buf(self._root_subject_types)
 
-  def graph_trace(self, execution_request):
+  def graph_trace(self, session, execution_request):
     with temporary_file_path() as path:
-      self._native.lib.graph_trace(self._scheduler, execution_request, path.encode())
+      self._native.lib.graph_trace(self._scheduler, session, execution_request, path.encode())
       with open(path, 'r') as fd:
         for line in fd.readlines():
           yield line.rstrip()
@@ -302,8 +302,8 @@ class Scheduler:
                            '`self._native._peek_cffi_extern_method_runtime_exceptions()`.')
     return roots
 
-  def lease_files_in_graph(self):
-    self._native.lib.lease_files_in_graph(self._scheduler)
+  def lease_files_in_graph(self, session):
+    self._native.lib.lease_files_in_graph(self._scheduler, session)
 
   def garbage_collect_store(self):
     self._native.lib.garbage_collect_store(self._scheduler)
@@ -350,7 +350,7 @@ class SchedulerSession:
 
   def trace(self, execution_request):
     """Yields a stringified 'stacktrace' starting from the scheduler's roots."""
-    for line in self._scheduler.graph_trace(execution_request.native):
+    for line in self._scheduler.graph_trace(self._session, execution_request.native):
       yield line
 
   def visualize_graph_to_file(self, filename):
@@ -613,7 +613,7 @@ class SchedulerSession:
     return result
 
   def lease_files_in_graph(self):
-    self._scheduler.lease_files_in_graph()
+    self._scheduler.lease_files_in_graph(self._session)
 
   def garbage_collect_store(self):
     self._scheduler.garbage_collect_store()

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -409,7 +409,7 @@ impl<N: Node> Entry<N> {
     result_run_token: RunToken,
     dep_generations: Vec<Generation>,
     result: Option<Result<N::Item, N::Error>>,
-    complete_as_dirty: bool,
+    has_dirty_dependencies: bool,
     _graph: &mut super::InnerGraph<N>,
   ) {
     let mut state = self.state.lock();
@@ -475,7 +475,7 @@ impl<N: Node> Entry<N> {
           let (generation, next_result) = if let Some(result) = result {
             let next_result = if !self.node.cacheable(context) {
               EntryResult::Uncacheable(result, context.session_id().clone())
-            } else if complete_as_dirty {
+            } else if has_dirty_dependencies {
               EntryResult::Dirty(result)
             } else {
               EntryResult::Clean(result)
@@ -491,7 +491,7 @@ impl<N: Node> Entry<N> {
             // NB: The `expect` here avoids a clone and a comparison: see the method docs.
             let mut result =
               previous_result.expect("A Node cannot be marked clean without a previous result.");
-            if complete_as_dirty {
+            if has_dirty_dependencies {
               result.dirty();
             } else {
               result.clean();

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -194,18 +194,15 @@ impl<N: Node> Entry<N> {
   /// Spawn the execution of the node on an Executor, which will cause it to execute outside of
   /// the Graph lock and call back into the graph lock to set the final value.
   ///
-  pub(crate) fn run<C>(
-    context_factory: &C,
+  pub(crate) fn run(
+    context_factory: &N::Context,
     node: &N,
     entry_id: EntryId,
     run_token: RunToken,
     generation: Generation,
     previous_dep_generations: Option<Vec<Generation>>,
     previous_result: Option<EntryResult<N>>,
-  ) -> EntryState<N>
-  where
-    C: NodeContext<Node = N>,
-  {
+  ) -> EntryState<N> {
     // Increment the RunToken to uniquely identify this work.
     let run_token = run_token.next();
     let context = context_factory.clone_for(entry_id);
@@ -280,14 +277,11 @@ impl<N: Node> Entry<N> {
   /// need to consume the state (which avoids cloning some of the values held there), so we take it
   /// by value.
   ///
-  pub(crate) fn get<C>(
+  pub(crate) fn get(
     &mut self,
-    context: &C,
+    context: &N::Context,
     entry_id: EntryId,
-  ) -> BoxFuture<(N::Item, Generation), N::Error>
-  where
-    C: NodeContext<Node = N>,
-  {
+  ) -> BoxFuture<(N::Item, Generation), N::Error> {
     {
       let mut state = self.state.lock();
 
@@ -400,17 +394,15 @@ impl<N: Node> Entry<N> {
   /// complete _while_ a batch of nodes are being marked as dirty, and this exclusive access ensures
   /// that can't happen.
   ///
-  pub(crate) fn complete<C>(
+  pub(crate) fn complete(
     &mut self,
-    context: &C,
+    context: &N::Context,
     entry_id: EntryId,
     result_run_token: RunToken,
     dep_generations: Vec<Generation>,
     result: Option<Result<N::Item, N::Error>>,
     _graph: &mut super::InnerGraph<N>,
-  ) where
-    C: NodeContext<Node = N>,
-  {
+  ) {
     let mut state = self.state.lock();
 
     // We care about exactly one case: a Running state with the same run_token. All other states

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -889,9 +889,9 @@ impl<N: Node> Graph<N> {
     run_token: RunToken,
     result: Option<Result<N::Item, N::Error>>,
   ) {
-    let (entry, complete_as_dirty, dep_generations) = {
+    let (entry, has_dirty_dependencies, dep_generations) = {
       let inner = self.inner.lock();
-      let mut complete_as_dirty = false;
+      let mut has_dirty_dependencies = false;
       // Get the Generations of all dependencies of the Node. We can trust that these have not changed
       // since we began executing, as long as we are not currently marked dirty (see the method doc).
       let dep_generations = inner
@@ -903,14 +903,14 @@ impl<N: Node> Graph<N> {
           // independent of matching Generation values. This is to allow for the behaviour that an
           // uncacheable Node should always have dirty dependents, transitively.
           if !entry.node().cacheable(context) || !entry.is_clean(context) {
-            complete_as_dirty = true;
+            has_dirty_dependencies = true;
           }
           entry.generation()
         })
         .collect();
       (
         inner.entry_for_id(entry_id).cloned(),
-        complete_as_dirty,
+        has_dirty_dependencies,
         dep_generations,
       )
     };
@@ -922,7 +922,7 @@ impl<N: Node> Graph<N> {
         run_token,
         dep_generations,
         result,
-        complete_as_dirty,
+        has_dirty_dependencies,
         &mut inner,
       );
     }

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -74,7 +74,7 @@ pub trait NodeVisualizer<N: Node> {
   ///
   /// Returns a GraphViz color name/id within Self::color_scheme for the given Entry.
   ///
-  fn color(&mut self, entry: &Entry<N>) -> String;
+  fn color(&mut self, entry: &Entry<N>, context: &N::Context) -> String;
 }
 
 ///

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -37,7 +37,7 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   ///
   /// If the node result is cacheable, return true.
   ///
-  fn cacheable(&self) -> bool;
+  fn cacheable(&self, context: &Self::Context) -> bool;
 
   /// Nodes optionally have a user-facing name (distinct from their Debug and Display
   /// implementations). This user-facing name is intended to provide high-level information
@@ -107,11 +107,24 @@ pub trait NodeContext: Clone + Send + 'static {
   type Node: Node;
 
   ///
+  /// The Session ID type for this Context. Some Node behaviours (in particular: Node::cacheable)
+  /// have Session-specific semantics. More than one context object might be associated with a
+  /// single caller "session".
+  ///
+  type SessionId: Clone + Debug + Eq;
+
+  ///
   /// Creates a clone of this NodeContext to be used for a different Node.
   ///
   /// To clone a Context for use for the same Node, `Clone` is used directly.
   ///
   fn clone_for(&self, entry_id: EntryId) -> <Self::Node as Node>::Context;
+
+  ///
+  /// Returns the SessionId for this Context, which should uniquely identify a caller's run for the
+  /// purposes of "once per Session" behaviour.
+  ///
+  fn session_id(&self) -> &Self::SessionId;
 
   ///
   /// Returns a reference to the Graph for this Context.

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{EntryId, Graph, InvalidationResult, Node, NodeContext, NodeError};
 #[test]
 fn create() {
   let graph = Arc::new(Graph::new());
-  let context = TContext::new(0, graph.clone());
+  let context = TContext::new(graph.clone());
   assert_eq!(
     graph.create(TNode(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
@@ -29,7 +29,7 @@ fn create() {
 #[test]
 fn invalidate_and_clean() {
   let graph = Arc::new(Graph::new());
-  let context = TContext::new(0, graph.clone());
+  let context = TContext::new(graph.clone());
 
   // Create three nodes.
   assert_eq!(
@@ -58,14 +58,14 @@ fn invalidate_and_clean() {
 #[test]
 fn invalidate_and_rerun() {
   let graph = Arc::new(Graph::new());
-  let context0 = TContext::new(0, graph.clone());
+  let context = TContext::new(graph.clone());
 
   // Create three nodes.
   assert_eq!(
-    graph.create(TNode(2), &context0).wait(),
+    graph.create(TNode(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context0.runs(), vec![TNode(2), TNode(1), TNode(0)]);
+  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0)]);
 
   // Clear the middle Node, which dirties the upper node.
   assert_eq!(
@@ -76,20 +76,20 @@ fn invalidate_and_rerun() {
     }
   );
 
-  // Request with a new context, which will cause both the middle and upper nodes to rerun since
+  // Request with a different salt, which will cause both the middle and upper nodes to rerun since
   // their input values have changed.
-  let context1 = TContext::new(1, graph.clone());
+  let context = context.new_session(1).with_salt(1);
   assert_eq!(
-    graph.create(TNode(2), &context1).wait(),
+    graph.create(TNode(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 1), T(2, 1)])
   );
-  assert_eq!(context1.runs(), vec![TNode(1), TNode(2)]);
+  assert_eq!(context.runs(), vec![TNode(1), TNode(2)]);
 }
 
 #[test]
 fn invalidate_with_changed_dependencies() {
   let graph = Arc::new(Graph::new());
-  let context = TContext::new(0, graph.clone());
+  let context = TContext::new(graph.clone());
 
   // Create three nodes.
   assert_eq!(
@@ -107,11 +107,8 @@ fn invalidate_with_changed_dependencies() {
   );
 
   // Request with a new context that truncates execution at the middle Node.
-  let context = TContext::new_with_dependencies(
-    0,
-    vec![(TNode(1), None)].into_iter().collect(),
-    graph.clone(),
-  );
+  let context =
+    TContext::new(graph.clone()).with_dependencies(vec![(TNode(1), None)].into_iter().collect());
   assert_eq!(
     graph.create(TNode(2), &context).wait(),
     Ok(vec![T(1, 0), T(2, 0)])
@@ -160,7 +157,7 @@ fn invalidate_randomly() {
   let mut iterations = 0;
   let mut max_distinct_context_values = 0;
   loop {
-    let context = TContext::new(iterations, graph.clone());
+    let context = TContext::new(graph.clone()).with_salt(iterations);
 
     // Compute the root, and validate its output.
     let node_output = match graph.create(TNode(range), &context).wait() {
@@ -195,6 +192,42 @@ fn invalidate_randomly() {
 }
 
 #[test]
+fn dirty_dependents_of_uncacheable_node() {
+  let graph = Arc::new(Graph::new());
+
+  // Create a context for which the bottommost Node is not cacheable.
+  let context = {
+    let mut uncacheable = HashSet::new();
+    uncacheable.insert(TNode(0));
+    TContext::new(graph.clone()).with_uncacheable(uncacheable)
+  };
+
+  // Create three nodes.
+  assert_eq!(
+    graph.create(TNode(2), &context).wait(),
+    Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
+  );
+  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0)]);
+
+  // Re-request the root in a new session and confirm that only the bottom node re-runs.
+  let context = context.new_session(1);
+  assert_eq!(
+    graph.create(TNode(2), &context).wait(),
+    Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
+  );
+  assert_eq!(context.runs(), vec![TNode(0)]);
+
+  // Re-request with a new session and different salt, and confirm that everything re-runs bottom
+  // up (the order of node cleaning).
+  let context = context.new_session(2).with_salt(1);
+  assert_eq!(
+    graph.create(TNode(2), &context).wait(),
+    Ok(vec![T(0, 1), T(1, 1), T(2, 1)])
+  );
+  assert_eq!(context.runs(), vec![TNode(0), TNode(1), TNode(2)]);
+}
+
+#[test]
 fn drain_and_resume() {
   // Confirms that after draining a Graph that has running work, we are able to resume the work
   // and have it complete successfully.
@@ -208,7 +241,7 @@ fn drain_and_resume() {
   let context = {
     let mut delays = HashMap::new();
     delays.insert(TNode(1), delay_in_task);
-    TContext::new_with_delays(0, delays, graph.clone())
+    TContext::new(graph.clone()).with_delays(delays)
   };
 
   // Spawn a background thread that will mark the Graph draining after a short delay.
@@ -243,11 +276,9 @@ fn cyclic_failure() {
   // Confirms that an attempt to create a cycle fails.
   let graph = Arc::new(Graph::new());
   let top = TNode(2);
-  let context = TContext::new_with_dependencies(
-    0,
+  let context = TContext::new(graph.clone()).with_dependencies(
     // Request creation of a cycle by sending the bottom most node to the top.
     vec![(TNode(0), Some(top))].into_iter().collect(),
-    graph.clone(),
   );
 
   assert_eq!(graph.create(TNode(2), &context).wait(), Err(TError::Cyclic));
@@ -262,7 +293,7 @@ fn cyclic_dirtying() {
   let initial_bot = TNode(0);
 
   // Request with a context that creates a path downward.
-  let context_down = TContext::new(0, graph.clone());
+  let context_down = TContext::new(graph.clone());
   assert_eq!(
     graph.create(initial_top.clone(), &context_down).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
@@ -270,13 +301,11 @@ fn cyclic_dirtying() {
 
   // Clear the bottom node, and then clean it with a context that causes the path to reverse.
   graph.invalidate_from_roots(|n| n == &initial_bot);
-  let context_up = TContext::new_with_dependencies(
-    1,
+  let context_up = context_down.with_salt(1).with_dependencies(
     // Reverse the path from bottom to top.
     vec![(TNode(1), None), (TNode(0), Some(TNode(1)))]
       .into_iter()
       .collect(),
-    graph.clone(),
   );
 
   let res = graph.create(initial_bot, &context_up).wait();
@@ -407,7 +436,7 @@ impl Node for TNode {
 
   fn run(self, context: TContext) -> BoxFuture<Vec<T>, TError> {
     context.ran(self.clone());
-    let token = T(self.0, context.id());
+    let token = T(self.0, context.salt());
     if let Some(dep) = context.dependency_of(&self) {
       context.maybe_delay(&self);
       context
@@ -426,8 +455,8 @@ impl Node for TNode {
     None
   }
 
-  fn cacheable(&self) -> bool {
-    true
+  fn cacheable(&self, context: &Self::Context) -> bool {
+    !context.uncacheable.contains(self)
   }
 }
 
@@ -489,28 +518,41 @@ impl TNode {
 ///
 #[derive(Clone)]
 struct TContext {
-  id: usize,
+  session_id: usize,
+  // A value that is included in every value computed by this context. Stands in for "the state of the
+  // outside world". A test that wants to "change the outside world" and observe its effect on the
+  // graph should change the salt to do so.
+  salt: usize,
   // A mapping from source to optional destination that drives what values each TNode depends on.
   // If there is no entry in this map for a node, then TNode::run will default to requesting
   // the next smallest node. Finally, if a None entry is present, a node will have no
   // dependencies.
   edges: Arc<HashMap<TNode, Option<TNode>>>,
-  delays: HashMap<TNode, Duration>,
+  delays: Arc<HashMap<TNode, Duration>>,
+  uncacheable: Arc<HashSet<TNode>>,
   graph: Arc<Graph<TNode>>,
   runs: Arc<Mutex<Vec<TNode>>>,
   entry_id: Option<EntryId>,
 }
 impl NodeContext for TContext {
   type Node = TNode;
+  type SessionId = usize;
+
   fn clone_for(&self, entry_id: EntryId) -> TContext {
     TContext {
-      id: self.id,
+      session_id: self.session_id,
+      salt: self.salt,
       edges: self.edges.clone(),
       delays: self.delays.clone(),
+      uncacheable: self.uncacheable.clone(),
       graph: self.graph.clone(),
       runs: self.runs.clone(),
       entry_id: Some(entry_id),
     }
+  }
+
+  fn session_id(&self) -> &usize {
+    &self.session_id
   }
 
   fn graph(&self) -> &Graph<TNode> {
@@ -529,49 +571,50 @@ impl NodeContext for TContext {
 }
 
 impl TContext {
-  fn new(id: usize, graph: Arc<Graph<TNode>>) -> TContext {
+  fn new(graph: Arc<Graph<TNode>>) -> TContext {
     TContext {
-      id,
+      session_id: 0,
+      salt: 0,
       edges: Arc::default(),
-      delays: HashMap::default(),
+      delays: Arc::default(),
+      uncacheable: Arc::default(),
       graph,
       runs: Arc::new(Mutex::new(Vec::new())),
       entry_id: None,
     }
   }
 
-  fn new_with_dependencies(
-    id: usize,
-    edges: HashMap<TNode, Option<TNode>>,
-    graph: Arc<Graph<TNode>>,
-  ) -> TContext {
-    TContext {
-      id,
-      edges: Arc::new(edges),
-      delays: HashMap::default(),
-      graph,
-      runs: Arc::new(Mutex::new(Vec::new())),
-      entry_id: None,
-    }
+  fn with_dependencies(mut self, edges: HashMap<TNode, Option<TNode>>) -> TContext {
+    self.edges = Arc::new(edges);
+    self
   }
 
-  fn new_with_delays(
-    id: usize,
-    delays: HashMap<TNode, Duration>,
-    graph: Arc<Graph<TNode>>,
-  ) -> TContext {
-    TContext {
-      id,
-      edges: Arc::default(),
-      delays,
-      graph,
-      runs: Arc::new(Mutex::new(Vec::new())),
-      entry_id: None,
-    }
+  fn with_delays(mut self, delays: HashMap<TNode, Duration>) -> TContext {
+    self.delays = Arc::new(delays);
+    self
   }
 
-  fn id(&self) -> usize {
-    self.id
+  fn with_uncacheable(mut self, uncacheable: HashSet<TNode>) -> TContext {
+    self.uncacheable = Arc::new(uncacheable);
+    self
+  }
+
+  fn with_salt(mut self, salt: usize) -> TContext {
+    self.salt = salt;
+    self
+  }
+
+  fn new_session(mut self, new_session_id: usize) -> TContext {
+    self.session_id = new_session_id;
+    {
+      let mut runs = self.runs.lock();
+      runs.clear();
+    }
+    self
+  }
+
+  fn salt(&self) -> usize {
+    self.salt
   }
 
   fn get(&self, dst: TNode) -> BoxFuture<Vec<T>, TError> {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -283,6 +283,7 @@ impl Context {
 
 impl NodeContext for Context {
   type Node = NodeKey;
+  type SessionId = String;
 
   ///
   /// Clones this Context for a new EntryId. Because the Core of the context is an Arc, this
@@ -294,6 +295,10 @@ impl NodeContext for Context {
       core: self.core.clone(),
       session: self.session.clone(),
     }
+  }
+
+  fn session_id(&self) -> &Self::SessionId {
+    self.session.build_id()
   }
 
   fn graph(&self) -> &Graph<NodeKey> {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -246,17 +246,17 @@ impl Core {
 
 #[derive(Clone)]
 pub struct Context {
-  pub entry_id: EntryId,
+  entry_id: Option<EntryId>,
   pub core: Arc<Core>,
   pub session: Session,
 }
 
 impl Context {
-  pub fn new(entry_id: EntryId, core: Arc<Core>, session: Session) -> Context {
+  pub fn new(core: Arc<Core>, session: Session) -> Context {
     Context {
-      entry_id: entry_id,
-      core: core,
-      session: session,
+      entry_id: None,
+      core,
+      session,
     }
   }
 
@@ -266,10 +266,12 @@ impl Context {
   pub fn get<N: WrappedNode>(&self, node: N) -> BoxFuture<N::Item, Failure> {
     // TODO: Odd place for this... could do it periodically in the background?
     maybe_drop_handles();
-    self
-      .core
-      .graph
-      .get(self.entry_id, self, node.into())
+    let result = if let Some(entry_id) = self.entry_id {
+      self.core.graph.get(entry_id, self, node.into()).to_boxed()
+    } else {
+      self.core.graph.create(node.into(), self).to_boxed()
+    };
+    result
       .map(|node_result| {
         node_result
           .try_into()
@@ -288,7 +290,7 @@ impl NodeContext for Context {
   ///
   fn clone_for(&self, entry_id: EntryId) -> Context {
     Context {
-      entry_id: entry_id,
+      entry_id: Some(entry_id),
       core: self.core.clone(),
       session: self.session.clone(),
     }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -923,9 +923,9 @@ impl NodeVisualizer<NodeKey> for Visualizer {
     "set312"
   }
 
-  fn color(&mut self, entry: &Entry<NodeKey>) -> String {
+  fn color(&mut self, entry: &Entry<NodeKey>, context: &<NodeKey as Node>::Context) -> String {
     let max_colors = 12;
-    match entry.peek() {
+    match entry.peek(context) {
       None => "white".to_string(),
       Some(Err(Failure::Throw(..))) => "4".to_string(),
       Some(Err(Failure::Invalidated)) => "12".to_string(),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1087,11 +1087,9 @@ impl Node for NodeKey {
     }
   }
 
-  fn cacheable(&self) -> bool {
+  fn cacheable(&self, _context: &Self::Context) -> bool {
     match self {
       &NodeKey::Task(ref s) => s.task.cacheable,
-      // TODO Select nodes are made uncacheable as a workaround to #6146. Will be worked on in #6598
-      &NodeKey::Select(_) => false,
       _ => true,
     }
   }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -44,6 +44,7 @@ struct InnerSession {
   should_record_zipkin_spans: bool,
   // A place to store info about workunits in rust part
   workunit_store: WorkUnitStore,
+  // The unique id for this run. Used as the id of the session, and for metrics gathering purposes.
   build_id: String,
   should_report_workunits: bool,
 }
@@ -110,7 +111,7 @@ impl Session {
     self.0.workunit_store.clone()
   }
 
-  pub fn build_id(&self) -> &str {
+  pub fn build_id(&self) -> &String {
     &self.0.build_id
   }
 


### PR DESCRIPTION
### Problem

The rust level `Node::cacheable` flag is currently only used to mark `@goal_rule`s as uncacheable (because they are allowed to operate on `@sideeffecting` types, such as the `Console` and the `Workspace`). But since the implementation of `cacheable` did not allow it to operate deeply in the Graph, we additionally needed to mark their parent `Select` nodes uncacheable, and could not use the flag in more positions.

Via #7350, #8495, #8347, and #8974, it has become clear that we would like to safely allow nodes deeper in the graph to be uncacheable, as this allows for the re-execution of non-deterministic processes, or re-consumption of un-trackable state, such as:
1. a process receiving stdin from a user
2. an intrinsic rule that pokes an un-watched file on the filesystem
3. reading from a stateful process like git

Note that these would all be intrinsic Nodes: it's not clear that we want to expose this facility to `@rule`s directly.

### Solution

Finish adding support for uncacheable nodes. Fixes #6598.

When an uncacheable node completes, it will now keep the value it completed with (in order to correctly compute a `Generation` value), but it will re-compute the value once per `Session`. The accurate `Generation` value for the uncacheable node allows its dependents to "clean" themselves and not re-run unless the uncacheable node produced a different value than it had before. 

### Result

The `Node::cacheable` flag may be safely used deeper in the graph, with the semantics that requests for any of an uncacheable node's dependents will cause it to re-run once per `Session`. The dependents will not re-run unless the value of the uncacheable node changes (regardless of the `Session`).