### PR TITLE
[IntelliJ] Add `javac_options` and `extra_jvm_options` to the output of `export-dep-as-jar`

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -221,7 +221,7 @@ class BaseZincCompile(JvmCompile):
     if zinc_args is not None:
       for compile_context in compile_contexts:
         with open(compile_context.args_file, 'r') as fp:
-          args = fp.read().split()
+          args = fp.read().strip().split('\n')
         zinc_args[compile_context.target] = args
 
   def create_empty_extra_products(self):

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -367,6 +367,13 @@ class ExportDepAsJar(ConsoleTask):
 
     for target in modulizable_targets:
       zinc_args_for_target = zinc_args_for_all_targets.get(target)
+      if zinc_args_for_target is None:
+        if not isinstance(target, JvmTarget):
+          # non-JvmTarget targets (JvmApp, PythonLibrary, Page...) are not compiled with the jvm.
+          # Therefore, they don't need compiler args.
+          zinc_args_for_target = []
+        else:
+          raise TaskError(f"There was an error exporting target {target} - There were no zinc arguments registered for it")
       info = self._process_target(target, modulizable_targets, resource_target_map, runtime_classpath, zinc_args_for_target)
       targets_map[target.address.spec] = info
 

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -170,11 +170,10 @@ class ExportDepAsJar(ConsoleTask):
     )
     return dependencies_to_include
 
-  def _extract_compiler_args_from_zinc_args(self, args):
-    scalac_option_prefix = '-S'
-    return [option[len(scalac_option_prefix):] for option in args if option.startswith(scalac_option_prefix)]
+  def _extract_arguments_with_prefix_from_zinc_args(self, args, prefix):
+    return [option[len(prefix):] for option in args if option.startswith(prefix)]
 
-  def _process_target(self, current_target, modulizable_target_set, resource_target_map, runtime_classpath, compiler_options_and_plugins):
+  def _process_target(self, current_target, modulizable_target_set, resource_target_map, runtime_classpath, zinc_args_for_target):
     """
     :type current_target:pants.build_graph.target.Target
     """
@@ -190,7 +189,7 @@ class ExportDepAsJar(ConsoleTask):
       'is_target_root': current_target in modulizable_target_set,
       'transitive': current_target.transitive,
       'scope': str(current_target.scope),
-      'compiler_options': self._extract_compiler_args_from_zinc_args(compiler_options_and_plugins.get(current_target))
+      'scalac_args': self._extract_arguments_with_prefix_from_zinc_args(zinc_args_for_target, '-S')
     }
 
     if not current_target.is_synthetic:
@@ -337,7 +336,7 @@ class ExportDepAsJar(ConsoleTask):
         library_entry['sources'] = jarred_sources.name
     return library_entry
 
