### PR TITLE
Allow options to be registered passively.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -633,7 +633,9 @@ class RunTracker(Subsystem):
     """
     scope_to_look_up = scope if scope != 'GLOBAL' else ''
     try:
-      value = self._all_options.for_scope(scope_to_look_up, inherit_from_enclosing_scope=False).as_dict()
+      value = self._all_options.for_scope(
+        scope_to_look_up, inherit_from_enclosing_scope=False,
+        include_passive_options=True).as_dict()
       if option is None:
         return value
       else:

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -130,6 +130,8 @@ class HelpInfoExtracter:
     advanced_options = []
     # Sort the arguments, so we display the help in alphabetical order.
     for args, kwargs in sorted(option_registrations_iter):
+      if kwargs.get('passive'):
+        continue
       ohi = self.get_option_help_info(args, kwargs)
       if kwargs.get('advanced'):
         advanced_options.append(ohi)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -548,39 +548,43 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   "tags ('-' prefix).  Useful with ::, to find subsets of targets "
                   "(e.g., integration tests.)")
 
-    if register.bootstrap.v2:
-      register('--v2-ui', default=False, type=bool, daemon=False,
-               help='Whether to show v2 engine execution progress.')
-      if not register.bootstrap.v1:
-        loop_flag = '--loop'
-        register(loop_flag, type=bool,
-                 help='Run v2 @goal_rules continuously as file changes are detected.')
-        register('--loop-max', type=int, default=2**32, advanced=True,
-                 help=f'The maximum number of times to loop when `{loop_flag}` is specified.')
+    register('--v2-ui', default=False, type=bool, daemon=False,
+             passive=not register.bootstrap.v2,
+             help='Whether to show v2 engine execution progress.')
 
-    if register.bootstrap.v1:
-      register('-x', '--time', type=bool,
-               help='Output a timing report at the end of the run.')
-      register('-e', '--explain', type=bool,
-               help='Explain the execution of goals.')
-      register('-t', '--timeout', advanced=True, type=int, metavar='<seconds>',
-               removal_version="1.26.0.dev1",
-               removal_hint="This option is not used and may be removed with no change in behavior. ",
-               help='Number of seconds to wait for http connections.')
-      # TODO: After moving to the new options system these abstraction leaks can go away.
-      register('-k', '--kill-nailguns', advanced=True, type=bool,
-               help='Kill nailguns before exiting')
-      register('--fail-fast', advanced=True, type=bool, recursive=True,
-               help='Exit as quickly as possible on error, rather than attempting to continue '
-                    'to process the non-erroneous subset of the input.')
-      register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
-               help='The cache key generation. Bump this to invalidate every artifact for a scope.')
-      register('--workdir-max-build-entries', advanced=True, type=int, default=8,
-               help='Maximum number of previous builds to keep per task target pair in workdir. '
-               'If set, minimum 2 will always be kept to support incremental compilation.')
-      register('--max-subprocess-args', advanced=True, type=int, default=100, recursive=True,
-               help='Used to limit the number of arguments passed to some subprocesses by breaking '
-               'the command up into multiple invocations.')
+    loop_flag = '--loop'
+    loop_passive = register.bootstrap.v1 or not register.bootstrap.v2
+    register(loop_flag, type=bool,
+             passive=loop_passive,
+             help='Run v2 @goal_rules continuously as file changes are detected.')
+    register('--loop-max', type=int, default=2**32, advanced=True,
+             passive=loop_passive,
+             help=f'The maximum number of times to loop when `{loop_flag}` is specified.')
+
+    no_v1 = not register.bootstrap.v1
+    register('-x', '--time', type=bool, passive=no_v1,
+             help='Output a timing report at the end of the run.')
+    register('-e', '--explain', type=bool, passive=no_v1,
+             help='Explain the execution of goals.')
+    register('-t', '--timeout', advanced=True, type=int, metavar='<seconds>', passive=no_v1,
+             removal_version="1.26.0.dev1",
+             removal_hint="This option is not used and may be removed with no change in behavior. ",
+             help='Number of seconds to wait for http connections.')
+    # TODO: After moving to the new options system these abstraction leaks can go away.
+    register('-k', '--kill-nailguns', advanced=True, type=bool, passive=no_v1,
+             help='Kill nailguns before exiting')
+    register('--fail-fast', advanced=True, type=bool, recursive=True, passive=no_v1,
+             help='Exit as quickly as possible on error, rather than attempting to continue '
+                  'to process the non-erroneous subset of the input.')
+    register('--cache-key-gen-version', advanced=True, default='200', recursive=True, passive=no_v1,
+             help='The cache key generation. Bump this to invalidate every artifact for a scope.')
+    register('--workdir-max-build-entries', advanced=True, type=int, default=8, passive=no_v1,
+             help='Maximum number of previous builds to keep per task target pair in workdir. '
+             'If set, minimum 2 will always be kept to support incremental compilation.')
+    register('--max-subprocess-args', advanced=True, type=int, default=100, recursive=True,
+             passive=no_v1,
+             help='Used to limit the number of arguments passed to some subprocesses by breaking '
+             'the command up into multiple invocations.')
     register('--lock', advanced=True, type=bool, default=True,
              help='Use a global lock to exclude other versions of pants from running during '
                   'critical operations.')

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -466,7 +466,7 @@ class Options:
     self.walk_parsers(register_all_scoped_names)
     return sorted(all_scoped_flag_names, key=lambda flag_info: flag_info.scoped_arg)
 
-  def _make_parse_args_request(self, flags_in_scope, namespace):
+  def _make_parse_args_request(self, flags_in_scope, namespace, include_passive_options=False):
     levenshtein_max_distance = (
       self._bootstrap_option_values.option_name_check_distance
       if self._bootstrap_option_values
@@ -477,12 +477,15 @@ class Options:
       namespace=namespace,
       get_all_scoped_flag_names=lambda: self._all_scoped_flag_names_for_fuzzy_matching,
       levenshtein_max_distance=levenshtein_max_distance,
+      include_passive_options=include_passive_options
     )
 
   # TODO: Eagerly precompute backing data for this?
   @memoized_method
   def for_scope(
-    self, scope: str, inherit_from_enclosing_scope: bool = True,
+      self, scope: str,
+      inherit_from_enclosing_scope: bool = True,
+      include_passive_options: bool = False
   ) -> OptionValueContainer:
     """Return the option values for the given scope.
 
