### PR TITLE
Rename `ProvenancedBuildFileAddress` to `AddressWithOrigin`

### DIFF
--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -26,7 +26,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import AddressProvenanceMap
+from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import (
   Digest,
@@ -234,7 +234,7 @@ def validate_args(args: Tuple[str, ...]):
 
 @goal_rule
 async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, console: Console,
-                        provenance_map: AddressProvenanceMap, python_setup: PythonSetup,
+                        address_origin_map: AddressOriginMap, python_setup: PythonSetup,
                         distdir: DistDir, workspace: Workspace) -> SetupPy:
   """Run setup.py commands on all exported targets addressed."""
   args = tuple(options.values.args)
@@ -249,7 +249,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   for hydrated_target in targets:
     if _is_exported(hydrated_target):
       exported_targets.append(ExportedTarget(hydrated_target))
-    elif provenance_map.is_single_address(hydrated_target.address):
+    elif address_origin_map.is_single_address(hydrated_target.address):
       explicit_nonexported_targets.append(hydrated_target)
   if explicit_nonexported_targets:
     raise TargetNotExported(

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -18,10 +18,14 @@ class Addresses(Collection[Address]):
 
 
 @dataclass(frozen=True)
-class ProvenancedBuildFileAddress:
+class ProvenancedAddress:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
-  build_file_address: BuildFileAddress
+  address: BuildFileAddress
   provenance: Spec
+
+
+class ProvenancedAddresses(Collection[ProvenancedAddress]):
+  pass
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):
@@ -29,10 +33,6 @@ class BuildFileAddresses(Collection[BuildFileAddress]):
   def addresses(self) -> List[Address]:
     """Converts the BuildFileAddress objects in this collection to Address objects."""
     return [bfa.to_address() for bfa in self]
-
-
-class ProvenancedBuildFileAddresses(Collection[ProvenancedBuildFileAddress]):
-  pass
 
 
 class NotSerializableError(TypeError):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -18,13 +18,13 @@ class Addresses(Collection[Address]):
 
 
 @dataclass(frozen=True)
-class ProvenancedAddress:
+class AddressWithOrigin:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
   address: BuildFileAddress
-  provenance: Spec
+  origin: Spec
 
 
-class ProvenancedAddresses(Collection[ProvenancedAddress]):
+class AddressesWithOrigins(Collection[AddressWithOrigin]):
   pass
 
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -14,9 +14,9 @@ from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import (
   AddressableDescriptor,
+  AddressesWithOrigins,
+  AddressWithOrigin,
   BuildFileAddresses,
-  ProvenancedAddress,
-  ProvenancedAddresses,
 )
 from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
@@ -204,10 +204,10 @@ def _hydrate(item_type, spec_path, **kwargs):
 
 
 @rule
