### PR TITLE
Fix fingerprinting for --native-build-step-toolchain-variant

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -433,11 +433,6 @@ fragment: True
 [sitegen]
 config_path: src/docs/docsite.json
 
-# TODO(#6848, #7122): A gcc toolchain is currently required to build the tensorflow_custom_op example. This
-# should be removed when we can fully support both toolchains, and select between them with constraints.
-[native-build-step]
-toolchain_variant: gnu
-
 [native-build-step.cpp-compile-settings]
 # TensorFlow 1.13 on python 3.7 specifically uses a newer C++ ABI than any other TensorFlow release,
 # so in this repo's CI we override this option to avoid using the previous ABI for our python 3.7

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -43,6 +43,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                Platform.linux: ToolchainVariant.gnu,
              }),
              type=ToolchainVariant,
+             fingerprint=True,
              help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Note that "
                   "currently, despite the choice of toolchain, all linking is done with binutils "
                   "ld on Linux, and the XCode CLI Tools on MacOS.")


### PR DESCRIPTION
### Problem

The hardcoded `toolchain_variant` in `pants.ini` should have been removed when the default for `--native-build-step-toolchain-variant` was set to a different value on osx vs linux. Additionally, that option wasn't fingerprinted, even though it has a material effect on the build result.

### Solution

- Remove the `toolchain_variant` setting in `pants.ini`.
- Add `fingerprint=True` to the `--toolchain-variant` option registration.

### Result

`./pants test examples/tests/python/example_test/tensorflow_custom_op` works out of the box on osx!