### PR TITLE
[thrift linter] use non-zero exit on warning when strict and zero exit warning when not strict

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -45,7 +45,7 @@ class ThriftLinterTest(TaskTestBase):
     self._run_java_mock.assert_called_once_with(
       classpath='foo_classpath',
       main='com.twitter.scrooge.linter.Main',
-      args=['--fatal-warnings', '--ignore-errors', '--include-path', 'src/thrift/users',
+      args=['--warnings', '--include-path', 'src/thrift/users',
             '--include-path', 'src/thrift/tweet', 'src/thrift/tweet/A.thrift'],
       jvm_options=get_default_jvm_options(),
       workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])
@@ -69,7 +69,7 @@ class ThriftLinterTest(TaskTestBase):
     self._run_java_mock.assert_called_once_with(
       classpath='foo_classpath',
       main='com.twitter.scrooge.linter.Main',
-      args=['--fatal-warnings', '--ignore-errors',
+      args=['--warnings',
             '--include-path', 'src/thrift/tweet', 'src/thrift/tweet/B.thrift'],
       jvm_options=get_default_jvm_options(),
       workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -13,6 +13,7 @@ F = TypeVar("F", bound=FuncType)
 
 class ThriftLinterTest(PantsRunIntegrationTest):
 
+  lint_warn_token = "LINT-WARN"
   lint_error_token = "LINT-ERROR"
   thrift_folder_root = 'contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter'
 
@@ -66,7 +67,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertIn(self.lint_error_token, pants_run.stdout_data)
+    self.assertIn(self.lint_warn_token, pants_run.stdout_data)
 
   @rename_build_file
   def test_bad_strict(self):
@@ -82,7 +83,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertIn(self.lint_error_token, pants_run.stdout_data)
+    self.assertIn(self.lint_warn_token, pants_run.stdout_data)
 
   @rename_build_file
   def test_bad_default_override(self):
@@ -116,7 +117,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     cmd = ['--no-scrooge-linter-strict', 'lint.thrift', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertIn(self.lint_error_token, pants_run.stdout_data)
+    self.assertIn(self.lint_warn_token, pants_run.stdout_data)
 
   @rename_build_file
   def test_bad_non_strict_override(self):
@@ -143,4 +144,4 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_ini_config = {'scrooge-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_success(pants_run)
-    self.assertIn(self.lint_error_token, pants_run.stdout_data)
+    self.assertIn(self.lint_warn_token, pants_run.stdout_data)


### PR DESCRIPTION
### Problem

with --no-strict, fatal_warnings is not respected. 

### Solution

1. with `--strict`, fatal_warnings is on, so warnings are considered as errors.
2. with `--no-strict`, warnings is on, but will not fail the run.
3. with `--ignore-errors`, always exit 0 despite of errors or warnings.


### Behavior comparison

**Before** |   |   |  
-- | -- | -- | --
is_strict |   |   |  
0 | fatal warning: warning treated as errors | exit 0 upon error |  
1 | fatal warning: warning treated as errors | exit non-zero upon error |  
**After** |   |   |  
is_strict | ignore_errors (available with the patch) |   |  
0 | 0 | regular warning | exit non-zero upon error
0 | 1 | regular warning | exit 0 upon error
1 | 0 | fatal warning: warning treated as errors | exit non-zero upon error
1 | 1 | fatal warning: warning treated as errors | exit 0 upon error

