### PR TITLE
[IntelliJ] Add compiler options and plugins to the output of `export-dep-as-jar`

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/A.scala
+++ b/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/A.scala
@@ -1,0 +1,8 @@
+package org.pantsbuild.example.compiler_options
+
+// Unused import
+import scala.collection.Map
+
+object A {
+  private val unused = ???
+}

--- a/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/BUILD
@@ -1,0 +1,21 @@
+# Needs the pants config file in this folder to compile:
+# ./pants --pants-config-files='+["examples/src/scala/org/pantsbuild/example/scalac/compiler_options/pants.compiler_options.ini"]' ...
+scala_library(
+  name="with_nonfatal_warnings",
+  compiler_option_sets = {"non_fatal_warnings"},
+  sources=globs("*.scala"),
+)
+
+scala_library(
+  name="with_nonfatal_warnings_and_plugin",
+  compiler_option_sets = {"non_fatal_warnings"},
+  sources=globs("*.scala"),
+  dependencies=[
+    'examples/src/scala/org/pantsbuild/example/scalac/plugin:simple_scalac_plugin'
+  ],
+   scalac_plugins=['simple_scalac_plugin'],
+   scalac_plugin_args = {
+     'simple_scalac_plugin': ['args', 'from', 'target', 'local']
+   }
+)
+

