### PR TITLE
Split zinc argfile by newline instead of space

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -221,7 +221,7 @@ class BaseZincCompile(JvmCompile):
     if zinc_args is not None:
       for compile_context in compile_contexts:
         with open(compile_context.args_file, 'r') as fp:
-          args = fp.read().split()
+          args = fp.read().strip().split('\n')
         zinc_args[compile_context.target] = args
 
   def create_empty_extra_products(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -45,3 +45,12 @@ python_tests(
   timeout = 900,
   tags = {'integration', 'partially_type_checked'},
 )
+
+python_tests(
+  name='zinc_compile',
+  sources=['test_zinc_compile.py'],
+  dependencies=[
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
+    'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
+  ]
+)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
@@ -1,0 +1,46 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
+from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import BaseZincCompile
+from pants.testutil.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants.util.contextutil import temporary_file_path
+
+
+class ZincCompileTest(JvmToolTaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return BaseZincCompile
+
+  def setUp(self):
+    super().setUp()
+
+    self.java_target = self.make_target(
+      ':java',
+      target_type=JavaLibrary
+    )
+
+  def get_task(self, specs=[]):
+    context = self.context(target_roots=[self.target(spec) for spec in specs])
+    task = self.create_task(context)
+    return task
+
+  def test_spaces_preservend_when_populating_zinc_args_product_from_argfile(self):
+    with temporary_file_path() as arg_file_path:
+      compile_contexts = {self.java_target: CompileContext(
+        self.java_target,
+        analysis_file="", classes_dir="", jar_file="", log_dir="",
+        args_file=arg_file_path,
+        sources=[], post_compile_merge_dir=""
+      )}
+      task = self.get_task()
+      args = ['-classpath', 'a.jar:b.jar', '-C-Xplugin:some_javac_plugin with args']
+      task.context.products.safe_create_data('zinc_args', init_func=lambda: {self.java_target: []})
+      task.write_argsfile(compile_contexts[self.java_target], args)
+      task.register_extra_products_from_contexts([self.java_target], compile_contexts)
+      zinc_args = task.context.products.get_data('zinc_args')[self.java_target]
+      assert args == zinc_args


### PR DESCRIPTION
### Problem

When loading the zinc argfile to populate the `zinc_args` product, we split the file by space and not newline. While this is fine for most options, `javac` compiler args in general should come in a single string, separated by spaces (`["-C-Xplugin:simple_javac_plugin arg1 arg2"]`), instead of one string per arg (`["-C-Xplugin:simple_javac_plugin", "arg1", "arg2"]`).

### Solution

Split the contents of the argfile by newline instead of spaces.

### Result

The `zinc_args` product is consistent with Zinc's parsing of arguments in this regard.