### PR TITLE
Handle Ctrl-C in the V2 UI

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -271,6 +271,9 @@ class Scheduler:
 
   def _run_and_return_roots(self, session, execution_request):
     raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
+    if raw_roots == self._native.ffi.NULL:
+      raise KeyboardInterrupt
+
     remaining_runtime_exceptions_to_capture = list(self._native.consume_cffi_extern_method_runtime_exceptions())
     try:
       roots = []

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -64,7 +64,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3277,7 +3277,7 @@ name = "ui"
 version = "0.0.1"
 dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3879,7 +3879,7 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd"
+"checksum termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -502,6 +502,9 @@ pub extern "C" fn scheduler_execute(
       with_session(session_ptr, |session| {
         match scheduler.execute(execution_request, session) {
           Ok(raw_results) => Box::into_raw(RawNodes::create(raw_results)),
+          //TODO: Passing a raw null pointer to Python is a less-than-ideal way
+          //of noting an error condition. When we have a better way to send complicated
+          //error-signaling values over the FFI boundary, we should revisit this.
           Err(ExecutionTermination::KeyboardInterrupt) => std::ptr::null(),
         }
       })

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -44,6 +44,8 @@ mod types;
 pub use crate::context::Core;
 pub use crate::core::{Function, Key, Params, TypeId, Value};
 pub use crate::handles::Handle;
-pub use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
+pub use crate::scheduler::{
+  ExecutionRequest, ExecutionTermination, RootResult, Scheduler, Session,
+};
 pub use crate::tasks::{Rule, Tasks};
 pub use crate::types::Types;

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -18,8 +18,12 @@ use indexmap::IndexMap;
 use log::{debug, info, warn};
 use logging::logger::LOGGER;
 use parking_lot::Mutex;
-use ui::EngineDisplay;
+use ui::{EngineDisplay, KeyboardCommand};
 use workunit_store::WorkUnitStore;
+
+pub enum ExecutionTermination {
+  KeyboardInterrupt,
+}
 
 ///
 /// A Session represents a related series of requests (generally: one run of the pants CLI) on an
