### PR TITLE
Update docs to use the new `!` exclude syntax for BUILD files

### DIFF
--- a/src/docs/announce_201409.md
+++ b/src/docs/announce_201409.md
@@ -89,7 +89,7 @@ list](http://pantsbuild.org/howto_contribute.html) and follow
 **Organization Perspectives:**
 
 -   [Introducing Pants: a build system for large-scale codebases like
-    Foursquare’s](http://engineering.foursquare.com/2014/09/16/introducing-pants-a-build-system-for-large-scale-codebases-like-foursquares/),
+    Foursquare’s](https://enterprise.foursquare.com/intersections/article/introducing-pants-a-build-system-for-large-scale/),
     Foursquare Engineering Blog
 -   [Trying on
     Pants](http://corner.squareup.com/2014/09/trying-on-pants.html),

--- a/src/docs/build_files.md
+++ b/src/docs/build_files.md
@@ -143,8 +143,8 @@ techniques can be especially helpful:
 *What targets does a BUILD file define?* Use the `list` goal:
 
     :::bash
-    $ ./pants list src/java/myproject/example/hello/greet
-    src/java/myproject/example/hello/greet:greet
+    $ ./pants list src/python/myproject/example
+    src/python/myproject/example:example
 
 *Are any BUILD files broken?*
 List **every** target to see if there are any errors:

--- a/src/docs/build_files.md
+++ b/src/docs/build_files.md
@@ -47,7 +47,7 @@ A target definition in a `BUILD` file looks something like
         'src/java/org/pantsbuild/auth',
         ':base'
       ],
-      sources=globs('*.java', exclude=[['Base.java']]),
+      sources=['*.java', '!Base.java'],
       tags={'common'},
     )
 
@@ -83,25 +83,19 @@ or otherwise depends on code in other targets, list those targets here.
 
 ### sources
 
-The source files in this target. These are usually defined in one of three ways:
+The source files in this target. These are defined in one of two ways:
 
-+ If the `sources` argument is _not_ passed (and the `--target-arguments-implicit-sources` option is
-  set: enabled by default in `1.4.0.dev2`), many target types define a default ("implicit") source
-  glob to collect all relevant files in the current directory. When possible, this style is
++ If the `sources` argument is _not_ passed, many target types define a sensible default `sources` value to collect all relevant files in the current directory. When possible, this style is
   recommended because it encourages 1:1:1 (see the
   [[Target Granularity|pants('src/docs:build_files')]] section for more information).
-    - As an example: `java_library` defaults to collecting `globs('*.java', exclude=[globs('*Test.java')])`.
-+ Explicitly globbing over the files in the BUILD file's directory: `sources=globs('*.java')`.
-+ Enumerating the files: `sources=['FileUtil.java', 'NetUtil.java']`.
+    - For example, `java_library` defaults to collecting `['*.java', '!*Test.java']`.
++ Explicitly providing file names and globs: `sources=['App.java', '*Util.java']`.
 
-You can exclude files from the results of a glob. For example, to glob over unit tests
+You can exclude files by prefixing the file name or glob with `!`. For example, to collect unit tests
 but not integration tests you could use something like this:
-<br>`sources=globs('*.py', exclude=[globs('*_integration.py')])`.
-<br>The value of `exclude=` is a list of things that evaluate to lists of source files,
-i.e., globs or literal lists. This is why there are double-brackets around `Base.java` in
-the example target above.
+<br>`sources=['*_test.py', '!*_integration_test.py']`.
 
-You can also recursively glob over files in all subdirectories of the BUILD file's directory: `sources=rglobs('*.java')`.
+You can also recursively glob over files in all subdirectories of the BUILD file's directory: `sources=['**/*.java']`.
 However this is discouraged as it tends to lead to coarse-grained dependencies, and Pants's
 advantages come into play when you have many fine-grained dependencies.
 
@@ -149,8 +143,8 @@ techniques can be especially helpful:
 *What targets does a BUILD file define?* Use the `list` goal:
 
     :::bash
-    $ ./pants list examples/src/java/org/pantsbuild/example/hello/greet
-    examples/src/java/org/pantsbuild/example/hello/greet:greet
+    $ ./pants list src/java/myproject/example/hello/greet
+    src/java/myproject/example/hello/greet:greet
 
 *Are any BUILD files broken?*
 List **every** target to see if there are any errors:

--- a/src/docs/common_tasks/bundle.md
+++ b/src/docs/common_tasks/bundle.md
@@ -42,7 +42,7 @@ Add an `archive` parameter to your `jvm_app` target. Here's an example:
 Add a `--bundle-jvm-archive` option when invoking the Pants executable. Here's an example:
 
     ::bash
-    $ ./pants bundle src/java/myproject:bundle --bundle-jvm-archive=zip
+    $ ./pants bundle src/java/com/myorg/myproject:bundle --bundle-jvm-archive=zip
 
 **Note**: If you perform *neither* of the steps explained in #1 and #2, no bundle will be created.
 

--- a/src/docs/common_tasks/bundle.md
+++ b/src/docs/common_tasks/bundle.md
@@ -18,9 +18,10 @@ The `pants bundle` command enables you to bundle a project into a single archive
 In order to use the `bundle` goal, you need to target a `jvm_app` definition. Here's an example target:
 
     ::python
-    jvm_app(name='bundle',
+    jvm_app(
+      name='bundle',
       basename='my-project-deployable-bundle',
-      binary=':my-project-binary-target', # should point to a jvm_binary target
+      binary=':my-binary-target', # should point to a jvm_binary target
     )
 
 There are two ways to specify the desired file format:
@@ -30,7 +31,8 @@ There are two ways to specify the desired file format:
 Add an `archive` parameter to your `jvm_app` target. Here's an example:
 
     ::python
-    jvm_app(name='bundle',
+    jvm_app(
+      name='bundle',
       archive='zip',
       # etc
     )
@@ -40,7 +42,7 @@ Add an `archive` parameter to your `jvm_app` target. Here's an example:
 Add a `--bundle-jvm-archive` option when invoking the Pants executable. Here's an example:
 
     ::bash
-    $ ./pants bundle myproject/subproject:bundle --bundle-jvm-archive=zip
+    $ ./pants bundle src/java/myproject:bundle --bundle-jvm-archive=zip
 
 **Note**: If you perform *neither* of the steps explained in #1 and #2, no bundle will be created.
 

--- a/src/docs/common_tasks/compile.md
+++ b/src/docs/common_tasks/compile.md
@@ -9,7 +9,7 @@ You need to compile a JVM binary or library target that you're working on, e.g. 
 The `compile` goal enables you to compile Scala or Java [[binaries|]] and libraries. Here's an example:
 
     :::bash
-    $ ./pants compile src/scala/myproject/hello/exe:exe
+    $ ./pants compile src/scala/com/myorg/myproject/hello/exe:exe
 
 
 The `compile` goal requires you to target a `BUILD` file containing either a `java_library`, `scala_library`, `java_binary` or `scala_binary` target. For the CLI example above, the target `BUILD` file might look something like this:
@@ -17,7 +17,7 @@ The `compile` goal requires you to target a `BUILD` file containing either a `ja
     :::python
     jvm_binary(
       dependencies=[
-        'src/scala/myproject/example/hello/welcome:welcome',
+        'src/scala/com/myorg/myproject/example/hello/welcome:welcome',
       ],
       source='Exe.scala',
       main='org.pantsbuild.example.hello.exe.Exe',

--- a/src/docs/common_tasks/compile.md
+++ b/src/docs/common_tasks/compile.md
@@ -9,7 +9,7 @@ You need to compile a JVM binary or library target that you're working on, e.g. 
 The `compile` goal enables you to compile Scala or Java [[binaries|]] and libraries. Here's an example:
 
     :::bash
-    $ ./pants compile examples/src/scala/org/pantsbuild/hello/exe:exe
+    $ ./pants compile src/scala/myproject/hello/exe:exe
 
 
 The `compile` goal requires you to target a `BUILD` file containing either a `java_library`, `scala_library`, `java_binary` or `scala_binary` target. For the CLI example above, the target `BUILD` file might look something like this:
@@ -17,7 +17,7 @@ The `compile` goal requires you to target a `BUILD` file containing either a `ja
     :::python
     jvm_binary(
       dependencies=[
-        'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
+        'src/scala/myproject/example/hello/welcome:welcome',
       ],
       source='Exe.scala',
       main='org.pantsbuild.example.hello.exe.Exe',

--- a/src/docs/common_tasks/dependencies.md
+++ b/src/docs/common_tasks/dependencies.md
@@ -12,36 +12,33 @@ your target. Dependencies to other targets are typically added to
 
 ## Discussion
 
-Below is an example `scala_library` definition that specifies dependencies on other targets:
+Below is an example `python_library` definition that specifies dependencies on other targets:
 
     ::python
-    # myproject/src/main/scala/BUILD
-    scala_library(
-      name='scala',
-      sources=['*.scala'],
+    # src/python/myproject/example/BUILD
+    python_library(
       dependencies=[
-        'myproject/library-a',
-        'myproject/library-b:some-target'
-      ]
+        'src/python/myproject/library-a',
+        'src/python/myproject/library-b:some-target',
+      ],
     )
 
 In this example, we have two dependencies, both of which reside in the same repository as our code. They are referenced by the relative path from the root of the repository, to the location of the `BUILD` file that defines the buildable target you wish to depend on.
 
-You should always target dependencies through their `scala_library` or
-other library target definition. Many projects have set up aliases that
+You should always target dependencies through their library target definition (e.g. `scala_library` or `python_library`). Many projects have set up aliases that
 are shorter. For more info, see
 [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]].
 
-NOTE: In many cases, you can specify a library target path without specifying a target name. In the example above, the `myproject/library-a` library is targeted without a target name. That's because the target name, in this case, is the same as that of the directory. Here's what that `BUILD` file might look like:
+NOTE: In many cases, you can specify a library target path without specifying a target name. In the example above, the `src/python/myproject/library-a` library is targeted without a target name. That's because the target name, in this case, is the same as that of the directory. Here's what that `BUILD` file might look like:
 
     ::python
-    # myproject/library-a/BUILD
+    # src/python/myproject/library-a
 
     target(
       name='library-a',
       dependencies=[
         # ...
-      ]
+      ],
     )
 
 This is called a **default target name** and can be used whenever the target and directory names match.

--- a/src/docs/common_tasks/dependencies.md
+++ b/src/docs/common_tasks/dependencies.md
@@ -16,8 +16,9 @@ Below is an example `scala_library` definition that specifies dependencies on ot
 
     ::python
     # myproject/src/main/scala/BUILD
-    scala_library(name='scala',
-      sources=rglobs('\*.scala'),
+    scala_library(
+      name='scala',
+      sources=['*.scala'],
       dependencies=[
         'myproject/library-a',
         'myproject/library-b:some-target'
@@ -36,7 +37,8 @@ NOTE: In many cases, you can specify a library target path without specifying a 
     ::python
     # myproject/library-a/BUILD
 
-    target(name='library-a',
+    target(
+      name='library-a',
       dependencies=[
         # ...
       ]

--- a/src/docs/common_tasks/file_bundles.md
+++ b/src/docs/common_tasks/file_bundles.md
@@ -13,15 +13,16 @@ Add a `bundles` list to your `jvm_app` target definition (more info on `jvm_app`
 Here is an example `jvm_app` definition that shows different possibilities for defining file bundles (and explains them below):
 
     ::python
-    jvm_app(name='bundle',
-      bundle(fileset=rglobs('src/main/resources/*')), # 1
-      bundle(fileset=globs('config/*') - globs('*.xml'), # 2
-      bundle(relative_to='src', fileset=globs('src/scripts/*.sh')) # 3
+    jvm_app(
+      name='bundle',
+      bundle(fileset=['src/main/resources/**/*')), # 1
+      bundle(fileset=['config/*', '!*.xml']), # 2
+      bundle(fileset=['src/scripts/*.sh'], relative_to='src') # 3
     )
 
 
