### PR TITLE
First usage of async-await

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -52,11 +52,10 @@ dependencies = [
 name = "async_semaphore"
 version = "0.0.1"
 dependencies = [
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -228,6 +227,11 @@ dependencies = [
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytesize"
@@ -888,12 +892,95 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-executor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1789,6 +1876,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1893,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ppv-lite86"
 version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1828,6 +1940,7 @@ dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
  "hashing 0.0.1",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2811,6 +2924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +2999,15 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3498,6 +3631,7 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cargo 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7e90b5f23ae79af3ec0e4dc670349167fd47d6c1134f139cf0627817a4792bf"
@@ -3555,7 +3689,16 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
+"checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+"checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
+"checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
+"checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
+"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum fwdansi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34dd4c507af68d37ffef962063dfa1944ce0dd4d5b82043dbab1dabe088610c3"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -3643,8 +3786,12 @@ dependencies = [
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
+"checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f36c478cd43382388dfc3a3679af175c03d19ed8039e79a3e4447e944cd3f3"
@@ -3738,6 +3885,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
+"checksum tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
@@ -3745,6 +3893,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 "checksum tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
 "checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -86,7 +86,7 @@ bytes = "0.4.5"
 concrete_time = { path = "concrete_time" }
 fnv = "1.0.5"
 fs = { path = "fs" }
-futures = "0.1.27"
+futures01 = { package = "futures", version = "0.1" }
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"

--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -6,11 +6,9 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-futures = "^0.1.16"
+futures = "0.3"
 log = "0.4"
 parking_lot = "0.6"
 
-
 [dev-dependencies]
-tokio-timer = "0.2"
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-core", "macros", "time"] }

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -99,7 +99,7 @@ impl Drop for Permit {
     let mut inner = self.inner.lock();
     inner.available_permits += 1;
     if let Some(waiter) = inner.waiters.front() {
-      waiter.waker.clone().wake()
+      waiter.waker.wake_by_ref()
     }
   }
 }

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -27,16 +27,16 @@
 #![allow(clippy::mutex_atomic)]
 
 use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 
-use futures::future::Future;
-use futures::task::{self, Task};
-use futures::{Async, Poll};
 use parking_lot::Mutex;
 
 struct Waiter {
   id: usize,
-  task: Task,
+  waker: Waker,
 }
 
 struct Inner {
@@ -71,22 +71,15 @@ impl AsyncSemaphore {
   ///
   /// Runs the given Future-creating function (and the Future it returns) under the semaphore.
   ///
-  pub fn with_acquired<F, B, T, E>(&self, f: F) -> Box<dyn Future<Item = T, Error = E> + Send>
+  pub async fn with_acquired<F, B, O>(self, f: F) -> O
   where
     F: FnOnce() -> B + Send + 'static,
-    B: Future<Item = T, Error = E> + Send + 'static,
+    B: Future<Output = O> + Send + 'static,
   {
-    Box::new(
-      self
-        .acquire()
-        .map_err(|()| panic!("Acquisition is infalliable."))
-        .and_then(|permit| {
-          f().map(move |t| {
-            drop(permit);
-            t
-          })
-        }),
-    )
+    let permit = self.acquire().await;
+    let res = f().await;
+    drop(permit);
+    res
   }
 
   fn acquire(&self) -> PermitFuture {
@@ -106,7 +99,7 @@ impl Drop for Permit {
     let mut inner = self.inner.lock();
     inner.available_permits += 1;
     if let Some(waiter) = inner.waiters.front() {
-      waiter.task.notify()
+      waiter.waker.clone().wake()
     }
   }
 }
@@ -134,10 +127,9 @@ impl Drop for PermitFuture {
 }
 
 impl Future for PermitFuture {
-  type Item = Permit;
-  type Error = ();
+  type Output = Permit;
 
-  fn poll(&mut self) -> Poll<Permit, ()> {
+  fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     let inner = self.inner.clone();
     let acquired = {
       let mut inner = inner.lock();
@@ -145,7 +137,7 @@ impl Future for PermitFuture {
         let waiter_id = inner.next_waiter_id;
         let this_waiter = Waiter {
           id: waiter_id,
-          task: task::current(),
+          waker: cx.waker().clone(),
         };
         self.waiter_id = Some(waiter_id);
         inner.next_waiter_id += 1;
@@ -181,9 +173,9 @@ impl Future for PermitFuture {
       }
     };
     if acquired {
-      Ok(Async::Ready(Permit { inner }))
+      Poll::Ready(Permit { inner })
     } else {
-      Ok(Async::NotReady)
+      Poll::Pending
     }
   }
 }

--- a/src/rust/engine/async_semaphore/src/tests.rs
+++ b/src/rust/engine/async_semaphore/src/tests.rs
@@ -12,7 +12,7 @@ use tokio::time::{delay_for, timeout};
 async fn acquire_and_release() {
   let sema = AsyncSemaphore::new(1);
 
-  sema.with_acquired(|| future::ready::<()>(())).await;
+  sema.with_acquired(|| future::ready(())).await;
 }
 
 #[tokio::test]
@@ -41,7 +41,7 @@ async fn at_most_n_acquisitions() {
 
   tokio::spawn(handle2.with_acquired(move || {
     tx_thread2.send(()).unwrap();
-    future::ok::<_, ()>(())
+    future::ready(())
   }));
 
   // thread2 should not signal until we unblock thread1.

--- a/src/rust/engine/async_semaphore/src/tests.rs
+++ b/src/rust/engine/async_semaphore/src/tests.rs
@@ -1,73 +1,67 @@
 use crate::AsyncSemaphore;
-use futures::{future, Future};
-use std::sync::mpsc;
-use std::thread;
-use std::time::{Duration, Instant};
 
-use tokio_timer::Delay;
+use std::time::Duration;
 
-#[test]
-fn acquire_and_release() {
+use futures::channel::oneshot;
+use futures::future::{self, FutureExt};
+
+use tokio;
+use tokio::time::{delay_for, timeout};
+
+#[tokio::test]
+async fn acquire_and_release() {
   let sema = AsyncSemaphore::new(1);
 
-  sema
-    .with_acquired(|| future::ok::<_, ()>(()))
-    .wait()
-    .unwrap();
+  sema.with_acquired(|| future::ready::<()>(())).await;
 }
 
-#[test]
-fn at_most_n_acquisitions() {
+#[tokio::test]
+async fn at_most_n_acquisitions() {
   let sema = AsyncSemaphore::new(1);
   let handle1 = sema.clone();
   let handle2 = sema.clone();
 
-  let (tx_thread1, acquired_thread1) = mpsc::channel();
-  let (unblock_thread1, rx_thread1) = mpsc::channel();
-  let (tx_thread2, acquired_thread2) = mpsc::channel();
+  let (tx_thread1, acquired_thread1) = oneshot::channel();
+  let (unblock_thread1, rx_thread1) = oneshot::channel();
+  let (tx_thread2, acquired_thread2) = oneshot::channel();
 
-  thread::spawn(move || {
-    handle1
-      .with_acquired(move || {
-        // Indicate that we've acquired, and then wait to be signaled to exit.
-        tx_thread1.send(()).unwrap();
-        rx_thread1.recv().unwrap();
-        future::ok::<_, ()>(())
-      })
-      .wait()
-      .unwrap();
-  });
+  tokio::spawn(handle1.with_acquired(move || {
+    async {
+      // Indicate that we've acquired, and then wait to be signaled to exit.
+      tx_thread1.send(()).unwrap();
+      rx_thread1.await.unwrap();
+      future::ready(())
+    }
+  }));
 
   // Wait for thread1 to acquire, and then launch thread2.
-  acquired_thread1
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread1 didn't acquire.");
+  if let Err(_) = timeout(Duration::from_secs(5), acquired_thread1).await {
+    panic!("thread1 didn't acquire.");
+  }
 
-  thread::spawn(move || {
-    handle2
-      .with_acquired(move || {
-        tx_thread2.send(()).unwrap();
-        future::ok::<_, ()>(())
-      })
-      .wait()
-      .unwrap();
-  });
+  tokio::spawn(handle2.with_acquired(move || {
+    tx_thread2.send(()).unwrap();
+    future::ok::<_, ()>(())
+  }));
 
   // thread2 should not signal until we unblock thread1.
-  match acquired_thread2.recv_timeout(Duration::from_millis(100)) {
-    Err(_) => (),
-    Ok(_) => panic!("thread2 should not have acquired while thread1 was holding."),
-  }
+  let acquired_thread2 =
+    match future::select(delay_for(Duration::from_millis(100)), acquired_thread2).await {
+      future::Either::Left((_, acquired_thread2)) => acquired_thread2,
+      future::Either::Right(_) => {
+        panic!("thread2 should not have acquired while thread1 was holding.")
+      }
+    };
 
   // Unblock thread1 and confirm that thread2 acquires.
   unblock_thread1.send(()).unwrap();
-  acquired_thread2
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread2 didn't acquire.");
+  if let Err(_) = timeout(Duration::from_secs(5), acquired_thread2).await {
+    panic!("thread2 didn't acquire.");
+  }
 }
 
-#[test]
-fn drop_while_waiting() {
+#[tokio::test]
+async fn drop_while_waiting() {
   // This tests that a task in the waiters queue of the semaphore is removed
   // from the queue when the future that is was polling gets dropped.
   //
@@ -86,124 +80,123 @@ fn drop_while_waiting() {
   // If the SECOND future was not removed from the waiters queue we would not get a signal
   // that thread3 acquired the lock because the 2nd task would be blocking the queue trying to
   // poll a non existant future.
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
   let sema = AsyncSemaphore::new(1);
   let handle1 = sema.clone();
   let handle2 = sema.clone();
   let handle3 = sema.clone();
 
-  let (tx_thread1, acquired_thread1) = mpsc::channel();
-  let (unblock_thread1, rx_thread1) = mpsc::channel();
-  let (tx_inqueue_thread3, queued_thread3) = mpsc::channel();
-  let (tx_thread3, acquired_thread3) = mpsc::channel();
-  let (unblock_thread3, rx_thread3) = mpsc::channel();
-  let (tx_thread2_attempt_1, did_not_acquire_thread2_attempt_1) = mpsc::channel();
+  let (tx_thread1, acquired_thread1) = oneshot::channel();
+  let (unblock_thread1, rx_thread1) = oneshot::channel();
+  let (tx_thread3, acquired_thread3) = oneshot::channel();
+  let (unblock_thread3, rx_thread3) = oneshot::channel();
+  let (tx_thread2_attempt_1, did_not_acquire_thread2_attempt_1) = oneshot::channel();
 
-  runtime.spawn(handle1.with_acquired(move || {
-    // Indicate that we've acquired, and then wait to be signaled to exit.
-    tx_thread1.send(()).unwrap();
-    rx_thread1.recv().unwrap();
-    future::ok::<_, ()>(())
+  tokio::spawn(handle1.with_acquired(move || {
+    async {
+      // Indicate that we've acquired, and then wait to be signaled to exit.
+      tx_thread1.send(()).unwrap();
+      rx_thread1.await.unwrap();
+      future::ready(())
+    }
   }));
 
   // Wait for thread1 to acquire, and then launch thread2.
-  acquired_thread1
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread1 didn't acquire.");
+  if let Err(_) = timeout(Duration::from_secs(5), acquired_thread1).await {
+    panic!("thread1 didn't acquire.");
+  }
 
   // thread2 will wait for a little while, but then drop its PermitFuture to give up on waiting.
-  runtime.spawn(future::lazy(move || {
+  tokio::spawn(future::lazy(move |_| {
     let permit_future = handle2.acquire();
-    let delay_future = Delay::new(Instant::now() + Duration::from_millis(10));
-    delay_future
-      .select2(permit_future)
-      .map(move |raced_result| {
-        // We expect to have timed out, because the other Future will not resolve until asked.
-        match raced_result {
-          future::Either::B(_) => panic!("Expected to time out."),
-          future::Either::A(_) => {}
-        };
-        tx_thread2_attempt_1.send(()).unwrap();
-      })
-      .map_err(|_| panic!("Permit or duration failed."))
-  }));
-
-  runtime.spawn(future::lazy(move || {
-    tx_inqueue_thread3.send(()).unwrap();
-    handle3.with_acquired(move || {
-      // Indicate that we've acquired, and then wait to be signaled to exit.
-      tx_thread3.send(()).unwrap();
-      rx_thread3.recv().unwrap();
-      future::ok::<_, ()>(())
+    let delay_future = delay_for(Duration::from_millis(100));
+    future::select(delay_future, permit_future).map(move |raced_result| {
+      // We expect to have timed out, because the other Future will not resolve until asked.
+      match raced_result {
+        future::Either::Left(_) => {}
+        future::Either::Right(_) => panic!("Expected to time out."),
+      };
+      tx_thread2_attempt_1.send(()).unwrap();
     })
   }));
 
-  queued_thread3
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread3 didn't ever queue up.");
+  tokio::spawn(handle3.with_acquired(move || {
+    async {
+      // Indicate that we've acquired, and then wait to be signaled to exit.
+      tx_thread3.send(()).unwrap();
+      rx_thread3.await.unwrap();
+      future::ready(())
+    }
+  }));
 
   // thread2 should signal that it did not successfully acquire for the first attempt.
-  did_not_acquire_thread2_attempt_1
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread2 should have failed to acquire by now.");
+  if let Err(_) = timeout(Duration::from_secs(5), did_not_acquire_thread2_attempt_1).await {
+    panic!("thread2 should have failed to acquire by now.");
+  }
 
   // Unblock thread1 and confirm that thread3 acquires.
   unblock_thread1.send(()).unwrap();
-  acquired_thread3
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread3 didn't acquire.");
+  if let Err(_) = timeout(Duration::from_secs(5), acquired_thread3).await {
+    panic!("thread3 didn't acquire.");
+  }
   unblock_thread3.send(()).unwrap();
 }
 
-#[test]
-fn dropped_future_is_removed_from_queue() {
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn dropped_future_is_removed_from_queue() {
   let sema = AsyncSemaphore::new(1);
   let handle1 = sema.clone();
   let handle2 = sema.clone();
 
-  let (tx_thread1, acquired_thread1) = mpsc::channel();
-  let (unblock_thread1, rx_thread1) = mpsc::channel();
-  let (tx_thread2, acquired_thread2) = mpsc::channel();
-  let (unblock_thread2, rx_thread2) = mpsc::channel();
+  let (tx_thread1, acquired_thread1) = oneshot::channel();
+  let (unblock_thread1, rx_thread1) = oneshot::channel::<()>();
+  let (tx_thread2, gave_up_thread2) = oneshot::channel();
+  let (unblock_thread2, rx_thread2) = oneshot::channel();
 
-  runtime.spawn(handle1.with_acquired(move || {
-    // Indicate that we've acquired, and then wait to be signaled to exit.
-    tx_thread1.send(()).unwrap();
-    rx_thread1.recv().unwrap();
-    future::ok::<_, ()>(())
+  let join_handle1 = tokio::spawn(handle1.with_acquired(move || {
+    async {
+      // Indicate that we've acquired, and then wait to be signaled to exit.
+      tx_thread1.send(()).unwrap();
+      rx_thread1.await.unwrap();
+      future::ready(())
+    }
   }));
 
-  // Wait for thread1 to acquire, and then launch thread2.
-  acquired_thread1
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread1 didn't acquire.");
-  let waiter = handle2.with_acquired(move || future::ok::<_, ()>(()));
-  runtime.spawn(future::ok::<_, ()>(()).select(waiter).then(move |res| {
-    let mut waiter_fute = match res {
-      Ok((_, fute)) => fute,
-      Err(_) => panic!("future::ok is infallible"),
-    };
-    // We explicitly poll the future here because the select call resolves
-    // immediately when called on a future::ok result, and the second future
-    // is never polled.
-    let _waiter_res = waiter_fute.poll();
-    tx_thread2.send(()).unwrap();
-    rx_thread2.recv().unwrap();
-    drop(waiter_fute);
-    tx_thread2.send(()).unwrap();
-    rx_thread2.recv().unwrap();
-    future::ok::<_, ()>(())
-  }));
-  acquired_thread2
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread2 didn't acquire.");
+  // Wait for the first handle to acquire, and then launch thread2.
+  if let Err(_) = timeout(Duration::from_secs(5), acquired_thread1).await {
+    panic!("thread1 didn't acquire.");
+  }
+  let waiter = handle2.with_acquired(|| future::ready(()));
+  let join_handle2 = tokio::spawn(async move {
+    match future::select(delay_for(Duration::from_millis(100)), waiter.boxed()).await {
+      future::Either::Left(((), waiter_fute)) => {
+        tx_thread2.send(()).unwrap();
+        rx_thread2.await.unwrap();
+        drop(waiter_fute);
+        ()
+      }
+      future::Either::Right(_) => {
+        panic!("The delay_for result should always be ready first!");
+      }
+    }
+  });
+
+  // Wait for thread2 to give up on acquiring.
+  if let Err(_) = timeout(Duration::from_secs(5), gave_up_thread2).await {
+    panic!("thread2 didn't give up on acquiring.");
+  }
   assert_eq!(1, sema.num_waiters());
+
+  // Then cause it to drop its attempt.
   unblock_thread2.send(()).unwrap();
-  acquired_thread2
-    .recv_timeout(Duration::from_secs(5))
-    .expect("thread2 didn't drop future.");
+  if let Err(_) = timeout(Duration::from_secs(5), join_handle2).await {
+    panic!("thread2 didn't exit.");
+  }
   assert_eq!(0, sema.num_waiters());
-  unblock_thread2.send(()).unwrap();
+
+  // Finally, release in thread1.
   unblock_thread1.send(()).unwrap();
+  if let Err(_) = timeout(Duration::from_secs(5), join_handle1).await {
+    panic!("thread1 didn't exit.");
+  }
+  assert_eq!(0, sema.num_waiters());
 }

--- a/src/rust/engine/boxfuture/Cargo.toml
+++ b/src/rust/engine/boxfuture/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/pantsbuild/pants/tree/master/src/rust/engine/bo
 license = "Apache-2.0"
 
 [dependencies]
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }

--- a/src/rust/engine/boxfuture/src/lib.rs
+++ b/src/rust/engine/boxfuture/src/lib.rs
@@ -30,7 +30,7 @@
 // https://github.com/alexcrichton/futures-rs/issues/228 has background for its removal.
 // This avoids needing to call Box::new() around every future that we produce.
 
-use futures::future::Future;
+use futures01::future::Future;
 
 pub type BoxFuture<T, E> = Box<dyn Future<Item = T, Error = E> + Send>;
 
@@ -60,7 +60,7 @@ macro_rules! try_future {
     match $x {
       Ok(value) => value,
       Err(error) => {
-        use futures::future::err;
+        use futures01::future::err;
         return err(error).to_boxed();
       }
     }

--- a/src/rust/engine/engine_cffi/Cargo.toml
+++ b/src/rust/engine/engine_cffi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 engine = { path = ".." }
-futures = "0.1.27"
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../hashing" }
 log = "0.4"
 logging = { path = "../logging" }

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -44,7 +44,7 @@ use engine::{
   externs, nodes, Core, ExecutionRequest, Function, Handle, Key, Params, RootResult, Rule,
   Scheduler, Session, Tasks, TypeId, Types, Value,
 };
-use futures::Future;
+use futures01::{future, Future};
 use hashing::{Digest, EMPTY_DIGEST};
 use log::{error, warn, Log};
 use logging::logger::LOGGER;
@@ -871,7 +871,7 @@ pub extern "C" fn capture_snapshots(
   with_scheduler(scheduler_ptr, |scheduler| {
     let core = scheduler.core.clone();
     core.executor.block_on(
-      futures::future::join_all(
+      future::join_all(
         path_globs_and_roots
           .into_iter()
           .map(|(path_globs, root, digest_hint)| {
@@ -1050,7 +1050,7 @@ pub extern "C" fn materialize_directories(
     let types = &scheduler.core.types;
     let construct_materialize_directories_results = types.construct_materialize_directories_results;
     let construct_materialize_directory_result = types.construct_materialize_directory_result;
-    let work_future = futures::future::join_all(
+    let work_future = future::join_all(
       digests_and_path_prefixes
         .into_iter()
         .map(|(digest, path_prefix)| {

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 bytes = "0.4.5"
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 glob = "0.2.11"
 ignore = "0.4.4"
 lazy_static = "1"

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -12,7 +12,7 @@ dirs = "1"
 env_logger = "0.5.4"
 errno = "0.2.3"
 fuse = "0.3.1"
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4.5"
 clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -29,7 +29,6 @@
 use clap;
 use env_logger;
 use fs;
-use futures;
 
 use rand;
 
@@ -39,7 +38,7 @@ use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use clap::{value_t, App, Arg, SubCommand};
 use fs::GlobMatching;
-use futures::future::Future;
+use futures01::{future, Future};
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
 use protobuf::Message;
@@ -629,7 +628,7 @@ fn expand_files_helper(
             files_unlocked.push((format!("{}{}", prefix, file.name), try_future!(file_digest)));
           }
         }
-        futures::future::join_all(
+        future::join_all(
           dir
             .get_directories()
             .iter()
@@ -647,7 +646,7 @@ fn expand_files_helper(
         .map(|_| Some(()))
         .to_boxed()
       }
-      None => futures::future::ok(None).to_boxed(),
+      None => future::ok(None).to_boxed(),
     })
     .to_boxed()
 }
@@ -667,7 +666,7 @@ fn ensure_uploaded_to_remote(
       .map(Some)
       .to_boxed()
   } else {
-    futures::future::ok(None).to_boxed()
+    future::ok(None).to_boxed()
   };
   summary.map(move |summary| SummaryWithDigest { digest, summary })
 }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use boxfuture::{BoxFuture, Boxable};
-use futures::future;
-use futures::Future;
+use futures01::future;
+use futures01::Future;
 use glob::Pattern;
 use log::warn;
 use parking_lot::Mutex;

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -7,8 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use boxfuture::{BoxFuture, Boxable};
-use futures01::future;
-use futures01::Future;
+use futures01::{future, Future};
 use glob::Pattern;
 use log::warn;
 use parking_lot::Mutex;

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::glob_matching::GlobMatching;
 use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
-use futures::{future, Future};
+use futures01::{future, Future};
 use glob::{MatchOptions, Pattern};
 use lazy_static::lazy_static;
 use std::cmp::min;
@@ -615,7 +615,7 @@ impl PosixFS {
     let vfs = self.clone();
     self
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         vfs.scandir_sync(&dir_relative_to_root)
       }))
   }
@@ -675,7 +675,7 @@ impl PosixFS {
     let path_abs = self.root.0.join(&file.path);
     self
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         let is_executable = path_abs.metadata()?.permissions().mode() & 0o100 == 0o100;
         std::fs::File::open(&path_abs)
           .and_then(|mut f| {
@@ -701,7 +701,7 @@ impl PosixFS {
     let link_abs = self.root.0.join(link.0.as_path());
     self
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         link_abs
           .read_link()
           .and_then(|path_buf| {
@@ -831,7 +831,7 @@ impl PathStatGetter<io::Error> for Arc<PosixFS> {
           let fs2 = self.clone();
           self
             .executor
-            .spawn_on_io_pool(futures::future::lazy(move || fs2.stat_sync(path)))
+            .spawn_on_io_pool(future::lazy(move || fs2.stat_sync(path)))
             .then(|stat_result| match stat_result {
               Ok(v) => Ok(Some(v)),
               Err(err) => match err.kind() {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -613,11 +613,9 @@ impl PosixFS {
     dir_relative_to_root: Dir,
   ) -> impl Future<Item = DirectoryListing, Error = io::Error> {
     let vfs = self.clone();
-    self
-      .executor
-      .spawn_on_io_pool(future::lazy(move || {
-        vfs.scandir_sync(&dir_relative_to_root)
-      }))
+    self.executor.spawn_on_io_pool(future::lazy(move || {
+      vfs.scandir_sync(&dir_relative_to_root)
+    }))
   }
 
   fn scandir_sync(&self, dir_relative_to_root: &Dir) -> Result<DirectoryListing, io::Error> {
@@ -673,61 +671,57 @@ impl PosixFS {
   pub fn read_file(&self, file: &File) -> impl Future<Item = FileContent, Error = io::Error> {
     let path = file.path.clone();
     let path_abs = self.root.0.join(&file.path);
-    self
-      .executor
-      .spawn_on_io_pool(future::lazy(move || {
-        let is_executable = path_abs.metadata()?.permissions().mode() & 0o100 == 0o100;
-        std::fs::File::open(&path_abs)
-          .and_then(|mut f| {
-            let mut content = Vec::new();
-            f.read_to_end(&mut content)?;
-            Ok(FileContent {
-              path: path,
-              content: Bytes::from(content),
-              is_executable,
-            })
+    self.executor.spawn_on_io_pool(future::lazy(move || {
+      let is_executable = path_abs.metadata()?.permissions().mode() & 0o100 == 0o100;
+      std::fs::File::open(&path_abs)
+        .and_then(|mut f| {
+          let mut content = Vec::new();
+          f.read_to_end(&mut content)?;
+          Ok(FileContent {
+            path: path,
+            content: Bytes::from(content),
+            is_executable,
           })
-          .map_err(|e| {
-            io::Error::new(
-              e.kind(),
-              format!("Failed to read file {:?}: {}", path_abs, e),
-            )
-          })
-      }))
+        })
+        .map_err(|e| {
+          io::Error::new(
+            e.kind(),
+            format!("Failed to read file {:?}: {}", path_abs, e),
+          )
+        })
+    }))
   }
 
   pub fn read_link(&self, link: &Link) -> impl Future<Item = PathBuf, Error = io::Error> {
     let link_parent = link.0.parent().map(Path::to_owned);
     let link_abs = self.root.0.join(link.0.as_path());
-    self
-      .executor
-      .spawn_on_io_pool(future::lazy(move || {
-        link_abs
-          .read_link()
-          .and_then(|path_buf| {
-            if path_buf.is_absolute() {
-              Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Absolute symlink: {:?}", link_abs),
-              ))
-            } else {
-              link_parent
-                .map(|parent| parent.join(path_buf))
-                .ok_or_else(|| {
-                  io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Symlink without a parent?: {:?}", link_abs),
-                  )
-                })
-            }
-          })
-          .map_err(|e| {
-            io::Error::new(
-              e.kind(),
-              format!("Failed to read link {:?}: {}", link_abs, e),
-            )
-          })
-      }))
+    self.executor.spawn_on_io_pool(future::lazy(move || {
+      link_abs
+        .read_link()
+        .and_then(|path_buf| {
+          if path_buf.is_absolute() {
+            Err(io::Error::new(
+              io::ErrorKind::InvalidData,
+              format!("Absolute symlink: {:?}", link_abs),
+            ))
+          } else {
+            link_parent
+              .map(|parent| parent.join(path_buf))
+              .ok_or_else(|| {
+                io::Error::new(
+                  io::ErrorKind::InvalidData,
+                  format!("Symlink without a parent?: {:?}", link_abs),
+                )
+              })
+          }
+        })
+        .map_err(|e| {
+          io::Error::new(
+            e.kind(),
+            format!("Failed to read link {:?}: {}", link_abs, e),
+          )
+        })
+    }))
   }
 
   ///

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -6,7 +6,7 @@ use crate::{
   PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior, VFS,
 };
 use boxfuture::{BoxFuture, Boxable};
-use futures::future::{self, Future};
+use futures01::future::{self, Future};
 use std;
 use std::collections::HashMap;
 use std::path::{Components, Path, PathBuf};

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -12,7 +12,7 @@ concrete_time = { path = "../../concrete_time" }
 digest = "0.8"
 dirs = "1"
 fs = { path = ".." }
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 indexmap = "1.0.2"

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -37,7 +37,7 @@ use bytes::Bytes;
 use concrete_time::TimeSpan;
 use dirs;
 use fs::FileContent;
-use futures::{future, Future};
+use futures01::{future, Future};
 use hashing::Digest;
 use protobuf::Message;
 use serde_derive::Serialize;

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -3,7 +3,7 @@ use super::{EntryType, ShrinkBehavior, GIGABYTES};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
-use futures::future::{self, Future};
+use futures01::{future, Future};
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use lmdb::Error::NotFound;
 use lmdb::{self, Cursor, Database, RwTransaction, Transaction, WriteFlags};
@@ -267,7 +267,7 @@ impl ByteStore {
     self
       .inner
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         let fingerprint = {
           let mut hasher = Sha256::default();
           hasher.input(&bytes);

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -5,7 +5,7 @@ use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::{Bytes, BytesMut};
 use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
-use futures::{self, future, Future, IntoFuture, Sink, Stream};
+use futures01::{future, Future, IntoFuture, Sink, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
 use serverset::{Retry, Serverset};
@@ -150,7 +150,7 @@ impl ByteStore {
             let resource_name = resource_name.clone();
             let bytes = bytes.clone();
             let stream =
-              futures::stream::unfold::<_, _, futures::future::FutureResult<_, grpcio::Error>, _>(
+              futures01::stream::unfold::<_, _, future::FutureResult<_, grpcio::Error>, _>(
                 (0, false),
                 move |(offset, has_sent_any)| {
                   if offset >= bytes.len() && has_sent_any {

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -5,8 +5,8 @@ use crate::Store;
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
 use fs::{Dir, File, GlobMatching, PathGlobs, PathStat, PosixFS, SymlinkBehavior};
-use futures::future::{self, join_all};
-use futures::Future;
+use futures01::future::{self, join_all};
+use futures01::Future;
 use hashing::{Digest, EMPTY_DIGEST};
 use indexmap::{self, IndexMap};
 use itertools::Itertools;
@@ -397,7 +397,7 @@ impl Snapshot {
     let store2 = store.clone();
     Self::get_directory_or_err(store.clone(), root_digest, workunit_store.clone())
       .and_then(move |dir| {
-        futures::future::loop_fn(
+        future::loop_fn(
           (dir, PathBuf::new(), prefix),
           move |(dir, already_stripped, prefix)| {
             let has_already_stripped_any = already_stripped.components().next().is_some();
@@ -420,10 +420,10 @@ impl Snapshot {
               let files: Vec<_> = dir.get_files().iter().map(|file| file.get_name().to_owned()).collect();
 
               match (saw_matching_dir, extra_directories.is_empty() && files.is_empty()) {
-                (false, true) => futures::future::ok(futures::future::Loop::Break(bazel_protos::remote_execution::Directory::new())).to_boxed(),
+                (false, true) => future::ok(future::Loop::Break(bazel_protos::remote_execution::Directory::new())).to_boxed(),
                 (false, false) => {
                   // Prefer "No subdirectory found" error to "had extra files" error.
-                  futures::future::err(format!(
+                  future::err(format!(
                     "Cannot strip prefix {} from root directory {:?} - {}directory{} didn't contain a directory named {}{}",
                     already_stripped.join(&prefix).display(),
                     root_digest,
@@ -434,7 +434,7 @@ impl Snapshot {
                   )).to_boxed()
                 },
                 (true, false) => {
-                  futures::future::err(format!(
+                  future::err(format!(
                     "Cannot strip prefix {} from root directory {:?} - {}directory{} contained non-matching {}",
                     already_stripped.join(&prefix).display(),
                     root_digest,
@@ -452,13 +452,13 @@ impl Snapshot {
                   let dir = Self::get_directory_or_err(store.clone(), try_future!(maybe_digest), workunit_store.clone());
                   dir
                       .map(|dir| {
-                        futures::future::Loop::Continue((dir, next_already_stripped, remaining_prefix))
+                        future::Loop::Continue((dir, next_already_stripped, remaining_prefix))
                       })
                       .to_boxed()
                 }
               }
             } else {
-              futures::future::ok(futures::future::Loop::Break(dir)).to_boxed()
+              future::ok(future::Loop::Break(dir)).to_boxed()
             }
           },
         )

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -1,4 +1,4 @@
-use futures::future::Future;
+use futures01::future::Future;
 use hashing::{Digest, Fingerprint};
 use tempfile;
 use testutil::data::TestDirectory;

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 use bazel_protos;
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
-use futures::Future;
+use futures01::Future;
 use hashing::{Digest, Fingerprint};
 use maplit::btreemap;
 use mock::StubCAS;

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 fnv = "1.0.5"
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../hashing" }
 indexmap = "1.0.2"
 log = "0.4"

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use crate::node::{EntryId, Node, NodeContext, NodeError};
 
-use futures::future::{self, Future};
-use futures::sync::oneshot;
+use futures01::future::{self, Future};
+use futures01::sync::oneshot;
 use log::{self, trace};
 use parking_lot::Mutex;
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -46,7 +46,7 @@ use std::time::{Duration, Instant};
 
 use fnv::FnvHasher;
 
-use futures::future::{self, Future};
+use futures01::future::{self, Future};
 use indexmap::IndexSet;
 use log::{debug, trace, warn};
 use parking_lot::Mutex;
@@ -664,7 +664,7 @@ impl<N: Node> Graph<N> {
               .into_iter()
               .map(|e| e.node().to_string())
               .collect();
-            return futures::future::err(N::Error::cyclic(path_strs)).to_boxed();
+            return future::err(N::Error::cyclic(path_strs)).to_boxed();
           } else {
             // Valid dependency.
             trace!(

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use boxfuture::BoxFuture;
 use hashing::Digest;
 
-use futures::future::Future;
+use futures01::future::Future;
 use petgraph::stable_graph;
 
 use crate::entry::Entry;

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use boxfuture::{BoxFuture, Boxable};
-use futures::future::{self, Future};
+use futures01::future::{self, Future};
 use hashing::Digest;
 use parking_lot::Mutex;
 

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 chrono = "0.4.10"
-futures = "0.1.27"
+futures01 = { package = "futures", version = "0.1" }
 lazy_static = "1"
 log = "0.4"
 num_enum = "0.1.1"

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -3,7 +3,7 @@
 
 use crate::PythonLogLevel;
 use chrono;
-use futures::task_local;
+use futures01::task_local;
 use lazy_static::lazy_static;
 use log::{log, set_logger, set_max_level, LevelFilter, Log, Metadata, Record};
 use parking_lot::Mutex;
@@ -267,7 +267,7 @@ task_local! {
 }
 
 pub fn set_destination(destination: Destination) {
-  if futures::task::is_in_task() {
+  if futures01::task::is_in_task() {
     TASK_DESTINATION.with(|task_destination| {
       *task_destination.lock() = Some(destination);
     })
@@ -287,7 +287,7 @@ pub fn get_destination() -> Destination {
     THREAD_DESTINATION.with(|destination| *destination.lock())
   }
 
-  if futures::task::is_in_task() {
+  if futures01::task::is_in_task() {
     get_task_destination().unwrap_or_else(get_thread_destination)
   } else {
     get_thread_destination()

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -16,6 +16,7 @@ derivative = "1.0.2"
 digest = "0.8"
 fs = { path = "../fs" }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
 libc = "0.2.39"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "0.4.5"
 derivative = "1.0.2"
 digest = "0.8"
 fs = { path = "../fs" }
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
 libc = "0.2.39"

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::Future;
+use futures01::{future, Future};
 use log::{debug, warn};
 use protobuf::Message;
 
@@ -44,7 +44,7 @@ impl crate::CommandRunner for CommandRunner {
       .lookup(key, context.clone())
       .then(move |maybe_result| {
         match maybe_result {
-          Ok(Some(result)) => return futures::future::ok(result).to_boxed(),
+          Ok(Some(result)) => return future::ok(result).to_boxed(),
           Err(err) => {
             warn!("Error loading process execution result from local cache: {} - continuing to execute", err);
             // Falling through to re-execute.
@@ -67,7 +67,7 @@ impl crate::CommandRunner for CommandRunner {
                   Ok(result)
                 }).to_boxed()
             } else {
-              futures::future::ok(result).to_boxed()
+              future::ok(result).to_boxed()
             }
           })
           .to_boxed()
@@ -104,7 +104,7 @@ impl CommandRunner {
           .map(Some)
           .to_boxed()
         } else {
-          futures::future::ok(None).to_boxed()
+          future::ok(None).to_boxed()
         }
       })
   }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -40,6 +40,9 @@ use std::time::Duration;
 use store::UploadSummary;
 use workunit_store::WorkUnitStore;
 
+use futures::compat::Future01CompatExt;
+use futures::future::{FutureExt, TryFutureExt};
+
 use async_semaphore::AsyncSemaphore;
 use hashing::Digest;
 
@@ -396,7 +399,10 @@ impl CommandRunner for BoundedCommandRunner {
     self
       .inner
       .1
-      .with_acquired(move || inner.0.run(req, context))
+      .clone()
+      .with_acquired(move || inner.0.run(req, context).compat())
+      .boxed()
+      .compat()
       .to_boxed()
   }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -29,7 +29,7 @@
 #[macro_use]
 extern crate derivative;
 
-use boxfuture::BoxFuture;
+use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
@@ -397,6 +397,7 @@ impl CommandRunner for BoundedCommandRunner {
       .inner
       .1
       .with_acquired(move || inner.0.run(req, context))
+      .to_boxed()
   }
 
   fn extract_compatible_request(

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -3,7 +3,7 @@ use tempfile;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
 use fs::{self, GlobExpansionConjunction, GlobMatching, PathGlobs, StrictGlobMatching};
-use futures::{future, Future, Stream};
+use futures01::{future, Future, Stream};
 use log::info;
 use nails::execution::{ChildOutput, ExitCode};
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use boxfuture::{try_future, BoxFuture, Boxable};
 use futures01::future::Future;
 use futures01::stream::Stream;
+use futures::compat::Future01CompatExt;
+use futures::future::{FutureExt, TryFutureExt};
 use log::{debug, trace};
 use nails::execution::{child_channel, ChildInput, ChildOutput, Command};
 use tokio::net::TcpStream;
@@ -253,6 +255,7 @@ impl CapturedWorkdir for CommandRunner {
 
     let nails_command = self
       .async_semaphore
+      .clone()
       .with_acquired(move || {
         // Get the port of a running nailgun server (or a new nailgun server if it doesn't exist)
         nailgun_pool.connect(
@@ -264,8 +267,10 @@ impl CapturedWorkdir for CommandRunner {
           store,
           req.input_files,
           workunit_store,
-        )
+        ).compat()
       })
+      .boxed()
+      .compat()
       .map_err(|e| format!("Failed to connect to nailgun! {}", e))
       .inspect(move |_| debug!("Connected to nailgun instance {}", &nailgun_name3))
       .and_then(move |nailgun_port| {

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
-use futures::future::Future;
-use futures::stream::Stream;
+use futures01::future::Future;
+use futures01::stream::Stream;
 use log::{debug, trace};
 use nails::execution::{child_channel, ChildInput, ChildOutput, Command};
 use tokio::net::TcpStream;

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
-use futures01::future::Future;
-use futures01::stream::Stream;
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
+use futures01::future::Future;
+use futures01::stream::Stream;
 use log::{debug, trace};
 use nails::execution::{child_channel, ChildInput, ChildOutput, Command};
 use tokio::net::TcpStream;
@@ -258,16 +258,18 @@ impl CapturedWorkdir for CommandRunner {
       .clone()
       .with_acquired(move || {
         // Get the port of a running nailgun server (or a new nailgun server if it doesn't exist)
-        nailgun_pool.connect(
-          nailgun_name.clone(),
-          nailgun_req,
-          workdir_for_this_nailgun,
-          nailgun_req_digest,
-          build_id,
-          store,
-          req.input_files,
-          workunit_store,
-        ).compat()
+        nailgun_pool
+          .connect(
+            nailgun_name.clone(),
+            nailgun_req,
+            workdir_for_this_nailgun,
+            nailgun_req_digest,
+            build_id,
+            store,
+            req.input_files,
+            workunit_store,
+          )
+          .compat()
       })
       .boxed()
       .compat()

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -11,7 +11,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
-use futures::future::Future;
+use futures01::future::Future;
 use log::{debug, info};
 use parking_lot::Mutex;
 use regex::Regex;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat};
-use futures::{future, Future, Stream};
+use futures01::{future, Future, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
 use libc;
@@ -762,7 +762,7 @@ impl CommandRunner {
     history: ExecutionHistory,
     maybe_cancel_remote_exec_token: Option<CancelRemoteExecutionToken>,
   ) -> BoxFuture<
-    futures::future::Loop<
+    future::Loop<
       FallibleExecuteProcessResult,
       (
         ExecutionHistory,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2,7 +2,7 @@ use bazel_protos;
 use bazel_protos::operations::Operation;
 use bazel_protos::remote_execution::ExecutedActionMetadata;
 use bytes::Bytes;
-use futures::Future;
+use futures01::{future, Future};
 use grpcio;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use mock;
@@ -2219,7 +2219,7 @@ fn remote_workunits_are_stored() {
 
   let workunit_store_2 = workunit_store.clone();
   runtime
-    .block_on(futures::future::lazy(move || {
+    .block_on(future::lazy(move || {
       command_runner.extract_execute_response(
         OperationOrStatus::Operation(operation),
         &mut ExecutionHistory::default(),

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -3,7 +3,7 @@ use crate::{
   MultiPlatformExecuteProcessRequest,
 };
 use boxfuture::{BoxFuture, Boxable};
-use futures::future::{err, ok, Either, Future};
+use futures01::future::{err, ok, Either, Future};
 use log::{debug, trace};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
-use futures::future::Future;
+use futures01::future::Future;
 use hashing::EMPTY_DIGEST;
 use parking_lot::Mutex;
 use std::sync::Arc;

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 boxfuture = { path = "../boxfuture" }
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 parking_lot = "0.6"
 tokio-timer = "0.2"
 

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -26,10 +26,8 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use futures;
-
 use boxfuture::{BoxFuture, Boxable};
-use futures::Future;
+use futures01::{future, Future};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -294,7 +292,7 @@ impl<T: Clone + Send + Sync + 'static> Serverset<T> {
     if inner.can_make_more_connections() {
       // Find a healthy server without a connection, connect to it.
       if let Some(ret) = inner.connect() {
-        return futures::future::ok(ret).to_boxed();
+        return future::ok(ret).to_boxed();
       }
     }
 
@@ -302,7 +300,7 @@ impl<T: Clone + Send + Sync + 'static> Serverset<T> {
       let next_connection = inner.next_connection;
       inner.next_connection = inner.next_connection.wrapping_add(1);
       let connection = &inner.connections[next_connection % inner.connections.len()];
-      return futures::future::ok((
+      return future::ok((
         connection.connection.clone(),
         HealthReportToken {
           server_index: connection.server_index,

--- a/src/rust/engine/serverset/src/tests.rs
+++ b/src/rust/engine/serverset/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{BackoffConfig, Health, Serverset};
-use futures::{self, Future};
+use futures01::{future, Future};
 use parking_lot::Mutex;
 use std;
 use std::collections::HashSet;
@@ -172,7 +172,7 @@ fn expect_both(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, rep
   let visited = Arc::new(Mutex::new(HashSet::new()));
 
   runtime
-    .block_on(futures::future::join_all(
+    .block_on(future::join_all(
       (0..repetitions)
         .into_iter()
         .map(|_| {

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bytes = "0.4.5"
 fs = { path = "../fs" }
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../hashing" }
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -177,29 +177,27 @@ impl ShardedLmdb {
     initial_lease: bool,
   ) -> impl Future<Item = (), Error = String> {
     let store = self.clone();
-    self
-      .executor
-      .spawn_on_io_pool(future::lazy(move || {
-        let (env, db, lease_database) = store.get(&key);
-        let put_res = env.begin_rw_txn().and_then(|mut txn| {
-          txn.put(db, &key, &bytes, WriteFlags::NO_OVERWRITE)?;
-          if initial_lease {
-            store.lease(
-              lease_database,
-              &key,
-              Self::default_lease_until_secs_since_epoch(),
-              &mut txn,
-            )?;
-          }
-          txn.commit()
-        });
-
-        match put_res {
-          Ok(()) => Ok(()),
-          Err(lmdb::Error::KeyExist) => Ok(()),
-          Err(err) => Err(format!("Error storing key {:?}: {}", key.to_hex(), err)),
+    self.executor.spawn_on_io_pool(future::lazy(move || {
+      let (env, db, lease_database) = store.get(&key);
+      let put_res = env.begin_rw_txn().and_then(|mut txn| {
+        txn.put(db, &key, &bytes, WriteFlags::NO_OVERWRITE)?;
+        if initial_lease {
+          store.lease(
+            lease_database,
+            &key,
+            Self::default_lease_until_secs_since_epoch(),
+            &mut txn,
+          )?;
         }
-      }))
+        txn.commit()
+      });
+
+      match put_res {
+        Ok(()) => Ok(()),
+        Err(lmdb::Error::KeyExist) => Ok(()),
+        Err(err) => Err(format!("Error storing key {:?}: {}", key.to_hex(), err)),
+      }
+    }))
   }
 
   fn lease(
@@ -233,23 +231,21 @@ impl ShardedLmdb {
     f: F,
   ) -> impl Future<Item = Option<T>, Error = String> {
     let store = self.clone();
-    self
-      .executor
-      .spawn_on_io_pool(future::lazy(move || {
-        let (env, db, _) = store.get(&fingerprint);
-        let ro_txn = env
-          .begin_ro_txn()
-          .map_err(|err| format!("Failed to begin read transaction: {}", err));
-        ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
-          Ok(bytes) => f(Bytes::from(bytes)).map(Some),
-          Err(lmdb::Error::NotFound) => Ok(None),
-          Err(err) => Err(format!(
-            "Error loading fingerprint {:?}: {}",
-            fingerprint.to_hex(),
-            err,
-          )),
-        })
-      }))
+    self.executor.spawn_on_io_pool(future::lazy(move || {
+      let (env, db, _) = store.get(&fingerprint);
+      let ro_txn = env
+        .begin_ro_txn()
+        .map_err(|err| format!("Failed to begin read transaction: {}", err));
+      ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
+        Ok(bytes) => f(Bytes::from(bytes)).map(Some),
+        Err(lmdb::Error::NotFound) => Ok(None),
+        Err(err) => Err(format!(
+          "Error loading fingerprint {:?}: {}",
+          fingerprint.to_hex(),
+          err,
+        )),
+      })
+    }))
   }
 
   #[allow(clippy::identity_conversion)] // False positive: https://github.com/rust-lang/rust-clippy/issues/3913

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -27,7 +27,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use bytes::Bytes;
-use futures::Future;
+use futures01::{future, Future};
 use hashing::Fingerprint;
 use lmdb::{
   self, Database, DatabaseFlags, Environment, EnvironmentCopyFlags, EnvironmentFlags,
@@ -179,7 +179,7 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         let (env, db, lease_database) = store.get(&key);
         let put_res = env.begin_rw_txn().and_then(|mut txn| {
           txn.put(db, &key, &bytes, WriteFlags::NO_OVERWRITE)?;
@@ -235,7 +235,7 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_on_io_pool(futures::future::lazy(move || {
+      .spawn_on_io_pool(future::lazy(move || {
         let (env, db, _) = store.get(&fingerprint);
         let ro_txn = env
           .begin_ro_txn()

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::Future;
+use futures01::Future;
 
 use crate::core::{Failure, TypeId};
 use crate::handles::maybe_drop_handles;

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -5,7 +5,7 @@ use crate::nodes::MultiPlatformExecuteProcess;
 use crate::nodes::{lift_digest, DownloadedFile, NodeFuture, Snapshot};
 use boxfuture::{try_future, Boxable};
 use bytes;
-use futures::future::{self, Future};
+use futures01::{future, Future};
 use hashing;
 use std::path::PathBuf;
 
@@ -182,7 +182,7 @@ fn input_files_content_to_digest(context: Context, files_content: Value) -> Node
         .to_boxed()
     })
     .collect();
-  futures::future::join_all(digests)
+  future::join_all(digests)
     .and_then(|digests| {
       store::Snapshot::merge_directories(context.core.store(), digests, workunit_store)
         .map_err(|err| throw(&err))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{self, fmt};
 
-use futures::future::{self, Future};
-use futures::Stream;
+use futures01::future::{self, Future};
+use futures01::Stream;
 use url::Url;
 
 use crate::context::{Context, Core};
@@ -1049,7 +1049,7 @@ impl Node for NodeKey {
     };
 
     let context2 = context.clone();
-    futures::future::lazy(|| {
+    future::lazy(|| {
       if let Some(span_id) = maybe_span_id {
         set_parent_id(span_id);
       }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 
-use futures::future::{self, Future};
+use futures01::future::{self, Future};
 
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-futures = "0.1"
+futures01 = { package = "futures", version = "0.1" }
 futures-cpupool = "0.1"
 logging = { path = "../logging" }
 tokio = "0.1"

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -26,7 +26,7 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use futures::Future;
+use futures01::{future, Future};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -94,7 +94,7 @@ impl Executor {
     &self,
     future: F,
   ) -> impl Future<Item = Item, Error = Error> {
-    futures::sync::oneshot::spawn(
+    futures01::sync::oneshot::spawn(
       Self::future_with_correct_context(future),
       &self.runtime.executor(),
     )
@@ -160,7 +160,7 @@ impl Executor {
   ) -> impl Future<Item = Item, Error = Error> {
     let logging_destination = logging::get_destination();
     let workunit_parent_id = workunit_store::get_parent_id();
-    futures::lazy(move || {
+    future::lazy(move || {
       logging::set_destination(logging_destination);
       if let Some(parent_id) = workunit_parent_id {
         workunit_store::set_parent_id(parent_id);

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
-futures = "^0.1.16"
+futures01 = { package = "futures", version = "0.1" }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bazel_protos;
-use futures;
 use grpcio;
 
 use bytes::Bytes;
-use futures::{Future, IntoFuture, Stream};
+use futures01::{Future, IntoFuture, Stream};
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
 use testutil::data::{TestData, TestDirectory};
@@ -313,7 +312,7 @@ impl bazel_protos::bytestream_grpc::ByteStream for StubCASResponder {
       Ok(response) => self.send(
         &ctx,
         sink,
-        futures::stream::iter_ok(
+        futures01::stream::iter_ok(
           response
             .into_iter()
             .map(|chunk| (chunk, grpcio::WriteFlags::default())),

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use bazel_protos;
-use futures::{Future, Sink};
+use futures01::{Future, Sink};
 use grpcio;
 use parking_lot::Mutex;
 use protobuf;

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 concrete_time = { path = "../concrete_time" }
-futures = "0.1.27"
+futures01 = { package = "futures", version = "0.1" }
 parking_lot = "0.6"
 rand = "0.6"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -27,7 +27,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
-use futures::task_local;
+use futures01::task_local;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rand::Rng;
@@ -131,7 +131,7 @@ task_local! {
 }
 
 pub fn set_parent_id(parent_id: String) {
-  if futures::task::is_in_task() {
+  if futures01::task::is_in_task() {
     TASK_PARENT_ID.with(|task_parent_id| {
       *task_parent_id.lock() = Some(parent_id);
     })
@@ -139,7 +139,7 @@ pub fn set_parent_id(parent_id: String) {
 }
 
 pub fn get_parent_id() -> Option<String> {
-  if futures::task::is_in_task() {
+  if futures01::task::is_in_task() {
     TASK_PARENT_ID.with(|task_parent_id| {
       let task_parent_id = task_parent_id.lock();
       (*task_parent_id).clone()


### PR DESCRIPTION
### Problem

async-await was stabilized a few months ago, but we haven't begun using it!

### Solution

Port the `async_semaphore` crate to async-await, and introduce usage of the [futures compatibility layer](https://rust-lang.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html) to allow dependent crates to consume it by converting back from a `futures==0.3` (ie, stdlib future) to a `futures==0.1` future.

### Result

Further dependency crates within our graph can be ported, with futures converted back and forth between versions. Dependency crates that use the tokio runtime (`async_semaphore` does not) will likely need to introduce usage of [tokio-compat](https://tokio.rs/blog/2019-12-compat/) to bridge the gap between runtimes.