### PR TITLE
Resolve v2 plugins.

### DIFF
--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -57,7 +57,8 @@ class PluginResolver:
     self._interpreter = interpreter or PythonInterpreter.get()
 
     bootstrap_options = self._options_bootstrapper.get_bootstrap_options().for_global_scope()
-    self._plugin_requirements = bootstrap_options.plugins
+    self._plugin_requirements = sorted(
+      set(bootstrap_options.plugins) | set(bootstrap_options.plugins2))
     self._plugin_cache_dir = bootstrap_options.plugin_cache_dir
     self._plugins_force_resolve = bootstrap_options.plugins_force_resolve
 


### PR DESCRIPTION
Previously we would load backends from their entrypoints, but
we wouldn't actually install their wheels into the working set first.
