### PR TITLE
Add `--run-args` to allow passing arguments in V2

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.workunit import WorkUnitLabel
 
 from pants.contrib.cpp.targets.cpp_binary import CppBinary
@@ -23,18 +22,6 @@ class CppRun(CppTask):
 
   def execute(self):
     binary_target = self.require_single_root_target()
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.28.0.dev0',
-      entity_description='Using the old style of passthrough args for `run.cpp``',
-      hint_message="You passed arguments to the C++ executable through either the "
-                   "`--run-cpp-passthrough-args` option or the style "
-                   "`./pants run.cpp -- arg1 --arg2`. Instead, "
-                   "pass any arguments to the C++ executable like this: "
-                   "`./pants run --args='arg1 --arg2' src/cpp/path/to:target`.\n\n"
-                   "This change is meant to reduce confusion in how option scopes work with "
-                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
-    )
     if isinstance(binary_target, CppBinary):
       with self.context.new_workunit(name='cpp-run', labels=[WorkUnitLabel.RUN]) as workunit:
         cmd = [

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
@@ -3,6 +3,7 @@
 
 import os
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.process.xargs import Xargs
 
@@ -22,10 +23,25 @@ class GoRun(GoTask):
     round_manager.require_data('exec_binary')
 
   def execute(self):
+    deprecated_conditional(
+      lambda: self.get_passthru_args(),
+      removal_version='1.28.0.dev0',
+      entity_description='Using the old style of passthrough args for `run.go`',
+      hint_message="You passed arguments to the Go program through either the "
+                   "`--run-go-passthrough-args` option or the style "
+                   "`./pants run.go -- arg1 --arg2`. Instead, "
+                   "pass any arguments to the Go program like this: "
+                   "`./pants run --args='arg1 --arg2' src/go/path/to:target`.\n\n"
+                   "This change is meant to reduce confusion in how option scopes work with "
+                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
+    )
+
     target = self.require_single_root_target()
     if self.is_binary(target):
       binary_path = self.context.products.get_data('exec_binary')[target]
       # TODO(cgibb): Wrap with workunit and stdout/stderr plumbing.
-      res = Xargs.subprocess([binary_path]).execute(self.get_passthru_args())
+      res = Xargs.subprocess(
+        [binary_path]
+      ).execute([*self.get_passthru_args(), *self.get_options().args])
       if res != 0:
         raise TaskError(f'{os.path.basename(binary_path)} exited non-zero ({res})')

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
@@ -3,7 +3,6 @@
 
 import os
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.process.xargs import Xargs
 
@@ -23,19 +22,6 @@ class GoRun(GoTask):
     round_manager.require_data('exec_binary')
 
   def execute(self):
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.28.0.dev0',
-      entity_description='Using the old style of passthrough args for `run.go`',
-      hint_message="You passed arguments to the Go program through either the "
-                   "`--run-go-passthrough-args` option or the style "
-                   "`./pants run.go -- arg1 --arg2`. Instead, "
-                   "pass any arguments to the Go program like this: "
-                   "`./pants run --args='arg1 --arg2' src/go/path/to:target`.\n\n"
-                   "This change is meant to reduce confusion in how option scopes work with "
-                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
-    )
-
     target = self.require_single_root_target()
     if self.is_binary(target):
       binary_path = self.context.products.get_data('exec_binary')[target]

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.util.contextutil import pushd
@@ -24,20 +23,6 @@ class NodeRun(NodeTask):
     return True
 
   def execute(self):
-
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.28.0.dev0',
-      entity_description='Using the old style of passthrough args for `run.node`',
-      hint_message="You passed arguments to the Node program through either the "
-                   "`--run-node-passthrough-args` option or the style "
-                   "`./pants run.node -- arg1 --arg2`. Instead, "
-                   "pass any arguments to the Node program like this: "
-                   "`./pants run --args='arg1 --arg2' src/javascript/path/to:target`.\n\n"
-                   "This change is meant to reduce confusion in how option scopes work with "
-                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
-    )
-
     target = self.require_single_root_target()
 
     if self.is_node_module(target):

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.util.contextutil import pushd
@@ -23,6 +24,20 @@ class NodeRun(NodeTask):
     return True
 
   def execute(self):
