### PR TITLE
Preserve the filesystem spec used to find owning targets

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -8,6 +8,9 @@ from typing import Union
 from pants.base.specs import (
   AddressSpec,
   DescendantAddresses,
+  FilesystemGlobSpec,
+  FilesystemIgnoreSpec,
+  FilesystemLiteralSpec,
   FilesystemSpec,
   SiblingAddresses,
   SingleAddress,
@@ -72,13 +75,15 @@ class CmdLineSpecParser:
       spec_parts = spec.rsplit(':', 1)
       spec_path = self._normalize_spec_path(spec_parts[0])
       return SingleAddress(directory=spec_path, name=spec_parts[1])
-    if spec.startswith('!') or '*' in spec:
-      return FilesystemSpec(glob=spec)
+    if spec.startswith('!'):
+      return FilesystemIgnoreSpec(spec[1:])
+    if '*' in spec:
+      return FilesystemGlobSpec(spec)
     if PurePath(spec).suffix:
-      return FilesystemSpec(glob=self._normalize_spec_path(spec))
+      return FilesystemLiteralSpec(self._normalize_spec_path(spec))
     spec_path = self._normalize_spec_path(spec)
     if Path(self._root_dir, spec_path).is_file():
-      return FilesystemSpec(glob=spec_path)
+      return FilesystemLiteralSpec(spec_path)
     # Else we apply address shorthand, i.e. `src/python/pants/util` -> `src/python/pants/util:util`
     # TODO: Figure out what this should look like if (once?) filesystem specs allow directories.
     # Should this shorthand be removed so that directories may be unambiguously resolved to a

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -718,7 +718,9 @@ async def sources_snapshots_from_filesystem_specs(
 async def provenanced_addresses_from_filesystem_specs(
   filesystem_specs: FilesystemSpecs,
 ) -> ProvenancedBuildFileAddresses:
-  """Find the owner(s) for each FilesystemSpec."""
+  """Find the owner(s) for each FilesystemSpec while preserving the original FilesystemSpec those
+  owners come from (i.e., preserving the "provenance").
+  """
   pathglobs_per_include = (
     filesystem_specs.path_globs_for_spec(spec) for spec in filesystem_specs.includes
   )

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -48,5 +48,5 @@ python_tests(
     'testprojects/src/python:plugins_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout=90,
+  timeout=120,
 )

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -8,6 +8,9 @@ from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.specs import (
   AddressSpec,
   DescendantAddresses,
+  FilesystemGlobSpec,
+  FilesystemIgnoreSpec,
+  FilesystemLiteralSpec,
   FilesystemSpec,
   SiblingAddresses,
   SingleAddress,
@@ -26,6 +29,18 @@ def desc(directory: str) -> DescendantAddresses:
 
 def sib(directory: str) -> SiblingAddresses:
   return SiblingAddresses(directory)
+
+
+def literal(file: str) -> FilesystemLiteralSpec:
+  return FilesystemLiteralSpec(file)
+
+
+def glob(val: str) -> FilesystemGlobSpec:
+  return FilesystemGlobSpec(val)
+
+
+def ignore(val: str) -> FilesystemIgnoreSpec:
+  return FilesystemIgnoreSpec(val)
 
 
 class CmdLineSpecParserTest(TestBase):
@@ -68,17 +83,17 @@ class CmdLineSpecParserTest(TestBase):
   def test_files(self) -> None:
     # We assume that specs with an extension are meant to be interpreted as filesystem specs.
     for f in ["a.txt", "a.tmp.cache.txt.bak", "a/b/c.txt", ".a.txt"]:
-      self.assert_filesystem_spec_parsed(f)
-    self.assert_filesystem_spec_parsed("./a.txt", expected_glob="a.txt")
-    self.assert_filesystem_spec_parsed("//./a.txt", expected_glob="a.txt")
+      self.assert_filesystem_spec_parsed(f, literal(f))
+    self.assert_filesystem_spec_parsed("./a.txt", literal("a.txt"))
+    self.assert_filesystem_spec_parsed("//./a.txt", literal("a.txt"))
 
   def test_globs(self) -> None:
-    for glob in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
-      self.assert_filesystem_spec_parsed(glob)
+    for val in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
+      self.assert_filesystem_spec_parsed(val, glob(val))
 
   def test_excludes(self) -> None:
-    for glob in ["!", "!a/b/", "!/a/b/*"]:
-      self.assert_filesystem_spec_parsed(glob)
+    for val in ["!", "!a/b/", "!/a/b/*"]:
+      self.assert_filesystem_spec_parsed(val, ignore(val[1:]))
 
   def test_ambiguous_files(self) -> None:
     # These could either be files or the shorthand for single addresses. We check if they exist on
@@ -86,18 +101,18 @@ class CmdLineSpecParserTest(TestBase):
     for spec in ["a", "b/c"]:
       self.assert_address_spec_parsed(spec, single(spec))
       self.create_file(spec)
-      self.assert_filesystem_spec_parsed(spec)
+      self.assert_filesystem_spec_parsed(spec, literal(spec))
 
   def test_absolute(self) -> None:
     self.assert_address_spec_parsed(os.path.join(self.build_root, 'a'), single('a'))
     self.assert_address_spec_parsed(os.path.join(self.build_root, 'a:a'), single('a', 'a'))
     self.assert_address_spec_parsed(os.path.join(self.build_root, 'a:'), sib('a'))
     self.assert_address_spec_parsed(os.path.join(self.build_root, 'a::'), desc('a'))
-    self.assert_filesystem_spec_parsed(os.path.join(self.build_root, 'a.txt'), expected_glob='a.txt')
+    self.assert_filesystem_spec_parsed(os.path.join(self.build_root, 'a.txt'), literal('a.txt'))
 
     with self.assertRaises(CmdLineSpecParser.BadSpecError):
       self.assert_address_spec_parsed('/not/the/buildroot/a', sib('a'))
-      self.assert_filesystem_spec_parsed('/not/the/buildroot/a.txt', expected_glob='a.txt')
+      self.assert_filesystem_spec_parsed('/not/the/buildroot/a.txt', literal('a.txt'))
 
   def test_absolute_double_slashed(self) -> None:
     # By adding a double slash, we are insisting that this absolute path is actually
@@ -107,7 +122,7 @@ class CmdLineSpecParserTest(TestBase):
     for spec in [double_absolute_address, double_absolute_file]:
       assert '//' == spec[:2], 'A sanity check that we have a leading-// absolute spec'
     self.assert_address_spec_parsed(double_absolute_address, single(double_absolute_address[2:]))
-    self.assert_filesystem_spec_parsed(double_absolute_file, expected_glob=double_absolute_file[2:])
+    self.assert_filesystem_spec_parsed(double_absolute_file, literal(double_absolute_file[2:]))
 
   def test_cmd_line_affordances(self) -> None:
     self.assert_address_spec_parsed('./:root', single('', 'root'))
@@ -128,9 +143,7 @@ class CmdLineSpecParserTest(TestBase):
     assert isinstance(spec, AddressSpec)
     assert spec == expected_spec
 
-  def assert_filesystem_spec_parsed(
-    self, spec_str: str, *, expected_glob: Optional[str] = None,
-  ) -> None:
+  def assert_filesystem_spec_parsed(self, spec_str: str, expected_spec: FilesystemSpec) -> None:
     spec = self._spec_parser.parse_spec(spec_str)
     assert isinstance(spec, FilesystemSpec)
-    assert spec == FilesystemSpec(expected_glob or spec_str)
+    assert spec == expected_spec

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -88,12 +88,12 @@ class CmdLineSpecParserTest(TestBase):
     self.assert_filesystem_spec_parsed("//./a.txt", literal("a.txt"))
 
   def test_globs(self) -> None:
-    for val in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
-      self.assert_filesystem_spec_parsed(val, glob(val))
+    for glob_str in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
+      self.assert_filesystem_spec_parsed(glob_str, glob(glob_str))
 
   def test_excludes(self) -> None:
-    for val in ["!", "!a/b/", "!/a/b/*"]:
-      self.assert_filesystem_spec_parsed(val, ignore(val[1:]))
+    for glob_str in ["!", "!a/b/", "!/a/b/*"]:
+      self.assert_filesystem_spec_parsed(glob_str, ignore(glob_str[1:]))
 
   def test_ambiguous_files(self) -> None:
     # These could either be files or the shorthand for single addresses. We check if they exist on


### PR DESCRIPTION
## Problem
Currently, when going from `FilesystemSpecs -> BuildFileAddresses`, we throw away all information about the original specs and how they map to the corresponding `BuildFileAddresses`. In contrast, `AddressSpecs` preserve this information through `ProvenancedBuildFileAddresses`.

Throwing away the `FilesystemSpec` "provenance" information prevents us from doing two things:

1) Handling globs vs. literal file specs differently in rules.
   * `./pants test src/python/pants/util/strutil.py` should fail because it can't find a `python_tests` target. `./pants test 'src/python/pants/util/*.py'` should not fail, even though it can't find any `python_tests` targets.
   * Analogy: `./pants test src/python/pants/util:strutil` does fail, whereas `./pants test src/python/pants/util:` no-ops.
2) Being more precise in how `fmt`, `lint`, and `test` operate.
    * Currently, these will run against the entire owning target, rather than only the specified file(s).

## Solution
First, introduce `FilesystemLiteralSpec`, `FilesystemGlobSpec`, and `FilesystemIgnoreSpec` so that we may effectively differentiate between the 3 types of filesystem specs. 

Then, tweak the rule `provenanced_addresses_from_filesystem_specs()` so that it no longer aggregates all `FilesystemSpecs` into one single `Snapshot`, but does this per-spec. This allows us to associate the resulting owners with the original `FilesystemSpec`.

## Result
Will close https://github.com/pantsbuild/pants/issues/9055.

Followups can use this information to do things like:
* Error when a `FilesystemLiteralSpec` has no owning targets (currently, we no-op).
* Error in `test.py` when a `FilesystemLiteralSpec`'s owner is not a `python_tests` target.
* Teach `fmt`, `lint`, and `test` to only operate on the specifid files.