### PR TITLE
Port to tokio 0.2, and to stdlib futures for fs and task_executor

### DIFF
--- a/src/rust/engine/ASYNC.md
+++ b/src/rust/engine/ASYNC.md
@@ -1,0 +1,9 @@
+
+# async-await port notes
+
+Many functions at the boundary between ported async-await, stdlib futures code and legacy
+future 0.1 code temporarily return futures 0.3 BoxFuture and use explicit lifetimes, because that
+is easier for a futures 0.1 consumer. stdlib futures consumers can easily call async functions with
+references (because they can remain "on the stack"), but an 0.1 future cannot. These methods can be
+swapped back to async once all callers are using async-await.
+

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,7 +211,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -906,6 +907,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -915,7 +917,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2068,6 +2070,7 @@ version = "0.0.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "process_execution 0.0.1",
  "store 0.1.0",
@@ -2790,7 +2793,6 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -3003,18 +3005,13 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-fs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-udp 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-uds 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3048,16 +3045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-connect"
 version = "0.1.0"
 source = "git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b#f7ad1ca437973d6e24037ac6f7d5ef1013833c0b"
@@ -3082,16 +3069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3192,37 +3169,6 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4001,11 +3947,9 @@ dependencies = [
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
-"checksum tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
 "checksum tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 "checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-"checksum tokio-fs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
 "checksum tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
@@ -4014,8 +3958,6 @@ dependencies = [
 "checksum tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 "checksum tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 "checksum tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-"checksum tokio-udp 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-"checksum tokio-uds 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -42,6 +42,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "async-trait"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "async_semaphore"
 version = "0.0.1"
 dependencies = [
@@ -682,12 +692,14 @@ dependencies = [
 name = "engine"
 version = "0.0.1"
 dependencies = [
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "concrete_time 0.0.1",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.0.1",
  "hashing 0.0.1",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -707,6 +719,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -722,6 +735,7 @@ dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
@@ -859,9 +873,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fs"
 version = "0.0.1"
 dependencies = [
- "boxfuture 0.0.1",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,8 +884,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1690,15 +1703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nails"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2030,7 +2043,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
- "nails 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nails 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2653,7 +2666,7 @@ version = "0.0.1"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2757,6 +2770,7 @@ dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
  "hashing 0.0.1",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2881,8 +2895,7 @@ dependencies = [
 name = "task_executor"
 version = "0.0.1"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -3010,8 +3023,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3043,22 +3055,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-compat"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3723,6 +3719,7 @@ dependencies = [
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -3874,7 +3871,7 @@ dependencies = [
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-"checksum nails 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2c608b13791e902e685701016a522b958ac1e1cb9197c6c002c44914947d52"
+"checksum nails 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbf022f659381fd767684f3f1d46b55a20b3d0902d4c722f9f78589d8afa4156"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
@@ -4005,7 +4002,6 @@ dependencies = [
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-"checksum tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4000e3c984d0e58ace4926f1eae4d830a90a76c386dccf5b82aeca4cbee6df"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
 "checksum tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 "checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -520,14 +520,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -879,6 +871,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2049,10 +2042,8 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-process 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -2068,7 +2059,7 @@ dependencies = [
  "process_execution 0.0.1",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2638,11 +2629,11 @@ version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2784,7 +2775,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2893,7 +2884,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -3019,9 +3010,19 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-macros 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3042,6 +3043,22 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-compat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3102,24 +3119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-process"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-signal 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,22 +3147,6 @@ dependencies = [
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3244,6 +3227,19 @@ dependencies = [
  "tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3769,7 +3765,6 @@ dependencies = [
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
@@ -4010,22 +4005,22 @@ dependencies = [
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
+"checksum tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4000e3c984d0e58ace4926f1eae4d830a90a76c386dccf5b82aeca4cbee6df"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
 "checksum tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 "checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 "checksum tokio-fs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
-"checksum tokio-process 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "382d90f43fa31caebe5d3bc6cfd854963394fff3b8cb59d5146607aaae7e7e43"
 "checksum tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 "checksum tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d7cf08f990090abd6c6a73cab46fed62f85e8aef8b99e4b918a9f4a637f0676"
-"checksum tokio-signal 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 "checksum tokio-sync 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 "checksum tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 "checksum tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 "checksum tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 "checksum tokio-udp 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 "checksum tokio-uds 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798"
+"checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum tower-add-origin 0.1.0 (git+https://github.com/pantsbuild/tower-http?rev=56049ee7f31d4f6c549f5d1d5fbbfd7937df3d00)" = "<none>"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -656,6 +656,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
@@ -668,7 +669,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -825,7 +826,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -857,7 +858,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -1132,7 +1133,7 @@ dependencies = [
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1238,7 +1239,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1255,7 +1256,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1506,7 +1507,7 @@ dependencies = [
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1648,7 +1649,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1987,7 +1988,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2005,7 +2006,7 @@ dependencies = [
  "process_execution 0.0.1",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2079,7 +2080,7 @@ name = "protoc"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2362,7 +2363,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2593,7 +2594,7 @@ dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2736,7 +2737,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -2843,7 +2844,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2942,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2998,7 +2999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3012,7 +3013,7 @@ dependencies = [
  "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3477,7 +3478,7 @@ dependencies = [
  "concrete_time 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3779,7 +3780,7 @@ dependencies = [
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+"checksum tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1501,12 +1501,12 @@ version = "0.0.1"
 dependencies = [
  "cargo 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3475,9 +3475,9 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time 0.0.1",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -103,14 +103,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -248,7 +240,6 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -431,32 +422,6 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cookie"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "copy_dir"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,8 +439,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -504,37 +483,6 @@ name = "crossbeam-channel"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -712,7 +660,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rule_graph 0.0.1",
  "sharded_lmdb 0.0.1",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -722,7 +670,7 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
@@ -789,14 +737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -984,15 +924,6 @@ dependencies = [
 name = "futures-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "futures-executor"
@@ -1188,6 +1119,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hashing"
 version = "0.0.1"
 dependencies = [
@@ -1240,14 +1189,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.1.0"
+name = "http"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1265,47 +1222,42 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.35"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1528,14 +1480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,14 +1530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memchr"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memoffset"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "mime"
@@ -1908,36 +1844,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1960,6 +1872,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2163,18 +2093,6 @@ dependencies = [
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "protobuf-codegen 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2421,36 +2339,36 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.24"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2519,14 +2437,25 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2557,17 +2486,32 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "scopeguard"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2630,13 +2574,13 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2998,31 +2942,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3035,40 +2963,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-connect"
 version = "0.1.0"
 source = "git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b#f7ad1ca437973d6e24037ac6f7d5ef1013833c0b"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3092,83 +2992,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-rustls"
-version = "0.10.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3282,6 +3113,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tower-util"
 version = "0.1.0"
 source = "git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c#7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c"
@@ -3295,14 +3131,6 @@ dependencies = [
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "try_from"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "typenum"
@@ -3462,10 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3481,6 +3308,8 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3496,6 +3325,17 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3562,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3671,7 +3511,6 @@ dependencies = [
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -3698,17 +3537,14 @@ dependencies = [
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
-"checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+"checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+"checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 "checksum crates-io 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "091018c3f5e8109d82d94b648555f0d4a308d15626da2fb22c76f32117e24569"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
-"checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
-"checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crypto-hash 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
@@ -3729,7 +3565,6 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -3748,7 +3583,6 @@ dependencies = [
 "checksum futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
 "checksum futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
 "checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
-"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
 "checksum futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
 "checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
@@ -3767,16 +3601,18 @@ dependencies = [
 "checksum grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63ccc27b0099347d2bea2c3d0f1c79c018a13cfd08b814a1992e341b645d5e1"
 "checksum grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29302b90cfa76231a757a887d1e3153331a63c7f80b6c75f86366334cbe70708"
 "checksum http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-"checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
+"checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
+"checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
-"checksum hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952"
+"checksum hyper 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+"checksum hyper-rustls 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e"
@@ -3799,14 +3635,12 @@ dependencies = [
 "checksum lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lmdb-sys 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
-"checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
-"checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
@@ -3839,12 +3673,12 @@ dependencies = [
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
-"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
-"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+"checksum pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 "checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
@@ -3862,7 +3696,6 @@ dependencies = [
 "checksum protobuf-codegen 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c12a571137dc99703cb46fa21f185834fc5578a65836573fcff127f7b53f41e1"
 "checksum protoc 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd83d2547a9e2c8bc6016607281b3ec7ef4871c55be6930915481d80350ab88"
 "checksum protoc-grpcio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b0292d93a536174ff6bafe8b5e8534aeeb2b039146bae59770c07f4d2c2458c9"
-"checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -3890,7 +3723,7 @@ dependencies = [
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
+"checksum reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -3898,13 +3731,15 @@ dependencies = [
 "checksum rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfix 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7150ac777a2931a53489f5a41eb0937b84e3092a20cd0e73ad436b65b507f607"
-"checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+"checksum rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+"checksum rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+"checksum security-framework 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
+"checksum security-framework-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
@@ -3912,7 +3747,7 @@ dependencies = [
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum serde_test 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "33f96dff8c3744387b53404ea33e834073b0791dcc1ea9c85b805745f9324704"
-"checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+"checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
@@ -3944,20 +3779,11 @@ dependencies = [
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
-"checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
-"checksum tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-"checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
-"checksum tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-"checksum tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d7cf08f990090abd6c6a73cab46fed62f85e8aef8b99e4b918a9f4a637f0676"
-"checksum tokio-sync 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-"checksum tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-"checksum tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
-"checksum tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
+"checksum tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
@@ -3968,9 +3794,9 @@ dependencies = [
 "checksum tower-h2 0.1.0 (git+https://github.com/pantsbuild/tower-h2?rev=44b0efb4983b769283efd5b2a3bc3decbf7c33de)" = "<none>"
 "checksum tower-http 0.1.0 (git+https://github.com/pantsbuild/tower-http?rev=56049ee7f31d4f6c549f5d1d5fbbfd7937df3d00)" = "<none>"
 "checksum tower-service 0.2.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)" = "<none>"
+"checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum tower-util 0.1.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)" = "<none>"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-"checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
@@ -3992,17 +3818,18 @@ dependencies = [
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
-"checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
+"checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
 "checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+"checksum wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8bbdd49e3e28b40dec6a9ba8d17798245ce32b019513a845369c641b275135d9"
 "checksum wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
 "checksum wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
 "checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
 "checksum wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
 "checksum web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
 "checksum webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
-"checksum webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
+"checksum webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -100,7 +100,7 @@ num_enum = "0.4"
 parking_lot = "0.6"
 process_execution = { path = "process_execution" }
 rand = "0.6"
-reqwest = { version = "0.9.22", default_features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.10", default_features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }
 sharded_lmdb = { path = "sharded_lmdb" }
 smallvec = "0.6"
@@ -108,7 +108,7 @@ store = { path = "fs/store" }
 tempfile = "3"
 time = "0.1.40"
 ui = { path = "ui" }
-url = "1.7.1"
+url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
 task_executor = { path = "task_executor" }
 tokio = { version = "0.2", features = ["rt-threaded"] }

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -81,12 +81,14 @@ default-members = [
 ]
 
 [dependencies]
+async-trait = "0.1"
 boxfuture = { path = "boxfuture" }
 bytes = "0.4.5"
 concrete_time = { path = "concrete_time" }
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"
@@ -109,6 +111,7 @@ ui = { path = "ui" }
 url = "1.7.1"
 uuid = { version = "0.7", features = ["v4"] }
 task_executor = { path = "task_executor" }
+tokio = { version = "0.2", features = ["rt-threaded"] }
 workunit_store = { path = "workunit_store" }
 
 [patch.crates-io]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -96,6 +96,7 @@ itertools = "0.8.2"
 lazy_static = "1"
 log = "0.4"
 logging = { path = "logging" }
+num_cpus = "1"
 num_enum = "0.4"
 parking_lot = "0.6"
 process_execution = { path = "process_execution" }
@@ -105,13 +106,13 @@ rule_graph = { path = "rule_graph" }
 sharded_lmdb = { path = "sharded_lmdb" }
 smallvec = "0.6"
 store = { path = "fs/store" }
+task_executor = { path = "task_executor" }
 tempfile = "3"
 time = "0.1.40"
+tokio = { version = "0.2", features = ["rt-threaded"] }
 ui = { path = "ui" }
 url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
-task_executor = { path = "task_executor" }
-tokio = { version = "0.2", features = ["rt-threaded"] }
 workunit_store = { path = "workunit_store" }
 
 [patch.crates-io]

--- a/src/rust/engine/engine_cffi/Cargo.toml
+++ b/src/rust/engine/engine_cffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 engine = { path = ".." }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../hashing" }
 log = "0.4"
 logging = { path = "../logging" }

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1118,7 +1118,7 @@ pub extern "C" fn init_logging(level: u64, show_rust_3rdparty_logs: bool) {
 
 #[no_mangle]
 pub extern "C" fn setup_pantsd_logger(log_file_ptr: *const raw::c_char, level: u64) -> PyResult {
-  logging::set_destination(Destination::Pantsd);
+  logging::set_thread_destination(Destination::Pantsd);
 
   let path_str = unsafe { CStr::from_ptr(log_file_ptr).to_string_lossy().into_owned() };
   let path = PathBuf::from(path_str);
@@ -1132,7 +1132,7 @@ pub extern "C" fn setup_pantsd_logger(log_file_ptr: *const raw::c_char, level: u
 // Might be called before externs are set, therefore can't return a PyResult
 #[no_mangle]
 pub extern "C" fn setup_stderr_logger(level: u64) {
-  logging::set_destination(Destination::Stderr);
+  logging::set_thread_destination(Destination::Stderr);
   LOGGER
     .set_stderr_logger(level)
     .expect("Error setting up STDERR logger");
@@ -1171,7 +1171,7 @@ pub extern "C" fn flush_log() {
 
 #[no_mangle]
 pub extern "C" fn override_thread_logging_destination(destination: Destination) {
-  logging::set_destination(destination);
+  logging::set_thread_destination(destination);
 }
 
 fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph<Rule> {

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -43,6 +43,7 @@ use engine::{
   externs, nodes, Core, ExecutionRequest, ExecutionTermination, Function, Handle, Key, Params,
   RootResult, Rule, Scheduler, Session, Tasks, TypeId, Types, Value,
 };
+use futures::compat::Future01CompatExt;
 use futures01::{future, Future};
 use hashing::{Digest, EMPTY_DIGEST};
 use log::{error, warn, Log};
@@ -896,7 +897,8 @@ pub extern "C" fn capture_snapshots(
           })
           .collect::<Vec<_>>(),
       )
-      .map(|values| externs::store_tuple(&values)),
+      .map(|values| externs::store_tuple(&values))
+      .compat(),
     )
   })
   .into()
@@ -926,11 +928,10 @@ pub extern "C" fn merge_directories(
     scheduler
       .core
       .executor
-      .block_on(store::Snapshot::merge_directories(
-        scheduler.core.store(),
-        digests,
-        workunit_store,
-      ))
+      .block_on(
+        store::Snapshot::merge_directories(scheduler.core.store(), digests, workunit_store)
+          .compat(),
+      )
       .map(|dir| nodes::Snapshot::store_directory(&scheduler.core, &dir))
       .into()
   })
@@ -975,13 +976,11 @@ pub extern "C" fn run_local_interactive_process(
               None => unreachable!()
             };
 
-            let write_operation = scheduler.core.store().materialize_directory(
+            scheduler.core.store().materialize_directory(
               destination,
               digest,
               session.workunit_store(),
-            );
-
-            scheduler.core.executor.spawn_on_io_pool(write_operation).wait()?;
+            ).wait()?;
           }
         }
 
@@ -1058,7 +1057,7 @@ pub extern "C" fn materialize_directories(
     let types = &scheduler.core.types;
     let construct_materialize_directories_results = types.construct_materialize_directories_results;
     let construct_materialize_directory_result = types.construct_materialize_directory_result;
-    let work_future = future::join_all(
+    future::join_all(
       digests_and_path_prefixes
         .into_iter()
         .map(|(digest, path_prefix)| {
@@ -1105,9 +1104,8 @@ pub extern "C" fn materialize_directories(
         &[externs::store_tuple(&entries)],
       );
       output
-    });
-
-    scheduler.core.executor.spawn_on_io_pool(work_future).wait()
+    })
+    .wait()
   })
   .into()
 }
@@ -1202,7 +1200,7 @@ where
   F: FnOnce(&Scheduler) -> T,
 {
   let scheduler = unsafe { Box::from_raw(scheduler_ptr) };
-  let t = f(&scheduler);
+  let t = scheduler.core.runtime.enter(|| f(&scheduler));
   mem::forget(scheduler);
   t
 }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -6,9 +6,9 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-boxfuture = { path = "../boxfuture" }
+async-trait = "0.1"
 bytes = "0.4.5"
-futures01 = { package = "futures", version = "0.1" }
+futures = "0.3"
 glob = "0.2.11"
 ignore = "0.4.4"
 lazy_static = "1"
@@ -19,5 +19,4 @@ tempfile = "3"
 
 [dev-dependencies]
 testutil = { path = "../testutil" }
-tokio = "0.1"
-tokio-compat = "0.1"
+tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -20,3 +20,4 @@ tempfile = "3"
 [dev-dependencies]
 testutil = { path = "../testutil" }
 tokio = "0.1"
+tokio-compat = "0.1"

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -13,6 +13,7 @@ env_logger = "0.5.4"
 errno = "0.2.3"
 fuse = "0.3.1"
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"
@@ -22,7 +23,7 @@ serverset = { path = "../../serverset" }
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.1.39"
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 workunit_store = { path = "../../workunit_store" }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -413,96 +413,100 @@ impl fuse::Filesystem for BuildResultFS {
     name: &OsStr,
     reply: fuse::ReplyEntry,
   ) {
-    let r = match (parent, name.to_str()) {
-      (ROOT, Some("digest")) => Ok(dir_attr_for(DIGEST_ROOT)),
-      (ROOT, Some("directory")) => Ok(dir_attr_for(DIRECTORY_ROOT)),
-      (DIGEST_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
-        Ok(digest) => self
-          .inode_for_file(digest, true)
-          .map_err(|err| {
-            error!("Error loading file by digest {}: {}", digest_str, err);
-            libc::EINVAL
-          })
-          .and_then(|maybe_inode| {
-            maybe_inode
-              .and_then(|inode| self.file_attr_for(inode))
-              .ok_or(libc::ENOENT)
-          }),
-        Err(err) => {
-          warn!("Invalid digest for file in digest root: {}", err);
-          Err(libc::ENOENT)
-        }
-      },
-      (DIRECTORY_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
-        Ok(digest) => self.dir_attr_for(digest),
-        Err(err) => {
-          warn!("Invalid digest for directory in directory root: {}", err);
-          Err(libc::ENOENT)
-        }
-      },
-      (parent, Some(filename)) => {
-        let maybe_cache_entry = self
-          .inode_digest_cache
-          .get(&parent)
-          .cloned()
-          .ok_or(libc::ENOENT);
-        maybe_cache_entry
-          .and_then(|cache_entry| {
-            let parent_digest = cache_entry.digest;
-            self
-              .runtime
-              .block_on(
-                self
-                  .store
-                  .load_directory(parent_digest, WorkUnitStore::new())
-                  .compat(),
-              )
-              .map_err(|err| {
-                error!("Error reading directory {:?}: {}", parent_digest, err);
-                libc::EINVAL
-              })?
-              .and_then(|(directory, _metadata)| self.node_for_digest(&directory, filename))
-              .ok_or(libc::ENOENT)
-          })
-          .and_then(|node| match node {
-            Node::Directory(directory_node) => {
-              let digest_result: Result<Digest, String> = directory_node.get_digest().into();
-              let digest = digest_result.map_err(|err| {
-                error!("Error parsing digest: {:?}", err);
-                libc::ENOENT
-              })?;
-              self.dir_attr_for(digest)
-            }
-            Node::File(file_node) => {
-              let digest_result: Result<Digest, String> = file_node.get_digest().into();
-              let digest = digest_result.map_err(|err| {
-                error!("Error parsing digest: {:?}", err);
-                libc::ENOENT
-              })?;
+    let runtime = self.runtime.clone();
+    runtime.enter(|| {
+      let r = match (parent, name.to_str()) {
+        (ROOT, Some("digest")) => Ok(dir_attr_for(DIGEST_ROOT)),
+        (ROOT, Some("directory")) => Ok(dir_attr_for(DIRECTORY_ROOT)),
+        (DIGEST_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
+          Ok(digest) => self
+            .inode_for_file(digest, true)
+            .map_err(|err| {
+              error!("Error loading file by digest {}: {}", digest_str, err);
+              libc::EINVAL
+            })
+            .and_then(|maybe_inode| {
+              maybe_inode
+                .and_then(|inode| self.file_attr_for(inode))
+                .ok_or(libc::ENOENT)
+            }),
+          Err(err) => {
+            warn!("Invalid digest for file in digest root: {}", err);
+            Err(libc::ENOENT)
+          }
+        },
+        (DIRECTORY_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
+          Ok(digest) => self.dir_attr_for(digest),
+          Err(err) => {
+            warn!("Invalid digest for directory in directory root: {}", err);
+            Err(libc::ENOENT)
+          }
+        },
+        (parent, Some(filename)) => {
+          let maybe_cache_entry = self
+            .inode_digest_cache
+            .get(&parent)
+            .cloned()
+            .ok_or(libc::ENOENT);
+          maybe_cache_entry
+            .and_then(|cache_entry| {
+              let parent_digest = cache_entry.digest;
               self
-                .inode_for_file(digest, file_node.get_is_executable())
+                .runtime
+                .block_on(
+                  self
+                    .store
+                    .load_directory(parent_digest, WorkUnitStore::new())
+                    .compat(),
+                )
                 .map_err(|err| {
-                  error!("Error loading file by digest {}: {}", filename, err);
+                  error!("Error reading directory {:?}: {}", parent_digest, err);
                   libc::EINVAL
-                })
-                .and_then(|maybe_inode| {
-                  maybe_inode
-                    .and_then(|inode| self.file_attr_for(inode))
-                    .ok_or(libc::ENOENT)
-                })
-            }
-          })
+                })?
+                .and_then(|(directory, _metadata)| self.node_for_digest(&directory, filename))
+                .ok_or(libc::ENOENT)
+            })
+            .and_then(|node| match node {
+              Node::Directory(directory_node) => {
+                let digest_result: Result<Digest, String> = directory_node.get_digest().into();
+                let digest = digest_result.map_err(|err| {
+                  error!("Error parsing digest: {:?}", err);
+                  libc::ENOENT
+                })?;
+                self.dir_attr_for(digest)
+              }
+              Node::File(file_node) => {
+                let digest_result: Result<Digest, String> = file_node.get_digest().into();
+                let digest = digest_result.map_err(|err| {
+                  error!("Error parsing digest: {:?}", err);
+                  libc::ENOENT
+                })?;
+                self
+                  .inode_for_file(digest, file_node.get_is_executable())
+                  .map_err(|err| {
+                    error!("Error loading file by digest {}: {}", filename, err);
+                    libc::EINVAL
+                  })
+                  .and_then(|maybe_inode| {
+                    maybe_inode
+                      .and_then(|inode| self.file_attr_for(inode))
+                      .ok_or(libc::ENOENT)
+                  })
+              }
+            })
+        }
+        _ => Err(libc::ENOENT),
+      };
+      match r {
+        Ok(r) => reply.entry(&TTL, &r, 1),
+        Err(err) => reply.error(err),
       }
-      _ => Err(libc::ENOENT),
-    };
-    match r {
-      Ok(r) => reply.entry(&TTL, &r, 1),
-      Err(err) => reply.error(err),
-    }
+    })
   }
 
   fn getattr(&mut self, _req: &fuse::Request<'_>, inode: Inode, reply: fuse::ReplyAttr) {
-    match inode {
+    let runtime = self.runtime.clone();
+    runtime.enter(|| match inode {
       ROOT => reply.attr(&TTL, &dir_attr_for(ROOT)),
       DIGEST_ROOT => reply.attr(&TTL, &dir_attr_for(DIGEST_ROOT)),
       DIRECTORY_ROOT => reply.attr(&TTL, &dir_attr_for(DIRECTORY_ROOT)),
@@ -520,7 +524,7 @@ impl fuse::Filesystem for BuildResultFS {
         }) => reply.attr(&TTL, &dir_attr_for(inode)),
         _ => reply.error(libc::ENOENT),
       },
-    }
+    })
   }
 
   // TODO: Find out whether fh is ever passed if open isn't explicitly implemented (and whether offset is ever negative)
@@ -533,53 +537,56 @@ impl fuse::Filesystem for BuildResultFS {
     size: u32,
     reply: fuse::ReplyData,
   ) {
-    match self.inode_digest_cache.get(&inode) {
-      Some(&InodeDetails {
-        digest,
-        entry_type: EntryType::File,
-        ..
-      }) => {
-        let reply = Arc::new(Mutex::new(Some(reply)));
-        let reply2 = reply.clone();
-        // TODO: Read from a cache of Futures driven from a CPU pool, so we can merge in-flight
-        // requests, rather than reading from the store directly here.
-        let result: Result<(), ()> = self
-          .runtime
-          .block_on(
-            self
-              .store
-              .load_file_bytes_with(
-                digest,
-                move |bytes| {
-                  let begin = std::cmp::min(offset as usize, bytes.len());
-                  let end = std::cmp::min(offset as usize + size as usize, bytes.len());
-                  let mut reply = reply.lock();
-                  reply.take().unwrap().data(&bytes.slice(begin, end));
-                },
-                WorkUnitStore::new(),
-              )
-              .compat(),
-          )
-          .map(|v| {
-            if v.is_none() {
+    let runtime = self.runtime.clone();
+    runtime.enter(|| {
+      match self.inode_digest_cache.get(&inode) {
+        Some(&InodeDetails {
+          digest,
+          entry_type: EntryType::File,
+          ..
+        }) => {
+          let reply = Arc::new(Mutex::new(Some(reply)));
+          let reply2 = reply.clone();
+          // TODO: Read from a cache of Futures driven from a CPU pool, so we can merge in-flight
+          // requests, rather than reading from the store directly here.
+          let result: Result<(), ()> = self
+            .runtime
+            .block_on(
+              self
+                .store
+                .load_file_bytes_with(
+                  digest,
+                  move |bytes| {
+                    let begin = std::cmp::min(offset as usize, bytes.len());
+                    let end = std::cmp::min(offset as usize + size as usize, bytes.len());
+                    let mut reply = reply.lock();
+                    reply.take().unwrap().data(&bytes.slice(begin, end));
+                  },
+                  WorkUnitStore::new(),
+                )
+                .compat(),
+            )
+            .map(|v| {
+              if v.is_none() {
+                let maybe_reply = reply2.lock().take();
+                if let Some(reply) = maybe_reply {
+                  reply.error(libc::ENOENT);
+                }
+              }
+            })
+            .or_else(|err| {
+              error!("Error loading bytes for {:?}: {}", digest, err);
               let maybe_reply = reply2.lock().take();
               if let Some(reply) = maybe_reply {
-                reply.error(libc::ENOENT);
+                reply.error(libc::EINVAL);
               }
-            }
-          })
-          .or_else(|err| {
-            error!("Error loading bytes for {:?}: {}", digest, err);
-            let maybe_reply = reply2.lock().take();
-            if let Some(reply) = maybe_reply {
-              reply.error(libc::EINVAL);
-            }
-            Ok(())
-          });
-        result.expect("Error from read future which should have been handled in the future ");
+              Ok(())
+            });
+          result.expect("Error from read future which should have been handled in the future ");
+        }
+        _ => reply.error(libc::ENOENT),
       }
-      _ => reply.error(libc::ENOENT),
-    }
+    })
   }
 
   fn readdir(
@@ -591,23 +598,26 @@ impl fuse::Filesystem for BuildResultFS {
     offset: i64,
     mut reply: fuse::ReplyDirectory,
   ) {
-    match self.readdir_entries(inode) {
-      Ok(entries) => {
-        // 0 is a magic offset which means no offset, whereas a non-zero offset means start
-        // _after_ that entry. Inconsistency is fun.
-        let to_skip = if offset == 0 { 0 } else { offset + 1 } as usize;
-        let mut i = offset;
-        for entry in entries.into_iter().skip(to_skip) {
-          if reply.add(entry.inode, i, entry.kind, entry.name) {
-            // Buffer is full, don't add more entries.
-            break;
+    let runtime = self.runtime.clone();
+    runtime.enter(|| {
+      match self.readdir_entries(inode) {
+        Ok(entries) => {
+          // 0 is a magic offset which means no offset, whereas a non-zero offset means start
+          // _after_ that entry. Inconsistency is fun.
+          let to_skip = if offset == 0 { 0 } else { offset + 1 } as usize;
+          let mut i = offset;
+          for entry in entries.into_iter().skip(to_skip) {
+            if reply.add(entry.inode, i, entry.kind, entry.name) {
+              // Buffer is full, don't add more entries.
+              break;
+            }
+            i += 1;
           }
-          i += 1;
+          reply.ok();
         }
-        reply.ok();
+        Err(err) => reply.error(err),
       }
-      Err(err) => reply.error(err),
-    }
+    })
   }
 
   // If this isn't implemented, OSX will try to manipulate ._ files to manage xattrs out of band, which adds both overhead and logspam.
@@ -618,7 +628,10 @@ impl fuse::Filesystem for BuildResultFS {
     _size: u32,
     reply: fuse::ReplyXattr,
   ) {
-    reply.size(0);
+    let runtime = self.runtime.clone();
+    runtime.enter(|| {
+      reply.size(0);
+    })
   }
 }
 

--- a/src/rust/engine/fs/brfs/src/syscall_tests.rs
+++ b/src/rust/engine/fs/brfs/src/syscall_tests.rs
@@ -4,24 +4,28 @@
 use super::mount;
 use super::tests::digest_to_filepath;
 use crate::tests::make_dirs;
+use futures::compat::Future01CompatExt;
 use libc;
 use std::ffi::CString;
 use std::path::Path;
 use store::Store;
 use testutil::data::TestData;
+use tokio::runtime::Handle;
 
-#[test]
-fn read_file_by_digest_exact_bytes() {
+#[tokio::test]
+async fn read_file_by_digest_exact_bytes() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -2,18 +2,20 @@ use tempfile;
 use testutil;
 
 use crate::mount;
+use futures::compat::Future01CompatExt;
 use hashing;
 use store::Store;
 use testutil::{
   data::{TestData, TestDirectory},
   file,
 };
+use tokio::runtime::Handle;
 
-#[test]
-fn missing_digest() {
+#[tokio::test]
+async fn missing_digest() {
   let (store_dir, mount_dir) = make_dirs();
 
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -26,18 +28,20 @@ fn missing_digest() {
     .exists());
 }
 
-#[test]
-fn read_file_by_digest() {
+#[tokio::test]
+async fn read_file_by_digest() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
 
   let test_bytes = TestData::roland();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
@@ -49,10 +53,10 @@ fn read_file_by_digest() {
   assert!(file::is_executable(&file_path));
 }
 
-#[test]
-fn list_directory() {
+#[tokio::test]
+async fn list_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -60,11 +64,15 @@ fn list_directory() {
   let test_bytes = TestData::roland();
   let test_directory = TestDirectory::containing_roland();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.record_directory(&test_directory.directory(), false))
+  store
+    .record_directory(&test_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
@@ -75,10 +83,10 @@ fn list_directory() {
   assert_eq!(vec!["roland"], file::list_dir(&virtual_dir));
 }
 
-#[test]
-fn read_file_from_directory() {
+#[tokio::test]
+async fn read_file_from_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -86,11 +94,15 @@ fn read_file_from_directory() {
   let test_bytes = TestData::roland();
   let test_directory = TestDirectory::containing_roland();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.record_directory(&test_directory.directory(), false))
+  store
+    .record_directory(&test_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
@@ -103,10 +115,10 @@ fn read_file_from_directory() {
   assert!(!file::is_executable(&roland));
 }
 
-#[test]
-fn list_recursive_directory() {
+#[tokio::test]
+async fn list_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -116,17 +128,25 @@ fn list_recursive_directory() {
   let test_directory = TestDirectory::containing_roland();
   let recursive_directory = TestDirectory::recursive();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.store_file_bytes(treat_bytes.bytes(), false))
+  store
+    .store_file_bytes(treat_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.record_directory(&test_directory.directory(), false))
+  store
+    .record_directory(&test_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
-  runtime
-    .block_on(store.record_directory(&recursive_directory.directory(), false))
+  store
+    .record_directory(&recursive_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
@@ -138,10 +158,10 @@ fn list_recursive_directory() {
   assert_eq!(vec!["roland"], file::list_dir(&virtual_dir.join("cats")));
 }
 
-#[test]
-fn read_file_from_recursive_directory() {
+#[tokio::test]
+async fn read_file_from_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -151,17 +171,25 @@ fn read_file_from_recursive_directory() {
   let test_directory = TestDirectory::containing_roland();
   let recursive_directory = TestDirectory::recursive();
 
-  runtime
-    .block_on(store.store_file_bytes(test_bytes.bytes(), false))
+  store
+    .store_file_bytes(test_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.store_file_bytes(treat_bytes.bytes(), false))
+  store
+    .store_file_bytes(treat_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.record_directory(&test_directory.directory(), false))
+  store
+    .record_directory(&test_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
-  runtime
-    .block_on(store.record_directory(&recursive_directory.directory(), false))
+  store
+    .record_directory(&recursive_directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");
@@ -178,10 +206,10 @@ fn read_file_from_recursive_directory() {
   assert!(!file::is_executable(&roland));
 }
 
-#[test]
-fn files_are_correctly_executable() {
+#[tokio::test]
+async fn files_are_correctly_executable() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -189,11 +217,15 @@ fn files_are_correctly_executable() {
   let treat_bytes = TestData::catnip();
   let directory = TestDirectory::with_mixed_executable_files();
 
-  runtime
-    .block_on(store.store_file_bytes(treat_bytes.bytes(), false))
+  store
+    .store_file_bytes(treat_bytes.bytes(), false)
+    .compat()
+    .await
     .expect("Storing bytes");
-  runtime
-    .block_on(store.record_directory(&directory.directory(), false))
+  store
+    .record_directory(&directory.directory(), false)
+    .compat()
+    .await
     .expect("Storing directory");
 
   let _fs = mount(mount_dir.path(), store, runtime).expect("Mounting");

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -12,6 +12,7 @@ clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
@@ -21,5 +22,5 @@ serde_json = "1.0"
 serde_derive = "1.0"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 workunit_store = { path = "../../workunit_store" }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -37,6 +37,8 @@ use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use clap::{value_t, App, Arg, SubCommand};
 use fs::GlobMatching;
+use futures::compat::Future01CompatExt;
+use futures::future::TryFutureExt;
 use futures01::{future, Future};
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
@@ -49,6 +51,7 @@ use std::process::exit;
 use std::sync::Arc;
 use std::time::Duration;
 use store::{Snapshot, Store, StoreFileByDigest, UploadSummary};
+use tokio::runtime::Handle;
 
 #[derive(Debug)]
 enum ExitCode {
@@ -71,7 +74,8 @@ struct SummaryWithDigest {
   summary: Option<UploadSummary>,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
   env_logger::init();
 
   match execute(
@@ -254,7 +258,7 @@ to this directory.",
               .default_value("3")
         )
       .get_matches(),
-  ) {
+  ).await {
     Ok(_) => {}
     Err(err) => {
       eprintln!("{}", err.0);
@@ -263,12 +267,14 @@ to this directory.",
   };
 }
 
-fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
+// TODO: Sure, it's a bit long...
+#[allow(clippy::cognitive_complexity)]
+async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
   let store_dir = top_match
     .value_of("local-store-path")
     .map(PathBuf::from)
     .unwrap_or_else(Store::default_path);
-  let runtime = task_executor::Executor::new();
+  let runtime = task_executor::Executor::new(Handle::current());
   let (store, store_has_remote) = {
     let (store_result, store_has_remote) = match top_match.values_of("server-address") {
       Some(cas_address) => {
@@ -353,11 +359,14 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             .parse::<usize>()
             .expect("size_bytes must be a non-negative number");
           let digest = Digest(fingerprint, size_bytes);
-          let write_result = runtime.block_on(store.load_file_bytes_with(
-            digest,
-            |bytes| io::stdout().write_all(&bytes).unwrap(),
-            workunit_store::WorkUnitStore::new(),
-          ))?;
+          let write_result = store
+            .load_file_bytes_with(
+              digest,
+              |bytes| io::stdout().write_all(&bytes).unwrap(),
+              workunit_store::WorkUnitStore::new(),
+            )
+            .compat()
+            .await?;
           write_result
             .ok_or_else(|| {
               ExitError(
@@ -380,18 +389,19 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           );
           let file = posix_fs
             .stat_sync(PathBuf::from(path.file_name().unwrap()))
-            .unwrap();
+            .unwrap()
+            .ok_or_else(|| format!("Tried to save file {:?} but it did not exist", path))?;
           match file {
             fs::Stat::File(f) => {
-              let digest = runtime
-                .block_on(
-                  store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs))
-                    .store_by_digest(f, workunit_store::WorkUnitStore::new()),
-                )
+              let digest = store::OneOffStoreFileByDigest::new(store.clone(), Arc::new(posix_fs))
+                .store_by_digest(f, workunit_store::WorkUnitStore::new())
+                .compat()
+                .await
                 .unwrap();
 
-              let report = runtime
-                .block_on(ensure_uploaded_to_remote(&store, store_has_remote, digest))
+              let report = ensure_uploaded_to_remote(&store, store_has_remote, digest)
+                .compat()
+                .await
                 .unwrap();
               print_upload_summary(args.value_of("output-mode"), &report);
 
@@ -419,12 +429,10 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .parse::<usize>()
           .expect("size_bytes must be a non-negative number");
         let digest = Digest(fingerprint, size_bytes);
-        runtime
-          .block_on(store.materialize_directory(
-            destination,
-            digest,
-            workunit_store::WorkUnitStore::new(),
-          ))
+        store
+          .materialize_directory(destination, digest, workunit_store::WorkUnitStore::new())
+          .compat()
+          .await
           .map(|metadata| {
             eprintln!("{}", serde_json::to_string_pretty(&metadata).unwrap());
           })
@@ -442,33 +450,35 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           args.value_of("root").unwrap(),
         ));
         let store_copy = store.clone();
-        let digest = runtime.block_on(
-          posix_fs
-            .expand(fs::PathGlobs::create(
-              &args
-                .values_of("globs")
-                .unwrap()
-                .map(str::to_string)
-                .collect::<Vec<String>>(),
-              // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
-              // that a valid assumption?
-              fs::StrictGlobMatching::Ignore,
-              fs::GlobExpansionConjunction::AllMatch,
-            )?)
-            .map_err(|e| format!("Error expanding globs: {:?}", e))
-            .and_then(move |paths| {
-              Snapshot::from_path_stats(
-                store_copy.clone(),
-                &store::OneOffStoreFileByDigest::new(store_copy, posix_fs),
-                paths,
-                workunit_store::WorkUnitStore::new(),
-              )
-            })
-            .map(|snapshot| snapshot.digest),
-        )?;
+        let digest = posix_fs
+          .expand(fs::PathGlobs::create(
+            &args
+              .values_of("globs")
+              .unwrap()
+              .map(str::to_string)
+              .collect::<Vec<String>>(),
+            // By using `Ignore`, we say that we don't care if some globs fail to expand. Is
+            // that a valid assumption?
+            fs::StrictGlobMatching::Ignore,
+            fs::GlobExpansionConjunction::AllMatch,
+          )?)
+          .compat()
+          .map_err(|e| format!("Error expanding globs: {:?}", e))
+          .and_then(move |paths| {
+            Snapshot::from_path_stats(
+              store_copy.clone(),
+              &store::OneOffStoreFileByDigest::new(store_copy, posix_fs),
+              paths,
+              workunit_store::WorkUnitStore::new(),
+            )
+          })
+          .map(|snapshot| snapshot.digest)
+          .compat()
+          .await?;
 
-        let report = runtime
-          .block_on(ensure_uploaded_to_remote(&store, store_has_remote, digest))
+        let report = ensure_uploaded_to_remote(&store, store_has_remote, digest)
+          .compat()
+          .await
           .unwrap();
         print_upload_summary(args.value_of("output-mode"), &report);
 
@@ -483,37 +493,37 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .expect("size_bytes must be a non-negative number");
         let digest = Digest(fingerprint, size_bytes);
         let proto_bytes = match args.value_of("output-format").unwrap() {
-          "binary" => runtime
-            .block_on(store.load_directory(digest, workunit_store::WorkUnitStore::new()))
+          "binary" => store
+            .load_directory(digest, workunit_store::WorkUnitStore::new())
+            .compat()
+            .await
             .map(|maybe_d| maybe_d.map(|(d, _metadata)| d.write_to_bytes().unwrap())),
-          "text" => runtime
-            .block_on(store.load_directory(digest, workunit_store::WorkUnitStore::new()))
+          "text" => store
+            .load_directory(digest, workunit_store::WorkUnitStore::new())
+            .compat()
+            .await
             .map(|maybe_p| maybe_p.map(|(p, _metadata)| format!("{:?}\n", p).as_bytes().to_vec())),
-          "recursive-file-list" => runtime
-            .block_on(expand_files(store, digest))
-            .map(|maybe_v| {
+          "recursive-file-list" => expand_files(store, digest).compat().await.map(|maybe_v| {
+            maybe_v
+              .map(|v| {
+                v.into_iter()
+                  .map(|(name, _digest)| format!("{}\n", name))
+                  .collect::<Vec<String>>()
+                  .join("")
+              })
+              .map(String::into_bytes)
+          }),
+          "recursive-file-list-with-digests" => {
+            expand_files(store, digest).compat().await.map(|maybe_v| {
               maybe_v
                 .map(|v| {
                   v.into_iter()
-                    .map(|(name, _digest)| format!("{}\n", name))
+                    .map(|(name, digest)| format!("{} {} {}\n", name, digest.0, digest.1))
                     .collect::<Vec<String>>()
                     .join("")
                 })
                 .map(String::into_bytes)
-            }),
-          "recursive-file-list-with-digests" => {
-            runtime
-              .block_on(expand_files(store, digest))
-              .map(|maybe_v| {
-                maybe_v
-                  .map(|v| {
-                    v.into_iter()
-                      .map(|(name, digest)| format!("{} {} {}\n", name, digest.0, digest.1))
-                      .collect::<Vec<String>>()
-                      .join("")
-                  })
-                  .map(String::into_bytes)
-              })
+            })
           }
           format => Err(format!(
             "Unexpected value of --output-format arg: {}",
@@ -541,12 +551,12 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         .parse::<usize>()
         .expect("size_bytes must be a non-negative number");
       let digest = Digest(fingerprint, size_bytes);
-      let v = match runtime.block_on(store.load_file_bytes_with(
-        digest,
-        |bytes| bytes,
-        workunit_store::WorkUnitStore::new(),
-      ))? {
-        None => runtime.block_on(
+      let v = match store
+        .load_file_bytes_with(digest, |bytes| bytes, workunit_store::WorkUnitStore::new())
+        .compat()
+        .await?
+      {
+        None => {
           store
             .load_directory(digest, workunit_store::WorkUnitStore::new())
             .map(|maybe_dir| {
@@ -557,8 +567,10 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
                     .expect("Error serializing Directory proto"),
                 )
               })
-            }),
-        )?,
+            })
+            .compat()
+            .await?
+        }
         Some((bytes, _metadata)) => Some(bytes),
       };
       match v {

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -6,8 +6,8 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use boxfuture::{BoxFuture, Boxable};
-use futures01::{future, Future};
+use async_trait::async_trait;
+use futures::future::{self, BoxFuture, TryFutureExt};
 use glob::Pattern;
 use log::warn;
 use parking_lot::Mutex;
@@ -17,6 +17,7 @@ use crate::{
   StrictGlobMatching, VFS,
 };
 
+#[async_trait]
 pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// Canonicalize the Link for the given Path to an underlying File or Dir. May result
@@ -26,15 +27,18 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// TODO: Should handle symlink loops (which would exhibit as an infinite loop in expand).
   ///
-  fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> BoxFuture<Option<PathStat>, E> {
-    GlobMatchingImplementation::canonicalize(self, symbolic_path, link)
+  async fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> Result<Option<PathStat>, E> {
+    GlobMatchingImplementation::canonicalize(self, symbolic_path, link).await
   }
 
   ///
   /// Recursively expands PathGlobs into PathStats while applying excludes.
   ///
-  fn expand(&self, path_globs: PathGlobs) -> BoxFuture<Vec<PathStat>, E> {
-    GlobMatchingImplementation::expand(self, path_globs)
+  /// TODO: See the note on references in ASYNC.md.
+  ///
+  fn expand<'a, 'b>(&'a self, path_globs: PathGlobs) -> BoxFuture<'b, Result<Vec<PathStat>, E>> {
+    let fs = self.clone();
+    Box::pin(async move { GlobMatchingImplementation::expand(&fs, path_globs).await })
   }
 }
 
@@ -44,70 +48,64 @@ impl<E: Display + Send + Sync + 'static, T: VFS<E>> GlobMatching<E> for T {}
 // traits don't allow specifying private methods (and we don't want to use a top-level `fn` because
 // it's much more awkward than just specifying `&self`).
 // The methods of `GlobMatching` are forwarded to methods here.
+#[async_trait]
 trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
-  fn directory_listing(
+  async fn directory_listing(
     &self,
     canonical_dir: Dir,
     symbolic_path: PathBuf,
     wildcard: Pattern,
     exclude: &Arc<GitignoreStyleExcludes>,
-  ) -> BoxFuture<Vec<PathStat>, E> {
+  ) -> Result<Vec<PathStat>, E> {
     // List the directory.
-    let context = self.clone();
-    let exclude = exclude.clone();
+    let dir_listing = self.scandir(canonical_dir).await?;
 
-    self
-      .scandir(canonical_dir)
-      .and_then(move |dir_listing| {
-        // Match any relevant Stats, and join them into PathStats.
-        future::join_all(
-          dir_listing
-            .0
-            .iter()
-            .filter(|stat| {
-              // Match relevant filenames.
-              stat
-                .path()
-                .file_name()
-                .map(|file_name| wildcard.matches_path(Path::new(file_name)))
-                .unwrap_or(false)
-            })
-            .filter_map(|stat| {
-              // Append matched filenames.
-              stat
-                .path()
-                .file_name()
-                .map(|file_name| symbolic_path.join(file_name))
-                .map(|symbolic_stat_path| (symbolic_stat_path, stat))
-            })
-            .map(|(stat_symbolic_path, stat)| {
-              // Canonicalize matched PathStats, and filter paths that are ignored by local excludes.
-              // Context ("global") ignore patterns are applied during `scandir`.
-              if exclude.is_ignored(&stat) {
-                future::ok(None).to_boxed()
-              } else {
-                match stat {
-                  Stat::Link(l) => context.canonicalize(stat_symbolic_path, l.clone()),
-                  Stat::Dir(d) => {
-                    future::ok(Some(PathStat::dir(stat_symbolic_path, d.clone()))).to_boxed()
-                  }
-                  Stat::File(f) => {
-                    future::ok(Some(PathStat::file(stat_symbolic_path, f.clone()))).to_boxed()
-                  }
-                }
+    // Match any relevant Stats, and join them into PathStats.
+    let path_stats = future::try_join_all(
+      dir_listing
+        .0
+        .iter()
+        .filter(|stat| {
+          // Match relevant filenames.
+          stat
+            .path()
+            .file_name()
+            .map(|file_name| wildcard.matches_path(Path::new(file_name)))
+            .unwrap_or(false)
+        })
+        .filter_map(|stat| {
+          // Append matched filenames.
+          stat
+            .path()
+            .file_name()
+            .map(|file_name| symbolic_path.join(file_name))
+            .map(|symbolic_stat_path| (symbolic_stat_path, stat))
+        })
+        .map(|(stat_symbolic_path, stat)| {
+          let context = self.clone();
+          let exclude = exclude.clone();
+          async move {
+            // Canonicalize matched PathStats, and filter paths that are ignored by local excludes.
+            // Context ("global") ignore patterns are applied during `scandir`.
+            if exclude.is_ignored(&stat) {
+              Ok(None)
+            } else {
+              match stat {
+                Stat::Link(l) => context.canonicalize(stat_symbolic_path, l.clone()).await,
+                Stat::Dir(d) => Ok(Some(PathStat::dir(stat_symbolic_path, d.clone()))),
+                Stat::File(f) => Ok(Some(PathStat::file(stat_symbolic_path, f.clone()))),
               }
-            })
-            .collect::<Vec<_>>(),
-        )
-      })
-      .map(|path_stats| {
-        // See the note above.
-        path_stats.into_iter().filter_map(|pso| pso).collect()
-      })
-      .to_boxed()
+            }
+          }
+        })
+        .collect::<Vec<_>>(),
+    )
+    .await?;
+    // See the note above.
+    Ok(path_stats.into_iter().filter_map(|pso| pso).collect())
   }
 
-  fn expand(&self, path_globs: PathGlobs) -> BoxFuture<Vec<PathStat>, E> {
+  async fn expand(&self, path_globs: PathGlobs) -> Result<Vec<PathStat>, E> {
     let PathGlobs {
       include,
       exclude,
@@ -117,7 +115,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     } = path_globs;
 
     if include.is_empty() {
-      return future::ok(vec![]).to_boxed();
+      return Ok(vec![]);
     }
 
     let result = Arc::new(Mutex::new(Vec::new()));
@@ -132,139 +130,144 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
       }
     }
 
-    future::join_all(roots)
-      .and_then(move |matched| {
-        if strict_match_behavior.should_check_glob_matches() {
-          // Get all the inputs which didn't transitively expand to any files.
-          let matching_inputs = sources
-            .iter()
-            .zip(matched.into_iter())
-            .filter_map(
-              |(source, matched)| {
-                if matched {
-                  Some(source.clone())
-                } else {
-                  None
-                }
-              },
-            )
-            .collect::<HashSet<_>>();
+    let matched = future::try_join_all(roots).await?;
 
-          let non_matching_inputs = sources
-            .into_iter()
-            .filter(|s| !matching_inputs.contains(s))
-            .collect::<HashSet<_>>();
-
-          let match_failed = match conjunction {
-            // All must match.
-            GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
-            // Only one needs to match.
-            GlobExpansionConjunction::AnyMatch => matching_inputs.is_empty(),
-          };
-
-          if match_failed {
-            let mut non_matching_inputs = non_matching_inputs
-              .iter()
-              .map(|parsed_source| parsed_source.0.clone())
-              .collect::<Vec<_>>();
-            non_matching_inputs.sort();
-            let single_glob = non_matching_inputs.len() == 1;
-            let prefix = format!("Unmatched glob{}", if single_glob { "" } else { "s" });
-            let origin = match &strict_match_behavior {
-              StrictGlobMatching::Warn(description) | StrictGlobMatching::Error(description) => {
-                format!(" from {}: ", description)
-              }
-              _ => ": ".to_string(),
-            };
-            let unmatched_globs = if single_glob {
-              format!("{:?}", non_matching_inputs[0])
+    if strict_match_behavior.should_check_glob_matches() {
+      // Get all the inputs which didn't transitively expand to any files.
+      let matching_inputs = sources
+        .iter()
+        .zip(matched.into_iter())
+        .filter_map(
+          |(source, matched)| {
+            if matched {
+              Some(source.clone())
             } else {
-              format!("{:?}", non_matching_inputs)
-            };
-            let exclude_patterns = exclude.exclude_patterns();
-            let excludes_portion = if exclude_patterns.is_empty() {
-              "".to_string()
-            } else {
-              let single_exclude = exclude_patterns.len() == 1;
-              if single_exclude {
-                format!(", exclude: {:?}", exclude_patterns[0])
-              } else {
-                format!(", excludes: {:?}", exclude_patterns)
-              }
-            };
-            let msg = format!(
-              "{}{}{}{}",
-              prefix, origin, unmatched_globs, excludes_portion
-            );
-            if strict_match_behavior.should_throw_on_error() {
-              return future::err(Self::mk_error(&msg));
-            } else {
-              warn!("{}", msg);
+              None
             }
-          }
-        }
+          },
+        )
+        .collect::<HashSet<_>>();
 
-        let mut path_stats = Arc::try_unwrap(result)
-          .unwrap_or_else(|_| panic!("expand violated its contract."))
-          .into_inner()
-          .into_iter()
+      let non_matching_inputs = sources
+        .into_iter()
+        .filter(|s| !matching_inputs.contains(s))
+        .collect::<HashSet<_>>();
+
+      let match_failed = match conjunction {
+        // All must match.
+        GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
+        // Only one needs to match.
+        GlobExpansionConjunction::AnyMatch => matching_inputs.is_empty(),
+      };
+
+      if match_failed {
+        let mut non_matching_inputs = non_matching_inputs
+          .iter()
+          .map(|parsed_source| parsed_source.0.clone())
           .collect::<Vec<_>>();
-        path_stats.sort_by(|a, b| a.path().cmp(b.path()));
-        path_stats.dedup_by(|a, b| a.path() == b.path());
-        future::ok(path_stats)
-      })
-      .to_boxed()
+        non_matching_inputs.sort();
+        let single_glob = non_matching_inputs.len() == 1;
+        let prefix = format!("Unmatched glob{}", if single_glob { "" } else { "s" });
+        let origin = match &strict_match_behavior {
+          StrictGlobMatching::Warn(description) | StrictGlobMatching::Error(description) => {
+            format!(" from {}: ", description)
+          }
+          _ => ": ".to_string(),
+        };
+        let unmatched_globs = if single_glob {
+          format!("{:?}", non_matching_inputs[0])
+        } else {
+          format!("{:?}", non_matching_inputs)
+        };
+        let exclude_patterns = exclude.exclude_patterns();
+        let excludes_portion = if exclude_patterns.is_empty() {
+          "".to_string()
+        } else {
+          let single_exclude = exclude_patterns.len() == 1;
+          if single_exclude {
+            format!(", exclude: {:?}", exclude_patterns[0])
+          } else {
+            format!(", excludes: {:?}", exclude_patterns)
+          }
+        };
+        let msg = format!(
+          "{}{}{}{}",
+          prefix, origin, unmatched_globs, excludes_portion
+        );
+        if strict_match_behavior.should_throw_on_error() {
+          return Err(Self::mk_error(&msg));
+        } else {
+          warn!("{}", msg);
+        }
+      }
+    }
+
+    let mut path_stats = Arc::try_unwrap(result)
+      .unwrap_or_else(|_| panic!("expand violated its contract."))
+      .into_inner()
+      .into_iter()
+      .collect::<Vec<_>>();
+    path_stats.sort_by(|a, b| a.path().cmp(b.path()));
+    path_stats.dedup_by(|a, b| a.path() == b.path());
+    Ok(path_stats)
   }
 
-  fn expand_single(
+  async fn expand_single(
     &self,
     result: Arc<Mutex<Vec<PathStat>>>,
     exclude: Arc<GitignoreStyleExcludes>,
     path_glob: PathGlob,
-  ) -> BoxFuture<bool, E> {
+  ) -> Result<bool, E> {
     match path_glob {
       PathGlob::Wildcard {
         canonical_dir,
         symbolic_path,
         wildcard,
-      } => self.expand_wildcard(result, exclude, canonical_dir, symbolic_path, wildcard),
+      } => {
+        self
+          .expand_wildcard(result, exclude, canonical_dir, symbolic_path, wildcard)
+          .await
+      }
       PathGlob::DirWildcard {
         canonical_dir,
         symbolic_path,
         wildcard,
         remainder,
-      } => self.expand_dir_wildcard(
-        result,
-        exclude,
-        canonical_dir,
-        symbolic_path,
-        wildcard,
-        remainder,
-      ),
+      } => {
+        self
+          .expand_dir_wildcard(
+            result,
+            exclude,
+            canonical_dir,
+            symbolic_path,
+            wildcard,
+            remainder,
+          )
+          .await
+      }
     }
   }
 
-  fn expand_wildcard(
+  async fn expand_wildcard(
     &self,
     result: Arc<Mutex<Vec<PathStat>>>,
     exclude: Arc<GitignoreStyleExcludes>,
     canonical_dir: Dir,
     symbolic_path: PathBuf,
     wildcard: Pattern,
-  ) -> BoxFuture<bool, E> {
+  ) -> Result<bool, E> {
     // Filter directory listing to append PathStats, with no continuation.
-    self
+    let path_stats = self
       .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude)
-      .map(move |path_stats| {
-        let mut result = result.lock();
-        let matched = !path_stats.is_empty();
-        result.extend(path_stats);
-        matched
-      })
-      .to_boxed()
+      .await?;
+
+    let mut result = result.lock();
+    let matched = !path_stats.is_empty();
+    result.extend(path_stats);
+    Ok(matched)
   }
 
-  fn expand_dir_wildcard(
+  async fn expand_dir_wildcard(
     &self,
     result: Arc<Mutex<Vec<PathStat>>>,
     exclude: Arc<GitignoreStyleExcludes>,
@@ -272,64 +275,58 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     symbolic_path: PathBuf,
     wildcard: Pattern,
     remainder: Vec<Pattern>,
-  ) -> BoxFuture<bool, E> {
+  ) -> Result<bool, E> {
     // Filter directory listing and recurse for matched Dirs.
     let context = self.clone();
-    self
+    let path_stats = self
       .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude)
-      .and_then(move |path_stats| {
-        path_stats
-          .into_iter()
-          .filter_map(|ps| match ps {
-            PathStat::Dir { path, stat } => Some(
-              PathGlob::parse_globs(stat, path, &remainder).map_err(|e| Self::mk_error(e.as_str())),
-            ),
-            PathStat::File { .. } => None,
-          })
-          .collect::<Result<Vec<_>, E>>()
+      .await?;
+
+    let path_globs = path_stats
+      .into_iter()
+      .filter_map(|ps| match ps {
+        PathStat::Dir { path, stat } => Some(
+          PathGlob::parse_globs(stat, path, &remainder).map_err(|e| Self::mk_error(e.as_str())),
+        ),
+        PathStat::File { .. } => None,
       })
-      .and_then(move |path_globs| {
-        let child_globs = path_globs
-          .into_iter()
-          .flat_map(Vec::into_iter)
-          .map(|pg| context.expand_single(result.clone(), exclude.clone(), pg))
-          .collect::<Vec<_>>();
-        future::join_all(child_globs)
-          .map(|child_matches| child_matches.into_iter().any(|m| m))
-          .to_boxed()
-      })
-      .to_boxed()
+      .collect::<Result<Vec<_>, E>>()?;
+
+    let child_globs = path_globs
+      .into_iter()
+      .flat_map(Vec::into_iter)
+      .map(|pg| context.expand_single(result.clone(), exclude.clone(), pg))
+      .collect::<Vec<_>>();
+
+    let child_matches = future::try_join_all(child_globs).await?;
+    Ok(child_matches.into_iter().any(|m| m))
   }
 
-  fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> BoxFuture<Option<PathStat>, E> {
+  async fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> Result<Option<PathStat>, E> {
     // Read the link, which may result in PathGlob(s) that match 0 or 1 Path.
     let context = self.clone();
-    self
+    // If the link destination can't be parsed as PathGlob(s), it is broken.
+    let link_globs = self
       .read_link(&link)
-      .map(|dest_path| {
-        // If the link destination can't be parsed as PathGlob(s), it is broken.
-        dest_path
-          .to_str()
-          .and_then(|dest_str| {
-            // Escape any globs in the parsed dest, which should guarantee one output PathGlob.
-            PathGlob::create(&[Pattern::escape(dest_str)]).ok()
-          })
-          .unwrap_or_else(|| vec![])
+      .await?
+      .to_str()
+      .and_then(|dest_str| {
+        // Escape any globs in the parsed dest, which should guarantee one output PathGlob.
+        PathGlob::create(&[Pattern::escape(dest_str)]).ok()
       })
-      .and_then(move |link_globs| {
-        future::result(PathGlobs::from_globs(link_globs))
-          .map_err(|e| Self::mk_error(e.as_str()))
-          .and_then(move |path_globs| context.expand(path_globs))
-      })
+      .unwrap_or_else(|| vec![]);
+
+    let path_globs = PathGlobs::from_globs(link_globs).map_err(|e| Self::mk_error(e.as_str()))?;
+    let mut path_stats = context
+      .expand(path_globs)
       .map_err(move |e| Self::mk_error(&format!("While expanding link {:?}: {}", link.0, e)))
-      .map(|mut path_stats| {
-        // Since we've escaped any globs in the parsed path, expect either 0 or 1 destination.
-        path_stats.pop().map(|ps| match ps {
-          PathStat::Dir { stat, .. } => PathStat::dir(symbolic_path, stat),
-          PathStat::File { stat, .. } => PathStat::file(symbolic_path, stat),
-        })
-      })
-      .to_boxed()
+      .await?;
+
+    // Since we've escaped any globs in the parsed path, expect either 0 or 1 destination.
+    Ok(path_stats.pop().map(|ps| match ps {
+      PathStat::Dir { stat, .. } => PathStat::dir(symbolic_path, stat),
+      PathStat::File { stat, .. } => PathStat::file(symbolic_path, stat),
+    }))
   }
 }
 

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -38,7 +38,7 @@ fn read_file() {
     0o600,
   );
   let fs = new_posixfs(&dir.path());
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+  let mut rt = tokio_compat::runtime::Runtime::new().unwrap();
   let file_content = rt
     .block_on(fs.read_file(&File {
       path: path.clone(),
@@ -159,7 +159,7 @@ fn scandir_empty() {
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("empty_enclosure");
   std::fs::create_dir(dir.path().join(&path)).unwrap();
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
+  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
   assert_eq!(
     runtime.block_on(posix_fs.scandir(Dir(path))).unwrap(),
     DirectoryListing(vec![])
@@ -195,7 +195,7 @@ fn scandir() {
     0o600,
   );
 
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
+  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
 
   // Symlink aware.
   assert_eq!(
@@ -284,7 +284,7 @@ fn path_stats_for_paths() {
   std::os::unix::fs::symlink("doesnotexist", &root_path.join("symlink_to_nothing")).unwrap();
 
   let posix_fs = Arc::new(new_posixfs(&root_path));
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
+  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
   let path_stats = runtime
     .block_on(posix_fs.path_stats(vec![
       PathBuf::from("executable_file"),
@@ -370,7 +370,7 @@ fn memfs_expand_basic() {
 
 fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
   let fs = new_posixfs(path);
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
+  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
   let stats = runtime
     .block_on(fs.scandir(Dir(PathBuf::from("."))))
     .unwrap();

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -5,30 +5,31 @@ use crate::{
   Dir, DirectoryListing, File, GlobExpansionConjunction, GlobMatching, Link, PathGlobs, PathStat,
   PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior, VFS,
 };
-use boxfuture::{BoxFuture, Boxable};
-use futures01::future::{self, Future};
+
+use async_trait::async_trait;
 use std;
 use std::collections::HashMap;
 use std::path::{Components, Path, PathBuf};
 use std::sync::Arc;
 use testutil::make_file;
+use tokio::runtime::Handle;
 
-#[test]
-fn is_executable_false() {
+#[tokio::test]
+async fn is_executable_false() {
   let dir = tempfile::TempDir::new().unwrap();
   make_file(&dir.path().join("marmosets"), &[], 0o611);
-  assert_only_file_is_executable(dir.path(), false);
+  assert_only_file_is_executable(dir.path(), false).await;
 }
 
-#[test]
-fn is_executable_true() {
+#[tokio::test]
+async fn is_executable_true() {
   let dir = tempfile::TempDir::new().unwrap();
   make_file(&dir.path().join("photograph_marmosets"), &[], 0o700);
-  assert_only_file_is_executable(dir.path(), true);
+  assert_only_file_is_executable(dir.path(), true).await;
 }
 
-#[test]
-fn read_file() {
+#[tokio::test]
+async fn read_file() {
   let dir = tempfile::TempDir::new().unwrap();
   let path = PathBuf::from("marmosets");
   let content = "cute".as_bytes().to_vec();
@@ -38,37 +39,37 @@ fn read_file() {
     0o600,
   );
   let fs = new_posixfs(&dir.path());
-  let mut rt = tokio_compat::runtime::Runtime::new().unwrap();
-  let file_content = rt
-    .block_on(fs.read_file(&File {
+  let file_content = fs
+    .read_file(&File {
       path: path.clone(),
       is_executable: false,
-    }))
+    })
+    .await
     .unwrap();
   assert_eq!(file_content.path, path);
   assert_eq!(file_content.content, content);
 }
 
-#[test]
-fn read_file_missing() {
+#[tokio::test]
+async fn read_file_missing() {
   let dir = tempfile::TempDir::new().unwrap();
   new_posixfs(&dir.path())
     .read_file(&File {
       path: PathBuf::from("marmosets"),
       is_executable: false,
     })
-    .wait()
+    .await
     .expect_err("Expected error");
 }
 
-#[test]
-fn stat_executable_file() {
+#[tokio::test]
+async fn stat_executable_file() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("photograph_marmosets");
   make_file(&dir.path().join(&path), &[], 0o700);
   assert_eq!(
-    posix_fs.stat_sync(path.clone()).unwrap(),
+    posix_fs.stat_sync(path.clone()).unwrap().unwrap(),
     super::Stat::File(File {
       path: path,
       is_executable: true,
@@ -76,14 +77,14 @@ fn stat_executable_file() {
   )
 }
 
-#[test]
-fn stat_nonexecutable_file() {
+#[tokio::test]
+async fn stat_nonexecutable_file() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("marmosets");
   make_file(&dir.path().join(&path), &[], 0o600);
   assert_eq!(
-    posix_fs.stat_sync(path.clone()).unwrap(),
+    posix_fs.stat_sync(path.clone()).unwrap().unwrap(),
     super::Stat::File(File {
       path: path,
       is_executable: false,
@@ -91,20 +92,20 @@ fn stat_nonexecutable_file() {
   )
 }
 
-#[test]
-fn stat_dir() {
+#[tokio::test]
+async fn stat_dir() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("enclosure");
   std::fs::create_dir(dir.path().join(&path)).unwrap();
   assert_eq!(
-    posix_fs.stat_sync(path.clone()).unwrap(),
+    posix_fs.stat_sync(path.clone()).unwrap().unwrap(),
     super::Stat::Dir(Dir(path))
   )
 }
 
-#[test]
-fn stat_symlink() {
+#[tokio::test]
+async fn stat_symlink() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("marmosets");
@@ -113,13 +114,13 @@ fn stat_symlink() {
   let link_path = PathBuf::from("remarkably_similar_marmoset");
   std::os::unix::fs::symlink(&dir.path().join(path), dir.path().join(&link_path)).unwrap();
   assert_eq!(
-    posix_fs.stat_sync(link_path.clone()).unwrap(),
+    posix_fs.stat_sync(link_path.clone()).unwrap().unwrap(),
     super::Stat::Link(Link(link_path))
   )
 }
 
-#[test]
-fn stat_symlink_oblivious() {
+#[tokio::test]
+async fn stat_symlink_oblivious() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs_symlink_oblivious(&dir.path());
   let path = PathBuf::from("marmosets");
@@ -129,7 +130,7 @@ fn stat_symlink_oblivious() {
   std::os::unix::fs::symlink(&dir.path().join(path), dir.path().join(&link_path)).unwrap();
   // Symlink oblivious stat will give us the destination type.
   assert_eq!(
-    posix_fs.stat_sync(link_path.clone()).unwrap(),
+    posix_fs.stat_sync(link_path.clone()).unwrap().unwrap(),
     super::Stat::File(File {
       path: link_path,
       is_executable: false,
@@ -137,37 +138,37 @@ fn stat_symlink_oblivious() {
   )
 }
 
-#[test]
-fn stat_other() {
+#[tokio::test]
+async fn stat_other() {
   new_posixfs("/dev")
     .stat_sync(PathBuf::from("null"))
     .expect_err("Want error");
 }
 
-#[test]
-fn stat_missing() {
+#[tokio::test]
+async fn stat_missing() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
-  posix_fs
-    .stat_sync(PathBuf::from("no_marmosets"))
-    .expect_err("Want error");
+  assert_eq!(
+    posix_fs.stat_sync(PathBuf::from("no_marmosets")).unwrap(),
+    None,
+  );
 }
 
-#[test]
-fn scandir_empty() {
+#[tokio::test]
+async fn scandir_empty() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   let path = PathBuf::from("empty_enclosure");
   std::fs::create_dir(dir.path().join(&path)).unwrap();
-  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
   assert_eq!(
-    runtime.block_on(posix_fs.scandir(Dir(path))).unwrap(),
+    posix_fs.scandir(Dir(path)).await.unwrap(),
     DirectoryListing(vec![])
   );
 }
 
-#[test]
-fn scandir() {
+#[tokio::test]
+async fn scandir() {
   let dir = tempfile::TempDir::new().unwrap();
   let path = PathBuf::from("enclosure");
   std::fs::create_dir(dir.path().join(&path)).unwrap();
@@ -195,12 +196,11 @@ fn scandir() {
     0o600,
   );
 
-  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
-
   // Symlink aware.
   assert_eq!(
-    runtime
-      .block_on(new_posixfs(&dir.path()).scandir(Dir(path.clone())))
+    new_posixfs(&dir.path())
+      .scandir(Dir(path.clone()))
+      .await
       .unwrap(),
     DirectoryListing(vec![
       Stat::File(File {
@@ -222,8 +222,9 @@ fn scandir() {
 
   // Symlink oblivious.
   assert_eq!(
-    runtime
-      .block_on(new_posixfs_symlink_oblivious(&dir.path()).scandir(Dir(path)))
+    new_posixfs_symlink_oblivious(&dir.path())
+      .scandir(Dir(path))
+      .await
       .unwrap(),
     DirectoryListing(vec![
       Stat::File(File {
@@ -247,18 +248,18 @@ fn scandir() {
   );
 }
 
-#[test]
-fn scandir_missing() {
+#[tokio::test]
+async fn scandir_missing() {
   let dir = tempfile::TempDir::new().unwrap();
   let posix_fs = new_posixfs(&dir.path());
   posix_fs
     .scandir(Dir(PathBuf::from("no_marmosets_here")))
-    .wait()
+    .await
     .expect_err("Want error");
 }
 
-#[test]
-fn path_stats_for_paths() {
+#[tokio::test]
+async fn path_stats_for_paths() {
   let dir = tempfile::TempDir::new().unwrap();
   let root_path = dir.path();
 
@@ -284,9 +285,8 @@ fn path_stats_for_paths() {
   std::os::unix::fs::symlink("doesnotexist", &root_path.join("symlink_to_nothing")).unwrap();
 
   let posix_fs = Arc::new(new_posixfs(&root_path));
-  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
-  let path_stats = runtime
-    .block_on(posix_fs.path_stats(vec![
+  let path_stats = posix_fs
+    .path_stats(vec![
       PathBuf::from("executable_file"),
       PathBuf::from("regular_file"),
       PathBuf::from("dir"),
@@ -295,7 +295,8 @@ fn path_stats_for_paths() {
       PathBuf::from("dir_symlink"),
       PathBuf::from("symlink_to_nothing"),
       PathBuf::from("doesnotexist"),
-    ]))
+    ])
+    .await
     .unwrap();
   let v: Vec<Option<PathStat>> = vec![
     Some(PathStat::file(
@@ -340,8 +341,8 @@ fn path_stats_for_paths() {
   assert_eq!(v, path_stats);
 }
 
-#[test]
-fn memfs_expand_basic() {
+#[tokio::test]
+async fn memfs_expand_basic() {
   // Create two files, with the effect that there is a nested directory for the longer path.
   let p1 = PathBuf::from("some/file");
   let p2 = PathBuf::from("some/other");
@@ -354,7 +355,7 @@ fn memfs_expand_basic() {
   .unwrap();
 
   assert_eq!(
-    fs.expand(globs).wait().unwrap(),
+    fs.expand(globs).await.unwrap(),
     vec![
       PathStat::file(
         p1.clone(),
@@ -368,12 +369,9 @@ fn memfs_expand_basic() {
   );
 }
 
-fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
+async fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
   let fs = new_posixfs(path);
-  let mut runtime = tokio_compat::runtime::Runtime::new().unwrap();
-  let stats = runtime
-    .block_on(fs.scandir(Dir(PathBuf::from("."))))
-    .unwrap();
+  let stats = fs.scandir(Dir(PathBuf::from("."))).await.unwrap();
   assert_eq!(stats.0.len(), 1);
   match stats.0.get(0).unwrap() {
     &super::Stat::File(File {
@@ -384,14 +382,19 @@ fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
 }
 
 fn new_posixfs<P: AsRef<Path>>(dir: P) -> PosixFS {
-  PosixFS::new(dir.as_ref(), &[], task_executor::Executor::new()).unwrap()
+  PosixFS::new(
+    dir.as_ref(),
+    &[],
+    task_executor::Executor::new(Handle::current()),
+  )
+  .unwrap()
 }
 
 fn new_posixfs_symlink_oblivious<P: AsRef<Path>>(dir: P) -> PosixFS {
   PosixFS::new_with_symlink_behavior(
     dir.as_ref(),
     &[],
-    task_executor::Executor::new(),
+    task_executor::Executor::new(Handle::current()),
     SymlinkBehavior::Oblivious,
   )
   .unwrap()
@@ -446,21 +449,19 @@ impl MemFS {
   }
 }
 
+#[async_trait]
 impl VFS<String> for Arc<MemFS> {
-  fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, String> {
+  async fn read_link(&self, link: &Link) -> Result<PathBuf, String> {
     // The creation of a static filesystem does not allow for Links.
-    future::err(format!("{:?} does not exist within this filesystem.", link)).to_boxed()
+    Err(format!("{:?} does not exist within this filesystem.", link))
   }
 
-  fn scandir(&self, dir: Dir) -> BoxFuture<Arc<DirectoryListing>, String> {
-    future::result(
-      self
-        .contents
-        .get(&dir)
-        .cloned()
-        .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir)),
-    )
-    .to_boxed()
+  async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
+    self
+      .contents
+      .get(&dir)
+      .cloned()
+      .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir))
   }
 
   fn is_ignored(&self, _stat: &Stat) -> bool {

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -36,5 +36,5 @@ workunit_store = {path = "../../workunit_store" }
 maplit = "*"
 mock = { path = "../../testutil/mock" }
 testutil = { path = "../../testutil" }
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-core"] }
 walkdir = "2"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -29,7 +29,6 @@ serde_derive = "1.0"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3"
-tokio-threadpool = "0.1.12"
 uuid = { version = "0.7.1", features = ["v4"] }
 workunit_store = {path = "../../workunit_store" }
 
@@ -37,5 +36,5 @@ workunit_store = {path = "../../workunit_store" }
 maplit = "*"
 mock = { path = "../../testutil/mock" }
 testutil = { path = "../../testutil" }
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio = { version = "0.2", features = ["rt-core", "macros"] }
 walkdir = "2"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -13,6 +13,7 @@ digest = "0.8"
 dirs = "1"
 fs = { path = ".." }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 indexmap = "1.0.2"

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -3,6 +3,7 @@ use super::{EntryType, ShrinkBehavior, GIGABYTES};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
+use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, Future};
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use lmdb::Error::NotFound;
@@ -274,17 +275,23 @@ impl ByteStore {
     self
       .inner
       .executor
-      .spawn_on_io_pool(future::lazy(move || {
+      .spawn_blocking(move || {
         let fingerprint = {
           let mut hasher = Sha256::default();
           hasher.input(&bytes);
           Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
         };
         Ok(Digest(fingerprint, bytes.len()))
-      }))
+      })
+      .boxed()
+      .compat()
       .and_then(move |digest| {
         future::done(dbs)
-          .and_then(move |db| db.store_bytes(digest.0, bytes2, initial_lease))
+          .and_then(move |db| {
+            db.store_bytes(digest.0, bytes2, initial_lease)
+              .boxed()
+              .compat()
+          })
           .map(move |()| digest)
       })
   }
@@ -313,7 +320,7 @@ impl ByteStore {
                 } else {
                     Err(format!("Got hash collision reading from store - digest {:?} was requested, but retrieved bytes with that fingerprint had length {}. Congratulations, you may have broken sha256! Underlying bytes: {:?}", digest, bytes.len(), bytes))
                 }
-            }).to_boxed()
+            }).boxed().compat().to_boxed()
   }
 
   pub fn all_digests(&self, entry_type: EntryType) -> Result<Vec<Digest>, String> {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -1,101 +1,126 @@
 use crate::local::ByteStore;
-use crate::tests::block_on;
 use crate::{EntryType, ShrinkBehavior};
 use bytes::{BufMut, Bytes, BytesMut};
+use futures::compat::Future01CompatExt;
 use hashing::{Digest, Fingerprint};
 use std::path::Path;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
+use tokio::runtime::Handle;
 use walkdir::WalkDir;
 
-#[test]
-fn save_file() {
+#[tokio::test]
+async fn save_file() {
   let dir = TempDir::new().unwrap();
 
   let testdata = TestData::roland();
   assert_eq!(
-    block_on(new_store(dir.path()).store_bytes(EntryType::File, testdata.bytes(), false,)),
+    new_store(dir.path())
+      .store_bytes(EntryType::File, testdata.bytes(), false,)
+      .compat()
+      .await,
     Ok(testdata.digest())
   );
 }
 
-#[test]
-fn save_file_is_idempotent() {
+#[tokio::test]
+async fn save_file_is_idempotent() {
   let dir = TempDir::new().unwrap();
 
   let testdata = TestData::roland();
-  block_on(new_store(dir.path()).store_bytes(EntryType::File, testdata.bytes(), false)).unwrap();
+  new_store(dir.path())
+    .store_bytes(EntryType::File, testdata.bytes(), false)
+    .compat()
+    .await
+    .unwrap();
   assert_eq!(
-    block_on(new_store(dir.path()).store_bytes(EntryType::File, testdata.bytes(), false,)),
+    new_store(dir.path())
+      .store_bytes(EntryType::File, testdata.bytes(), false,)
+      .compat()
+      .await,
     Ok(testdata.digest())
   );
 }
 
-#[test]
-fn roundtrip_file() {
+#[tokio::test]
+async fn roundtrip_file() {
   let testdata = TestData::roland();
   let dir = TempDir::new().unwrap();
 
   let store = new_store(dir.path());
-  let hash = prime_store_with_file_bytes(&store, testdata.bytes());
-  assert_eq!(load_file_bytes(&store, hash), Ok(Some(testdata.bytes())));
+  let hash = prime_store_with_file_bytes(&store, testdata.bytes()).await;
+  assert_eq!(
+    load_file_bytes(&store, hash).await,
+    Ok(Some(testdata.bytes()))
+  );
 }
 
-#[test]
-fn missing_file() {
+#[tokio::test]
+async fn missing_file() {
   let dir = TempDir::new().unwrap();
   assert_eq!(
-    load_file_bytes(&new_store(dir.path()), TestData::roland().digest()),
+    load_file_bytes(&new_store(dir.path()), TestData::roland().digest()).await,
     Ok(None)
   );
 }
 
-#[test]
-fn record_and_load_directory_proto() {
+#[tokio::test]
+async fn record_and_load_directory_proto() {
   let dir = TempDir::new().unwrap();
   let testdir = TestDirectory::containing_roland();
 
   assert_eq!(
-    block_on(new_store(dir.path()).store_bytes(EntryType::Directory, testdir.bytes(), false,)),
+    new_store(dir.path())
+      .store_bytes(EntryType::Directory, testdir.bytes(), false,)
+      .compat()
+      .await,
     Ok(testdir.digest())
   );
 
   assert_eq!(
-    load_directory_proto_bytes(&new_store(dir.path()), testdir.digest()),
+    load_directory_proto_bytes(&new_store(dir.path()), testdir.digest()).await,
     Ok(Some(testdir.bytes()))
   );
 }
 
-#[test]
-fn missing_directory() {
+#[tokio::test]
+async fn missing_directory() {
   let dir = TempDir::new().unwrap();
   let testdir = TestDirectory::containing_roland();
 
   assert_eq!(
-    load_directory_proto_bytes(&new_store(dir.path()), testdir.digest()),
+    load_directory_proto_bytes(&new_store(dir.path()), testdir.digest()).await,
     Ok(None)
   );
 }
 
-#[test]
-fn file_is_not_directory_proto() {
+#[tokio::test]
+async fn file_is_not_directory_proto() {
   let dir = TempDir::new().unwrap();
   let testdata = TestData::roland();
 
-  block_on(new_store(dir.path()).store_bytes(EntryType::File, testdata.bytes(), false)).unwrap();
+  new_store(dir.path())
+    .store_bytes(EntryType::File, testdata.bytes(), false)
+    .compat()
+    .await
+    .unwrap();
 
   assert_eq!(
-    load_directory_proto_bytes(&new_store(dir.path()), testdata.digest()),
+    load_directory_proto_bytes(&new_store(dir.path()), testdata.digest()).await,
     Ok(None)
   );
 }
 
-#[test]
-fn garbage_collect_nothing_to_do() {
+#[tokio::test]
+async fn garbage_collect_nothing_to_do() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes = Bytes::from("0123456789");
-  block_on(store.store_bytes(EntryType::File, bytes.clone(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
   store
     .shrink(10, ShrinkBehavior::Fast)
     .expect("Error shrinking");
@@ -110,17 +135,22 @@ fn garbage_collect_nothing_to_do() {
         .unwrap(),
         10
       )
-    ),
+    )
+    .await,
     Ok(Some(bytes))
   );
 }
 
-#[test]
-fn garbage_collect_nothing_to_do_with_lease() {
+#[tokio::test]
+async fn garbage_collect_nothing_to_do_with_lease() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes = Bytes::from("0123456789");
-  block_on(store.store_bytes(EntryType::File, bytes.clone(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
   let file_fingerprint = Fingerprint::from_hex_string(
     "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
   )
@@ -133,13 +163,13 @@ fn garbage_collect_nothing_to_do_with_lease() {
     .shrink(10, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   assert_eq!(
-    load_bytes(&store, EntryType::File, file_digest),
+    load_bytes(&store, EntryType::File, file_digest).await,
     Ok(Some(bytes))
   );
 }
 
-#[test]
-fn garbage_collect_remove_one_of_two_files_no_leases() {
+#[tokio::test]
+async fn garbage_collect_remove_one_of_two_files_no_leases() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes_1 = Bytes::from("0123456789");
@@ -154,14 +184,30 @@ fn garbage_collect_remove_one_of_two_files_no_leases() {
   )
   .unwrap();
   let digest_2 = Digest(fingerprint_2, 10);
-  block_on(store.store_bytes(EntryType::File, bytes_1.clone(), false)).expect("Error storing");
-  block_on(store.store_bytes(EntryType::File, bytes_2.clone(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes_1.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes_2.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
   store
     .shrink(10, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   let mut entries = Vec::new();
-  entries.push(load_bytes(&store, EntryType::File, digest_1).expect("Error loading bytes"));
-  entries.push(load_bytes(&store, EntryType::File, digest_2).expect("Error loading bytes"));
+  entries.push(
+    load_bytes(&store, EntryType::File, digest_1)
+      .await
+      .expect("Error loading bytes"),
+  );
+  entries.push(
+    load_bytes(&store, EntryType::File, digest_2)
+      .await
+      .expect("Error loading bytes"),
+  );
   assert_eq!(
     1,
     entries.iter().filter(|maybe| maybe.is_some()).count(),
@@ -170,8 +216,8 @@ fn garbage_collect_remove_one_of_two_files_no_leases() {
   );
 }
 
-#[test]
-fn garbage_collect_remove_both_files_no_leases() {
+#[tokio::test]
+async fn garbage_collect_remove_both_files_no_leases() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes_1 = Bytes::from("0123456789");
@@ -186,44 +232,64 @@ fn garbage_collect_remove_both_files_no_leases() {
   )
   .unwrap();
   let digest_2 = Digest(fingerprint_2, 10);
-  block_on(store.store_bytes(EntryType::File, bytes_1.clone(), false)).expect("Error storing");
-  block_on(store.store_bytes(EntryType::File, bytes_2.clone(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes_1.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  store
+    .store_bytes(EntryType::File, bytes_2.clone(), false)
+    .compat()
+    .await
+    .expect("Error storing");
   store
     .shrink(1, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   assert_eq!(
-    load_bytes(&store, EntryType::File, digest_1),
+    load_bytes(&store, EntryType::File, digest_1).await,
     Ok(None),
     "Should have garbage collected {:?}",
     fingerprint_1
   );
   assert_eq!(
-    load_bytes(&store, EntryType::File, digest_2),
+    load_bytes(&store, EntryType::File, digest_2).await,
     Ok(None),
     "Should have garbage collected {:?}",
     fingerprint_2
   );
 }
 
-#[test]
-fn garbage_collect_remove_one_of_two_directories_no_leases() {
+#[tokio::test]
+async fn garbage_collect_remove_one_of_two_directories_no_leases() {
   let dir = TempDir::new().unwrap();
 
   let testdir = TestDirectory::containing_roland();
   let other_testdir = TestDirectory::containing_dnalor();
 
   let store = new_store(dir.path());
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), false)).expect("Error storing");
-  block_on(store.store_bytes(EntryType::Directory, other_testdir.bytes(), false))
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  store
+    .store_bytes(EntryType::Directory, other_testdir.bytes(), false)
+    .compat()
+    .await
     .expect("Error storing");
   store
     .shrink(80, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   let mut entries = Vec::new();
-  entries
-    .push(load_bytes(&store, EntryType::Directory, testdir.digest()).expect("Error loading bytes"));
   entries.push(
-    load_bytes(&store, EntryType::Directory, other_testdir.digest()).expect("Error loading bytes"),
+    load_bytes(&store, EntryType::Directory, testdir.digest())
+      .await
+      .expect("Error loading bytes"),
+  );
+  entries.push(
+    load_bytes(&store, EntryType::Directory, other_testdir.digest())
+      .await
+      .expect("Error loading bytes"),
   );
   assert_eq!(
     1,
@@ -233,106 +299,137 @@ fn garbage_collect_remove_one_of_two_directories_no_leases() {
   );
 }
 
-#[test]
-fn garbage_collect_remove_file_with_leased_directory() {
+#[tokio::test]
+async fn garbage_collect_remove_file_with_leased_directory() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
 
   let testdir = TestDirectory::containing_roland();
   let testdata = TestData::fourty_chars();
 
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), true)).expect("Error storing");
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), true)
+    .compat()
+    .await
+    .expect("Error storing");
 
-  block_on(store.store_bytes(EntryType::File, testdata.bytes(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, testdata.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
 
   store
     .shrink(80, ShrinkBehavior::Fast)
     .expect("Error shrinking");
 
   assert_eq!(
-    load_bytes(&store, EntryType::File, testdata.digest()),
+    load_bytes(&store, EntryType::File, testdata.digest()).await,
     Ok(None),
     "File was present when it should've been garbage collected"
   );
   assert_eq!(
-    load_bytes(&store, EntryType::Directory, testdir.digest()),
+    load_bytes(&store, EntryType::Directory, testdir.digest()).await,
     Ok(Some(testdir.bytes())),
     "Directory was missing despite lease"
   );
 }
 
-#[test]
-fn garbage_collect_remove_file_while_leased_file() {
+#[tokio::test]
+async fn garbage_collect_remove_file_while_leased_file() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
 
   let testdir = TestDirectory::containing_roland();
 
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), false)).expect("Error storing");
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
   let fourty_chars = TestData::fourty_chars();
-  block_on(store.store_bytes(EntryType::File, fourty_chars.bytes(), true)).expect("Error storing");
+  store
+    .store_bytes(EntryType::File, fourty_chars.bytes(), true)
+    .compat()
+    .await
+    .expect("Error storing");
 
   store
     .shrink(80, ShrinkBehavior::Fast)
     .expect("Error shrinking");
 
   assert_eq!(
-    load_bytes(&store, EntryType::File, fourty_chars.digest()),
+    load_bytes(&store, EntryType::File, fourty_chars.digest()).await,
     Ok(Some(fourty_chars.bytes())),
     "File was missing despite lease"
   );
   assert_eq!(
-    load_bytes(&store, EntryType::Directory, testdir.digest()),
+    load_bytes(&store, EntryType::Directory, testdir.digest()).await,
     Ok(None),
     "Directory was present when it should've been garbage collected"
   );
 }
 
-#[test]
-fn garbage_collect_fail_because_too_many_leases() {
+#[tokio::test]
+async fn garbage_collect_fail_because_too_many_leases() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
 
   let testdir = TestDirectory::containing_roland();
   let fourty_chars = TestData::fourty_chars();
 
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), true)).expect("Error storing");
-  block_on(store.store_bytes(EntryType::File, fourty_chars.bytes(), true)).expect("Error storing");
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), true)
+    .compat()
+    .await
+    .expect("Error storing");
+  store
+    .store_bytes(EntryType::File, fourty_chars.bytes(), true)
+    .compat()
+    .await
+    .expect("Error storing");
 
-  block_on(store.store_bytes(EntryType::File, TestData::roland().bytes(), false))
+  store
+    .store_bytes(EntryType::File, TestData::roland().bytes(), false)
+    .compat()
+    .await
     .expect("Error storing");
 
   assert_eq!(store.shrink(80, ShrinkBehavior::Fast), Ok(160));
 
   assert_eq!(
-    load_bytes(&store, EntryType::File, fourty_chars.digest()),
+    load_bytes(&store, EntryType::File, fourty_chars.digest()).await,
     Ok(Some(fourty_chars.bytes())),
     "Leased file should still be present"
   );
   assert_eq!(
-    load_bytes(&store, EntryType::Directory, testdir.digest()),
+    load_bytes(&store, EntryType::Directory, testdir.digest()).await,
     Ok(Some(testdir.bytes())),
     "Leased directory should still be present"
   );
   // Whether the unleased file is present is undefined.
 }
 
-#[test]
-fn garbage_collect_and_compact() {
+async fn write_one_meg(store: &ByteStore, byte: u8) {
+  let mut bytes = BytesMut::with_capacity(1024 * 1024);
+  for _ in 0..1024 * 1024 {
+    bytes.put(byte);
+  }
+  store
+    .store_bytes(EntryType::File, bytes.freeze(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+}
+
+#[tokio::test]
+async fn garbage_collect_and_compact() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
 
-  let write_one_meg = |byte: u8| {
-    let mut bytes = BytesMut::with_capacity(1024 * 1024);
-    for _ in 0..1024 * 1024 {
-      bytes.put(byte);
-    }
-    block_on(store.store_bytes(EntryType::File, bytes.freeze(), false)).expect("Error storing");
-  };
+  write_one_meg(&store, b'0').await;
 
-  write_one_meg(b'0');
-
-  write_one_meg(b'1');
+  write_one_meg(&store, b'1').await;
 
   let size = get_directory_size(dir.path());
   assert!(
@@ -353,103 +450,128 @@ fn garbage_collect_and_compact() {
   );
 }
 
-#[test]
-fn entry_type_for_file() {
+#[tokio::test]
+async fn entry_type_for_file() {
   let testdata = TestData::roland();
   let testdir = TestDirectory::containing_roland();
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), false)).expect("Error storing");
-  prime_store_with_file_bytes(&store, testdata.bytes());
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
     store.entry_type(&testdata.fingerprint()),
     Ok(Some(EntryType::File))
   )
 }
 
-#[test]
-fn entry_type_for_directory() {
+#[tokio::test]
+async fn entry_type_for_directory() {
   let testdata = TestData::roland();
   let testdir = TestDirectory::containing_roland();
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), false)).expect("Error storing");
-  prime_store_with_file_bytes(&store, testdata.bytes());
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
     store.entry_type(&testdir.fingerprint()),
     Ok(Some(EntryType::Directory))
   )
 }
 
-#[test]
-fn entry_type_for_missing() {
+#[tokio::test]
+async fn entry_type_for_missing() {
   let testdata = TestData::roland();
   let testdir = TestDirectory::containing_roland();
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
-  block_on(store.store_bytes(EntryType::Directory, testdir.bytes(), false)).expect("Error storing");
-  prime_store_with_file_bytes(&store, testdata.bytes());
+  store
+    .store_bytes(EntryType::Directory, testdir.bytes(), false)
+    .compat()
+    .await
+    .expect("Error storing");
+  prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
     store.entry_type(&TestDirectory::recursive().fingerprint()),
     Ok(None)
   )
 }
 
-#[test]
-pub fn empty_file_is_known() {
+#[tokio::test]
+async fn empty_file_is_known() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let empty_file = TestData::empty();
   assert_eq!(
-    block_on(store.load_bytes_with(EntryType::File, empty_file.digest(), |b| b)),
+    store
+      .load_bytes_with(EntryType::File, empty_file.digest(), |b| b)
+      .compat()
+      .await,
     Ok(Some(empty_file.bytes())),
   )
 }
 
-#[test]
-pub fn empty_directory_is_known() {
+#[tokio::test]
+async fn empty_directory_is_known() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let empty_dir = TestDirectory::empty();
   assert_eq!(
-    block_on(store.load_bytes_with(EntryType::Directory, empty_dir.digest(), |b| b)),
+    store
+      .load_bytes_with(EntryType::Directory, empty_dir.digest(), |b| b)
+      .compat()
+      .await,
     Ok(Some(empty_dir.bytes())),
   )
 }
 
-#[test]
-pub fn all_digests() {
+#[tokio::test]
+async fn all_digests() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
-  let digest = prime_store_with_file_bytes(&store, TestData::roland().bytes());
+  let digest = prime_store_with_file_bytes(&store, TestData::roland().bytes()).await;
   assert_eq!(Ok(vec![digest]), store.all_digests(EntryType::File));
 }
 
 pub fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
-  ByteStore::new(task_executor::Executor::new(), dir).unwrap()
+  ByteStore::new(task_executor::Executor::new(Handle::current()), dir).unwrap()
 }
 
-pub fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::File, digest)
+pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
+  load_bytes(&store, EntryType::File, digest).await
 }
 
-pub fn load_directory_proto_bytes(
+pub async fn load_directory_proto_bytes(
   store: &ByteStore,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::Directory, digest)
+  load_bytes(&store, EntryType::Directory, digest).await
 }
 
-fn load_bytes(
+pub async fn load_bytes(
   store: &ByteStore,
   entry_type: EntryType,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  block_on(store.load_bytes_with(entry_type, digest, |b| b))
+  store
+    .load_bytes_with(entry_type, digest, |b| b)
+    .compat()
+    .await
 }
 
-fn prime_store_with_file_bytes(store: &ByteStore, bytes: Bytes) -> Digest {
-  block_on(store.store_bytes(EntryType::File, bytes, false)).expect("Error storing file bytes")
+async fn prime_store_with_file_bytes(store: &ByteStore, bytes: Bytes) -> Digest {
+  store
+    .store_bytes(EntryType::File, bytes, false)
+    .compat()
+    .await
+    .expect("Error storing file bytes")
 }
 
 fn get_directory_size(path: &Path) -> usize {

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -1,6 +1,7 @@
 use crate::remote::ByteStore;
 use crate::{EntryType, MEGABYTES};
 use bytes::Bytes;
+use futures::compat::Future01CompatExt;
 use hashing::Digest;
 use mock::StubCAS;
 use serverset::BackoffConfig;
@@ -9,73 +10,78 @@ use std::time::Duration;
 use testutil::data::{TestData, TestDirectory};
 use workunit_store::WorkUnitStore;
 
-use crate::tests::{big_file_bytes, big_file_digest, big_file_fingerprint, block_on, new_cas};
+use crate::tests::{big_file_bytes, big_file_digest, big_file_fingerprint, new_cas};
 
-#[test]
-fn loads_file() {
+#[tokio::test]
+async fn loads_file() {
   let testdata = TestData::roland();
   let cas = new_cas(10);
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()).unwrap(),
+    load_file_bytes(&new_byte_store(&cas), testdata.digest())
+      .await
+      .unwrap(),
     Some(testdata.bytes())
   );
 }
 
-#[test]
-fn missing_file() {
+#[tokio::test]
+async fn missing_file() {
   let cas = StubCAS::empty();
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), TestData::roland().digest()),
+    load_file_bytes(&new_byte_store(&cas), TestData::roland().digest()).await,
     Ok(None)
   );
 }
 
-#[test]
-fn load_directory() {
+#[tokio::test]
+async fn load_directory() {
   let cas = new_cas(10);
   let testdir = TestDirectory::containing_roland();
 
   assert_eq!(
-    load_directory_proto_bytes(&new_byte_store(&cas), testdir.digest()),
+    load_directory_proto_bytes(&new_byte_store(&cas), testdir.digest()).await,
     Ok(Some(testdir.bytes()))
   );
 }
 
-#[test]
-fn missing_directory() {
+#[tokio::test]
+async fn missing_directory() {
   let cas = StubCAS::empty();
 
   assert_eq!(
     load_directory_proto_bytes(
       &new_byte_store(&cas),
       TestDirectory::containing_roland().digest()
-    ),
+    )
+    .await,
     Ok(None)
   );
 }
 
-#[test]
-fn load_file_grpc_error() {
+#[tokio::test]
+async fn load_file_grpc_error() {
   let cas = StubCAS::always_errors();
 
-  let error =
-    load_file_bytes(&new_byte_store(&cas), TestData::roland().digest()).expect_err("Want error");
+  let error = load_file_bytes(&new_byte_store(&cas), TestData::roland().digest())
+    .await
+    .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
     format!("Bad error message, got: {}", error)
   )
 }
 
-#[test]
-fn load_directory_grpc_error() {
+#[tokio::test]
+async fn load_directory_grpc_error() {
   let cas = StubCAS::always_errors();
 
   let error = load_directory_proto_bytes(
     &new_byte_store(&cas),
     TestDirectory::containing_roland().digest(),
   )
+  .await
   .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
@@ -83,58 +89,61 @@ fn load_directory_grpc_error() {
   )
 }
 
-#[test]
-fn fetch_less_than_one_chunk() {
+#[tokio::test]
+async fn fetch_less_than_one_chunk() {
   let testdata = TestData::roland();
   let cas = new_cas(testdata.bytes().len() + 1);
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()),
+    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
     Ok(Some(testdata.bytes()))
   )
 }
 
-#[test]
-fn fetch_exactly_one_chunk() {
+#[tokio::test]
+async fn fetch_exactly_one_chunk() {
   let testdata = TestData::roland();
   let cas = new_cas(testdata.bytes().len());
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()),
+    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
     Ok(Some(testdata.bytes()))
   )
 }
 
-#[test]
-fn fetch_multiple_chunks_exact() {
+#[tokio::test]
+async fn fetch_multiple_chunks_exact() {
   let testdata = TestData::roland();
   let cas = new_cas(1);
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()),
+    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
     Ok(Some(testdata.bytes()))
   )
 }
 
-#[test]
-fn fetch_multiple_chunks_nonfactor() {
+#[tokio::test]
+async fn fetch_multiple_chunks_nonfactor() {
   let testdata = TestData::roland();
   let cas = new_cas(9);
 
   assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()),
+    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
     Ok(Some(testdata.bytes()))
   )
 }
 
-#[test]
-fn write_file_one_chunk() {
+#[tokio::test]
+async fn write_file_one_chunk() {
   let testdata = TestData::roland();
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    block_on(store.store_bytes(testdata.bytes(), WorkUnitStore::new())),
+    store
+      .store_bytes(testdata.bytes(), WorkUnitStore::new())
+      .compat()
+      .await,
     Ok(testdata.digest())
   );
 
@@ -142,8 +151,8 @@ fn write_file_one_chunk() {
   assert_eq!(blobs.get(&testdata.fingerprint()), Some(&testdata.bytes()));
 }
 
-#[test]
-fn write_file_multiple_chunks() {
+#[tokio::test]
+async fn write_file_multiple_chunks() {
   let cas = StubCAS::empty();
 
   let store = ByteStore::new(
@@ -165,7 +174,10 @@ fn write_file_multiple_chunks() {
   let fingerprint = big_file_fingerprint();
 
   assert_eq!(
-    block_on(store.store_bytes(all_the_henries.clone(), WorkUnitStore::new())),
+    store
+      .store_bytes(all_the_henries.clone(), WorkUnitStore::new())
+      .compat()
+      .await,
     Ok(big_file_digest())
   );
 
@@ -186,14 +198,17 @@ fn write_file_multiple_chunks() {
   }
 }
 
-#[test]
-fn write_empty_file() {
+#[tokio::test]
+async fn write_empty_file() {
   let empty_file = TestData::empty();
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    block_on(store.store_bytes(empty_file.bytes(), WorkUnitStore::new())),
+    store
+      .store_bytes(empty_file.bytes(), WorkUnitStore::new())
+      .compat()
+      .await,
     Ok(empty_file.digest())
   );
 
@@ -204,12 +219,15 @@ fn write_empty_file() {
   );
 }
 
-#[test]
-fn write_file_errors() {
+#[tokio::test]
+async fn write_file_errors() {
   let cas = StubCAS::always_errors();
 
   let store = new_byte_store(&cas);
-  let error = block_on(store.store_bytes(TestData::roland().bytes(), WorkUnitStore::new()))
+  let error = store
+    .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
+    .compat()
+    .await
     .expect_err("Want error");
   assert!(
     error.contains("Error from server"),
@@ -221,8 +239,8 @@ fn write_file_errors() {
   );
 }
 
-#[test]
-fn write_connection_error() {
+#[tokio::test]
+async fn write_connection_error() {
   let store = ByteStore::new(
     vec![String::from("doesnotexist.example")],
     None,
@@ -236,7 +254,10 @@ fn write_connection_error() {
     1,
   )
   .unwrap();
-  let error = block_on(store.store_bytes(TestData::roland().bytes(), WorkUnitStore::new()))
+  let error = store
+    .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
+    .compat()
+    .await
     .expect_err("Want error");
   assert!(
     error.contains("Error attempting to upload digest"),
@@ -244,22 +265,25 @@ fn write_connection_error() {
   );
 }
 
-#[test]
-fn list_missing_digests_none_missing() {
+#[tokio::test]
+async fn list_missing_digests_none_missing() {
   let cas = new_cas(1024);
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    block_on(store.list_missing_digests(
-      store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-      WorkUnitStore::new(),
-    )),
+    store
+      .list_missing_digests(
+        store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
+        WorkUnitStore::new(),
+      )
+      .compat()
+      .await,
     Ok(HashSet::new())
   );
 }
 
-#[test]
-fn list_missing_digests_some_missing() {
+#[tokio::test]
+async fn list_missing_digests_some_missing() {
   let cas = StubCAS::empty();
 
   let store = new_byte_store(&cas);
@@ -270,33 +294,39 @@ fn list_missing_digests_some_missing() {
   digest_set.insert(digest);
 
   assert_eq!(
-    block_on(store.list_missing_digests(
-      store.find_missing_blobs_request(vec![digest].iter()),
-      WorkUnitStore::new(),
-    )),
+    store
+      .list_missing_digests(
+        store.find_missing_blobs_request(vec![digest].iter()),
+        WorkUnitStore::new(),
+      )
+      .compat()
+      .await,
     Ok(digest_set)
   );
 }
 
-#[test]
-fn list_missing_digests_error() {
+#[tokio::test]
+async fn list_missing_digests_error() {
   let cas = StubCAS::always_errors();
 
   let store = new_byte_store(&cas);
 
-  let error = block_on(store.list_missing_digests(
-    store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-    WorkUnitStore::new(),
-  ))
-  .expect_err("Want error");
+  let error = store
+    .list_missing_digests(
+      store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
+      WorkUnitStore::new(),
+    )
+    .compat()
+    .await
+    .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
     format!("Bad error message, got: {}", error)
   );
 }
 
-#[test]
-fn reads_from_multiple_cas_servers() {
+#[tokio::test]
+async fn reads_from_multiple_cas_servers() {
   let roland = TestData::roland();
   let catnip = TestData::catnip();
 
@@ -318,12 +348,12 @@ fn reads_from_multiple_cas_servers() {
   .unwrap();
 
   assert_eq!(
-    load_file_bytes(&store, roland.digest()),
+    load_file_bytes(&store, roland.digest()).await,
     Ok(Some(roland.bytes()))
   );
 
   assert_eq!(
-    load_file_bytes(&store, catnip.digest()),
+    load_file_bytes(&store, catnip.digest()).await,
     Ok(Some(catnip.bytes()))
   );
 
@@ -347,21 +377,24 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
   .unwrap()
 }
 
-pub fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::File, digest)
+pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
+  load_bytes(&store, EntryType::File, digest).await
 }
 
-pub fn load_directory_proto_bytes(
+pub async fn load_directory_proto_bytes(
   store: &ByteStore,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::Directory, digest)
+  load_bytes(&store, EntryType::Directory, digest).await
 }
 
-fn load_bytes(
+async fn load_bytes(
   store: &ByteStore,
   entry_type: EntryType,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  block_on(store.load_bytes_with(entry_type, digest, |b| b, WorkUnitStore::new()))
+  store
+    .load_bytes_with(entry_type, digest, |b| b, WorkUnitStore::new())
+    .compat()
+    .await
 }

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -5,8 +5,8 @@ use crate::Store;
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
 use fs::{Dir, File, GlobMatching, PathGlobs, PathStat, PosixFS, SymlinkBehavior};
-use futures01::future::{self, join_all};
-use futures01::Future;
+use futures::future::TryFutureExt;
+use futures01::future::{self, join_all, Future};
 use hashing::{Digest, EMPTY_DIGEST};
 use indexmap::{self, IndexMap};
 use itertools::Itertools;
@@ -547,6 +547,7 @@ impl Snapshot {
 
         posix_fs
           .expand(path_globs)
+          .compat()
           .map_err(|err| format!("Error expanding globs: {}", err))
           .and_then(|path_stats| {
             Snapshot::from_path_stats(
@@ -710,6 +711,7 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
     self
       .posix_fs
       .read_file(&file)
+      .compat()
       .map_err(move |err| format!("Error reading file {:?}: {:?}", file, err))
       .and_then(move |content| store.store_file_bytes(content.content, true))
       .to_boxed()

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 chrono = "0.4.10"
-futures01 = { package = "futures", version = "0.1" }
 lazy_static = "1"
 log = "0.4"
 num_enum = "0.4"
 parking_lot = "0.6"
 simplelog = "0.7.4"
+tokio = { version = "0.2", features = ["rt-util"] }
 ui = { path = "../ui" }
 uuid = { version = "0.7", features = ["v4"] }
 

--- a/src/rust/engine/logging/src/lib.rs
+++ b/src/rust/engine/logging/src/lib.rs
@@ -47,7 +47,7 @@ macro_rules! debug_log {
 
 pub mod logger;
 
-pub use logger::{get_destination, set_destination, Destination};
+pub use logger::{get_destination, scope_task_destination, set_thread_destination, Destination};
 
 pub type Logger = logger::Logger;
 

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -2,20 +2,24 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use crate::PythonLogLevel;
-use chrono;
-use futures01::task_local;
-use lazy_static::lazy_static;
-use log::{log, set_logger, set_max_level, LevelFilter, Log, Metadata, Record};
-use parking_lot::Mutex;
-use simplelog::{ConfigBuilder, LevelPadding, WriteLogger};
+
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::future::Future;
 use std::io::{stderr, Stderr, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+use chrono;
+use lazy_static::lazy_static;
+use log::{log, set_logger, set_max_level, LevelFilter, Log, Metadata, Record};
+use parking_lot::Mutex;
+use simplelog::{ConfigBuilder, LevelPadding, WriteLogger};
+use tokio::task_local;
 use ui::EngineDisplay;
 use uuid::Uuid;
 
@@ -268,37 +272,44 @@ pub enum Destination {
 }
 
 thread_local! {
-  pub static THREAD_DESTINATION: Mutex<Destination> = Mutex::new(Destination::Stderr)
+  static THREAD_DESTINATION: RefCell<Destination> = RefCell::new(Destination::Stderr)
 }
 
 task_local! {
-  static TASK_DESTINATION: Mutex<Option<Destination>> = Mutex::new(None)
+  static TASK_DESTINATION: Destination;
 }
 
-pub fn set_destination(destination: Destination) {
-  if futures01::task::is_in_task() {
-    TASK_DESTINATION.with(|task_destination| {
-      *task_destination.lock() = Some(destination);
-    })
-  } else {
-    THREAD_DESTINATION.with(|thread_destination| {
-      *thread_destination.lock() = destination;
-    })
-  }
+///
+/// Set the current log destination for a Thread, but _not_ for a Task. Tasks must always be spawned
+/// by callers using the `scope_task_destination` helper (generally via task_executor::Executor.)
+///
+pub fn set_thread_destination(destination: Destination) {
+  THREAD_DESTINATION.with(|thread_destination| {
+    *thread_destination.borrow_mut() = destination;
+  })
 }
 
+///
+/// Propagate the current log destination to a Future representing a newly spawned Task. Usage of
+/// this method should mostly be contained to task_executor::Executor.
+///
+pub async fn scope_task_destination<F>(destination: Destination, f: F) -> F::Output
+where
+  F: Future,
+{
+  TASK_DESTINATION.scope(destination, f).await
+}
+
+///
+/// Get the current log destination, from either a Task or a Thread.
+///
+/// TODO: Having this return an Option and tracking down all cases where it has defaulted would be
+/// good.
+///
 pub fn get_destination() -> Destination {
-  fn get_task_destination() -> Option<Destination> {
-    TASK_DESTINATION.with(|destination| *destination.lock())
-  }
-
-  fn get_thread_destination() -> Destination {
-    THREAD_DESTINATION.with(|destination| *destination.lock())
-  }
-
-  if futures01::task::is_in_task() {
-    get_task_destination().unwrap_or_else(get_thread_destination)
+  if let Ok(destination) = TASK_DESTINATION.try_with(|destination| *destination) {
+    destination
   } else {
-    get_thread_destination()
+    THREAD_DESTINATION.with(|destination| *destination.borrow())
   }
 }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -21,7 +21,7 @@ grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
-nails = "0.3"
+nails = "0.4"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 sha2 = "0.8"
 sharded_lmdb = {  path = "../sharded_lmdb" }
@@ -29,7 +29,7 @@ store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"
 concrete_time = { path = "../concrete_time" }
-tokio = { version = "0.2", features = ["process", "rt-threaded", "time"] }
+tokio = { version = "0.2", features = ["process", "rt-threaded", "tcp", "time"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 uname = "0.1.1"
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -47,3 +47,4 @@ parking_lot = "0.6"
 spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../testutil" }
+tokio = { version = "0.2", features = ["macros"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -29,10 +29,8 @@ store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"
 concrete_time = { path = "../concrete_time" }
-tokio = "0.1"
-tokio-codec = "0.1"
-tokio-process = "0.2.1"
-tokio-timer = "0.2"
+tokio = { version = "0.2", features = ["process", "rt-threaded", "time"] }
+tokio-util = { version = "0.2", features = ["codec"] }
 uname = "0.1.1"
 workunit_store = { path = "../workunit_store" }
 regex = "1.3.1"

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -2,6 +2,7 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   ExecuteProcessRequestMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
 };
+use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use sharded_lmdb::ShardedLmdb;
 use std::collections::{BTreeMap, BTreeSet};
@@ -12,14 +13,15 @@ use std::time::Duration;
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::TestData;
+use tokio::runtime::Handle;
 
 struct RoundtripResults {
   uncached: Result<FallibleExecuteProcessResultWithPlatform, String>,
   maybe_cached: Result<FallibleExecuteProcessResultWithPlatform, String>,
 }
 
-fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
-  let runtime = task_executor::Executor::new();
+async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
+  let runtime = task_executor::Executor::new(Handle::current());
   let work_dir = TempDir::new().unwrap();
   let store_dir = TempDir::new().unwrap();
   let store = Store::local_only(runtime.clone(), store_dir.path()).unwrap();
@@ -62,7 +64,10 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     is_nailgunnable: false,
   };
 
-  let local_result = runtime.block_on(local.run(request.clone().into(), Context::default()));
+  let local_result = local
+    .run(request.clone().into(), Context::default())
+    .compat()
+    .await;
 
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
@@ -83,7 +88,10 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     metadata,
   );
 
-  let uncached_result = runtime.block_on(caching.run(request.clone().into(), Context::default()));
+  let uncached_result = caching
+    .run(request.clone().into(), Context::default())
+    .compat()
+    .await;
 
   assert_eq!(local_result, uncached_result);
 
@@ -91,7 +99,10 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   // fail due to a FileNotFound error. So, If the second run succeeds, that implies that the
   // cache was successfully used.
   std::fs::remove_file(&script_path).unwrap();
-  let maybe_cached_result = runtime.block_on(caching.run(request.into(), Context::default()));
+  let maybe_cached_result = caching
+    .run(request.into(), Context::default())
+    .compat()
+    .await;
 
   RoundtripResults {
     uncached: uncached_result,
@@ -99,15 +110,15 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   }
 }
 
-#[test]
-fn cache_success() {
-  let results = run_roundtrip(0);
+#[tokio::test]
+async fn cache_success() {
+  let results = run_roundtrip(0).await;
   assert_eq!(results.uncached, results.maybe_cached);
 }
 
-#[test]
-fn failures_not_cached() {
-  let results = run_roundtrip(1);
+#[tokio::test]
+async fn failures_not_cached() {
+  let results = run_roundtrip(1).await;
   assert_ne!(results.uncached, results.maybe_cached);
   assert_eq!(results.uncached.unwrap().exit_code, 1);
   assert_eq!(results.maybe_cached.unwrap().exit_code, 127); // aka the return code for file not found

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -3,7 +3,9 @@ use tempfile;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
 use fs::{self, GlobExpansionConjunction, GlobMatching, PathGlobs, StrictGlobMatching};
-use futures01::{future, Future, Stream};
+use futures::future::{FutureExt, TryFutureExt};
+use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use futures01::{future, Future};
 use log::info;
 use nails::execution::{ChildOutput, ExitCode};
 
@@ -13,13 +15,13 @@ use std::fs::create_dir_all;
 use std::ops::Neg;
 use std::os::unix::{fs::symlink, process::ExitStatusExt};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::Arc;
 use store::{OneOffStoreFileByDigest, Snapshot, Store};
 
-use tokio::timer::Timeout;
-use tokio_codec::{BytesCodec, FramedRead};
-use tokio_process::CommandExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::{
   Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
@@ -88,6 +90,7 @@ impl CommandRunner {
 
     posix_fs
       .expand(output_globs)
+      .compat()
       .map_err(|err| format!("Error expanding output globs: {}", err))
       .and_then(|path_stats| {
         Snapshot::from_path_stats(
@@ -143,33 +146,40 @@ impl StreamedHermeticCommand {
     self
   }
 
-  fn stream(&mut self) -> Result<impl Stream<Item = ChildOutput, Error = String> + Send, String> {
+  ///
+  /// TODO: See the note on references in ASYNC.md.
+  ///
+  fn stream<'a, 'b>(&'a mut self) -> Result<BoxStream<'b, Result<ChildOutput, String>>, String> {
     self
       .inner
       .stdin(Stdio::null())
       .stdout(Stdio::piped())
       .stderr(Stdio::piped())
-      .spawn_async()
+      .spawn()
       .map_err(|e| format!("Error launching process: {:?}", e))
       .and_then(|mut child| {
-        let stdout_stream = FramedRead::new(child.stdout().take().unwrap(), BytesCodec::new())
-          .map(|bytes| ChildOutput::Stdout(bytes.into()));
-        let stderr_stream = FramedRead::new(child.stderr().take().unwrap(), BytesCodec::new())
-          .map(|bytes| ChildOutput::Stderr(bytes.into()));
-        let exit_stream = child.into_stream().map(|exit_status| {
-          ChildOutput::Exit(ExitCode(
-            exit_status
-              .code()
-              .or_else(|| exit_status.signal().map(Neg::neg))
-              .expect("Child process should exit via returned code or signal."),
-          ))
-        });
+        let stdout_stream = FramedRead::new(child.stdout.take().unwrap(), BytesCodec::new())
+          .map_ok(|bytes| ChildOutput::Stdout(bytes.into()))
+          .boxed();
+        let stderr_stream = FramedRead::new(child.stderr.take().unwrap(), BytesCodec::new())
+          .map_ok(|bytes| ChildOutput::Stderr(bytes.into()))
+          .boxed();
+        let exit_stream = child
+          .into_stream()
+          .map_ok(|exit_status| {
+            ChildOutput::Exit(ExitCode(
+              exit_status
+                .code()
+                .or_else(|| exit_status.signal().map(Neg::neg))
+                .expect("Child process should exit via returned code or signal."),
+            ))
+          })
+          .boxed();
 
         Ok(
-          stdout_stream
-            .select(stderr_stream)
-            .select(exit_stream)
-            .map_err(|e| format!("Failed to consume process outputs: {:?}", e)),
+          futures::stream::select_all(vec![stdout_stream, stderr_stream, exit_stream])
+            .map_err(|e| format!("Failed to consume process outputs: {:?}", e))
+            .boxed(),
         )
       })
   }
@@ -185,31 +195,27 @@ pub struct ChildResults {
 }
 
 impl ChildResults {
-  pub fn collect_from<E>(
-    stream: impl Stream<Item = ChildOutput, Error = E> + Send,
-  ) -> impl Future<Item = ChildResults, Error = E> {
-    let init = (
-      BytesMut::with_capacity(8192),
-      BytesMut::with_capacity(8192),
-      0,
-    );
-    stream
-      .fold(
-        init,
-        |(mut stdout, mut stderr, mut exit_code), child_output| {
-          match child_output {
-            ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
-            ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
-            ChildOutput::Exit(code) => exit_code = code.0,
-          };
-          Ok((stdout, stderr, exit_code)) as Result<_, E>
-        },
-      )
-      .map(|(stdout, stderr, exit_code)| ChildResults {
+  pub fn collect_from(
+    mut stream: BoxStream<Result<ChildOutput, String>>,
+  ) -> futures::future::BoxFuture<Result<ChildResults, String>> {
+    let mut stdout = BytesMut::with_capacity(8192);
+    let mut stderr = BytesMut::with_capacity(8192);
+    let mut exit_code = 1;
+
+    Box::pin(async move {
+      while let Some(child_output_res) = stream.next().await {
+        match child_output_res? {
+          ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
+          ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
+          ChildOutput::Exit(code) => exit_code = code.0,
+        };
+      }
+      Ok(ChildResults {
         stdout: stdout.into(),
         stderr: stderr.into(),
         exit_code,
       })
+    })
   }
 }
 
@@ -258,12 +264,12 @@ impl super::CommandRunner for CommandRunner {
   }
 }
 impl CapturedWorkdir for CommandRunner {
-  fn run_in_workdir(
-    &self,
-    workdir_path: &Path,
+  fn run_in_workdir<'a, 'b, 'c>(
+    &'a self,
+    workdir_path: &'b Path,
     req: ExecuteProcessRequest,
     _context: Context,
-  ) -> Result<Box<dyn Stream<Item = ChildOutput, Error = String> + Send>, String> {
+  ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String> {
     StreamedHermeticCommand::new(&req.argv[0])
       .args(&req.argv[1..])
       .current_dir(if let Some(working_directory) = req.working_directory {
@@ -273,11 +279,6 @@ impl CapturedWorkdir for CommandRunner {
       })
       .envs(&req.env)
       .stream()
-      .map(|s| {
-        // NB: Converting from `impl Stream` to `Box<dyn Stream>` requires this odd dance.
-        let stream: Box<dyn Stream<Item = _, Error = _> + Send> = Box::new(s);
-        stream
-      })
   }
 }
 
@@ -376,8 +377,12 @@ pub trait CapturedWorkdir {
       //   https://github.com/pantsbuild/pants/issues/6089
       .map(ChildResults::collect_from)
       .and_then(move |child_results_future| {
-        Timeout::new(child_results_future, req_timeout).map_err(|e| e.to_string())
+        timeout(req_timeout, child_results_future)
+          .boxed()
+          .compat()
+          .map_err(|e| e.to_string())
       })
+      .and_then(|res| res)
       .and_then(move |child_results| {
         let output_snapshot = if output_file_paths.is_empty() && output_dir_paths.is_empty() {
           future::ok(store::Snapshot::empty()).to_boxed()
@@ -448,10 +453,13 @@ pub trait CapturedWorkdir {
       .to_boxed()
   }
 
-  fn run_in_workdir(
-    &self,
-    workdir_path: &Path,
+  ///
+  /// TODO: See the note on references in ASYNC.md.
+  ///
+  fn run_in_workdir<'a, 'b, 'c>(
+    &'a self,
+    workdir_path: &'b Path,
     req: ExecuteProcessRequest,
     context: Context,
-  ) -> Result<Box<dyn Stream<Item = ChildOutput, Error = String> + Send>, String>;
+  ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String>;
 }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -5,6 +5,7 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   FallibleExecuteProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
 };
+use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
 use std;
@@ -16,10 +17,11 @@ use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 use testutil::path::find_bash;
 use testutil::{as_bytes, owned_string_vec};
+use tokio::runtime::Handle;
 
-#[test]
+#[tokio::test]
 #[cfg(unix)]
-fn stdout() {
+async fn stdout() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
@@ -33,7 +35,8 @@ fn stdout() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -48,9 +51,9 @@ fn stdout() {
   )
 }
 
-#[test]
+#[tokio::test]
 #[cfg(unix)]
-fn stdout_and_stderr_and_exit_code() {
+async fn stdout_and_stderr_and_exit_code() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "echo -n foo ; echo >&2 -n bar ; exit 1"]),
     env: BTreeMap::new(),
@@ -64,7 +67,8 @@ fn stdout_and_stderr_and_exit_code() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -79,9 +83,9 @@ fn stdout_and_stderr_and_exit_code() {
   )
 }
 
-#[test]
+#[tokio::test]
 #[cfg(unix)]
-fn capture_exit_code_signal() {
+async fn capture_exit_code_signal() {
   // Launch a process that kills itself with a signal.
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "kill $$"]),
@@ -96,7 +100,8 @@ fn capture_exit_code_signal() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -111,9 +116,9 @@ fn capture_exit_code_signal() {
   )
 }
 
-#[test]
+#[tokio::test]
 #[cfg(unix)]
-fn env() {
+async fn env() {
   let mut env: BTreeMap<String, String> = BTreeMap::new();
   env.insert("FOO".to_string(), "foo".to_string());
   env.insert("BAR".to_string(), "not foo".to_string());
@@ -131,7 +136,8 @@ fn env() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   let stdout = String::from_utf8(result.unwrap().stdout.to_vec()).unwrap();
   let got_env: BTreeMap<String, String> = stdout
@@ -150,9 +156,9 @@ fn env() {
   assert_eq!(env, got_env);
 }
 
-#[test]
+#[tokio::test]
 #[cfg(unix)]
-fn env_is_deterministic() {
+async fn env_is_deterministic() {
   fn make_request() -> ExecuteProcessRequest {
     let mut env = BTreeMap::new();
     env.insert("FOO".to_string(), "foo".to_string());
@@ -174,14 +180,14 @@ fn env_is_deterministic() {
     }
   }
 
-  let result1 = run_command_locally(make_request());
-  let result2 = run_command_locally(make_request());
+  let result1 = run_command_locally(make_request()).await;
+  let result2 = run_command_locally(make_request()).await;
 
   assert_eq!(result1.unwrap(), result2.unwrap());
 }
 
-#[test]
-fn binary_not_found() {
+#[tokio::test]
+async fn binary_not_found() {
   run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["echo", "-n", "foo"]),
     env: BTreeMap::new(),
@@ -196,11 +202,12 @@ fn binary_not_found() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   })
+  .await
   .expect_err("Want Err");
 }
 
-#[test]
-fn output_files_none() {
+#[tokio::test]
+async fn output_files_none() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&[&find_bash(), "-c", "exit 0"]),
     env: BTreeMap::new(),
@@ -214,7 +221,8 @@ fn output_files_none() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
   assert_eq!(
     result.unwrap(),
     FallibleExecuteProcessResultWithPlatform {
@@ -228,8 +236,8 @@ fn output_files_none() {
   )
 }
 
-#[test]
-fn output_files_one() {
+#[tokio::test]
+async fn output_files_one() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -247,7 +255,8 @@ fn output_files_one() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -262,8 +271,8 @@ fn output_files_one() {
   )
 }
 
-#[test]
-fn output_dirs() {
+#[tokio::test]
+async fn output_dirs() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -286,7 +295,8 @@ fn output_dirs() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -301,8 +311,8 @@ fn output_dirs() {
   )
 }
 
-#[test]
-fn output_files_many() {
+#[tokio::test]
+async fn output_files_many() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -326,7 +336,8 @@ fn output_files_many() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -341,8 +352,8 @@ fn output_files_many() {
   )
 }
 
-#[test]
-fn output_files_execution_failure() {
+#[tokio::test]
+async fn output_files_execution_failure() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -364,7 +375,8 @@ fn output_files_execution_failure() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -379,8 +391,8 @@ fn output_files_execution_failure() {
   )
 }
 
-#[test]
-fn output_files_partial_output() {
+#[tokio::test]
+async fn output_files_partial_output() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -400,7 +412,8 @@ fn output_files_partial_output() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -415,8 +428,8 @@ fn output_files_partial_output() {
   )
 }
 
-#[test]
-fn output_overlapping_file_and_dir() {
+#[tokio::test]
+async fn output_overlapping_file_and_dir() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -434,7 +447,8 @@ fn output_overlapping_file_and_dir() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -449,8 +463,8 @@ fn output_overlapping_file_and_dir() {
   )
 }
 
-#[test]
-fn jdk_symlink() {
+#[tokio::test]
+async fn jdk_symlink() {
   let preserved_work_tmpdir = TempDir::new().unwrap();
   let roland = TestData::roland().bytes();
   std::fs::write(preserved_work_tmpdir.path().join("roland"), roland.clone())
@@ -468,7 +482,8 @@ fn jdk_symlink() {
     jdk_home: Some(preserved_work_tmpdir.path().to_path_buf()),
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
   assert_eq!(
     result,
     Ok(FallibleExecuteProcessResultWithPlatform {
@@ -482,8 +497,8 @@ fn jdk_symlink() {
   )
 }
 
-#[test]
-fn test_directory_preservation() {
+#[tokio::test]
+async fn test_directory_preservation() {
   let preserved_work_tmpdir = TempDir::new().unwrap();
   let preserved_work_root = preserved_work_tmpdir.path().to_owned();
 
@@ -510,7 +525,8 @@ fn test_directory_preservation() {
     false,
     None,
     None,
-  );
+  )
+  .await;
   result.unwrap();
 
   assert!(preserved_work_root.exists());
@@ -524,8 +540,8 @@ fn test_directory_preservation() {
   assert!(rolands_path.exists());
 }
 
-#[test]
-fn test_directory_preservation_error() {
+#[tokio::test]
+async fn test_directory_preservation_error() {
   let preserved_work_tmpdir = TempDir::new().unwrap();
   let preserved_work_root = preserved_work_tmpdir.path().to_owned();
 
@@ -552,6 +568,7 @@ fn test_directory_preservation_error() {
     None,
     None,
   )
+  .await
   .expect_err("Want process to fail");
 
   assert!(preserved_work_root.exists());
@@ -559,8 +576,8 @@ fn test_directory_preservation_error() {
   assert_eq!(testutil::file::list_dir(&preserved_work_root).len(), 1);
 }
 
-#[test]
-fn all_containing_directories_for_outputs_are_created() {
+#[tokio::test]
+async fn all_containing_directories_for_outputs_are_created() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -584,7 +601,8 @@ fn all_containing_directories_for_outputs_are_created() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -599,8 +617,8 @@ fn all_containing_directories_for_outputs_are_created() {
   )
 }
 
-#[test]
-fn output_empty_dir() {
+#[tokio::test]
+async fn output_empty_dir() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -618,7 +636,8 @@ fn output_empty_dir() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
-  });
+  })
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -636,19 +655,23 @@ fn output_empty_dir() {
 /// This test attempts to make sure local only scratch files are materialized correctly by
 /// making sure that with input_files being empty, we would be able to capture the content of
 /// the local only scratch inputs as outputs.
-#[test]
-fn local_only_scratch_files_materialized() {
+#[tokio::test]
+async fn local_only_scratch_files_materialized() {
   let store_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new();
+  let executor = task_executor::Executor::new(Handle::current());
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
   // Prepare the store to contain roland, because the EPR needs to materialize it
   let roland_directory_digest = TestDirectory::containing_roland().digest();
-  executor
-    .block_on(store.record_directory(&TestDirectory::containing_roland().directory(), true))
+  store
+    .record_directory(&TestDirectory::containing_roland().directory(), true)
+    .compat()
+    .await
     .expect("Error saving directory");
-  executor
-    .block_on(store.store_file_bytes(TestData::roland().bytes(), false))
+  store
+    .store_file_bytes(TestData::roland().bytes(), false)
+    .compat()
+    .await
     .expect("Error saving file bytes");
 
   let work_dir = TempDir::new().unwrap();
@@ -672,7 +695,8 @@ fn local_only_scratch_files_materialized() {
     true,
     Some(store),
     Some(executor),
-  );
+  )
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -687,8 +711,8 @@ fn local_only_scratch_files_materialized() {
   );
 }
 
-#[test]
-fn timeout() {
+#[tokio::test]
+async fn timeout() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec![
       find_bash(),
@@ -707,6 +731,7 @@ fn timeout() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   })
+  .await
   .unwrap();
 
   assert_eq!(result.exit_code, -15);
@@ -715,22 +740,28 @@ fn timeout() {
   assert_that(&error_msg).contains("sleepy-cat");
 }
 
-#[test]
-fn working_directory() {
+#[tokio::test]
+async fn working_directory() {
   let store_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new();
+  let executor = task_executor::Executor::new(Handle::current());
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
   // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
   // from the ./cats directory.
-  executor
-    .block_on(store.store_file_bytes(TestData::roland().bytes(), false))
+  store
+    .store_file_bytes(TestData::roland().bytes(), false)
+    .compat()
+    .await
     .expect("Error saving file bytes");
-  executor
-    .block_on(store.record_directory(&TestDirectory::containing_roland().directory(), true))
+  store
+    .record_directory(&TestDirectory::containing_roland().directory(), true)
+    .compat()
+    .await
     .expect("Error saving directory");
-  executor
-    .block_on(store.record_directory(&TestDirectory::nested().directory(), true))
+  store
+    .record_directory(&TestDirectory::nested().directory(), true)
+    .compat()
+    .await
     .expect("Error saving directory");
 
   let work_dir = TempDir::new().unwrap();
@@ -753,7 +784,8 @@ fn working_directory() {
     true,
     Some(store),
     Some(executor),
-  );
+  )
+  .await;
 
   assert_eq!(
     result.unwrap(),
@@ -768,21 +800,21 @@ fn working_directory() {
   );
 }
 
-fn run_command_locally(
+async fn run_command_locally(
   req: ExecuteProcessRequest,
 ) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let work_dir = TempDir::new().unwrap();
-  run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned())
+  run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned()).await
 }
 
-fn run_command_locally_in_dir_with_cleanup(
+async fn run_command_locally_in_dir_with_cleanup(
   req: ExecuteProcessRequest,
   dir: PathBuf,
 ) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
-  run_command_locally_in_dir(req, dir, true, None, None)
+  run_command_locally_in_dir(req, dir, true, None, None).await
 }
 
-fn run_command_locally_in_dir(
+async fn run_command_locally_in_dir(
   req: ExecuteProcessRequest,
   dir: PathBuf,
   cleanup: bool,
@@ -790,9 +822,9 @@ fn run_command_locally_in_dir(
   executor: Option<task_executor::Executor>,
 ) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let store_dir = TempDir::new().unwrap();
-  let executor = executor.unwrap_or_else(task_executor::Executor::new);
+  let executor = executor.unwrap_or_else(|| task_executor::Executor::new(Handle::current()));
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
   let runner = crate::local::CommandRunner::new(store, executor.clone(), dir, cleanup);
-  executor.block_on(runner.run(req.into(), Context::default()))
+  runner.run(req.into(), Context::default()).compat().await
 }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -299,6 +299,6 @@ impl CapturedWorkdir for CommandRunner {
           .map_ok(ChildOutput::Exit)
       });
 
-    Ok(futures::stream::select(stdio_read.map(|r| Ok(r)), nails_command.into_stream()).boxed())
+    Ok(futures::stream::select(stdio_read.map(Ok), nails_command.into_stream()).boxed())
   }
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -85,7 +85,6 @@ impl Drop for CancelRemoteExecutionToken {
               Ok(_) => debug!("Canceled operation {} successfully", operation_name),
               Err(err) => debug!("Failed to cancel operation {}, err {}", operation_name, err),
             }
-            ()
           });
         }
         Err(err) => debug!(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -10,6 +10,8 @@ use bytes::Bytes;
 use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat};
+use futures::compat::Future01CompatExt;
+use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, Future, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
@@ -18,7 +20,7 @@ use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use store::{Snapshot, Store, StoreFileByDigest};
-use tokio_timer::Delay;
+use tokio::time::delay_for;
 
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, ExecutionStats,
@@ -78,13 +80,13 @@ impl Drop for CancelRemoteExecutionToken {
         .cancel_operation_async(&cancel_op_req)
       {
         Ok(receiver) => {
-          self.executor.spawn_and_ignore(receiver.then(move |res| {
-            match res {
+          self.executor.spawn_and_ignore(async move {
+            match receiver.compat().await {
               Ok(_) => debug!("Canceled operation {} successfully", operation_name),
               Err(err) => debug!("Failed to cancel operation {}, err {}", operation_name, err),
             }
-            Ok(())
-          }));
+            ()
+          });
         }
         Err(err) => debug!(
           "Failed to schedule cancel operation: {}, err {}",
@@ -412,11 +414,14 @@ impl super::CommandRunner for CommandRunner {
                                   .to_boxed()
                             } else {
                               // maybe the delay here should be the min of remaining time and the backoff period
-                              Delay::new(Instant::now() + backoff_period)
-                                  .map_err(move |e| {
+                              delay_for(backoff_period)
+                                  .unit_error()
+                                  .boxed()
+                                  .compat()
+                                  .map_err(move |()| {
                                     format!(
-                                      "Future-Delay errored at operation result polling for {}, {}: {}",
-                                      operation_name, description, e
+                                      "Future-Delay errored at operation result polling for {}, {}",
+                                      operation_name, description
                                     )
                                   })
                                   .and_then(move |_| {

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -6,96 +6,98 @@ use crate::{
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
+use futures::compat::Future01CompatExt;
+use futures::future::{FutureExt, TryFutureExt};
 use futures01::future::Future;
 use hashing::EMPTY_DIGEST;
 use parking_lot::Mutex;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio;
-use tokio_timer::Delay;
+use tokio::time::delay_for;
 
-#[test]
-fn test_no_speculation() {
+#[tokio::test]
+async fn test_no_speculation() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(0, 0, 100, false, false, true, true);
+    run_speculation_test(0, 0, 100, false, false, true, true).await;
   assert_eq![1, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m1")];
 }
 
-#[test]
-fn test_speculate() {
+#[tokio::test]
+async fn test_speculate() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(100, 0, 10, false, false, true, true);
+    run_speculation_test(100, 0, 10, false, false, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m2")]
 }
 
-#[test]
-fn first_req_slow_success() {
+#[tokio::test]
+async fn first_req_slow_success() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(500, 1000, 250, false, false, true, true);
+    run_speculation_test(500, 1000, 250, false, false, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m1")]
 }
 
-#[test]
-fn first_req_slow_fail() {
+#[tokio::test]
+async fn first_req_slow_fail() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(1000, 0, 100, true, false, true, true);
+    run_speculation_test(1000, 0, 100, true, false, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m2")]
 }
 
-#[test]
-fn first_req_fast_fail() {
+#[tokio::test]
+async fn first_req_fast_fail() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(500, 1000, 250, true, false, true, true);
+    run_speculation_test(500, 1000, 250, true, false, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap_err(), Bytes::from("m1")]
 }
 
-#[test]
-fn only_fail_on_primary_result() {
+#[tokio::test]
+async fn only_fail_on_primary_result() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(1000, 0, 100, true, true, true, true);
+    run_speculation_test(1000, 0, 100, true, true, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![2, *finished_counter.lock()];
   assert_eq![result.unwrap_err(), Bytes::from("m1")]
 }
 
-#[test]
-fn platform_compatible_with_1st_runs_once() {
+#[tokio::test]
+async fn platform_compatible_with_1st_runs_once() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(0, 0, 100, false, false, true, false);
+    run_speculation_test(0, 0, 100, false, false, true, false).await;
   assert_eq![1, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m1")]
 }
 
-#[test]
-fn platform_compatible_with_2nd_runs_once() {
+#[tokio::test]
+async fn platform_compatible_with_2nd_runs_once() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(0, 0, 100, false, false, false, true);
+    run_speculation_test(0, 0, 100, false, false, false, true).await;
   assert_eq![1, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m2")]
 }
 
-#[test]
-fn platform_compatible_with_both_speculates() {
+#[tokio::test]
+async fn platform_compatible_with_both_speculates() {
   let (result, call_counter, finished_counter) =
-    run_speculation_test(1000, 1000, 500, false, false, true, true);
+    run_speculation_test(1000, 1000, 500, false, false, true, true).await;
   assert_eq![2, *call_counter.lock()];
   assert_eq![1, *finished_counter.lock()];
   assert_eq![result.unwrap().stdout, Bytes::from("m1")]
 }
 
-fn run_speculation_test(
+async fn run_speculation_test(
   r1_latency_ms: u64,
   r2_latency_ms: u64,
   speculation_delay_ms: u64,
@@ -108,7 +110,6 @@ fn run_speculation_test(
   Arc<Mutex<u32>>,
   Arc<Mutex<u32>>,
 ) {
-  let runtime = tokio::runtime::Runtime::new().unwrap();
   let execute_request = echo_foo_request();
   let msg1: String = "m1".into();
   let msg2: String = "m2".into();
@@ -135,7 +136,7 @@ fn run_speculation_test(
     Duration::from_millis(speculation_delay_ms),
   );
   (
-    runtime.block_on_all(runner.run(execute_request, context)),
+    runner.run(execute_request, context).compat().await,
     call_counter,
     finished_counter,
   )
@@ -211,7 +212,7 @@ impl CommandRunner for DelayedCommandRunner {
     _req: MultiPlatformExecuteProcessRequest,
     _context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
-    let delay = Delay::new(Instant::now() + self.delay);
+    let delay = delay_for(self.delay).unit_error().compat();
     let exec_result = self.result.clone();
     let command_runner = self.clone();
     command_runner.incr_call_counter();

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 [dependencies]
 clap = "2"
 env_logger = "0.5.4"
+futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../hashing" }
 process_execution = { path = "../process_execution" }
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
-tokio = { version = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 workunit_store = { path = "../workunit_store"}

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -12,5 +12,5 @@ hashing = { path = "../hashing" }
 process_execution = { path = "../process_execution" }
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-threaded"] }
 workunit_store = { path = "../workunit_store"}

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -8,10 +8,11 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 parking_lot = "0.6"
-tokio-timer = "0.2"
+tokio = { version = "0.2", features = ["time"] }
 
 [dev-dependencies]
 maplit = "1"
 testutil = { path = "../testutil" }
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-core"] }

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "0.2", features = ["time"] }
 [dev-dependencies]
 maplit = "1"
 testutil = { path = "../testutil" }
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/src/rust/engine/serverset/src/tests.rs
+++ b/src/rust/engine/serverset/src/tests.rs
@@ -168,7 +168,11 @@ fn waits_if_all_unhealthy() {
   );
 }
 
-fn expect_both(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, repetitions: usize) {
+fn expect_both(
+  runtime: &mut tokio::runtime::Runtime,
+  s: &Serverset<String>,
+  repetitions: usize,
+) {
   let visited = Arc::new(Mutex::new(HashSet::new()));
 
   runtime
@@ -191,7 +195,11 @@ fn expect_both(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, rep
   assert_eq!(unwrap(visited), expect);
 }
 
-fn mark_bad_as_bad(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, health: Health) {
+fn mark_bad_as_bad(
+  runtime: &mut tokio::runtime::Runtime,
+  s: &Serverset<String>,
+  health: Health,
+) {
   let mark_bad_as_baded_bad = Arc::new(Mutex::new(false));
   for _ in 0..2 {
     let s = s.clone();

--- a/src/rust/engine/serverset/src/tests.rs
+++ b/src/rust/engine/serverset/src/tests.rs
@@ -168,11 +168,7 @@ fn waits_if_all_unhealthy() {
   );
 }
 
-fn expect_both(
-  runtime: &mut tokio::runtime::Runtime,
-  s: &Serverset<String>,
-  repetitions: usize,
-) {
+fn expect_both(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, repetitions: usize) {
   let visited = Arc::new(Mutex::new(HashSet::new()));
 
   runtime
@@ -195,11 +191,7 @@ fn expect_both(
   assert_eq!(unwrap(visited), expect);
 }
 
-fn mark_bad_as_bad(
-  runtime: &mut tokio::runtime::Runtime,
-  s: &Serverset<String>,
-  health: Health,
-) {
+fn mark_bad_as_bad(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, health: Health) {
   let mark_bad_as_baded_bad = Arc::new(Mutex::new(false));
   for _ in 0..2 {
     let s = s.clone();

--- a/src/rust/engine/serverset/src/tests.rs
+++ b/src/rust/engine/serverset/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::{BackoffConfig, Health, Serverset};
+use futures::compat::Future01CompatExt;
 use futures01::{future, Future};
 use parking_lot::Mutex;
 use std;
@@ -6,6 +7,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use testutil::owned_string_vec;
+use tokio::time::delay_for;
 
 fn backoff_config() -> BackoffConfig {
   BackoffConfig::new(Duration::from_millis(10), 2.0, Duration::from_millis(100)).unwrap()
@@ -18,9 +20,8 @@ fn no_servers_is_error() {
     .expect_err("Want error constructing with no servers");
 }
 
-#[test]
-fn one_request_works() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn one_request_works() {
   let s = Serverset::new(
     owned_string_vec(&["good"]),
     fake_connect,
@@ -29,12 +30,11 @@ fn one_request_works() {
   )
   .unwrap();
 
-  assert_eq!(rt.block_on(s.next()).unwrap().0, "good".to_owned());
+  assert_eq!(s.next().compat().await.unwrap().0, "good".to_owned());
 }
 
-#[test]
-fn round_robins() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn round_robins() {
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
     fake_connect,
@@ -43,12 +43,11 @@ fn round_robins() {
   )
   .unwrap();
 
-  expect_both(&mut rt, &s, 2);
+  expect_both(&s, 2).await
 }
 
-#[test]
-fn handles_overflow_internally() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn handles_overflow_internally() {
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
     fake_connect,
@@ -60,7 +59,7 @@ fn handles_overflow_internally() {
 
   // 3 because we may skip some values if the number of servers isn't a factor of
   // std::usize::MAX, so we make sure to go around them all again after overflowing.
-  expect_both(&mut rt, &s, 3)
+  expect_both(&s, 3).await
 }
 
 fn unwrap<T: std::fmt::Debug>(wrapped: Arc<Mutex<T>>) -> T {
@@ -69,9 +68,8 @@ fn unwrap<T: std::fmt::Debug>(wrapped: Arc<Mutex<T>>) -> T {
     .into_inner()
 }
 
-#[test]
-fn skips_unhealthy() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn skips_unhealthy() {
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
     fake_connect,
@@ -80,14 +78,13 @@ fn skips_unhealthy() {
   )
   .unwrap();
 
-  mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
+  mark_bad_as_bad(&s, Health::Unhealthy).await;
 
-  expect_only_good(&mut rt, &s, Duration::from_millis(10));
+  expect_only_good(&s, Duration::from_millis(10)).await;
 }
 
-#[test]
-fn reattempts_unhealthy() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn reattempts_unhealthy() {
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
     fake_connect,
@@ -96,16 +93,15 @@ fn reattempts_unhealthy() {
   )
   .unwrap();
 
-  mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
+  mark_bad_as_bad(&s, Health::Unhealthy).await;
 
-  expect_only_good(&mut rt, &s, Duration::from_millis(10));
+  expect_only_good(&s, Duration::from_millis(10)).await;
 
-  expect_both(&mut rt, &s, 3);
+  expect_both(&s, 3).await
 }
 
-#[test]
-fn backoff_when_unhealthy() {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
+#[tokio::test]
+async fn backoff_when_unhealthy() {
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
     fake_connect,
@@ -114,25 +110,25 @@ fn backoff_when_unhealthy() {
   )
   .unwrap();
 
-  mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
+  mark_bad_as_bad(&s, Health::Unhealthy).await;
 
-  expect_only_good(&mut rt, &s, Duration::from_millis(10));
+  expect_only_good(&s, Duration::from_millis(10)).await;
 
   // mark_bad_as_bad asserts that we attempted to use the bad server as a side effect, so this
   // checks that we did re-use the server after the lame period.
-  mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
+  mark_bad_as_bad(&s, Health::Unhealthy).await;
 
-  expect_only_good(&mut rt, &s, Duration::from_millis(20));
+  expect_only_good(&s, Duration::from_millis(20)).await;
 
-  mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
+  mark_bad_as_bad(&s, Health::Unhealthy).await;
 
-  expect_only_good(&mut rt, &s, Duration::from_millis(40));
+  expect_only_good(&s, Duration::from_millis(40)).await;
 
-  expect_both(&mut rt, &s, 3);
+  expect_both(&s, 3).await
 }
 
-#[test]
-fn waits_if_all_unhealthy() {
+#[tokio::test]
+async fn waits_if_all_unhealthy() {
   let backoff_config = backoff_config();
   let s = Serverset::new(
     owned_string_vec(&["good", "bad"]),
@@ -141,21 +137,20 @@ fn waits_if_all_unhealthy() {
     backoff_config,
   )
   .unwrap();
-  let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
   // We will get an address 4 times, and mark it as unhealthy each of those times.
   // That means that each server will be marked bad twice, which according to our backoff config
   // means they should be marked as unavailable for 20ms each.
   for _ in 0..4 {
     let s = s.clone();
-    let (_server, token) = runtime.block_on(s.next()).unwrap();
+    let (_server, token) = s.next().compat().await.unwrap();
     s.report_health(token, Health::Unhealthy);
   }
 
   let start = std::time::Instant::now();
 
   // This should take at least 20ms because both servers are marked as unhealthy.
-  let _ = runtime.block_on(s.next()).unwrap();
+  let _ = s.next().compat().await.unwrap();
 
   // Make sure we waited for at least 10ms; we should have waited 20ms, but it may have taken a
   // little time to mark a server as unhealthy, so we have some padding between what we expect
@@ -168,35 +163,36 @@ fn waits_if_all_unhealthy() {
   );
 }
 
-fn expect_both(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, repetitions: usize) {
+async fn expect_both(s: &Serverset<String>, repetitions: usize) {
   let visited = Arc::new(Mutex::new(HashSet::new()));
 
-  runtime
-    .block_on(future::join_all(
-      (0..repetitions)
-        .into_iter()
-        .map(|_| {
-          let saw = visited.clone();
-          let s = s.clone();
-          s.next().map(move |(server, token)| {
-            saw.lock().insert(server);
-            s.report_health(token, Health::Healthy)
-          })
+  future::join_all(
+    (0..repetitions)
+      .into_iter()
+      .map(|_| {
+        let saw = visited.clone();
+        let s = s.clone();
+        s.next().map(move |(server, token)| {
+          saw.lock().insert(server);
+          s.report_health(token, Health::Healthy)
         })
-        .collect::<Vec<_>>(),
-    ))
-    .unwrap();
+      })
+      .collect::<Vec<_>>(),
+  )
+  .compat()
+  .await
+  .unwrap();
 
   let expect: HashSet<_> = owned_string_vec(&["good", "bad"]).into_iter().collect();
   assert_eq!(unwrap(visited), expect);
 }
 
-fn mark_bad_as_bad(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>, health: Health) {
+async fn mark_bad_as_bad(s: &Serverset<String>, health: Health) {
   let mark_bad_as_baded_bad = Arc::new(Mutex::new(false));
   for _ in 0..2 {
     let s = s.clone();
     let mark_bad_as_baded_bad = mark_bad_as_baded_bad.clone();
-    let (server, token) = runtime.block_on(s.next()).unwrap();
+    let (server, token) = s.next().compat().await.unwrap();
     if &server == "bad" {
       *mark_bad_as_baded_bad.lock() = true;
       s.report_health(token, health);
@@ -210,11 +206,7 @@ fn mark_bad_as_bad(runtime: &mut tokio::runtime::Runtime, s: &Serverset<String>,
   );
 }
 
-fn expect_only_good(
-  runtime: &mut tokio::runtime::Runtime,
-  s: &Serverset<String>,
-  duration: Duration,
-) {
+async fn expect_only_good(s: &Serverset<String>, duration: Duration) {
   let buffer = Duration::from_millis(1);
 
   let start = std::time::Instant::now();
@@ -224,7 +216,7 @@ fn expect_only_good(
     let s = s.clone();
     let should_break = should_break.clone();
     let did_get_at_least_one_good = did_get_at_least_one_good.clone();
-    let (server, token) = runtime.block_on(s.next()).unwrap();
+    let (server, token) = s.next().compat().await.unwrap();
     if start.elapsed() < duration - buffer {
       assert_eq!("good", &server);
       *did_get_at_least_one_good.lock() = true;
@@ -236,7 +228,7 @@ fn expect_only_good(
 
   assert!(*did_get_at_least_one_good.lock());
 
-  std::thread::sleep(buffer * 2);
+  delay_for(buffer * 2).await;
 }
 
 /// For tests, we just use Strings as servers, as it's an easy type we can make from addresses.

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bytes = "0.4.5"
 fs = { path = "../fs" }
-futures01 = { package = "futures", version = "0.1" }
+futures = "0.3"
 hashing = { path = "../hashing" }
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -26,7 +26,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use bytes::Bytes;
-use futures01::{future, Future};
+use futures::future::BoxFuture;
 use hashing::{Fingerprint, FINGERPRINT_SIZE};
 use lmdb::{
   self, Database, DatabaseFlags, Environment, EnvironmentCopyFlags, EnvironmentFlags,
@@ -228,14 +228,17 @@ impl ShardedLmdb {
     self.lmdbs.values().cloned().collect()
   }
 
-  pub fn store_bytes(
-    &self,
+  ///
+  /// TODO: See the note on references in ASYNC.md.
+  ///
+  pub fn store_bytes<'a, 'b>(
+    &'a self,
     fingerprint: Fingerprint,
     bytes: Bytes,
     initial_lease: bool,
-  ) -> impl Future<Item = (), Error = String> {
+  ) -> BoxFuture<'b, Result<(), String>> {
     let store = self.clone();
-    self.executor.spawn_on_io_pool(future::lazy(move || {
+    self.executor.spawn_blocking(move || {
       let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::schema_version());
       let (env, db, lease_database) = store.get(&fingerprint);
       let put_res = env.begin_rw_txn().and_then(|mut txn| {
@@ -260,7 +263,7 @@ impl ShardedLmdb {
           err
         )),
       }
-    }))
+    })
   }
 
   fn lease(
@@ -285,17 +288,22 @@ impl ShardedLmdb {
     (now_since_epoch + time::Duration::from_secs(2 * 60 * 60)).as_secs()
   }
 
+  ///
+  /// TODO: See the note on references in ASYNC.md.
+  ///
   pub fn load_bytes_with<
+    'a,
+    'b,
     T: Send + 'static,
     F: Fn(Bytes) -> Result<T, String> + Send + Sync + 'static,
   >(
-    &self,
+    &'a self,
     fingerprint: Fingerprint,
     f: F,
-  ) -> impl Future<Item = Option<T>, Error = String> {
+  ) -> BoxFuture<'b, Result<Option<T>, String>> {
     let store = self.clone();
     let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::schema_version());
-    self.executor.spawn_on_io_pool(future::lazy(move || {
+    self.executor.spawn_blocking(move || {
       let (env, db, _) = store.get(&fingerprint);
       let ro_txn = env
         .begin_ro_txn()
@@ -309,7 +317,7 @@ impl ShardedLmdb {
           err,
         )),
       })
-    }))
+    })
   }
 
   #[allow(clippy::identity_conversion)] // False positive: https://github.com/rust-lang/rust-clippy/issues/3913

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -30,7 +30,7 @@ use reqwest;
 use rule_graph::RuleGraph;
 use sharded_lmdb::ShardedLmdb;
 use store::Store;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 
 const GIGABYTES: usize = 1024 * 1024 * 1024;
 
@@ -90,7 +90,17 @@ impl Core {
     let mut remote_store_servers = remote_store_servers;
     remote_store_servers.shuffle(&mut rand::thread_rng());
 
-    let runtime = Runtime::new().map_err(|e| format!("Failed to start the runtime: {}", e))?;
+    let runtime = Builder::new()
+      // This use of Builder (rather than just Runtime::new()) is to allow us to lower the
+      // max_threads setting. As of tokio `0.2.13`, the core threads default to num_cpus, and
+      // the max threads default to a fixed value of 512. In practice, it appears to be slower
+      // to allow 512 threads, and with the default stack size, 512 threads would use 1GB of RAM.
+      .core_threads(num_cpus::get())
+      .max_threads(num_cpus::get() * 4)
+      .threaded_scheduler()
+      .enable_all()
+      .build()
+      .map_err(|e| format!("Failed to start the runtime: {}", e))?;
     let executor = task_executor::Executor::new(runtime.handle().clone());
     // We re-use these certs for both the execution and store service; they're generally tied together.
     let root_ca_certs = if let Some(path) = remote_root_ca_certs_path {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -51,7 +51,7 @@ pub struct Core {
   pub executor: task_executor::Executor,
   store: Store,
   pub command_runner: Box<dyn process_execution::CommandRunner>,
-  pub http_client: reqwest::r#async::Client,
+  pub http_client: reqwest::Client,
   pub vfs: PosixFS,
   pub build_root: PathBuf,
 }
@@ -223,7 +223,7 @@ impl Core {
       ));
     }
 
-    let http_client = reqwest::r#async::Client::new();
+    let http_client = reqwest::Client::new();
     let rule_graph = RuleGraph::new(tasks.as_map(), root_subject_types);
 
     Ok(Core {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -316,7 +316,6 @@ impl NodeContext for Context {
   {
     self.core.executor.spawn_and_ignore(async move {
       let _ = future.compat().await;
-      ()
     });
   }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -349,7 +349,6 @@ impl Scheduler {
       } else {
         Scheduler::execute_helper(context, sender, roots, count - 1);
       }
-      ()
     });
   }
 

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 futures01 = { package = "futures", version = "0.1" }
 futures-cpupool = "0.1"
 logging = { path = "../logging" }
-tokio = "0.1"
+tokio = { version = "0.2", features = ["rt-threaded"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-futures01 = { package = "futures", version = "0.1" }
-futures-cpupool = "0.1"
+futures = "0.3"
 logging = { path = "../logging" }
-tokio = { version = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["blocking", "rt-threaded"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -27,7 +27,6 @@
 
 use std::future::Future;
 
-use futures::future;
 use futures::future::{BoxFuture, FutureExt};
 
 use tokio::runtime::{Handle, Runtime};
@@ -149,13 +148,12 @@ impl Executor {
   fn future_with_correct_context<F: Future>(future: F) -> impl Future<Output = F::Output> {
     let logging_destination = logging::get_destination();
     let workunit_parent_id = workunit_store::get_parent_id();
-    future::lazy(move |_| {
+    async move {
       logging::set_destination(logging_destination);
       if let Some(parent_id) = workunit_parent_id {
         workunit_store::set_parent_id(parent_id);
       }
-      future
-    })
-    .then(|f| f)
+      future.await
+    }
   }
 }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 concrete_time = { path = "../concrete_time" }
-futures01 = { package = "futures", version = "0.1" }
 parking_lot = "0.6"
 rand = "0.6"
+tokio = { version = "0.2", features = ["rt-util"] }


### PR DESCRIPTION
### Problem

We're on an older version of tokio, which doesn't smoothly support usage of async/await.

### Solution

Switch to tokio 0.2, which supports directly spawning and awaiting (via its macros) stdlib futures, which is an important step toward being able to utilize async/await more broadly. Additionally, port the `fs` and `task_executor` crates to stdlib futures.

Finally, transitively fixup for the new APIs: in particular, since both `task_executor` and `tokio` now consume stdlib futures to spawn tasks, we switch all relevant tests and main methods to use the `tokio::main` and `tokio::test` macros, which annotate async methods and spawn a runtime to allow for `await`ing futures inline. 

### Result

Progress toward more usage of async/await!