### PR TITLE
Add `--owners-not-found-behavior` option for when file args do not have any owning targets

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -320,6 +320,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     # Setup and run GoalRunner.
     return GoalRunner.Factory(
       self._build_root,
+      self._options_bootstrapper,
       self._options,
       self._build_config,
       self._run_tracker,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -46,7 +46,7 @@ from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.option.global_options import GlobMatchErrorBehavior
+from pants.option.global_options import GlobMatchErrorBehavior, OwnersNotFoundBehavior, GlobalOptions
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper, Filespec
 
@@ -719,7 +719,7 @@ async def sources_snapshots_from_filesystem_specs(
 
 @rule
 async def provenanced_addresses_from_filesystem_specs(
-  filesystem_specs: FilesystemSpecs,
+  filesystem_specs: FilesystemSpecs, global_options: GlobalOptions,
 ) -> ProvenancedBuildFileAddresses:
   """Find the owner(s) for each FilesystemSpec while preserving the original FilesystemSpec those
   owners come from (i.e., preserving the "provenance").
@@ -735,13 +735,20 @@ async def provenanced_addresses_from_filesystem_specs(
   )
   result: List[ProvenancedBuildFileAddress] = []
   for spec, owners in zip(filesystem_specs.includes, owners_per_include):
-    if isinstance(spec, FilesystemLiteralSpec) and not owners.addresses:
+    if (
+      global_options.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
+      and isinstance(spec, FilesystemLiteralSpec) and not owners.addresses
+    ):
       file_path = PurePath(spec.to_spec_string())
-      raise ResolveError(
+      msg = (
         f"No owning targets could be found for the file `{file_path}`.\n\nPlease check "
         f"that there is a BUILD file in `{file_path.parent}` with a target whose `sources` field "
         f"includes `{file_path}`. See https://www.pantsbuild.org/build_files.html."
       )
+      if global_options.owners_not_found_behavior == OwnersNotFoundBehavior.warn:
+        logger.warning(msg)
+      else:
+        raise ResolveError(msg)
     result.extend(
       ProvenancedBuildFileAddress(build_file_address=bfa, provenance=spec)
       for bfa in owners.addresses

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -46,7 +46,11 @@ from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.option.global_options import GlobMatchErrorBehavior, OwnersNotFoundBehavior, GlobalOptions
+from pants.option.global_options import (
+  GlobalOptions,
+  GlobMatchErrorBehavior,
+  OwnersNotFoundBehavior,
+)
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper, Filespec
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -7,6 +7,7 @@ import os.path
 from collections import defaultdict, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Any, Dict, Iterable, List, Tuple, cast
 
 from twitter.common.collections import OrderedSet
@@ -17,6 +18,7 @@ from pants.base.specs import (
   AddressSpec,
   AddressSpecs,
   AscendantAddresses,
+  FilesystemLiteralSpec,
   FilesystemSpecs,
   SingleAddress,
 )
@@ -39,6 +41,7 @@ from pants.engine.legacy.structs import (
   SourcesField,
   TargetAdaptor,
 )
+from pants.engine.mapper import ResolveError
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
@@ -732,6 +735,13 @@ async def provenanced_addresses_from_filesystem_specs(
   )
   result: List[ProvenancedBuildFileAddress] = []
   for spec, owners in zip(filesystem_specs.includes, owners_per_include):
+    if isinstance(spec, FilesystemLiteralSpec) and not owners.addresses:
+      file_path = PurePath(spec.to_spec_string())
+      raise ResolveError(
+        f"No owning targets could be found for the file `{file_path}`.\n\nPlease check "
+        f"that there is a BUILD file in `{file_path.parent}` with a target whose `sources` field "
+        f"includes `{file_path}`. See https://www.pantsbuild.org/build_files.html."
+      )
     result.extend(
       ProvenancedBuildFileAddress(build_file_address=bfa, provenance=spec)
       for bfa in owners.addresses

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -319,7 +319,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
       "--owners-not-found-behavior", advanced=True,
       type=OwnersNotFoundBehavior, default=OwnersNotFoundBehavior.error,
       help="What to do when file arguments do not have any owning target. This happens when there "
-           "are no targets with the file argument included in their `sources` field."
+           "are no targets whose `sources` fields include the file argument."
     )
     register("--files-not-found-behavior", advanced=True,
              type=FileNotFoundBehavior, default=FileNotFoundBehavior.warn,
@@ -352,8 +352,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                "`./pants list src/python/f1.py src/python/f2.py` or even "
                "`./pants fmt 'src/python/**/*.py'`.\n\nInstead of `--owner-of=@my_file`, use "
                "`--spec-file=my_file`.\n\nJust like with `--owner-of`, Pants will "
-               "try to find the owner(s) of the file and then operate on those owning targets. "
-               "Unlike `--owner-of`, Pants will fail if there is no owning target for that file."
+               "try to find the owner(s) of the file and then operate on those owning targets.\n\n"
+               "Unlike `--owner-of`, Pants defaults to failing if there is no owning target for "
+               "that file. You may change this through `--owners-not-found-behavior=ignore` or "
+               "`--owners-not-found-behavior=warn`."
              ),
              help='Select the targets that own these files. '
                   'This is the third target calculation strategy along with the --changed-* '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -339,7 +339,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                "`./pants list src/python/f1.py src/python/f2.py` or even "
                "`./pants fmt 'src/python/**/*.py'`.\n\nInstead of `--owner-of=@my_file`, use "
                "`--spec-file=my_file`.\n\nJust like with `--owner-of`, Pants will "
-               "try to find the owner(s) of the file and then operate on those owning targets."
+               "try to find the owner(s) of the file and then operate on those owning targets. "
+               "Unlike `--owner-of`, Pants will fail if there is no owning target for that file."
              ),
              help='Select the targets that own these files. '
                   'This is the third target calculation strategy along with the --changed-* '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -51,6 +51,13 @@ class FileNotFoundBehavior(Enum):
     return GlobMatchErrorBehavior(self.value)
 
 
+class OwnersNotFoundBehavior(Enum):
+  """What to do when a file argument cannot be mapped to an owning target."""
+  ignore = "ignore"
+  warn = "warn"
+  error = "error"
+
+
 class BuildFileImportsBehavior(Enum):
   allow = "allow"
   warn = "warn"
@@ -308,6 +315,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). '
                   'The `--pants-distdir` and `--pants-workdir` locations are inherently ignored.')
+    register(
+      "--owners-not-found-behavior", advanced=True,
+      type=OwnersNotFoundBehavior, default=OwnersNotFoundBehavior.error,
+      help="What to do when file arguments do not have any owning target. This happens when there "
+           "are no targets with the file argument included in their `sources` field."
+    )
     register("--files-not-found-behavior", advanced=True,
              type=FileNotFoundBehavior, default=FileNotFoundBehavior.warn,
              help="What to do when files and globs specified in BUILD files, such as in the "

--- a/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
@@ -27,10 +27,17 @@ class FilesystemSpecsIntegrationTest(PantsRunIntegrationTest):
     )
 
   def test_no_owner(self) -> None:
-    no_owning_file = 'testprojects/tests/python/pants/nonexistent/test_nonexistent.py'
+    """Literal file args should fail when there is no owner, but globs should be fine."""
+    nonexistent_folder = "testprojects/tests/python/pants/nonexistent"
+    no_owning_file = f'{nonexistent_folder}/test_nonexistent.py'
     touch(no_owning_file)
     try:
       pants_run = self.run_pants(['list', no_owning_file])
+      self.assert_failure(pants_run)
+      assert f"No owning targets could be found for the file `{no_owning_file}`." in pants_run.stderr_data
+
+      pants_run = self.run_pants(['list', f"{nonexistent_folder}/*.py"])
       assert 'WARNING: No targets were matched in' in pants_run.stderr_data
+      self.assert_success(pants_run)
     finally:
       rm_rf(os.path.dirname(no_owning_file))


### PR DESCRIPTION
### Prior behavior
Currently, we no-op when there is no owner for a file arg:
```
▶ ./pants --no-print-exception-stacktrace filedeps --no-transitive build-support/pants_venv
Scrubbed PYTHONPATH....

```

This is confusing. If a user were to run `./pants filedeps build-support:pants_venv`, where `:pants_venv` does not exist, then we would throw an exception.

### New option
Now, we allow users to decide whether they want to `error`, `warn`, or `allow`, with a default of `error`.

```
▶ ./pants --no-print-exception-stacktrace filedeps --no-transitive build-support/pants_venv
Scrubbed PYTHONPATH...

ERROR: No owning targets could be found for the file `build-support/pants_venv`.

Please check that there is a BUILD file in `build-support` with a target whose `sources` field includes `build-support/pants_venv`. See https://www.pantsbuild.org/build_files.html.
```

The `allow` is for certain applications like scripts that might operate on files not incorporated by Pants, which Pants should gracefully no-op over.

### Exception for file globs
We do not apply this option when file globs are used, like `./pants filedeps 'build-support/**/*'`. This mirrors the behavior of the target globs `:` and `::`, which will find all possible targets and no-op on non-targets.