--- a/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/pants.compiler_options.ini
+++ b/examples/src/scala/org/pantsbuild/example/scalac/compiler_options/pants.compiler_options.ini
@@ -1,0 +1,18 @@
+[compile.rsc]
+compiler_option_sets_enabled_args: {
+  'fatal_warnings': [
+    '-S-Xfatal-warnings',
+    '-S-Ywarn-unused'
+  ],
+  'non_fatal_warnings': [
+      '-S-Ywarn-unused'
+  ],
+  'option-set-requiring-scalac-plugin': [
+     '-S-P:simple_scalac_plugin:abc',
+     '-S-P:simple_scalac_plugin:def',
+  ],
+  }
+
+compiler_option_sets_enabled_scalac_plugins: {
+  'option-set-requiring-scalac-plugin': ['simple_scalac_plugin'],
+  }

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -2,12 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
+python_library(
+  name='base_compile_integration_test',
+  sources=['base_scalac_plugin_integration_test.py'],
+  dependencies=[
+    'examples/src/scala/org/pantsbuild/example:scalac_directory',
+    'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
+  ],
+  tags = {'partially_type_checked'},
+)
+
 python_tests(
   name='scalac_plugin_integration',
   sources=['test_scalac_plugin_integration.py'],
   dependencies=[
-    'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
-    'examples/src/scala/org/pantsbuild/example:scalac_directory',
+    ':base_compile_integration_test'
   ],
   timeout = 640,
   tags = {'integration', 'partially_type_checked'},

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/base_scalac_plugin_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/base_scalac_plugin_integration_test.py
@@ -1,6 +1,9 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.util.collections import recursively_update
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+
 
 class ScalacPluginIntegrationTestBase(BaseCompileIT):
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/base_scalac_plugin_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/base_scalac_plugin_integration_test.py
@@ -1,0 +1,38 @@
+
+from pants.util.collections import recursively_update
+from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+
+class ScalacPluginIntegrationTestBase(BaseCompileIT):
+
+  def with_global_plugin_enabled(self, config={}):
+    recursively_update(config, {'scala': {'scalac_plugins': ['simple_scalac_plugin']}})
+    return config
+
+  def with_global_plugin_args(self, args, config={}):
+    if args is not None:
+      recursively_update(config,  {'scala': {
+        'scalac_plugin_args': {
+          'simple_scalac_plugin': args
+        }
+      }})
+    return config
+
+  def with_other_global_plugin_enabled(self, config={}):
+    recursively_update(config, {'scala': {'scalac_plugins': ['other_simple_scalac_plugin']}})
+    return config
+
+  def with_compiler_option_sets_enabled_scalac_plugins(self, config={}):
+    recursively_update(config, {
+      'compile.rsc': {
+        'compiler_option_sets_enabled_args': {
+          'option-set-requiring-scalac-plugin': [
+            '-S-P:simple_scalac_plugin:abc',
+            '-S-P:simple_scalac_plugin:def',
+          ],
+        },
+        'compiler_option_sets_enabled_scalac_plugins': {
+          'option-set-requiring-scalac-plugin': ['simple_scalac_plugin'],
+        },
+      }
+    })
+    return config

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
@@ -1,10 +1,12 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+
+from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import \
+  ScalacPluginIntegrationTestBase
 
 
-class ScalacPluginIntegrationTest(BaseCompileIT):
+class ScalacPluginIntegrationTest(ScalacPluginIntegrationTestBase):
   example_dir = 'examples/src/scala/org/pantsbuild/example/scalac/plugin'
 
   def _do_test(self, expected_args, config, target):
@@ -18,26 +20,14 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
   # Note that in the terminology of this test, "global" means specified via options for
   # all targets, and "local" means specified on an individual target.
   def _do_test_global(self, args, extra_config={}, expected_args=None):
-    config = {
-      'scala': {
-        'scalac_plugins': ['simple_scalac_plugin'],
-        'scalac_plugin_args': {
-          'simple_scalac_plugin': args
-        },
-      },
-      **extra_config
-    }
+    config = self.with_global_plugin_enabled(
+              self.with_global_plugin_args(args, extra_config)
+            )
     # Must compile the plugin explicitly, since there's no dep.
     self._do_test((expected_args or args), config, 'global')
 
   def _do_test_local_with_global_args(self, args):
-    config = {
-      'scala': {
-        'scalac_plugin_args': {
-          'simple_scalac_plugin': args
-        }
-      }
-    } if args is not None else {}
+    config = self.with_global_plugin_args(args, {})
     self._do_test(args, config, 'local_with_global_args')
 
   def test_global(self):
@@ -47,11 +37,7 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
 
   def test_global_with_local_args(self):
     self._do_test(['args', 'from', 'target', 'global_with_local_args'],
-                  {
-                    'scala': {
-                      'scalac_plugins': ['simple_scalac_plugin'],
-                    },
-                  },
+                  self.with_global_plugin_enabled(),
                   'global_with_local_args')
 
   def test_local_with_global_args(self):
@@ -66,31 +52,18 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
     # Test that a plugin can use another plugin:  While compiling simple_scalac_plugin
     # we will use other_simple_scalac_plugin (because it's globally specified).
     # This is a regression test for https://github.com/pantsbuild/pants/issues/4475.
-    config = {
+    config = self.with_other_global_plugin_enabled({
       'scala': {
-        'scalac_plugins': ['other_simple_scalac_plugin'],
         'scalac_plugin_args': {
           'other_simple_scalac_plugin': ['foo']
         }
       }
-    }
+    })
     self._do_test(['args', 'from', 'target', 'local'], config, 'local')
 
   def test_compiler_option_sets_enabled_scalac_plugins(self):
     self._do_test_global(
       args=[],
-      extra_config={
-        'compile.rsc': {
-          'compiler_option_sets_enabled_args': {
-            'option-set-requiring-scalac-plugin': [
-              '-S-P:simple_scalac_plugin:abc',
-              '-S-P:simple_scalac_plugin:def',
-            ],
-          },
-          'compiler_option_sets_enabled_scalac_plugins': {
-            'option-set-requiring-scalac-plugin': ['simple_scalac_plugin'],
-          },
-        }
-      },
+      extra_config=self.with_compiler_option_sets_enabled_scalac_plugins(),
       expected_args=['abc', 'def'],
     )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import \
-  ScalacPluginIntegrationTestBase
+from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import (
+  ScalacPluginIntegrationTestBase,
+)
 
 
 class ScalacPluginIntegrationTest(ScalacPluginIntegrationTestBase):

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -74,7 +74,43 @@ python_tests(
 )
 
 python_tests(
-  name = 'test_export_dep_as_jar',
+  name = 'export_integration',
+  sources = ['test_export_integration.py'],
+  dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'examples/src/java/org/pantsbuild/example:hello_directory',
+    'examples/src/scala/org/pantsbuild/example:scala_with_java_sources_directory',
+    'examples/tests/java/org/pantsbuild/example:usethrift_directory',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/build_graph',
+    'src/python/pants/ivy',
+    'src/python/pants/java/distribution',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/testutil/subsystem',
+    'src/python/pants/testutil:int-test',
+    'testprojects/maven_layout:provided_patching_directory',
+    'testprojects/src/java/org/pantsbuild/testproject:exclude_directory',
+    'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
+    'testprojects/tests/java/org/pantsbuild/testproject:ivyclassifier_directory',
+    'testprojects/tests/java/org/pantsbuild/testproject:testjvms_directory',
+    ':resolve_jars_test_mixin',
+  ],
+  tags = {'integration', 'partially_type_checked'},
+  timeout = 630,
+)
+
+python_tests(
+  name = 'export_dep_as_jar_integration',
+  sources = ['test_export_dep_as_jar_integration.py'],
+  dependencies = [
+    'tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala:base_compile_integration_test',
+  ],
+  tags = {"integration", "partially_type_checked"},
+  timeout = 630,
+)
+
+python_tests(
+  name = 'export_dep_as_jar',
   sources = ['test_export_dep_as_jar.py'],
   dependencies = [
     'src/python/pants/java/jar',
@@ -101,32 +137,6 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
   ],
   tags = {"partially_type_checked"},
-)
-
-python_tests(
-  name = 'export_integration',
-  sources = ['test_export_integration.py'],
-  dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    'examples/src/java/org/pantsbuild/example:hello_directory',
-    'examples/src/scala/org/pantsbuild/example:scala_with_java_sources_directory',
-    'examples/tests/java/org/pantsbuild/example:usethrift_directory',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/build_graph',
-    'src/python/pants/ivy',
-    'src/python/pants/java/distribution',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/testutil/subsystem',
-    'src/python/pants/testutil:int-test',
-    'testprojects/maven_layout:provided_patching_directory',
-    'testprojects/src/java/org/pantsbuild/testproject:exclude_directory',
-    'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
-    'testprojects/tests/java/org/pantsbuild/testproject:ivyclassifier_directory',
-    'testprojects/tests/java/org/pantsbuild/testproject:testjvms_directory',
-    ':resolve_jars_test_mixin',
-  ],
-  tags = {'integration', 'partially_type_checked'},
-  timeout = 630,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -5,6 +5,7 @@ import json
 import os
 import textwrap
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 from zipfile import ZipFile
 
 from pants.backend.jvm.register import build_file_aliases as register_jvm
