### PR TITLE
Include related subsystems in `./pants help` for V1 goals and subsystems

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import wrap
-from typing import List
+from typing import List, Optional
 
 from colors import cyan, green, magenta, red
 
@@ -32,7 +32,9 @@ class HelpFormatter:
   def _maybe_color(self, color, s):
     return color(s) if self._color else s
 
-  def format_options(self, scope, description, option_registrations_iter):
+  def format_options(
+    self, scope: str, description: Optional[str], option_registrations_iter,
+  ) -> List[str]:
     """Return a help message for the specified options.
 
     :param option_registrations_iter: An iterator over (args, kwargs) pairs, as passed in to
@@ -41,7 +43,7 @@ class HelpFormatter:
     oshi = HelpInfoExtracter(self._scope).get_option_scope_help_info(option_registrations_iter)
     lines = []
 
-    def add_option(ohis, *, category=None):
+    def add_option(ohis, *, category: Optional[str] = None) -> None:
       lines.append('')
       display_scope = scope or 'Global'
       if category:

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import wrap
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 from colors import cyan, green, magenta, red
 
@@ -33,7 +33,12 @@ class HelpFormatter:
     return color(s) if self._color else s
 
   def format_options(
-    self, scope: str, description: Optional[str], option_registrations_iter,
+    self,
+    *,
+    scope: str,
+    description: Optional[str],
+    related_subsystem_scopes: Iterable[str],
+    option_registrations_iter,
   ) -> List[str]:
     """Return a help message for the specified options.
 
@@ -52,6 +57,8 @@ class HelpFormatter:
         lines.append(self._maybe_green(f'{display_scope}:'))
         if description:
           lines.append(description)
+        if related_subsystem_scopes:
+          lines.append(f"Related subsystems: {', '.join(sorted(related_subsystem_scopes))}")
       lines.append(' ')
       if not ohis:
         lines.append('No options available.')

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -32,12 +32,22 @@ class OptionHelpFormatterTest(unittest.TestCase):
     kwargs = {'advanced': True}
     lines = HelpFormatter(
       scope='', show_recursive=False, show_advanced=False, color=False
-    ).format_options(scope='', description='', option_registrations_iter=[(args, kwargs)])
+    ).format_options(
+      scope='',
+      description='',
+      related_subsystem_scopes=[],
+      option_registrations_iter=[(args, kwargs)],
+    )
     assert len(lines) == 5
     assert not any("--foo" in line for line in lines)
     lines = HelpFormatter(
       scope='', show_recursive=True, show_advanced=True, color=False
-    ).format_options(scope='', description='', option_registrations_iter=[(args, kwargs)])
+    ).format_options(
+      scope='',
+      description='',
+      related_subsystem_scopes=[],
+      option_registrations_iter=[(args, kwargs)],
+    )
     assert len(lines) == 14
 
   def test_format_help_choices(self):

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -119,11 +119,11 @@ class HelpInfoExtracter:
       values = (str(choice) for choice in kwargs.get('choices', []))
     return ', '.join(values) or None
 
-  def __init__(self, scope):
+  def __init__(self, scope: str) -> None:
     self._scope = scope
     self._scope_prefix = scope.replace('.', '-')
 
-  def get_option_scope_help_info(self, option_registrations_iter):
+  def get_option_scope_help_info(self, option_registrations_iter) -> OptionScopeHelpInfo:
     """Returns an OptionScopeHelpInfo for the options registered with the (args, kwargs) pairs."""
     basic_options = []
     recursive_options = []
@@ -140,10 +140,12 @@ class HelpInfoExtracter:
       else:
         basic_options.append(ohi)
 
-    return OptionScopeHelpInfo(scope=self._scope,
-                               basic=basic_options,
-                               recursive=recursive_options,
-                               advanced=advanced_options)
+    return OptionScopeHelpInfo(
+      scope=self._scope,
+      basic=basic_options,
+      recursive=recursive_options,
+      advanced=advanced_options,
+    )
 
   def get_option_help_info(self, args, kwargs):
     """Returns an OptionHelpInfo for the option registered with the given (args, kwargs)."""

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -35,7 +35,12 @@ class HelpPrinter:
     union_membership: UnionMembership,
   ) -> None:
     self._options = options
-    self._help_request = help_request or self._options.help_request
+    self._help_request = cast(HelpRequest, help_request or self._options.help_request)
+    if self._help_request is None:
+      raise AssertionError(
+        "HelpPrinter was instantiated without any corresponding `help_request`. This means that "
+        "there would be nothing to print and that there was a mistake from the call site."
+      )
     self._union_membership = union_membership
 
   @property
@@ -133,13 +138,13 @@ class HelpPrinter:
 
       print(self._format_help(ScopeInfo(GLOBAL_SCOPE, ScopeInfo.GLOBAL)))
 
-  def _format_help(self, scope_info):
-    """Return a help message for the options registered on this object.
-
-    Assumes that self._help_request is an instance of OptionsHelp.
-
-    :param scope_info: Scope of the options.
-    """
+  def _format_help(self, scope_info: ScopeInfo) -> str:
+    """Return a help message for the options registered on this object."""
+    if not isinstance(self._help_request, OptionsHelp):
+      raise AssertionError(
+        f"`self._help_request` was expected to have type OptionsHelp but had type "
+        f"{type(self._help_request)}"
+      )
     scope = scope_info.scope
     description = scope_info.description
     help_formatter = HelpFormatter(


### PR DESCRIPTION
Implements part of https://github.com/pantsbuild/pants/issues/8884.

Now that we're moving many options to subsystems, instead of tasks, we need to improve the discoverability of subsystems like `isort` and `python-setup`.

For V1, this is easy to naively do by calling `SubsystemClientMixin.subsystem_closure_iter()`, which will find the transitive subsystems depended upon by that subsystem. Not every subsystem dependency seems to actually be properly declared, so the output isn't perfect, but it's an improvement from before:

```
▶ ./pants help python-native-code.test.pytest-prep

python-native-code.test.pytest-prep:
A subsystem which exposes components of the native backend to the python backend.
Related subsystems: gcc, libc, llvm, native-toolchain, python-native-code

No options available.



native-toolchain.python-native-code:
Abstraction over platform-specific tools to compile and link native code.
Related subsystems: gcc, libc, llvm, native-toolchain

No options available.
```

A followup will add support for V2 susbsystems and goals by traversing the rule graph for all `subsystem_rules` used.