### PR TITLE
Expand `config_test.py` to better define the Config API

### DIFF
--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -27,6 +27,7 @@ python_tests(
   name="tests",
   sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
   dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':option',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -208,7 +208,7 @@ class _ConfigValues(ABC):
 
   @abstractmethod
   def defaults(self) -> Mapping[str, Any]:
-    """All the DEFAULT values."""
+    """All the DEFAULT values (not interpolated)."""
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -1,17 +1,33 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import textwrap
-import unittest
+from textwrap import dedent
+from typing import Dict
+
+from twitter.common.collections import OrderedSet
 
 from pants.option.config import Config
-from pants.util.contextutil import temporary_file, temporary_file_path
+from pants.testutil.test_base import TestBase
+from pants.util.contextutil import temporary_file
 
 
-class ConfigTest(unittest.TestCase):
+class ConfigTest(TestBase):
+
+  def _setup_config(self, config1_content: str, config2_content: str, *, suffix: str) -> Config:
+    with temporary_file(binary_mode=False, suffix=suffix) as config1, \
+      temporary_file(binary_mode=False, suffix=suffix) as config2:
+      config1.write(config1_content)
+      config1.close()
+      config2.write(config2_content)
+      config2.close()
+      parsed_config = Config.load(
+        config_paths=[config1.name, config2.name], seed_values={"buildroot": self.build_root}
+      )
+      assert [config1.name, config2.name] == parsed_config.sources()
+    return parsed_config
 
   def setUp(self) -> None:
-    self.ini1_content = textwrap.dedent(
+    ini1_content = dedent(
       """
       [DEFAULT]
       name: foo
@@ -22,72 +38,175 @@ class ConfigTest(unittest.TestCase):
       disclaimer:
         Let it be known
         that.
-      blank_section:
 
       [a]
       list: [1, 2, 3, %(answer)s]
-      listappend: +[7, 8, 9]
+      list2: +[7, 8, 9]
 
       [b]
       preempt: True
+      
+      [b.nested]
       dict: {
           'a': 1,
           'b': %(answer)s,
-          'c': ['%(answer)s', %(answer)s]
+          'c': ['%(answer)s', '%(answer)s'],
         }
+      
+      [b.nested.nested-again]
+      movie: inception
       """
     )
-
-    self.ini2_content = textwrap.dedent(
+    ini2_content = dedent(
       """
       [a]
       fast: True
 
       [b]
       preempt: False
+      
+      [c.child]
+      no_values_in_parent: True
 
       [defined_section]
       """
     )
+    self.config = self._setup_config(ini1_content, ini2_content, suffix=".ini")
+    self.default_seed_values = Config._determine_seed_values(
+      seed_values={"buildroot": self.build_root},
+    )
+    self.default_file1_values = {
+      "name": "foo",
+      "answer": "42",
+      "scale": "1.2",
+      "path": "/a/b/42",
+      "embed": "/a/b/42::foo",
+      "disclaimer": "\nLet it be known\nthat.",
+    }
+    self.expected_file1_options = {
+      "a": {
+        "list": "[1, 2, 3, 42]",
+        "list2": "+[7, 8, 9]",
+      },
+      "b": {
+        "preempt": "True",
+      },
+      "b.nested": {
+        "dict": "{\n'a': 1,\n'b': 42,\n'c': ['42', '42'],\n}"
+      },
+      "b.nested.nested-again": {
+        "movie": "inception",
+      },
+    }
+    self.expected_file2_options: Dict[str, Dict[str, str]] = {
+      "a": {
+        "fast": "True",
+      },
+      "b": {
+        "preempt": "False",
+      },
+      "c.child": {
+        "no_values_in_parent": "True",
+      },
+      "defined_section": {},
+    }
+    self.expected_combined_values: Dict[str, Dict[str, str]] = {
+      **self.expected_file1_options,
+      **self.expected_file2_options,
+      "a": {
+        **self.expected_file2_options["a"], **self.expected_file1_options["a"],
+      },
+    }
 
-    with temporary_file(binary_mode=False) as ini1, \
-      temporary_file(binary_mode=False) as ini2, \
-      temporary_file_path() as buildroot:
-      ini1.write(self.ini1_content)
-      ini1.close()
-      ini2.write(self.ini2_content)
-      ini2.close()
-      self.config = Config.load(
-        config_paths=[ini1.name, ini2.name], seed_values={"buildroot": buildroot}
-      )
-      self.assertEqual([ini1.name, ini2.name], self.config.sources())
+  def test_sections(self) -> None:
+    expected_sections = list(
+      OrderedSet([*self.expected_file2_options.keys(), *self.expected_file1_options.keys()])
+    )
+    assert self.config.sections() == expected_sections
+    for section in expected_sections:
+      assert self.config.has_section(section) is True
+    # We should only look at explicitly defined sections. For example, if `cache.java` is defined
+    # but `cache` is not, then `cache` should not be included in the sections.
+    assert self.config.has_section('c') is False
 
-  def test_getstring(self) -> None:
-    self.assertEqual('/a/b/42', self.config.get('a', 'path'))
-    self.assertEqual('/a/b/42::foo', self.config.get('a', 'embed'))
-    self.assertEqual('[1, 2, 3, 42]', self.config.get('a', 'list'))
-    self.assertEqual('+[7, 8, 9]', self.config.get('a', 'listappend'))
-    self.assertEqual(
-      """
-Let it be known
-that.""",
-      self.config.get('b', 'disclaimer'))
+  def test_has_option(self) -> None:
+    # Check has all DEFAULT values
+    for default_option in (*self.default_seed_values.keys(), *self.default_file1_values.keys()):
+      assert self.config.has_option(section="DEFAULT", option=default_option) is True
+    # Check every explicitly defined section has its options + the seed defaults
+    for section, options in self.expected_combined_values.items():
+      for option in (*options, *self.default_seed_values):
+        assert self.config.has_option(section=section, option=option) is True
+    # Check every section for file1 also has file1's DEFAULT values
+    for section in self.expected_file1_options:
+      for option in self.default_file1_values:
+        assert self.config.has_option(section=section, option=option) is True
+    # Check that file1's DEFAULT values don't apply to sections only defined in file2
+    sections_only_in_file2 = set(self.expected_file2_options.keys()) - set(
+      self.expected_file1_options.keys()
+    )
+    for section in sections_only_in_file2:
+      for option in self.default_file1_values:
+        assert self.config.has_option(section=section, option=option) is False
+    # Check that non-existent options are False
+    nonexistent_options = {
+      "DEFAULT": "fake",
+      "a": "fake",
+      "b": "fast",
+    }
+    for section, option in nonexistent_options.items():
+      assert self.config.has_option(section=section, option=option) is False
+
+  def test_list_all_options(self) -> None:
+    # This is used in `options_bootstrapper.py` to validate that every option is recognized.
+    file1_config = self.config.configs()[1]
+    file2_config = self.config.configs()[0]
+    for section, options in self.expected_file1_options.items():
+      assert file1_config.values.options(section=section) == [
+        *options.keys(), *self.default_seed_values.keys(), *self.default_file1_values.keys(),
+      ]
+    for section, options in self.expected_file2_options.items():
+      assert file2_config.values.options(section=section) == [
+        *options.keys(), *self.default_seed_values.keys()]
+
+  def test_default_values(self) -> None:
+    # This is used in `options_bootstrapper.py` to ignore default values when validating options.
+    file1_config = self.config.configs()[1]
+    file2_config = self.config.configs()[0]
+    # NB: string interpolation should only happen when calling _ConfigValues.get_value(). The
+    # values for _ConfigValues.defaults() are not yet interpolated.
+    default_file1_values_unexpanded = {
+      **self.default_file1_values, "path": "/a/b/%(answer)s", "embed": "%(path)s::foo",
+    }
+    assert file1_config.values.defaults() == {
+      **self.default_seed_values, **default_file1_values_unexpanded,
+    }
+    assert file2_config.values.defaults() == self.default_seed_values
+
+  def test_get(self) -> None:
+    # Check the DEFAULT section
+    for option, value in {**self.default_seed_values, **self.default_file1_values}.items():
+      assert self.config.get(section="DEFAULT", option=option) == value
+    # Check the combined values, including that each section has the default seed values
+    for section, section_values in self.expected_combined_values.items():
+      for option, value in {**section_values, **self.default_seed_values}.items():
+        assert self.config.get(section=section, option=option) == value
+    # Check that each section from file1 also has file1's default values
+    for section in self.expected_file1_options:
+      for option, value in self.default_file1_values.items():
+        assert self.config.get(section=section, option=option) == value
 
     def check_defaults(default: str) -> None:
-      assert self.config.get('c', 'fast') is None
-      assert self.config.get('c', 'preempt', None) is None
-      assert self.config.get('c', 'jake', default=default) == default
+      assert self.config.get(section='c', option='fast') is None
+      assert self.config.get(section='c', option='preempt', default=None) is None
+      assert self.config.get(section='c', option='jake', default=default) == default
 
     check_defaults('')
     check_defaults('42')
 
-  def test_default_section(self) -> None:
-    self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
-    self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
-
-  def test_sections(self) -> None:
-    self.assertEqual(['a', 'b', 'defined_section'], self.config.sections())
-
   def test_empty(self) -> None:
     config = Config.load([])
-    self.assertEqual([], config.sections())
+    assert config.sections() == []
+    assert config.sources() == []
+    assert config.has_section("DEFAULT") is False
+    assert config.has_option(section="DEFAULT", option="name") is False


### PR DESCRIPTION
The tests now check every part of the `Config` and `_ConfigValues` APIs from `config.py`, including several new edge cases that trick up a naive implementation of TOML, JSON, and YAML.

Beyond ensuring that our current implementation works correctly, this provides a baseline for adding TOML support. Through test-driven development, we will now be able to prove that `_IniValues` and `_TomlValues` behave identically.