### PR TITLE
Fix V2 `test` and `setup-py2` to work with file args

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -10,7 +10,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, Exiter
-from pants.base.specs import AddressSpec, Specs
+from pants.base.specs import Specs
 from pants.base.workunit import WorkUnit
 from pants.bin.goal_runner import GoalRunner
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -270,16 +270,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     self._reporting.initialize(self._run_tracker, self._options, start_time=self._run_start_time)
 
     spec_parser = CmdLineSpecParser(get_buildroot())
-    specs: List[str] = []
-    for spec in self._options.specs:
-      parsed_spec = spec_parser.parse_spec(spec)
-      # NB: we parse the spec so that we may normalize the target shorthand, e.g.
-      # `src/python/pants/util` -> `src/python/pants/util:util`.
-      if isinstance(parsed_spec, AddressSpec):
-        specs.append(parsed_spec.to_spec_string())
-      # In contrast, filesystem specs need no normalization so we use the raw spec.
-      else:
-        specs.append(spec)
+    specs = [spec_parser.parse_spec(spec).to_spec_string() for spec in self._options.specs]
     # Note: This will not include values from `--owner-of` or `--changed-*` flags.
     self._run_tracker.run_info.add_info("specs_from_command_line", specs, stringify=False)
 

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from functools import update_wrapper
 from typing import Any, List, Set, Tuple, Type
 
-from pants.base.specs import AddressSpec
+from pants.base.specs import Spec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
@@ -21,7 +21,7 @@ class Addresses(Collection[Address]):
 class ProvenancedBuildFileAddress:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
   build_file_address: BuildFileAddress
-  provenance: AddressSpec
+  provenance: Spec
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -9,7 +9,15 @@ from typing import Dict
 from twitter.common.collections import OrderedSet
 
 from pants.base.project_tree import Dir
