### PR TITLE
Fix deprecation warning for `--transitive` for goals that ignore the option

### DIFF
--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -7,13 +7,12 @@ from contextlib import contextmanager
 
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
-from pants.task.target_restriction_mixins import HasTransitiveOptionMixin
 from pants.task.task import QuietTaskMixin, Task
 from pants.util.dirutil import safe_open
 from pants.util.meta import classproperty
 
 
-class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
+class ConsoleTask(QuietTaskMixin, Task):
   """A task whose only job is to print information to the console.
 
   ConsoleTasks are not intended to modify build state.
@@ -38,19 +37,22 @@ class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
 
   @property
   def act_transitively(self):
-    deprecated_conditional(
-      lambda: self.get_options().is_default("transitive"),
-      entity_description=f"Pants defaulting to `--transitive` for `{self.options_scope}`",
-      removal_version="1.27.0.dev0",
-      hint_message="Currently, Pants defaults to `--transitive`, which means that it "
-                   "will run against transitive dependencies for the targets you specify on the "
-                   "command line, rather than only the targets you specify. This is often useful, "
-                   "such as running `./pants dependencies --transitive`, but it is surprising "
-                   "to have this behavior by default.\n\nTo prepare for this change to the default "
-                   f"value, set in `pants.ini` under the section `{self.options_scope}` the value "
-                   "`transitive: False`. In Pants 1.27.0, you can safely remove the setting."
-    )
-    return self.get_options().transitive
+    if self._register_console_transitivity_option:
+      deprecated_conditional(
+        lambda: self.get_options().is_default("transitive"),
+        entity_description=f"Pants defaulting to `--transitive` for `{self.options_scope}`",
+        removal_version="1.27.0.dev0",
+        hint_message="Currently, Pants defaults to `--transitive`, which means that it "
+                     "will run against transitive dependencies for the targets you specify on the "
+                     "command line, rather than only the targets you specify. This is often useful, "
+                     "such as running `./pants dependencies --transitive`, but it is surprising "
+                     "to have this behavior by default.\n\nTo prepare for this change to the default "
+                     f"value, set in `pants.ini` under the section `{self.options_scope}` the value "
+                     "`transitive: False`. In Pants 1.27.0, you can safely remove the setting."
+      )
+      return self.get_options().transitive
+    # `Task` defaults to returning `True` in `act_transitively`, so we keep that default value.
+    return self.get_options().get("transitive", True)
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/8955, we deprecated the `--transitive` option for 11 console tasks where the option did not do anything. 

But, a bug in the implementation meant that we would print a deprecation warning unless the user explicitly used `--no-transitive` or `--transitive`, which is deprecated as well, so it was impossible to run these tasks without some deprecation warning.

Also, the tasks would stop working properly once the `--transitive` option is removed because `ConsoleTask` was extending `HasTransitiveOptionsMixin`, which calls `self.get_options().transitive`. This would throw an exception if there was no option `--transitive` defined.