### PR TITLE
Fix V2 Python linters to work without `pants.backend.python` registered

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -6,12 +6,14 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit
 from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
 )
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
@@ -96,4 +98,12 @@ async def lint(
 
 
 def rules():
-  return [lint, subsystem_rule(Bandit), UnionRule(PythonLintTarget, BanditTarget)]
+  return [
+    lint,
+    subsystem_rule(Bandit),
+    UnionRule(PythonLintTarget, BanditTarget),
+    *download_pex_bin.rules(),
+    *pex.rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
+  ]

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -7,8 +7,6 @@ import pytest
 
 from pants.backend.python.lint.bandit.rules import BanditTarget
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -33,15 +31,7 @@ class BanditIntegrationTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return (
-      *super().rules(),
-      *bandit_rules(),
-      *download_pex_bin.rules(),
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
-      RootRule(BanditTarget),
-    )
+    return (*super().rules(), *bandit_rules(), RootRule(BanditTarget))
 
   def run_bandit(
     self,

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -9,12 +9,14 @@ from typing import Optional, Tuple
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_format_target import PythonFormatTarget
 from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
 )
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
@@ -158,4 +160,8 @@ def rules():
     subsystem_rule(Black),
     UnionRule(PythonFormatTarget, BlackTarget),
     UnionRule(PythonLintTarget, BlackTarget),
+    *download_pex_bin.rules(),
+    *pex.rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
   ]

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -7,8 +7,6 @@ import pytest
 
 from pants.backend.python.lint.black.rules import BlackTarget
 from pants.backend.python.lint.black.rules import rules as black_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.legacy.structs import TargetAdaptor
@@ -32,15 +30,7 @@ class BlackIntegrationTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return (
-      *super().rules(),
-      *black_rules(),
-      *download_pex_bin.rules(),
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
-      RootRule(BlackTarget),
-    )
+    return (*super().rules(), *black_rules(), RootRule(BlackTarget))
 
   def run_black(
     self,

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -6,12 +6,14 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
 )
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
@@ -96,4 +98,12 @@ async def lint(
 
 
 def rules():
-  return [lint, subsystem_rule(Flake8), UnionRule(PythonLintTarget, Flake8Target)]
+  return [
+    lint,
+    subsystem_rule(Flake8),
+    UnionRule(PythonLintTarget, Flake8Target),
+    *download_pex_bin.rules(),
+    *pex.rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
+  ]

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -7,8 +7,6 @@ import pytest
 
 from pants.backend.python.lint.flake8.rules import Flake8Target
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -34,15 +32,7 @@ class Flake8IntegrationTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return (
-      *super().rules(),
-      *flake8_rules(),
-      *download_pex_bin.rules(),
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
-      RootRule(Flake8Target),
-    )
+    return (*super().rules(), *flake8_rules(), RootRule(Flake8Target))
 
   def run_flake8(
     self,

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -7,12 +7,14 @@ from typing import List, Optional, Tuple
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_format_target import PythonFormatTarget
 from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
 )
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
@@ -152,4 +154,8 @@ def rules():
     subsystem_rule(Isort),
     UnionRule(PythonFormatTarget, IsortTarget),
     UnionRule(PythonLintTarget, IsortTarget),
+    *download_pex_bin.rules(),
+    *pex.rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
   ]

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -5,8 +5,6 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.rules import IsortTarget
 from pants.backend.python.lint.isort.rules import rules as isort_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.legacy.structs import TargetAdaptor
@@ -38,15 +36,7 @@ class IsortIntegrationTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return (
-      *super().rules(),
-      *isort_rules(),
-      *download_pex_bin.rules(),
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
-      RootRule(IsortTarget),
-    )
+    return (*super().rules(), *isort_rules(), RootRule(IsortTarget))
 
   def run_isort(
     self,

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import List
 
+from pants.backend.python.lint.python_lint_target import PYTHON_TARGET_TYPES
 from pants.engine.legacy.structs import (
   PantsPluginAdaptor,
   PythonAppAdaptor,
@@ -13,7 +14,7 @@ from pants.engine.legacy.structs import (
   TargetAdaptor,
 )
 from pants.engine.objects import union
-from pants.engine.rules import UnionMembership, UnionRule, rule
+from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.fmt import AggregatedFmtResults, FmtResult, FormatTarget
 
@@ -79,9 +80,6 @@ def rules():
     binary_adaptor,
     tests_adaptor,
     plugin_adaptor,
-    UnionRule(FormatTarget, PythonTargetAdaptor),
-    UnionRule(FormatTarget, PythonAppAdaptor),
-    UnionRule(FormatTarget, PythonBinaryAdaptor),
-    UnionRule(FormatTarget, PythonTestsAdaptor),
-    UnionRule(FormatTarget, PantsPluginAdaptor),
+    *(RootRule(target_type) for target_type in PYTHON_TARGET_TYPES),
+    *(UnionRule(FormatTarget, target_type) for target_type in PYTHON_TARGET_TYPES)
   ]

--- a/src/python/pants/backend/python/lint/python_format_target_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_format_target_integration_test.py
@@ -11,8 +11,6 @@ from pants.backend.python.lint.python_format_target import (
   _ConcretePythonFormatTarget,
   format_python_target,
 )
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.legacy.structs import TargetAdaptor
@@ -33,10 +31,6 @@ class PythonFormatTargetIntegrationTest(TestBase):
       format_python_target,
       *black_rules(),
       *isort_rules(),
-      *download_pex_bin.rules(),
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
       RootRule(_ConcretePythonFormatTarget),
       RootRule(BlackTarget),
       RootRule(IsortTarget),

--- a/src/python/pants/backend/python/lint/python_lint_target.py
+++ b/src/python/pants/backend/python/lint/python_lint_target.py
@@ -12,7 +12,7 @@ from pants.engine.legacy.structs import (
   TargetAdaptor,
 )
 from pants.engine.objects import union
-from pants.engine.rules import UnionMembership, UnionRule, rule
+from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.lint import LintResult, LintResults, LintTarget
 
@@ -39,6 +39,15 @@ async def lint_python_target(
     for member in union_membership.union_rules[PythonLintTarget]
   )
   return LintResults(results)
+
+
+PYTHON_TARGET_TYPES = [
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+  PantsPluginAdaptor,
+]
 
 
 @rule
@@ -74,9 +83,6 @@ def rules():
     binary_adaptor,
     tests_adaptor,
     plugin_adaptor,
-    UnionRule(LintTarget, PythonTargetAdaptor),
-    UnionRule(LintTarget, PythonAppAdaptor),
-    UnionRule(LintTarget, PythonBinaryAdaptor),
-    UnionRule(LintTarget, PythonTestsAdaptor),
-    UnionRule(LintTarget, PantsPluginAdaptor),
+    *(RootRule(target_type) for target_type in PYTHON_TARGET_TYPES),
+    *(UnionRule(LintTarget, target_type) for target_type in PYTHON_TARGET_TYPES)
   ]


### PR DESCRIPTION
We should be able to use this config:

```toml
[GLOBAL]
backend_packages2 = [
  "pants.backend.python.lint.bandit",
  "pants.backend.python.lint.black",
  "pants.backend.python.lint.flake8",
  "pants.backend.python.lint.isort",
]
```

But this currently fails when `pants.backend.python` is not registered at the same time, because all of these backends depend upon rules declared in `pants.backend.python`.

This fixes that implicit dependency so that the `pants.backend.python.lint.*` backends explicitly declare all dependencies.