### PR TITLE
Change invalid file args to error instead of warn

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -724,11 +724,10 @@ async def sources_snapshots_from_filesystem_specs(
   snapshot = await Get[Snapshot](
     PathGlobs(
       globs=(fs_spec.glob for fs_spec in filesystem_specs),
-      # We unconditionally warn when globs do not match, rather than ignoring or erroring. We
-      # should not error because we can still do meaningful work with the globs that do match, and
-      # the warning will be very obvious to the user. Warning is less hostile than erroring.
-      glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-      # We validate that _every_ glob is valid.
+      # We error on unmatched globs for consistency with unmatched address specs. This also
+      # ensures that scripts don't silently do the wrong thing.
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      # We check that _every_ glob is valid.
       conjunction=GlobExpansionConjunction.all_match,
       description_of_origin="file arguments",
     )


### PR DESCRIPTION
As pointed to in https://github.com/pantsbuild/pants/pull/9022#discussion_r372876809, we should error for consistency with address specs and to ensure that scripts don't silently misbehave.

We also stick with the prior decision to not add an option to configure the behavior of unmatched filesystem specs, just as we don't have this option for unmatched address specs.

We don't need a deprecation cycle here because file args currently only work with `validate` and `cloc2`, which are both V2 goals and ~experimental.