@@ -284,6 +285,8 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     context.products.safe_create_data('export_dep_as_jar_classpath',
                                       init_func=lambda: runtime_classpath)
 
+    context.products.safe_create_data('zinc_args', init_func=lambda: MagicMock())
+
     bootstrap_task = BootstrapJvmTools(context, self.pants_workdir)
     bootstrap_task.execute()
     task = self.create_task(context)
@@ -360,6 +363,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     jvm_target = result['targets']['project_info:jvm_target']
     jvm_target['libraries'] = sorted(jvm_target['libraries'])
     expected_jvm_target = {
+      'compiler_options': [],
       'excludes': [],
       'globs': {'globs': ['project_info/this/is/a/source/Foo.scala',
                           'project_info/this/is/a/source/Bar.scala']},

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -1,0 +1,94 @@
+import json
+import re
+
+from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import \
+  ScalacPluginIntegrationTestBase
+
+
+class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
+
+  example_dir = 'examples/src/scala/org/pantsbuild/example/scalac'
+  commonly_expected_compiler_options = ['-encoding', 'UTF-8', '-g:vars', '-target:jvm-1.8', '-deprecation', '-unchecked', '-feature']
+
+  def _do_test_compiler_options_in_export_output(self, config, target):
+    with self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir(
+        ['export-dep-as-jar', target], workdir, config)
+    self.assert_success(pants_run)
+    export_result = json.loads(pants_run.stdout_data)
+    return export_result
+
+  def _check_compiler_options_for_target_are(self, target, expected_options_patterns, config):
+    compiler_options = self._do_test_compiler_options_in_export_output(config, target
+                       )['targets'][target]['compiler_options']
+
+    strigified_options = ' '.join(compiler_options)
+
+    expected_options_patterns += self.commonly_expected_compiler_options
+
+    assert len(expected_options_patterns) == len(compiler_options)
+    for pattern in expected_options_patterns:
+      assert (pattern in compiler_options) or \
+             re.match(pattern, strigified_options)
+
+  def test_compile_with_compiler_options(self):
+    target_to_test = f'{self.example_dir}/compiler_options:with_nonfatal_warnings'
+    config = {
+      'compile.rsc': {
+        'compiler_option_sets_enabled_args': {
+          'non_fatal_warnings': [
+            '-S-Ywarn-unused'
+          ]
+        }
+      }
+    }
+    expected_options = ['-Ywarn-unused']
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_global_compiler_plugin_with_global_options(self):
+    target_to_test = f'{self.example_dir}/plugin:global'
+    config = self.with_global_plugin_args(
+              ['arg1', 'arg2'],
+              self.with_global_plugin_enabled()
+            )
+    expected_options = [
+      r'\-Xplugin\:.*examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin/current/zinc/classes.*',
+      '-P:simple_scalac_plugin:arg1',
+      '-P:simple_scalac_plugin:arg2',
+    ]
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_global_compiler_plugin_with_compiler_option_sets(self):
+    target_to_test = f'{self.example_dir}/plugin:global'
+    config = self.with_compiler_option_sets_enabled_scalac_plugins()
+    expected_options = [
+      r'\-Xplugin\:.*examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin/current/zinc/classes.*',
+      '-P:simple_scalac_plugin:abc',
+      '-P:simple_scalac_plugin:def',
+    ]
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_global_compiler_plugin_with_local_options(self):
+    target_to_test = f'{self.example_dir}/plugin:global_with_local_args'
+    config = self.with_global_plugin_enabled()
+
+    expected_options = [
+      r'\-Xplugin\:.*examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin/current/zinc/classes.*',
+      '-P:simple_scalac_plugin:args',
+      '-P:simple_scalac_plugin:from',
+      '-P:simple_scalac_plugin:target',
+      '-P:simple_scalac_plugin:global_with_local_args',
+    ]
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_local_compiler_plugin_with_local_options(self):
+    target_to_test = f'{self.example_dir}/plugin:local'
+    config = {}
+    expected_options = [
+      r'\-Xplugin\:.*examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin/current/zinc/classes.*',
+      '-P:simple_scalac_plugin:args',
+      '-P:simple_scalac_plugin:from',
+      '-P:simple_scalac_plugin:target',
+      '-P:simple_scalac_plugin:local',
+    ]
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -1,8 +1,12 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import json
 import re
 
-from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import \
-  ScalacPluginIntegrationTestBase
+from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import (
+  ScalacPluginIntegrationTestBase,
+)
 
 
 class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):