-1. The `rglobs` definition will recursively include all files in the `src/main/resources` directory, *including all sub-directories*. More info can be found in [[Use globs and rglobs to group files|pants('src/docs/common_tasks:globs')]].
-2. All files in the `config` directory are included except any `.xml` files.
+1. All files in the `src/main/resources` directory are recursively included.
+2. All files in the `config` directory are included, except any `.xml` files.
 3. All `.sh` files in the `src/scripts` directory will be included. The `relative_to` effectively strips away the specified directory, in this case `src`, which means that all files in `src/scripts` would end up in the root of the bundle. If you specified `relative_to='src/scripts'` instead, for example, all files would end up in the root directory.
 
 ## See Also

--- a/src/docs/common_tasks/globs.md
+++ b/src/docs/common_tasks/globs.md
@@ -6,29 +6,33 @@ You're creating a target definition for library, binary, or other target and wan
 
 ## Solution
 
-Instead of listing files one by one, e.g. `sources=['file1', 'file2', 'file3']`, you can specify either a `globs` or an `rglobs`.
+Instead of listing files one by one, e.g. `sources=['file1', 'file2', 'file3']`, you can directly 
+use globs like `*.java`. To exclude certain files or globs, you can prefix the value with `!`, like `!ignore.java`.
 
 ## Discussion
 
 Let's say that you're creating a `scala_library` target definition and you want to include, as sources, all of the `.scala` files contained in the same directory as your `BUILD` file. Here's an example target definition that would accomplish that using a `globs`:
 
     ::python
