### PR TITLE
Move MockOptions into testutil library

### DIFF
--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -4,7 +4,6 @@
 import logging
 from textwrap import dedent
 from typing import Dict, Optional
-from unittest.mock import Mock
 
 from pants.base.specs import DescendantAddresses, SingleAddress, Spec
 from pants.build_graph.address import Address, BuildFileAddress
@@ -26,13 +25,8 @@ from pants.rules.core.test import (
   run_tests,
 )
 from pants.source.wrapped_globs import EagerFilesetWithSpec
-from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+from pants.testutil.engine.util import MockConsole, MockGet, MockOptions, run_rule
 from pants.testutil.test_base import TestBase
-
-
-class MockOptions:
-  def __init__(self, **values):
-    self.values = Mock(**values)
 
 
 class TestTest(TestBase):

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from io import StringIO
 from types import CoroutineType, GeneratorType
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, get_type_hints
+from unittest.mock import Mock
 
 from colors import blue, green, red
 
@@ -168,6 +169,13 @@ def remove_locations_from_traceback(trace):
   new_trace = location_pattern.sub('LOCATION-INFO', trace)
   new_trace = address_pattern.sub('0xEEEEEEEEE', new_trace)
   return new_trace
+
+
+class MockOptions:
+  """Test mock for any options type."""
+
+  def __init__(self, **values):
+    self.values = Mock(**values)
 
 
 class MockConsole:


### PR DESCRIPTION
The test for the v2 `test` goal defines a `MockOptions` type since it specifically needs to create an options mock. But this is really a more general piece of functionality that ought to live in a testutil library so other test files can make use of it. 