-from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress, more_specific
+from pants.base.specs import (
+  AddressSpec,
+  AddressSpecs,
+  FilesystemSpec,
+  FilesystemSpecs,
+  SingleAddress,
+  Spec,
+  more_specific,
+)
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import (
@@ -19,6 +27,7 @@ from pants.engine.addressable import (
   ProvenancedBuildFileAddresses,
 )
 from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
+from pants.engine.legacy.graph import Owners, OwnersRequest
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
 from pants.engine.parser import HydratedStruct
@@ -253,32 +262,42 @@ async def provenanced_addresses_from_address_families(
 
   # NB: This may be empty, as the result of filtering by tag and exclude patterns!
   return ProvenancedBuildFileAddresses(
-    tuple(
-      ProvenancedBuildFileAddress(
-        build_file_address=addr, provenance=addr_to_provenance[addr]
-      )
-      for addr in matched_addresses
-    )
+    ProvenancedBuildFileAddress(build_file_address=addr, provenance=addr_to_provenance[addr])
+    for addr in matched_addresses
+  )
+
+
+@rule
+async def provenanced_addresses_from_filesystem_specs(
+  filesystem_specs: FilesystemSpecs,
+) -> ProvenancedBuildFileAddresses:
+  snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
+  owners = await Get[Owners](OwnersRequest(sources=snapshot.files))
+  # TODO(#9055): do we care about preserving the original provenance? This would be tricky to
+  # implement. For now, we use a no-op `FilesystemSpec("")`.
+  return ProvenancedBuildFileAddresses(
+    ProvenancedBuildFileAddress(build_file_address=bfa, provenance=FilesystemSpec(""))
+    for bfa in owners.addresses
   )
 
 
 @rule
 def remove_provenance(pbfas: ProvenancedBuildFileAddresses) -> BuildFileAddresses:
-  return BuildFileAddresses(tuple(pbfa.build_file_address for pbfa in pbfas))
+  return BuildFileAddresses(pbfa.build_file_address for pbfa in pbfas)
 
 
 @dataclass(frozen=True)
 class AddressProvenanceMap:
-  bfaddr_to_address_spec: Dict[BuildFileAddress, AddressSpec]
+  bfaddr_to_spec: Dict[BuildFileAddress, Spec]
 
-  def is_single_address(self, address: BuildFileAddress):
-    return isinstance(self.bfaddr_to_address_spec.get(address), SingleAddress)
+  def is_single_address(self, address: BuildFileAddress) -> bool:
+    return isinstance(self.bfaddr_to_spec.get(address), SingleAddress)
 
 
 @rule
 def address_provenance_map(pbfas: ProvenancedBuildFileAddresses) -> AddressProvenanceMap:
   return AddressProvenanceMap(
-    bfaddr_to_address_spec={pbfa.build_file_address: pbfa.provenance for pbfa in pbfas.dependencies}
+    bfaddr_to_spec={pbfa.build_file_address: pbfa.provenance for pbfa in pbfas.dependencies}
   )
 
 
@@ -305,6 +324,7 @@ def create_graph_rules(address_mapper: AddressMapper):
     # AddressSpec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
     provenanced_addresses_from_address_families,
+    provenanced_addresses_from_filesystem_specs,
     remove_provenance,
     address_provenance_map,
     # Root rules representing parameters that might be provided via root subjects.

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -17,6 +17,7 @@ from pants.base.specs import (
   AddressSpec,
   AddressSpecs,
   AscendantAddresses,
+  FilesystemSpec,
   FilesystemSpecs,
   SingleAddress,
 )
@@ -25,7 +26,11 @@ from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import (
+  BuildFileAddresses,
+  ProvenancedBuildFileAddress,
+  ProvenancedBuildFileAddresses,
+)
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import (
@@ -710,6 +715,20 @@ async def sources_snapshots_from_filesystem_specs(
   return SourcesSnapshots([SourcesSnapshot(snapshot)])
 
 
+@rule
+async def provenanced_addresses_from_filesystem_specs(
+  filesystem_specs: FilesystemSpecs,
+) -> ProvenancedBuildFileAddresses:
+  snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
+  owners = await Get[Owners](OwnersRequest(sources=snapshot.files))
+  # TODO(#9055): do we care about preserving the original provenance? This would be tricky to
+  # implement. For now, we use a no-op `FilesystemSpec("")`.
+  return ProvenancedBuildFileAddresses(
+    ProvenancedBuildFileAddress(build_file_address=bfa, provenance=FilesystemSpec(""))
+    for bfa in owners.addresses
+  )
+
+
 def create_legacy_graph_tasks():
   """Create tasks to recursively parse the legacy graph."""
   return [
@@ -722,6 +741,7 @@ def create_legacy_graph_tasks():
     hydrate_bundles,
     sort_targets,
     hydrate_sources_snapshot,
+    provenanced_addresses_from_filesystem_specs,
     sources_snapshots_from_build_file_addresses,
     sources_snapshots_from_filesystem_specs,
     RootRule(FilesystemSpecs),

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -710,13 +710,6 @@ async def sources_snapshots_from_filesystem_specs(
   return SourcesSnapshots([SourcesSnapshot(snapshot)])
 
 
-@rule
-async def owners_from_filesystem_specs(filesystem_specs: FilesystemSpecs) -> BuildFileAddresses:
-  snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
-  owners = await Get[Owners](OwnersRequest(sources=snapshot.files))
-  return owners.addresses
-
-
 def create_legacy_graph_tasks():
   """Create tasks to recursively parse the legacy graph."""
   return [
@@ -727,7 +720,6 @@ def create_legacy_graph_tasks():
     find_owners,
     hydrate_sources,
     hydrate_bundles,
-    owners_from_filesystem_specs,
     sort_targets,
     hydrate_sources_snapshot,
     sources_snapshots_from_build_file_addresses,

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from typing import Dict, Optional
 from unittest.mock import Mock
 
-from pants.base.specs import AddressSpec, DescendantAddresses, SingleAddress
+from pants.base.specs import DescendantAddresses, SingleAddress, Spec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import AddressProvenanceMap
@@ -189,7 +189,7 @@ class TestTest(TestBase):
     self,
     *,
     address: Address,
-    bfaddr_to_address_spec: Optional[Dict[BuildFileAddress, AddressSpec]] = None,
+    bfaddr_to_spec: Optional[Dict[BuildFileAddress, Spec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
   ) -> AddressAndTestResult:
@@ -215,7 +215,7 @@ class TestTest(TestBase):
         rule_args=[
           HydratedTarget(address, target_adaptor, ()),
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
-          AddressProvenanceMap(bfaddr_to_address_spec=bfaddr_to_address_spec or {}),
+          AddressProvenanceMap(bfaddr_to_spec=bfaddr_to_spec or {}),
         ],
         mock_gets=[
           MockGet(
@@ -242,7 +242,7 @@ class TestTest(TestBase):
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
         address=bfaddr.to_address(),
-        bfaddr_to_address_spec={bfaddr: SingleAddress(directory='some/dir', name='bin')},
+        bfaddr_to_spec={bfaddr: SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
@@ -255,7 +255,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')}
+      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
       bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
@@ -265,7 +265,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_address_spec={bfaddr: DescendantAddresses(directory='some/dir')},
+      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
     assert result == AddressAndTestResult(bfaddr.to_address(), None)


### PR DESCRIPTION
### Problem

`test.py` and `run_setup_py.py` both use the type `AddressProvenanceMap`, which itself uses `ProvenancedBuildFileAddresses`. There is no way to go from `FilesystemSpecs -> ProvenancedBuildFileAddresses`—only `FilesystemSpecs -> BuildFileAddresses`—so file args don't work with the `test` and `setup-py2` goals.

Generally, `ProvenancedBuildFileAddress` is a way to preserve the "provenance" (or origin) of how a `BuildFileAddress` was resolved:

https://github.com/pantsbuild/pants/blob/1ebe376f1a4d672c9955e7b80c8a6caba48a7719/src/python/pants/engine/addressable.py#L20-L24

When resolving `AddressSpecs`, we roughly follow this flow: `AddressSpecs -> ProvenancedBuildFileAddresses -> BuildFileAddresses`, unlike `FilesystemSpecs -> BuildFileAddresses`.

### Solution

Tweak `ProvenancedBuildFileAddress`'s definition to use `Spec` rather than `AddressSpec`, so that the origin may come from a `FilesystemSpec`.

Then, add a rule to go from `FilesystemSpecs -> ProvenancedBuildFileAddresses`. It would be very difficult to backtrace the original `FilesystemSpec` that resulted in the owning `BuildFileAddress` (https://github.com/pantsbuild/pants/issues/9055), so for now we provide a no-op implementation. Currently, this `provenance` would never be consumed for Filesystem Specs so this is safe to do.

### Result

_All_ goals now work with file args.

If we decide in https://github.com/pantsbuild/pants/issues/9055 that we do care about preserving the provenance for filesystem specs enough to re-architect how filesystem args are implemented, then we have a foundation to build off of. 