### PR TITLE
Simplify calculating runtime lib path env var

### DIFF
--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.engine.platform import Platform
+from pants.util.enums import match
 from pants.util.memo import memoized_classproperty
 from pants.util.strutil import create_path_env_var
 
@@ -161,8 +162,6 @@ class _Executable(_ExtensibleAlgebraic):
     :rtype: list of str
     """
 
-  _platform = Platform.current
-
   @property
   def invocation_environment_dict(self):
     """A dict to use as this _Executable's execution environment.
@@ -173,9 +172,14 @@ class _Executable(_ExtensibleAlgebraic):
 
     :rtype: dict of string -> string
     """
+    lib_path_env_var: str = match(Platform.current, {
+      Platform.darwin: "DYLD_LIBRARY_PATH",
+      Platform.linux: "LD_LIBRARY_PATH",
+    })
+
     return {
       'PATH': create_path_env_var(self.path_entries),
-      self._platform.runtime_lib_path_env_var: create_path_env_var(self.runtime_library_dirs),
+      lib_path_env_var: create_path_env_var(self.runtime_library_dirs),
     }
 
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -5,8 +5,7 @@ from enum import Enum
 from typing import Callable, List
 
 from pants.engine.rules import rule
-from pants.util.enums import match
-from pants.util.memo import memoized_classproperty, memoized_property
+from pants.util.memo import memoized_classproperty
 from pants.util.osutil import get_normalized_os_name
 
 
@@ -18,13 +17,6 @@ class Platform(Enum):
   @memoized_classproperty
   def current(cls) -> 'Platform':
     return Platform(get_normalized_os_name())
-
-  @memoized_property
-  def runtime_lib_path_env_var(self) -> str:
-    return match(self, {
-      Platform.darwin: "DYLD_LIBRARY_PATH",
-      Platform.linux: "LD_LIBRARY_PATH",
-    })
 
 
 class PlatformConstraint(Enum):


### PR DESCRIPTION
We only compute the `runtime_lib_path_env_var` in one place in the pants codebase, so it makes sense to do that computation there, rather than have it exist as a method on the `Platform` type. 