### PR TITLE
Replace `BuildFileAddress` with `Address` for `HydratedTarget` and `TargetAdaptor`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -36,7 +36,7 @@ async def create_python_awslambda(
   # TODO: We must enforce that everything is built for Linux, no matter the local platform.
   pex_filename = f'{lambda_tgt_adaptor.address.target_name}.pex'
   pex_request = CreatePexFromTargetClosure(
-    addresses=Addresses((lambda_tgt_adaptor.address.to_address(),)),
+    addresses=Addresses([lambda_tgt_adaptor.address]),
     entry_point=None,
     output_filename=pex_filename
   )

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -29,7 +29,7 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> Cr
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
   request = CreatePexFromTargetClosure(
-    addresses=Addresses((python_binary_adaptor.address.to_address(),)),
+    addresses=Addresses((python_binary_adaptor.address,)),
     entry_point=entry_point,
     output_filename=f'{python_binary_adaptor.address.target_name}.pex'
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -99,13 +99,13 @@ async def setup_pytest_for_target(
   # TODO: Rather than consuming the TestOptions subsystem, the TestRunner should pass on coverage
   # configuration via #7490.
   transitive_hydrated_targets = await Get[TransitiveHydratedTargets](
-    Addresses((test_target.address.to_address(),))
+    Addresses((test_target.address,))
   )
   all_targets = transitive_hydrated_targets.closure
 
   resolved_requirements_pex = await Get[Pex](
     CreatePexFromTargetClosure(
-      addresses=Addresses((test_target.address.to_address(),)),
+      addresses=Addresses((test_target.address,)),
       output_filename='pytest-with-requirements.pex',
       entry_point="pytest:main",
       additional_requirements=pytest.get_requirement_strings(),
@@ -132,7 +132,7 @@ async def setup_pytest_for_target(
   # optimization, this ensures that any transitive sources, such as a test project file named
   # test_fail.py, do not unintentionally end up being run as tests.
   source_root_stripped_test_target_sources = await Get[SourceRootStrippedSources](
-    Address, test_target.address.to_address()
+    Address, test_target.address
   )
 
   coverage_args = []

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -18,7 +18,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
@@ -130,9 +130,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
     if passthrough_args:
       args.append(f"--pytest-args='{passthrough_args}'")
     options_bootstrapper = create_options_bootstrapper(args=args)
-    target = PythonTestsAdaptor(
-      address=BuildFileAddress(rel_path=f"{self.source_root}/BUILD", target_name="target"),
-    )
+    target = PythonTestsAdaptor(address=Address.parse(f"{self.source_root}:target"))
     test_result = self.request_single_product(TestResult, Params(target, options_bootstrapper))
     debug_request = self.request_single_product(
       TestDebugRequest, Params(target, options_bootstrapper),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -249,7 +249,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   for hydrated_target in targets:
     if _is_exported(hydrated_target):
       exported_targets.append(ExportedTarget(hydrated_target))
-    elif address_origin_map.is_single_address(hydrated_target.address.to_address()):
+    elif address_origin_map.is_single_address(hydrated_target.address):
       explicit_nonexported_targets.append(hydrated_target)
   if explicit_nonexported_targets:
     raise TargetNotExported(
@@ -259,7 +259,7 @@ async def run_setup_pys(targets: HydratedTargets, options: SetupPyOptions, conso
   if options.values.transitive:
     # Expand out to all owners of the entire dep closure.
     tht = await Get[TransitiveHydratedTargets](
-      Addresses(et.hydrated_target.address.to_address() for et in exported_targets))
+      Addresses(et.hydrated_target.address for et in exported_targets))
     owners = await MultiGet(
       Get[ExportedTarget](OwnedDependency(ht)) for ht in tht.closure if is_ownable_target(ht)
     )
@@ -471,7 +471,7 @@ def _is_exported(target: HydratedTarget) -> bool:
 @rule(name="Compute distribution's 3rd party requirements")
 async def get_requirements(dep_owner: DependencyOwner) -> ExportedTargetRequirements:
   tht = await Get[TransitiveHydratedTargets](
-    Addresses([dep_owner.exported_target.hydrated_target.address.to_address()]))
+    Addresses([dep_owner.exported_target.hydrated_target.address]))
 
   ownable_tgts = [tgt for tgt in tht.closure if is_ownable_target(tgt)]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_tgts)
@@ -515,7 +515,7 @@ async def get_owned_dependencies(dependency_owner: DependencyOwner) -> OwnedDepe
   Includes dependency_owner itself.
   """
   tht = await Get[TransitiveHydratedTargets](
-    Addresses([dependency_owner.exported_target.hydrated_target.address.to_address()]))
+    Addresses([dependency_owner.exported_target.hydrated_target.address]))
   ownable_targets = [tgt for tgt in tht.closure
                      if isinstance(tgt.adaptor, (PythonTargetAdaptor, ResourcesAdaptor))]
   owners = await MultiGet(Get[ExportedTarget](OwnedDependency(ht)) for ht in ownable_targets)
@@ -547,7 +547,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     [t for t in ancestor_tgts if _is_exported(t)], key=lambda t: t.address, reverse=True)
   exported_ancestor_iter = iter(exported_ancestor_tgts)
   for exported_ancestor in exported_ancestor_iter:
-    tht = await Get[TransitiveHydratedTargets](Addresses([exported_ancestor.address.to_address()]))
+    tht = await Get[TransitiveHydratedTargets](Addresses([exported_ancestor.address]))
     if hydrated_target in tht.closure:
       owner = exported_ancestor
       # Find any exported siblings of owner that also depend on hydrated_target. They have the
@@ -555,7 +555,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
       sibling_owners = []
       sibling = next(exported_ancestor_iter, None)
       while sibling and sibling.address.spec_path == owner.address.spec_path:
-        tht = await Get[TransitiveHydratedTargets](Addresses([sibling.address.to_address()]))
+        tht = await Get[TransitiveHydratedTargets](Addresses([sibling.address]))
         if hydrated_target in tht.closure:
           sibling_owners.append(sibling)
         sibling = next(exported_ancestor_iter, None)

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -39,6 +39,10 @@ class AddressesWithOrigins(Collection[AddressWithOrigin]):
   pass
 
 
+class BuildFileAddresses(Collection[BuildFileAddress]):
+  """NB: V2 should generally use Addresses instead of BuildFileAddresses."""
+
+
 class NotSerializableError(TypeError):
   """Indicates an addressable descriptor is illegally installed in a non-Serializable type."""
 

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,7 +5,7 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from functools import update_wrapper
-from typing import Any, List, Set, Tuple, Type, Union
+from typing import Any, Set, Tuple, Type, Union
 
 from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpec, FilesystemResolvedSpec
@@ -37,13 +37,6 @@ class AddressWithOrigin:
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):
   pass
-
-
-class BuildFileAddresses(Collection[BuildFileAddress]):
-  @property
-  def addresses(self) -> List[Address]:
-    """Converts the BuildFileAddress objects in this collection to Address objects."""
-    return [bfa.to_address() for bfa in self]
 
 
 class NotSerializableError(TypeError):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -31,7 +31,7 @@ class Addresses(Collection[Address]):
 @dataclass(frozen=True)
 class AddressWithOrigin:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
-  address: BuildFileAddress
+  address: Address
   origin: Union[AddressSpec, FilesystemResolvedSpec]
 
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -18,6 +18,7 @@ from pants.engine.addressable import (
   Addresses,
   AddressesWithOrigins,
   AddressWithOrigin,
+  BuildFileAddresses,
 )
 from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper
@@ -90,6 +91,12 @@ async def find_build_file(address: Address) -> BuildFileAddress:
     for build_file_address in address_family.addressables.keys()
     if build_file_address == address
   )
+
+
+@rule
+async def find_build_files(addresses: Addresses) -> BuildFileAddresses:
+  bfas = await MultiGet(Get[BuildFileAddress](Address, address) for address in addresses)
+  return BuildFileAddresses(bfas)
 
 
 @rule
@@ -306,6 +313,7 @@ def create_graph_rules(address_mapper: AddressMapper):
     hydrate_struct,
     parse_address_family,
     find_build_file,
+    find_build_files,
     # AddressSpec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
     addresses_with_origins_from_address_families,

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -9,7 +9,7 @@ from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpecs, DescendantAddresses, SiblingAddresses
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
-from pants.engine.addressable import BuildFileAddresses
+from pants.engine.addressable import Addresses
 from pants.util.dirutil import fast_relpath
 
 
@@ -63,7 +63,7 @@ class LegacyAddressMapper(AddressMapper):
   def _internal_scan_specs(self, specs, fail_fast=True, missing_is_fatal=True):
     # TODO: This should really use `product_request`, but on the other hand, we need to
     # deprecate the entire `AddressMapper` interface anyway. See #4769.
-    request = self._scheduler.execution_request([BuildFileAddresses], [AddressSpecs(tuple(specs))])
+    request = self._scheduler.execution_request([Addresses], [AddressSpecs(tuple(specs))])
     returns, throws = self._scheduler.execute(request)
 
     if throws:

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -9,7 +9,7 @@ from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpecs, DescendantAddresses, SiblingAddresses
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
-from pants.engine.addressable import Addresses
+from pants.engine.addressable import BuildFileAddresses
 from pants.util.dirutil import fast_relpath
 
 
@@ -63,7 +63,7 @@ class LegacyAddressMapper(AddressMapper):
   def _internal_scan_specs(self, specs, fail_fast=True, missing_is_fatal=True):
     # TODO: This should really use `product_request`, but on the other hand, we need to
     # deprecate the entire `AddressMapper` interface anyway. See #4769.
-    request = self._scheduler.execution_request([Addresses], [AddressSpecs(tuple(specs))])
+    request = self._scheduler.execution_request([BuildFileAddresses], [AddressSpecs(tuple(specs))])
     returns, throws = self._scheduler.execute(request)
 
     if throws:

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -8,7 +8,7 @@ from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_list
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
@@ -31,10 +31,10 @@ class TargetAdaptor(StructWithDeps):
   """
 
   @property
-  def address(self) -> BuildFileAddress:
+  def address(self) -> Address:
     # TODO: this isn't actually safe to override as not being Optional. There are
     # some cases where this property is not defined. But, then we get a ton of MyPy issues.
-    return cast(BuildFileAddress, super().address)
+    return cast(Address, super().address)
 
   def get_sources(self) -> Optional["GlobsWithConjunction"]:
     """Returns target's non-deferred sources if exists or the default sources if defined.
@@ -138,7 +138,7 @@ class SourcesField:
   lazy construction will be more natural.
     see https://github.com/pantsbuild/pants/issues/3560
 
-  :param address: The BuildFileAddress of the TargetAdaptor for which this field is an argument.
+  :param address: The Address of the TargetAdaptor for which this field is an argument.
   :param arg: The name of this argument: usually 'sources', but occasionally also 'resources' in the
     case of python resource globs.
   :param filespecs: The merged filespecs dict the describes the paths captured by this field.
@@ -146,7 +146,7 @@ class SourcesField:
   :param validate_fn: A function which takes an EagerFilesetWithSpec and throws if it's not
     acceptable. This API will almost certainly change in the near future.
   """
-  address: BuildFileAddress
+  address: Address
   arg: str
   filespecs: wrapped_globs.Filespec
   base_globs: "BaseGlobs"
@@ -187,7 +187,7 @@ class PageAdaptor(TargetAdaptor):
 @dataclass(frozen=True)
 class BundlesField:
   """Represents the `bundles` argument, each of which has a PathGlobs to represent its `fileset`."""
-  address: BuildFileAddress
+  address: Address
   bundles: Any
   filespecs_list: List[wrapped_globs.Filespec]
   path_globs_list: List[PathGlobs]

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -4,7 +4,7 @@
 from collections.abc import MutableMapping, MutableSequence
 from typing import Any, Dict, Iterable, Optional, cast
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_list
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
 from pants.util.objects import SubclassesOf, SuperclassesOf
@@ -108,14 +108,14 @@ class Struct(Serializable, SerializableFactory, Validatable):
     return self._kwargs.get('name')
 
   @property
-  def address(self) -> Optional[BuildFileAddress]:
+  def address(self) -> Optional[Address]:
     """Return the address of this object, if any.
 
     In general structs need not be identified by an address, in which case they are
     generally embedded objects; ie: attributes values of enclosing named structs.
     Any top-level struct, though, will be identifiable via a unique address.
     """
-    return cast(Optional[BuildFileAddress], self._kwargs.get('address'))
+    return cast(Optional[Address], self._kwargs.get('address'))
 
   @property
   def type_alias(self) -> str:

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 from typing import List, Tuple, Type
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
   Digest,
@@ -43,7 +43,7 @@ class FmtTest(TestBase):
       dirs=()
     )
     return HydratedTarget(
-      address=BuildFileAddress(rel_path="src/BUILD", target_name=name),
+      address=Address.parse(f"src:{name}"),
       adaptor=adaptor_type(
         sources=EagerFilesetWithSpec("src", {"globs": []}, snapshot=mocked_snapshot),
         name=name,

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -4,7 +4,7 @@
 from typing import Optional
 from unittest.mock import Mock
 
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address
 from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
@@ -30,9 +30,7 @@ class StripSourceRootsTests(TestBase):
     adaptor.address.spec_path = original_path
     if target_type_alias:
       adaptor.type_alias = target_type_alias
-    target = HydratedTarget(
-      BuildFileAddress(rel_path='some/target/BUILD', target_name='target'), adaptor, (),
-    )
+    target = HydratedTarget(Address.parse("some/target/BUILD:target"), adaptor, ())
     stripped_sources = self.request_single_product(
       SourceRootStrippedSources, Params(target, create_options_bootstrapper())
     )

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -30,7 +30,7 @@ class StripSourceRootsTests(TestBase):
     adaptor.address.spec_path = original_path
     if target_type_alias:
       adaptor.type_alias = target_type_alias
-    target = HydratedTarget(Address.parse("some/target/BUILD:target"), adaptor, ())
+    target = HydratedTarget(Address.parse("some/target:target"), adaptor, ())
     stripped_sources = self.request_single_product(
       SourceRootStrippedSources, Params(target, create_options_bootstrapper())
     )

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -120,7 +120,7 @@ class AddressAndTestResult:
     address_origin_map: AddressOriginMap
   ) -> bool:
     is_valid_target_type = (
-      address_origin_map.is_single_address(target.address.to_address())
+      address_origin_map.is_single_address(target.address)
       or union_membership.is_member(TestTarget, target.adaptor)
     )
     has_sources = hasattr(target.adaptor, "sources") and target.adaptor.sources.snapshot.files
@@ -181,7 +181,7 @@ async def coordinator_of_tests(
   if not AddressAndTestResult.is_testable(
     target, union_membership=union_membership, address_origin_map=address_origin_map
   ):
-    return AddressAndTestResult(target.address.to_address(), None)
+    return AddressAndTestResult(target.address, None)
 
   # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
   # live TTY, periodically dump heavy hitters to stderr. See
@@ -195,14 +195,14 @@ async def coordinator_of_tests(
     f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
     f"{target.address.reference()}"
   )
-  return AddressAndTestResult(target.address.to_address(), result)
+  return AddressAndTestResult(target.address, result)
 
 
 @rule
 async def coordinator_of_debug_tests(target: HydratedTarget) -> AddressAndDebugRequest:
   logger.info(f"Starting tests in debug mode: {target.address.reference()}")
   request = await Get[TestDebugRequest](TestTarget, target.adaptor)
-  return AddressAndDebugRequest(target.address.to_address(), request)
+  return AddressAndDebugRequest(target.address, request)
 
 
 def rules():

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 from unittest.mock import Mock
 
 from pants.base.specs import DescendantAddresses, SingleAddress, Spec
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
@@ -172,7 +172,7 @@ class TestTest(TestBase):
   def run_coordinator_of_tests(
     self,
     *,
-    address: BuildFileAddress,
+    address: Address,
     addr_to_origin: Optional[Dict[Address, Spec]] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
@@ -212,44 +212,44 @@ class TestTest(TestBase):
     return result
 
   def test_coordinator_single_test_target(self) -> None:
-    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
-    result = self.run_coordinator_of_tests(address=bfaddr)
+    addr = Address.parse("some/dir:tests")
+    result = self.run_coordinator_of_tests(address=addr)
     assert result == AddressAndTestResult(
-      bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
+      addr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
     )
 
   def test_coordinator_single_non_test_target(self) -> None:
-    bfaddr = BuildFileAddress(target_name='bin', rel_path='some/dir')
+    addr = Address.parse("some/dir:bin")
     # Note that this is not the same error message the end user will see, as we're resolving
     # union Get requests in run_rule, not the real engine.  But this test still asserts that
     # we error when we expect to error.
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
-        address=bfaddr,
-        addr_to_origin={bfaddr.to_address(): SingleAddress(directory='some/dir', name='bin')},
+        address=addr,
+        addr_to_origin={addr: SingleAddress(directory='some/dir', name='bin')},
         test_target_type=False,
       )
 
   def test_coordinator_empty_sources(self) -> None:
-    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
-    result = self.run_coordinator_of_tests(address=bfaddr, include_sources=False)
-    assert result == AddressAndTestResult(bfaddr.to_address(), None)
+    addr = Address.parse("some/dir:tests")
+    result = self.run_coordinator_of_tests(address=addr, include_sources=False)
+    assert result == AddressAndTestResult(addr, None)
 
   def test_coordinator_globbed_test_target(self) -> None:
-    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='tests')
+    addr = Address.parse("some/dir:tests")
     result = self.run_coordinator_of_tests(
-      address=bfaddr,
-      addr_to_origin={bfaddr.to_address(): DescendantAddresses(directory='some/dir')}
+      address=addr,
+      addr_to_origin={addr: DescendantAddresses(directory='some/dir')}
     )
     assert result == AddressAndTestResult(
-      bfaddr.to_address(), TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
+      addr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
     )
 
   def test_coordinator_globbed_non_test_target(self) -> None:
-    bfaddr = BuildFileAddress(rel_path='some/dir', target_name='bin')
+    addr = Address.parse("some/dir:bin")
     result = self.run_coordinator_of_tests(
-      address=bfaddr,
-      addr_to_origin={bfaddr.to_address(): DescendantAddresses(directory='some/dir')},
+      address=addr,
+      addr_to_origin={addr: DescendantAddresses(directory='some/dir')},
       test_target_type=False,
     )
-    assert result == AddressAndTestResult(bfaddr.to_address(), None)
+    assert result == AddressAndTestResult(addr, None)

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -50,11 +50,10 @@ async def find_owners(
   changed_request: ChangedRequest,
 ) -> ChangedAddresses:
   owners = await Get[Owners](OwnersRequest(sources=changed_request.sources))
-  direct_owners = Addresses(bfa.to_address() for bfa in owners.addresses)
 
   # If the ChangedRequest does not require dependees, then we're done.
   if changed_request.include_dependees == IncludeDependeesOption.NONE:
-    return ChangedAddresses(direct_owners)
+    return ChangedAddresses(owners.addresses)
 
   # Otherwise: find dependees.
   all_addresses = await Get[Addresses](AddressSpecs((DescendantAddresses(''),)))
@@ -68,8 +67,8 @@ async def find_owners(
     target_types_from_build_file_aliases(bfa), address_mapper, all_structs
   )
   if changed_request.include_dependees == IncludeDependeesOption.DIRECT:
-    return ChangedAddresses(Addresses(graph.dependents_of_addresses(direct_owners)))
-  return ChangedAddresses(Addresses(graph.transitive_dependents_of_addresses(direct_owners)))
+    return ChangedAddresses(Addresses(graph.dependents_of_addresses(owners.addresses)))
+  return ChangedAddresses(Addresses(graph.transitive_dependents_of_addresses(owners.addresses)))
 
 
 @dataclass(frozen=True)

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -33,12 +33,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
       "Snapshot(PathGlobs(globs=(\'testprojects/src/python/sources/*.txt\', \'testprojects/src/python/sources/*.rs\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
-      'Unmatched glob from testprojects/src/python/sources/BUILD for target :some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
+      'Unmatched glob from testprojects/src/python/sources:some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
       "Snapshot(PathGlobs(globs=(\'testprojects/src/python/sources/*.scala\', \'!testprojects/src/python/sources/*Test.scala\', \'!testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
-      'Unmatched glob from testprojects/src/python/sources/BUILD for target :missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
+      'Unmatched glob from testprojects/src/python/sources:missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
       "['a/b/file1.txt']",
@@ -47,7 +47,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
       "Snapshot(PathGlobs(globs=(\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
-      'Unmatched glob from testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD for target :missing-bundle-fileset\'s `bundles` field:: "testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"',
+      'Unmatched glob from testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset\'s `bundles` field:: "testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"',
     ]
   }
 
@@ -123,7 +123,6 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       'missing-zglobs': ['**/*.a'],
       'missing-literal-files': ['another_nonexistent_file.txt', 'nonexistent_test_file.txt'],
     }
-    build_path = os.path.join(self._SOURCES_TARGET_BASE, "BUILD")
     with self.setup_sources_targets():
       for target in target_to_unmatched_globs:
         target_full = f'{self._SOURCES_TARGET_BASE}:{target}'
@@ -138,7 +137,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
           f'"{os.path.join(self._SOURCES_TARGET_BASE, glob)}"'
           for glob in unmatched_globs
         )
-        error_origin = f"from {build_path} for target :{target}'s `sources` field"
+        error_origin = f"from {self._SOURCES_TARGET_BASE}:{target}'s `sources` field"
         if len(unmatched_globs) == 1:
           assert f"[WARN] Unmatched glob {error_origin}: {formatted_globs}" in pants_run.stderr_data
         else:
@@ -156,8 +155,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
 
   def test_missing_bundles_warnings(self):
     target_full = f'{self._BUNDLE_TARGET_BASE}:missing-bundle-fileset'
-    build_path = os.path.join(self._BUNDLE_TARGET_BASE, "BUILD")
-    error_origin = f"from {build_path} for target :missing-bundle-fileset's `bundles` field"
+    error_origin = f"from {target_full}'s `bundles` field"
     with self.setup_bundle_target():
       pants_run = self.run_pants(['filedeps', target_full], config={
         GLOBAL_SCOPE_CONFIG_SECTION: {


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/6657. Now, the engine always uses `Address` by default, unless a rule author explicitly calls `await Get[BuildFileAddress](Address)`.

To keep things working with V1, we introduce `LegacyHydratedTarget` so that the V1 code still uses `BuildFileAddress`.