+
+    deprecated_conditional(
+      lambda: self.get_passthru_args(),
+      removal_version='1.28.0.dev0',
+      entity_description='Using the old style of passthrough args for `run.node`',
+      hint_message="You passed arguments to the Node program through either the "
+                   "`--run-node-passthrough-args` option or the style "
+                   "`./pants run.node -- arg1 --arg2`. Instead, "
+                   "pass any arguments to the Node program like this: "
+                   "`./pants run --args='arg1 --arg2' src/javascript/path/to:target`.\n\n"
+                   "This change is meant to reduce confusion in how option scopes work with "
+                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
+    )
+
     target = self.require_single_root_target()
 
     if self.is_node_module(target):
@@ -31,7 +46,7 @@ class NodeRun(NodeTask):
         result, command = self.run_script(
           self.get_options().script_name,
           target=target,
-          script_args=self.get_passthru_args(),
+          script_args=[*self.get_passthru_args(), *self.get_options().args],
           node_paths=node_paths.all_node_paths,
           workunit_name=target.address.reference(),
           workunit_labels=[WorkUnitLabel.RUN])

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -6,7 +6,6 @@ import logging
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jvm_task import JvmTask
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.fs.fs import expand_path
@@ -60,19 +59,6 @@ class JvmRun(JvmTask):
     # execution engine.  I do not want task code to learn the lock location.
     # http://jira.local.twitter.com/browse/AWESOME-1317
     target = self.require_single_root_target()
-
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.28.0.dev0',
-      entity_description='Using the old style of passthrough args for `run.jvm`',
-      hint_message="You passed arguments to the JVM program through either the "
-                   "`--run-jvm-passthrough-args` option or the style "
-                   "`./pants run.jvm -- arg1 --arg2`. Instead, "
-                   "pass any arguments to the JVM program like this: "
-                   "`./pants run --args='arg1 --arg2' src/java/path/to:target`.\n\n"
-                   "This change is meant to reduce confusion in how option scopes work with "
-                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
-    )
 
     working_dir = None
     cwd_opt = self.get_options().cwd

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -6,6 +6,7 @@ import logging
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jvm_task import JvmTask
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.fs.fs import expand_path
@@ -45,6 +46,7 @@ class JvmRun(JvmTask):
     super().__init__(*args, **kwargs)
     self.only_write_cmd_line = self.get_options().only_write_cmd_line
     self.args.extend(self.get_passthru_args())
+    self.args.extend(self.get_options().args)
 
   def execute(self):
     # The called binary may block for a while, allow concurrent pants activity during this pants
@@ -58,6 +60,19 @@ class JvmRun(JvmTask):
     # execution engine.  I do not want task code to learn the lock location.
     # http://jira.local.twitter.com/browse/AWESOME-1317
     target = self.require_single_root_target()
+
+    deprecated_conditional(
+      lambda: self.get_passthru_args(),
+      removal_version='1.28.0.dev0',
+      entity_description='Using the old style of passthrough args for `run.jvm`',
+      hint_message="You passed arguments to the JVM program through either the "
+                   "`--run-jvm-passthrough-args` option or the style "
+                   "`./pants run.jvm -- arg1 --arg2`. Instead, "
+                   "pass any arguments to the JVM program like this: "
+                   "`./pants run --args='arg1 --arg2' src/java/path/to:target`.\n\n"
+                   "This change is meant to reduce confusion in how option scopes work with "
+                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
+    )
 
     working_dir = None
     cwd_opt = self.get_options().cwd

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -5,7 +5,6 @@ import signal
 
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.util.osutil import safe_kill
@@ -20,20 +19,6 @@ class PythonRun(PythonExecutionTaskBase):
 
   def execute(self):
     binary = self.require_single_root_target()
-
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.28.0.dev0',
-      entity_description='Using the old style of passthrough args for `run.py`',
-      hint_message="You passed arguments to the Python program through either the "
-                   "`--run-py-passthrough-args` option or the style "
-                   "`./pants run.py -- arg1 --arg2`. Instead, "
-                   "pass any arguments to the Python program like this: "
-                   "`./pants run --args='arg1 --arg2' src/python/path/to:target`.\n\n"
-                   "This change is meant to reduce confusion in how option scopes work with "
-                   "passthrough args and for parity with the V2 implementation of the `run` goal.",
-    )
-
     if isinstance(binary, PythonBinary):
       # We can't throw if binary isn't a PythonBinary, because perhaps we were called on a
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -11,6 +11,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
+from pants.option.custom_types import shell_str
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
@@ -21,6 +22,15 @@ class RunOptions(GoalSubsystem):
 
   # NB: To be runnable, you must be a BinaryTarget.
   required_union_implementations = (BinaryTarget,)
