### PR TITLE
Allow going from `Addresses -> Address`

### DIFF
--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -61,3 +61,19 @@ class BackendConfigurationError(BuildConfigurationError):
 
 class IncompatiblePlatformsError(Exception):
   """Indicates that target platforms are incompatible with a target that contains native code."""
+
+
+class MappingError(Exception):
+  """Indicates an error mapping addressable objects."""
+
+
+class UnaddressableObjectError(MappingError):
+  """Indicates an un-addressable object was found at the top level."""
+
+
+class DuplicateNameError(MappingError):
+  """Indicates more than one top-level object was found with the same name."""
+
+
+class ResolveError(MappingError):
+  """Indicates an error resolving targets."""

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -104,6 +104,11 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   address_family = await Get[AddressFamily](Dir(address.spec_path))
   struct = address_family.addressables.get(address)  # type: ignore[call-overload]
 
+  # TODO: remove this once we use Address instead of BuildFileAddress for TargetAdaptor. However,
+  # make sure that this codepath will still call `_raise_did_you_mean`. Likely, we should extract
+  # most the logic from the rule `find_build_file` into a top level function.
+  build_file_address = await Get[BuildFileAddress](Address, address)
+
   inline_dependencies = []
 
   def maybe_append(outer_key, value):
@@ -183,10 +188,6 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
         hydrated_args[key] = maybe_consume(key, value)
     return _hydrate(type(item), address.spec_path, **hydrated_args)
 
-  # TODO: remove this once we use Address instead of BuildFileAddress for TargetAdaptor. However,
-  # make sure that this codepath will still call `_raise_did_you_mean`. Likely, we should extract
-  # most the logic from the rule `find_build_file` into a top level function.
-  build_file_address = await Get[BuildFileAddress](Address, address)
   return HydratedStruct(consume_dependencies(struct, args={"address": build_file_address}))
 
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.exceptions import ResolveError
 from pants.base.project_tree import Dir
 from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress, Spec, more_specific
 from pants.build_graph.address import Address, BuildFileAddress
@@ -20,7 +21,7 @@ from pants.engine.addressable import (
   BuildFileAddresses,
 )
 from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
-from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
+from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -5,11 +5,11 @@ import logging
 import os
 
 from pants.base.build_file import BuildFile
