### PR TITLE
Stop using `globs` in testprojects/

### DIFF
--- a/testprojects/3rdparty/BUILD
+++ b/testprojects/3rdparty/BUILD
@@ -3,40 +3,40 @@
 
 files(
   name = 'checkstyle_directory',
-  sources = rglobs('checkstyle/*'),
+  sources = ['checkstyle/**/*'],
 )
 
 files(
   name = 'com_directory',
-  sources = rglobs('com/*'),
+  sources = ['com/**/*'],
 )
 
 files(
   name = 'cucumber_directory',
-  sources = rglobs('cucumber/*'),
+  sources = ['cucumber/**/*'],
 )
 
 files(
   name = 'javactool_directory',
-  sources = rglobs('javactool/*'),
+  sources = ['javactool/**/*'],
 )
 
 files(
   name = 'jetty_directory',
-  sources = rglobs('jetty/*'),
+  sources = ['jetty/**/*'],
 )
 
 files(
   name = 'managed_directory',
-  sources = rglobs('managed/*'),
+  sources = ['managed/**/*'],
 )
 
 files(
   name = 'org_directory',
-  sources = rglobs('org/*'),
+  sources = ['org/**/*'],
 )
 
 files(
   name = 'python_directory',
-  sources = rglobs('python/*'),
+  sources = ['python/**/*'],
 )