-    scala_library(name='scala',
-      sources=globs('*.scala'),
+    scala_library(
+      name='lib',
+      sources=['*.scala'],
     )
 
-If you had Scala files in sub-directories that you wanted to include as well, you could use an `rglobs`:
+If you had Scala files in sub-directories that you wanted to include as well, you could use a recursive glob:
 
     ::python
-    scala_library(name='scala',
-      sources=rglobs('*.scala'),
+    scala_library(
+      name='lib',
+      sources=['**/*.scala'],
     )
 
 You can also exclude files from a particular directory:
 
     ::python
-    scala_library(name='scala',
-      sources=rglobs('*.scala', exclude=[rglobs('dir_to_exclude/*.scala')]),
+    scala_library(
+      name='lib',
+      sources=['**/*.scala', '!dir_to_exclude/**/*.scala'],
     )
 
 ## See Also

--- a/src/docs/common_tasks/jvm_binary.md
+++ b/src/docs/common_tasks/jvm_binary.md
@@ -28,8 +28,8 @@ Here's an example `jvm_binary` definition:
       basename='myproject-bin',
       main='com.acme.myproject.Main',
       dependencies=[
-        'src/java/myproject/server',
-        'src/java/myproject/analytics',
+        'src/java/com/myorg/myproject/server',
+        'src/java/com/myorg/myproject/analytics',
       ],
       bundles=[
         bundle(fileset=['assets/*']),

--- a/src/docs/common_tasks/jvm_binary.md
+++ b/src/docs/common_tasks/jvm_binary.md
@@ -23,15 +23,16 @@ In any `jvm_binary` target you must specify the following:
 Here's an example `jvm_binary` definition:
 
     ::python
-    jvm_binary(name='bin',
+    jvm_binary(
+      name='bin',
       basename='myproject-bin',
       main='com.acme.myproject.Main',
       dependencies=[
-        'server-lib/src/main/java',
-        'analytics-lib/src/main/java',
+        'src/java/myproject/server',
+        'src/java/myproject/analytics',
       ],
       bundles=[
-        bundle(fileset=globs('assets/*'))
+        bundle(fileset=['assets/*']),
       ]
     )
 

--- a/src/docs/common_tasks/jvm_library.md
+++ b/src/docs/common_tasks/jvm_library.md
@@ -11,7 +11,7 @@ You need to define a new Scala or Java **library target** that other projects ca
 Add a `scala_library` or `java_library` target to a `BUILD` file in the appropriate directory. A `scala_library` or `java_library` target will enable you to compile the library using Pants' `compile` goal. Here's an example:
 
     ::bash
-    $ ./pants compile src/scala/myproject/example:hello
+    $ ./pants compile src/scala/com/myorg/myproject/example:hello
 
 ## Discussion
 
@@ -24,13 +24,13 @@ A `scala_library` or `java_library` target should specify the following:
 Here's an example target definition:
 
     ::python
-    # src/scala/myproject/example/BUILD
+    # src/scala/com/myorg/myproject/example/BUILD
     scala_library(
       name='scala',
       sources=['*.scala'],
       dependencies=[
-        'src/scala/myproject/client-lib',
-        'src/scala/myproject/analytics-lib',
+        'src/scala/com/myorg/myproject/client-lib',
+        'src/scala/com/myorg/myproject/analytics-lib',
         'static/resources/json:config',
       ],
     )
@@ -38,7 +38,7 @@ Here's an example target definition:
 That library can then be compiled with:
 
     ::python
-    $ ./pants compile src/scala/myproject/example
+    $ ./pants compile src/scala/com/myorg/myproject/example
 
 You can combine library targets together into a single target using a **target aggregate**. More info can be found in [[Create a Target Aggregate|pants('src/docs/common_tasks:target_aggregate')]].
 

--- a/src/docs/common_tasks/jvm_library.md
+++ b/src/docs/common_tasks/jvm_library.md
@@ -11,34 +11,34 @@ You need to define a new Scala or Java **library target** that other projects ca
 Add a `scala_library` or `java_library` target to a `BUILD` file in the appropriate directory. A `scala_library` or `java_library` target will enable you to compile the library using Pants' `compile` goal. Here's an example:
 
     ::bash
-    $ ./pants compile myproject/src/main/scala
-    # Assuming there's a BUILD file with a scala_library definition named "scala" in that location
+    $ ./pants compile src/scala/myproject/example:hello
 
 ## Discussion
 
 A `scala_library` or `java_library` target should specify the following:
 
 * A `name` for the library. This may be something like just `scala` if you have only one `scala_library` target in a project or something more specific like `client-lib`.
-* Either a single `source` file or a list of `sources`. If you're including just a few files, you should consider specifying a sources list, e.g. `sources=['File1.scala', 'File2.scala']`; if you're including, you may want to specify a `globs` or `rglobs`, e.g. `sources=globs('*.scala')`. More info can be found in [[Use globs and rglobs to Group Files|pants('src/docs/common_tasks:globs')]]. The example further down use an `rglobs` definition.
+* Either the `source` field with a single file or the `sources` field with a list of file names and globs.
 * A list of `dependencies` (optional). More info on dependencies can be found in [[Add a Dependency on Another Target|pants('src/docs/common_tasks:dependencies')]].
 
 Here's an example target definition:
 
     ::python
-    # myproject/src/main/scala/BUILD
-    scala_library(name='scala',
-      sources=globs('*.scala'),
+    # src/scala/myproject/example/BUILD
+    scala_library(
+      name='scala',
+      sources=['*.scala'],
       dependencies=[
-        'client-lib',
-        'analytics-lib',
+        'src/scala/myproject/client-lib',
+        'src/scala/myproject/analytics-lib',
         'static/resources/json:config',
       ],
     )
 
-That library can then be compiled (perhaps for debugging purposes):
+That library can then be compiled with:
 
     ::python
-    $ ./pants compile myproject/src/main/scala
+    $ ./pants compile src/scala/myproject/example
 
 You can combine library targets together into a single target using a **target aggregate**. More info can be found in [[Create a Target Aggregate|pants('src/docs/common_tasks:target_aggregate')]].
 

--- a/src/docs/common_tasks/jvm_tests.md
+++ b/src/docs/common_tasks/jvm_tests.md
@@ -11,7 +11,7 @@ For more info on running tests, see [[Run Tests for Your Project|pants('src/docs
 Create a `junit_tests` target definition for your library. With the test target definition in place, you can run the tests using the `test` goal:
 
     ::bash
-    $ ./pants test myproject/src/test/java:tests
+    $ ./pants test src/java/myproject/example:tests
 
 ## Discussion
 
@@ -25,17 +25,18 @@ A `junit_tests` target definition should specify the following:
 Here's an example:
 
     ::python
-    junit_tests(name='java-tests',
-      sources=rglobs('*.java'),
+    junit_tests(
+      name='tests',
+      sources=['*.java'],
       dependencies=[
-        'myproject/src/main/java', # Our own Java library that we're testing
-      ]
+        'src/java/myproject/example:lib',
+      ],
     )
 
 With that target definition, you can then run the test using Pants:
 
     ::bash
-    $ ./pants test myproject/src/tests/java:java-tests
+    $ ./pants test src/java/myproject/example:tests
 
 When you run a test, Pants will compile any libraries being tested and then run the actual tests. You should see many lines of Pants-specific output followed by the test results. Here's an example:
 

--- a/src/docs/common_tasks/jvm_tests.md
+++ b/src/docs/common_tasks/jvm_tests.md
@@ -11,7 +11,7 @@ For more info on running tests, see [[Run Tests for Your Project|pants('src/docs
 Create a `junit_tests` target definition for your library. With the test target definition in place, you can run the tests using the `test` goal:
 
     ::bash
-    $ ./pants test src/java/myproject/example:tests
+    $ ./pants test src/java/com/myorg/myproject/example:tests
 
 ## Discussion
 
@@ -29,14 +29,14 @@ Here's an example:
       name='tests',
       sources=['*.java'],
       dependencies=[
-        'src/java/myproject/example:lib',
+        'src/java/com/myorg/myproject/example:lib',
       ],
     )
 
 With that target definition, you can then run the test using Pants:
 
     ::bash
-    $ ./pants test src/java/myproject/example:tests
+    $ ./pants test src/java/com/myorg/myproject/example:tests
 
 When you run a test, Pants will compile any libraries being tested and then run the actual tests. You should see many lines of Pants-specific output followed by the test results. Here's an example:
 

--- a/src/docs/common_tasks/list_goals.md
+++ b/src/docs/common_tasks/list_goals.md
@@ -14,19 +14,20 @@ Invoke the `goals` goal:
 The resulting list should look something like this:
 
     :::
-    Installed goals:
-                   autoblame: Finds the responsible individuals, group, JIRA project and BUILD file for a given target,
-                   bash-completion: Generate a Bash shell script that teaches Bash how to autocomplete pants command lines.
-                   bench: Run benchmarks.
-                   binary: Create a runnable binary.
+    Use `./pants help $goal` to get help for a particular goal.
+
+        bash-completion: Generate a Bash shell script that teaches Bash how to autocomplete pants command lines.
+                  bench: Run benchmarks.
+                 binary: Create a runnable binary.
+              bootstrap: Bootstrap tools needed by subsequent build steps.
                    # etc.
 
 You can get help output for each Pants goal (including all the available flags for that goal) by appending the `-h` or `--help` flags or the `help` command. Here are three equivalent examples:
 
     :::bash
-    $ ./pants goals -h
-    $ ./pants goals --help
-    $ ./pants goals help
+    $ ./pants test -h
+    $ ./pants test --help
+    $ ./pants help test
 
 ## See Also
 

--- a/src/docs/common_tasks/list_targets.md
+++ b/src/docs/common_tasks/list_targets.md
@@ -6,16 +6,16 @@ You want to find out which Pants targets are currently available in your project
 
 ## Solution
 
-Use the `list` goal and specify a folder containing a `BUILD` file. This command, for example, would show all targets available in `myproject/BUILD`:
+Use the `list` goal and specify a folder containing a `BUILD` file. This command, for example, would show all targets available in `src/python/myproject/example/BUILD`:
 
 ```bash
-$ ./pants list myproject/:
+$ ./pants list src/python/myproject/example:
 ```
 
-This command would show all targets available in the `myproject` directory *as well as in all subdirectories*:
+This command would show all targets available in the `src/python/myproject` directory *as well as in all subdirectories*:
 
 ```bash
-$ ./pants list myproject/::
+$ ./pants list src/python/myproject::
 ```
 
 Note the syntactical difference between the single colon and the double colon.
@@ -23,15 +23,11 @@ Note the syntactical difference between the single colon and the double colon.
 The output from a `./pants list` invocation may look something like this:
 
 ```bash
-$ ./pants list server/:
+$ ./pants list server:
 server/server:analytics
 server/server:bin
 server/server:tests
 ```
-
-## Warning
-
-We do not recommend using `./pants list ::` unless you're working with a very small Pants project. This command will list *all* targets currently available in the entire project, which can be a very slow operation in larger projects.
 
 ## See Also
 

--- a/src/docs/common_tasks/login.md
+++ b/src/docs/common_tasks/login.md
@@ -17,18 +17,17 @@ However, in many cases the server expects you to provide credentials to an authe
 in exchange for a session id, and then provide that session id in subsequent requests to the other endpoints.
 
 In the latter case, you can perform that authentication using the `login` goal, and specifying the 
-provider you're authenticating against, either with the `--to` option or with a passthru arg:
+provider you're authenticating against with the `--to` option:
 
 ```bash
 $ ./pants login --to=myauthprovider
-$ ./pants login -- myauthprovider
 ```
 
 This submits credentials from `.netrc` to the provider's authentication endpoint using HTTP basic auth, 
 and stores all returned cookies (which, presumably, include the session id), for future use with the other 
 endpoints.
 
-In the future the `login` goal will optionally prompt for a username and password, allowing you to
+In the future, the `login` goal will optionally prompt for a username and password, allowing you to
 bypass `.netrc` altogether.
 
 

--- a/src/docs/common_tasks/pex.md
+++ b/src/docs/common_tasks/pex.md
@@ -13,7 +13,7 @@ If you need to create a Python library target instead, see [[Define a Python Lib
 Define a `python_binary` target that you can build as a PEX using the `binary` goal:
 
     ::bash
-    $ ./pants binary myproject/src/python:my-python-binary
+    $ ./pants binary src/python/myproject/example:my-python-binary
 
 ## Discussion
 
@@ -28,15 +28,17 @@ In a `python_ binary` target, you should specify:
 Here's an example `python_binary` target:
 
     ::python
-    python_library(name='myproject-lib',
+    python_library(
+      name='myproject-lib',
       # Other parameters
     )
 
-    python_binary(name='myproject-bin',
+    python_binary(
+      name='myproject-bin',
       source='main.py',
       dependencies=[
-        ':myproject-lib'
-      ]
+        ':myproject-lib',
+      ],
     )
 
 ## See Also

--- a/src/docs/common_tasks/python_library.md
+++ b/src/docs/common_tasks/python_library.md
@@ -21,12 +21,13 @@ A `python_library` target definition should specify the following:
 Here is an example target definition:
 
     ::python
-    python_library(name='my-python-lib',
-      sources=globs('*.py'),
+    python_library(
+      name='my-python-lib',
+      sources=['*.py'],
       dependencies=[
-        'server/src/python:server-lib',
-        'client/src/python:client-lib',
-        'static/json:config'
+        'src/python/myproject/server:server-lib',
+        'src/python/myproject/client:client-lib',
+        'src/static/json:config',
       ],
     )
 
@@ -34,7 +35,7 @@ Now, another library or binary can depend on the target you created:
 
     ::python
     dependencies=[
-      'myproject/src/python:my-python-lib'
+      'src/python/myproject/example:my-python-lib',
     ]
 
 ## See Also

--- a/src/docs/common_tasks/python_proto_gen.md
+++ b/src/docs/common_tasks/python_proto_gen.md
@@ -25,14 +25,13 @@ Then, you can add a dependency on this target in your python binary's `BUILD` fi
 python_binary(
   source='server.py',
   dependencies=[
-#    [...]
-    'examples/src/protobuf/org/pantsbuild/example/grpcio/service'
+    'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
   ],
 )
 ```
 
 ## Example:
-An example Python grpc client/server can be found in [/examples/src/python/example/grpcio](https://github.com/pantsbuild/pants/tree/master/examples/src/python/example/grpcio)
+An example Python gRPC client/server can be found in [/examples/src/python/example/grpcio](https://github.com/pantsbuild/pants/tree/master/examples/src/python/example/grpcio)
 
 to create a gRPC server execute
 ```bash

--- a/src/docs/common_tasks/python_proto_gen.md
+++ b/src/docs/common_tasks/python_proto_gen.md
@@ -25,7 +25,7 @@ Then, you can add a dependency on this target in your python binary's `BUILD` fi
 python_binary(
   source='server.py',
   dependencies=[
-    'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
+    'src/protobuf/org/pantsbuild/example/grpcio/service',
   ],
 )
 ```
@@ -35,12 +35,12 @@ An example Python gRPC client/server can be found in [/examples/src/python/examp
 
 to create a gRPC server execute
 ```bash
-./pants run examples/src/python/example/grpcio/server
+./pants run src/python/example/grpcio/server
 ```
 
 and when server is running, run client example:
 ```bash
-./pants run examples/src/python/example/grpcio/client
+./pants run src/python/example/grpcio/client
 ```
 
 generated code can be found as usual in pants output directory:

--- a/src/docs/common_tasks/python_tests.md
+++ b/src/docs/common_tasks/python_tests.md
@@ -9,7 +9,7 @@ You need to define a test target for your Python library that you can run using 
 Define a `python_tests` target definition that specifies which Python files will be used for testing and which library or libraries will be tested. With that target definition in place, you'll be able to run the tests like this:
 
     ::bash
-    $ ./pants test myproject/src/test/python:tests
+    $ ./pants test src/python/myproject/example:tests
 
 ## Discussion
 
@@ -27,14 +27,14 @@ Here's an example:
       name='tests',
       sources=['test_*.py'],
       dependencies=[
-        'myproject/src/main/python',
+        'src/python/myproject/example:lib',
       ]
     )
 
 With that target definition, you can then run the tests using Pants:
 
     ::bash
-    $ ./pants test myproject/src/test/python:tests
+    $ ./pants test src/python/myproject/example:tests
 
 When you run a test, Pants will compile any libraries being tested and then run the actual tests. You should see many lines of Pants-specific output followed by the test results. Here's an example:
 

--- a/src/docs/common_tasks/python_tests.md
+++ b/src/docs/common_tasks/python_tests.md
@@ -23,8 +23,9 @@ You should specify the following in a `python_tests` definition:
 Here's an example:
 
     ::python
-    python_tests(name='python-tests',
-      sources=globs('*.py'),
+    python_tests(
+      name='tests',
+      sources=['test_*.py'],
       dependencies=[
         'myproject/src/main/python',
       ]
@@ -33,7 +34,7 @@ Here's an example:
 With that target definition, you can then run the tests using Pants:
 
     ::bash
-    $ ./pants test myproject/src/test/python:python-tests
+    $ ./pants test myproject/src/test/python:tests
 
 When you run a test, Pants will compile any libraries being tested and then run the actual tests. You should see many lines of Pants-specific output followed by the test results. Here's an example:
 

--- a/src/docs/common_tasks/repl.md
+++ b/src/docs/common_tasks/repl.md
@@ -9,7 +9,7 @@ You're working on a Scala or Python project and would like to interact with a li
 The pants `repl` goal will open up an interactive Scala or Python REPL session for a library target.
 
     ::bash
-    $ ./pants repl myproject/src/main/scala
+    $ ./pants repl src/python/myproject/example:lib
 
 ## Discussion
 
@@ -26,7 +26,7 @@ If you're working on a Scala project that has, for example, `com.twitter.util.Fu
 It's also possible to open the Scala REPL without first compiling the specified library using the `repl-dirty` goal:
 
     ::bash
-    $ ./pants repl-dirty myproject/src/main/scala
+    $ ./pants repl-dirty src/scala/com/myorg/myproject/example
 
 ## See Also
 

--- a/src/docs/common_tasks/resources.md
+++ b/src/docs/common_tasks/resources.md
@@ -49,7 +49,7 @@ Once your resource bundle has been specified, you can depend on it from the targ
       name='server',
       sources=['*.java'],
       dependencies=[
-        'myproject/src/main/resources:config',
+        'src/resources:config',
       ]
     )
 

--- a/src/docs/common_tasks/resources.md
+++ b/src/docs/common_tasks/resources.md
@@ -13,39 +13,43 @@ Create a `resources` target that tells Pants which files to include in the resou
 A `resources` target definition must include a `name` and a list of `sources`, which can consist of a simple list of file names, multiple `globs` or `rglobs` definitions (more on that in [[Use globs and rglobs to Group Files|pants('src/docs/common_tasks:globs')]]), or any combination thereof. This would create a resource bundle with two files:
 
     ::python
-    resources(name='config'
-      sources=['server-config.yaml', 'logging-config.xml']
+    resources(
+      name='config'
+      sources=['server-config.yaml', 'logging-config.xml'],
     )
 
 This would include a glob of files to a resource bundle:
 
     ::python
-    resources(name='templates',
-      sources=rglobs('*.mustache')
+    resources(
+      name='templates',
+      sources=['**/*.mustache'],
     )
 
 This would include a mixture of globs, rglobs, and specific files:
 
     ::python
-    resources(name='all'
-      sources=globs('*.json') + rglobs('templates/*') + ['logback.xml']
+    resources(
+      name='all'
+      sources=['*.json', 'templates/**/*', 'logback.xml'],
     )
 
-You can also exclude files, globs, or rglobs using the `-` operator:
+You can also exclude files and globs by prefixing them with `!`:
 
     ::python
-    resources(name='python-resources',
-      sources=rglobs('*') - rglobs('*.pyc')
+    resources(
+      name='python-resources',
+      sources=['**/*', '!**/*.pyc'],
     )
 
 Once your resource bundle has been specified, you can depend on it from the target that consumes the resources:
 
     ::python
-    java_library(name='server',
-      sources=globs('*.java'),
+    java_library(
+      name='server',
+      sources=['*.java'],
       dependencies=[
-        ...
-        'myproject/src/main/resources:config'
+        'myproject/src/main/resources:config',
       ]
     )
 

--- a/src/docs/common_tasks/run.md
+++ b/src/docs/common_tasks/run.md
@@ -20,7 +20,8 @@ If you need to pass in command-line arguments when running an executable, see **
 The `run` goal will both compile *and* execute a binary target. For Scala and Java projects, you can run any target with a `jvm_binary` definition. Here's an example of a `BUILD` file that would enable you to run a Scala or Java target:
 
     :::python
-    jvm_binary(name='bin',
+    jvm_binary(
+      name='bin',
       basename='my-executable',
       ...
     )
@@ -28,14 +29,15 @@ The `run` goal will both compile *and* execute a binary target. For Scala and Ja
 You can also run a Scala or Java binary target without compiling it first, using the `run-dirty` goal:
 
     :::bash
-    $ ./pants run-dirty myproject/src/main/scala:bin
+    $ ./pants run-dirty src/scala/myproject/example:bin
 
 ### Python
 
 For Python projects, executables are specified using a `python_binary` definition. Here's an example:
 
     :::python
-    python_binary(name='bin',
+    python_binary(
+      name='bin',
       basename='my-executable',
       ...
     )

--- a/src/docs/common_tasks/run.md
+++ b/src/docs/common_tasks/run.md
@@ -29,7 +29,7 @@ The `run` goal will both compile *and* execute a binary target. For Scala and Ja
 You can also run a Scala or Java binary target without compiling it first, using the `run-dirty` goal:
 
     :::bash
-    $ ./pants run-dirty src/scala/myproject/example:bin
+    $ ./pants run-dirty src/scala/com/myorg/myproject/example:bin
 
 ### Python
 

--- a/src/docs/common_tasks/target_aggregate.md
+++ b/src/docs/common_tasks/target_aggregate.md
@@ -2,24 +2,24 @@
 
 ## Problem
 
-You want to create a common target that when run in turn run several other targets
+You want to create a common target that when run in turn run several other targets.
 
 ## Solution
 
-Use a literal `target` definition in your BUILD file to specify an aggregate target that depends on all the targets you wish to run
+Use a literal `target` definition in your BUILD file to specify an aggregate target that depends on all the targets you wish to run.
 
-Here's an example `target` definition that creates a target names `agg` dependent on two modules named `dep1` and `dep2`:
+Here's an example `target` definition that creates a target names `agg` dependent on two targets with different types:
 
     :: python
-    # agg/BUILD
-    target(name='agg',
+    target(
+      name='agg',
       dependencies=[
-        'myproject/src/main/scala/com/twitter/myproject/subproject/dep1:scala',
-        'myproject/src/main/scala/com/twitter/myproject/subproject/dep2:scala'
-      ]
+        'src/python/myproject/dep:lib',
+        'src/java/org/myproject/dep:lib',
+      ],
     )
 
-Triggering any goal for `agg` will trigger said goal for both `dep1` and `dep2`
+Triggering any goal for `agg` will trigger said goal for both the Python and Java targets.
 
 If you wish to create an alias for an existing target see [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]]
 

--- a/src/docs/common_tasks/target_aggregate.md
+++ b/src/docs/common_tasks/target_aggregate.md
@@ -15,7 +15,7 @@ Here's an example `target` definition that creates a target names `agg` dependen
       name='agg',
       dependencies=[
         'src/python/myproject/dep:lib',
-        'src/java/org/myproject/dep:lib',
+        'src/java/com/myorg/myproject/dep:lib',
       ],
     )
 

--- a/src/docs/common_tasks/test.md
+++ b/src/docs/common_tasks/test.md
@@ -9,9 +9,9 @@ You want to run a test or test suite that you've written for your project (or se
 The `test` goal will run any tests contained in the specified target. Here's an example:
 
     ::bash
-    $ ./pants test myproject/src/test/scala:scala-tests
+    $ ./pants test src/test/scala/example:tests
 
-For Scala and Java, test suites are defined in `junit_tests` target definitions, while Python test suites are defined in `python_tests` definitions. For each test target type, you need to specify. More on these target types can be found in [[Specify a Test Suite|pants('src/docs/common_tasks:test_suite')]].
+For Scala and Java, test suites are defined in `junit_tests` target definitions, while Python test suites are defined in `python_tests` definitions. More on these target types can be found in [[Specify a Test Suite|pants('src/docs/common_tasks:test_suite')]].
 
 ## Discussion
 

--- a/src/docs/common_tasks/test.md
+++ b/src/docs/common_tasks/test.md
@@ -9,7 +9,7 @@ You want to run a test or test suite that you've written for your project (or se
 The `test` goal will run any tests contained in the specified target. Here's an example:
 
     ::bash
-    $ ./pants test src/test/scala/example:tests
+    $ ./pants test src/python/myproject/example:tests
 
 For Scala and Java, test suites are defined in `junit_tests` target definitions, while Python test suites are defined in `python_tests` definitions. More on these target types can be found in [[Specify a Test Suite|pants('src/docs/common_tasks:test_suite')]].
 

--- a/src/docs/common_tasks/test_suite.md
+++ b/src/docs/common_tasks/test_suite.md
@@ -20,7 +20,7 @@ Below is an example `junit_tests` definition followed by a `python_tests` defini
       name='tests',
       sources=['test_*.scala'],
       dependencies=[
-        'src/scala/myproject/example:lib',
+        'src/scala/com/myorg/myproject/example:lib',
       ],
     )
 

--- a/src/docs/common_tasks/test_suite.md
+++ b/src/docs/common_tasks/test_suite.md
@@ -16,21 +16,23 @@ For Scala or Java, create a `junit_tests` target definition that defines your su
 Below is an example `junit_tests` definition followed by a `python_tests` definition:
 
     ::python
-    junit_tests(name='scala-tests',
-      sources=rglobs('*.scala'),
+    junit_tests(
+      name='tests',
+      sources=['test_*.scala'],
       dependencies=[
-        'myproject/src/main/scala',
-      ]
+        'src/scala/myproject/example:lib',
+      ],
     )
 
-    python_tests(name='python-tests',
-      sources=globs('*.py'),
+    python_tests(
+      name='tests',
+      sources=['test_*.py'],
       dependencies=[
-        'myproject/src/python',
-      ]
+        'src/python/myproject/example:lib',
+      ],
     )
 
 Now you can [[run the test|pants('src/docs/common_tasks:test')]] using the Pants `test` goal like this:
 
     ::bash
-    $ ./pants test myproject/src/tests:scala-tests
+    $ ./pants test src/python/myproject/example:tests

--- a/src/docs/common_tasks/thrift_gen.md
+++ b/src/docs/common_tasks/thrift_gen.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-You've created Thrift definitions (structs, services, etc.) and you need to generated either Thrift-based
+You've created Thrift definitions (structs, services, etc.) and you need to generate either Thrift-based
 
 * **classes** for use within your Scala or Java project, or
 * **libraries** that can be used by your project or other projects.
@@ -12,7 +12,7 @@ You've created Thrift definitions (structs, services, etc.) and you need to gene
 Use the `gen` goal to generate code from Thrift definitions. Here's an example:
 
     ::bash
-    $ ./pants gen myproject/src/thrift:thrift-scala
+    $ ./pants gen src/thrift/example:thrift-scala
 
 If you need to compile a Scala or Java [[library target|pants('src/docs/common_tasks:jvm_library')]] instead, use the `compile` goal instead.
 
@@ -26,14 +26,15 @@ There are two types of Thrift target definitions that you will find in `BUILD` f
 You can use the `gen` and `compile` goals directly with `java_thrift_library` targets. Thus, you could target a `BUILD` file containing this definition...
 
     ::python
-    java_thrift_library(name='thrift-java',
+    java_thrift_library(
+      name='thrift-java',
       # Other parameters
     )
 
 ...like this using Pants:
 
     ::bash
-    $ ./pants gen myproject/src/main/thrift:thrift-java
+    $ ./pants gen src/thrift/example:thrift-java
 
 To learn more about Thrift, check out the [[Thrift Example docs|pants('examples/src/thrift/org/pantsbuild/example:readme')]].
 

--- a/src/docs/first_tutorial.md
+++ b/src/docs/first_tutorial.md
@@ -17,11 +17,11 @@ Pants "bootstrap" itself, downloading and compiling things it needs:
 Now you're ready to invoke pants for more useful things.
 
 You invoke pants with *goals* (like `test` or `bundle`) and the *targets* to use (like
-`examples/tests/java/org/pantsbuild/example/hello/greet:greet`). For
+`src/python/myproject/example:tests`). For
 example,
 
     :::bash
-    $ ./pants test examples/tests/java/org/pantsbuild/example/hello/greet:greet
+    $ ./pants test src/python/myproject/example:tests
 
 Goals (the "verbs" of Pants) produce new files from targets (the "nouns").
 
@@ -40,7 +40,7 @@ Pants knows about goals ("verbs" like `bundle` and `test`) and targets
 invocation looks like
 
     :::bash
-    $ ./pants test examples/tests/java/org/pantsbuild/example/hello/greet:greet
+    $ ./pants test src/python/myproject/example:tests
 
 Looking at the pieces of this we see
 
@@ -62,7 +62,7 @@ example, before it run tests, it must compile the code.
 You can specify more than one goal on a command line. E.g., to run
 tests *and* run a binary, we could have said `./pants test run ...`
 
-`examples/tests/java/org/pantsbuild/example/hello/greet:greet`<br>
+`src/python/myproject/example:tests`<br>
 This is a *build target*, a "build-able" thing in your source code. To
 define these, you set up configuration files named `BUILD` in your
 source code file tree. (You'll see more about these later.)
@@ -125,7 +125,7 @@ tell Pants to "fail fast" on the first `junit` test failure instead of running a
 `junit` tests like so:
 
     :::bash
-    $ ./pants test.junit --fail-fast examples/tests/java/org/pantsbuild/example/hello/greet:greet
+    $ ./pants test.junit --fail-fast src/java/myproject/example/hello:tests
 
 Here, `test` has become `test.junit`. The `test` goal is made up of parts, or *tasks*: `test.junit`,
 `test.pytest`, and `test.specs`. We want to specify a flag to the `test.junit` task, so we
@@ -138,16 +138,16 @@ for a goal or task go immediately after that goal or task.
 You can specify options for more than one part of a goal. For example,
 
     :::bash
-    $ ./pants test.junit --fail-fast test.pytest --options='-k seq' examples/tests::
+    $ ./pants test.junit --fail-fast test.pytest --no-fail-fast src/java:: src/python::
 
-Here, the `--fail-fast` flag affects `test.junit` and `--options` affects `test.pytest`.
+Here, the `--fail-fast` flag affects `test.junit` and `--no-fail-fast` affects `test.pytest`.
 
 Pants has some global options, options not associated with just one goal. For example,
 If you pass the global `-ldebug` flag after the word `goal` but before any particular goal or
 task, you get verbose debug-level logging for all goals:
 
     :::bash
-    $ ./pants -ldebug test examples/tests/java/org/pantsbuild/example/hello/greet:
+    $ ./pants -ldebug test src/java/myproject/example/hello:tests
     09:18:53 00:00 [main]
                    (To run a reporting server: ./pants server)
     09:18:53 00:00   [bootstrap]
@@ -263,9 +263,9 @@ A target definition in a `BUILD` file looks something like
         '3rdparty:commons-math',
         '3rdparty:thrift',
         'src/java/org/pantsbuild/auth',
-        ':base'
+        ':base',
       ],
-      sources=globs('*.java'),
+      sources=['*.java'],
     )
 
 Here, `java_library` is the target's *type*. Different target types
@@ -289,17 +289,11 @@ refer to them here.
 List of source files, which must be under the directory tree rooted
 at the BUILD file's directory.
 
-You can provide an explicit list, e.g.,
-`sources=['Foo.java', 'Bar.java']`, or use the `globs` function
-to glob over files, e.g., `sources=globs('*.java')`. Similarly,
-`rglobs` will apply the glob pattern recursively in all subdirectories
-of the BUILD file's directory.
+You can provide explicit file names and also use globs, e.g. `sources=['Foo.java', 'subdir/**/*.java']`. To exclude a file or glob, prefix the value with `!`, e.g. `sources=['*.java', '!ignore.java']`.
 
 If you omit `sources` in a target, Pants will attempt to apply a
 sensible default that depends on the target type.
-E.g., `junit_tests` will default to globbing over `*Test.java`,
-`java_library` will default to globbing over `*.java`, minus the
-test files, and so on.
+For example, `junit_tests` will default to `sources=['*Test.java']`, while `java_library` will default to `sources=['*.java', '!*Test.java']`.
 
 
 The Usual Commands
@@ -312,13 +306,13 @@ will still compile them since it knows it must compile before it can
 test.
 
     :::bash
-    $ ./pants test src/java/com/myorg/myproject tests/java/com/myorg/myproject
+    $ ./pants test src/python/myproject:: src/java/myproject::
 
 **Run a binary**<br>
 Use pants to execute a binary target.  Compiles the code first if it is not up to date.
 
     :::bash
-    $ ./pants run examples/src/java/org/pantsbuild/example/hello/simple
+    $ ./pants run src/java/myproject/example/hello/simple
 
 **Get Help**<br>
 Get the list of goals:

--- a/src/docs/first_tutorial.md
+++ b/src/docs/first_tutorial.md
@@ -125,7 +125,7 @@ tell Pants to "fail fast" on the first `junit` test failure instead of running a
 `junit` tests like so:
 
     :::bash
-    $ ./pants test.junit --fail-fast src/java/myproject/example/hello:tests
+    $ ./pants test.junit --fail-fast src/java/com/myorg/myproject/example/hello:tests
 
 Here, `test` has become `test.junit`. The `test` goal is made up of parts, or *tasks*: `test.junit`,
 `test.pytest`, and `test.specs`. We want to specify a flag to the `test.junit` task, so we
@@ -262,7 +262,7 @@ A target definition in a `BUILD` file looks something like
       dependencies = [
         '3rdparty:commons-math',
         '3rdparty:thrift',
-        'src/java/org/pantsbuild/auth',
+        'src/java/com/myorg/myproject/example',
         ':base',
       ],
       sources=['*.java'],
@@ -306,13 +306,13 @@ will still compile them since it knows it must compile before it can
 test.
 
     :::bash
-    $ ./pants test src/python/myproject:: src/java/myproject::
+    $ ./pants test src/python:: src/java::
 
 **Run a binary**<br>
-Use pants to execute a binary target.  Compiles the code first if it is not up to date.
+Use pants to execute a binary target. Compiles the code first if it is not up to date.
 
     :::bash
-    $ ./pants run src/java/myproject/example/hello/simple
+    $ ./pants run src/python/myproject/example:my_script
 
 **Get Help**<br>
 Get the list of goals:

--- a/src/docs/target_addresses.md
+++ b/src/docs/target_addresses.md
@@ -14,14 +14,14 @@ The following target addresses all specify the same single target.
 -   The fully qualified target address is `//` plus the BUILD file's directory path plus target name:
 
         :::bash
-        $ ./pants list //examples/src/java/org/pantsbuild/example/hello/main:main
-        examples/src/java/org/pantsbuild/example/hello/main:main
+        $ ./pants list //src/java/myproject/example/hello/main:main
+        src/java/myproject/example/hello/main:main
 
 -   The starting double-slash is optional if the target isn't in the build root directory:
 
         :::bash
-        $ ./pants list examples/src/java/org/pantsbuild/example/hello/main:main
-        examples/src/java/org/pantsbuild/example/hello/main:main
+        $ ./pants list src/java/myproject/example/hello/main:main
+        src/java/myproject/example/hello/main:main
 
     It's idiomatic to omit the double-slash when possible.  However it's required when referencing
     targets in the build root, so that the command-line parser can distinguish such targets from
@@ -32,8 +32,8 @@ The following target addresses all specify the same single target.
 -   The target name is optional if it is the same as the parent directory name:
 
         :::bash
-        $ ./pants list examples/src/java/org/pantsbuild/example/hello/main
-        examples/src/java/org/pantsbuild/example/hello/main:main
+        $ ./pants list src/java/myproject/example/hello/main
+        src/java/myproject/example/hello/main:main
 
     It's idiomatic to omit the repetition of the target name in this case.
 
@@ -41,8 +41,8 @@ The following target addresses all specify the same single target.
     option can be passed to run the goal on the target which own that file.
 
         ::::bash
-        $ ./pants --owner-of=examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java list
-        examples/src/java/org/pantsbuild/example/hello/main:main
+        $ ./pants --owner-of=src/java/myproject/example/hello/main/HelloMain.java list
+        src/java/myproject/example/hello/main:main
     
     It's also worth noting that multiple instances of `--owner-of=` are accepted in order to work with multiple
     files and pants will execute the goal on all the targets that own those files. Additionally, `fromfile`
@@ -53,13 +53,13 @@ The following target addresses all specify the same single target.
     command-line to accommodate tab completion:
 
         :::bash
-        $ ./pants list ./examples/src/java/org/pantsbuild/example/hello/main/
+        $ ./pants list ./src/java/myproject/example/hello/main/
         examples/src/java/org/pantsbuild/example/hello/main:main
 
     Absolute paths are also allowed on the command-line, to support flexibility in scripting:
 
         :::bash
-        $ pants goal list $REPO_ROOT/src/java/org/pantsbuild/example/hello/main
+        $ pants list $REPO_ROOT/src/java/myproject/example/hello/main
         src/java/org/pantsbuild/example/hello/main:main
 
 These last two forms are not allowed in target addresses in `BUILD` files.
@@ -69,9 +69,16 @@ You can reference another target in the same BUILD file by starting with a
 colon ``:targetname`` instead of specifying the whole path:
 
     :::python
-    java_library(name='application', ...)
-    java_library(name='mybird',
-      dependencies=[':application'],
+    java_library(
+      name='application',
+      ...,
+     )
+     
+    java_library(
+      name='mybird',
+      dependencies=[
+        ':application',
+      ],
     )
 
 Note that, apart from this shorthand, addresses in BUILD files are always relative to the buildroot,
@@ -83,7 +90,7 @@ are not allowed in BUILD files.
 A trailing single colon specifies a glob of targets at the specified location:
 
     :::bash
-    $ ./pants list tests/python/pants_test/:
+    $ ./pants list tests/python/pants_test:
     src/python/pants/testutil:int-test
     tests/python/pants_test:base_test
     tests/python/pants_test:test_infra
@@ -92,7 +99,7 @@ A trailing single colon specifies a glob of targets at the specified location:
 A trailing double colon specifies a recursive glob of targets at the specified location:
 
     :::bash
-    $ ./pants list tests/python/pants_test/::
+    $ ./pants list tests/python/pants_test::
     src/python/pants/testutil:int-test
     tests/python/pants_test:base_test
     tests/python/pants_test:test_infra

--- a/src/docs/target_addresses.md
+++ b/src/docs/target_addresses.md
@@ -14,14 +14,14 @@ The following target addresses all specify the same single target.
 -   The fully qualified target address is `//` plus the BUILD file's directory path plus target name:
 
         :::bash
-        $ ./pants list //src/java/myproject/example/hello/main:main
-        src/java/myproject/example/hello/main:main
+        $ ./pants list //src/python/myproject/example/hello/main:main
+        src/python/myproject/example/hello/main:main
 
 -   The starting double-slash is optional if the target isn't in the build root directory:
 
         :::bash
-        $ ./pants list src/java/myproject/example/hello/main:main
-        src/java/myproject/example/hello/main:main
+        $ ./pants list src/python/myproject/example/hello/main:main
+        src/python/myproject/example/hello/main:main
 
     It's idiomatic to omit the double-slash when possible.  However it's required when referencing
     targets in the build root, so that the command-line parser can distinguish such targets from
@@ -32,8 +32,8 @@ The following target addresses all specify the same single target.
 -   The target name is optional if it is the same as the parent directory name:
 
         :::bash
-        $ ./pants list src/java/myproject/example/hello/main
-        src/java/myproject/example/hello/main:main
+        $ ./pants list src/python/myproject/example/hello/main
+        src/python/myproject/example/hello/main:main
 
     It's idiomatic to omit the repetition of the target name in this case.
 
@@ -41,8 +41,8 @@ The following target addresses all specify the same single target.
     option can be passed to run the goal on the target which own that file.
 
         ::::bash
-        $ ./pants --owner-of=src/java/myproject/example/hello/main/HelloMain.java list
-        src/java/myproject/example/hello/main:main
+        $ ./pants --owner-of=src/python/myproject/example/hello.py list
+        src/python/myproject/example/hello:app
     
     It's also worth noting that multiple instances of `--owner-of=` are accepted in order to work with multiple
     files and pants will execute the goal on all the targets that own those files. Additionally, `fromfile`
@@ -53,14 +53,14 @@ The following target addresses all specify the same single target.
     command-line to accommodate tab completion:
 
         :::bash
-        $ ./pants list ./src/java/myproject/example/hello/main/
-        examples/src/java/org/pantsbuild/example/hello/main:main
+        $ ./pants list ./src/python/myproject/example/hello/
+        src/python/myproject/example/hello:app
 
     Absolute paths are also allowed on the command-line, to support flexibility in scripting:
 
         :::bash
-        $ pants list $REPO_ROOT/src/java/myproject/example/hello/main
-        src/java/org/pantsbuild/example/hello/main:main
+        $ pants list $REPO_ROOT/src/python/myproject/example/hello
+        src/python/myproject/example/hello:app
 
 These last two forms are not allowed in target addresses in `BUILD` files.
 They are just for command-line convenience.

--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -55,7 +55,7 @@ Ivy Resolution
 You can view Ivy's report of how it resolved each (transitive) third-party dependency:
 
     :::bash
-    $ ./pants resolve.ivy --open examples/tests/java/org/pantsbuild/example/hello/greet
+    $ ./pants resolve.ivy --open src/java/myproject/example/hello/greet
 
 
 Ivy HTTP Debugging

--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -55,7 +55,7 @@ Ivy Resolution
 You can view Ivy's report of how it resolved each (transitive) third-party dependency:
 
     :::bash
-    $ ./pants resolve.ivy --open src/java/myproject/example/hello/greet
+    $ ./pants resolve.ivy --open src/java/com/myorg/myproject/example/hello/greet
 
 
 Ivy HTTP Debugging


### PR DESCRIPTION
Given that we're soon deprecating `globs`, `rglobs`, and `zglobs`, we need to update the docs to do the right thing.

This also makes some other small improvements:
* Always put the fields of a target definition on a new line for consistent formatting.
* Rename `myproject/src/main/java/example` to `src/java/example`. While this subproject naming scheme is common at large organizations like Twitter, smaller and medium-sized monorepos will likely default to `src/python` and `src/java`. This seems like the most sensible default.