### PR TITLE
Re-pin pytest, and add a pin for zipp.

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -123,8 +123,9 @@ class PythonTestRunnerIntegrationTest(TestBase):
   def run_pytest(self, *, passthrough_args: Optional[str] = None) -> TestResult:
     args = [
       "--backend-packages2=pants.backend.python",
-      "--pytest-version=pytest>=4.6.6,<4.7",  # so that we can run Python 2 tests
-      "--pytest-pytest-plugins=zipp==1.0.0",  # transitive dep of Pytest; we pin to ensure Python 2 support
+      # pin to lower versions so that we can run Python 2 tests
+      "--pytest-version=pytest>=4.6.6,<4.7",
+      "--pytest-pytest-plugins=['zipp==1.0.0']",
     ]
     if passthrough_args:
       args.append(f"--pytest-args='{passthrough_args}'")

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -18,14 +18,19 @@ class PyTest(Subsystem):
       help="Arguments to pass directly to Pytest, e.g. `--pytest-args=\"-k test_foo --quiet\"`",
     )
     register(
-      '--version', default='pytest', fingerprint=True,
+      '--version', default='pytest>=5.3.5,<5.4', fingerprint=True,
       help="Requirement string for Pytest.",
     )
     register(
       '--pytest-plugins',
       type=list,
       fingerprint=True,
-      default=['pytest-timeout', 'pytest-cov'],
+      default=[
+        'pytest-timeout>=1.3.4,<1.4',
+        'pytest-cov>=2.8.1,<2.9',
+        # NB: zipp has frequently destabilized builds due to floating transitive versions under pytest.
+        'zipp==2.1.0',
+      ],
       help="Requirement strings for any plugins or additional requirements you'd like to use.",
     )
     register(

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -28,7 +28,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
   pytest_setup_for_python_2_tests = {
     'pytest': {
       'version': 'pytest==4.6.6',  # so that we can run Python 2 tests
-      'pytest_plugins': 'zipp==1.0.0',  # transitive dep of Pytest
+      'pytest_plugins': ['zipp==1.0.0'],  # transitive dep of Pytest
     }
   }
 


### PR DESCRIPTION
### Problem

Floating transitive 3rdparty deps of `pytest` caused master to break due to a re-resolve.

### Solution

Re-pin `pytest`, and add a pin for the problematic dependency (`zipp`) as well.