### PR TITLE
Allow test specs to be used with --no-fast for junit

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -84,6 +84,7 @@ pantsd_invalidation_globs: +[
 pants_ignore: +[
     # venv directories under build-support.
     '/build-support/virtualenvs/',
+    '/build-support/*.venv/',
 
     # An absolute symlink to the Pants Rust toolchain sources.
     '/build-support/bin/native/src',

--- a/src/python/pants/java/junit/junit_xml_parser.py
+++ b/src/python/pants/java/junit/junit_xml_parser.py
@@ -5,10 +5,11 @@ import fnmatch
 import os
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 from twitter.common.collections import OrderedSet
 
+from pants.build_graph.target import Target
 from pants.util.dirutil import safe_walk
 from pants.util.meta import frozen_after_init
 from pants.util.xml_parser import XmlParser
@@ -70,6 +71,15 @@ class RegistryOfTests:
     :rtype: bool
     """
     return len(self._test_to_target) == 0
+
+  def filter(self, targets: Sequence[Target]) -> 'RegistryOfTests':
+    """Returns a new instance containing only the given test targets."""
+    target_set = set(targets)
+    return RegistryOfTests(
+      (test, target)
+      for test, target in self._test_to_target.items()
+      if target in target_set
+    )
 
   def match_test_spec(self, possible_test_specs):
     """

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -467,6 +467,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:coverage_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:cucumber_directory',
+    'testprojects/tests/java/org/pantsbuild/testproject:dummies_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:htmlreport_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:matcher_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:syntheticjar_directory',

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -176,6 +176,15 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     self.assert_failure(pants_run)
     self.assertIn("No target found for test specifier", pants_run.stdout_data)
 
+  def test_junit_run_no_fast_multi(self):
+    pants_run = self.run_pants(['test.junit',
+                                '--no-fast',
+                                '--test=PassingTest',
+                                'testprojects/tests/java/org/pantsbuild/testproject/dummies:passing_target',
+                                'testprojects/tests/java/org/pantsbuild/testproject/matcher'])
+    self.assert_success(pants_run)
+    self.assertIn("OK (2 tests)", pants_run.stdout_data)
+
   def test_junit_run_timeout_succeeds(self):
     sleeping_target = 'testprojects/tests/java/org/pantsbuild/testproject/timeout:sleeping_target'
     pants_run = self.run_pants(['clean-all',


### PR DESCRIPTION
### Problem

Using `--no-fast` with a `--test` spec for JUnit resulted in an exception, because test target filtering would happen per partition.

### Solution

Execute filtering up front, causing the error to trigger only when none of the targets has a matching test.