+from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpecs, DescendantAddresses, SiblingAddresses
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.mapper import ResolveError
 from pants.util.dirutil import fast_relpath
 
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -724,14 +724,15 @@ async def addresses_with_origins_from_filesystem_specs(
         logger.warning(msg)
       else:
         raise ResolveError(msg)
-    # We preserve what literal files any globs resolved to. This allows downstream goals to be
-    # more precise in which files they operate on.
-    origin = (
-      spec
-      if isinstance(spec, FilesystemLiteralSpec) else
-      FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
-    )
-    result.extend(AddressWithOrigin(address, origin) for address in owners.addresses)
+    for address in owners.addresses:
+      # We preserve what literal files any globs resolved to. This allows downstream goals to be
+      # more precise in which files they operate on.
+      origin = (
+        spec
+        if isinstance(spec, FilesystemLiteralSpec) else
+        FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
+      )
+      result.append(AddressWithOrigin(address=address, origin=origin))
   return AddressesWithOrigins(result)
 
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Iterable, List, Tuple, cast
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.exceptions import TargetDefinitionException
+from pants.base.exceptions import ResolveError, TargetDefinitionException
 from pants.base.parse_context import ParseContext
 from pants.base.specs import (
   AddressSpec,
@@ -43,7 +43,6 @@ from pants.engine.legacy.structs import (
   SourcesField,
   TargetAdaptor,
 )
-from pants.engine.mapper import ResolveError
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -235,25 +235,6 @@ class LegacyBuildGraph(BuildGraph):
         'Build graph construction failed: {} {}'.format(type(e).__name__, str(e))
       )
 
-  def _inject_addresses(self, subjects):
-    """Injects targets into the graph for each of the given `Address` objects, and then yields them.
-
-    TODO: See #5606 about undoing the split between `_inject_addresses` and `_inject_address_specs`.
-    """
-    logger.debug('Injecting addresses to %s: %s', self, subjects)
-    with self._resolve_context():
-      addresses = tuple(subjects)
-      thts, = self._scheduler.product_request(TransitiveHydratedTargets,
-                                              [BuildFileAddresses(addresses)])
-
-    self._index(thts.closure)
-
-    yielded_addresses = set()
-    for address in subjects:
-      if address not in yielded_addresses:
-        yielded_addresses.add(address)
-        yield address
-
   def _inject_address_specs(self, address_specs: AddressSpecs):
     """Injects targets into the graph for the given `AddressSpecs` object.
 
@@ -689,25 +670,14 @@ async def hydrate_sources_snapshot(hydrated_struct: HydratedStruct) -> SourcesSn
 
 
 @rule
-async def sources_snapshots_from_build_file_addresses(
-  address_specs: AddressSpecs,
-) -> SourcesSnapshots:
-  """Request SourcesSnapshots for the given BuildFileAddresses.
+async def sources_snapshots_from_address_specs(address_specs: AddressSpecs) -> SourcesSnapshots:
+  """Request SourcesSnapshots for the given address specs.
 
   Each address will map to a corresponding SourcesSnapshot. This rule avoids hydrating any other
-  fields."""
-
-  # NB: this line must be an `await Get`, rather than directly requesting `BuildFileAddresses`
-  # directly in the rule signature. Why? The `owners_from_filesystem_specs()` rule provides a way
-  # to go from FilesystemSpecs -> BuildFileAddresses. Then, this rule provides a way to go from
-  # BuildFileAddresses -> SourcesSnapshots. But, we already have a way to go from
-  # FilesystemSpecs -> SourcesSnapshots directly, so there are now two ways to go from
-  # FilesystemSpecs -> SourcesSnapshot and the graph does not like the ambiguity. By having the
-  # rule request AddressSpecs instead, we remove the ambiguity.
-  build_file_addresses = await Get[BuildFileAddresses](AddressSpecs, address_specs)
-  snapshots = await MultiGet(
-    Get[SourcesSnapshot](Address, a) for a in build_file_addresses.addresses
-  )
+  fields.
+  """
+  addresses = await Get[Addresses](AddressSpecs, address_specs)
+  snapshots = await MultiGet(Get[SourcesSnapshot](Address, a) for a in addresses)
   return SourcesSnapshots(snapshots)
 
 
@@ -754,15 +724,14 @@ async def addresses_with_origins_from_filesystem_specs(
         logger.warning(msg)
       else:
         raise ResolveError(msg)
-    for address in owners.addresses:
-      # We preserve what literal files any globs resolved to. This allows downstream goals to be
-      # more precise in which files they operate on.
-      origin = (
-        spec
-        if isinstance(spec, FilesystemLiteralSpec) else
-        FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
-      )
-      result.append(AddressWithOrigin(address=address, origin=origin))
+    # We preserve what literal files any globs resolved to. This allows downstream goals to be
+    # more precise in which files they operate on.
+    origin = (
+      spec
+      if isinstance(spec, FilesystemLiteralSpec) else
+      FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
+    )
+    result.extend(AddressWithOrigin(address, origin) for address in owners.addresses)
   return AddressesWithOrigins(result)
 
 
@@ -779,7 +748,7 @@ def create_legacy_graph_tasks():
     sort_targets,
     hydrate_sources_snapshot,
     addresses_with_origins_from_filesystem_specs,
-    sources_snapshots_from_build_file_addresses,
+    sources_snapshots_from_address_specs,
     sources_snapshots_from_filesystem_specs,
     RootRule(FilesystemSpecs),
     RootRule(OwnersRequest),

--- a/src/python/pants/engine/legacy/graph_test.py
+++ b/src/python/pants/engine/legacy/graph_test.py
@@ -14,6 +14,9 @@ def make_graph(name_to_deps: Dict[str, Tuple[str, ...]]) -> Dict[str, HydratedTa
   name_to_ht: Dict[str, HydratedTarget] = {}
 
   def make_ht(nm: str) -> HydratedTarget:
+    # NB: The HydratedTargets are not valid HydratedTargets, such as using a str instead of
+    # Address for the .address field. This is okay because it makes the tests much easier to work
+    # with and the topo_sort rule does not actually care about the HydratedTarget fields.
     if nm not in name_to_ht:
       dep_hts = tuple(make_ht(dep) for dep in name_to_deps[nm])
       name_to_ht[nm] = HydratedTarget(

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -10,10 +10,10 @@ from typing import Dict, Tuple
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.base.deprecated import warn_or_error
+from pants.base.exceptions import UnaddressableObjectError
 from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.legacy.structs import BundleAdaptor, Globs, RGlobs, TargetAdaptor, ZGlobs
-from pants.engine.mapper import UnaddressableObjectError
 from pants.engine.objects import Serializable
 from pants.engine.parser import ParseError, Parser, SymbolTable
 from pants.option.global_options import BuildFileImportsBehavior

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -32,6 +32,8 @@ class TargetAdaptor(StructWithDeps):
 
   @property
   def address(self) -> BuildFileAddress:
+    # TODO: this isn't actually safe to override as not being Optional. There are
+    # some cases where this property is not defined. But, then we get a ton of MyPy issues.
     return cast(BuildFileAddress, super().address)
 
   def get_sources(self) -> Optional["GlobsWithConjunction"]:

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -5,6 +5,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
+from pants.base.exceptions import DuplicateNameError, MappingError, UnaddressableObjectError
 from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
@@ -13,18 +14,6 @@ from pants.util.meta import frozen_after_init
 
 
 ThinAddressableObject = Union[Serializable, Any]
-
-
-class MappingError(Exception):
-  """Indicates an error mapping addressable objects."""
-
-
-class UnaddressableObjectError(MappingError):
-  """Indicates an un-addressable object was found at the top level."""
-
-
-class DuplicateNameError(MappingError):
-  """Indicates more than one top-level object was found with the same name."""
 
 
 @dataclass(frozen=True)
@@ -145,10 +134,6 @@ class AddressFamily:
   def __repr__(self):
     return 'AddressFamily(namespace={!r}, objects_by_name={!r})'.format(
         self.namespace, list(self.objects_by_name.keys()))
-
-
-class ResolveError(MappingError):
-  """Indicates an error resolving targets."""
 
 
 @frozen_after_init

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -15,6 +15,7 @@ from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
 from pants.base.deprecated import deprecated_conditional
+from pants.base.exceptions import ResolveError
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.specs import Specs
@@ -49,7 +50,7 @@ from pants.engine.legacy.structs import (
   TargetAdaptor,
 )
 from pants.engine.legacy.structs import rules as structs_rules
-from pants.engine.mapper import AddressMapper, ResolveError
+from pants.engine.mapper import AddressMapper
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
 from pants.engine.platform import create_platform_rules

--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -39,31 +39,26 @@ class Filedeps(Goal):
 @goal_rule
 def file_deps(
   console: Console,
-  filedeps_options: FiledepsOptions,
+  options: FiledepsOptions,
   build_root: BuildRoot,
-  transitive_hydrated_targets: TransitiveHydratedTargets
+  transitive_hydrated_targets: TransitiveHydratedTargets,
 ) -> Filedeps:
-
-  absolute = filedeps_options.values.absolute
-  globs = filedeps_options.values.globs
-
   unique_rel_paths: Set[str] = set()
-
   for hydrated_target in transitive_hydrated_targets.closure:
     adaptor = hydrated_target.adaptor
-    if hydrated_target.address.rel_path:
-      unique_rel_paths.add(hydrated_target.address.rel_path)
+    unique_rel_paths.add(hydrated_target.address.rel_path)
+
     if hasattr(adaptor, "sources"):
       sources_paths = (
         adaptor.sources.snapshot.files
-        if not globs
+        if not options.values.globs
         else adaptor.sources.filespec["globs"]
       )
       unique_rel_paths.update(sources_paths)
 
-  with filedeps_options.line_oriented(console) as print_stdout:
+  with options.line_oriented(console) as print_stdout:
     for rel_path in sorted(unique_rel_paths):
-      final_path = str(Path(build_root.path, rel_path)) if absolute else rel_path
+      final_path = str(Path(build_root.path, rel_path)) if options.values.absolute else rel_path
       print_stdout(final_path)
 
   return Filedeps(exit_code=0)

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -4,7 +4,8 @@
 from pathlib import Path
 
 from pants.base.build_root import BuildRoot
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
@@ -43,11 +44,11 @@ async def run(
   workspace: Workspace,
   runner: InteractiveRunner,
   build_root: BuildRoot,
-  bfa: BuildFileAddress,
+  addresses: Addresses,
   options: RunOptions,
 ) -> Run:
-  target = bfa.to_address()
-  binary = await Get[CreatedBinary](Address, target)
+  address = addresses.expect_single()
+  binary = await Get[CreatedBinary](Address, address)
 
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
     path_relative_to_build_root = str(Path(tmpdir).relative_to(build_root.path))
@@ -55,7 +56,7 @@ async def run(
       DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
     )
 
-    console.write_stdout(f"Running target: {target}\n")
+    console.write_stdout(f"Running target: {address}\n")
     full_path = str(Path(tmpdir, binary.binary_name))
     run_request = InteractiveProcessRequest(
       argv=(full_path, *options.values.args),
@@ -66,12 +67,12 @@ async def run(
       result = runner.run_local_interactive_process(run_request)
       exit_code = result.process_exit_code
       if result.process_exit_code == 0:
-        console.write_stdout(f"{target} ran successfully.\n")
+        console.write_stdout(f"{address} ran successfully.\n")
       else:
-        console.write_stderr(f"{target} failed with code {result.process_exit_code}!\n")
+        console.write_stderr(f"{address} failed with code {result.process_exit_code}!\n")
 
     except Exception as e:
-      console.write_stderr(f"Exception when attempting to run {target}: {e!r}\n")
+      console.write_stderr(f"Exception when attempting to run {address}: {e!r}\n")
       exit_code = -1
 
   return Run(exit_code)

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -7,8 +7,8 @@ from enum import Enum
 from typing import Optional
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
-from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.addressable import BuildFileAddresses
+from pants.build_graph.address import Address
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import Digest
@@ -109,7 +109,7 @@ class Test(Goal):
 
 @dataclass(frozen=True)
 class AddressAndTestResult:
-  address: BuildFileAddress
+  address: Address
   test_result: Optional[TestResult]  # If None, target was not a test target.
 
   @staticmethod
@@ -129,21 +129,21 @@ class AddressAndTestResult:
 
 @dataclass(frozen=True)
 class AddressAndDebugRequest:
-  address: BuildFileAddress
+  address: Address
   request: TestDebugRequest
 
 
 @goal_rule
 async def run_tests(
-  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: BuildFileAddresses,
+  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: Addresses,
 ) -> Test:
   if options.values.debug:
-    address = await Get[BuildFileAddress](BuildFileAddresses, addresses)
-    addr_debug_request = await Get[AddressAndDebugRequest](Address, address.to_address())
+    address = addresses.expect_single()
+    addr_debug_request = await Get[AddressAndDebugRequest](Address, address)
     result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
     return Test(result.process_exit_code)
 
-  results = await MultiGet(Get[AddressAndTestResult](Address, addr.to_address()) for addr in addresses)
+  results = await MultiGet(Get[AddressAndTestResult](Address, addr) for addr in addresses)
   did_any_fail = False
   filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
 
@@ -181,7 +181,7 @@ async def coordinator_of_tests(
   if not AddressAndTestResult.is_testable(
     target, union_membership=union_membership, address_origin_map=address_origin_map
   ):
-    return AddressAndTestResult(target.address, None)
+    return AddressAndTestResult(target.address.to_address(), None)
 
   # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
   # live TTY, periodically dump heavy hitters to stderr. See
@@ -195,14 +195,14 @@ async def coordinator_of_tests(
     f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
     f"{target.address.reference()}"
   )
-  return AddressAndTestResult(target.address, result)
+  return AddressAndTestResult(target.address.to_address(), result)
 
 
 @rule
 async def coordinator_of_debug_tests(target: HydratedTarget) -> AddressAndDebugRequest:
   logger.info(f"Starting tests in debug mode: {target.address.reference()}")
   request = await Get[TestDebugRequest](TestTarget, target.adaptor)
-  return AddressAndDebugRequest(target.address, request)
+  return AddressAndDebugRequest(target.address.to_address(), request)
 
 
 def rules():

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -6,6 +6,7 @@ import re
 import unittest
 from typing import Tuple, Type, cast
 
+from pants.base.exceptions import ResolveError
 from pants.base.project_tree import Dir
 from pants.base.specs import AddressSpecs, SiblingAddresses, SingleAddress
 from pants.build_graph.address import Address
@@ -19,7 +20,7 @@ from pants.engine.build_files import (
 )
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
+from pants.engine.mapper import AddressFamily, AddressMapper
 from pants.engine.nodes import Return, State, Throw
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -16,7 +16,7 @@ from pants.engine.build_files import (
   addresses_with_origins_from_address_families,
   create_graph_rules,
   parse_address_family,
-  remove_origins,
+  strip_address_origins,
 )
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
@@ -90,7 +90,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         ),
       ],
     )
-    return cast(BuildFileAddresses, run_rule(remove_origins, rule_args=[pbfas]))
+    return cast(BuildFileAddresses, run_rule(strip_address_origins, rule_args=[pbfas]))
 
   def test_duplicated(self) -> None:
     """Test that matching the same AddressSpec twice succeeds."""

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from pants.base.exceptions import DuplicateNameError, UnaddressableObjectError
 from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError
@@ -130,8 +130,8 @@ HydratedStructs = Collection[HydratedStruct]
 
 
 @rule
-async def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> HydratedStructs:
-  tacs = await MultiGet(Get[HydratedStruct](Address, a) for a in build_file_addresses.addresses)
+async def unhydrated_structs(addresses: Addresses) -> HydratedStructs:
+  tacs = await MultiGet(Get[HydratedStruct](Address, a) for a in addresses)
   return HydratedStructs(tacs)
 
 

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -6,19 +6,13 @@ import unittest
 from contextlib import contextmanager
 from textwrap import dedent
 
+from pants.base.exceptions import DuplicateNameError, UnaddressableObjectError
 from pants.base.specs import AddressSpec, AddressSpecs, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
-from pants.engine.mapper import (
-  AddressFamily,
-  AddressMap,
-  AddressMapper,
-  DifferingFamiliesError,
-  DuplicateNameError,
-  UnaddressableObjectError,
-)
+from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/pull/9083.

This allows us to entirely use `Addresses` and `Address` in V2 rules, rather than `BuildFileAddresses`. Tangibly, `run` and `test` can now request `Addresses` in their signature.

The only remaining piece is changing `HydratedTarget`, `TargetWithOrigin`, and `TargetAdaptor` to store `Address` rather than `BuildFileAddress`, which is saved for a followup due to issues with V1 still expecting `BuildFileAddress`.