### PR TITLE
Decouple `--owner-of` implementation from` --changed-*`

### DIFF
--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -42,8 +42,10 @@ class LegacyAddressMapper(AddressMapper):
     # NB: this will cause any BUILD file, whether it contains the address declaration or not to be
     # considered the one that declared it. That's ok though, because the spec path should be enough
     # information for debugging most of the time.
-    return any(address.spec_path == os.path.dirname(fp)
-               for fp in file_paths if BuildFile._is_buildfile_name(os.path.basename(fp)))
+    return any(
+      address.spec_path == os.path.dirname(fp)
+      for fp in file_paths if BuildFile._is_buildfile_name(os.path.basename(fp))
+    )
 
   @staticmethod
   def is_declaring_file(address, file_path):

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -436,7 +436,7 @@ class InvalidOwnersOfArgs(Exception):
 class OwnersRequest:
   """A request for the owners (and optionally, transitive dependees) of a set of file paths."""
   sources: Tuple[str, ...]
-  include_dependees: IncludeDependeesOption
+  include_dependees: IncludeDependeesOption = IncludeDependeesOption.NONE
 
   def validate(self, *, pants_bin_name: str) -> None:
     """Ensure that users are passing valid args."""

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -63,6 +63,7 @@ from pants.option.global_options import (
 )
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.scm.subsystems.changed import rules as changed_rules
 
 
 logger = logging.getLogger(__name__)
@@ -418,7 +419,7 @@ class EngineInitializer:
     # Create a Scheduler containing graph and filesystem rules, with no installed goals. The
     # LegacyBuildGraph will explicitly request the products it needs.
     rules = (
-      [
+      *(
         RootRule(Console),
         glob_match_error_behavior_singleton,
         build_configuration_singleton,
@@ -426,16 +427,17 @@ class EngineInitializer:
         union_membership_singleton,
         build_root_singleton,
         single_build_file_address,
-      ] +
-      create_legacy_graph_tasks() +
-      create_fs_rules() +
-      create_interactive_runner_rules() +
-      create_process_rules() +
-      create_platform_rules() +
-      create_graph_rules(address_mapper) +
-      create_options_parsing_rules() +
-      structs_rules() +
-      rules
+      ),
+      *create_legacy_graph_tasks(),
+      *create_fs_rules(),
+      *create_interactive_runner_rules(),
+      *create_process_rules(),
+      *create_platform_rules(),
+      *create_graph_rules(address_mapper),
+      *create_options_parsing_rules(),
+      *structs_rules(),
+      *changed_rules(),
+      *rules,
     )
 
     goal_map = EngineInitializer._make_goal_map_from_rules(rules)

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -13,7 +13,7 @@ from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
 from pants.engine.scheduler import SchedulerSession
 from pants.option.options import Options
-from pants.scm.subsystems.changed import ChangedRequest
+from pants.scm.subsystems.changed import ChangedAddresses, ChangedOptions, ChangedRequest
 
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,6 @@ class SpecsCalculator:
     exclude_patterns: Optional[Iterable[str]] = None,
     tags: Optional[Iterable[str]] = None,
   ) -> Specs:
-    # Determine the literal specs.
     specs = cls.parse_specs(
       raw_specs=options.specs,
       build_root=build_root,
@@ -74,20 +73,15 @@ class SpecsCalculator:
       tags=tags,
     )
 
-    # Determine `Changed` arguments directly from options to support pre-`Subsystem`
-    # initialization paths.
-    changed_options = options.for_scope('changed')
-    changed_request = ChangedRequest.from_options(changed_options)
-
-    # Determine the `--owner-of=` arguments provided from the global options
+    changed_options = ChangedOptions.from_options(options.for_scope('changed'))
     owned_files = options.for_global_scope().owner_of
 
     logger.debug('specs are: %s', specs)
