### PR TITLE
Refactor `engine/legacy/structs.py`

### DIFF
--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -23,7 +23,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.engine.legacy.graph import HydratedField
-from pants.engine.legacy.structs import SourcesField
+from pants.engine.legacy.structs import Files, SourcesField
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import SchedulerSession
 from pants.engine.selectors import Params
@@ -270,7 +270,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
       ),
       arg='sources',
       filespecs={'globs': package_relative_path_globs},
-      base_globs=None,
+      base_globs=Files(spec_path=package_dir),
       path_globs=PathGlobs(
         tuple(os.path.join(package_dir, path) for path in package_relative_path_globs),
       ),

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  sources=globs('test_*.py', exclude=[globs('*_integration.py')]),
+  sources=globs('test_*.py', exclude=['*_integration.py']),
   dependencies=[
     'src/python/pants/binaries',
     'src/python/pants/net',

--- a/tests/python/pants_test/engine/legacy/test_filemap_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filemap_integration.py
@@ -57,7 +57,7 @@ class FilemapIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.do_command('filemap',
                                   self._mk_target('exclude_strings_disallowed'),
                                   success=False)
-      self.assertRegex(pants_run.stderr_data, r'Excludes of type `.*` are not supported')
+      self.assertRegex(pants_run.stderr_data, r'Excludes should be a list of strings. Got:')
 
   def test_exclude_list_of_strings(self):
     test_out = self._extract_exclude_output('exclude_list_of_strings')

--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -17,5 +17,5 @@ class StructTest(unittest.TestCase):
   def test_excludes_of_wrong_type(self) -> None:
     with self.assertRaises(ValueError) as cm:
       Files(exclude='*.md', spec_path='')  # type: ignore[arg-type]
-    self.assertEqual('Excludes should be a list of strings. Got: "*.md"',
+    self.assertEqual("Excludes should be a list of strings. Got: '*.md'",
                      str(cm.exception))

--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -16,6 +16,6 @@ class StructTest(unittest.TestCase):
 
   def test_excludes_of_wrong_type(self) -> None:
     with self.assertRaises(ValueError) as cm:
-      Files(exclude='*.md', spec_path='')
-    self.assertEqual('Excludes of type `str` are not supported: got "*.md"',
+      Files(exclude='*.md', spec_path='')  # type: ignore[arg-type]
+    self.assertEqual('Excludes should be a list of strings. Got: "*.md"',
                      str(cm.exception))

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -116,7 +116,9 @@ class FilesetRelPathWrapperTest(TestBase):
     self.add_to_build_file('y/BUILD', dedent("""
       dummy_target(name="y", sources=globs("*.java", exclude="fleem.java"))
       """))
-    with self.assertRaisesRegex(AddressLookupError, 'Excludes of type.*are not supported.*'):
+    with self.assertRaisesWithMessageContaining(
+      AddressLookupError, "Excludes should be a list of strings. Got: 'fleem.java'"
+    ):
       self.context().scan()
 
   def test_glob_exclude_string_in_list(self) -> None:


### PR DESCRIPTION
Adds type hints, stops using dynamic `**kwargs` where possible, and uses early returns to simplify some functions.

This is prework for adding support for excludes to `sources` lists.