### PR TITLE
Deprecate `--glob-expansion-failure` in favor of `--files-not-found-behavior`

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -718,14 +718,17 @@ async def sources_snapshots_from_build_file_addresses(
 
 @rule
 async def sources_snapshots_from_filesystem_specs(
-  filesystem_specs: FilesystemSpecs, glob_match_error_behavior: GlobMatchErrorBehavior,
+  filesystem_specs: FilesystemSpecs,
 ) -> SourcesSnapshots:
   """Resolve the snapshot associated with the provided filesystem specs."""
   snapshot = await Get[Snapshot](
     PathGlobs(
       globs=(fs_spec.glob for fs_spec in filesystem_specs),
-      glob_match_error_behavior=glob_match_error_behavior,
-      # We validate that _every_ filesystem spec is valid.
+      # We unconditionally warn when globs do not match, rather than ignoring or erroring. We
+      # should not error because we can still do meaningful work with the globs that do match, and
+      # the warning will be very obvious to the user. Warning is less hostile than erroring.
+      glob_match_error_behavior=GlobMatchErrorBehavior.warn,
+      # We validate that _every_ glob is valid.
       conjunction=GlobExpansionConjunction.all_match,
       description_of_origin="file arguments",
     )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -287,6 +287,18 @@ class EngineInitializer:
     """Construct and return the components necessary for LegacyBuildGraph construction."""
     build_root = get_buildroot()
     bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+    glob_expansion_failure_configured = not bootstrap_options.is_default("glob_expansion_failure")
+    files_not_found_behavior_configured = not bootstrap_options.is_default("files_not_found_behavior")
+    if glob_expansion_failure_configured and files_not_found_behavior_configured:
+      raise ValueError(
+        "Conflicting options used. You uses the new, preferred `--files-not-found-behavior`, but "
+        "also used the deprecated `--glob-expansion-failure`.\n\nPlease "
+        "specify only one of these (preferably `--files-not-found-behavior`).")
+    glob_match_error_behavior = (
+      bootstrap_options.files_not_found_behavior.to_glob_match_error_behavior()
+      if files_not_found_behavior_configured else
+      bootstrap_options.glob_expansion_failure
+    )
     return EngineInitializer.setup_legacy_graph_extended(
       OptionsInitializer.compute_pants_ignore(build_root, bootstrap_options),
       bootstrap_options.local_store_dir,
@@ -295,7 +307,7 @@ class EngineInitializer:
       build_configuration,
       build_root=build_root,
       native=native,
-      glob_match_error_behavior=bootstrap_options.glob_expansion_failure,
+      glob_match_error_behavior=glob_match_error_behavior,
       build_ignore_patterns=bootstrap_options.build_ignore,
       exclude_target_regexps=bootstrap_options.exclude_target_regexp,
       subproject_roots=bootstrap_options.subproject_roots,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -291,7 +291,7 @@ class EngineInitializer:
     files_not_found_behavior_configured = not bootstrap_options.is_default("files_not_found_behavior")
     if glob_expansion_failure_configured and files_not_found_behavior_configured:
       raise ValueError(
-        "Conflicting options used. You uses the new, preferred `--files-not-found-behavior`, but "
+        "Conflicting options used. You used the new, preferred `--files-not-found-behavior`, but "
         "also used the deprecated `--glob-expansion-failure`.\n\nPlease "
         "specify only one of these (preferably `--files-not-found-behavior`).")
     glob_match_error_behavior = (

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -42,6 +42,15 @@ class GlobMatchErrorBehavior(Enum):
   error = "error"
 
 
+class FileNotFoundBehavior(Enum):
+  """What to do when globs do not match in BUILD files or filesystem specs."""
+  warn = "warn"
+  error = "error"
+
+  def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
+    return GlobMatchErrorBehavior(self.value)
+
+
 @dataclass(frozen=True)
 class ExecutionOptions:
   """A collection of all options related to (remote) execution of processes.
@@ -293,8 +302,20 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). '
                   'The `--pants-distdir` and `--pants-workdir` locations are inherently ignored.')
+    register("--files-not-found-behavior", advanced=True,
+             type=FileNotFoundBehavior, default=FileNotFoundBehavior.warn,
+             help="What to do when files specified on the command line or in BUILD files cannot be "
+                  "found. This happens when the files do not exist on your machine or when they "
+                  "are ignored by the `--pants-ignore` option.")
     register('--glob-expansion-failure', advanced=True,
-             default=GlobMatchErrorBehavior.warn, type=GlobMatchErrorBehavior,
+             type=GlobMatchErrorBehavior, default=GlobMatchErrorBehavior.warn,
+             removal_version="1.27.0.dev0",
+             removal_hint="If you currently set `--glob-expansion-failure=error`, instead set "
+                          "`--files-not-found-behavior=error`.\n\n"
+                          "If you currently set `--glob-expansion-failure=ignore`, you will "
+                          "need to instead either set `--files-not-found-behavior=warn` (the "
+                          "default) or `--files-not-found-behavior=error`. Ignoring when files are "
+                          "not found often results in subtle bugs, so we are removing the option.",
              help="What to do when files specified on the command line or in BUILD files cannot be "
                   "found. This happens when the files do not exist on your machine or when they "
                   "are ignored by the `--pants-ignore` option.")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -43,7 +43,7 @@ class GlobMatchErrorBehavior(Enum):
 
 
 class FileNotFoundBehavior(Enum):
-  """What to do when globs do not match in BUILD files or filesystem specs."""
+  """What to do when globs do not match in BUILD files."""
   warn = "warn"
   error = "error"
 
@@ -304,9 +304,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'The `--pants-distdir` and `--pants-workdir` locations are inherently ignored.')
     register("--files-not-found-behavior", advanced=True,
              type=FileNotFoundBehavior, default=FileNotFoundBehavior.warn,
-             help="What to do when files specified on the command line or in BUILD files cannot be "
-                  "found. This happens when the files do not exist on your machine or when they "
-                  "are ignored by the `--pants-ignore` option.")
+             help="What to do when files and globs specified in BUILD files, such as in the "
+                  "`sources` field, cannot be found. This happens when the files do not exist on "
+                  "your machine or when they are ignored by the `--pants-ignore` option.")
     register('--glob-expansion-failure', advanced=True,
              type=GlobMatchErrorBehavior, default=GlobMatchErrorBehavior.warn,
              removal_version="1.27.0.dev0",
@@ -316,9 +316,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                           "need to instead either set `--files-not-found-behavior=warn` (the "
                           "default) or `--files-not-found-behavior=error`. Ignoring when files are "
                           "not found often results in subtle bugs, so we are removing the option.",
-             help="What to do when files specified on the command line or in BUILD files cannot be "
-                  "found. This happens when the files do not exist on your machine or when they "
-                  "are ignored by the `--pants-ignore` option.")
+             help="What to do when files and globs specified in BUILD files, such as in the "
+                  "`sources` field, cannot be found. This happens when the files do not exist on "
+                  "your machine or when they are ignored by the `--pants-ignore` option.")
 
     # TODO(#7203): make a regexp option type!
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,


### PR DESCRIPTION
As proposed in https://docs.google.com/document/d/15xphZcFnowytF0Qu2sO1PG7wHAWoyLof7hK0jVa5T8E/edit?disco=AAAAI4KUmss, we decided to remove the ability for users to ignore glob failures. It is not safe for them to ignore failures as it often leads to subtle bugs.
We've recently improved glob match errors—such as describing the origin of the failure—such that we can now be comfortable requiring users to deal with unmatched globs in their BUILD files.

Notably, we still allow rule authors to use `GlobMatchErrorBehavior.ignore`. This only impacts the options we expose to end users.

--

This also changes file args (aka filesystem specs) to always warn no matter what, rather than using whatever `--files-not-found-behavior` is configured to. Those should not be coupled because they are very different use cases.