### PR TITLE
Add type hints to `build_graph`

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -36,7 +36,7 @@ class BuildConfiguration:
     self._rules = OrderedSet()
     self._union_rules = OrderedDict()
 
-  def registered_aliases(self):
+  def registered_aliases(self) -> BuildFileAliases:
     """Return the registered aliases exposed in BUILD files.
 
     These returned aliases aren't so useful for actually parsing BUILD files.
@@ -44,7 +44,6 @@ class BuildConfiguration:
 
     :returns: A new BuildFileAliases instance containing this BuildConfiguration's registered alias
               mappings.
-    :rtype: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
     """
     target_factories_by_alias = self._target_by_alias.copy()
     target_factories_by_alias.update(self._target_macro_factory_by_alias)

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -80,7 +80,6 @@ python_library(
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',
-    'src/python/pants/engine:scheduler',
     'src/python/pants/engine:selectors',
     'src/python/pants/option',
     'src/python/pants/scm/subsystems:changed',

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -80,6 +80,7 @@ python_library(
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',
+    'src/python/pants/engine:scheduler',
     'src/python/pants/engine:selectors',
     'src/python/pants/option',
     'src/python/pants/scm/subsystems:changed',

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Dict, Iterable, List, Tuple, cast
+from typing import Any, Dict, Iterable, Iterator, List, Set, Tuple, Type, cast
 
 from twitter.common.collections import OrderedSet
 
@@ -26,8 +26,10 @@ from pants.base.specs import (
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.app_base import AppBase, Bundle
+from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
+from pants.build_graph.target import Target
 from pants.engine.addressable import (
   Addresses,
   AddressesWithOrigins,
@@ -46,6 +48,7 @@ from pants.engine.legacy.structs import (
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
+from pants.engine.scheduler import SchedulerSession
 from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import (
   GlobalOptions,
@@ -59,7 +62,7 @@ from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapp
 logger = logging.getLogger(__name__)
 
 
-def target_types_from_build_file_aliases(aliases):
+def target_types_from_build_file_aliases(aliases: BuildFileAliases) -> Dict[str, Type[Target]]:
   """Given BuildFileAliases, return the concrete target types constructed for each alias."""
   target_types = dict(aliases.target_types)
   for alias, factory in aliases.target_macro_factories.items():
@@ -84,11 +87,13 @@ class LegacyBuildGraph(BuildGraph):
   """
 
   @classmethod
-  def create(cls, scheduler, build_file_aliases):
+  def create(
+    cls, scheduler: SchedulerSession, build_file_aliases: BuildFileAliases,
+  ) -> "LegacyBuildGraph":
     """Construct a graph given a Scheduler and BuildFileAliases."""
     return cls(scheduler, target_types_from_build_file_aliases(build_file_aliases))
 
-  def __init__(self, scheduler, target_types):
+  def __init__(self, scheduler: SchedulerSession, target_types: Dict[str, Type[Target]]) -> None:
     """Construct a graph given a Scheduler, and set of target type aliases.
 
     :param scheduler: A Scheduler that is configured to be able to resolve TransitiveHydratedTargets.
@@ -98,17 +103,17 @@ class LegacyBuildGraph(BuildGraph):
     self._target_types = target_types
     super().__init__()
 
-  def clone_new(self):
+  def clone_new(self) -> "LegacyBuildGraph":
     """Returns a new BuildGraph instance of the same type and with the same __init__ params."""
     return LegacyBuildGraph(self._scheduler, self._target_types)
 
-  def _index(self, hydrated_targets):
+  def _index(self, hydrated_targets: Iterable["HydratedTarget"]) -> Set[BuildFileAddress]:
     """Index from the given roots into the storage provided by the base class.
 
     This is an additive operation: any existing connections involving these nodes are preserved.
     """
-    all_addresses = set()
-    new_targets = list()
+    all_addresses: Set[BuildFileAddress] = set()
+    new_targets: List[Target] = list()
 
     # Index the ProductGraph.
     for hydrated_target in hydrated_targets:
@@ -122,7 +127,8 @@ class LegacyBuildGraph(BuildGraph):
     # additional "traversable_(dependency_)?specs".
     deps_to_inject = OrderedSet()
     addresses_to_inject = set()
-    def inject(target, dep_spec, is_dependency):
+
+    def inject(target: Target, dep_spec: str, is_dependency: bool) -> None:
       address = Address.parse(dep_spec, relative_to=target.address.spec_path)
       if not any(address == t.address for t in target.dependencies):
         addresses_to_inject.add(address)
@@ -145,7 +151,7 @@ class LegacyBuildGraph(BuildGraph):
 
     return all_addresses
 
-  def _index_target(self, target_adaptor):
+  def _index_target(self, target_adaptor: TargetAdaptor) -> Target:
     """Instantiate the given TargetAdaptor, index it in the graph, and return a Target."""
     # Instantiate the target.
     address = target_adaptor.address
@@ -164,7 +170,7 @@ class LegacyBuildGraph(BuildGraph):
       self._target_dependees_by_address[dependency].add(address)
     return target
 
-  def _instantiate_target(self, target_adaptor):
+  def _instantiate_target(self, target_adaptor: TargetAdaptor) -> Target:
     """Given a TargetAdaptor struct previously parsed from a BUILD file, instantiate a Target."""
     target_cls = self._target_types[target_adaptor.type_alias]
     try:
@@ -185,7 +191,7 @@ class LegacyBuildGraph(BuildGraph):
           target_adaptor.address,
           'Failed to instantiate Target with type {}: {}'.format(target_cls, e))
 
-  def _instantiate_app(self, target_cls, kwargs):
+  def _instantiate_app(self, target_cls: Type[Target], kwargs) -> Target:
     """For App targets, convert BundleAdaptor to BundleProps."""
     parse_context = ParseContext(kwargs['address'].spec_path, dict())
     bundleprops_factory = Bundle(parse_context)
@@ -196,15 +202,15 @@ class LegacyBuildGraph(BuildGraph):
 
     return target_cls(build_graph=self, **kwargs)
 
-  def _instantiate_remote_sources(self, kwargs):
+  def _instantiate_remote_sources(self, kwargs) -> RemoteSources:
     """For RemoteSources target, convert "dest" field to its real target type."""
     kwargs['dest'] = _DestWrapper((self._target_types[kwargs['dest']],))
     return RemoteSources(build_graph=self, **kwargs)
 
-  def inject_address_closure(self, address):
+  def inject_address_closure(self, address: Address) -> None:
     self.inject_addresses_closure([address])
 
-  def inject_addresses_closure(self, addresses):
+  def inject_addresses_closure(self, addresses: Iterable[Address]) -> None:
     addresses = set(addresses) - set(self._target_by_address.keys())
     if not addresses:
       return
@@ -212,11 +218,15 @@ class LegacyBuildGraph(BuildGraph):
     for _ in self._inject_address_specs(AddressSpecs(dependencies)):
       pass
 
-  def inject_roots_closure(self, address_specs: AddressSpecs, fail_fast=None):
+  def inject_roots_closure(
+    self, address_specs: AddressSpecs, fail_fast=None,
+  ) -> Iterator[BuildFileAddress]:
     for address in self._inject_address_specs(address_specs):
       yield address
 
-  def inject_address_specs_closure(self, address_specs: Iterable[AddressSpec], fail_fast=None):
+  def inject_address_specs_closure(
+    self, address_specs: Iterable[AddressSpec], fail_fast=None,
+  ) -> Iterator[BuildFileAddress]:
     # Request loading of these address specs.
     for address in self._inject_address_specs(AddressSpecs(address_specs)):
       yield address
@@ -227,7 +237,7 @@ class LegacyBuildGraph(BuildGraph):
     return self.get_target(address)
 
   @contextmanager
-  def _resolve_context(self):
+  def _resolve_context(self) -> Iterator[None]:
     try:
       yield
     except Exception as e:
@@ -235,7 +245,7 @@ class LegacyBuildGraph(BuildGraph):
         'Build graph construction failed: {} {}'.format(type(e).__name__, str(e))
       )
 
-  def _inject_address_specs(self, address_specs: AddressSpecs):
+  def _inject_address_specs(self, address_specs: AddressSpecs) -> Iterator[BuildFileAddress]:
     """Injects targets into the graph for the given `AddressSpecs` object.
 
     Yields the resulting addresses.
@@ -245,8 +255,7 @@ class LegacyBuildGraph(BuildGraph):
 
     logger.debug('Injecting address specs to %s: %s', self, address_specs)
     with self._resolve_context():
-      thts, = self._scheduler.product_request(TransitiveHydratedTargets,
-                                              [address_specs])
+      thts, = self._scheduler.product_request(TransitiveHydratedTargets, [address_specs])
 
     self._index(thts.closure)
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -48,7 +48,6 @@ from pants.engine.legacy.structs import (
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
-from pants.engine.scheduler import SchedulerSession
 from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import (
   GlobalOptions,
@@ -87,13 +86,11 @@ class LegacyBuildGraph(BuildGraph):
   """
 
   @classmethod
-  def create(
-    cls, scheduler: SchedulerSession, build_file_aliases: BuildFileAliases,
-  ) -> "LegacyBuildGraph":
+  def create(cls, scheduler, build_file_aliases: BuildFileAliases) -> "LegacyBuildGraph":
     """Construct a graph given a Scheduler and BuildFileAliases."""
     return cls(scheduler, target_types_from_build_file_aliases(build_file_aliases))
 
-  def __init__(self, scheduler: SchedulerSession, target_types: Dict[str, Type[Target]]) -> None:
+  def __init__(self, scheduler, target_types: Dict[str, Type[Target]]) -> None:
     """Construct a graph given a Scheduler, and set of target type aliases.
 
     :param scheduler: A Scheduler that is configured to be able to resolve TransitiveHydratedTargets.


### PR DESCRIPTION
While we are trying to remove `BuildFileAddress` (in favor of `Address`) from the V2 engine code where possible, the V1 code must still use `BuildFileAddress` because this is assumed in most places and we don't want to spend the resources to fix that assumption.

This is prework to making further progress on https://github.com/pantsbuild/pants/pull/9083 so that MyPy can help to detect issues with the V1 implementation.