### PR TITLE
No longer use `globs`, `rglobs`, and `zglobs` internally

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name = '3rdparty_directory',
-  sources = rglobs('3rdparty/*'),
+  sources = ['3rdparty/**/*'],
 )
 
 # We use this to establish the build root, rather than `./pants`, because we cannot safely use the
@@ -33,7 +33,7 @@ files(
 
 files(
   name = 'scalajs_3rdparty_directory',
-  sources = rglobs('contrib/scalajs/3rdparty/*'),
+  sources = ['contrib/scalajs/3rdparty/**/*'],
 )
 
 files(

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name = 'bash_scripts',
-  sources = globs('*.sh'),
+  sources = ['*.sh'],
 )
 
 # We include this entry, even though the scripts are already covered by individual `python_binary`
@@ -11,7 +11,7 @@ files(
 # stripping the source root from the files.
 files(
   name = 'python_scripts',
-  sources = globs('*.py'),
+  sources = ['*.py'],
 )
 
 python_binary(

--- a/build-support/checkstyle/BUILD
+++ b/build-support/checkstyle/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/eslint/BUILD
+++ b/build-support/eslint/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/ivy/BUILD
+++ b/build-support/ivy/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = rglobs('*'),
+  sources = ['**/*'],
 )

--- a/build-support/migration-support/BUILD
+++ b/build-support/migration-support/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()
+
+python_tests(
+  name='tests',
+  dependencies=[
+    ':migration-support',
+    'src/python/pants/testutil:test_base',
+    'src/python/pants/util:contextutil',
+  ],
+)

--- a/build-support/migration-support/README.md
+++ b/build-support/migration-support/README.md
@@ -1,0 +1,3 @@
+# Migration support
+
+Various scripts we distribute to help users migrate to new behavior when we make disruptive changes.

--- a/build-support/migration-support/fix_deprecated_globs_usage.py
+++ b/build-support/migration-support/fix_deprecated_globs_usage.py
@@ -2,10 +2,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""A script to modernize the `sources` and `bundles` fields of BUILD files to use the new...
-instead of the deprecated `globs`, `rglobs`, and `zglobs` style.
+"""A script to replace deprecated uses of `globs`, `rglobs`, and `zglobs` in BUILD files with a
+direct list of files and globs.
 
-Run `python3 modernize_sources.py --help`.
+Run `python3 fix_deprecated_globs_usage.py --help`.
 """
 
 import argparse

--- a/build-support/migration-support/fix_deprecated_globs_usage_test.py
+++ b/build-support/migration-support/fix_deprecated_globs_usage_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import List, Optional, Tuple
 
-from modernize_sources import SCRIPT_RESTRICTIONS, generate_possibly_new_build, warning_msg
+from fix_deprecated_globs_usage import SCRIPT_RESTRICTIONS, generate_possibly_new_build, warning_msg
 
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir

--- a/build-support/migration-support/modernize_sources.py
+++ b/build-support/migration-support/modernize_sources.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""A script to modernize the `sources` and `bundles` fields of BUILD files to use the new...
+instead of the deprecated `globs`, `rglobs`, and `zglobs` style.
+
+Run `python3 modernize_sources.py --help`.
+"""
+
+import argparse
+import ast
+import itertools
+import logging
+import os.path
+import re
+from difflib import unified_diff
+from enum import Enum
+from functools import partial
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Set, Union
+
+
+def main() -> None:
+  args = create_parser().parse_args()
+  build_files: Set[Path] = set(
+    itertools.chain.from_iterable(folder.rglob("BUILD*") for folder in args.folders)
+  )
+  updates: Dict[Path, List[str]] = {}
+  for build in build_files:
+    possibly_new_build = generate_possibly_new_build(build)
+    if possibly_new_build is not None:
+      updates[build] = possibly_new_build
+  for build, new_content in updates.items():
+    if args.preview:
+      print(generate_diff(build, new_content))
+    else:
+      build.write_text('\n'.join(new_content) + "\n")
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description='Modernize BUILD files to no longer use globs, rglobs, and zglobs.',
+  )
+  parser.add_argument(
+    'folders', type=Path, nargs='*',
+    help="Folders to recursively search for `BUILD` files",
+  )
+  parser.add_argument(
+    '-p', '--preview', action='store_true',
+    help="Output to stdout rather than overwriting BUILD files.",
+  )
+  return parser
+
+
+class GlobType(Enum):
+  globs = "globs"
+  rglobs = "rglobs"
+  zglobs = "zglobs"
+
+
+class GlobFunction(NamedTuple):
+  glob_type: GlobType
+  includes: List[str]
+  excludes: Optional[List[str]]
+
+  @staticmethod
+  def normalize_rglob(rglob: str) -> str:
+    """We must expand rglobs for them to work properly.
+
+    In rglobs, * at the beginning of a path component means "any number of directories, including 0".
+    So every time we see ^*, we need to output "**/*whatever".
+
+    See https://github.com/pantsbuild/pants/blob/9832c8f6d8b60648cf906775506864aad0ffdb33/src/python/pants/source/wrapped_globs.py#L303
+    for the original implementation.
+    """
+    components = rglob.split(os.path.sep)
+    out: List[str] = []
+    for component in components:
+      if component == '**':
+        if out and out[-1].startswith("**"):
+          continue
+        out.append(component)
+      elif component[0] == '*':
+        if out and out[-1].startswith("**"):
+          # We want to translate *.py to **/*.py, not **/**/*.py
+          out.append(component)
+        else:
+          out.append('**/' + component)
+      else:
+        out.append(component)
+    return os.path.join(*out)
+
+  @classmethod
+  def parse(cls, glob_func: ast.Call) -> "GlobFunction":
+    glob_type = GlobType(glob_func.func.id)
+    include_globs: List[str] = [arg.s for arg in glob_func.args]
+
+    # Excludes are tricky...The optional `exclude` keyword is guaranteed to have a list as its
+    # value, but that list can have any of these elements:
+    #  * `str`
+    #  * `glob`, `rglob`, or `zglob`
+    #  * list of either of the above options
+    exclude_globs: Optional[List[str]] = None
+    exclude_arg: Optional[ast.keyword] = next(iter(glob_func.keywords), None)
+    if exclude_arg is not None:
+      exclude_elements: List[Union[ast.Call, ast.Str, ast.List]] = exclude_arg.value.elts
+      nested_exclude_elements: List[Union[ast.Call, ast.Str]] = list(
+        itertools.chain.from_iterable(
+          nested_list.elts for nested_list in exclude_elements
+          if isinstance(nested_list, ast.List)
+        )
+      )
+      combined_exclude_elements: List[Union[ast.Call, ast.Str]] = [
+        *exclude_elements, *nested_exclude_elements,
+      ]
+      exclude_globs = [arg.s for arg in combined_exclude_elements if isinstance(arg, ast.Str)]
+      exclude_glob_functions = (
+        cls.parse(glob) for glob in combined_exclude_elements if isinstance(glob, ast.Call)
+      )
+      for exclude_glob_function in exclude_glob_functions:
+        exclude_globs.extend(exclude_glob_function.includes)
+      # We sort because of how we use recursion to evaluate `globs` within the `exclude` clause.
+      # Without sorting, the results would appear out of order. Given this difficulty, it's not
+      # worth trying to preserve the original order.
+      exclude_globs.sort()
+
+    if glob_type == GlobType.rglobs:
+      include_globs = [cls.normalize_rglob(include) for include in include_globs]
+
+    return GlobFunction(
+      glob_type=glob_type,
+      includes=include_globs,
+      excludes=exclude_globs,
+    )
+
+  def convert_to_sources_list(self, *, use_single_quotes: bool = False) -> str:
+    escaped_excludes = [f"!{exclude}" for exclude in self.excludes or ()]
+    quote = "'" if use_single_quotes else '"'
+    quoted_globs = (f'{quote}{glob}{quote}' for glob in (*self.includes, *escaped_excludes))
+    return f"[{', '.join(quoted_globs)}]"
+
+
+def use_single_quotes(line: str) -> bool:
+  num_single_quotes = sum(1 for c in line if c == "'")
+  num_double_quotes = sum(1 for c in line if c == '"')
+  return num_single_quotes > num_double_quotes
+
+
+def warning_msg(
+  *, build_file: Path, lineno: int, field_name: str, replacement: str, script_restriction: str,
+) -> str:
+  return (
+    f"Could not update {build_file} at line {lineno}. This script {script_restriction}. Please "
+    f"manually update the `{field_name}` field to `{replacement}`."
+  )
+
+
+SCRIPT_RESTRICTIONS = {
+  "no_comments": "cannot safely preserve comments",
+  "no_bundles": "cannot safely update `bundles` fields",
+  "sources_must_be_single_line": (
+    "can only safely update the `sources` field when its declared on a single line"
+  ),
+  "sources_must_be_distinct_line": (
+    "can only safely update the `sources` field when it's declared on a new distinct line, "
+    "separate from the target type and other fields"
+  ),
+}
+
+
+def generate_possibly_new_build(build_file: Path) -> Optional[List[str]]:
+  """If any targets use `globs`, `rglobs`, or `zglobs`, this will return a replaced BUILD file."""
+  original_text = build_file.read_text()
+  original_text_lines = original_text.splitlines()
+  updated_text_lines = original_text_lines.copy()
+
+  targets: List[ast.Call] = [
+    target.value for target in ast.parse(original_text).body
+    if isinstance(target.value, ast.Call)
+  ]
+  for target in targets:
+    bundles_arg: Optional[ast.keyword] = next(
+      (kwarg for kwarg in target.keywords if kwarg.arg == "bundles"), None,
+    )
+    if bundles_arg is not None:
+      bundle_funcs: List[ast.Call] = [
+        element for element in bundles_arg.value.elts
+        if isinstance(element, ast.Call) and element.func.id == "bundle"
+      ]
+      for bundle_func in bundle_funcs:
+        # Every `bundle` is guaranteed to have a `fileset` defined.
+        fileset_arg: [ast.keyword] = next(
+          kwarg for kwarg in bundle_func.keywords if kwarg.arg == "fileset"
+        )
+        if not isinstance(fileset_arg.value, ast.Call):
+          continue
+
+        parsed_glob_function = GlobFunction.parse(fileset_arg.value)
+        lineno = fileset_arg.value.lineno
+        original_line = updated_text_lines[lineno - 1].rstrip()
+        formatted_replacement = parsed_glob_function.convert_to_sources_list(
+          use_single_quotes=use_single_quotes(original_line),
+        )
+        logging.warning(
+          warning_msg(
+            build_file=build_file,
+            lineno=lineno,
+            field_name="bundle(filespec=)",
+            replacement=formatted_replacement,
+            script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
+          )
+        )
+    sources_arg: Optional[ast.keyword] = next(
+      (kwarg for kwarg in target.keywords if kwarg.arg == "sources"), None,
+    )
+    if not sources_arg or not isinstance(sources_arg.value, ast.Call):
+      continue
+
+    parsed_glob_function = GlobFunction.parse(sources_arg.value)
+    lineno: int = sources_arg.value.lineno
+    original_line = updated_text_lines[lineno - 1].rstrip()
+    formatted_replacement = parsed_glob_function.convert_to_sources_list(
+      use_single_quotes=use_single_quotes(original_line),
+    )
+
+    sources_warning = partial(
+      warning_msg,
+      build_file=build_file,
+      lineno=lineno,
+      field_name="sources",
+      replacement=formatted_replacement,
+    )
+
+    if '#' in original_line:
+      logging.warning(sources_warning(script_restriction=SCRIPT_RESTRICTIONS["no_comments"]))
+      continue
+
+    has_multiple_lines = not (original_line.endswith(')') or original_line[-2:] == "),")
+    if has_multiple_lines:
+      logging.warning(
+        sources_warning(script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_single_line"])
+      )
+      continue
+
+    prefix = re.match(r"\s*sources\s*=\s*", original_line)
+    if not prefix:
+      logging.warning(
+        sources_warning(script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_distinct_line"])
+      )
+      continue
+
+    updated_text_lines[lineno - 1] = f"{prefix[0]}{formatted_replacement},"
+
+  return updated_text_lines if updated_text_lines != original_text_lines else None
+
+
+def generate_diff(build_file: Path, new_content: List[str]) -> str:
+
+  def green(s: str) -> str:
+    return f"\x1b[32m{s}\x1b[0m"
+
+  def red(s: str) -> str:
+    return f"\x1b[31m{s}\x1b[0m"
+
+  diff = unified_diff(
+    build_file.read_text().splitlines(),
+    new_content,
+    fromfile=str(build_file),
+    tofile=str(build_file),
+  )
+  msg = ''
+  for line in diff:
+    if line.startswith('+') and not line.startswith('+++'):
+      msg += green(line)
+    elif line.startswith('-') and not line.startswith('---'):
+      msg += red(line)
+    else:
+      msg += line
+    if not (line.startswith('+++') or line.startswith('---') or line.startswith('@@ ')):
+      msg += '\n'
+  return msg
+
+
+if __name__ == '__main__':
+  logging.basicConfig(format="[%(levelname)s]: %(message)s")
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass

--- a/build-support/migration-support/modernize_sources_test.py
+++ b/build-support/migration-support/modernize_sources_test.py
@@ -1,0 +1,374 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from functools import partial
+from pathlib import Path
+from textwrap import dedent
+from typing import List, Optional, Tuple
+
+from modernize_sources import SCRIPT_RESTRICTIONS, generate_possibly_new_build, warning_msg
+
+from pants.testutil.test_base import TestBase
+from pants.util.contextutil import temporary_dir
+
+
+Result = Optional[List[str]]
+
+
+class ModernizeSourcesTest(TestBase):
+
+  @staticmethod
+  def run_on_build_file(content: str) -> Tuple[Result, Path]:
+    with temporary_dir() as tmpdir:
+      build = Path(tmpdir, "BUILD")
+      build.write_text(content)
+      result = generate_possibly_new_build(build)
+    return result, build
+
+  def capture_warnings(self, *, build_file_content: str) -> Tuple[Result, Path, List[str]]:
+    with self.captured_logging() as captured:
+      result, build = self.run_on_build_file(build_file_content)
+    return result, build, captured.warnings()
+
+  def assert_rewrite(
+    self, *, original: str, expected: str, include_field_after_sources: bool = True,
+  ) -> None:
+    template = dedent(
+      """\
+      # A stray comment
+      
+      python_library(
+        name="lib",
+        {sources_field}
+        {dependencies_field}
+      )
+    
+      python_binary(
+        name="bin",
+        dependencies=[
+          ':lib',
+        ],
+      )
+      """
+    )
+    dependencies_field = dedent(
+      """\
+      dependencies=[
+        'src/python/pants/util',
+      ],
+      """
+    ) if include_field_after_sources else ''
+    result, _ = self.run_on_build_file(
+      template.format(sources_field=original, dependencies_field=dependencies_field),
+    )
+    if original == expected:
+      assert result is None
+    else:
+      assert result == template.format(
+        sources_field=expected, dependencies_field=dependencies_field
+      ).splitlines()
+
+  def assert_warning_raised(
+    self,
+    *,
+    build_file_content: str,
+    line_number: int,
+    field_name: str,
+    replacement: str,
+    script_restriction: str,
+  ) -> None:
+    result, build, warnings = self.capture_warnings(build_file_content=build_file_content)
+    assert result is None  # i.e., the script will not change the BUILD
+    assert len(warnings) == 1
+    assert warnings[0] == "root: " + warning_msg(
+      build_file=build,
+      lineno=line_number,
+      field_name=field_name,
+      replacement=replacement,
+      script_restriction=script_restriction,
+    )
+
+  def test_no_op_when_already_valid(self) -> None:
+    valid_entries = [
+      "sources=['foo.py'],",
+      "sources=['!ignore.py'],",
+      "sources=[],",
+      "sources=['foo.py', '!ignore.py'],",
+    ]
+    for entry in valid_entries:
+      self.assert_rewrite(original=entry, expected=entry)
+
+  def test_includes(self) -> None:
+    self.assert_rewrite(original="sources=globs(),", expected="sources=[],")
+    self.assert_rewrite(original="sources=zglobs(),", expected="sources=[],")
+    self.assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
+    self.assert_rewrite(original="sources=zglobs('foo.py'),", expected="sources=['foo.py'],")
+    self.assert_rewrite(
+      original="sources=globs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
+    )
+    self.assert_rewrite(
+      original="sources=zglobs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
+    )
+
+  def test_excludes(self) -> None:
+    self.assert_rewrite(original="sources=globs(exclude=[]),", expected="sources=[],")
+
+    # `exclude` elements are strings
+    self.assert_rewrite(
+      original="sources=globs(exclude=['ignore.py']),", expected="sources=['!ignore.py'],"
+    )
+    self.assert_rewrite(
+      original="sources=globs(exclude=['ignore.py', 'ignore2.py']),",
+      expected="sources=['!ignore.py', '!ignore2.py'],"
+    )
+
+    # `exclude` elements are globs
+    self.assert_rewrite(
+      original="sources=globs(exclude=[globs('ignore.py')]),",
+      expected="sources=['!ignore.py'],"
+    )
+    self.assert_rewrite(
+      original="sources=globs(exclude=[globs('ignore.py'), globs('ignore2.py')]),",
+      expected="sources=['!ignore.py', '!ignore2.py'],"
+    )
+
+    # `exclude` elements are lists
+    self.assert_rewrite(
+      original="sources=globs(exclude=[['ignore.py']]),",
+      expected="sources=['!ignore.py'],"
+    )
+    self.assert_rewrite(
+      original="sources=globs(exclude=[[globs('ignore.py')]]),",
+      expected="sources=['!ignore.py'],"
+    )
+
+    # `exclude` elements are all of the above
+    self.assert_rewrite(
+      original="sources=globs(exclude=['ignore1.py', globs('ignore2.py'), ['ignore3.py'], [globs('ignore4.py')]]),",
+      expected="sources=['!ignore1.py', '!ignore2.py', '!ignore3.py', '!ignore4.py'],"
+    )
+
+    # check that `exclude` plays nicely with includes
+    self.assert_rewrite(
+      original="sources=globs('foo.py', 'bar.py', exclude=['ignore1.py', 'ignore2.py']),",
+      expected="sources=['foo.py', 'bar.py', '!ignore1.py', '!ignore2.py'],"
+    )
+
+  def test_normalizes_rglobs(self) -> None:
+    # Expand when the path component starts with a `*`
+    self.assert_rewrite(original="sources=rglobs('*'),", expected="sources=['**/*'],")
+    self.assert_rewrite(original="sources=rglobs('*.txt'),", expected="sources=['**/*.txt'],")
+    self.assert_rewrite(original="sources=rglobs('test/*.txt'),", expected="sources=['test/**/*.txt'],")
+    self.assert_rewrite(original="sources=rglobs('*/*/*.txt'),", expected="sources=['**/*/*/**/*.txt'],")
+
+    # Don't expand in these cases
+    self.assert_rewrite(original="sources=rglobs('foo.py'),", expected="sources=['foo.py'],")
+    self.assert_rewrite(original="sources=rglobs('test_*'),", expected="sources=['test_*'],")
+    self.assert_rewrite(original="sources=rglobs('**/*'),", expected="sources=['**/*'],")
+
+    # Check the intersection with the `exclude` clause
+    self.assert_rewrite(
+      original="sources=rglobs('foo.py', exclude=['*']),",
+      expected="sources=['foo.py', '!*'],",
+    )
+    self.assert_rewrite(
+      original="sources=globs('foo.py', exclude=[rglobs('*')]),",
+      expected="sources=['foo.py', '!**/*'],",
+    )
+
+  def test_correctly_formats_rewrite(self) -> None:
+    # Preserve the original `sources` prefix, including whitespace
+    self.assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
+    self.assert_rewrite(original="sources = globs('foo.py'),", expected="sources = ['foo.py'],")
+    self.assert_rewrite(original="sources =globs('foo.py'),", expected="sources =['foo.py'],")
+    self.assert_rewrite(original="sources= globs('foo.py'),", expected="sources= ['foo.py'],")
+    self.assert_rewrite(original="sources  = globs('foo.py'),", expected="sources  = ['foo.py'],")
+    self.assert_rewrite(original="sources =  globs('foo.py'),", expected="sources =  ['foo.py'],")
+    self.assert_rewrite(original="  sources=globs('foo.py'),", expected="  sources=['foo.py'],")
+
+    # Strip stray trailing whitespace
+    self.assert_rewrite(original="sources=globs('foo.py'),      ", expected="sources=['foo.py'],")
+
+    # Preserve whether the original used single quotes or double quotes
+    self.assert_rewrite(original="""sources=globs("foo.py"),""", expected="""sources=["foo.py"],""")
+    self.assert_rewrite(
+      original="""sources=globs("double.py", "foo.py", 'single.py'),""",
+      expected="""sources=["double.py", "foo.py", "single.py"],""",
+    )
+
+    # Always use a trailing comma
+    self.assert_rewrite(
+      original="sources=globs('foo.py')",
+      expected="sources=['foo.py'],",
+      include_field_after_sources=False,
+    )
+
+    # Maintain insertion order for includes
+    self.assert_rewrite(
+      original="sources=globs('dog.py', 'cat.py'),", expected="sources=['dog.py', 'cat.py'],",
+    )
+
+  def test_warns_when_sources_shares_a_line(self) -> None:
+    assert_warning = partial(
+      self.assert_warning_raised,
+      field_name="sources",
+      replacement="['foo.py']",
+      script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_distinct_line"],
+    )
+    assert_warning(
+      build_file_content="files(sources=globs('foo.py'))",
+      line_number=1,
+    )
+    assert_warning(
+      build_file_content=dedent(
+        """\
+        files(
+          name='bad', sources=globs('foo.py'),
+        )
+        """
+      ),
+      line_number=2,
+    )
+
+  def test_warns_when_sources_is_multiline(self) -> None:
+    assert_warning = partial(
+      self.assert_warning_raised,
+      field_name="sources",
+      replacement='["foo.py", "bar.py"]',
+      script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_single_line"],
+      line_number=3,
+    )
+    assert_warning(
+      build_file_content=dedent(
+        """\
+        files(
+          name='bad',
+          sources=globs(
+            "foo.py",
+            "bar.py",
+          ),
+        )
+        """
+      ),
+      # We can't easily infer whether to use single vs. double quotes
+      replacement='["foo.py", "bar.py"]',
+    )
+    assert_warning(
+      build_file_content=dedent(
+        """\
+        files(
+          name='bad',
+          sources=globs('foo.py',
+                        'bar.py'),
+        )
+        """
+      ),
+      replacement="['foo.py', 'bar.py']",
+    )
+
+  def test_warns_on_comments(self) -> None:
+    self.assert_warning_raised(
+      build_file_content=dedent(
+        """\
+        files(
+          sources=globs('foo.py'),  # a comment
+        )
+        """
+      ),
+      line_number=2,
+      replacement="['foo.py']",
+      field_name="sources",
+      script_restriction=SCRIPT_RESTRICTIONS["no_comments"],
+    )
+
+  def test_warns_on_bundles(self) -> None:
+    def assert_no_op(build_file_content: str) -> None:
+      result, _ = self.run_on_build_file(build_file_content)
+      assert result is None
+
+    assert_no_op(
+      dedent(
+        """\
+        jvm_app(
+          bundles=[],
+        )
+        """
+      )
+    )
+    assert_no_op(
+      dedent(
+        """\
+        jvm_app(
+          bundles=[
+            bundle(fileset=[]),
+          ],
+        )
+        """
+      )
+    )
+    assert_no_op(
+      dedent(
+        """\
+        jvm_app(
+          bundles=[
+            bundle(fileset=['foo.java', '!ignore.java']),
+          ],
+        )
+        """
+      )
+    )
+
+    self.assert_warning_raised(
+      build_file_content=dedent(
+        """\
+        jvm_app(
+          bundles=[
+            bundle(fileset=globs('foo.java')),
+          ],
+        )
+        """
+      ),
+      field_name="bundle(filespec=)",
+      line_number=3,
+      replacement="['foo.java']",
+      script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
+    )
+
+    def check_multiple_bad_bundle_entries(
+      build_file_content: str, *, replacements_and_line_numbers: List[Tuple[str, int]]
+    ) -> None:
+      result, build, warnings = self.capture_warnings(build_file_content=build_file_content)
+      assert result is None
+      for warning, replacement_and_line_number in zip(warnings, replacements_and_line_numbers):
+        replacement, line_number = replacement_and_line_number
+        assert warning == "root: " + warning_msg(
+          build_file=build,
+          lineno=line_number,
+          field_name="bundle(filespec=)",
+          replacement=replacement,
+          script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
+        )
+
+    check_multiple_bad_bundle_entries(
+      dedent(
+        """\
+        jvm_app(
+          bundles=[
+            bundle(fileset=globs('foo.java')),
+            bundle(fileset=globs('bar.java')),
+          ],
+        )
+        """
+      ),
+      replacements_and_line_numbers=[("['foo.java']", 3), ("['bar.java']", 4)]
+    )
+    check_multiple_bad_bundle_entries(
+      dedent(
+        """\
+        jvm_app(
+          bundles=[bundle(fileset=globs('foo.java')), bundle(fileset=globs('bar.java'))],
+        )
+        """
+      ),
+      replacements_and_line_numbers=[("['foo.java']", 2), ("['bar.java']", 2)]
+    )

--- a/build-support/mypy/BUILD
+++ b/build-support/mypy/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/pylint/BUILD
+++ b/build-support/pylint/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/regexes/BUILD
+++ b/build-support/regexes/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/scalafmt/BUILD
+++ b/build-support/scalafmt/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/build-support/scalastyle/BUILD
+++ b/build-support/scalastyle/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources = globs('*'),
+  sources = ['*'],
 )

--- a/contrib/avro/BUILD
+++ b/contrib/avro/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='avro_tests_directory',
-  sources=rglobs('tests/avro/*'),
+  sources=['tests/avro/**/*'],
 )

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
@@ -19,5 +19,5 @@ contrib_plugin(
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
 )

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
@@ -4,7 +4,7 @@
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
     'examples/src/java/org/pantsbuild/example:hello_directory',

--- a/contrib/cpp/BUILD
+++ b/contrib/cpp/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
 )

--- a/contrib/errorprone/BUILD
+++ b/contrib/errorprone/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='java_tests_directory',
-  sources=rglobs('tests/java/*'),
+  sources=['tests/java/**/*'],
 )

--- a/contrib/findbugs/BUILD
+++ b/contrib/findbugs/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='java_tests_directory',
-  sources=rglobs('tests/java/*'),
+  sources=['tests/java/**/*'],
 )

--- a/contrib/go/BUILD
+++ b/contrib/go/BUILD
@@ -8,5 +8,5 @@ page(
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
 )

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=globs('*.py'),  # Need explicit sources, because `go_test.py` won't match the default.
+  sources=['*.py'],  # Need explicit sources, because `go_test.py` won't match the default.
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:ansicolors',

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -34,7 +34,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources = globs('test_*_integration.py'),
+  sources = ['test_*_integration.py'],
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go:examples_directory',

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
+  sources = ['*.py', '!*_integration.py'],
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go/src/python/pants/contrib/go/targets',
@@ -22,7 +22,7 @@ python_tests(
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go:examples_directory',

--- a/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='wsdl_tests_directory',
-  sources=rglobs('tests/wsdl/*'),
+  sources=['tests/wsdl/**/*'],
 )

--- a/contrib/mypy/BUILD
+++ b/contrib/mypy/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
 )

--- a/contrib/node/BUILD
+++ b/contrib/node/BUILD
@@ -8,7 +8,7 @@ page(
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
   dependencies = [
     '//:3rdparty_directory',
   ],
@@ -16,5 +16,5 @@ files(
 
 files(
   name='testprojects_directory',
-  sources=rglobs('testprojects/*'),
+  sources=['testprojects/**/*'],
 )

--- a/contrib/node/examples/src/node/hello-test/BUILD
+++ b/contrib/node/examples/src/node/hello-test/BUILD
@@ -1,6 +1,6 @@
 node_module(
   name='pantsbuild-hello-mocha',
-  sources=globs('package.json', 'yarn.lock', '.babelrc', 'index.js', 'test/*.js'),
+  sources=['package.json', 'yarn.lock', '.babelrc', 'index.js', 'test/*.js'],
   package_manager='yarn',
 )
 

--- a/contrib/node/examples/src/node/hello/BUILD
+++ b/contrib/node/examples/src/node/hello/BUILD
@@ -1,5 +1,5 @@
 node_module(
   name='pantsbuild-hello-node',
-  sources=globs('package.json', 'yarn.lock', '.babelrc', 'index.js'),
+  sources=['package.json', 'yarn.lock', '.babelrc', 'index.js'],
   package_manager='yarn',
 )

--- a/contrib/node/examples/src/node/preinstalled-project/BUILD
+++ b/contrib/node/examples/src/node/preinstalled-project/BUILD
@@ -2,7 +2,7 @@
 # an alternative Node module resolver.
 
 node_preinstalled_module(
-  sources=globs('package.json', 'src/*.js', 'test/*.js'),
+  sources=['package.json', 'src/*.js', 'test/*.js'],
   dependencies_archive_url=
     'https://node-preinstalled-modules.pantsbuild.org/node_modules.tar.gz'
 )

--- a/contrib/node/examples/src/node/server-project/BUILD
+++ b/contrib/node/examples/src/node/server-project/BUILD
@@ -3,7 +3,7 @@
 # package.json enough to get this benefit without any duplication.
 
 node_module(
-  sources=globs('package.json', 'checkarg', 'src/*.js', 'test/*.js', 'yarn.lock'),
+  sources=['package.json', 'checkarg', 'src/*.js', 'test/*.js', 'yarn.lock'],
   package_manager='yarn',
 )
 

--- a/contrib/node/examples/src/node/web-build-tool/BUILD
+++ b/contrib/node/examples/src/node/web-build-tool/BUILD
@@ -1,6 +1,6 @@
 # dev_dependency is set to True.  This module will not be included in any JS bundle or JVM binary.
 node_module(
-  sources=globs('package.json','web-build-tool','webpack.config.base.js'),
+  sources=['package.json', 'web-build-tool', 'webpack.config.base.js'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/babel-loader',
     'contrib/node/examples/3rdparty/node/css-loader',

--- a/contrib/node/examples/src/node/web-component-button/BUILD
+++ b/contrib/node/examples/src/node/web-component-button/BUILD
@@ -2,7 +2,7 @@
 # transpile since there is no build_script declared.
 node_module(
   name='web-component-button',
-  sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
+  sources=['package.json', 'webpack.config.js', 'src/*', 'test/*'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',
     'contrib/node/examples/3rdparty/node/react',
@@ -36,7 +36,7 @@ node_bundle(
 # web-component-button-processed target invokes webpack transpiling via build_script.
 node_module(
   name='web-component-button-processed',
-  sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
+  sources=['package.json', 'webpack.config.js', 'src/*', 'test/*'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',
     'contrib/node/examples/3rdparty/node/react',
@@ -54,7 +54,7 @@ node_bundle(
 # Used to testing dependencies bundling.
 node_module(
   name='web-component-button-processed-with-dependency-artifacts',
-  sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
+  sources=['package.json', 'webpack.config.js', 'src/*', 'test/*'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',
     'contrib/node/examples/3rdparty/node/react',

--- a/contrib/node/examples/src/node/web-dependency-test/BUILD
+++ b/contrib/node/examples/src/node/web-dependency-test/BUILD
@@ -1,7 +1,7 @@
 # No build script specified. Dependents will include raw installation results:
 # src/*, package.json and node_modules installed by mocha.
 node_module(
-  sources=globs('package.json', 'src/*'),
+  sources=['package.json', 'src/*'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',
   ]

--- a/contrib/node/examples/src/node/web-project/BUILD
+++ b/contrib/node/examples/src/node/web-project/BUILD
@@ -1,5 +1,5 @@
 node_module(
-  sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
+  sources=['package.json', 'webpack.config.js', 'src/*', 'test/*'],
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',
     'contrib/node/examples/3rdparty/node/react',

--- a/contrib/node/examples/src/node/yarn-workspaces/BUILD
+++ b/contrib/node/examples/src/node/yarn-workspaces/BUILD
@@ -1,5 +1,5 @@
 node_module(
-  sources=globs('package.json', 'yarn.lock', 'adder/**', 'add-two/**'),
+  sources=['package.json', 'yarn.lock', 'adder/**', 'add-two/**'],
   package_manager='yarn',
   dependencies=[
     'contrib/node/examples/src/node/yarn-workspaces/add-one',

--- a/contrib/node/examples/src/node/yarn-workspaces/add-one/BUILD
+++ b/contrib/node/examples/src/node/yarn-workspaces/add-one/BUILD
@@ -1,5 +1,5 @@
 node_module(
-  sources=globs('package.json', 'yarn.lock', 'index.js', 'test/*.js', 'cli.js'),
+  sources=['package.json', 'yarn.lock', 'index.js', 'test/*.js', 'cli.js'],
   package_manager='yarn',
   bin_executables = {
     'add-one': 'cli.js'

--- a/contrib/node/testprojects/lockfile-invalidation/BUILD
+++ b/contrib/node/testprojects/lockfile-invalidation/BUILD
@@ -1,5 +1,5 @@
 node_module(
   name='lockfiles',
-  sources=globs('package.json', 'yarn.lock', '.babelrc', 'index.js'),
+  sources=['package.json', 'yarn.lock', '.babelrc', 'index.js'],
   package_manager='yarn',
 )

--- a/contrib/node/tests/node/npm-path-injection/BUILD
+++ b/contrib/node/tests/node/npm-path-injection/BUILD
@@ -1,6 +1,6 @@
 node_module(
   name='npm-path-injection',
-  sources=globs('package.json', 'npm-shrinkwrap.json', '.babelrc', 'test/*.js'),
+  sources=['package.json', 'npm-shrinkwrap.json', '.babelrc', 'test/*.js'],
   package_manager='npm',
 )
 

--- a/contrib/node/tests/node/yarnpkg-path-injection/BUILD
+++ b/contrib/node/tests/node/yarnpkg-path-injection/BUILD
@@ -1,6 +1,6 @@
 node_module(
   name='yarnpkg-path-injection',
-  sources=globs('package.json', 'yarn.lock', '.babelrc', 'test/*.js'),
+  sources=['package.json', 'yarn.lock', '.babelrc', 'test/*.js'],
   package_manager='yarn',
 )
 

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
@@ -22,5 +22,5 @@ python_library(
 
 resources(
   name='resources',
-  sources=globs('templates/python_eval/*.mustache'),
+  sources=['templates/python_eval/*.mustache'],
 )

--- a/contrib/scalajs/BUILD
+++ b/contrib/scalajs/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name='examples_directory',
-  sources=rglobs('examples/*'),
+  sources=['examples/**/*'],
   dependencies=[
     'examples/src/scala/org/pantsbuild/example:fact_directory',
   ],

--- a/contrib/scalajs/examples/src/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
+++ b/contrib/scalajs/examples/src/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
@@ -5,5 +5,5 @@ scala_js_binary(
   dependencies=[
     'examples/src/scala/org/pantsbuild/example/fact:fact-js',
   ],
-  sources=globs('*.scala'),
+  sources=['*.scala'],
 )

--- a/contrib/scrooge/BUILD
+++ b/contrib/scrooge/BUILD
@@ -3,10 +3,10 @@
 
 files(
   name='scala_tests_directory',
-  sources=rglobs('tests/scala/*'),
+  sources=['tests/scala/**/*'],
 )
 
 files(
   name='thrift_tests_directory',
-  sources=rglobs('tests/thrift/*'),
+  sources=['tests/thrift/**/*'],
 )

--- a/examples/3rdparty/BUILD
+++ b/examples/3rdparty/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name='python_directory',
-  sources=rglobs('python/*'),
+  sources=['python/**/*'],
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name = '3rdparty_directory',
-  sources = rglobs('3rdparty/*'),
+  sources = ['3rdparty/**/*'],
 )
 
 files(

--- a/examples/src/antlr/org/pantsbuild/example/BUILD
+++ b/examples/src/antlr/org/pantsbuild/example/BUILD
@@ -10,5 +10,5 @@ target(
 
 files(
   name = 'exp_directory',
-  sources = rglobs('exp/*'),
+  sources = ['exp/**/*'],
 )

--- a/examples/src/java/org/pantsbuild/example/BUILD
+++ b/examples/src/java/org/pantsbuild/example/BUILD
@@ -72,7 +72,7 @@ page(
 
 files(
   name = 'annotation_directory',
-  sources = rglobs('annotation/*'),
+  sources = ['annotation/**/*'],
   dependencies = [
     'examples/src/antlr/org/pantsbuild/example:exp_directory',
   ],
@@ -80,7 +80,7 @@ files(
 
 files(
   name = 'antlr3_directory',
-  sources = rglobs('antlr3/*'),
+  sources = ['antlr3/**/*'],
   dependencies = [
     'examples/src/antlr/org/pantsbuild/example:exp_directory',
   ],
@@ -88,7 +88,7 @@ files(
 
 files(
   name = 'antlr4_directory',
-  sources = rglobs('antlr4/*'),
+  sources = ['antlr4/**/*'],
   dependencies = [
     'examples/src/antlr/org/pantsbuild/example:exp_directory',
   ],
@@ -96,12 +96,12 @@ files(
 
 files(
   name = 'autovalue_directory',
-  sources = rglobs('autovalue/*'),
+  sources = ['autovalue/**/*'],
 )
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
   dependencies = [
     'examples/src/resources/org/pantsbuild/example:hello_directory',
   ],
@@ -113,17 +113,17 @@ files(
 # dependency in `all_targets` to get this working with the testprojects integration test.
 files(
   name = 'java_sources_directory',
-  sources = rglobs('java_sources/*'),
+  sources = ['java_sources/**/*'],
 )
 
 files(
   name = 'javac_directory',
-  sources = rglobs('javac/*'),
+  sources = ['javac/**/*'],
 )
 
 files(
   name = 'jaxb_directory',
-  sources = rglobs('jaxb/*'),
+  sources = ['jaxb/**/*'],
   dependencies = [
     'examples/src/resources/org/pantsbuild/example:jaxb_directory',
   ],
@@ -131,7 +131,7 @@ files(
 
 files(
   name = 'make_it_rain_directory',
-  sources = rglobs('make_it_rain/*'),
+  sources = ['make_it_rain/**/*'],
   dependencies = [
     'examples/src/thrift/org/pantsbuild/example:distance_directory',
     'examples/src/thrift/org/pantsbuild/example:precipitation_directory',
@@ -140,7 +140,7 @@ files(
 
 files(
   name = 'protobuf_directory',
-  sources = rglobs('protobuf/*'),
+  sources = ['protobuf/**/*'],
   dependencies = [
     'examples/src/protobuf/org/pantsbuild/example:distance_directory',
     'examples/src/protobuf/org/pantsbuild/example:imports_directory',
@@ -150,7 +150,7 @@ files(
 
 files(
   name = 'wire_directory',
-  sources = rglobs('wire/*'),
+  sources = ['wire/**/*'],
   dependencies = [
     'examples/src/wire/org/pantsbuild/example:element_directory',
     'examples/src/wire/org/pantsbuild/example:roots_directory',

--- a/examples/src/java/org/pantsbuild/example/hello/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/main/BUILD
@@ -11,7 +11,7 @@ jvm_app(
     ':main-bin'
   ],
   bundles = [
-    bundle(relative_to='config', fileset=globs('config/*'))
+    bundle(relative_to='config', fileset=['config/*'])
   ]
 )
 

--- a/examples/src/protobuf/org/pantsbuild/example/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/BUILD
@@ -13,12 +13,12 @@ target(
 
 files(
   name = 'distance_directory',
-  sources = rglobs('distance/*'),
+  sources = ['distance/**/*'],
 )
 
 files(
   name = 'grpcio_directory',
-  sources = rglobs('grpcio/*'),
+  sources = ['grpcio/**/*'],
   dependencies = [
     'examples:3rdparty_directory',
   ],
@@ -26,11 +26,11 @@ files(
 
 files(
   name = 'imports_directory',
-  sources = rglobs('imports/*'),
+  sources = ['imports/**/*'],
 )
 
 files(
   name = 'unpacked_jars_directory',
-  sources = rglobs('unpacked_jars/*'),
+  sources = ['unpacked_jars/**/*'],
 )
 

--- a/examples/src/protobuf/org/pantsbuild/example/imports/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/imports/BUILD
@@ -3,7 +3,7 @@
 
 # Local sources which depend on remote sources extracted from a jar.
 java_protobuf_library(
-  sources=globs('*.proto'),
+  sources=['*.proto'],
   dependencies=[
     ':remote',
   ],

--- a/examples/src/python/example/BUILD
+++ b/examples/src/python/example/BUILD
@@ -30,7 +30,7 @@ page(
 
 files(
   name='grpcio_directory',
-  sources=rglobs('grpcio/*'),
+  sources=['grpcio/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
     'examples/src/protobuf/org/pantsbuild/example:grpcio_directory',
@@ -39,17 +39,17 @@ files(
 
 files(
   name='hello_directory',
-  sources=rglobs('hello/*'),
+  sources=['hello/**/*'],
 )
 
 files(
   name='pants_publish_plugin_directory',
-  sources=rglobs('pants_publish_plugin/*'),
+  sources=['pants_publish_plugin/**/*'],
 )
 
 files(
   name='tensorflow_custom_op_directory',
-  sources=rglobs('tensorflow_custom_op/*'),
+  sources=['tensorflow_custom_op/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
   ],

--- a/examples/src/python/example/hello/main/BUILD
+++ b/examples/src/python/example/hello/main/BUILD
@@ -17,6 +17,6 @@ python_app(
   name='hello-app',
   binary=':main',
   bundles=[
-    bundle(fileset=globs('BUILD')),
+    bundle(fileset=['BUILD']),
   ],
 )

--- a/examples/src/resources/org/pantsbuild/example/BUILD
+++ b/examples/src/resources/org/pantsbuild/example/BUILD
@@ -3,15 +3,15 @@
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
 )
 
 files(
   name = 'jaxb_directory',
-  sources = rglobs('jaxb/*'),
+  sources = ['jaxb/**/*'],
 )
 
 files(
   name = 'names_directory',
-  sources = rglobs('names/*'),
+  sources = ['names/**/*'],
 )

--- a/examples/src/resources/org/pantsbuild/example/jaxb/BUILD
+++ b/examples/src/resources/org/pantsbuild/example/jaxb/BUILD
@@ -2,6 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jaxb_library(
-  sources=globs('*.xsd'),
+  sources=['*.xsd'],
   package='org.pantsbuild.example.jaxb.api',
 )

--- a/examples/src/scala/org/pantsbuild/example/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/BUILD
@@ -24,12 +24,12 @@ page(
 
 files(
   name = 'fact_directory',
-  sources = rglobs('fact/*'),
+  sources = ['fact/**/*'],
 )
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/resources/org/pantsbuild/example:hello_directory',
@@ -38,7 +38,7 @@ files(
 
 files(
   name = 'jvm_run_directory',
-  sources = rglobs('jvm_run/*'),
+  sources = ['jvm_run/**/*'],
   dependencies = [
     ':hello_directory',
   ],
@@ -46,7 +46,7 @@ files(
 
 files(
   name = 'scala_with_java_sources_directory',
-  sources = rglobs('scala_with_java_sources/*'),
+  sources = ['scala_with_java_sources/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:java_sources_directory',
   ],
@@ -54,15 +54,15 @@ files(
 
 files(
   name = 'scalac_directory',
-  sources = rglobs('scalac/*'),
+  sources = ['scalac/**/*'],
 )
 
 files(
   name = 'several_scala_targets_directory',
-  sources = rglobs('several_scala_targets/*'),
+  sources = ['several_scala_targets/**/*'],
 )
 
 files(
   name = 'styleissue_directory',
-  sources = rglobs('styleissue/*'),
+  sources = ['styleissue/**/*'],
 )

--- a/examples/src/scala/org/pantsbuild/example/fact/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/fact/BUILD
@@ -4,5 +4,5 @@
 # A pure scala library, with no Java or 3rdparty dependencies.
 scala_library()
 scala_js_library(name='fact-js',
-  sources=globs('*.scala'),
+  sources=['*.scala'],
 )

--- a/examples/src/thrift/org/pantsbuild/example/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/BUILD
@@ -18,7 +18,7 @@ page(
 
 files(
   name = 'distance_directory',
-  sources = rglobs('distance/*'),
+  sources = ['distance/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
   ],
@@ -26,7 +26,7 @@ files(
 
 files(
   name = 'precipitation_directory',
-  sources = rglobs('precipitation/*'),
+  sources = ['precipitation/**/*'],
   dependencies = [
     ':distance_directory',
     'examples/3rdparty:python_directory',

--- a/examples/src/wire/org/pantsbuild/example/BUILD
+++ b/examples/src/wire/org/pantsbuild/example/BUILD
@@ -12,15 +12,15 @@ target(
 
 files(
   name = 'element_directory',
-  sources = rglobs('element/*'),
+  sources = ['element/**/*'],
 )
 
 files(
   name = 'roots_directory',
-  sources = rglobs('roots/*'),
+  sources = ['roots/**/*'],
 )
 
 files(
   name = 'temperature_directory',
-  sources = rglobs('temperature/*'),
+  sources = ['temperature/**/*'],
 )

--- a/examples/tests/java/org/pantsbuild/example/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/BUILD
@@ -16,7 +16,7 @@ target(
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/resources/org/pantsbuild/example:hello_directory',
@@ -25,7 +25,7 @@ files(
 
 files(
   name = 'useantlr_directory',
-  sources = rglobs('useantlr/*'),
+  sources = ['useantlr/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:antlr3_directory',
     'examples/src/java/org/pantsbuild/example:antlr4_directory',
@@ -34,7 +34,7 @@ files(
 
 files(
   name = 'usejaxb_directory',
-  sources = rglobs('usejaxb/*'),
+  sources = ['usejaxb/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:jaxb_directory',
     'examples/src/resources/org/pantsbuild/example:jaxb_directory',
@@ -43,7 +43,7 @@ files(
 
 files(
   name = 'useproto_directory',
-  sources = rglobs('useproto/*'),
+  sources = ['useproto/**/*'],
   dependencies = [
     'examples/src/protobuf/org/pantsbuild/example:distance_directory',
   ],
@@ -51,7 +51,7 @@ files(
 
 files(
   name = 'useprotoimports_directory',
-  sources = rglobs('useprotoimports/*'),
+  sources = ['useprotoimports/**/*'],
   dependencies = [
     'examples/src/protobuf/org/pantsbuild/example:imports_directory',
   ],
@@ -59,7 +59,7 @@ files(
 
 files(
   name = 'usethrift_directory',
-  sources = rglobs('usethrift/*'),
+  sources = ['usethrift/**/*'],
   dependencies = [
     'examples/src/thrift/org/pantsbuild/example:distance_directory',
     'examples/src/thrift/org/pantsbuild/example:precipitation_directory',
@@ -68,7 +68,7 @@ files(
 
 files(
   name = 'usewire_directory',
-  sources = rglobs('usethrift/*'),
+  sources = ['usethrift/**/*'],
   dependencies = [
     'examples/src/wire/org/pantsbuild/example:temperature_directory',
   ],

--- a/examples/tests/python/example_test/BUILD
+++ b/examples/tests/python/example_test/BUILD
@@ -12,12 +12,12 @@ target(
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
 )
 
 files(
   name = 'tensorflow_custom_op_directory',
-  sources = rglobs('tensorflow_custom_op/*'),
+  sources = ['tensorflow_custom_op/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
     'examples/src/python/example:tensorflow_custom_op_directory',
@@ -26,7 +26,7 @@ files(
 
 files(
   name = 'usethriftpy_directory',
-  sources = rglobs('usethriftpy/*'),
+  sources = ['usethriftpy/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
     'examples/src/thrift/org/pantsbuild/example:distance_directory',

--- a/examples/tests/scala/org/pantsbuild/example/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/BUILD
@@ -11,7 +11,7 @@ target(
 
 files(
   name = 'hello_directory',
-  sources = rglobs('hello/*'),
+  sources = ['hello/**/*'],
   dependencies = [
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
@@ -19,5 +19,5 @@ files(
 
 files(
   name = 'specs2_directory',
-  sources = rglobs('specs2/*'),
+  sources = ['specs2/**/*'],
 )

--- a/src/java/org/pantsbuild/BUILD
+++ b/src/java/org/pantsbuild/BUILD
@@ -3,5 +3,5 @@
 
 files(
   name = 'junit_directory',
-  sources = rglobs('junit/*'),
+  sources = ['junit/**/*'],
 )

--- a/src/java/org/pantsbuild/testing/BUILD
+++ b/src/java/org/pantsbuild/testing/BUILD
@@ -3,7 +3,7 @@
 
 java_library(
   # We have to use explicit sources here to grab `EasyMockTest.java` which otherwise gets excluded.
-  sources=globs('*.java'),
+  sources=['*.java'],
   dependencies=[
     '3rdparty:easymock',
     '3rdparty:guava',

--- a/src/java/org/pantsbuild/tools/junit/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/BUILD
@@ -24,7 +24,7 @@ java_library(
     'src/java/org/pantsbuild/junit/annotations',
     'src/java/org/pantsbuild/tools/junit/withretry',
   ],
-  sources=globs('*.java', 'impl/*.java', 'impl/experimental/*.java'),
+  sources=['*.java', 'impl/*.java', 'impl/experimental/*.java'],
 )
 
 jvm_binary(

--- a/src/python/pants/backend/docgen/tasks/BUILD
+++ b/src/python/pants/backend/docgen/tasks/BUILD
@@ -30,5 +30,5 @@ python_library(
 
 resources(
   name = 'resources',
-  sources = globs('templates/*/*.mustache'),
+  sources = ['templates/*/*.mustache'],
 )

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -67,7 +67,7 @@ python_library(
 
 resources(
   name='ivy_utils_resources',
-  sources=globs('templates/ivy_utils/*.mustache'),
+  sources=['templates/ivy_utils/*.mustache'],
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -355,7 +355,7 @@ python_library(
 
 resources(
   name = 'jar_publish_resources',
-  sources = globs('templates/jar_publish/*.mustache'),
+  sources = ['templates/jar_publish/*.mustache'],
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/reports/templates/BUILD
+++ b/src/python/pants/backend/jvm/tasks/reports/templates/BUILD
@@ -1,5 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(sources=globs('*.mustache'))
+resources(
+  sources=['*.mustache'],
+)
 

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -126,5 +126,5 @@ python_library(
 
 resources(
   name = 'idea_resources',
-  sources = globs('templates/idea/*.mustache'),
+  sources = ['templates/idea/*.mustache'],
 )

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -20,7 +20,7 @@ python_library(
 
 python_library(
   name = 'all_utils',
-  sources = globs('*.py', exclude=[['__init__.py', 'register.py']]),
+  sources = ['*.py', '!__init__.py', '!register.py'],
   dependencies = [
     ':interpreter_cache',
     ':python_artifact',

--- a/src/python/pants/backend/python/lint/BUILD
+++ b/src/python/pants/backend/python/lint/BUILD
@@ -13,7 +13,7 @@ python_library(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     'src/python/pants/backend/python/lint',
     'src/python/pants/backend/python/lint/black',

--- a/src/python/pants/backend/python/lint/bandit/BUILD
+++ b/src/python/pants/backend/python/lint/bandit/BUILD
@@ -19,7 +19,7 @@ python_library(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     ':bandit',
     'src/python/pants/backend/python/lint',

--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -19,7 +19,7 @@ python_library(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     ':black',
     'src/python/pants/backend/python/lint',

--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -19,7 +19,7 @@ python_library(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     ':flake8',
     'src/python/pants/backend/python/lint',

--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -19,7 +19,7 @@ python_library(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     ':isort',
     'src/python/pants/backend/python/lint',

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -21,7 +21,7 @@ python_library(
 
 python_tests(
   name='tests',
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
+  sources=['*_test.py', '!*_integration_test.py'],
   dependencies=[
     ':rules',
     'src/python/pants/backend/python/subsystems',
@@ -46,7 +46,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     ':rules',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -33,5 +33,5 @@ python_library(
 
 resources(
   name='templates',
-  sources=globs('templates/**/*.mustache'),
+  sources=['templates/**/*.mustache'],
 )

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -18,7 +18,7 @@ python_library(
 
 python_tests(
   name='tests',
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
+  sources=['*_test.py', '!*_integration_test.py'],
   dependencies=[
     'src/python/pants/build_graph',
     'src/python/pants/help',
@@ -31,7 +31,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
   ],

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -16,5 +16,5 @@ python_library(
 
 resources(
   name='resources',
-  sources=globs('*.class'),
+  sources=['*.class'],
 )

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources = rglobs('*.py'),
+  sources = ['**/*.py'],
   dependencies = [
     '3rdparty/python:requests',
     '3rdparty/python:pyopenssl',

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -25,7 +25,7 @@ python_library(
 
 python_tests(
   name="tests",
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
+  sources=['*_test.py', '!*_integration_test.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':option',
@@ -41,7 +41,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=globs('*.py', exclude=[['report.py']]),
+  sources=['*.py', '!report.py'],
   dependencies=[
     '3rdparty/python:ansicolors',
     '3rdparty/python:dataclasses',
@@ -29,7 +29,7 @@ python_library(
 
 resources(
   name='reporting_resources',
-  sources=rglobs('assets/*', 'templates/*.mustache')
+  sources=['assets/**/*', 'templates/**/*.mustache'],
 )
 
 python_library(

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -24,7 +24,7 @@ python_library(
 
 python_tests(
   name = "tests",
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
+  sources=['*_test.py', '!*_integration_test.py'],
   dependencies = [
     ':core',
     'src/python/pants:version',
@@ -46,7 +46,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration_test.py'),
+  sources=['*_integration_test.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
     'examples/src/java/org/pantsbuild/example:hello_directory',

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources = globs('*.py', exclude=[globs('payload_fields.py')]),
+  sources = ['*.py', '!payload_fields.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:dataclasses',

--- a/src/rust/engine/BUILD
+++ b/src/rust/engine/BUILD
@@ -3,14 +3,7 @@
 
 # Track files depended on to build the native engine to allow for downstream invalidations.
 files(
-  sources=zglobs(
-    '**/Cargo.*',
-    '**/*.rs',
-    exclude=[
-      zglobs('**/target/*'),
-      'process_execution/bazel_protos'
-    ]
-  ),
+  sources=["**/Cargo.*", "**/*.rs", "!**/target/*", "!process_execution/bazel_protos"],
   dependencies=[
     'src/rust/engine/process_execution/bazel_protos'
   ]

--- a/src/rust/engine/process_execution/bazel_protos/BUILD
+++ b/src/rust/engine/process_execution/bazel_protos/BUILD
@@ -3,11 +3,5 @@
 
 # Track files depended on to build the native engine to allow for downstream invalidations.
 files(
-  sources=zglobs(
-    '**/Cargo.*',
-    '**/*.rs',
-    exclude=[
-      zglobs('**/target/*'),
-    ]
-  )
+  sources=["**/Cargo.*", "**/*.rs", "!**/target/*"],
 )

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/BUILD
@@ -3,5 +3,5 @@
 
 resources(
   name='zinc-native-image-configuration',
-  sources=rglobs('*'),
+  sources=['**/*'],
 )

--- a/tests/java/org/pantsbuild/tools/junit/impl/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/impl/BUILD
@@ -13,6 +13,6 @@ junit_tests(
     'tests/java/org/pantsbuild/tools/junit/lib:test-dep',
     'tests/scala/org/pantsbuild/tools/junit/lib:scala-test-dep',
   ],
-  sources=globs('*Test.java'),
+  sources=['*Test.java'],
   timeout=180,
 )

--- a/tests/java/org/pantsbuild/tools/junit/lib/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/lib/BUILD
@@ -5,7 +5,7 @@ java_library(
   name='test-dep',
   # We need to use explicit sources here since we want to own both library code in this directory
   # and code that looks like tests.
-  sources=globs('*.java'),
+  sources=['*.java'],
   dependencies=[
     '3rdparty/jvm/com/squareup/burst:burst-junit4',
     '3rdparty:guava',

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -3,7 +3,7 @@
 
 
 python_tests(
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
+  sources = ['*.py', '!*_integration.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:dataclasses',
@@ -19,7 +19,7 @@ python_tests(
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies = [
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/codegen/antlr/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/python/BUILD
@@ -3,7 +3,7 @@
 
 
 python_tests(
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
+  sources = ['*.py', '!*_integration.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/codegen/antlr/python',
@@ -18,7 +18,7 @@ python_tests(
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies = [
     'src/python/pants/testutil:int-test',
     'tests/python/pants_test:interpreter_selection_utils',

--- a/tests/python/pants_test/backend/codegen/grpcio/BUILD
+++ b/tests/python/pants_test/backend/codegen/grpcio/BUILD
@@ -8,6 +8,6 @@ python_tests(
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:task_test_base',
   ],
-  sources=globs('*.py'),
+  sources=['*.py'],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
+  sources = ['*.py', '!*_integration.py'],
   dependencies = [
     'src/python/pants/backend/codegen/protobuf/java',
     'src/python/pants/java/jar',
@@ -20,7 +20,7 @@ python_tests(
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies = [
     'src/python/pants/testutil:int-test',
     'examples/src/java/org/pantsbuild/example:protobuf_directory',

--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -3,7 +3,7 @@
 
 
 python_tests(
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
+  sources = ['*.py', '!*_integration.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:parameterized',
@@ -24,7 +24,7 @@ python_tests(
 
 python_tests(
   name = 'integration',
-  sources = globs('*_integration.py'),
+  sources = ['*_integration.py'],
   dependencies = [
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/BUILD
+++ b/tests/python/pants_test/backend/jvm/BUILD
@@ -12,7 +12,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration.py'),
+  sources=['*_integration.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
     'examples/tests/java/org/pantsbuild/example:hello_directory',

--- a/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/BUILD
@@ -1,1 +1,3 @@
-files(sources=globs('*.xml'))
+files(
+  sources=['*.xml'],
+)

--- a/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name = 'junit_xml',
-  sources = rglobs('junit_xml/*.xml'),
+  sources = ['junit_xml/**/*.xml'],
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -43,7 +43,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration.py'),
+  sources=['*_integration.py'],
   dependencies=[
     ':pants_requirement_integration_test_base',
     'src/python/pants/base:build_environment',

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  sources=globs('test_*.py', exclude=[globs('*_integration.py')]),
+  sources=['test_*.py', '!*_integration.py'],
   dependencies=[
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/subsystems',
@@ -33,7 +33,7 @@ python_tests(
 
 python_tests(
   name='integration',
-  sources=globs('*_integration.py'),
+  sources=['*_integration.py'],
   dependencies=[
     'src/python/pants/backend/native',
     'src/python/pants/backend/native/targets',

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  sources=globs('test_*.py', exclude=['*_integration.py']),
+  sources=['test_*.py', '!*_integration.py'],
   dependencies=[
     'src/python/pants/binaries',
     'src/python/pants/net',

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -22,20 +22,20 @@ resources(
   name='fs_test',
   # Note that this test data dir is bundled into a tarfile, to preserve symlink structure
   # when copied into a chroot.
-  sources=rglobs('fs_test/*')
+  sources=['fs_test/**/*'],
 )
 
 resources(
   name='graph_test',
-  sources=rglobs('graph_test/*')
+  sources=['graph_test/**/*'],
 )
 
 resources(
   name='mapper_test',
-  sources=rglobs('mapper_test/*')
+  sources=['mapper_test/**/*'],
 )
 
 resources(
   name='scheduler_inputs',
-  sources=rglobs('scheduler_inputs/*')
+  sources=['scheduler_inputs/**/*'],
 )

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -59,5 +59,5 @@ python_tests(
 
 files(
   name = 'jar_publish_resources_directory',
-  sources = rglobs('jar_publish_resources/*'),
+  sources = ['jar_publish_resources/**/*'],
 )

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -3,7 +3,7 @@
 
 python_library(
   name = 'mock_logger',
-  sources = globs('mock_logger.py'),
+  sources = ['mock_logger.py'],
   dependencies = [
     'src/python/pants/testutil:mock_logger',
     'tests/python/pants_test:deprecated_testinfra',

--- a/tests/resources/org/pantsbuild/tools/ivy/BUILD
+++ b/tests/resources/org/pantsbuild/tools/ivy/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 files(
-  sources=rglobs('*.jar', '*.properties', '*.xml'),
+  sources=['**/*.jar', '**/*.properties', '**/*.xml'],
 )

--- a/tests/resources/org/pantsbuild/tools/jar/BUILD
+++ b/tests/resources/org/pantsbuild/tools/jar/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 resources(
-  sources=globs('*.jar'),
+  sources=['*.jar'],
 )

--- a/tests/scala/org/pantsbuild/tools/junit/lib/BUILD
+++ b/tests/scala/org/pantsbuild/tools/junit/lib/BUILD
@@ -7,5 +7,5 @@ scala_library(
     '3rdparty:scalatest',
     'tests/java/org/pantsbuild/tools/junit/lib:test-dep',
   ],
-  sources=globs('*.scala')
+  sources=['*.scala'],
 )


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/issues/5427, we will be deprecating `globs`, `rglobs` and `zglobs` in BUILD files. This PR prepares the repo for that change.

Most importantly, this automates the process through a new script `build-support/migration-support/fix_deprecated_globs_usage.py`. This task is highly tedious but also highly automatable. Thanks to the script, we were able to update all 104 of our BUILD files in less than 3 minutes (2 minutes of manual changes flagged by the script).

When we deprecate `globs`, we will include instructions to curl the script and run it so that our users don't have to waste time updating BUILD files. 

Because we plan to distribute the `fix_deprecated_globs_usage.py` (and because it's complex), we add exhaustive unit tests.