### PR TITLE
Use `Addresses` instead of `BuildFileAddresses` in most rules

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import goal_rule
@@ -17,9 +17,7 @@ class ListAndDieForTesting(Goal):
 
 
 @goal_rule
-def fast_list_and_die_for_testing(
-  console: Console, addresses: BuildFileAddresses
-) -> ListAndDieForTesting:
+def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> ListAndDieForTesting:
   for address in addresses.dependencies:
     console.print_stdout(address.spec)
   return ListAndDieForTesting(exit_code=42)

--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -41,14 +41,14 @@ class AWSLambdaGoal(Goal):
 
 @goal_rule
 async def create_awslambda(
-    addresses: BuildFileAddresses,
+    addresses: Addresses,
     console: Console,
     options: AWSLambdaOptions,
     distdir: DistDir,
     workspace: Workspace) -> AWSLambdaGoal:
   with options.line_oriented(console) as print_stdout:
     print_stdout(f"Generating AWS lambdas in `./{distdir.relpath}`")
-    awslambdas = await MultiGet(Get[CreatedAWSLambda](Address, address.to_address())
+    awslambdas = await MultiGet(Get[CreatedAWSLambda](Address, address)
                                 for address in addresses)
     merged_digest = await Get[Digest](
       DirectoriesToMerge(tuple(awslambda.digest for awslambda in awslambdas))

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -14,7 +14,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.legacy.structs import PythonAWSLambdaAdaptor
@@ -36,7 +36,7 @@ async def create_python_awslambda(
   # TODO: We must enforce that everything is built for Linux, no matter the local platform.
   pex_filename = f'{lambda_tgt_adaptor.address.target_name}.pex'
   pex_request = CreatePexFromTargetClosure(
-    build_file_addresses=BuildFileAddresses((lambda_tgt_adaptor.address,)),
+    addresses=Addresses((lambda_tgt_adaptor.address.to_address(),)),
     entry_point=None,
     output_filename=pex_filename
   )

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -12,7 +12,7 @@ from pants.backend.python.rules.pex import (
 )
 from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
@@ -21,7 +21,7 @@ from pants.engine.selectors import Get
 @dataclass(frozen=True)
 class CreatePexFromTargetClosure:
   """Represents a request to create a PEX from the closure of a set of targets."""
-  build_file_addresses: BuildFileAddresses
+  addresses: Addresses
   output_filename: str
   entry_point: Optional[str] = None
   additional_requirements: Tuple[str, ...] = ()
@@ -32,8 +32,7 @@ class CreatePexFromTargetClosure:
 @rule(name="Create PEX from targets")
 async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
                                          python_setup: PythonSetup) -> Pex:
-  transitive_hydrated_targets = await Get[TransitiveHydratedTargets](BuildFileAddresses,
-                                                                     request.build_file_addresses)
+  transitive_hydrated_targets = await Get[TransitiveHydratedTargets](Addresses, request.addresses)
   all_targets = transitive_hydrated_targets.closure
   all_target_adaptors = [t.adaptor for t in all_targets]
 

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -5,7 +5,7 @@ from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule
@@ -29,7 +29,7 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> Cr
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
   request = CreatePexFromTargetClosure(
-    build_file_addresses=BuildFileAddresses((python_binary_adaptor.address,)),
+    addresses=Addresses((python_binary_adaptor.address.to_address(),)),
     entry_point=entry_point,
     output_filename=f'{python_binary_adaptor.address.target_name}.pex'
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -13,7 +13,7 @@ from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent
 from pants.engine.interactive_runner import InteractiveProcessRequest
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
@@ -99,13 +99,13 @@ async def setup_pytest_for_target(
   # TODO: Rather than consuming the TestOptions subsystem, the TestRunner should pass on coverage
   # configuration via #7490.
   transitive_hydrated_targets = await Get[TransitiveHydratedTargets](
-    BuildFileAddresses((test_target.address,))
+    Addresses((test_target.address.to_address(),))
   )
   all_targets = transitive_hydrated_targets.closure
 
   resolved_requirements_pex = await Get[Pex](
     CreatePexFromTargetClosure(
-      build_file_addresses=BuildFileAddresses((test_target.address,)),
+      addresses=Addresses((test_target.address.to_address(),)),
       output_filename='pytest-with-requirements.pex',
       entry_point="pytest:main",
       additional_requirements=pytest.get_requirement_strings(),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -249,7 +249,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   for hydrated_target in targets:
     if _is_exported(hydrated_target):
       exported_targets.append(ExportedTarget(hydrated_target))
-    elif address_origin_map.is_single_address(hydrated_target.address):
+    elif address_origin_map.is_single_address(hydrated_target.address.to_address()):
       explicit_nonexported_targets.append(hydrated_target)
   if explicit_nonexported_targets:
     raise TargetNotExported(

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -25,7 +25,7 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.base.specs import AddressSpecs, AscendantAddresses
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import (
@@ -259,7 +259,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   if options.values.transitive:
     # Expand out to all owners of the entire dep closure.
     tht = await Get[TransitiveHydratedTargets](
-      BuildFileAddresses([et.hydrated_target.address for et in exported_targets]))
+      Addresses(et.hydrated_target.address.to_address() for et in exported_targets))
     owners = await MultiGet(
       Get[ExportedTarget](OwnedDependency(ht)) for ht in tht.closure if is_ownable_target(ht)
     )
@@ -471,7 +471,7 @@ def _is_exported(target: HydratedTarget) -> bool:
 @rule(name="Compute distribution's 3rd party requirements")
 async def get_requirements(dep_owner: DependencyOwner) -> ExportedTargetRequirements:
   tht = await Get[TransitiveHydratedTargets](
-    BuildFileAddresses([dep_owner.exported_target.hydrated_target.address]))
+    Addresses([dep_owner.exported_target.hydrated_target.address.to_address()]))
 
   ownable_tgts = [tgt for tgt in tht.closure if is_ownable_target(tgt)]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_tgts)
@@ -515,7 +515,7 @@ async def get_owned_dependencies(dependency_owner: DependencyOwner) -> OwnedDepe
   Includes dependency_owner itself.
   """
   tht = await Get[TransitiveHydratedTargets](
-    BuildFileAddresses([dependency_owner.exported_target.hydrated_target.address]))
+    Addresses([dependency_owner.exported_target.hydrated_target.address.to_address()]))
   ownable_targets = [tgt for tgt in tht.closure
                      if isinstance(tgt.adaptor, (PythonTargetAdaptor, ResourcesAdaptor))]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_targets)
@@ -547,7 +547,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     [t for t in ancestor_tgts if _is_exported(t)], key=lambda t: t.address, reverse=True)
   exported_ancestor_iter = iter(exported_ancestor_tgts)
   for exported_ancestor in exported_ancestor_iter:
-    tht = await Get[TransitiveHydratedTargets](BuildFileAddresses([exported_ancestor.address]))
+    tht = await Get[TransitiveHydratedTargets](Addresses([exported_ancestor.address.to_address()]))
     if hydrated_target in tht.closure:
       owner = exported_ancestor
       # Find any exported siblings of owner that also depend on hydrated_target. They have the
@@ -555,7 +555,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
       sibling_owners = []
       sibling = next(exported_ancestor_iter, None)
       while sibling and sibling.address.spec_path == owner.address.spec_path:
-        tht = await Get[TransitiveHydratedTargets](BuildFileAddresses([sibling.address]))
+        tht = await Get[TransitiveHydratedTargets](Addresses([sibling.address.to_address()]))
         if hydrated_target in tht.closure:
           sibling_owners.append(sibling)
         sibling = next(exported_ancestor_iter, None)

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -9,7 +9,7 @@ from pants.base.specs import AddressSpecs, FilesystemSpecs, SingleAddress, Specs
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_parser import BuildFileParser
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.legacy.graph import LegacyBuildGraph
 from pants.engine.round_engine import RoundEngine
 from pants.engine.selectors import Params
@@ -69,7 +69,7 @@ class GoalRunnerFactory:
     # V1 tasks do not understand FilesystemSpecs, so we eagerly convert them into AddressSpecs.
     if self._specs.filesystem_specs.dependencies:
       owned_addresses, = self._graph_session.scheduler_session.product_request(
-        BuildFileAddresses, [Params(self._specs.filesystem_specs, self._options_bootstrapper)]
+        Addresses, [Params(self._specs.filesystem_specs, self._options_bootstrapper)]
       )
       updated_address_specs = AddressSpecs(
         dependencies=tuple(

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -211,25 +211,21 @@ class Address:
 
     :API: public
     """
-    # TODO(pl): Maybe we should just always start with // for simplicity?
-    return '{spec_path}:{target_name}'.format(spec_path=self._spec_path or '//',
-                                              target_name=self._target_name)
+    return f"{self._spec_path or '//'}:{self._target_name}"
 
   @property
   def path_safe_spec(self) -> str:
     """
     :API: public
     """
-    return ('{safe_spec_path}.{target_name}'
-            .format(safe_spec_path=self._spec_path.replace(os.sep, '.'),
-                    target_name=self._target_name.replace(os.sep, '.')))
+    return f"{self._spec_path.replace(os.sep, '.')}.{self._target_name.replace(os.sep, '.')}"
 
   @property
   def relative_spec(self) -> str:
     """
     :API: public
     """
-    return ':{target_name}'.format(target_name=self._target_name)
+    return f':{self._target_name}'
 
   def reference(self, referencing_path: Optional[str] = None) -> str:
     """How to reference this address in a BUILD file.
@@ -256,6 +252,9 @@ class Address:
     return not self == other
 
   def __repr__(self) -> str:
+    return f"Address({self.spec_path}, {self.target_name})"
+
+  def __str__(self) -> str:
     return self.spec
 
   def __lt__(self, other):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -267,17 +267,17 @@ def remove_origins(addresses_with_origins: AddressesWithOrigins) -> BuildFileAdd
 
 @dataclass(frozen=True)
 class AddressOriginMap:
-  bfaddr_to_origin: Dict[BuildFileAddress, Spec]
+  addr_to_origin: Dict[Address, Spec]
 
-  def is_single_address(self, address: BuildFileAddress) -> bool:
-    return isinstance(self.bfaddr_to_origin.get(address), SingleAddress)
+  def is_single_address(self, address: Address) -> bool:
+    return isinstance(self.addr_to_origin.get(address), SingleAddress)
 
 
 @rule
 def address_origin_map(addresses_with_origins: AddressesWithOrigins) -> AddressOriginMap:
   return AddressOriginMap(
-    bfaddr_to_origin={
-      address_with_origin.address: address_with_origin.origin
+    addr_to_origin={
+      address_with_origin.address.to_address(): address_with_origin.origin
       for address_with_origin in addresses_with_origins
     }
   )

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -14,6 +14,7 @@ from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import (
   AddressableDescriptor,
+  Addresses,
   AddressesWithOrigins,
   AddressWithOrigin,
   BuildFileAddresses,
@@ -283,6 +284,12 @@ def address_origin_map(addresses_with_origins: AddressesWithOrigins) -> AddressO
   )
 
 
+# TODO(#6657): Remove this once BFA is removed.
+@rule
+def bfas_to_addresses(build_file_addresses: BuildFileAddresses) -> Addresses:
+  return Addresses(bfa.to_address() for bfa in build_file_addresses)
+
+
 def _address_spec_to_globs(address_mapper: AddressMapper, address_specs: AddressSpecs) -> PathGlobs:
   """Given an AddressSpecs object, return a PathGlobs object for the build files that it matches."""
   patterns = set()
@@ -308,6 +315,7 @@ def create_graph_rules(address_mapper: AddressMapper):
     addresses_with_origins_from_address_families,
     remove_origins,
     address_origin_map,
+    bfas_to_addresses,
     # Root rules representing parameters that might be provided via root subjects.
     RootRule(Address),
     RootRule(BuildFileAddress),

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -27,7 +27,12 @@ from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
-from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin, BuildFileAddresses
+from pants.engine.addressable import (
+  Addresses,
+  AddressesWithOrigins,
+  AddressWithOrigin,
+  BuildFileAddresses,
+)
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import (
@@ -562,11 +567,9 @@ def topo_sort(targets: Iterable[HydratedTarget]) -> Tuple[HydratedTarget, ...]:
   return tuple(tgt for tgt in res if tgt in input_set)
 
 
-
 @rule
-async def hydrated_targets(build_file_addresses: BuildFileAddresses) -> HydratedTargets:
-  """Requests HydratedTarget instances for BuildFileAddresses."""
-  targets = await MultiGet(Get[HydratedTarget](Address, a) for a in build_file_addresses.addresses)
+async def hydrated_targets(addresses: Addresses) -> HydratedTargets:
+  targets = await MultiGet(Get[HydratedTarget](Address, a) for a in addresses)
   return HydratedTargets(targets)
 
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -506,10 +506,8 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
 
 
 @rule
-async def transitive_hydrated_targets(
-  build_file_addresses: BuildFileAddresses
-) -> TransitiveHydratedTargets:
-  """Given BuildFileAddresses, kicks off recursion on expansion of TransitiveHydratedTargets.
+async def transitive_hydrated_targets(addresses: Addresses) -> TransitiveHydratedTargets:
+  """Given Addresses, kicks off recursion on expansion of TransitiveHydratedTargets.
 
   The TransitiveHydratedTarget struct represents a structure-shared graph, which we walk
   and flatten here. The engine memoizes the computation of TransitiveHydratedTarget, so
@@ -518,7 +516,7 @@ async def transitive_hydrated_targets(
   """
 
   transitive_hydrated_targets = await MultiGet(
-    Get[TransitiveHydratedTarget](Address, a) for a in build_file_addresses.addresses
+    Get[TransitiveHydratedTarget](Address, a) for a in addresses
   )
 
   closure = OrderedSet()

--- a/src/python/pants/engine/legacy/graph_test.py
+++ b/src/python/pants/engine/legacy/graph_test.py
@@ -16,7 +16,9 @@ def make_graph(name_to_deps: Dict[str, Tuple[str, ...]]) -> Dict[str, HydratedTa
   def make_ht(nm: str) -> HydratedTarget:
     if nm not in name_to_ht:
       dep_hts = tuple(make_ht(dep) for dep in name_to_deps[nm])
-      name_to_ht[nm] = HydratedTarget(address=nm, adaptor=TargetAdaptor(), dependencies=dep_hts)
+      name_to_ht[nm] = HydratedTarget(
+        address=nm, adaptor=TargetAdaptor(), dependencies=dep_hts,  # type: ignore[arg-type]
+      )
     return name_to_ht[nm]
 
   for name in name_to_deps:
@@ -40,7 +42,7 @@ def test_topo_sort(name_to_deps: Dict[str, Tuple[str, ...]],
 
   # Note that here we check not just for a valid topo sort, but for a specific one from amongst
   # all valid ones. This is therefore implementation- and input order-dependent.
-  assert expected_order == tuple(ht.address for ht in topo_sort(hts))
+  assert expected_order == tuple(ht.address for ht in topo_sort(hts))  # type: ignore[comparison-overlap]
 
   # Now we do a more general check for validity of the result, but for every possible input order.
   def assert_is_topo_order(ordered_hts):
@@ -58,4 +60,4 @@ def test_topo_sort_filtered() -> None:
   name_to_deps: Dict[str, Tuple[str, ...]] = {'A': (), 'B': ('A',), 'C': ('B',), 'D': ('A',), 'E': ('C', 'D')}
   name_to_ht: Dict[str, HydratedTarget] = make_graph(name_to_deps)
   filtered_hts = [name_to_ht['E'], name_to_ht['A'], name_to_ht['B']]
-  assert ('A', 'B', 'E') == tuple(ht.address for ht in topo_sort(filtered_hts))
+  assert ('A', 'B', 'E') == tuple(ht.address for ht in topo_sort(filtered_hts))  # type: ignore[comparison-overlap]

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -6,7 +6,7 @@ import os.path
 from abc import ABCMeta, abstractmethod
 from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 
 from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.target import Target
@@ -29,6 +29,10 @@ class TargetAdaptor(StructWithDeps):
 
   Extends StructWithDeps to add a `dependencies` field marked Addressable.
   """
+
+  @property
+  def address(self) -> BuildFileAddress:
+    return cast(BuildFileAddress, super().address)
 
   def get_sources(self) -> Optional["GlobsWithConjunction"]:
     """Returns target's non-deferred sources if exists or the default sources if defined.

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from collections.abc import MutableMapping, MutableSequence
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, cast
 
+from pants.build_graph.address import BuildFileAddress
 from pants.engine.addressable import addressable, addressable_list
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
 from pants.util.objects import SubclassesOf, SuperclassesOf
@@ -106,19 +107,15 @@ class Struct(Serializable, SerializableFactory, Validatable):
     """
     return self._kwargs.get('name')
 
-  # TODO: this should return Optional[Address], but then we get a bunch of errors in rules using
-  # TargetAdaptor. Possibly, wait for the Target API to deal with this.
   @property
-  def address(self):
+  def address(self) -> Optional[BuildFileAddress]:
     """Return the address of this object, if any.
 
     In general structs need not be identified by an address, in which case they are
     generally embedded objects; ie: attributes values of enclosing named structs.
     Any top-level struct, though, will be identifiable via a unique address.
-
-    :rtype: :class:`pants.build_graph.address.Address`
     """
-    return self._kwargs.get('address')
+    return cast(Optional[BuildFileAddress], self._kwargs.get('address'))
 
   @property
   def type_alias(self) -> str:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -434,19 +434,17 @@ class EngineInitializer:
 
     @rule
     async def single_build_file_address(
-      build_file_addresses: BuildFileAddresses,
+      addresses: BuildFileAddresses,
     ) -> BuildFileAddress:
-      if len(build_file_addresses.dependencies) == 0:
+      if len(addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
-      if len(build_file_addresses.dependencies) > 1:
-        targets = [bfa.to_address() for bfa in build_file_addresses]
-        output = '\n '.join(str(target) for target in targets)
-
+      if len(addresses.dependencies) > 1:
+        output = '\n '.join(address.spec for address in addresses)
         raise ResolveError(
           "Expected a single target, but was given multiple targets:\n"
           f"Did you mean one of:\n {output}"
         )
-      return build_file_addresses.dependencies[0]
+      return addresses.dependencies[0]
 
     # Create a Scheduler containing graph and filesystem rules, with no installed goals. The
     # LegacyBuildGraph will explicitly request the products it needs.

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -40,7 +40,7 @@ class Binary(Goal):
 
 @goal_rule
 async def create_binary(
-  addresses: BuildFileAddresses,
+  addresses: Addresses,
   console: Console,
   workspace: Workspace,
   options: BinaryOptions,
@@ -48,7 +48,7 @@ async def create_binary(
 ) -> Binary:
   with options.line_oriented(console) as print_stdout:
     print_stdout(f"Generating binaries in `./{distdir.relpath}`")
-    binaries = await MultiGet(Get[CreatedBinary](Address, address.to_address()) for address in addresses)
+    binaries = await MultiGet(Get[CreatedBinary](Address, address) for address in addresses)
     merged_digest = await Get[Digest](
       DirectoriesToMerge(tuple(binary.digest for binary in binaries))
     )

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import List, Tuple, Type
 
+from pants.build_graph.address import BuildFileAddress
 from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
   Digest,
@@ -42,12 +43,12 @@ class FmtTest(TestBase):
       dirs=()
     )
     return HydratedTarget(
-      address=f"src/{name}",
+      address=BuildFileAddress(rel_path="src/BUILD", target_name=name),
       adaptor=adaptor_type(
         sources=EagerFilesetWithSpec("src", {"globs": []}, snapshot=mocked_snapshot),
         name=name,
       ),
-      dependencies=()
+      dependencies=(),
     )
 
   def run_fmt_rule(self, *, targets: List[HydratedTarget]) -> Tuple[Fmt, str]:

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -3,7 +3,7 @@
 
 from typing import Union
 
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTargets
@@ -33,16 +33,14 @@ class List(Goal):
 
 
 @goal_rule
-async def list_targets(
-  console: Console, list_options: ListOptions, build_file_addresses: BuildFileAddresses,
-) -> List:
+async def list_targets(console: Console, list_options: ListOptions, addresses: Addresses) -> List:
   provides = list_options.values.provides
   provides_columns = list_options.values.provides_columns
   documented = list_options.values.documented
-  collection: Union[HydratedTargets, BuildFileAddresses]
+  collection: Union[HydratedTargets, Addresses]
   if provides or documented:
     # To get provides clauses or documentation, we need hydrated targets.
-    collection = await Get[HydratedTargets](BuildFileAddresses, build_file_addresses)
+    collection = await Get[HydratedTargets](Addresses, addresses)
     if provides:
       extractors = dict(
           address=lambda target: target.address.spec,
@@ -72,7 +70,7 @@ async def list_targets(
       print_fn = print_documented
   else:
     # Otherwise, we can use only addresses.
-    collection = build_file_addresses
+    collection = addresses
     print_fn = lambda address: address.spec
 
   with list_options.line_oriented(console) as print_stdout:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -71,7 +71,7 @@ async def run(
         console.write_stderr(f"{target} failed with code {result.process_exit_code}!\n")
 
     except Exception as e:
-      console.write_stderr(f"Exception when attempting to run {target} : {e}\n")
+      console.write_stderr(f"Exception when attempting to run {target}: {e!r}\n")
       exit_code = -1
 
   return Run(exit_code)

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -4,6 +4,7 @@
 from typing import Optional
 from unittest.mock import Mock
 
+from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
@@ -24,13 +25,14 @@ class StripSourceRootsTests(TestBase):
   ) -> None:
     adaptor = Mock()
     adaptor.sources = Mock()
-    source_files = {original_path: "print('random python')"}
-    adaptor.sources.snapshot = self.make_snapshot(source_files)
+    adaptor.sources.snapshot = self.make_snapshot({original_path: "print('random python')"})
     adaptor.address = Mock()
     adaptor.address.spec_path = original_path
     if target_type_alias:
       adaptor.type_alias = target_type_alias
-    target = HydratedTarget('some/target/address', adaptor, tuple())
+    target = HydratedTarget(
+      BuildFileAddress(rel_path='some/target/BUILD', target_name='target'), adaptor, (),
+    )
     stripped_sources = self.request_single_product(
       SourceRootStrippedSources, Params(target, create_options_bootstrapper())
     )

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -66,7 +66,7 @@ class TestDebugRequest:
 class TestTarget:
   """A union for registration of a testable target type."""
 
-  # Prevent this class from being detected by pytest as a test class.
+  # Prevent this class from being detected by Pytest as a test class.
   __test__ = False
 
   @staticmethod
@@ -120,7 +120,7 @@ class AddressAndTestResult:
     address_origin_map: AddressOriginMap
   ) -> bool:
     is_valid_target_type = (
-      address_origin_map.is_single_address(target.address)
+      address_origin_map.is_single_address(target.address.to_address())
       or union_membership.is_member(TestTarget, target.adaptor)
     )
     has_sources = hasattr(target.adaptor, "sources") and target.adaptor.sources.snapshot.files
@@ -207,7 +207,7 @@ async def coordinator_of_debug_tests(target: HydratedTarget) -> AddressAndDebugR
 
 def rules():
   return [
-      coordinator_of_tests,
-      coordinator_of_debug_tests,
-      run_tests,
-    ]
+    coordinator_of_tests,
+    coordinator_of_debug_tests,
+    run_tests,
+  ]

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -132,7 +132,7 @@ class TestTest(TestBase):
         raise Exception("Unrecognised target")
       return AddressAndTestResult(target, tr)
 
-    def make_debug_request(target):
+    def make_debug_request(target: BuildFileAddress) -> AddressAndDebugRequest:
       request = TestDebugRequest(ipr=self.make_successful_ipr() if target == target1 else self.make_failure_ipr())
       return AddressAndDebugRequest(target, request)
 
@@ -187,7 +187,7 @@ class TestTest(TestBase):
     self,
     *,
     address: BuildFileAddress,
-    bfaddr_to_origin: Optional[Dict[BuildFileAddress, Spec]] = None,
+    addr_to_origin: Optional[Dict[Address, Spec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
   ) -> AddressAndTestResult:
@@ -213,7 +213,7 @@ class TestTest(TestBase):
         rule_args=[
           HydratedTarget(address, target_adaptor, ()),
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
-          AddressOriginMap(bfaddr_to_origin=bfaddr_to_origin or {}),
+          AddressOriginMap(addr_to_origin=addr_to_origin or {}),
         ],
         mock_gets=[
           MockGet(
@@ -240,7 +240,7 @@ class TestTest(TestBase):
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
         address=bfaddr,
-        bfaddr_to_origin={bfaddr: SingleAddress(directory='some/dir', name='bin')},
+        addr_to_origin={bfaddr.to_address(): SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
@@ -253,7 +253,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
     result = self.run_coordinator_of_tests(
       address=bfaddr,
-      bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')}
+      addr_to_origin={bfaddr.to_address(): DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
       bfaddr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
@@ -263,7 +263,7 @@ class TestTest(TestBase):
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
     result = self.run_coordinator_of_tests(
       address=bfaddr,
-      bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')},
+      addr_to_origin={bfaddr.to_address(): DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
     assert result == AddressAndTestResult(bfaddr, None)

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -77,7 +77,7 @@ class TestTest(TestBase):
         MockGet(
           product_type=BuildFileAddress,
           subject_type=BuildFileAddresses,
-          mock=lambda bfas: bfas.dependencies[0],
+          mock=lambda addresses: addresses.dependencies[0],
         ),
       ],
     )
@@ -85,7 +85,7 @@ class TestTest(TestBase):
     assert (0 if success else 1) == res.exit_code
 
   @staticmethod
-  def make_build_target_address(spec):
+  def make_build_target_address(spec: str) -> BuildFileAddress:
     address = Address.parse(spec)
     return BuildFileAddress(
       build_file=None,
@@ -93,7 +93,7 @@ class TestTest(TestBase):
       rel_path=f'{address.spec_path}/BUILD',
     )
 
-  def test_output_success(self):
+  def test_output_success(self) -> None:
     self.single_target_test(
       result=TestResult(status=Status.SUCCESS, stdout='Here is some output from a test', stderr=''),
       expected_console_output=dedent("""\
@@ -104,7 +104,7 @@ class TestTest(TestBase):
       """),
     )
 
-  def test_output_failure(self):
+  def test_output_failure(self) -> None:
     self.single_target_test(
       result=TestResult(status=Status.FAILURE, stdout='Here is some output from a test', stderr=''),
       expected_console_output=dedent("""\
@@ -116,14 +116,14 @@ class TestTest(TestBase):
       success=False,
     )
 
-  def test_output_mixed(self):
+  def test_output_mixed(self) -> None:
     console = MockConsole(use_colors=False)
     options = MockOptions(debug=False)
     runner = InteractiveRunner(self.scheduler)
     target1 = self.make_build_target_address("testprojects/tests/python/pants/passes")
     target2 = self.make_build_target_address("testprojects/tests/python/pants/fails")
 
-    def make_result(target):
+    def make_result(target: BuildFileAddress) -> AddressAndTestResult:
       if target == target1:
         tr = TestResult(status=Status.SUCCESS, stdout='I passed\n', stderr='')
       elif target == target2:
@@ -145,15 +145,13 @@ class TestTest(TestBase):
         MockGet(
           product_type=BuildFileAddress,
           subject_type=BuildFileAddresses,
-          mock=lambda tgt: BuildFileAddress(
-            rel_path=f'{tgt.spec_path}/BUILD', target_name=tgt.target_name,
-          )
+          mock=lambda addresses: addresses.dependencies[0]
         ),
       ],
     )
 
     self.assertEqual(1, res.exit_code)
-    self.assertEquals(console.stdout.getvalue(), dedent("""\
+    self.assertEqual(console.stdout.getvalue(), dedent("""\
       testprojects/tests/python/pants/passes stdout:
       I passed
 
@@ -165,7 +163,7 @@ class TestTest(TestBase):
       testprojects/tests/python/pants/fails                                           .....   FAILURE
       """))
 
-  def test_stderr(self):
+  def test_stderr(self) -> None:
     self.single_target_test(
       result=TestResult(status=Status.FAILURE, stdout='', stderr='Failure running the tests!'),
       expected_console_output=dedent("""\
@@ -177,7 +175,7 @@ class TestTest(TestBase):
       success=False,
     )
 
-  def test_debug_options(self):
+  def test_debug_options(self) -> None:
     self.single_target_test(
       result=None,
       expected_console_output='',
@@ -188,7 +186,7 @@ class TestTest(TestBase):
   def run_coordinator_of_tests(
     self,
     *,
-    address: Address,
+    address: BuildFileAddress,
     bfaddr_to_origin: Optional[Dict[BuildFileAddress, Spec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
@@ -227,45 +225,45 @@ class TestTest(TestBase):
       )
     return result
 
-  def test_coordinator_single_test_target(self):
-    addr = Address.parse("some/target")
-    result = self.run_coordinator_of_tests(address=addr)
+  def test_coordinator_single_test_target(self) -> None:
+    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
+    result = self.run_coordinator_of_tests(address=bfaddr)
     assert result == AddressAndTestResult(
-      addr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
+      bfaddr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
     )
 
-  def test_coordinator_single_non_test_target(self):
-    bfaddr = BuildFileAddress(None, 'bin', 'some/dir')
+  def test_coordinator_single_non_test_target(self) -> None:
+    bfaddr = BuildFileAddress(target_name='bin', rel_path='some/dir')
     # Note that this is not the same error message the end user will see, as we're resolving
     # union Get requests in run_rule, not the real engine.  But this test still asserts that
     # we error when we expect to error.
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
-        address=bfaddr.to_address(),
+        address=bfaddr,
         bfaddr_to_origin={bfaddr: SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
-  def test_coordinator_empty_sources(self):
-    addr = Address.parse("some/target")
-    result = self.run_coordinator_of_tests(address=addr, include_sources=False)
-    assert result == AddressAndTestResult(addr, None)
+  def test_coordinator_empty_sources(self) -> None:
+    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
+    result = self.run_coordinator_of_tests(address=bfaddr, include_sources=False)
+    assert result == AddressAndTestResult(bfaddr, None)
 
-  def test_coordinator_globbed_test_target(self):
+  def test_coordinator_globbed_test_target(self) -> None:
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
     result = self.run_coordinator_of_tests(
-      address=bfaddr.to_address(),
+      address=bfaddr,
       bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
-      bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
+      bfaddr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
     )
 
-  def test_coordinator_globbed_non_test_target(self):
+  def test_coordinator_globbed_non_test_target(self) -> None:
     bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
     result = self.run_coordinator_of_tests(
-      address=bfaddr.to_address(),
+      address=bfaddr,
       bfaddr_to_origin={bfaddr: DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
-    assert result == AddressAndTestResult(bfaddr.to_address(), None)
+    assert result == AddressAndTestResult(bfaddr, None)


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/issues/6657, there is little reason for `BuildFileAddress` to exist anymore. It is a clunky API, such as being verbose and subclassing `Address`.

This allows us to start using `Addresses` instead of `BuildFileAddresses` in most goals. There are still some awkward parts, like `HydratedTarget.address` being a `BuildFileAddress`, but those will be cleaned up in followup PRs.