### PR TITLE
Add `FilesystemResolvedGlobSpec` to preserve which specific files to operate on

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -323,10 +323,22 @@ class FilesystemSpec(Spec, metaclass=ABCMeta):
   pass
 
 
+class FilesystemResolvedSpec(FilesystemSpec, metaclass=ABCMeta):
+
+  @property
+  @abstractmethod
+  def resolved_files(self) -> Tuple[str, ...]:
+    """The literal files this spec refers to after resolving all globs and excludes."""
+
+
 @dataclass(frozen=True)
-class FilesystemLiteralSpec(FilesystemSpec):
+class FilesystemLiteralSpec(FilesystemResolvedSpec):
   """A literal file name, e.g. `foo.py`."""
   file: str
+
+  @property
+  def resolved_files(self) -> Tuple[str, ...]:
+    return self.file,
 
   def to_spec_string(self) -> str:
     return self.file
@@ -339,6 +351,12 @@ class FilesystemGlobSpec(FilesystemSpec):
 
   def to_spec_string(self) -> str:
     return self.glob
+
+
+@dataclass(frozen=True)
+class FilesystemResolvedGlobSpec(FilesystemGlobSpec, FilesystemResolvedSpec):
+  """A spec with resolved globs, e.g. `*.py` may resolve to `('f1.py', 'f2.py', '__init__.py')`."""
+  resolved_files: Tuple[str, ...]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,9 +5,9 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from functools import update_wrapper
-from typing import Any, List, Set, Tuple, Type
+from typing import Any, List, Set, Tuple, Type, Union
 
-from pants.base.specs import Spec
+from pants.base.specs import AddressSpec, FilesystemResolvedSpec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
@@ -21,7 +21,7 @@ class Addresses(Collection[Address]):
 class AddressWithOrigin:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
   address: BuildFileAddress
-  origin: Spec
+  origin: Union[AddressSpec, FilesystemResolvedSpec]
 
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -19,6 +19,7 @@ from pants.base.specs import (
   AddressSpecs,
   AscendantAddresses,
   FilesystemLiteralSpec,
+  FilesystemResolvedGlobSpec,
   FilesystemSpecs,
   SingleAddress,
 )
@@ -734,7 +735,9 @@ async def addresses_with_origins_from_filesystem_specs(
     Get[Owners](OwnersRequest(sources=snapshot.files)) for snapshot in snapshot_per_include
   )
   result: List[AddressWithOrigin] = []
-  for spec, owners in zip(filesystem_specs.includes, owners_per_include):
+  for spec, snapshot, owners in zip(
+    filesystem_specs.includes, snapshot_per_include, owners_per_include
+  ):
     if (
       global_options.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
       and isinstance(spec, FilesystemLiteralSpec) and not owners.addresses
@@ -749,10 +752,15 @@ async def addresses_with_origins_from_filesystem_specs(
         logger.warning(msg)
       else:
         raise ResolveError(msg)
-    result.extend(
-      AddressWithOrigin(address=bfa, origin=spec)
-      for bfa in owners.addresses
-    )
+    for address in owners.addresses:
+      # We preserve what literal files any globs resolved to. This allows downstream goals to be
+      # more precise in which files they operate on.
+      origin = (
+        spec
+        if isinstance(spec, FilesystemLiteralSpec) else
+        FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
+      )
+      result.append(AddressWithOrigin(address=address, origin=origin))
   return AddressesWithOrigins(result)
 
 


### PR DESCRIPTION
### Problem

To support more precise file args—where we only run over the specified files, rather than the whole target—we must know which specific file names to use.

This works fine when given `FilesystemLiteralSpec`s like `./pants fmt foo.py`, but we are no longer able to get which files were resolved when working with `FilesystemGlobSpec`s like `./pants fmt *.py`. 

Specifically, for globs, we must preserve which files were matched after applying all include globs _and_ exclude globs.

### Solution

First, add `FilesystemResolvedSpec` as a new abstract class with a property `resolved_files: Tuple[str, ...]`. Also add `FilesystemResolvedGlobSpec` and tweak `FilesystemLiteralSpec` to inherit this.

Then, change the rule `addresses_with_origins_from_filesystem_specs` to preserve the `snapshot.files` associated with the original `FilesystemSpec`.

### Result

Rules may now request `AddressesWithOrigins` and be able to get a list of all the resolved source files (when it's a `FilesystemSpec` rather than an `AddressSpec`).