-    logger.debug('changed_request is: %s', changed_request)
+    logger.debug('changed_options are: %s', changed_options)
     logger.debug('owned_files are: %s', owned_files)
     targets_specified = sum(
       1 for item
-      in (changed_request.is_actionable(), owned_files, specs.provided_specs.dependencies)
+      in (changed_options.is_actionable(), owned_files, specs.provided_specs.dependencies)
       if item
     )
 
@@ -98,19 +92,21 @@ class SpecsCalculator:
         '`--changed-*`, `--owner-of`, address specs, or filesystem specs.'
       )
 
-    if changed_request.is_actionable():
+    if changed_options.is_actionable():
       scm = get_scm()
       if not scm:
         raise InvalidSpecConstraint(
           'The `--changed-*` options are not available without a recognized SCM (usually git).'
         )
-      request = OwnersRequest(
-        sources=tuple(changed_request.changed_files(scm=scm)),
-        include_dependees=changed_request.include_dependees,
+      changed_request = ChangedRequest(
+        sources=tuple(changed_options.changed_files(scm=scm)),
+        include_dependees=changed_options.include_dependees,
       )
-      changed_addresses, = session.product_request(BuildFileAddresses, [request])
-      logger.debug('changed addresses: %s', changed_addresses)
-      dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses)
+      changed_addresses, = session.product_request(ChangedAddresses, [changed_request])
+      logger.debug('changed addresses: %s', changed_addresses.addresses)
+      dependencies = tuple(
+        SingleAddress(a.spec_path, a.target_name) for a in changed_addresses.addresses
+      )
       return Specs(
         address_specs=AddressSpecs(
           dependencies=dependencies, exclude_patterns=exclude_patterns, tags=tags,
@@ -119,9 +115,9 @@ class SpecsCalculator:
       )
 
     if owned_files:
-      request = OwnersRequest(sources=tuple(owned_files))
-      request.validate(pants_bin_name=options.for_global_scope().pants_bin_name)
-      owner_addresses, = session.product_request(BuildFileAddresses, [request])
+      owner_request = OwnersRequest(sources=tuple(owned_files))
+      owner_request.validate(pants_bin_name=options.for_global_scope().pants_bin_name)
+      owner_addresses, = session.product_request(BuildFileAddresses, [owner_request])
       logger.debug('owner addresses: %s', owner_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)
       return Specs(

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -117,6 +117,7 @@ class Git(Scm):
     self._remote = remote
     self._branch = branch
 
+  @property
   def current_rev_identifier(self):
     return 'HEAD'
 

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -3,8 +3,10 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import List, Optional, cast
 
+from pants.goal.workspace import ScmWorkspace
+from pants.scm.scm import Scm
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -17,39 +19,44 @@ class IncludeDependeesOption(Enum):
 @dataclass(frozen=True)
 class ChangedRequest:
   """Parameters required to compute a changed file/target set."""
-  changes_since: Any
-  diffspec: Any
+  changes_since: Optional[str]
+  diffspec: Optional[str]
   include_dependees: IncludeDependeesOption
-  fast: Any
+  fast: bool
 
   @classmethod
   def from_options(cls, options) -> "ChangedRequest":
     """Given an `Options` object, produce a `ChangedRequest`."""
-    return cls(options.changes_since,
-               options.diffspec,
-               options.include_dependees,
-               options.fast)
+    return cls(options.changes_since, options.diffspec, options.include_dependees, options.fast)
 
-  def is_actionable(self):
+  def is_actionable(self) -> bool:
     return bool(self.changes_since or self.diffspec)
+
+  def changed_files(self, *, scm: Scm) -> List[str]:
+    """Determines the files changed according to SCM/workspace and options."""
+    workspace = ScmWorkspace(scm)
+    if self.diffspec:
+      return cast(List[str], workspace.changes_in(self.diffspec))
+
+    changes_since = self.changes_since or scm.current_rev_identifier
+    return cast(List[str], workspace.touched_files(changes_since))
 
 
 class Changed(Subsystem):
   """A subsystem for global `changed` functionality.
 
-  This supports the "legacy" `changed`, `test-changed` and `compile-changed` goals as well as the
-  v2 engine style `--changed-*` argument target root replacements which can apply to any goal (e.g.
-  `./pants --changed-parent=HEAD~3 list` replaces `./pants --changed-parent=HEAD~3 changed`).
+  This supports the `--changed-*` argument target root replacements, e.g.
+  `./pants --changed-parent=HEAD~3 list`.
   """
   options_scope = 'changed'
 
   @classmethod
   def register_options(cls, register):
-    register('--changes-since', '--parent', '--since',
+    register('--changes-since', '--parent', '--since', type=str, default=None,
              help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
-    register('--diffspec',
+    register('--diffspec', type=str, default=None,
              help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
     register('--include-dependees', type=IncludeDependeesOption, default=IncludeDependeesOption.NONE,
              help='Include direct or transitive dependees of changed targets.')
-    register('--fast', type=bool,
+    register('--fast', type=bool, default=False,
              help='Stop searching for owners once a source is mapped to at least one owning target.')

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -8,7 +8,6 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
-from pants.scm.subsystems.changed import IncludeDependeesOption
 from pants.testutil.test_base import TestBase
 
 
@@ -22,7 +21,7 @@ class SourceMapperTest(TestBase):
     )
 
   def owner(self, owner, f):
-    request = OwnersRequest(sources=(f,), include_dependees=IncludeDependeesOption.NONE)
+    request = OwnersRequest(sources=(f,))
     addresses = self.request_single_product(BuildFileAddresses, request)
     self.assertEqual(set(owner), {i.spec for i in addresses})
 

--- a/tests/python/pants_test/engine/legacy/test_owners_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_owners_integration.py
@@ -33,7 +33,7 @@ class ListOwnersIntegrationTest(PantsRunIntegrationTest):
   def test_owner_list_two_target_specs(self):
     # Test that any of these combinations fail with the same error message.
     expected_error = ('Multiple target selection methods provided. Please use only one of '
-                      '--changed-*, --owner-of, address specs, or filesystem specs.')
+                      '`--changed-*`, `--owner-of`, address specs, or filesystem specs.')
     pants_run_1 = self.do_command('--owner-of=testprojects/tests/python/pants/dummies/test_pass.py',
                                   '--changed-parent=master',
                                   'list',


### PR DESCRIPTION
### Problem

Soon, we will be deprecating `--owner-of` in favor of filesystem specs. To do this, we will likely end up using `OwnersRequest` or a derivative in the rule to go from `FilesystemSpecs -> BuildFileAddresses`.

However, currently, the rule `find_owners(OwnersRequest) -> BuildFileAddresses` is much more complex than necessary because it is able to calculate both `--owner-of` and `--changed-*`, where `--changed-*` is a more complex calculation. As a result, the rule `find_owners()` has direct dependencies on `AddressMapper` and `BuildConfiguration`, along with several `await Get`s never used by `--owner-of`.

We want `--owner-of` to be as simple as possible so that it may be more easily leveraged for filesystem specs. 

### Solution

Simplify `OwnersRequest` to no longer have a field `include_dependees` and to only ever find direct owners. Add a new `changed.find_owners()` rule which will use the `OwnersOf` rule to compute the direct owners, then add its own logic to calculate dependencies and combine the results.

This builds heavily off of https://github.com/pantsbuild/pants/pull/8917 but is not as ambitious due to concerns with caching of `SCM`: https://github.com/pantsbuild/pants/pull/8917/files#r364023925

### Result

`--owner-of` and `--changed-*` behave identically to before, but have less tight of coupling. `--changed-*` still depends on `--owner-of`, but `--owner-of` now no longer has any dependency on `--change-*`.

This should make filesystem specs support easier to add.