### PR TITLE
Checks all targets for exportable in recursive mode

### DIFF
--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -599,10 +599,10 @@ class SetupPy(Task):
     return setup_dir, reduced_deps
 
   def _get_exported_targets(self):
-      if self.context.products.is_required_data(self.PYTHON_DISTS_RECURSIVE_PRODUCT):
-          return self.context.targets()
+    if self.context.products.is_required_data(self.PYTHON_DISTS_RECURSIVE_PRODUCT):
+      return self.context.targets()
 
-      return self.context.target_roots
+    return self.context.target_roots
 
   def execute(self):
     # We drive creation of setup.py distributions from the original target graph, grabbing codegen'd

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -603,7 +603,8 @@ class SetupPy(Task):
     def is_exported_python_target(t):
       return t.is_original and self.has_provides(t) and not is_local_python_dist(t)
 
-    exported_python_targets = OrderedSet(t for t in self.context.target_roots
+    targets_to_check = self.context.targets() if self._recursive else self.context.target_roots
+    exported_python_targets = OrderedSet(t for t in targets_to_check
                                          if is_exported_python_target(t))
     if not exported_python_targets:
       raise TaskError('setup-py target(s) must provide an artifact.')


### PR DESCRIPTION
### Problem
 
I have a custom (non-Python) target that depends on published python dists that i would like to set `round_manager.require_data(SETUPPY.PUBLiSHED_PYTHON_DISTS)` for. When doing this, i get errors since my root-target is not a dist.

Full Context [here](https://pantsbuild.slack.com/archives/C046T6T9U/p1580305404034700)

### Solution

When recursive mode is on, check all targets for exportable in setup-py