-async def provenanced_addresses_from_address_families(
+async def addresses_with_origins_from_address_families(
   address_mapper: AddressMapper, address_specs: AddressSpecs,
-) -> ProvenancedAddresses:
-  """Given an AddressMapper and list of AddressSpecs, return matching ProvenancedAddresses.
+) -> AddressesWithOrigins:
+  """Given an AddressMapper and list of AddressSpecs, return matching AddressesWithOrigins.
 
   :raises: :class:`ResolveError` if:
      - there were no matching AddressFamilies, or
@@ -221,7 +221,7 @@ async def provenanced_addresses_from_address_families(
   address_family_by_directory = {af.namespace: af for af in address_families}
 
   matched_addresses = OrderedSet()
-  addr_to_provenance: Dict[BuildFileAddress, AddressSpec] = {}
+  addr_to_origin: Dict[BuildFileAddress, AddressSpec] = {}
 
   for address_spec in address_specs:
     # NB: if an address spec is provided which expands to some number of targets, but those targets
@@ -239,7 +239,7 @@ async def provenanced_addresses_from_address_families(
       )
       for addr, _ in all_addr_tgt_pairs:
         # A target might be covered by multiple specs, so we take the most specific one.
-        addr_to_provenance[addr] = more_specific(addr_to_provenance.get(addr), address_spec)
+        addr_to_origin[addr] = more_specific(addr_to_origin.get(addr), address_spec)
     except AddressSpec.AddressResolutionError as e:
       raise AddressLookupError(e) from e
     except SingleAddress._SingleAddressResolutionError as e:
@@ -252,33 +252,33 @@ async def provenanced_addresses_from_address_families(
     )
 
   # NB: This may be empty, as the result of filtering by tag and exclude patterns!
-  return ProvenancedAddresses(
-    ProvenancedAddress(address=addr, provenance=addr_to_provenance[addr])
+  return AddressesWithOrigins(
+    AddressWithOrigin(address=addr, origin=addr_to_origin[addr])
     for addr in matched_addresses
   )
 
 
 @rule
-def remove_provenance(provenanced_addresses: ProvenancedAddresses) -> BuildFileAddresses:
+def remove_origins(addresses_with_origins: AddressesWithOrigins) -> BuildFileAddresses:
   return BuildFileAddresses(
-    provenanced_address.address for provenanced_address in provenanced_addresses
+    address_with_origin.address for address_with_origin in addresses_with_origins
   )
 
 
 @dataclass(frozen=True)
-class AddressProvenanceMap:
-  bfaddr_to_spec: Dict[BuildFileAddress, Spec]
+class AddressOriginMap:
+  bfaddr_to_origin: Dict[BuildFileAddress, Spec]
 
   def is_single_address(self, address: BuildFileAddress) -> bool:
-    return isinstance(self.bfaddr_to_spec.get(address), SingleAddress)
+    return isinstance(self.bfaddr_to_origin.get(address), SingleAddress)
 
 
 @rule
-def address_provenance_map(provenanced_addresses: ProvenancedAddresses) -> AddressProvenanceMap:
-  return AddressProvenanceMap(
-    bfaddr_to_spec={
-      provenanced_address.address: provenanced_address.provenance
-      for provenanced_address in provenanced_addresses
+def address_origin_map(addresses_with_origins: AddressesWithOrigins) -> AddressOriginMap:
+  return AddressOriginMap(
+    bfaddr_to_origin={
+      address_with_origin.address: address_with_origin.origin
+      for address_with_origin in addresses_with_origins
     }
   )
 
@@ -305,9 +305,9 @@ def create_graph_rules(address_mapper: AddressMapper):
     parse_address_family,
     # AddressSpec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
-    provenanced_addresses_from_address_families,
-    remove_provenance,
-    address_provenance_map,
+    addresses_with_origins_from_address_families,
+    remove_origins,
+    address_origin_map,
     # Root rules representing parameters that might be provided via root subjects.
     RootRule(Address),
     RootRule(BuildFileAddress),

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -27,11 +27,7 @@ from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
-from pants.engine.addressable import (
-  BuildFileAddresses,
-  ProvenancedBuildFileAddress,
-  ProvenancedBuildFileAddresses,
-)
+from pants.engine.addressable import BuildFileAddresses, ProvenancedAddress, ProvenancedAddresses
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import (
@@ -724,7 +720,7 @@ async def sources_snapshots_from_filesystem_specs(
 @rule
 async def provenanced_addresses_from_filesystem_specs(
   filesystem_specs: FilesystemSpecs, global_options: GlobalOptions,
-) -> ProvenancedBuildFileAddresses:
+) -> ProvenancedAddresses:
   """Find the owner(s) for each FilesystemSpec while preserving the original FilesystemSpec those
   owners come from (i.e., preserving the "provenance").
   """
@@ -737,7 +733,7 @@ async def provenanced_addresses_from_filesystem_specs(
   owners_per_include = await MultiGet(
     Get[Owners](OwnersRequest(sources=snapshot.files)) for snapshot in snapshot_per_include
   )
-  result: List[ProvenancedBuildFileAddress] = []
+  result: List[ProvenancedAddress] = []
   for spec, owners in zip(filesystem_specs.includes, owners_per_include):
     if (
       global_options.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
@@ -754,10 +750,10 @@ async def provenanced_addresses_from_filesystem_specs(
       else:
         raise ResolveError(msg)
     result.extend(
-      ProvenancedBuildFileAddress(build_file_address=bfa, provenance=spec)
+      ProvenancedAddress(address=bfa, provenance=spec)
       for bfa in owners.addresses
     )
-  return ProvenancedBuildFileAddresses(result)
+  return ProvenancedAddresses(result)
 
 
 def create_legacy_graph_tasks():

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -9,7 +9,7 @@ from typing import Optional
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import AddressProvenanceMap
+from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import Digest
 from pants.engine.goal import Goal, GoalSubsystem
@@ -117,10 +117,10 @@ class AddressAndTestResult:
     target: HydratedTarget,
     *,
     union_membership: UnionMembership,
-    provenance_map: AddressProvenanceMap
+    address_origin_map: AddressOriginMap
   ) -> bool:
     is_valid_target_type = (
-      provenance_map.is_single_address(target.address)
+      address_origin_map.is_single_address(target.address)
       or union_membership.is_member(TestTarget, target.adaptor)
     )
     has_sources = hasattr(target.adaptor, "sources") and target.adaptor.sources.snapshot.files
@@ -175,11 +175,11 @@ async def run_tests(
 async def coordinator_of_tests(
   target: HydratedTarget,
   union_membership: UnionMembership,
-  provenance_map: AddressProvenanceMap
+  address_origin_map: AddressOriginMap
 ) -> AddressAndTestResult:
 
   if not AddressAndTestResult.is_testable(
-    target, union_membership=union_membership, provenance_map=provenance_map
+    target, union_membership=union_membership, address_origin_map=address_origin_map
   ):
     return AddressAndTestResult(target.address, None)
 

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 from pants.base.specs import DescendantAddresses, SingleAddress, Spec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import AddressProvenanceMap
+from pants.engine.build_files import AddressOriginMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.legacy.graph import HydratedTarget
@@ -189,7 +189,7 @@ class TestTest(TestBase):
     self,
     *,
     address: Address,
-    bfaddr_to_spec: Optional[Dict[BuildFileAddress, Spec]] = None,
+    bfaddr_to_origin: Optional[Dict[BuildFileAddress, Spec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
   ) -> AddressAndTestResult:
@@ -215,7 +215,7 @@ class TestTest(TestBase):
         rule_args=[
           HydratedTarget(address, target_adaptor, ()),
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
-          AddressProvenanceMap(bfaddr_to_spec=bfaddr_to_spec or {}),
+          AddressOriginMap(bfaddr_to_origin=bfaddr_to_origin or {}),
         ],
         mock_gets=[
           MockGet(
@@ -242,7 +242,7 @@ class TestTest(TestBase):
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
         address=bfaddr.to_address(),
-        bfaddr_to_spec={bfaddr: SingleAddress(directory='some/dir', name='bin')},
+        bfaddr_to_origin={bfaddr: SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
@@ -255,7 +255,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')}
+      bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
       bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
@@ -265,7 +265,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
     result = self.run_coordinator_of_tests(
       address=bfaddr.to_address(),
-      bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')},
+      bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
     assert result == AddressAndTestResult(bfaddr.to_address(), None)

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -12,10 +12,10 @@ from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses, addressable, addressable_dict
 from pants.engine.build_files import (
   ResolvedTypeMismatchError,
+  addresses_with_origins_from_address_families,
   create_graph_rules,
   parse_address_family,
-  provenanced_addresses_from_address_families,
-  remove_provenance,
+  remove_origins,
 )
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
@@ -74,7 +74,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     address_mapper: AddressMapper,
   ) -> BuildFileAddresses:
     pbfas = run_rule(
-      provenanced_addresses_from_address_families,
+      addresses_with_origins_from_address_families,
       rule_args=[address_mapper, address_specs],
       mock_gets=[
         MockGet(
@@ -89,7 +89,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         ),
       ],
     )
-    return cast(BuildFileAddresses, run_rule(remove_provenance, rule_args=[pbfas]))
+    return cast(BuildFileAddresses, run_rule(remove_origins, rule_args=[pbfas]))
 
   def test_duplicated(self) -> None:
     """Test that matching the same AddressSpec twice succeeds."""


### PR DESCRIPTION
Several `@goal_rule`s will soon start requesting `ProvenancedBuildFileAddresses`, rather than `BuildFileAddresses`, so that they may preserve the original `FilesystemSpec` to be more precise in what files they run over. (For example, `./pants fmt foo.py` only formatting `foo.py` rather than its whole owning target.). So, this type is going to start showing up in a lot of places.

We rename `ProvenancedBuildFileAddress` to `AddressWithOrigin` because:
1) Generally, we want to stop using `BuildFileAddress` per https://github.com/pantsbuild/pants/issues/6657. So, the name should not mention `BuildFile`.
2) While `provenance` is a valid technical term, it is unfamiliar for even many native English speakers (including myself - I had to look it up). Generally, we should avoid using inaccessible words when there is a better alternative. In contrast, `origin` is familiar to most English speakers.
3) Conceptually, this type refers to an `Address` that is _augmented with_ additional information from where that `Address` first comes from. `AddressWithOrigin` makes clear that the `WithOrigin` part is some extra information being preserved.