--- a/testprojects/BUILD
+++ b/testprojects/BUILD
@@ -3,7 +3,7 @@
 
 files(
   name = 'pants_plugins_directory',
-  sources = rglobs('pants-plugins/*'),
+  sources = ['pants-plugins/**/*'],
   dependencies = [
     'src/python/pants/testutil:test_base',
   ],

--- a/testprojects/maven_layout/BUILD
+++ b/testprojects/maven_layout/BUILD
@@ -15,30 +15,30 @@ target(
 
 files(
   name = 'junit_resource_collision_directory',
-  sources = rglobs('junit_resource_collision/*'),
+  sources = ['junit_resource_collision/**/*'],
 )
 
 files(
   name = 'maven_and_pants_directory',
-  sources = rglobs('maven_and_pants/*'),
+  sources = ['maven_and_pants/**/*'],
 )
 
 files(
   name = 'protolib-external-test_directory',
-  sources = rglobs('protolib-external-test/*'),
+  sources = ['protolib-external-test/**/*'],
 )
 
 files(
   name = 'protolib-test_directory',
-  sources = rglobs('protolib-test/*'),
+  sources = ['protolib-test/**/*'],
 )
 
 files(
   name = 'provided_patching_directory',
-  sources = rglobs('provided_patching/*'),
+  sources = ['provided_patching/**/*'],
 )
 
 files(
   name = 'resource_collision_directory',
-  sources = rglobs('resource_collision/*'),
+  sources = ['resource_collision/**/*'],
 )

--- a/testprojects/src/antlr/python/BUILD
+++ b/testprojects/src/antlr/python/BUILD
@@ -10,5 +10,5 @@ target(
 
 files(
   name = 'test_directory',
-  sources = rglobs('test/*'),
+  sources = ['test/**/*'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/BUILD
@@ -60,12 +60,12 @@ target(
 
 files(
   name = 'aliases_directory',
-  sources = rglobs('aliases/*'),
+  sources = ['aliases/**/*'],
 )
 
 files(
   name = 'annotation_directory',
-  sources = rglobs('annotation/*'),
+  sources = ['annotation/**/*'],
   dependencies = [
     'testprojects/3rdparty:com_directory',
   ],
@@ -73,12 +73,12 @@ files(
 
 files(
   name = 'bench_directory',
-  sources = rglobs('bench/*'),
+  sources = ['bench/**/*'],
 )
 
 files(
   name = 'bundle_directory',
-  sources = rglobs('bundle/*'),
+  sources = ['bundle/**/*'],
   dependencies = [
     'testprojects/src/resources/org/pantsbuild/testproject:bundleresources_directory',
     'testprojects/tests/resources/org/pantsbuild/testproject:bundleresources_directory',
@@ -87,17 +87,17 @@ files(
 
 files(
   name = 'compilation_warnings_directory',
-  sources = rglobs('compilation_warnings/*'),
+  sources = ['compilation_warnings/**/*'],
 )
 
 files(
   name = 'coverage_directory',
-  sources = rglobs('coverage/*'),
+  sources = ['coverage/**/*'],
 )
 
 files(
   name = 'cwdexample_directory',
-  sources = rglobs('cwdexample/*'),
+  sources = ['cwdexample/**/*'],
   dependencies = [
     'testprojects/3rdparty:checkstyle_directory',
   ],
@@ -105,42 +105,42 @@ files(
 
 files(
   name = 'cycle1_directory',
-  sources = rglobs('cycle1/*'),
+  sources = ['cycle1/**/*'],
 )
 
 files(
   name = 'cycle2_directory',
-  sources = rglobs('cycle2/*'),
+  sources = ['cycle2/**/*'],
 )
 
 files(
   name = 'deployexcludes_directory',
-  sources = rglobs('deployexcludes/*'),
+  sources = ['deployexcludes/**/*'],
 )
 
 files(
   name = 'depman_directory',
-  sources = rglobs('depman/*'),
+  sources = ['depman/**/*'],
 )
 
 files(
   name = 'dummies_directory',
-  sources = rglobs('dummies/*'),
+  sources = ['dummies/**/*'],
 )
 
 files(
   name = 'exclude_directory',
-  sources = rglobs('exclude/*'),
+  sources = ['exclude/**/*'],
 )
 
 files(
   name = 'extra_jvm_options_directory',
-  sources = rglobs('extra_jvm_options/*'),
+  sources = ['extra_jvm_options/**/*'],
 )
 
 files(
   name = 'ideacodeandresources_directory',
-  sources = rglobs('ideacodeandresources/*'),
+  sources = ['ideacodeandresources/**/*'],
   dependencies = [
     'testprojects/src/resources/org/pantsbuild/testproject:ideacodeandresources_directory',
   ],
@@ -148,7 +148,7 @@ files(
 
 files(
   name = 'idearesourcesonly_directory',
-  sources = rglobs('idearesourcesonly/*'),
+  sources = ['idearesourcesonly/**/*'],
   dependencies = [
     'testprojects/src/resources/org/pantsbuild/testproject:idearesourcesonly_directory',
   ],
@@ -156,7 +156,7 @@ files(
 
 files(
   name = 'inccompile_directory',
-  sources = rglobs('inccompile/*'),
+  sources = ['inccompile/**/*'],
   dependencies = [
     'testprojects/3rdparty:jetty_directory',
   ],
@@ -164,17 +164,17 @@ files(
 
 files(
   name = 'intransitive_directory',
-  sources = rglobs('intransitive/*'),
+  sources = ['intransitive/**/*'],
 )
 
 files(
   name = 'jarversionincompatibility_directory',
-  sources = rglobs('jarversionincompatibility/*'),
+  sources = ['jarversionincompatibility/**/*'],
 )
 
 files(
   name = 'javadepsonscala_directory',
-  sources = rglobs('javadepsonscala/*'),
+  sources = ['javadepsonscala/**/*'],
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject:javadepsonscala_directory',
   ],
@@ -182,7 +182,7 @@ files(
 
 files(
   name = 'javadepsonscalatransitive_directory',
-  sources = rglobs('javadepsonscalatransitive/*'),
+  sources = ['javadepsonscalatransitive/**/*'],
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject:javadepsonscalatransitive_directory',
   ],
@@ -193,32 +193,32 @@ files(
 # here. Instead, we declare this in `:all_targets`.
 files(
   name = 'javasources_directory',
-  sources = rglobs('javasources/*'),
+  sources = ['javasources/**/*'],
 )
 
 files(
   name = 'junit_directory',
-  sources = rglobs('junit/*'),
+  sources = ['junit/**/*'],
 )
 
 files(
   name = 'jvmprepcommand_directory',
-  sources = rglobs('jvmprepcommand/*'),
+  sources = ['jvmprepcommand/**/*'],
 )
 
 files(
   name = 'manifest_directory',
-  sources = rglobs('manifest/*'),
+  sources = ['manifest/**/*'],
 )
 
 files(
   name = 'missing_sources_directory',
-  sources = rglobs('missing_sources/*'),
+  sources = ['missing_sources/**/*'],
 )
 
 files(
   name = 'missingdepswhitelist_directory',
-  sources = rglobs('missingdepswhitelist/*'),
+  sources = ['missingdepswhitelist/**/*'],
   dependencies = [
     ':missingdepswhitelist2_directory',
     ':publish_directory',
@@ -227,12 +227,12 @@ files(
 
 files(
   name = 'missingdepswhitelist2_directory',
-  sources = rglobs('missingdepswhitelist2/*'),
+  sources = ['missingdepswhitelist2/**/*'],
 )
 
 files(
   name = 'missingdirectdepswhitelist_directory',
-  sources = rglobs('missingdirectdepswhitelist/*'),
+  sources = ['missingdirectdepswhitelist/**/*'],
   dependencies = [
     ':missingdirectdepswhitelist2_directory',
   ],
@@ -240,7 +240,7 @@ files(
 
 files(
   name = 'missingdirectdepswhitelist2_directory',
-  sources = rglobs('missingdirectdepswhitelist2/*'),
+  sources = ['missingdirectdepswhitelist2/**/*'],
   dependencies = [
     ':publish_directory',
   ],
@@ -248,7 +248,7 @@ files(
 
 files(
   name = 'missingjardepswhitelist_directory',
-  sources = rglobs('missingjardepswhitelist/*'),
+  sources = ['missingjardepswhitelist/**/*'],
   dependencies = [
     ':missingjardepswhitelist2_directory',
   ],
@@ -256,22 +256,22 @@ files(
 
 files(
   name = 'missingjardepswhitelist2_directory',
-  sources = rglobs('missingjardepswhitelist2/*'),
+  sources = ['missingjardepswhitelist2/**/*'],
 )
 
 files(
   name = 'nocache_directory',
-  sources = rglobs('nocache/*'),
+  sources = ['nocache/**/*'],
 )
 
 files(
   name = 'packageinfo_directory',
-  sources = rglobs('packageinfo/*'),
+  sources = ['packageinfo/**/*'],
 )
 
 files(
   name = 'page_directory',
-  sources = rglobs('page/*'),
+  sources = ['page/**/*'],
   dependencies = [
     'examples/src/java/org/pantsbuild/example:hello_directory',
   ],
@@ -279,17 +279,17 @@ files(
 
 files(
   name = 'phrases_directory',
-  sources = rglobs('phrases/*'),
+  sources = ['phrases/**/*'],
 )
 
 files(
   name = 'printversion_directory',
-  sources = rglobs('printversion/*'),
+  sources = ['printversion/**/*'],
 )
 
 files(
   name = 'proto-ordering_directory',
-  sources = rglobs('proto-ordering/*'),
+  sources = ['proto-ordering/**/*'],
   dependencies = [
     'testprojects/src/protobuf/org/pantsbuild/testproject:proto-ordering_directory',
   ],
@@ -297,12 +297,12 @@ files(
 
 files(
   name = 'provided_directory',
-  sources = rglobs('provided/*'),
+  sources = ['provided/**/*'],
 )
 
 files(
   name = 'publish_directory',
-  sources = rglobs('publish/*'),
+  sources = ['publish/**/*'],
   dependencies = [
     'testprojects/src/protobuf/org/pantsbuild/testproject:distance_directory',
   ],
@@ -310,22 +310,22 @@ files(
 
 files(
   name = 'resdependency_directory',
-  sources = rglobs('resdependency/*'),
+  sources = ['resdependency/**/*'],
 )
 
 files(
   name = 'runner_directory',
-  sources = rglobs('runner/*'),
+  sources = ['runner/**/*'],
 )
 
 files(
   name = 'runtime_directory',
-  sources = rglobs('runtime/*'),
+  sources = ['runtime/**/*'],
 )
 
 files(
   name = 'shading_directory',
-  sources = rglobs('shading/*'),
+  sources = ['shading/**/*'],
   dependencies = [
     ':shadingdep_directory',
   ],
@@ -333,12 +333,12 @@ files(
 
 files(
   name = 'shadingdep_directory',
-  sources = rglobs('shadingdep/*'),
+  sources = ['shadingdep/**/*'],
 )
 
 files(
   name = 'thriftdeptest_directory',
-  sources = rglobs('thriftdeptest/*'),
+  sources = ['thriftdeptest/**/*'],
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild:testproject_directory',
   ],
@@ -346,12 +346,12 @@ files(
 
 files(
   name = 'typeparameters_directory',
-  sources = rglobs('typeparameters/*'),
+  sources = ['typeparameters/**/*'],
 )
 
 files(
   name = 'unicode_directory',
-  sources = rglobs('unicode/*'),
+  sources = ['unicode/**/*'],
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
   ],
@@ -359,7 +359,7 @@ files(
 
 files(
   name = 'utf8proto_directory',
-  sources = rglobs('utf8proto/*'),
+  sources = ['utf8proto/**/*'],
   dependencies = [
     'testprojects/src/protobuf/org/pantsbuild/testproject:utf8proto_directory',
   ],

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
@@ -4,7 +4,7 @@
 #  annotation_processor() target to test resource mapping
 
 annotation_processor(
-  sources=globs('*.java'),
+  sources=['*.java'],
   processors=['org.pantsbuild.testproject.annotation.processor.ResourceMappingProcessor'],
   dependencies=[
     # NB: We use the oldest guava we can stomach here, in order to flush out classpath

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
@@ -4,7 +4,7 @@
 #  annotation_processor() target to test generating java code
 
 annotation_processor(
-  sources = globs('*.java'),
+  sources = ['*.java'],
   processors = ['org.pantsbuild.testproject.annotation.processorwithdep.processor.ProcessorWithDep'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker',

--- a/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
@@ -5,29 +5,32 @@ jvm_app(
   basename = 'bundle-example',
   binary=':bundle-bin',
   bundles=[
-    bundle(fileset=globs('data/*')),
+    bundle(fileset=['data/*']),
   ]
 )
 
-jvm_app(name='mapper',
+jvm_app(
+  name='mapper',
   binary=':bundle-bin',
   bundles=[
     bundle(
       mapper=DirectoryReMapper('testprojects/src/java/org/pantsbuild/testproject/bundle/a/b', 'bundle_files'),
-      fileset=globs('a/b/*')),
+      fileset=['a/b/*']),
   ]
 )
 
-jvm_app(name='relative_to',
+jvm_app(
+  name='relative_to',
   binary=':bundle-bin',
   bundles=[
     bundle(
       relative_to='a',
-      fileset=globs('a/b/*')),
+      fileset=['a/b/*']),
   ]
 )
 
-jvm_app(name='rel_path',
+jvm_app(
+  name='rel_path',
   binary=':bundle-bin',
   bundles=[
     bundle(
@@ -37,7 +40,8 @@ jvm_app(name='rel_path',
   ]
 )
 
-jvm_app(name='directory',
+jvm_app(
+  name='directory',
   binary=':bundle-bin',
   bundles=[
     bundle(
@@ -46,7 +50,8 @@ jvm_app(name='directory',
   ]
 )
 
-jvm_app(name='explicit_recursion',
+jvm_app(
+  name='explicit_recursion',
   binary=':bundle-bin',
   bundles=[
     bundle(
@@ -57,7 +62,8 @@ jvm_app(name='explicit_recursion',
 
 # The binary, the "runnable" part:
 
-jvm_binary(name = 'bundle-bin',
+jvm_binary(
+  name = 'bundle-bin',
   source = 'BundleMain.java',
   main = 'org.pantsbuild.testproject.bundle.BundleMain',
   basename = 'bundle-example-bin',

--- a/testprojects/src/java/org/pantsbuild/testproject/exclude/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/exclude/BUILD
@@ -15,8 +15,9 @@ jar_library(name = 'zinc',
   ]
 )
 
-java_library(name='foo',
-  sources=globs('Main.java'),
+java_library(
+  name='foo',
+  sources=['Main.java'],
   dependencies=[
     ':baz',
     ':zinc',
@@ -29,14 +30,16 @@ java_library(name='foo',
   ]
 )
 
-java_library(name='bar',
-  sources=globs('Main.java'),
+java_library(
+  name='bar',
+  sources=['Main.java'],
   dependencies=[
     ':nailgun-server',
     ':jmake',
   ]
 )
 
-java_library(name='baz',
-  sources=globs('Main.java'),
+java_library(
+  name='baz',
+  sources=['Main.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/javadepsonscala/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javadepsonscala/BUILD
@@ -5,5 +5,5 @@ java_library(
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala'
   ],
-  sources=rglobs('*.java')
+  sources=['**/*.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
@@ -5,6 +5,6 @@ java_library(
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:scala'
   ],
-  sources = rglobs('*.java'),
+  sources = ['**/*.java'],
   strict_deps = True
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/javasources/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javasources/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=[
     'testprojects/src/scala/org/pantsbuild/testproject/javasources',
   ]

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet',
     'testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist2'

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist2/BUILD
@@ -5,5 +5,5 @@ java_library(
   # Keep the name until https://github.com/pantsbuild/intellij-pants-plugin/issues/211
   # is resolved.
   name = 'missingdepswhitelist2',
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2'
   ]

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2/BUILD
@@ -2,6 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=['testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet']
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2',
   ]

--- a/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java'),
+  sources=['**/*.java'],
   dependencies=[
     '3rdparty:guava',
   ]

--- a/testprojects/src/java/org/pantsbuild/testproject/packageinfo/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/packageinfo/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  sources=rglobs('*.java')
+  sources=['**/*.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
@@ -53,5 +53,5 @@ java_library(
 
 resources(
   name='readme',
-  sources=globs('*.txt'),
+  sources=['*.txt'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/thriftdeptest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/thriftdeptest/BUILD
@@ -5,5 +5,5 @@ java_library(
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild/testproject:thrift-java',
   ],
-  sources = rglobs('*.java')
+  sources = ['**/*.java'],
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/BUILD
@@ -13,20 +13,20 @@ target(
 
 files(
   name = 'distance_directory',
-  sources = rglobs('distance/*'),
+  sources = ['distance/**/*'],
 )
 
 files(
   name = 'import_from_buildroot_directory',
-  sources = rglobs('import_from_buildroot/*'),
+  sources = ['import_from_buildroot/**/*'],
 )
 
 files(
   name = 'proto-ordering_directory',
-  sources = rglobs('proto-ordering/*'),
+  sources = ['proto-ordering/**/*'],
 )
 
 files(
   name = 'utf8proto_directory',
-  sources = rglobs('utf8proto/*'),
+  sources = ['utf8proto/**/*'],
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/distance/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/distance/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(
-  sources=globs('*.proto'),
+  sources=['*.proto'],
   provides=artifact(
     org='org.pantsbuild.testproject.protobuf',
     name='distance',

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/BUILD
@@ -2,6 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(
-  sources=globs('*.proto'),
+  sources=['*.proto'],
   dependencies=['testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo']
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(
-  sources=globs('*.proto'),
+  sources=['*.proto'],
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(
-  sources=globs('*.proto'),
+  sources=['*.proto'],
 )

--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -23,7 +23,7 @@ target(
 
 files(
   name = 'antlr_directory',
-  sources = rglobs('antlr/*'),
+  sources = ['antlr/**/*'],
   dependencies = [
     'testprojects/src/antlr/python:test_directory',
   ],
@@ -31,52 +31,52 @@ files(
 
 files(
   name = 'bad_requirements_directory',
-  sources = rglobs('bad_requirements/*'),
+  sources = ['bad_requirements/**/*'],
 )
 
 files(
   name = 'build_file_imports_function_directory',
-  sources = rglobs('build_file_imports_function/*'),
+  sources = ['build_file_imports_function/**/*'],
 )
 
 files(
   name = 'build_file_imports_module_directory',
-  sources = rglobs('build_file_imports_module/*'),
+  sources = ['build_file_imports_module/**/*'],
 )
 
 files(
   name = 'coordinated_runs_directory',
-  sources = rglobs('coordinated_runs/*'),
+  sources = ['coordinated_runs/**/*'],
 )
 
 files(
   name = 'interpreter_selection_directory',
-  sources = rglobs('interpreter_selection/*'),
+  sources = ['interpreter_selection/**/*'],
 )
 
 files(
   name = 'nested_runs_directory',
-  sources = rglobs('nested_runs/*'),
+  sources = ['nested_runs/**/*'],
 )
 
 files(
   name = 'no_build_file_directory',
-  sources = rglobs('no_build_file/*'),
+  sources = ['no_build_file/**/*'],
 )
 
 files(
   name = 'plugins_directory',
-  sources = rglobs('plugins/*'),
+  sources = ['plugins/**/*'],
 )
 
 files(
   name = 'print_env_directory',
-  sources = rglobs('print_env/*'),
+  sources = ['print_env/**/*'],
 )
 
 files(
   name = 'python_distribution_directory',
-  sources = rglobs('python_distribution/*'),
+  sources = ['python_distribution/**/*'],
   dependencies = [
     'testprojects/3rdparty:python_directory',
   ],
@@ -85,15 +85,15 @@ files(
 
 files(
   name = 'python_targets_directory',
-  sources = rglobs('python_targets/*'),
+  sources = ['python_targets/**/*'],
 )
 
 files(
   name = 'sources_directory',
-  sources = rglobs('sources/*'),
+  sources = ['sources/**/*'],
 )
 
 files(
   name = 'unicode_directory',
-  sources = rglobs('unicode/*'),
+  sources = ['unicode/**/*'],
 )

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/BUILD
@@ -1,3 +1,3 @@
 python_library(
-  sources=globs('*.py')
+  sources=['*.py'],
 )

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -5,10 +5,10 @@ python_library(
   dependencies=[
     ':text',
   ],
-  sources=globs('*.py'),
+  sources=['*.py'],
 )
 
 resources(
   name='text',
-  sources=globs('*.txt'),
+  sources=['*.txt'],
 )

--- a/testprojects/src/resources/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/resources/org/pantsbuild/testproject/BUILD
@@ -3,20 +3,20 @@
 
 files(
   name = 'buildfile_path_directory',
-  sources = rglobs('buildfile_path/*'),
+  sources = ['buildfile_path/**/*'],
 )
 
 files(
   name = 'bundleresources_directory',
-  sources = rglobs('bundleresources/*'),
+  sources = ['bundleresources/**/*'],
 )
 
 files(
   name = 'ideacodeandresources_directory',
-  sources = rglobs('ideacodeandresources/*'),
+  sources = ['ideacodeandresources/**/*'],
 )
 
 files(
   name = 'idearesourcesonly_directory',
-  sources = rglobs('idearesourcesonly/*'),
+  sources = ['idearesourcesonly/**/*'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/BUILD
@@ -26,42 +26,42 @@ target(
 
 files(
   name = 'compilation_failure_directory',
-  sources = rglobs('compilation_failure/*'),
+  sources = ['compilation_failure/**/*'],
 )
 
 files(
   name = 'compilation_warnings_directory',
-  sources = rglobs('compilation_warnings/*'),
+  sources = ['compilation_warnings/**/*'],
 )
 
 files(
   name = 'custom_scala_platform_directory',
-  sources = rglobs('custom_scala_platform/*'),
+  sources = ['custom_scala_platform/**/*'],
 )
 
 files(
   name = 'emptyscala_directory',
-  sources = rglobs('emptyscala/*'),
+  sources = ['emptyscala/**/*'],
 )
 
 files(
   name = 'exclude_direct_dep_directory',
-  sources = rglobs('exclude_direct_dep/*'),
+  sources = ['exclude_direct_dep/**/*'],
 )
 
 files(
   name = 'javadepsonscala_directory',
-  sources = rglobs('javadepsonscala/*'),
+  sources = ['javadepsonscala/**/*'],
 )
 
 files(
   name = 'javadepsonscalatransitive_directory',
-  sources = rglobs('javadepsonscalatransitive/*'),
+  sources = ['javadepsonscalatransitive/**/*'],
 )
 
 files(
   name = 'javasources_directory',
-  sources = rglobs('javasources/*'),
+  sources = ['javasources/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/java/org/pantsbuild/testproject:publish_directory'
@@ -70,22 +70,22 @@ files(
 
 files(
   name = 'mutual_directory',
-  sources = rglobs('mutual/*'),
+  sources = ['mutual/**/*'],
 )
 
 files(
   name = 'procedure_syntax_directory',
-  sources = rglobs('procedure_syntax/*'),
+  sources = ['procedure_syntax/**/*'],
 )
 
 files(
   name = 'public_inference_directory',
-  sources = rglobs('public_inference/*'),
+  sources = ['public_inference/**/*'],
 )
 
 files(
   name = 'publish_directory',
-  sources = rglobs('publish/*'),
+  sources = ['publish/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:publish_directory'
   ],
@@ -93,12 +93,12 @@ files(
 
 files(
   name = 'rsc_compat_directory',
-  sources = rglobs('rsc_compat/*'),
+  sources = ['rsc_compat/**/*'],
 )
 
 files(
   name = 'scaladepsonboth_directory',
-  sources = rglobs('scaladepsonboth/*'),
+  sources = ['scaladepsonboth/**/*'],
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
   ],
@@ -106,12 +106,12 @@ files(
 
 files(
   name = 'sharedsources_directory',
-  sources = rglobs('sharedsources/*'),
+  sources = ['sharedsources/**/*'],
 )
 
 files(
   name = 'thriftdeptest_directory',
-  sources = rglobs('thriftdeptest/*'),
+  sources = ['thriftdeptest/**/*'],
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild:testproject_directory',
   ],
@@ -119,5 +119,5 @@ files(
 
 files(
   name = 'unicode_directory',
-  sources = rglobs('unicode/*'),
+  sources = ['unicode/**/*'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/emptyscala/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/emptyscala/BUILD
@@ -1,3 +1,3 @@
 scala_library(
-  sources=globs('*'),
+  sources=['*'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  sources = rglobs('*.scala')
+  sources = ['**/*.scala'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
@@ -6,5 +6,5 @@ scala_library(
     'testprojects/src/java/org/pantsbuild/testproject/javasources',
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet:greet'
   ],
-  sources = rglobs('*.scala')
+  sources = ['**/*.scala'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/scaladepsonboth/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/scaladepsonboth/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  sources = rglobs('*.scala'),
+  sources = ['**/*.scala'],
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/javasources',
   ]

--- a/testprojects/src/scala/org/pantsbuild/testproject/thriftdeptest/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/thriftdeptest/BUILD
@@ -5,7 +5,7 @@ scala_library(
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild/testproject:thrift-java',
   ],
-  sources = rglobs('*.scala'),
+  sources = ['**/*.scala'],
   # NB: this setting is a temporary way to get tests passing, as Scrooge and Thrift
   # require JDK 8 to function properly. This constraint should really be specified in
   # source code, not in test BUILD files. See #6956

--- a/testprojects/src/thrift/org/pantsbuild/BUILD
+++ b/testprojects/src/thrift/org/pantsbuild/BUILD
@@ -12,7 +12,7 @@ target(
 
 files(
   name='constants_only_directory',
-  sources=rglobs('constants_only/*'),
+  sources=['constants_only/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
   ],
@@ -20,7 +20,7 @@ files(
 
 files(
   name='testproject_directory',
-  sources=rglobs('testproject/*'),
+  sources=['testproject/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
   ],
@@ -28,7 +28,7 @@ files(
 
 files(
   name='thrift_exports_directory',
-  sources=rglobs('thrift_exports/*'),
+  sources=['thrift_exports/**/*'],
   dependencies = [
     'examples/3rdparty:python_directory',
   ],

--- a/testprojects/src/thrift/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/thrift/org/pantsbuild/testproject/BUILD
@@ -1,6 +1,6 @@
 java_thrift_library(
   name='thrift-java',
-  sources=rglobs('*.thrift'),
+  sources=['**/*.thrift'],
   compiler='scrooge',
   language='java',
   # NB: this setting is a temporary way to get tests passing, as Scrooge and Thrift

--- a/testprojects/tests/java/org/pantsbuild/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/BUILD
@@ -11,5 +11,5 @@ target(
 
 files(
   name = 'build_parsing_directory',
-  sources = rglobs('build_parsing/*'),
+  sources = ['build_parsing/**/*'],
 )

--- a/testprojects/tests/java/org/pantsbuild/build_parsing/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/build_parsing/BUILD
@@ -1,4 +1,6 @@
 jvm_app(
   name='trailing_glob_doublestar',
-  bundles=[bundle(fileset=globs('test_dir/**'))]
+  bundles=[
+    bundle(fileset=['test_dir/**']),
+  ],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/BUILD
@@ -34,7 +34,7 @@ target(
 
 files(
   name='annotation_directory',
-  sources=rglobs('annotation/*'),
+  sources=['annotation/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:annotation_directory',
   ],
@@ -42,12 +42,12 @@ files(
 
 files(
   name='buildrefactor_directory',
-  sources=rglobs('buildrefactor/*'),
+  sources=['buildrefactor/**/*'],
 )
 
 files(
   name='coverage_directory',
-  sources=rglobs('coverage/*'),
+  sources=['coverage/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:coverage_directory',
   ],
@@ -55,7 +55,7 @@ files(
 
 files(
   name='cucumber_directory',
-  sources=rglobs('cucumber/*'),
+  sources=['cucumber/**/*'],
   dependencies = [
     'testprojects/3rdparty:cucumber_directory',
     'testprojects/tests/resources/org/pantsbuild/testproject:cucumber_directory',
@@ -64,7 +64,7 @@ files(
 
 files(
   name='cwdexample_directory',
-  sources=rglobs('cwdexample/*'),
+  sources=['cwdexample/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:cwdexample_directory',
   ],
@@ -72,32 +72,32 @@ files(
 
 files(
   name='depman_directory',
-  sources=rglobs('depman/*'),
+  sources=['depman/**/*'],
 )
 
 files(
   name='dummies_directory',
-  sources=rglobs('dummies/*'),
+  sources=['dummies/**/*'],
 )
 
 files(
   name='exports_directory',
-  sources=rglobs('exports/*'),
+  sources=['exports/**/*'],
 )
 
 files(
   name='fail256_directory',
-  sources=rglobs('fail256/*'),
+  sources=['fail256/**/*'],
 )
 
 files(
   name='htmlreport_directory',
-  sources=rglobs('htmlreport/*'),
+  sources=['htmlreport/**/*'],
 )
 
 files(
   name='ideacodeandresources_directory',
-  sources=rglobs('ideacodeandresources/*'),
+  sources=['ideacodeandresources/**/*'],
   dependencies = [
     'testprojects/src/resources/org/pantsbuild/testproject:ideacodeandresources_directory',
     'testprojects/tests/resources/org/pantsbuild/testproject:ideacodeandresources_directory',
@@ -106,7 +106,7 @@ files(
 
 files(
   name='idearesourcesonly_directory',
-  sources=rglobs('idearesourcesonly/*'),
+  sources=['idearesourcesonly/**/*'],
   dependencies = [
     'testprojects/tests/resources/org/pantsbuild/testproject:idearesourcesonly_directory',
   ],
@@ -114,12 +114,12 @@ files(
 
 files(
   name='ideatestsandlib_directory',
-  sources=rglobs('ideatestsandlib/*'),
+  sources=['ideatestsandlib/**/*'],
 )
 
 files(
   name='ivyclassifier_directory',
-  sources=rglobs('ivyclassifier/*'),
+  sources=['ivyclassifier/**/*'],
   dependencies = [
     'testprojects/tests/resources/org/pantsbuild/testproject:ivyclassifier_directory',
   ]
@@ -127,47 +127,47 @@ files(
 
 files(
   name='matcher_directory',
-  sources=rglobs('matcher/*'),
+  sources=['matcher/**/*'],
 )
 
 files(
   name='parallel_directory',
-  sources=rglobs('parallel/*'),
+  sources=['parallel/**/*'],
 )
 
 files(
   name='parallelclassesandmethods_directory',
-  sources=rglobs('parallelclassesandmethods/*'),
+  sources=['parallelclassesandmethods/**/*'],
 )
 
 files(
   name='parallelmethods_directory',
-  sources=rglobs('parallelmethods/*'),
+  sources=['parallelmethods/**/*'],
 )
 
 files(
   name='strictdeps_directory',
-  sources=rglobs('strictdeps/*'),
+  sources=['strictdeps/**/*'],
 )
 
 files(
   name='syntheticjar_directory',
-  sources=rglobs('syntheticjar/*'),
+  sources=['syntheticjar/**/*'],
 )
 
 files(
   name='testjvms_directory',
-  sources=rglobs('testjvms/*'),
+  sources=['testjvms/**/*'],
 )
 
 files(
   name='timeout_directory',
-  sources=rglobs('timeout/*'),
+  sources=['timeout/**/*'],
 )
 
 files(
   name='unicode_directory',
-  sources=rglobs('unicode/*'),
+  sources=['unicode/**/*'],
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
@@ -175,6 +175,6 @@ files(
 
 files(
   name='workdirs_directory',
-  sources=rglobs('workdirs/*'),
+  sources=['workdirs/**/*'],
 )
 

--- a/testprojects/tests/java/org/pantsbuild/testproject/annotation/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/annotation/BUILD
@@ -3,7 +3,7 @@
 
 
 junit_tests(
-  sources=globs('*'),
+  sources=['*'],
   dependencies=[
     '3rdparty:junit',
     # causes the `@Deprecated` annotation to result in a resource file during compilation

--- a/testprojects/tests/java/org/pantsbuild/testproject/fail256/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/fail256/BUILD
@@ -3,7 +3,7 @@
 
 
 junit_tests(name='fail256',
-  sources=globs('*'),
+  sources=['*'],
   dependencies=[
     '3rdparty:junit'
   ],

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  sources=globs('ParallelTest*.java'),
+  sources=['ParallelTest*.java'],
   dependencies=[
     '3rdparty:junit',
   ],
@@ -13,8 +13,9 @@ junit_tests(
 # This target runs the same tests as the one above, but doesn't have the concurrency settings.
 # Relies on the test.junit options being set as follows:
 #   --test-junit-default-parallel --test-junit-parallel-threads=2
-junit_tests(name='cmdline',
-  sources=globs('ParallelTest*.java'),
+junit_tests(
+  name='cmdline',
+  sources=['ParallelTest*.java'],
   dependencies=[
     '3rdparty:junit',
   ],
@@ -22,8 +23,9 @@ junit_tests(name='cmdline',
 
 # These tests are annotated with @TestParallel so should be able to run
 # in parallel even when --test-junit-default-concurrency=SERIAL is set.
-junit_tests(name='annotated-parallel',
-  sources=globs('AnnotatedParallelTest*.java'),
+junit_tests(
+  name='annotated-parallel',
+  sources=['AnnotatedParallelTest*.java'],
   dependencies=[
     '3rdparty:junit',
     ':junit-runner-annotations'
@@ -35,8 +37,9 @@ junit_tests(name='annotated-parallel',
 # with @TestSerial, so they should run serially, even when even when
 # --test-junit-default-concurrency={PARALLEL_CLASSES, PARALLEL_METHODS, PARALLEL_CLASSES_AND_METHODS} is set
 # See: https://github.com/pantsbuild/pants/issues/3209
-junit_tests(name='annotated-serial',
-  sources=globs('AnnotatedSerialTest*.java'),
+junit_tests(
+  name='annotated-serial',
+  sources=['AnnotatedSerialTest*.java'],
   dependencies=[
     '3rdparty:junit',
     ':junit-runner-annotations'

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallelclassesandmethods/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallelclassesandmethods/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  sources=globs('*.java'),
+  sources=['*.java'],
   dependencies=[
     '3rdparty:junit',
   ],
@@ -13,8 +13,9 @@ junit_tests(
 # This target runs the same tests as the one above, but doesn't have the concurrency settings.
 # Relies on the test.junit options being set as follows:
 #   --test-junit-default-concurrency=PARALLEL_CLASSES_AND_METHODS --test-junit-parallel-threads=4
-junit_tests(name='cmdline',
-  sources=globs('*.java'),
+junit_tests(
+  name='cmdline',
+  sources=['*.java'],
   dependencies=[
     '3rdparty:junit',
   ],

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallelmethods/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallelmethods/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  sources=globs('*.java'),
+  sources=['*.java'],
   dependencies=[
     '3rdparty:junit',
   ],
@@ -13,8 +13,9 @@ junit_tests(
 # This target runs the same tests as the one above, but doesn't have the concurrency settings.
 # Relies on the test.junit options being set as follows:
 #   --test-junit-default-concurrency=PARALLEL_METHODS --test-junit-parallel-threads=4
-junit_tests(name='cmdline',
-  sources=globs('*.java'),
+junit_tests(
+  name='cmdline',
+  sources=['*.java'],
   dependencies=[
     '3rdparty:junit',
   ],

--- a/testprojects/tests/python/BUILD
+++ b/testprojects/tests/python/BUILD
@@ -11,7 +11,7 @@ target(
 
 files(
   name = 'example_test_directory',
-  sources = rglobs('example_test/*'),
+  sources = ['example_test/**/*'],
   dependencies = [
     'testprojects/src/python:python_distribution_directory',
   ],

--- a/testprojects/tests/python/pants/BUILD
+++ b/testprojects/tests/python/pants/BUILD
@@ -24,17 +24,17 @@ python_tests(
 
 files(
   name = 'build_parsing_directory',
-  sources = rglobs('build_parsing/*'),
+  sources = ['build_parsing/**/*'],
 )
 
 files(
   name = 'conf_test_directory',
-  sources = rglobs('conf_test/*'),
+  sources = ['conf_test/**/*'],
 )
 
 files(
   name = 'constants_only_directory',
-  sources = rglobs('constants_only/*'),
+  sources = ['constants_only/**/*'],
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild:constants_only_directory',
   ],
@@ -42,15 +42,15 @@ files(
 
 files(
   name = 'dummies_directory',
-  sources = rglobs('dummies/*'),
+  sources = ['dummies/**/*'],
 )
 
 files(
   name = 'file_sets_directory',
-  sources = rglobs('file_sets/*'),
+  sources = ['file_sets/**/*'],
 )
 
 files(
   name = 'timeout_directory',
-  sources = rglobs('timeout/*'),
+  sources = ['timeout/**/*'],
 )

--- a/testprojects/tests/python/pants/conf_test/BUILD
+++ b/testprojects/tests/python/pants/conf_test/BUILD
@@ -1,4 +1,4 @@
 python_tests(
   name='conf_test',
-  sources=globs('*.py')
+  sources=['*.py'],
 )

--- a/testprojects/tests/resources/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/BUILD
@@ -3,25 +3,25 @@
 
 files(
   name='bundleresources_directory',
-  sources=rglobs('bundleresources/*'),
+  sources=['bundleresources/**/*'],
 )
 
 files(
   name='cucumber_directory',
-  sources=rglobs('cucumber/*'),
+  sources=['cucumber/**/*'],
 )
 
 files(
   name='ideacodeandresources_directory',
-  sources=rglobs('ideacodeandresources/*'),
+  sources=['ideacodeandresources/**/*'],
 )
 
 files(
   name='idearesourcesonly_directory',
-  sources=rglobs('idearesourcesonly/*'),
+  sources=['idearesourcesonly/**/*'],
 )
 
 files(
   name='ivyclassifier_directory',
-  sources=rglobs('ivyclassifier/*'),
+  sources=['ivyclassifier/**/*'],
 )

--- a/testprojects/tests/scala/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/scala/org/pantsbuild/testproject/BUILD
@@ -13,15 +13,15 @@ target(
 
 files(
   name='cp-directories_directory',
-  sources=rglobs('cp-directories/*'),
+  sources=['cp-directories/**/*'],
 )
 
 files(
   name='exports_directory',
-  sources=rglobs('exports/*'),
+  sources=['exports/**/*'],
 )
 
 files(
   name='non_exports_directory',
-  sources=rglobs('non_exports/*'),
+  sources=['non_exports/**/*'],
 )

--- a/testprojects/tests/scala/org/pantsbuild/testproject/cp-directories/BUILD
+++ b/testprojects/tests/scala/org/pantsbuild/testproject/cp-directories/BUILD
@@ -6,5 +6,5 @@ junit_tests(
     '3rdparty:junit',
     '3rdparty:scalatest',
   ],
-  sources=globs('*.scala'),
+  sources=['*.scala'],
 )


### PR DESCRIPTION
Originally, we didn't update `testprojects/` to stop using `globs` et al. because some of the testprojects intentionally use `globs`. 

But, turns out, there are about 200 deprecated usages of `globs` (mostly from the chroot test migration) which may be safely updated.

This also makes the `fix_deprecated_globs_usage.py` script more robust. It was failing when a BUILD file had functions declared in it and with the argument `excludes=set(['foo.py'])`.