### PR TITLE
Modify options parser to allow `!` in file args

### DIFF
--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -447,7 +447,7 @@ async def get_ancestor_init_py(
   # we match each result to its originating glob (see use of zip below).
   ancestor_init_py_snapshots = await MultiGet[Snapshot](
     Get[Snapshot](PathGlobs,
-                  PathGlobs(include=(os.path.join(source_dir_ancestor[1], '__init__.py'),)))
+                  PathGlobs([os.path.join(source_dir_ancestor[1], '__init__.py')]))
     for source_dir_ancestor in source_dir_ancestors_list
   )
 

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -72,7 +72,7 @@ class CmdLineSpecParser:
       spec_parts = spec.rsplit(':', 1)
       spec_path = self._normalize_spec_path(spec_parts[0])
       return SingleAddress(directory=spec_path, name=spec_parts[1])
-    if '*' in spec:
+    if spec.startswith('!') or '*' in spec:
       return FilesystemSpec(glob=spec)
     if PurePath(spec).suffix:
       return FilesystemSpec(glob=self._normalize_spec_path(spec))

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -43,8 +43,10 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
 
   The AddressFamily may be empty, but it will not be None.
   """
-  patterns = (os.path.join(directory.path, p) for p in address_mapper.build_patterns)
-  path_globs = PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
+  path_globs = PathGlobs(
+    include=(os.path.join(directory.path, p) for p in address_mapper.build_patterns),
+    exclude=address_mapper.build_ignore_patterns,
+  )
   snapshot = await Get[Snapshot](PathGlobs, path_globs)
   files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -1,9 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os.path
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
-from os.path import dirname, join
 from typing import Dict
 
 from twitter.common.collections import OrderedSet
@@ -43,7 +43,7 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
 
   The AddressFamily may be empty, but it will not be None.
   """
-  patterns = tuple(join(directory.path, p) for p in address_mapper.build_patterns)
+  patterns = (os.path.join(directory.path, p) for p in address_mapper.build_patterns)
   path_globs = PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
   snapshot = await Get[Snapshot](PathGlobs, path_globs)
   files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
@@ -212,7 +212,7 @@ async def provenanced_addresses_from_address_families(
   """
   # Capture a Snapshot covering all paths for these AddressSpecs, then group by directory.
   snapshot = await Get[Snapshot](PathGlobs, _address_spec_to_globs(address_mapper, address_specs))
-  dirnames = {dirname(f) for f in snapshot.files}
+  dirnames = {os.path.dirname(f) for f in snapshot.files}
   address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}
 

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -180,7 +180,7 @@ class ArgSplitter:
         # We assume any args here are in global scope.
         if not self._check_for_help_request(arg):
           assign_flag_to_scope(arg, GLOBAL_SCOPE)
-      elif self.spec(arg):
+      elif self.likely_a_spec(arg):
         specs.append(arg)
       elif arg not in self._known_scopes:
         self._unknown_scopes.append(arg)
@@ -205,13 +205,17 @@ class ArgSplitter:
     )
 
   @staticmethod
-  def spec(arg: str) -> bool:
-    """Does arg 'look like' a Spec (rather than a goal name).
+  def likely_a_spec(arg: str) -> bool:
+    """Return whether `arg` looks like a spec, rather than a goal name.
 
     An arg is a spec if it looks like an AddressSpec or a FilesystemSpec.
     In the future we can expand this heuristic to support other kinds of specs, such as URLs.
     """
-    return os.path.sep in arg or ':' in arg or '*' in arg or Path(arg).exists()
+    return (
+      any(symbol in arg for symbol in (os.path.sep, ':', '*'))
+      or arg.startswith('!')
+      or Path(arg).exists()
+    )
 
   def _consume_scope(self) -> Tuple[Optional[str], List[str]]:
     """Returns a pair (scope, list of flags encountered in that scope).

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -77,10 +77,10 @@ class ArgSplitterTest(unittest.TestCase):
 
   def test_is_spec(self) -> None:
     def assert_spec(arg: str) -> None:
-      assert ArgSplitter.spec(arg) is True
+      assert ArgSplitter.likely_a_spec(arg) is True
 
     def assert_not_spec(arg: str) -> None:
-      assert ArgSplitter.spec(arg) is False
+      assert ArgSplitter.likely_a_spec(arg) is False
 
     unambiguous_specs = [
       'a/b/c',
@@ -96,6 +96,9 @@ class ArgSplitterTest(unittest.TestCase):
       'a/b/*.txt',
       'a/b/test*',
       'a/**/*',
+      '!',
+      '!/a/b',
+      '!/a/b.txt',
     ]
     for s in unambiguous_specs:
       assert_spec(s)
@@ -175,6 +178,8 @@ class ArgSplitterTest(unittest.TestCase):
     assert_test_goal_split('./pants test *', expected_specs=['*'])
     assert_test_goal_split('./pants test test/*.txt', expected_specs=['test/*.txt'])
     assert_test_goal_split('./pants test test/**/*', expected_specs=['test/**/*'])
+    assert_test_goal_split('./pants test !', expected_specs=['!'])
+    assert_test_goal_split('./pants test !a/b', expected_specs=['!a/b'])
 
     # An argument that looks like a file, but is a known scope, should be interpreted as a goal.
     self.assert_valid_split(

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -76,6 +76,10 @@ class CmdLineSpecParserTest(TestBase):
     for glob in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
       self.assert_filesystem_spec_parsed(glob)
 
+  def test_excludes(self) -> None:
+    for glob in ["!", "!a/b/", "!/a/b/*"]:
+      self.assert_filesystem_spec_parsed(glob)
+
   def test_ambiguous_files(self) -> None:
     # These could either be files or the shorthand for single addresses. We check if they exist on
     # the file system to disambiguate.

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -308,7 +308,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
 
     cat_exe_req = CatExecutionRequest(
       ShellCat(BinaryLocation('/bin/cat')),
-      PathGlobs(include=['f*']),
+      PathGlobs(['f*']),
     )
 
     concatted = self.request_single_product(Concatted, cat_exe_req)


### PR DESCRIPTION
We will soon allow `!` in both the `sources` field of BUILD files and in file args (aka filesystem specs) to indicate excludes. This PR tweaks our options parsing logic to formalize support for `!` as a leading character.

This also lightly refactors `engine/legacy/structs.py` and some `PathGlobs`-related code in preparation for adding support to the `!` syntax.