### PR TITLE
Allow using file args with every goal

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -147,6 +147,7 @@ python_library(
   sources = ['specs.py'],
   dependencies = [
     '3rdparty/python:dataclasses',
+    'src/python/pants/engine:fs',
     'src/python/pants/engine:objects',
     'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -328,10 +328,9 @@ class FilesystemSpecs(Collection[FilesystemSpec]):
   def to_path_globs(self) -> PathGlobs:
     return PathGlobs(
       globs=(fs_spec.glob for fs_spec in self.dependencies),
-      # We unconditionally warn when globs do not match, rather than ignoring or erroring. We
-      # should not error because we can still do meaningful work with the globs that do match, and
-      # the warning will be very obvious to the user. Warning is less hostile than erroring.
-      glob_match_error_behavior=GlobMatchErrorBehavior.warn,
+      # We error on unmatched globs for consistency with unmatched address specs. This also
+      # ensures that scripts don't silently do the wrong thing.
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
       # We validate that _every_ glob is valid.
       conjunction=GlobExpansionConjunction.all_match,
       description_of_origin="file arguments",

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -18,7 +18,10 @@ from typing import (
   cast,
 )
 
+from pants.engine.fs import PathGlobs
 from pants.engine.objects import Collection
+from pants.option.custom_types import GlobExpansionConjunction
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.collections import assert_single_element
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
 from pants.util.filtering import create_filters, wrap_filters
@@ -321,7 +324,18 @@ class FilesystemSpec:
 
 
 class FilesystemSpecs(Collection[FilesystemSpec]):
-  pass
+
+  def to_path_globs(self) -> PathGlobs:
+    return PathGlobs(
+      globs=(fs_spec.glob for fs_spec in self.dependencies),
+      # We unconditionally warn when globs do not match, rather than ignoring or erroring. We
+      # should not error because we can still do meaningful work with the globs that do match, and
+      # the warning will be very obvious to the user. Warning is less hostile than erroring.
+      glob_match_error_behavior=GlobMatchErrorBehavior.warn,
+      # We validate that _every_ glob is valid.
+      conjunction=GlobExpansionConjunction.all_match,
+      description_of_origin="file arguments",
+    )
 
 
 class AmbiguousSpecs(Exception):

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -5,10 +5,11 @@ import logging
 import sys
 from typing import List
 
-from pants.base.specs import AddressSpecs, Specs
+from pants.base.specs import AddressSpecs, FilesystemSpecs, SingleAddress, Specs
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_parser import BuildFileParser
+from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import LegacyBuildGraph
 from pants.engine.round_engine import RoundEngine
 from pants.goal.context import Context
@@ -23,10 +24,6 @@ from pants.task.task import QuietTaskMixin
 
 
 logger = logging.getLogger(__name__)
-
-
-class FilesystemSpecsUnsupported(Exception):
-  """FS specs are not yet backported to V1 (but will be to replace `--owner-of`)."""
 
 
 class GoalRunnerFactory:
@@ -65,30 +62,21 @@ class GoalRunnerFactory:
     self._explain = self._global_options.explain
     self._kill_nailguns = self._global_options.kill_nailguns
 
+    # V1 tasks do not understand FilesystemSpecs, so we eagerly convert them into AddressSpecs.
     if self._specs.filesystem_specs.dependencies:
-      pants_bin_name = self._global_options.pants_bin_name
-      v1_goals = ' '.join(repr(goal) for goal in self._determine_v1_goals(options))
-      provided_specs = ' '.join(spec.glob for spec in self._specs.filesystem_specs)
-      approximate_original_command = f"{pants_bin_name} {v1_goals} {provided_specs}"
-      suggested_owners_args = " ".join(
-        f"--owner-of={spec.glob}" for spec in self._specs.filesystem_specs
+      owned_addresses, = self._graph_session.scheduler_session.product_request(
+        BuildFileAddresses, [self._specs.filesystem_specs]
       )
-      suggestion = f"run `{pants_bin_name} {suggested_owners_args} {v1_goals}`."
-      trying_to_use_globs = any("*" in spec.glob for spec in self._specs.filesystem_specs)
-      if trying_to_use_globs:
-        suggestion = (
-          f"run `{pants_bin_name} --owner-of=src/python/f1.py --owner-of=src/python/f2.py "
-          f"{v1_goals}`. (You must explicitly enumerate every file because " f"`--owner-of` does "
-          f"not support globs.)"
-        )
-      raise FilesystemSpecsUnsupported(
-        f"Instead of running `{approximate_original_command}`, {suggestion}\n\n"
-        f"Why? Filesystem specs like `src/python/example.py` and `src/**/*.java` (currently) only "
-        f"work when running goals implemented with the V2 engine. When using V1 goals, either use "
-        f"traditional address specs like `src/python/example:foo` and `::` or use `--owner-of` "
-        f"for Pants to find the file's owning target(s) for you.\n\n"
-        f"(You may find which goals are implemented in V1 by running `{pants_bin_name} --v1 --no-v2 "
-        f"goals` and find V2 goals by running `{pants_bin_name} --no-v1 --v2 goals`.)"
+      updated_address_specs = AddressSpecs(
+        dependencies=tuple(
+          SingleAddress(a.spec_path, a.target_name) for a in owned_addresses
+        ),
+        tags=self._specs.address_specs.matcher.tags,
+        exclude_patterns=self._specs.address_specs.matcher.exclude_patterns,
+      )
+      self._specs = Specs(
+        address_specs=updated_address_specs,
+        filesystem_specs=FilesystemSpecs([]),
       )
 
   def _determine_v1_goals(self, options: Options) -> List[Goal]:

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -39,7 +39,6 @@ from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper, Filespec
@@ -457,8 +456,13 @@ class OwnersRequest:
       )
 
 
+@dataclass(frozen=True)
+class Owners:
+  addresses: BuildFileAddresses
+
+
 @rule
-async def find_owners(owners_request: OwnersRequest) -> BuildFileAddresses:
+async def find_owners(owners_request: OwnersRequest) -> Owners:
   sources_set = OrderedSet(owners_request.sources)
   dirs_set = OrderedSet(os.path.dirname(source) for source in sources_set)
 
@@ -480,12 +484,13 @@ async def find_owners(owners_request: OwnersRequest) -> BuildFileAddresses:
     target_sources = target_kwargs.get('sources', None)
     return target_sources and any_matches_filespec(paths=sources_set, spec=target_sources.filespec)
 
-  return BuildFileAddresses(
+  owners = BuildFileAddresses(
     ht.adaptor.address
     for ht in candidate_targets
     if LegacyAddressMapper.any_is_declaring_file(ht.adaptor.address, sources_set)
     or owns_any_source(ht)
   )
+  return Owners(owners)
 
 
 @rule
@@ -675,12 +680,21 @@ async def hydrate_sources_snapshot(hydrated_struct: HydratedStruct) -> SourcesSn
 
 @rule
 async def sources_snapshots_from_build_file_addresses(
-  build_file_addresses: BuildFileAddresses,
+  address_specs: AddressSpecs,
 ) -> SourcesSnapshots:
   """Request SourcesSnapshots for the given BuildFileAddresses.
 
   Each address will map to a corresponding SourcesSnapshot. This rule avoids hydrating any other
   fields."""
+
+  # NB: this line must be an `await Get`, rather than directly requesting `BuildFileAddresses`
+  # directly in the rule signature. Why? The `owners_from_filesystem_specs()` rule provides a way
+  # to go from FilesystemSpecs -> BuildFileAddresses. Then, this rule provides a way to go from
+  # BuildFileAddresses -> SourcesSnapshots. But, we already have a way to go from
+  # FilesystemSpecs -> SourcesSnapshots directly, so there are now two ways to go from
+  # FilesystemSpecs -> SourcesSnapshot and the graph does not like the ambiguity. By having the
+  # rule request AddressSpecs instead, we remove the ambiguity.
+  build_file_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
   snapshots = await MultiGet(
     Get[SourcesSnapshot](Address, a) for a in build_file_addresses.addresses
   )
@@ -692,18 +706,15 @@ async def sources_snapshots_from_filesystem_specs(
   filesystem_specs: FilesystemSpecs,
 ) -> SourcesSnapshots:
   """Resolve the snapshot associated with the provided filesystem specs."""
-  snapshot = await Get[Snapshot](
-    PathGlobs(
-      globs=(fs_spec.glob for fs_spec in filesystem_specs),
-      # We error on unmatched globs for consistency with unmatched address specs. This also
-      # ensures that scripts don't silently do the wrong thing.
-      glob_match_error_behavior=GlobMatchErrorBehavior.error,
-      # We check that _every_ glob is valid.
-      conjunction=GlobExpansionConjunction.all_match,
-      description_of_origin="file arguments",
-    )
-  )
+  snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
   return SourcesSnapshots([SourcesSnapshot(snapshot)])
+
+
+@rule
+async def owners_from_filesystem_specs(filesystem_specs: FilesystemSpecs) -> BuildFileAddresses:
+  snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
+  owners = await Get[Owners](OwnersRequest(sources=snapshot.files))
+  return owners.addresses
 
 
 def create_legacy_graph_tasks():
@@ -716,6 +727,7 @@ def create_legacy_graph_tasks():
     find_owners,
     hydrate_sources,
     hydrate_bundles,
+    owners_from_filesystem_specs,
     sort_targets,
     hydrate_sources_snapshot,
     sources_snapshots_from_build_file_addresses,

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -117,9 +117,9 @@ class SpecsCalculator:
     if owned_files:
       owner_request = OwnersRequest(sources=tuple(owned_files))
       owner_request.validate(pants_bin_name=options.for_global_scope().pants_bin_name)
-      owner_addresses, = session.product_request(BuildFileAddresses, [owner_request])
-      logger.debug('owner addresses: %s', owner_addresses)
-      dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)
+      owners, = session.product_request(BuildFileAddresses, [owner_request])
+      logger.debug('owner addresses: %s', owners.addresses)
+      dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owners.addresses)
       return Specs(
         address_specs=AddressSpecs(
           dependencies=dependencies, exclude_patterns=exclude_patterns, tags=tags,

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -9,8 +9,7 @@ from twitter.common.collections import OrderedSet
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.specs import AddressSpec, AddressSpecs, FilesystemSpecs, SingleAddress, Specs
-from pants.engine.addressable import BuildFileAddresses
-from pants.engine.legacy.graph import OwnersRequest
+from pants.engine.legacy.graph import Owners, OwnersRequest
 from pants.engine.scheduler import SchedulerSession
 from pants.option.options import Options
 from pants.scm.subsystems.changed import ChangedAddresses, ChangedOptions, ChangedRequest
@@ -117,7 +116,7 @@ class SpecsCalculator:
     if owned_files:
       owner_request = OwnersRequest(sources=tuple(owned_files))
       owner_request.validate(pants_bin_name=options.for_global_scope().pants_bin_name)
-      owners, = session.product_request(BuildFileAddresses, [owner_request])
+      owners, = session.product_request(Owners, [owner_request])
       logger.debug('owner addresses: %s', owners.addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owners.addresses)
       return Specs(

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -10,6 +10,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import (
+  Owners,
   OwnersRequest,
   _DependentGraph,
   target_types_from_build_file_aliases,
@@ -52,11 +53,11 @@ async def find_owners(
   address_mapper: AddressMapper,
   changed_request: ChangedRequest,
 ) -> ChangedAddresses:
-  direct_owners = await Get[BuildFileAddresses](OwnersRequest(sources=changed_request.sources))
+  direct_owners = await Get[Owners](OwnersRequest(sources=changed_request.sources))
 
   # If the ChangedRequest does not require dependees, then we're done.
   if changed_request.include_dependees == IncludeDependeesOption.NONE:
-    return ChangedAddresses(direct_owners)
+    return ChangedAddresses(direct_owners.addresses)
 
   # Otherwise: find dependees.
   all_addresses = await Get[BuildFileAddresses](AddressSpecs((DescendantAddresses(''),)))
@@ -71,10 +72,10 @@ async def find_owners(
   )
   if changed_request.include_dependees == IncludeDependeesOption.DIRECT:
     return ChangedAddresses(
-      BuildFileAddresses(graph.dependents_of_addresses(direct_owners))
+      BuildFileAddresses(graph.dependents_of_addresses(direct_owners.addresses))
     )
   return ChangedAddresses(
-    BuildFileAddresses(graph.transitive_dependents_of_addresses(direct_owners))
+    BuildFileAddresses(graph.transitive_dependents_of_addresses(direct_owners.addresses))
   )
 
 

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -6,8 +6,7 @@ from textwrap import dedent
 # TODO: Create a dummy target type in this test and remove this dep.
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.addressable import BuildFileAddresses
-from pants.engine.legacy.graph import OwnersRequest
+from pants.engine.legacy.graph import OwnersRequest, Owners
 from pants.testutil.test_base import TestBase
 
 
@@ -22,8 +21,8 @@ class SourceMapperTest(TestBase):
 
   def owner(self, owner, f):
     request = OwnersRequest(sources=(f,))
-    addresses = self.request_single_product(BuildFileAddresses, request)
-    self.assertEqual(set(owner), {i.spec for i in addresses})
+    owners = self.request_single_product(Owners, request)
+    self.assertEqual(set(owner), {i.spec for i in owners.addresses})
 
   def test_target_address_for_source_yields_unique_addresses(self):
     # NB If the mapper returns more than one copy of an address, it may cause other code to do

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 # TODO: Create a dummy target type in this test and remove this dep.
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.legacy.graph import OwnersRequest, Owners
+from pants.engine.legacy.graph import Owners, OwnersRequest
 from pants.testutil.test_base import TestBase
 
 

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -61,8 +61,18 @@ python_tests(
 )
 
 python_tests(
+  name = 'filesystem_specs_integration',
+  sources = ['test_filesystem_specs_integration.py'],
+  dependencies = [
+    'src/python/pants/testutil:int-test',
+    'testprojects/tests/python:owners_integration_target',
+  ],
+  tags = {'integration', 'partially_type_checked'},
+)
+
+python_tests(
   name = 'owners_integration',
-  sources = [ 'test_owners_integration.py' ],
+  sources = ['test_owners_integration.py'],
   dependencies = [
     'src/python/pants/testutil:int-test',
     'testprojects/tests/python:owners_integration_target',

--- a/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+
+from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+from pants.util.dirutil import rm_rf, touch
+
+
+class FilesystemSpecsIntegrationTest(PantsRunIntegrationTest):
+
+  def test_valid_file(self) -> None:
+    pants_run = self.run_pants(["list", "testprojects/tests/python/pants/dummies/test_pass.py"])
+    self.assert_success(pants_run)
+    assert {
+      'testprojects/tests/python/pants:dummies_directory',
+      'testprojects/tests/python/pants/dummies:passing_target',
+      'testprojects/tests/python/pants:secondary_source_file_owner',
+    } == set(pants_run.stdout_data.splitlines())
+
+  def test_nonexistent_file(self) -> None:
+    pants_run = self.run_pants(["list", "src/fake.py"])
+    self.assert_failure(pants_run)
+    assert (
+      'Unmatched glob from file arguments: "src/fake.py"'
+      in pants_run.stderr_data
+    )
+
+  def test_no_owner(self) -> None:
+    no_owning_file = 'testprojects/tests/python/pants/nonexistent/test_nonexistent.py'
+    touch(no_owning_file)
+    try:
+      pants_run = self.run_pants(['list', no_owning_file])
+      assert 'WARNING: No targets were matched in' in pants_run.stderr_data
+    finally:
+      rm_rf(os.path.dirname(no_owning_file))


### PR DESCRIPTION
Now possible:

```bash
▶ ./pants list src/python/pants/util/strutil.py
src/python/pants:reversion_file_with_dependencies
src/python/pants/util:strutil

▶ ./v2 fmt2 src/python/pants/util/strutil.py
Fixing /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionCkme6x/src/python/pants/util/strutil.py

▶ ./pants filedeps --no-transitive src/python/pants/util/strutil.py
# NB `strutil.py` has two owners, so this shows more output than you'd probably expect. But, 
# this is the same thing we'd see with `--owner-of`.
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/tarutil.py
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/BUILD
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/releases/BUILD
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/BUILD
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/dirutil.py
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/releases/reversion.py
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/strutil.py
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/contextutil.py
```

The semantics are the same as `--owner-of`, but with some benefits:

- tab autocomplete works, unlike with `--owner-of`
- can list multiple files in a row
- can use globs, either expanded by the shell or the engine. This includes excludes support

## Followups
A followup will deprecate `--owner-of` and update documentation.

Later followups will enahnce file args to be more precise for certain goals like `test` and `fmt` so that they only run over the specified files, but, for now, we stick with `--owner-of` semantics.