### PR TITLE
Fix file args working with globs

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -18,7 +18,7 @@ from typing import (
   cast,
 )
 
-from pants.engine.fs import PathGlobs
+from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.objects import Collection
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -356,7 +356,11 @@ class FilesystemGlobSpec(FilesystemSpec):
 @dataclass(frozen=True)
 class FilesystemResolvedGlobSpec(FilesystemGlobSpec, FilesystemResolvedSpec):
   """A spec with resolved globs, e.g. `*.py` may resolve to `('f1.py', 'f2.py', '__init__.py')`."""
-  resolved_files: Tuple[str, ...]
+  _snapshot: Snapshot
+
+  @property
+  def resolved_files(self) -> Tuple[str, ...]:
+    return self._snapshot.files
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -755,15 +755,14 @@ async def addresses_with_origins_from_filesystem_specs(
         logger.warning(msg)
       else:
         raise ResolveError(msg)
-    for address in owners.addresses:
-      # We preserve what literal files any globs resolved to. This allows downstream goals to be
-      # more precise in which files they operate on.
-      origin = (
-        spec
-        if isinstance(spec, FilesystemLiteralSpec) else
-        FilesystemResolvedGlobSpec(glob=spec.glob, resolved_files=snapshot.files)
-      )
-      result.append(AddressWithOrigin(address=address, origin=origin))
+    # We preserve what literal files any globs resolved to. This allows downstream goals to be
+    # more precise in which files they operate on.
+    origin = (
+      spec
+      if isinstance(spec, FilesystemLiteralSpec) else
+      FilesystemResolvedGlobSpec(glob=spec.glob, _snapshot=snapshot)
+    )
+    result.extend(AddressWithOrigin(address=address, origin=origin) for address in owners.addresses)
   return AddressesWithOrigins(result)
 
 

--- a/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
@@ -18,6 +18,15 @@ class FilesystemSpecsIntegrationTest(PantsRunIntegrationTest):
       'testprojects/tests/python/pants:secondary_source_file_owner',
     } == set(pants_run.stdout_data.splitlines())
 
+  def test_valid_glob(self) -> None:
+    pants_run = self.run_pants(["list", "testprojects/tests/python/pants/dummies/*pass.py"])
+    self.assert_success(pants_run)
+    assert {
+      'testprojects/tests/python/pants:dummies_directory',
+      'testprojects/tests/python/pants/dummies:passing_target',
+      'testprojects/tests/python/pants:secondary_source_file_owner',
+    } == set(pants_run.stdout_data.splitlines())
+
   def test_nonexistent_file(self) -> None:
     pants_run = self.run_pants(["list", "src/fake.py"])
     self.assert_failure(pants_run)


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/9081 broke support for globs with file args. Turns out, dataclassess and abstract methods don't work as well as we thought.

This fixes the issue, optimizes some of the code, and adds a regression test.