### PR TITLE
Allow excludes in BUILD files and file args via new `!` syntax

### DIFF
--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -1,21 +1,30 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
+import pytest
 
-from pants.engine.legacy.structs import Files
+from pants.engine.fs import PathGlobs
+from pants.engine.legacy.structs import Files, Globs
+from pants.option.custom_types import GlobExpansionConjunction
 
 
-class StructTest(unittest.TestCase):
+def test_filespec_with_explicit_exclude() -> None:
+  globs = Globs(spec_path='')
+  assert globs.filespecs == {"globs": []}
+  globs = Globs(exclude=['*.md'], spec_path='')
+  assert globs.filespecs == {"globs": [], "exclude": [{"globs": ["*.md"]}]}
 
-  def test_filespec_with_excludes(self) -> None:
-    files = Files(spec_path='')
-    self.assertEqual({'globs': []}, files.filespecs)
-    files = Files(exclude=['*.md'], spec_path='')
-    self.assertEqual({'exclude': [{'globs': ['*.md']}], 'globs': []}, files.filespecs)
 
-  def test_excludes_of_wrong_type(self) -> None:
-    with self.assertRaises(ValueError) as cm:
-      Files(exclude='*.md', spec_path='')  # type: ignore[arg-type]
-    self.assertEqual("Excludes should be a list of strings. Got: '*.md'",
-                     str(cm.exception))
+def test_explicit_exclude_of_wrong_type() -> None:
+  with pytest.raises(ValueError) as excinfo:
+    Globs(exclude='*.md', spec_path='')  # type: ignore[arg-type]
+  assert str(excinfo.value) == "Excludes should be a list of strings. Got: '*.md'"
+
+
+def test_ignore_globs_parsed_correctly() -> None:
+  files = Files("foo.py", "!ignore.py", "!**/*", spec_path="")
+  assert files.to_path_globs(
+    relpath="src/python", conjunction=GlobExpansionConjunction.any_match,
+  ) == PathGlobs(["src/python/foo.py", "!src/python/ignore.py", "!src/python/**/*"])
+  # Check that we maintain backwards compatibility with the `filespecs` property used by V1.
+  assert files.filespecs == {"globs": ["foo.py"], "exclude": [{"globs": ["ignore.py", "**/*"]}]}


### PR DESCRIPTION
Before:

```python
python_target(
  sources=globs('foo.py', exclude=['ignore.py'])
)
```

After:

```python
python_target(
  sources=['foo.py', '!ignore.py']
)
```

Per https://github.com/pantsbuild/pants/issues/5427, this addition allows us to remove `globs`, `rglobs` and `zglobs` in BUILD files to always use a flat list of include and exclude globs.