@@ -332,7 +336,11 @@ impl Scheduler {
   ///
   /// Compute the results for roots in the given request.
   ///
-  pub fn execute(&self, request: &ExecutionRequest, session: &Session) -> Vec<RootResult> {
+  pub fn execute(
+    &self,
+    request: &ExecutionRequest,
+    session: &Session,
+  ) -> Result<Vec<RootResult>, ExecutionTermination> {
     // Bootstrap tasks for the roots, and then wait for all of them.
     debug!("Launching {} roots.", request.roots.len());
 
@@ -359,7 +367,7 @@ impl Scheduler {
     let mut tasks_to_display = IndexMap::new();
     let refresh_interval = Duration::from_millis(100);
 
-    match session.maybe_display() {
+    Ok(match session.maybe_display() {
       Some(display) => {
         {
           let mut display = display.lock();
@@ -371,12 +379,24 @@ impl Scheduler {
           if let Ok(res) = receiver.recv_timeout(refresh_interval) {
             break res;
           } else {
-            Scheduler::display_ongoing_tasks(
+            let render_result = Scheduler::display_ongoing_tasks(
               &self.core.graph,
               &roots,
               display,
               &mut tasks_to_display,
             );
+            match render_result {
+              Err(e) => warn!("{}", e),
+              Ok(KeyboardCommand::CtrlC) => {
+                info!("Exiting early in response to Ctrl-C");
+                {
+                  let mut display = display.lock();
+                  display.finish();
+                }
+                return Err(ExecutionTermination::KeyboardInterrupt);
+              }
+              Ok(KeyboardCommand::None) => (),
+            };
           }
         };
         LOGGER.deregister_engine_display(unique_handle);
@@ -391,7 +411,7 @@ impl Scheduler {
           break res;
         }
       },
-    }
+    })
   }
 
   fn display_ongoing_tasks(
@@ -399,7 +419,7 @@ impl Scheduler {
     roots: &[NodeKey],
     display: &Mutex<EngineDisplay>,
     tasks_to_display: &mut IndexMap<String, Duration>,
-  ) {
+  ) -> Result<KeyboardCommand, String> {
     // Update the graph. To do that, we iterate over heavy hitters.
 
     let worker_count = {
@@ -439,7 +459,7 @@ impl Scheduler {
     for i in tasks_to_display.len()..worker_count {
       d.update(i.to_string(), "".to_string());
     }
-    d.render();
+    d.render()
   }
 }
 

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/main.rs"
 
 [dependencies]
 rand = "0.5.1"
-termion = "1.5.4"
+termion = "1.5.5"
 unicode-segmentation = "1.6.0"

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -299,6 +299,13 @@ impl EngineDisplay {
       Ok(_) => {
         let initial_byte: u8 = buf[0];
         let mut iter = buf[1..].iter().map(|byte| Ok(*byte));
+        // TODO: calling `parse_event` in this way means that we will potentially miss keyboard
+        // events - a Ctrl-C event has to be the very first event in each `render` frame, or it
+        // won't be handled. In practice, the refresh interval is 100 ms, which is fast enough
+        // on human timescales that hitting Ctrl-C while the program is running will wind up
+        // at the beginning of some frame.  Note that internally termion uses this function
+        // in the context of the `next()` function of an Iterator:
+        // https://github.com/redox-os/termion/blob/master/src/input.rs .
         let event_or_err = parse_event(initial_byte, &mut iter);
         match event_or_err {
           Ok(Event::Key(Key::Ctrl('c'))) => Ok(KeyboardCommand::CtrlC),

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -28,12 +28,14 @@
 use termion;
 
 use std::collections::{BTreeMap, VecDeque};
+use std::io::Read;
 use std::io::Write;
 use std::io::{stdout, Result, Stdout};
 
 use termion::raw::IntoRawMode;
 use termion::raw::RawTerminal;
 use termion::screen::AlternateScreen;
+use termion::{async_stdin, AsyncReader};
 use termion::{clear, color, cursor};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -55,6 +57,11 @@ enum PrintableMsgOutput {
   Stderr,
 }
 
+pub enum KeyboardCommand {
+  None,
+  CtrlC,
+}
+
 pub struct EngineDisplay {
   sigil: char,
   divider: String,
@@ -65,6 +72,7 @@ pub struct EngineDisplay {
   printable_msgs: VecDeque<PrintableMsg>,
   cursor_start: (u16, u16),
   terminal_size: (u16, u16),
+  async_stdin: AsyncReader,
 }
 
 // TODO: Prescribe a threading/polling strategy for callers - or implement a built-in one.
@@ -95,6 +103,7 @@ impl EngineDisplay {
       // as we've done here is the safest way to avoid terminal oddness.
       cursor_start: (1, 1),
       terminal_size: EngineDisplay::get_size(),
+      async_stdin: async_stdin(),
     }
   }
 
@@ -266,13 +275,39 @@ impl EngineDisplay {
   }
 
   // Paints one screen of rendering.
-  pub fn render(&mut self) {
+  pub fn render(&mut self) -> std::result::Result<KeyboardCommand, String> {
     self.set_size();
     self.clear();
     let max_log_rows = self.get_max_log_rows();
     let rendered_count = self.render_logs(max_log_rows);
     self.render_actions(rendered_count);
-    self.flush().expect("could not flush terminal!");
+    if let Err(err) = self.flush() {
+      return Err(format!("Could not flush terminal: {}", err));
+    }
+    self.handle_stdin()
+  }
+
+  fn handle_stdin(&mut self) -> std::result::Result<KeyboardCommand, String> {
+    use termion::event::{parse_event, Event, Key};
+    //This buffer must have non-zero size because termion's `read` implementation for
+    //AsyncReader will return early without doing anything if it is of length 0.
+    //(See https://docs.rs/termion/1.5.4/src/termion/async.rs.html#69 )
+    let mut buf: [u8; 32] = [0; 32];
+
+    match self.async_stdin.read(&mut buf) {
+      Ok(0) => Ok(KeyboardCommand::None),
+      Ok(_) => {
+        let initial_byte: u8 = buf[0];
+        let mut iter = buf[1..].iter().map(|byte| Ok(*byte));
+        let event_or_err = parse_event(initial_byte, &mut iter);
+        match event_or_err {
+          Ok(Event::Key(Key::Ctrl('c'))) => Ok(KeyboardCommand::CtrlC),
+          Err(err) => Err(format!("EngineDisplay keyboard event error: {}", err)),
+          _ => Ok(KeyboardCommand::None),
+        }
+      }
+      Err(err) => Err(format!("EngineDisplay stdin error: {}", err)),
+    }
   }
 
   // Starts the EngineDisplay at the current cursor position.
@@ -338,7 +373,9 @@ impl EngineDisplay {
   // Initiates one last screen render, then terminates the EngineDisplay and returns the cursor
   // to a static position, then prints all buffered stdout/stderr output.
   pub fn finish(&mut self) {
-    self.render();
+    //We don't care about handling the output from render() here, since we're about to shut down
+    //the EngineDisplay anyway.
+    let _ = self.render();
     {
       self.terminal = Console::Uninitialized; //This forces the AlternateScreen to drop, restoring the original terminal state.
     }

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -76,15 +76,15 @@ fn main() {
 
   for worker_id in worker_ids.clone() {
     display.add_worker(worker_id);
-    display.render();
+    let _ = display.render();
     thread::sleep(Duration::from_millis(63));
   }
 
-  display.render();
+  let _ = display.render();
   thread::sleep(Duration::from_secs(1));
 
   while !done {
-    display.render();
+    let _ = display.render();
     thread::sleep(Duration::from_millis(55));
 
     gen_display_work(


### PR DESCRIPTION
### Problem

The v2 console UI sets the terminal to raw mode, causing it to no longer detect Ctrl-C as a sign that the user is trying to interrupt the process.

### Solution

This commit re-architects the `render()` method on `EngineDisplay` to poll for keyboard events every time it runs, and return a sigil value if it detects the key combination Ctrl-C. The scheduler's `execute` method passes up this potential error value to the `scheduler_execute` FFI function, which in turn signals that a Ctrl-C has been pressed by returning a null pointer to Python. In Python, the code checks for a null pointer and raises a Python KeyboardInterrupt if one is found.

### Result

Hitting Ctrl-C should now have the same effect as it did in V1, i.e. raising a Python KeyboardInterrupt and quitting the program after cleanup.