### PR TITLE
make python binary creation avoid writing to a shared cache

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -56,10 +56,12 @@ class PythonBinaryCreate(Task):
 
   @classmethod
   def implementation_version(cls):
-    return super().implementation_version() + [('PythonBinaryCreate', 2)]
+    return super().implementation_version() + [('PythonBinaryCreate', 3)]
 
   @property
-  def cache_target_dirs(self):
+  def create_target_dirs(self):
+    # The pex files produced by this task are (often) platform-specific, and should not be sent to a
+    # remote cache where a pants from another platform might pick it up and fail to execute it.
     return True
 
   @classmethod


### PR DESCRIPTION
### Problem

Python binary creation will currently result in a pex being written not just to `dist/`, but also to a shared local or remote cache. Since the platform of the pex file isn't currently mixed into the cache key (and it's not immediately clear how to do so), this results in pulling pex files from the wrong platform if you have both linux and osx users with a shared buildcache, or possibly even if you're building a pex for radically different versions of osx (this hasn't happened yet, but seems plausible).

We currently have worked around this by ensuring that python binary creation only writes to a local cache, but there's currently nothing stopping users from using a remote cache by default for their caching (which is common) and having that silently also apply to python binary creation (which is what happens if the options for `[cache.binary.py]` aren't specifically overridden.

### Solution

- Convert the `cache_target_dirs` property into `create_target_dirs`.
  - This will still create a `vt.results_dir` for versioned targets, but does *not* write them to the cache.

### Result

It will be much more difficult to accidentally pull in a pex file for the wrong platform!