-  def generate_targets_map(self, targets, runtime_classpath, compiler_options_and_plugins):
+  def generate_targets_map(self, targets, runtime_classpath, zinc_args_for_all_targets):
     """Generates a dictionary containing all pertinent information about the target graph.
 
     The return dictionary is suitable for serialization by json.dumps.
@@ -365,7 +364,8 @@ class ExportDepAsJar(ConsoleTask):
       libraries_map[t.id] = self._make_libraries_entry(t, resource_target_map, runtime_classpath)
 
     for target in modulizable_targets:
-      info = self._process_target(target, modulizable_targets, resource_target_map, runtime_classpath, compiler_options_and_plugins)
+      zinc_args_for_target = zinc_args_for_all_targets.get(target)
+      info = self._process_target(target, modulizable_targets, resource_target_map, runtime_classpath, zinc_args_for_target)
       targets_map[target.address.spec] = info
 
     graph_info = self.initialize_graph_info()
@@ -376,14 +376,14 @@ class ExportDepAsJar(ConsoleTask):
 
   def console_output(self, targets):
 
-    compiler_options_and_plugins = self.context.products.get_data('zinc_args')
-    if compiler_options_and_plugins is None:
+    zinc_args_for_all_targets = self.context.products.get_data('zinc_args')
+    if zinc_args_for_all_targets is None:
       raise TaskError("There was an error compiling the targets - There there are no zing argument entries")
 
     runtime_classpath = self.context.products.get_data('export_dep_as_jar_classpath')
     if runtime_classpath is None:
       raise TaskError("There was an error compiling the targets - There is no export_dep_as_jar classpath")
-    graph_info = self.generate_targets_map(targets, runtime_classpath=runtime_classpath, compiler_options_and_plugins=compiler_options_and_plugins)
+    graph_info = self.generate_targets_map(targets, runtime_classpath=runtime_classpath, zinc_args_for_all_targets=zinc_args_for_all_targets)
 
     if self.get_options().formatted:
       return json.dumps(graph_info, indent=4, separators=(',', ': ')).splitlines()

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -189,7 +189,9 @@ class ExportDepAsJar(ConsoleTask):
       'is_target_root': current_target in modulizable_target_set,
       'transitive': current_target.transitive,
       'scope': str(current_target.scope),
-      'scalac_args': self._extract_arguments_with_prefix_from_zinc_args(zinc_args_for_target, '-S')
+      'scalac_args': self._extract_arguments_with_prefix_from_zinc_args(zinc_args_for_target, '-S'),
+      'javac_args': self._extract_arguments_with_prefix_from_zinc_args(zinc_args_for_target, '-C'),
+      'extra_jvm_options': current_target.payload.get_field_value('extra_jvm_options', [])
     }
 
     if not current_target.is_synthetic:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -45,3 +45,12 @@ python_tests(
   timeout = 900,
   tags = {'integration', 'partially_type_checked'},
 )
+
+python_tests(
+  name='zinc_compile',
+  sources=['test_zinc_compile.py'],
+  dependencies=[
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
+    'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
+  ]
+)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
@@ -1,0 +1,46 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
+from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import BaseZincCompile
+from pants.testutil.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants.util.contextutil import temporary_file_path
+
+
+class ZincCompileTest(JvmToolTaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return BaseZincCompile
+
+  def setUp(self):
+    super().setUp()
+
+    self.java_target = self.make_target(
+      ':java',
+      target_type=JavaLibrary
+    )
+
+  def get_task(self, specs=[]):
+    context = self.context(target_roots=[self.target(spec) for spec in specs])
+    task = self.create_task(context)
+    return task
+
+  def test_spaces_preservend_when_populating_zinc_args_product_from_argfile(self):
+    with temporary_file_path() as arg_file_path:
+      compile_contexts = {self.java_target: CompileContext(
+        self.java_target,
+        analysis_file="", classes_dir="", jar_file="", log_dir="",
+        args_file=arg_file_path,
+        sources=[], post_compile_merge_dir=""
+      )}
+      task = self.get_task()
+      args = ['-classpath', 'a.jar:b.jar', '-C-Xplugin:some_javac_plugin with args']
+      task.context.products.safe_create_data('zinc_args', init_func=lambda: {self.java_target: []})
+      task.write_argsfile(compile_contexts[self.java_target], args)
+      task.register_extra_products_from_contexts([self.java_target], compile_contexts)
+      zinc_args = task.context.products.get_data('zinc_args')[self.java_target]
+      assert args == zinc_args

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -104,6 +104,8 @@ python_tests(
   sources = ['test_export_dep_as_jar_integration.py'],
   dependencies = [
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala:base_compile_integration_test',
+    'testprojects/src/java/org/pantsbuild/testproject:extra_jvm_options_directory',
+    'examples/src/java/org/pantsbuild/example:javac_directory',
   ],
   tags = {"integration", "partially_type_checked"},
   timeout = 630,

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -363,7 +363,9 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     jvm_target = result['targets']['project_info:jvm_target']
     jvm_target['libraries'] = sorted(jvm_target['libraries'])
     expected_jvm_target = {
-      'compiler_options': [],
+      'scalac_args': [],
+      'javac_args': [],
+      'extra_jvm_options': [],
       'excludes': [],
       'globs': {'globs': ['project_info/this/is/a/source/Foo.scala',
                           'project_info/this/is/a/source/Bar.scala']},

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -15,8 +15,8 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
   javac_test_targets_dir = 'examples/src/java/org/pantsbuild/example/javac'
   commonly_expected_options = {
     'scalac_args':  ['-encoding', 'UTF-8', '-g:vars', '-target:jvm-1.8', '-deprecation', '-unchecked', '-feature'],
-    'javac_args': ['-encoding', 'UTF-8', '-g:vars', '-target:jvm-1.8', '-deprecation', '-unchecked', '-feature'],
-    'extra_jvm_args': [],
+    'javac_args': ['-encoding', 'UTF-8', '-source', '1.8', '-target', '1.8'],
+    'extra_jvm_options': [],
   }
 
   def _do_test_compiler_options_in_export_output(self, config, target):
@@ -107,4 +107,18 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
       '-P:simple_scalac_plugin:target',
       '-P:simple_scalac_plugin:local',
     ]}
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_javac_options(self):
+    target_to_test = f'{self.javac_test_targets_dir}/plugin:local'
+    config = {}
+    expected_options = {'javac_args': [
+      '-Xplugin:simple_javac_plugin args from target local',
+    ]}
+    self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
+
+  def test_extra_jvm_options(self):
+    target_to_test = f'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:opts'
+    config = {}
+    expected_options = {'extra_jvm_options': ['-Dproperty.color=orange', '-Dproperty.size=2', '-DMyFlag', '-Xmx1m']}
     self._check_compiler_options_for_target_are(target_to_test, expected_options, config)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -24,7 +24,7 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
 
   def _check_compiler_options_for_target_are(self, target, expected_options_patterns, config):
     compiler_options = self._do_test_compiler_options_in_export_output(config, target
-                       )['targets'][target]['compiler_options']
+                       )['targets'][target]['scalac_args']
 
     strigified_options = ' '.join(compiler_options)
 


### PR DESCRIPTION
### Problem

In addition to scalac options (implemented in #9036), we also need javac options and jvm options in order to faithfully reproduce compilation of source code in outside tools.

### Solution

- Added `javac_options` to the output of `export-dep-as-jar`, in the same way as scalac options in #9036.
- Added `extra_jvm_options` to the output of `export-dep-as-jar`, by reading the payload field of targets. Defaults to `[]` if not present.
- Modified integration test suite to allow to test this.
- Add tests for both of these usecases.

This is now ready for review. Commit cca7358d (Split zinc argfile by newline instead of space) is https://github.com/pantsbuild/pants/pull/9065, and this PR depends on that one. Other than that, every commit should be independently reviewable.