@@ -500,7 +503,7 @@ class Options:
 
     # Now add our values.
     flags_in_scope = self._scope_to_flags.get(scope, [])
-    parse_args_request = self._make_parse_args_request(flags_in_scope, values)
+    parse_args_request = self._make_parse_args_request(flags_in_scope, values, include_passive_options)
     self._parser_hierarchy.get_parser_by_scope(scope).parse_args(parse_args_request)
 
     # Check for any deprecation conditions, which are evaluated using `self._flag_matchers`.

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -215,7 +215,7 @@ class OptionsBootstrapper:
       for section in config.sections():
         scope = GLOBAL_SCOPE if section == GLOBAL_SCOPE_CONFIG_SECTION else section
         try:
-          valid_options_under_scope = set(options.for_scope(scope))
+          valid_options_under_scope = set(options.for_scope(scope, include_passive_options=True))
         # Only catch ConfigValidationError. Other exceptions will be raised directly.
         except Config.ConfigValidationError:
           error_log.append(f"Invalid scope [{section}] in {config.config_path}")


### PR DESCRIPTION
A "passive" option is one that cannot (normally) be referenced from
code, does not appear in help output, or specified via flag.
The only difference between a passive option and an unregistered
option is that if the former is specified in config, or in 
stats_option_scopes_to_record, it does not cause  config validation to fail.

This allows us to conditionally register options (e.g., in v1 vs. v2)
without having to edit config files when the condition changes in
order to avoid validation errors.

Also applies this to the previously conditionally-registered options.

