### PR TITLE
WIP: stop using `BuildFileAddresses` in V2

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -36,7 +36,7 @@ async def create_python_awslambda(
   # TODO: We must enforce that everything is built for Linux, no matter the local platform.
   pex_filename = f'{lambda_tgt_adaptor.address.target_name}.pex'
   pex_request = CreatePexFromTargetClosure(
-    addresses=Addresses((lambda_tgt_adaptor.address.to_address(),)),
+    addresses=Addresses((lambda_tgt_adaptor.address,)),
     entry_point=None,
     output_filename=pex_filename
   )

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -29,7 +29,7 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> Cr
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
   request = CreatePexFromTargetClosure(
-    addresses=Addresses((python_binary_adaptor.address.to_address(),)),
+    addresses=Addresses((python_binary_adaptor.address,)),
     entry_point=entry_point,
     output_filename=f'{python_binary_adaptor.address.target_name}.pex'
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -99,13 +99,13 @@ async def setup_pytest_for_target(
   # TODO: Rather than consuming the TestOptions subsystem, the TestRunner should pass on coverage
   # configuration via #7490.
   transitive_hydrated_targets = await Get[TransitiveHydratedTargets](
-    Addresses((test_target.address.to_address(),))
+    Addresses((test_target.address,))
   )
   all_targets = transitive_hydrated_targets.closure
 
   resolved_requirements_pex = await Get[Pex](
     CreatePexFromTargetClosure(
-      addresses=Addresses((test_target.address.to_address(),)),
+      addresses=Addresses((test_target.address,)),
       output_filename='pytest-with-requirements.pex',
       entry_point="pytest:main",
       additional_requirements=pytest.get_requirement_strings(),
@@ -132,7 +132,7 @@ async def setup_pytest_for_target(
   # optimization, this ensures that any transitive sources, such as a test project file named
   # test_fail.py, do not unintentionally end up being run as tests.
   source_root_stripped_test_target_sources = await Get[SourceRootStrippedSources](
-    Address, test_target.address.to_address()
+    Address, test_target.address
   )
 
   coverage_args = []

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -18,7 +18,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
@@ -129,9 +129,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
     if passthrough_args:
       args.append(f"--pytest-args='{passthrough_args}'")
     options_bootstrapper = create_options_bootstrapper(args=args)
-    target = PythonTestsAdaptor(
-      address=BuildFileAddress(rel_path=f"{self.source_root}/BUILD", target_name="target"),
-    )
+    target = PythonTestsAdaptor(address=Address.parse(f"{self.source_root}:target"))
     test_result = self.request_single_product(TestResult, Params(target, options_bootstrapper))
     debug_request = self.request_single_product(
       TestDebugRequest, Params(target, options_bootstrapper),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -249,7 +249,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   for hydrated_target in targets:
     if _is_exported(hydrated_target):
       exported_targets.append(ExportedTarget(hydrated_target))
-    elif address_origin_map.is_single_address(hydrated_target.address.to_address()):
+    elif address_origin_map.is_single_address(hydrated_target.address):
       explicit_nonexported_targets.append(hydrated_target)
   if explicit_nonexported_targets:
     raise TargetNotExported(
@@ -259,7 +259,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   if options.values.transitive:
     # Expand out to all owners of the entire dep closure.
     tht = await Get[TransitiveHydratedTargets](
-      Addresses(et.hydrated_target.address.to_address() for et in exported_targets))
+      Addresses(et.hydrated_target.address for et in exported_targets))
     owners = await MultiGet(
       Get[ExportedTarget](OwnedDependency(ht)) for ht in tht.closure if is_ownable_target(ht)
     )
@@ -471,7 +471,7 @@ def _is_exported(target: HydratedTarget) -> bool:
 @rule(name="Compute distribution's 3rd party requirements")
 async def get_requirements(dep_owner: DependencyOwner) -> ExportedTargetRequirements:
   tht = await Get[TransitiveHydratedTargets](
-    Addresses([dep_owner.exported_target.hydrated_target.address.to_address()]))
+    Addresses([dep_owner.exported_target.hydrated_target.address]))
 
   ownable_tgts = [tgt for tgt in tht.closure if is_ownable_target(tgt)]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_tgts)
@@ -515,7 +515,7 @@ async def get_owned_dependencies(dependency_owner: DependencyOwner) -> OwnedDepe
   Includes dependency_owner itself.
   """
   tht = await Get[TransitiveHydratedTargets](
-    Addresses([dependency_owner.exported_target.hydrated_target.address.to_address()]))
+    Addresses([dependency_owner.exported_target.hydrated_target.address]))
   ownable_targets = [tgt for tgt in tht.closure
                      if isinstance(tgt.adaptor, (PythonTargetAdaptor, ResourcesAdaptor))]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_targets)
@@ -547,7 +547,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     [t for t in ancestor_tgts if _is_exported(t)], key=lambda t: t.address, reverse=True)
   exported_ancestor_iter = iter(exported_ancestor_tgts)
   for exported_ancestor in exported_ancestor_iter:
-    tht = await Get[TransitiveHydratedTargets](Addresses([exported_ancestor.address.to_address()]))
+    tht = await Get[TransitiveHydratedTargets](Addresses([exported_ancestor.address]))
     if hydrated_target in tht.closure:
       owner = exported_ancestor
       # Find any exported siblings of owner that also depend on hydrated_target. They have the
@@ -555,7 +555,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
       sibling_owners = []
       sibling = next(exported_ancestor_iter, None)
       while sibling and sibling.address.spec_path == owner.address.spec_path:
-        tht = await Get[TransitiveHydratedTargets](Addresses([sibling.address.to_address()]))
+        tht = await Get[TransitiveHydratedTargets](Addresses([sibling.address]))
         if hydrated_target in tht.closure:
           sibling_owners.append(sibling)
         sibling = next(exported_ancestor_iter, None)

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -20,7 +20,7 @@ class Addresses(Collection[Address]):
 @dataclass(frozen=True)
 class AddressWithOrigin:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
-  address: BuildFileAddress
+  address: Address
   origin: Union[AddressSpec, FilesystemResolvedSpec]
 
 

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -8,7 +8,7 @@ from pants.base.build_file import BuildFile
 from pants.base.specs import AddressSpecs, DescendantAddresses, SiblingAddresses
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.mapper import ResolveError
 from pants.util.dirutil import fast_relpath
 
@@ -63,7 +63,7 @@ class LegacyAddressMapper(AddressMapper):
   def _internal_scan_specs(self, specs, fail_fast=True, missing_is_fatal=True):
     # TODO: This should really use `product_request`, but on the other hand, we need to
     # deprecate the entire `AddressMapper` interface anyway. See #4769.
-    request = self._scheduler.execution_request([BuildFileAddresses], [AddressSpecs(tuple(specs))])
+    request = self._scheduler.execution_request([Addresses], [AddressSpecs(tuple(specs))])
     returns, throws = self._scheduler.execute(request)
 
     if throws:

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -755,15 +755,14 @@ async def addresses_with_origins_from_filesystem_specs(
         logger.warning(msg)
       else:
         raise ResolveError(msg)
-    for address in owners.addresses:
-      # We preserve what literal files any globs resolved to. This allows downstream goals to be
-      # more precise in which files they operate on.
-      origin = (
-        spec
-        if isinstance(spec, FilesystemLiteralSpec) else
-        FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
-      )
-      result.append(AddressWithOrigin(address=address, origin=origin))
+    # We preserve what literal files any globs resolved to. This allows downstream goals to be
+    # more precise in which files they operate on.
+    origin = (
+      spec
+      if isinstance(spec, FilesystemLiteralSpec) else
+      FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
+    )
+    result.extend(AddressWithOrigin(address, origin) for address in owners.addresses)
   return AddressesWithOrigins(result)
 
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -23,7 +23,7 @@ from pants.base.specs import (
   FilesystemSpecs,
   SingleAddress,
 )
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
 from pants.build_graph.build_graph import BuildGraph
@@ -373,7 +373,7 @@ class HydratedTarget:
   Transitive graph walks collect ordered sets of TransitiveHydratedTargets which involve a huge amount
   of hashing: we implement eq/hash via direct usage of an Address field to speed that up.
   """
-  address: BuildFileAddress
+  address: Address
   adaptor: TargetAdaptor
   dependencies: Tuple[Address, ...]
 
@@ -591,7 +591,7 @@ async def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
   for field in hydrated_fields:
     kwargs[field.name] = field.value
   return HydratedTarget(
-    address=target_adaptor.address,
+    address=target_adaptor.address.to_address(),
     adaptor=type(target_adaptor)(**kwargs),
     dependencies=tuple(target_adaptor.dependencies),
   )

--- a/src/python/pants/engine/legacy/graph_test.py
+++ b/src/python/pants/engine/legacy/graph_test.py
@@ -14,6 +14,9 @@ def make_graph(name_to_deps: Dict[str, Tuple[str, ...]]) -> Dict[str, HydratedTa
   name_to_ht: Dict[str, HydratedTarget] = {}
 
   def make_ht(nm: str) -> HydratedTarget:
+    # NB: The HydratedTargets are not valid HydratedTargets, such as using a str instead of
+    # Address for the .address field. This is okay because it makes the tests much easier to work
+    # with and the topo_sort rule does not actually care about the HydratedTarget fields.
     if nm not in name_to_ht:
       dep_hts = tuple(make_ht(dep) for dep in name_to_deps[nm])
       name_to_ht[nm] = HydratedTarget(

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -8,7 +8,7 @@ from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_list
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
@@ -31,8 +31,10 @@ class TargetAdaptor(StructWithDeps):
   """
 
   @property
-  def address(self) -> BuildFileAddress:
-    return cast(BuildFileAddress, super().address)
+  def address(self) -> Address:
+    # TODO: this isn't actually safe to override as Address instead of Optional[Address]. There are
+    # some cases where Address is not defined. But, then we get a ton of MyPy issues.
+    return cast(Address, super().address)
 
   def get_sources(self) -> Optional["GlobsWithConjunction"]:
     """Returns target's non-deferred sources if exists or the default sources if defined.
@@ -144,7 +146,7 @@ class SourcesField:
   :param validate_fn: A function which takes an EagerFilesetWithSpec and throws if it's not
     acceptable. This API will almost certainly change in the near future.
   """
-  address: BuildFileAddress
+  address: Address
   arg: str
   filespecs: wrapped_globs.Filespec
   base_globs: "BaseGlobs"
@@ -185,7 +187,7 @@ class PageAdaptor(TargetAdaptor):
 @dataclass(frozen=True)
 class BundlesField:
   """Represents the `bundles` argument, each of which has a PathGlobs to represent its `fileset`."""
-  address: BuildFileAddress
+  address: Address
   bundles: Any
   filespecs_list: List[wrapped_globs.Filespec]
   path_globs_list: List[PathGlobs]

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -4,7 +4,7 @@
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any, Dict, Iterable, Optional, cast
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_list
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
 from pants.util.objects import SubclassesOf, SuperclassesOf
@@ -108,14 +108,14 @@ class Struct(Serializable, SerializableFactory, Validatable):
     return self._kwargs.get('name')
 
   @property
-  def address(self) -> Optional[BuildFileAddress]:
+  def address(self) -> Optional[Address]:
     """Return the address of this object, if any.
 
     In general structs need not be identified by an address, in which case they are
     generally embedded objects; ie: attributes values of enclosing named structs.
     Any top-level struct, though, will be identifiable via a unique address.
     """
-    return cast(Optional[BuildFileAddress], self._kwargs.get('address'))
+    return cast(Optional[Address], self._kwargs.get('address'))
 
   @property
   def type_alias(self) -> str:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -433,9 +433,7 @@ class EngineInitializer:
       return cast(BuildRoot, BuildRoot.instance)
 
     @rule
-    async def single_build_file_address(
-      addresses: BuildFileAddresses,
-    ) -> BuildFileAddress:
+    async def single_address(addresses: BuildFileAddresses) -> BuildFileAddress:
       if len(addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
       if len(addresses.dependencies) > 1:
@@ -456,7 +454,7 @@ class EngineInitializer:
         symbol_table_singleton,
         union_membership_singleton,
         build_root_singleton,
-        single_build_file_address,
+        single_address,
       ),
       *create_legacy_graph_tasks(),
       *create_fs_rules(),

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -18,11 +18,11 @@ from pants.base.deprecated import deprecated_conditional
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.specs import Specs
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.remote_sources import RemoteSources
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
@@ -433,7 +433,7 @@ class EngineInitializer:
       return cast(BuildRoot, BuildRoot.instance)
 
     @rule
-    async def single_address(addresses: BuildFileAddresses) -> BuildFileAddress:
+    async def single_address(addresses: Addresses) -> Address:
       if len(addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
       if len(addresses.dependencies) > 1:

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 from typing import List, Tuple, Type
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
   Digest,
@@ -43,7 +43,7 @@ class FmtTest(TestBase):
       dirs=()
     )
     return HydratedTarget(
-      address=BuildFileAddress(rel_path="src/BUILD", target_name=name),
+      address=Address.parse(f"src:{name}"),
       adaptor=adaptor_type(
         sources=EagerFilesetWithSpec("src", {"globs": []}, snapshot=mocked_snapshot),
         name=name,

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
@@ -43,9 +44,10 @@ async def run(
   workspace: Workspace,
   runner: InteractiveRunner,
   build_root: BuildRoot,
-  address: Address,
+  addresses: Addresses,
   options: RunOptions,
 ) -> Run:
+  address = addresses.expect_single()
   binary = await Get[CreatedBinary](Address, address)
 
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -5,13 +5,13 @@ from typing import cast
 from unittest.mock import Mock
 
 from pants.base.build_root import BuildRoot
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.rules.core.binary import CreatedBinary
 from pants.rules.core.run import Run, run
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
-from pants.testutil.goal_rule_test_base import GoalRuleTestBase
+from pants.testutil.test_base import TestBase
 
 
 # TODO: Create a utility to mock GoalSubsystems.
@@ -20,8 +20,7 @@ class MockOptions:
     self.values = Mock(**values)
 
 
-class RunTest(GoalRuleTestBase):
-  goal_cls = Run
+class RunTest(TestBase):
 
   def create_mock_binary(self, program_text: bytes) -> CreatedBinary:
     input_files_content = InputFilesContent((
@@ -38,16 +37,17 @@ class RunTest(GoalRuleTestBase):
   ) -> Run:
     workspace = Workspace(self.scheduler)
     interactive_runner = InteractiveRunner(self.scheduler)
-    address = Address.parse(address_spec)
-    bfa = BuildFileAddress(
-      build_file=None,
-      target_name=address.target_name,
-      rel_path=f'{address.spec_path}/BUILD'
-    )
     BuildRoot().path = self.build_root
     res = run_rule(
       run,
-      rule_args=[console, workspace, interactive_runner, BuildRoot(), bfa, MockOptions(args=[])],
+      rule_args=[
+        console,
+        workspace,
+        interactive_runner,
+        BuildRoot(),
+        Address.parse(address_spec),
+        MockOptions(args=[]),
+      ],
       mock_gets=[
         MockGet(
           product_type=CreatedBinary,

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -4,7 +4,7 @@
 from typing import Optional
 from unittest.mock import Mock
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
@@ -30,9 +30,7 @@ class StripSourceRootsTests(TestBase):
     adaptor.address.spec_path = original_path
     if target_type_alias:
       adaptor.type_alias = target_type_alias
-    target = HydratedTarget(
-      BuildFileAddress(rel_path='some/target/BUILD', target_name='target'), adaptor, (),
-    )
+    target = HydratedTarget(Address.parse('some/target/BUILD:target'), adaptor, ())
     stripped_sources = self.request_single_product(
       SourceRootStrippedSources, Params(target, create_options_bootstrapper())
     )

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -138,7 +138,7 @@ async def run_tests(
   console: Console, options: TestOptions, runner: InteractiveRunner, addresses: Addresses,
 ) -> Test:
   if options.values.debug:
-    address = await Get[Address](Addresses, addresses)
+    address = addresses.expect_single()
     addr_debug_request = await Get[AddressAndDebugRequest](Address, address)
     result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
     return Test(result.process_exit_code)
@@ -175,14 +175,13 @@ async def run_tests(
 async def coordinator_of_tests(
   target: HydratedTarget,
   union_membership: UnionMembership,
-  # TODO: get this working. Uncommenting it out results in graph ambiguity.
-  # address_origin_map: AddressOriginMap
+  address_origin_map: AddressOriginMap
 ) -> AddressAndTestResult:
 
-  # if not AddressAndTestResult.is_testable(
-  #   target, union_membership=union_membership, address_origin_map=address_origin_map
-  # ):
-  #   return AddressAndTestResult(target.address, None)
+  if not AddressAndTestResult.is_testable(
+    target, union_membership=union_membership, address_origin_map=address_origin_map
+  ):
+    return AddressAndTestResult(target.address, None)
 
   # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
   # live TTY, periodically dump heavy hitters to stderr. See

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -7,8 +7,8 @@ from enum import Enum
 from typing import Optional
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
-from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.addressable import BuildFileAddresses
+from pants.build_graph.address import Address
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import Digest
@@ -135,15 +135,15 @@ class AddressAndDebugRequest:
 
 @goal_rule
 async def run_tests(
-  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses,
+  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: Addresses,
 ) -> Test:
   if options.values.debug:
-    debug_address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
-    addr_debug_request = await Get[AddressAndDebugRequest](Address, debug_address.to_address())
+    address = await Get[Address](Addresses, addresses)
+    addr_debug_request = await Get[AddressAndDebugRequest](Address, address)
     result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
     return Test(result.process_exit_code)
 
-  results = await MultiGet(Get[AddressAndTestResult](Address, addr.to_address()) for addr in addresses)
+  results = await MultiGet(Get[AddressAndTestResult](Address, addr) for addr in addresses)
   did_any_fail = False
   filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -109,7 +109,7 @@ class Test(Goal):
 
 @dataclass(frozen=True)
 class AddressAndTestResult:
-  address: BuildFileAddress
+  address: Address
   test_result: Optional[TestResult]  # If None, target was not a test target.
 
   @staticmethod
@@ -120,7 +120,7 @@ class AddressAndTestResult:
     address_origin_map: AddressOriginMap
   ) -> bool:
     is_valid_target_type = (
-      address_origin_map.is_single_address(target.address.to_address())
+      address_origin_map.is_single_address(target.address)
       or union_membership.is_member(TestTarget, target.adaptor)
     )
     has_sources = hasattr(target.adaptor, "sources") and target.adaptor.sources.snapshot.files
@@ -129,7 +129,7 @@ class AddressAndTestResult:
 
 @dataclass(frozen=True)
 class AddressAndDebugRequest:
-  address: BuildFileAddress
+  address: Address
   request: TestDebugRequest
 
 
@@ -138,8 +138,8 @@ async def run_tests(
   console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses,
 ) -> Test:
   if options.values.debug:
-    address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
-    addr_debug_request = await Get[AddressAndDebugRequest](Address, address.to_address())
+    debug_address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
+    addr_debug_request = await Get[AddressAndDebugRequest](Address, debug_address.to_address())
     result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
     return Test(result.process_exit_code)
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -175,13 +175,14 @@ async def run_tests(
 async def coordinator_of_tests(
   target: HydratedTarget,
   union_membership: UnionMembership,
-  address_origin_map: AddressOriginMap
+  # TODO: get this working. Uncommenting it out results in graph ambiguity.
+  # address_origin_map: AddressOriginMap
 ) -> AddressAndTestResult:
 
-  if not AddressAndTestResult.is_testable(
-    target, union_membership=union_membership, address_origin_map=address_origin_map
-  ):
-    return AddressAndTestResult(target.address, None)
+  # if not AddressAndTestResult.is_testable(
+  #   target, union_membership=union_membership, address_origin_map=address_origin_map
+  # ):
+  #   return AddressAndTestResult(target.address, None)
 
   # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
   # live TTY, periodically dump heavy hitters to stderr. See

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -7,8 +7,8 @@ from typing import Dict, Optional
 from unittest.mock import Mock
 
 from pants.base.specs import DescendantAddresses, SingleAddress, Spec
-from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.addressable import BuildFileAddresses
+from pants.build_graph.address import Address
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
@@ -59,10 +59,10 @@ class TestTest(TestBase):
     console = MockConsole(use_colors=False)
     options = MockOptions(debug=debug)
     runner = InteractiveRunner(self.scheduler)
-    addr = self.make_build_target_address("some/target")
+    addr = Address.parse("some/target")
     res = run_rule(
       run_tests,
-      rule_args=[console, options, runner, BuildFileAddresses([addr])],
+      rule_args=[console, options, runner, Addresses([addr])],
       mock_gets=[
         MockGet(
           product_type=AddressAndTestResult,
@@ -75,22 +75,14 @@ class TestTest(TestBase):
           mock=lambda _: AddressAndDebugRequest(addr, TestDebugRequest(ipr=self.make_successful_ipr() if success else self.make_failure_ipr()))
         ),
         MockGet(
-          product_type=BuildFileAddress,
-          subject_type=BuildFileAddresses,
+          product_type=Address,
+          subject_type=Addresses,
           mock=lambda addresses: addresses.dependencies[0],
         ),
       ],
     )
     assert console.stdout.getvalue() == expected_console_output
     assert (0 if success else 1) == res.exit_code
-
-  @staticmethod
-  def make_build_target_address(spec: str) -> BuildFileAddress:
-    address = Address.parse(spec)
-    return BuildFileAddress(
-      target_name=address.target_name,
-      rel_path=f'{address.spec_path}/BUILD',
-    )
 
   def test_output_success(self) -> None:
     self.single_target_test(
@@ -119,10 +111,10 @@ class TestTest(TestBase):
     console = MockConsole(use_colors=False)
     options = MockOptions(debug=False)
     runner = InteractiveRunner(self.scheduler)
-    target1 = self.make_build_target_address("testprojects/tests/python/pants/passes")
-    target2 = self.make_build_target_address("testprojects/tests/python/pants/fails")
+    target1 = Address.parse("testprojects/tests/python/pants/passes")
+    target2 = Address.parse("testprojects/tests/python/pants/fails")
 
-    def make_result(target: BuildFileAddress) -> AddressAndTestResult:
+    def make_result(target: Address) -> AddressAndTestResult:
       if target == target1:
         tr = TestResult(status=Status.SUCCESS, stdout='I passed\n', stderr='')
       elif target == target2:
@@ -131,19 +123,19 @@ class TestTest(TestBase):
         raise Exception("Unrecognised target")
       return AddressAndTestResult(target, tr)
 
-    def make_debug_request(target: BuildFileAddress) -> AddressAndDebugRequest:
+    def make_debug_request(target: Address) -> AddressAndDebugRequest:
       request = TestDebugRequest(ipr=self.make_successful_ipr() if target == target1 else self.make_failure_ipr())
       return AddressAndDebugRequest(target, request)
 
     res = run_rule(
       run_tests,
-      rule_args=[console, options, runner, (target1, target2)],
+      rule_args=[console, options, runner, Addresses([target1, target2])],
       mock_gets=[
         MockGet(product_type=AddressAndTestResult, subject_type=Address, mock=make_result),
         MockGet(product_type=AddressAndDebugRequest, subject_type=Address, mock=make_debug_request),
         MockGet(
-          product_type=BuildFileAddress,
-          subject_type=BuildFileAddresses,
+          product_type=Address,
+          subject_type=Addresses,
           mock=lambda addresses: addresses.dependencies[0]
         ),
       ],

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -50,7 +50,7 @@ async def find_owners(
   changed_request: ChangedRequest,
 ) -> ChangedAddresses:
   owners = await Get[Owners](OwnersRequest(sources=changed_request.sources))
-  direct_owners = Addresses(bfa.to_address() for bfa in owners.addresses)
+  direct_owners = Addresses(address for address in owners.addresses)
 
   # If the ChangedRequest does not require dependees, then we're done.
   if changed_request.include_dependees == IncludeDependeesOption.NONE:

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -15,7 +15,7 @@ from pants.engine.build_files import (
   addresses_with_origins_from_address_families,
   create_graph_rules,
   parse_address_family,
-  remove_origins,
+  strip_address_origins,
 )
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
@@ -89,7 +89,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         ),
       ],
     )
-    return cast(BuildFileAddresses, run_rule(remove_origins, rule_args=[pbfas]))
+    return cast(BuildFileAddresses, run_rule(strip_address_origins, rule_args=[pbfas]))
 
   def test_duplicated(self) -> None:
     """Test that matching the same AddressSpec twice succeeds."""

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (
@@ -136,8 +136,8 @@ HydratedStructs = Collection[HydratedStruct]
 
 
 @rule
-async def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> HydratedStructs:
-  tacs = await MultiGet(Get[HydratedStruct](Address, a) for a in build_file_addresses.addresses)
+async def unhydrated_structs(addresses: Addresses) -> HydratedStructs:
+  tacs = await MultiGet(Get[HydratedStruct](Address, a) for a in addresses)
   return HydratedStructs(tacs)
 
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/pull/9083.

While there are some select situations where we want to use `BuildFileAddress`, generally it is a much clunkier API than we would like due to subclassing `Address` and because it is very wordy.

Now, when we need a `BuildFileAddress`, we can `await Get[BuildFileAddress](Address)`.