### PR DESCRIPTION
### Problem

In order to faithfully reproduce the compilation of targets, tools that consume `export-dep-as-jar` need access to the compiler options and compiler plugins used by pants.

- Context on compiler options:
  - Compiler options (for scalac) are defined in pants.ini under scope `compile.rsc`, in what we call "compiler option sets".
  - A target may choose to enable or disable some of these option sets. Therefore, compiler options are per-target.
- Context on how pants implements using scalac plugins: [here](https://www.pantsbuild.org/scalac_plugins.html#using-scalac-plugins)

### Solution

- Consume the `zinc_args` product in `export-dep-as-jar`. (credit to @stuhood  that pointed me in the direction of prior art)
- Filter all the `zinc_args` to leave only the scalac ones (the ones starting with `-S`), and strip the prefix to leave pure scalac args.
- Output it, per target, in `export-dep-as-jar`.

### Result

The entries for modulizable targets in the output of `export-dep-as-jar` now contain a field, `compiler_options`, that contains the aggregated command line information that would be passed to scalac.

Example output:
```
❯ ./pants --pants-config-files='+["examples/src/scala/org/pantsbuild/example/scalac/compiler_options/pants.compiler_options.ini"]' export-dep-as-jar examples/src/scala/org/pantsbuild/example/scalac/compiler_options:with_nonfatal_warnings_and_plugin

...
{
    "version": "1.0.14",
    "targets": {
        "examples/src/scala/org/pantsbuild/example/scalac/compiler_options:with_nonfatal_warnings_and_plugin": {
            "id": "examples.src.scala.org.pantsbuild.example.scalac.compiler_options.with_nonfatal_warnings_and_plugin",
            ...
            "compiler_options": [
                "-Ywarn-unused",
                "-Xplugin:.pants.d/compile/rsc/c1e3836b60e5/examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin/current/zinc/classes:.pants.d/compile/rsc/c1e3836b60e5/examples.src.scala.org.pantsbuild.example.scalac.plugin.other_simple_scalac_plugin/current/zinc/classes:.pants.d/compile/rsc/c1e3836b60e5/examples.src.scala.org.pantsbuild.example.scalac.plugin.simple_scalac_plugin_helper/current/zinc/classes",
                "-P:simple_scalac_plugin:args",
                "-P:simple_scalac_plugin:from",
                "-P:simple_scalac_plugin:target",
                "-P:simple_scalac_plugin:local"
            ],
            ...
        }
    },
    ...
}


```

### TODO

- [X] Add more tests, at least to represent all cases under `tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py`
- [X] Decide whether we want to strip the zinc prefixes (`-S`) out of the options. EDIT: Yes we do
- [X] Clean up all the logging
- [X] Haven't even thought about javac plugins yet, but I don't think it will be too difficult.

Commits are independently reviewable.