### PR TITLE
Remove origin check from release.sh script

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -339,35 +339,6 @@ function dry_run_install() {
     -f "${DEPLOY_3RDPARTY_WHEEL_DIR}/${VERSION}" -f "${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
 }
 
-ALLOWED_ORIGIN_URLS=(
-  git@github.com:pantsbuild/pants.git
-  git@github.com:pantsbuild/pants
-  https://github.com/pantsbuild/pants.git
-  https://github.com/pantsbuild/pants
-)
-
-function check_origin() {
-  banner "Checking for a valid git origin"
-
-  origin_url="$(git remote -v | grep origin | grep "\(push\)" | cut -f2 | cut -d' ' -f1)"
-  for url in "${ALLOWED_ORIGIN_URLS[@]}"
-  do
-    if [[ "${origin_url}" == "${url}" ]]
-    then
-      return
-    fi
-  done
-  msg=$(cat << EOM
-Your origin url is not valid for releasing:
-  ${origin_url}
-
-It must be one of:
-$(echo "${ALLOWED_ORIGIN_URLS[@]}" | tr ' ' '\n' | sed -E "s|^|  |")
-EOM
-)
-  die "$msg"
-}
-
 function get_branch() {
   git branch | grep -E '^\* ' | cut -d' ' -f2-
 }
@@ -771,7 +742,7 @@ elif [[ "${test_release}" == "true" ]]; then
 else
   banner "Releasing packages to PyPI"
   (
-    check_origin && check_clean_branch && check_pgp && check_owners && \
+    check_clean_branch && check_pgp && check_owners && \
       publish_packages && tag_release && publish_docs_if_master && \
       banner "Successfully released packages to PyPI"
   ) || die "Failed to release packages to PyPI."

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -69,10 +69,6 @@ script fail:
         password: <fill me in>
         EOF
 
-  - Note that the release script expects your pantsbuild/pants git remote to be named `origin`.
-    If you have another name for it, you should `git remote rename othername origin` before running
-    the release script, and rename it back afterwards.
-
 1. Prepare Release
 ------------------
 


### PR DESCRIPTION
### Problem

The release.sh script runs a check to see if the "origin" remote is one of several variants of the URL for the official Github pants repo. However, nothing else in the script makes any reference to a remote locally-called "origin" - the function that actually creates the tag (rightly) refers to the offiical Github repo with a fully-qualified URL. This means that the release.sh script breaks for anyone who names their reference to the official repo with something other than "origin" (I use "upstream" for this, for instance). 

### Solution

Simply remove this check. 