+
+  @classmethod
+  def register_options(cls, register) -> None:
+    super().register_options(register)
+    register(
+      '--args', type=list, member_type=shell_str, fingerprint=True,
+      help="Arguments to pass directly to the executed target, e.g. "
+           "`--run-args=\"val1 val2 --debug\"`",
+    )
 
 
 class Run(Goal):
@@ -34,6 +44,7 @@ async def run(
   runner: InteractiveRunner,
   build_root: BuildRoot,
   bfa: BuildFileAddress,
+  options: RunOptions,
 ) -> Run:
   target = bfa.to_address()
   binary = await Get[CreatedBinary](Address, target)
@@ -47,7 +58,7 @@ async def run(
     console.write_stdout(f"Running target: {target}\n")
     full_path = str(Path(tmpdir, binary.binary_name))
     run_request = InteractiveProcessRequest(
-      argv=(full_path,),
+      argv=(full_path, *options.values.args),
       run_in_workspace=True,
     )
 

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from typing import cast
+from unittest.mock import Mock
 
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address, BuildFileAddress
@@ -11,6 +12,12 @@ from pants.rules.core.binary import CreatedBinary
 from pants.rules.core.run import Run, run
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
+
+
+# TODO: Create a utility to mock GoalSubsystems.
+class MockOptions:
+  def __init__(self, **values):
+    self.values = Mock(**values)
 
 
 class RunTest(GoalRuleTestBase):
@@ -40,7 +47,7 @@ class RunTest(GoalRuleTestBase):
     BuildRoot().path = self.build_root
     res = run_rule(
       run,
-      rule_args=[console, workspace, interactive_runner, BuildRoot(), bfa],
+      rule_args=[console, workspace, interactive_runner, BuildRoot(), bfa, MockOptions(args=[])],
       mock_gets=[
         MockGet(
           product_type=CreatedBinary,
@@ -60,8 +67,8 @@ class RunTest(GoalRuleTestBase):
       address_spec='some/addr',
     )
     self.assertEqual(res.exit_code, 0)
-    self.assertEquals(console.stdout.getvalue(), "Running target: some/addr:addr\nsome/addr:addr ran successfully.\n")
-    self.assertEquals(console.stderr.getvalue(), "")
+    self.assertEqual(console.stdout.getvalue(), "Running target: some/addr:addr\nsome/addr:addr ran successfully.\n")
+    self.assertEqual(console.stderr.getvalue(), "")
 
   def test_materialize_input_files(self) -> None:
     program_text = b'#!/usr/bin/python\nprint("hello")'
@@ -94,5 +101,5 @@ class RunTest(GoalRuleTestBase):
       address_spec='some/addr'
     )
     self.assertEqual(res.exit_code, 1)
-    self.assertEquals(console.stdout.getvalue(), "Running target: some/addr:addr\n")
-    self.assertEquals(console.stderr.getvalue(), "some/addr:addr failed with code 1!\n")
+    self.assertEqual(console.stdout.getvalue(), "Running target: some/addr:addr\n")
+    self.assertEqual(console.stderr.getvalue(), "some/addr:addr failed with code 1!\n")

--- a/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen_integration.py
+++ b/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen_integration.py
@@ -9,9 +9,7 @@ class AntlrPyGenIntegrationTest(PantsRunIntegrationTest):
 
   @skip_unless_python27_present
   def test_antlr_py_gen_integration(self):
-    result = self.run_pants(['run',
-                             'testprojects/src/python/antlr:eval-bin',
-                             '--run-py-args="123 * 321"'])
+    result = self.run_pants(['run', '--args="123 * 321"', 'testprojects/src/python/antlr:eval-bin'])
     self.assertEqual(0, result.returncode)
     self.assertIn('39483', result.stdout_data)
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -23,7 +23,9 @@ class JvmRunTest(JvmTaskTestBase):
     """Run the JvmRun task in command line only mode  with the specified extra options.
     :returns: the command line string
     """
-    self.set_options(only_write_cmd_line='a', **options)
+    # NB: We must set `--run-args=[]` because the unit test does not properly set up the
+    # `RunOptions(GoalSubsystem)`.
+    self.set_options(only_write_cmd_line='a', args=[], **options)
     jvm_binary = self.make_target('src/java/org/pantsbuild:binary', JvmBinary,
       main='org.pantsbuild.Binary', extra_jvm_options=extra_jvm_options)
     context = self.context(target_roots=[jvm_binary])


### PR DESCRIPTION
This adds support for passthrough args to V2 `run`. We also backport the V1 run tasks to also respect `--run-args` to reduce confusion with V1 vs. V2.