### PR TITLE
Refactor `PathGlobs` to support `!` ignore globs in its constructor

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -60,7 +60,7 @@ async def lint(
   config_path: Optional[str] = bandit.options.config
   config_snapshot = await Get[Snapshot](
     PathGlobs(
-      include=tuple([config_path] if config_path else []),
+      globs=tuple([config_path] if config_path else []),
       glob_match_error_behavior=GlobMatchErrorBehavior.error,
       description_of_origin="the option `--bandit-config`",
     )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -50,7 +50,7 @@ async def setup_black(black: Black) -> BlackSetup:
   config_path: Optional[str] = black.options.config
   config_snapshot = await Get[Snapshot](
     PathGlobs(
-      include=tuple([config_path] if config_path else []),
+      globs=tuple([config_path] if config_path else []),
       glob_match_error_behavior=GlobMatchErrorBehavior.error,
       description_of_origin="the option `--black-config`",
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -60,7 +60,7 @@ async def lint(
   config_path: Optional[str] = flake8.options.config
   config_snapshot = await Get[Snapshot](
     PathGlobs(
-      include=tuple([config_path] if config_path else []),
+      globs=tuple([config_path] if config_path else []),
       glob_match_error_behavior=GlobMatchErrorBehavior.error,
       description_of_origin="the option `--flake8-config`",
     )

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -49,7 +49,7 @@ async def setup_isort(isort: Isort) -> IsortSetup:
   config_path: Optional[List[str]] = isort.options.config
   config_snapshot = await Get[Snapshot](
     PathGlobs(
-      include=config_path or (),
+      globs=config_path or (),
       glob_match_error_behavior=GlobMatchErrorBehavior.error,
       conjunction=GlobExpansionConjunction.all_match,
       description_of_origin="the option `--isort-config`",

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -44,8 +44,10 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
   The AddressFamily may be empty, but it will not be None.
   """
   path_globs = PathGlobs(
-    include=(os.path.join(directory.path, p) for p in address_mapper.build_patterns),
-    exclude=address_mapper.build_ignore_patterns,
+    globs=(
+      *(os.path.join(directory.path, p) for p in address_mapper.build_patterns),
+      *(f"!{p}" for p in address_mapper.build_ignore_patterns),
+    )
   )
   snapshot = await Get[Snapshot](PathGlobs, path_globs)
   files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
@@ -285,7 +287,7 @@ def _address_spec_to_globs(address_mapper: AddressMapper, address_specs: Address
   patterns = set()
   for address_spec in address_specs:
     patterns.update(address_spec.make_glob_patterns(address_mapper))
-  return PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
+  return PathGlobs(globs=(*patterns, *(f"!{p}" for p in address_mapper.build_ignore_patterns)))
 
 
 def create_graph_rules(address_mapper: AddressMapper):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -59,23 +59,21 @@ class PathGlobs:
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
-  include: Tuple[str, ...]
-  exclude: Tuple[str, ...]
+  globs: Tuple[str, ...]
   glob_match_error_behavior: GlobMatchErrorBehavior
   conjunction: GlobExpansionConjunction
   description_of_origin: str
 
   def __init__(
     self,
-    include: Iterable[str],
-    exclude: Iterable[str] = (),
+    globs: Iterable[str],
     glob_match_error_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.ignore,
     conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match,
     description_of_origin: Optional[str] = None,
   ) -> None:
     """
-    :param include: globs to match, e.g. "foo.txt" or "**/*.txt"
-    :param exclude: globs to exclude, in the same style as the args to `include`
+    :param globs: globs to match, e.g. `foo.txt` or `**/*.txt`. To exclude something, prefix it
+                  with `!`, e.g. `!ignore.py`.
     :param glob_match_error_behavior: whether to warn or error upon match failures
     :param conjunction: whether all `include`s must match or only at least one must match
     :param description_of_origin: a human-friendly description of where this PathGlobs request is
@@ -83,8 +81,7 @@ class PathGlobs:
                                   globs. For example, this might be
                                   "the option `--isort-config`".
     """
-    self.include = tuple(include)
-    self.exclude = tuple(exclude)
+    self.globs = tuple(globs)
     self.glob_match_error_behavior = glob_match_error_behavior
     self.conjunction = conjunction
     self.description_of_origin = description_of_origin or ""

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -723,7 +723,7 @@ async def sources_snapshots_from_filesystem_specs(
   """Resolve the snapshot associated with the provided filesystem specs."""
   snapshot = await Get[Snapshot](
     PathGlobs(
-      include=(fs_spec.glob for fs_spec in filesystem_specs),
+      globs=(fs_spec.glob for fs_spec in filesystem_specs),
       glob_match_error_behavior=glob_match_error_behavior,
       # We validate that _every_ filesystem spec is valid.
       conjunction=GlobExpansionConjunction.all_match,

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -359,8 +359,10 @@ class BaseGlobs(Locatable, metaclass=ABCMeta):
   def to_path_globs(self, relpath: str, conjunction: GlobExpansionConjunction) -> PathGlobs:
     """Return a PathGlobs representing the included and excluded Files for these patterns."""
     return PathGlobs(
-      include=tuple(os.path.join(relpath, glob) for glob in self._parsed_include),
-      exclude=tuple(os.path.join(relpath, exclude) for exclude in self._parsed_exclude),
+      globs=(
+        *(os.path.join(relpath, glob) for glob in self._parsed_include),
+        *(f"!{os.path.join(relpath, glob)}" for glob in self._parsed_exclude)
+      ),
       conjunction=conjunction,
     )
 

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -32,7 +32,7 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
     else:
       all_paths.add(f"**/{path}/")
 
-  snapshot = await Get[Snapshot](PathGlobs(include=tuple(all_paths)))
+  snapshot = await Get[Snapshot](PathGlobs(globs=sorted(all_paths)))
 
   all_source_roots: Set[SourceRoot] = set()
 

--- a/src/python/pants/source/filespec.py
+++ b/src/python/pants/source/filespec.py
@@ -11,7 +11,7 @@ from pants.source.wrapped_globs import Filespec
 def globs_matches(
   paths: Iterable[str], patterns: Iterable[str], exclude_patterns: Iterable[str],
 ) -> bool:
-  path_globs = PathGlobs(include=patterns, exclude=exclude_patterns)
+  path_globs = PathGlobs(globs=(*patterns, *(f"!{e}" for e in exclude_patterns)))
   return Native().match_path_globs(path_globs, paths)
 
 

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -281,12 +281,12 @@ class SimpleCodegenTask(Task):
       results_dir_relpath = fast_relpath(synthetic_target_dir, get_buildroot())
       buildroot_relative_globs = tuple(os.path.join(results_dir_relpath, file) for file in files)
       buildroot_relative_excludes = tuple(
-        os.path.join(results_dir_relpath, file)
-          for file in self.sources_exclude_globs
+        f"!{os.path.join(results_dir_relpath, file)}"
+        for file in self.sources_exclude_globs
       )
       to_capture.append(
         PathGlobsAndRoot(
-          PathGlobs(buildroot_relative_globs, buildroot_relative_excludes),
+          PathGlobs(globs=(*buildroot_relative_globs, *buildroot_relative_excludes)),
           get_buildroot(),
           # The digest is stored adjacent to the hash-versioned `vt.current_results_dir`.
           Digest.load(vt.current_results_dir),

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -450,7 +450,6 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
                 .unwrap()
                 .map(str::to_string)
                 .collect::<Vec<String>>(),
-              &[],
               // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
               // that a valid assumption?
               fs::StrictGlobMatching::Ignore,

--- a/src/rust/engine/fs/src/fs_tests.rs
+++ b/src/rust/engine/fs/src/fs_tests.rs
@@ -1,0 +1,35 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use super::GitignoreStyleExcludes;
+use super::PathGlob;
+use super::PathGlobs;
+use crate::{GlobExpansionConjunction, StrictGlobMatching};
+
+#[test]
+fn path_globs_create_distinguishes_between_includes_and_excludes() {
+  let include_globs = ["foo.rs".to_string(), "bar.rs".to_string()];
+  let parsed_exclude_globs = ["ignore.rs".to_string(), "**/*.rs".to_string()];
+
+  let mut glob_inputs: Vec<String> = vec![];
+  glob_inputs.extend_from_slice(&include_globs);
+  glob_inputs.extend(parsed_exclude_globs.iter().map(|glob| format!("!{}", glob)));
+
+  let pg = PathGlobs::create(
+    glob_inputs.as_slice(),
+    StrictGlobMatching::Ignore,
+    GlobExpansionConjunction::AllMatch,
+  )
+  .expect("Path globs failed to be created");
+
+  assert_eq!(
+    pg.include,
+    PathGlob::spread_filespecs(&include_globs).expect("Include globs failed to expand")
+  );
+  assert_eq!(
+    pg.exclude.patterns,
+    GitignoreStyleExcludes::create(&parsed_exclude_globs)
+      .expect("Exclude globs failed to expand")
+      .patterns
+  );
+}

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -348,7 +348,6 @@ fn memfs_expand_basic() {
   let fs = Arc::new(MemFS::new(vec![p1.clone(), p2.join("file")]));
   let globs = PathGlobs::create(
     &["some/*".into()],
-    &[],
     StrictGlobMatching::Ignore,
     GlobExpansionConjunction::AnyMatch,
   )

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -553,7 +553,6 @@ fn expand_all_sorted(posix_fs: Arc<PosixFS>, executor: &task_executor::Executor)
         // Don't error or warn if there are no paths matched -- that is a valid state.
         PathGlobs::create(
           &["**".to_owned()],
-          &[],
           StrictGlobMatching::Ignore,
           GlobExpansionConjunction::AllMatch,
         )

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -78,7 +78,6 @@ impl CommandRunner {
     // TODO: should we error when globs fail?
     let output_globs = try_future!(PathGlobs::create(
       &try_future!(output_paths),
-      &[],
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
     ));

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -480,14 +480,13 @@ impl Snapshot {
   }
 
   pub fn lift_path_globs(item: &Value) -> Result<PathGlobs, String> {
-    let include = externs::project_multi_strs(item, "include");
-    let exclude = externs::project_multi_strs(item, "exclude");
+    let globs = externs::project_multi_strs(item, "globs");
 
-    let origin = externs::project_str(item, "description_of_origin");
-    let description_of_origin = if origin.is_empty() {
+    let description_of_origin_field = externs::project_str(item, "description_of_origin");
+    let description_of_origin = if description_of_origin_field.is_empty() {
       None
     } else {
-      Some(origin)
+      Some(description_of_origin_field)
     };
 
     let glob_match_error_behavior =
@@ -500,12 +499,8 @@ impl Snapshot {
     let conjunction_string = externs::project_str(&conjunction_obj, "value");
     let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
 
-    PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {
-      format!(
-        "Failed to parse PathGlobs for include({:?}), exclude({:?}): {}",
-        include, exclude, e
-      )
-    })
+    PathGlobs::create(&globs, strict_glob_matching, conjunction)
+      .map_err(|e| format!("Failed to parse PathGlobs for globs({:?}): {}", globs, e))
   }
 
   pub fn store_directory(core: &Arc<Core>, item: &hashing::Digest) -> Value {

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -32,12 +32,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
   _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.txt\', \'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
+      "Snapshot(PathGlobs(globs=(\'testprojects/src/python/sources/*.txt\', \'testprojects/src/python/sources/*.rs\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
       'Unmatched glob from testprojects/src/python/sources/BUILD for target :some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
-      "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.scala\',), exclude=(\'testprojects/src/python/sources/*Test.scala\', \'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
+      "Snapshot(PathGlobs(globs=(\'testprojects/src/python/sources/*.scala\', \'!testprojects/src/python/sources/*Test.scala\', \'!testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
       'Unmatched glob from testprojects/src/python/sources/BUILD for target :missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -46,7 +46,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=(\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
+      "Snapshot(PathGlobs(globs=(\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
       'Unmatched glob from testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD for target :missing-bundle-fileset\'s `bundles` field:: "testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"',
     ]
   }

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -173,7 +173,7 @@ async def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -
   for java_file in java_files:
     if not java_file.endswith(".java"):
       raise ValueError(f"Can only compile .java files but got {java_file}")
-  sources_snapshot = await Get[Snapshot](PathGlobs, PathGlobs(java_files, ()))
+  sources_snapshot = await Get[Snapshot](PathGlobs, PathGlobs(java_files))
   output_dirs = tuple({os.path.dirname(java_file) for java_file in java_files})
   process_request = ExecuteProcessRequest(
     argv=javac_compile_req.argv_from_source_snapshot(sources_snapshot),


### PR DESCRIPTION
### Problem
Per https://github.com/pantsbuild/pants/issues/5427, we are generally unifying the way you mark includes and excludes into a single flattened list of globs, where the leading `!` in `!ignore.py` is used to indicate excludes.

It was proposed in https://github.com/pantsbuild/pants/pull/9025#pullrequestreview-349626588 that we extend this unification to `PathGlobs` as well. 

### Solution
Change the Python `PathGlobs` dataclass to have a `globs` field, rather than `include` and `exclude` fields.

Notably, we do not change the actual `PathGlobs` Rust struct. There, it is helpful to still differentiate between includes and excludes. Instead, this changes the Python API and `PathGlobs::create`.

### Result
It should be easier to add support for `!` ignores to BUILD files now. For no extra work, we now support `!` ignores with filesystem specs.

This change also allows rule authors to use the same style of ignores we now use in BUILD files and in filesystem specs when working with `PathGlobs`.
