### PR TITLE
Add a rule to strip source roots from a `Snapshot`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -22,7 +22,7 @@ from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonAWSLambdaAdaptor
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
-from pants.rules.core import strip_source_root
+from pants.rules.core import strip_source_roots
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.subsystem.util import init_subsystems
 from pants.testutil.test_base import TestBase
@@ -47,7 +47,7 @@ class TestPythonAWSLambdaCreation(TestBase):
       *pex_from_target_closure.rules(),
       *prepare_chrooted_python_sources.rules(),
       *python_native_code.rules(),
-      *strip_source_root.rules(),
+      *strip_source_roots.rules(),
       *subprocess_environment.rules(),
       RootRule(PythonAWSLambdaAdaptor),
       RootRule(download_pex_bin.DownloadedPexBin.Factory),

--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
@@ -8,7 +8,7 @@ from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -11,7 +11,7 @@ from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
 
 
 @rule

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -22,7 +22,7 @@ from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
 from pants.rules.core.test import TestDebugRequest, TestOptions, TestResult, TestTarget
 
 

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -26,7 +26,7 @@ from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import RootRule, subsystem_rule
 from pants.engine.selectors import Params
 from pants.python.python_requirement import PythonRequirement
-from pants.rules.core import strip_source_root
+from pants.rules.core import strip_source_roots
 from pants.rules.core.test import Status, TestDebugRequest, TestOptions, TestResult
 from pants.testutil.interpreter_selection_utils import skip_unless_python27_and_python3_present
 from pants.testutil.option.util import create_options_bootstrapper
@@ -114,7 +114,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
       *pex_from_target_closure.rules(),
       *prepare_chrooted_python_sources.rules(),
       *python_native_code.rules(),
-      *strip_source_root.rules(),
+      *strip_source_roots.rules(),
       *subprocess_environment.rules(),
       subsystem_rule(TestOptions),
       RootRule(PythonTestsAdaptor),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -51,7 +51,7 @@ from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.distdir import DistDir
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
 from pants.source.source_root import SourceRootConfig
 
 

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -39,7 +39,7 @@ from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.python.python_requirement import PythonRequirement
-from pants.rules.core.strip_source_root import strip_source_root
+from pants.rules.core.strip_source_roots import strip_source_roots_from_target
 from pants.source.source_root import SourceRootConfig
 from pants.testutil.subsystem.util import init_subsystem
 from pants.testutil.test_base import TestBase
@@ -68,7 +68,7 @@ class TestGenerateChroot(TestSetupPyBase):
       generate_chroot,
       get_sources,
       get_requirements,
-      strip_source_root,
+      strip_source_roots_from_target,
       get_ancestor_init_py,
       get_owned_dependencies,
       get_exporting_owner,
@@ -158,7 +158,7 @@ class TestGetSources(TestSetupPyBase):
   def rules(cls):
     return super().rules() + [
       get_sources,
-      strip_source_root,
+      strip_source_roots_from_target,
       get_ancestor_init_py,
       RootRule(SetupPySourcesRequest),
       RootRule(SourceRootConfig),

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -39,7 +39,10 @@ from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.python.python_requirement import PythonRequirement
-from pants.rules.core.strip_source_roots import strip_source_roots_from_target
+from pants.rules.core.strip_source_roots import (
+  strip_source_roots_from_snapshot,
+  strip_source_roots_from_target,
+)
 from pants.source.source_root import SourceRootConfig
 from pants.testutil.subsystem.util import init_subsystem
 from pants.testutil.test_base import TestBase
@@ -68,6 +71,7 @@ class TestGenerateChroot(TestSetupPyBase):
       generate_chroot,
       get_sources,
       get_requirements,
+      strip_source_roots_from_snapshot,
       strip_source_roots_from_target,
       get_ancestor_init_py,
       get_owned_dependencies,
@@ -158,6 +162,7 @@ class TestGetSources(TestSetupPyBase):
   def rules(cls):
     return super().rules() + [
       get_sources,
+      strip_source_roots_from_snapshot,
       strip_source_roots_from_target,
       get_ancestor_init_py,
       RootRule(SetupPySourcesRequest),

--- a/src/python/pants/backend/python/rules/setup_py_util.py
+++ b/src/python/pants/backend/python/rules/setup_py_util.py
@@ -12,7 +12,7 @@ from pants.engine.fs import FilesContent
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonTargetAdaptor, ResourcesAdaptor
 from pants.python.python_setup import PythonSetup
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
 from pants.source.source_root import SourceRoots
 from pants.util.strutil import ensure_text
 

--- a/src/python/pants/backend/python/rules/setup_py_util.py
+++ b/src/python/pants/backend/python/rules/setup_py_util.py
@@ -13,19 +13,12 @@ from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonTargetAdaptor, ResourcesAdaptor
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.strip_source_roots import SourceRootStrippedSources
-from pants.source.source_root import SourceRoots
+from pants.source.source_root import NoSourceRootError, SourceRoots
 from pants.util.strutil import ensure_text
 
 
 # Convenient type alias for the pair (package name, data files in the package).
 PackageDatum = Tuple[str, Tuple[str, ...]]
-
-
-class NoSourceRootError(Exception):
-  """Indicates we failed to map a source file to a source root.
-
-  This future-proofs us against switching --source-unmatched from 'create' to 'fail'.
-  """
 
 
 def source_root_or_raise(source_roots: SourceRoots, path: str) -> str:

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -11,7 +11,7 @@ from pants.rules.core import (
   list_roots,
   list_targets,
   run,
-  strip_source_root,
+  strip_source_roots,
   test,
 )
 
@@ -26,7 +26,7 @@ def rules():
     *list_targets.rules(),
     *filedeps.rules(),
     *run.rules(),
-    *strip_source_root.rules(),
+    *strip_source_roots.rules(),
     *distdir.rules(),
     *test.rules()
   ]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -20,7 +20,7 @@ class SourceRootStrippedSources:
 
 
 @dataclass(frozen=True)
-class SnapshotToStrip:
+class StripSourceRootsRequest:
   """A request to strip source roots for every file in the snapshot.
 
   The field `sentinel_file` is used to determine the source root for the files to be stripped. This
@@ -46,15 +46,15 @@ class SnapshotToStrip:
 
 @rule
 async def strip_source_roots_from_snapshot(
-  snapshot_to_strip: SnapshotToStrip, source_root_config: SourceRootConfig,
+  request: StripSourceRootsRequest, source_root_config: SourceRootConfig,
 ) -> SourceRootStrippedSources:
   """Removes source roots from a snapshot,
   e.g. `src/python/pants/util/strutil.py` -> `pants/util/strutil.py`.
   """
-  source_root = snapshot_to_strip.determine_source_root(source_root_config=source_root_config)
+  source_root = request.determine_source_root(source_root_config=source_root_config)
   resulting_digest = await Get[Digest](
     DirectoryWithPrefixToStrip(
-      directory_digest=snapshot_to_strip.snapshot.directory_digest,
+      directory_digest=request.snapshot.directory_digest,
       prefix=source_root,
     )
   )
@@ -86,7 +86,7 @@ async def strip_source_roots_from_target(
   # source root is for the target.
   sentinel_file = PurePath(hydrated_target.address.spec_path, "SENTINEL").as_posix()
   return await Get[SourceRootStrippedSources](
-    SnapshotToStrip(target_adaptor.sources.snapshot, sentinel_file=sentinel_file)
+    StripSourceRootsRequest(target_adaptor.sources.snapshot, sentinel_file=sentinel_file)
   )
 
 

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -2,13 +2,24 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from itertools import groupby
+from pathlib import PurePath
+from typing import cast
 
 from pants.build_graph.files import Files
-from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot
+from pants.engine.fs import (
+  EMPTY_SNAPSHOT,
+  Digest,
+  DirectoriesToMerge,
+  DirectoryWithPrefixToStrip,
+  PathGlobs,
+  Snapshot,
+  SnapshotSubset,
+)
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import rule, subsystem_rule
-from pants.engine.selectors import Get
-from pants.source.source_root import SourceRootConfig
+from pants.engine.selectors import Get, MultiGet
+from pants.source.source_root import NoSourceRootError, SourceRootConfig
 
 
 @dataclass(frozen=True)
@@ -17,9 +28,59 @@ class SourceRootStrippedSources:
   snapshot: Snapshot
 
 
+@dataclass(frozen=True)
+class SnapshotToStrip:
+  """A wrapper around Snapshot to remove graph ambiguity."""
+  snapshot: Snapshot
+
+
+@rule
+async def strip_source_roots_from_snapshot(
+  wrapped_snapshot: SnapshotToStrip, source_root_config: SourceRootConfig,
+) -> SourceRootStrippedSources:
+  """Removes source roots from a snapshot,
+  e.g. `src/python/pants/util/strutil.py` -> `pants/util/strutil.py`.
+  """
+  source_roots_object = source_root_config.get_source_roots()
+
+  def find_source_root(fp: str) -> str:
+    source_root = source_roots_object.safe_find_by_path(fp)
+    if source_root is not None:
+      return cast(str, source_root.path)
+    if source_root_config.options.unmatched == "fail":
+      raise NoSourceRootError(f"Could not find a source root for `{fp}`.")
+    # Otherwise, create a source root by using the parent directory.
+    return PurePath(fp).parent.as_posix()
+
+  files_grouped_by_source_root = {
+    source_root: tuple(files)
+    for source_root, files
+    in groupby(wrapped_snapshot.snapshot.files, key=find_source_root)
+  }
+  snapshot_subsets = await MultiGet(
+    Get[Snapshot](
+      SnapshotSubset(
+        directory_digest=wrapped_snapshot.snapshot.directory_digest,
+        globs=PathGlobs(files),
+      )
+    )
+    for files in files_grouped_by_source_root.values()
+  )
+  resulting_digests = await MultiGet(
+    Get[Digest](
+      DirectoryWithPrefixToStrip(directory_digest=snapshot.directory_digest, prefix=source_root)
+    )
+    for snapshot, source_root in zip(snapshot_subsets, files_grouped_by_source_root.keys())
+  )
+
+  merged_result = await Get[Digest](DirectoriesToMerge(resulting_digests))
+  resulting_snapshot = await Get[Snapshot](Digest, merged_result)
+  return SourceRootStrippedSources(snapshot=resulting_snapshot)
+
+
 @rule
 async def strip_source_roots_from_target(
-  hydrated_target: HydratedTarget, source_root_config: SourceRootConfig
+  hydrated_target: HydratedTarget,
 ) -> SourceRootStrippedSources:
   """Remove source roots from a target (depending upon the target type), e.g.
   `src/python/pants/util/strutil.py` -> `pants/util/strutil.py`.
@@ -37,26 +98,12 @@ async def strip_source_roots_from_target(
   if target_adaptor.type_alias == Files.alias():
     return SourceRootStrippedSources(snapshot=target_adaptor.sources.snapshot)
 
-  source_roots = source_root_config.get_source_roots()
-  source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
-  # If we found no source root, use the target's dir.
-  # Note that when --source-unmatched is 'create' (the default) we'll never return None,
-  # but will return the target's dir. This check allows this code to work even if
-  # --source-unmatched is 'fail'.
-  source_root_path = source_root.path if source_root else target_adaptor.address.spec_path
-
-  resulting_digest = await Get[Digest](
-    DirectoryWithPrefixToStrip(
-      directory_digest=target_adaptor.sources.snapshot.directory_digest,
-      prefix=source_root_path,
-    )
-  )
-  resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
-  return SourceRootStrippedSources(snapshot=resulting_snapshot)
+  return await Get[SourceRootStrippedSources](SnapshotToStrip(target_adaptor.sources.snapshot))
 
 
 def rules():
   return [
+    strip_source_roots_from_snapshot,
     strip_source_roots_from_target,
     subsystem_rule(SourceRootConfig),
   ]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -18,40 +18,37 @@ class SourceRootStrippedSources:
 
 
 @rule
-async def strip_source_root(
+async def strip_source_roots_from_target(
   hydrated_target: HydratedTarget, source_root_config: SourceRootConfig
 ) -> SourceRootStrippedSources:
-  """Relativize targets to their source root, e.g.
-  `src/python/pants/util/strutil.py` -> `pants/util/strutil.py ."""
-
+  """Remove source roots from a target (depending upon the target type), e.g.
+  `src/python/pants/util/strutil.py` -> `pants/util/strutil.py`.
+  """
   target_adaptor = hydrated_target.adaptor
-  source_roots = source_root_config.get_source_roots()
 
   # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
   # simplify the hasattr() checks here!
   if not hasattr(target_adaptor, 'sources'):
     return SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
 
-  digest = target_adaptor.sources.snapshot.directory_digest
-  source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
-  if source_root is None:
-    # If we found no source root, use the target's dir.
-    # Note that when --source-unmatched is 'create' (the default) we'll never return None,
-    # but will return the target's dir. This check allows this code to work even if
-    # --source-unmatched is 'fail'.
-    source_root_path = target_adaptor.address.spec_path
-  else:
-    source_root_path = source_root.path
-
   # Loose `Files`, as opposed to `Resources` or `Target`s, have no (implied) package
   # structure and so we do not remove their source root like we normally do, so that filesystem
   # APIs may still access the files. See pex_build_util.py's `_create_source_dumper`.
   if target_adaptor.type_alias == Files.alias():
-    source_root_path = ''
+    return SourceRootStrippedSources(snapshot=target_adaptor.sources.snapshot)
+
+  source_roots = source_root_config.get_source_roots()
+  source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
+  # If we found no source root, use the target's dir.
+  # Note that when --source-unmatched is 'create' (the default) we'll never return None,
+  # but will return the target's dir. This check allows this code to work even if
+  # --source-unmatched is 'fail'.
+  source_root_path = source_root.path if source_root else target_adaptor.address.spec_path
 
   resulting_digest = await Get[Digest](
     DirectoryWithPrefixToStrip(
-      directory_digest=digest, prefix=source_root_path
+      directory_digest=target_adaptor.sources.snapshot.directory_digest,
+      prefix=source_root_path,
     )
   )
   resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
@@ -59,4 +56,7 @@ async def strip_source_root(
 
 
 def rules():
-  return [strip_source_root, subsystem_rule(SourceRootConfig)]
+  return [
+    strip_source_roots_from_target,
+    subsystem_rule(SourceRootConfig),
+  ]

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -9,8 +9,8 @@ from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
-from pants.rules.core.strip_source_root import SourceRootStrippedSources
-from pants.rules.core.strip_source_root import rules as strip_source_root_rules
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import rules as strip_source_root_rules
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
@@ -20,7 +20,7 @@ class StripSourceRootsTests(TestBase):
   def rules(cls):
     return (*super().rules(), *strip_source_root_rules(), RootRule(HydratedTarget))
 
-  def assert_stripped_source_file(
+  def assert_stripped_target(
     self, *, original_path: str, expected_path: str, target_type_alias: Optional[str] = None,
   ) -> None:
     adaptor = Mock()
@@ -36,19 +36,19 @@ class StripSourceRootsTests(TestBase):
     )
     self.assertEqual(stripped_sources.snapshot.files, (expected_path,))
 
-  def test_source_roots_python(self):
-    self.assert_stripped_source_file(
+  def test_strip_python_target(self):
+    self.assert_stripped_target(
       original_path='src/python/pants/util/strutil.py', expected_path='pants/util/strutil.py',
     )
 
-  def test_source_roots_java(self):
-    self.assert_stripped_source_file(
+  def test_strip_java_target(self):
+    self.assert_stripped_target(
       original_path='src/java/some/path/to/something.java',
       expected_path='some/path/to/something.java',
     )
 
-  def test_dont_strip_source_for_files(self):
-    self.assert_stripped_source_file(
+  def test_dont_strip_files_target(self):
+    self.assert_stripped_target(
         original_path='src/python/pants/util/strutil.py',
         expected_path='src/python/pants/util/strutil.py',
         target_type_alias=Files.alias()

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -47,7 +47,7 @@ class StripSourceRootsTests(TestBase):
     ) -> List[str]:
       input_snapshot = self.make_snapshot({fp: "" for fp in paths})
       return self.get_stripped_files(
-        StripSourceRootsRequest(input_snapshot, sentinel_file=paths[0]), args=args,
+        StripSourceRootsRequest(input_snapshot, representative_path=paths[0]), args=args,
       )
 
     # Normal source roots

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -13,7 +13,7 @@ from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
-from pants.rules.core.strip_source_roots import SnapshotToStrip, SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSourceRootsRequest
 from pants.rules.core.strip_source_roots import rules as strip_source_root_rules
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
@@ -26,14 +26,17 @@ class StripSourceRootsTests(TestBase):
       *super().rules(),
       *strip_source_root_rules(),
       RootRule(HydratedTarget),
-      RootRule(SnapshotToStrip),
+      RootRule(StripSourceRootsRequest),
     )
 
   def get_stripped_files(
-    self, original: Union[SnapshotToStrip, HydratedTarget], *, args: Optional[List[str]] = None,
+    self,
+    request: Union[StripSourceRootsRequest, HydratedTarget],
+    *,
+    args: Optional[List[str]] = None,
   ) -> List[str]:
     result = self.request_single_product(
-      SourceRootStrippedSources, Params(original, create_options_bootstrapper(args=args))
+      SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args))
     )
     return sorted(result.snapshot.files)
 
@@ -44,7 +47,7 @@ class StripSourceRootsTests(TestBase):
     ) -> List[str]:
       input_snapshot = self.make_snapshot({fp: "" for fp in paths})
       return self.get_stripped_files(
-        SnapshotToStrip(input_snapshot, sentinel_file=paths[0]), args=args,
+        StripSourceRootsRequest(input_snapshot, sentinel_file=paths[0]), args=args,
       )
 
     # Normal source roots

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -1,15 +1,18 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional
+from functools import partial
+from typing import List, Optional, Union
 from unittest.mock import Mock
 
-from pants.build_graph.address import Address
+import pytest
+
 from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
+from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SnapshotToStrip, SourceRootStrippedSources
 from pants.rules.core.strip_source_roots import rules as strip_source_root_rules
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
@@ -18,38 +21,77 @@ from pants.testutil.test_base import TestBase
 class StripSourceRootsTests(TestBase):
   @classmethod
   def rules(cls):
-    return (*super().rules(), *strip_source_root_rules(), RootRule(HydratedTarget))
-
-  def assert_stripped_target(
-    self, *, original_path: str, expected_path: str, target_type_alias: Optional[str] = None,
-  ) -> None:
-    adaptor = Mock()
-    adaptor.sources = Mock()
-    adaptor.sources.snapshot = self.make_snapshot({original_path: "print('random python')"})
-    adaptor.address = Mock()
-    adaptor.address.spec_path = original_path
-    if target_type_alias:
-      adaptor.type_alias = target_type_alias
-    target = HydratedTarget(Address.parse("some/target:target"), adaptor, ())
-    stripped_sources = self.request_single_product(
-      SourceRootStrippedSources, Params(target, create_options_bootstrapper())
-    )
-    self.assertEqual(stripped_sources.snapshot.files, (expected_path,))
-
-  def test_strip_python_target(self):
-    self.assert_stripped_target(
-      original_path='src/python/pants/util/strutil.py', expected_path='pants/util/strutil.py',
+    return (
+      *super().rules(),
+      *strip_source_root_rules(),
+      RootRule(HydratedTarget),
+      RootRule(SnapshotToStrip),
     )
 
-  def test_strip_java_target(self):
-    self.assert_stripped_target(
-      original_path='src/java/some/path/to/something.java',
-      expected_path='some/path/to/something.java',
+  def get_stripped_files(
+    self, original: Union[SnapshotToStrip, HydratedTarget], *, args: Optional[List[str]] = None,
+  ) -> List[str]:
+    result = self.request_single_product(
+      SourceRootStrippedSources, Params(original, create_options_bootstrapper(args=args))
+    )
+    return sorted(result.snapshot.files)
+
+  def test_strip_snapshot(self) -> None:
+    original_paths = [
+      "src/python/project/example.py",
+      "src/java/com/project/example.java",
+      "tests/python/project_test/example.py",
+      "no-source-root/example.txt",
+    ]
+    stripped_paths = [
+      "project/example.py",
+      "com/project/example.java",
+      "project_test/example.py",
+      "example.txt",
+    ]
+
+    input_snapshot = self.make_snapshot({fp: "" for fp in original_paths})
+    get_stripped_files_for_snapshot = partial(
+      self.get_stripped_files, SnapshotToStrip(input_snapshot)
     )
 
-  def test_dont_strip_files_target(self):
-    self.assert_stripped_target(
-        original_path='src/python/pants/util/strutil.py',
-        expected_path='src/python/pants/util/strutil.py',
-        target_type_alias=Files.alias()
-    )
+    assert get_stripped_files_for_snapshot() == sorted(stripped_paths)
+
+    # Also test that we error when `--source-unmatched=fail`
+    with pytest.raises(ExecutionError) as exc:
+      get_stripped_files_for_snapshot(args=["--source-unmatched=fail"])
+    assert "NoSourceRootError: Could not find a source root for `no-source-root/example.txt`" in str(exc.value)
+
+  def test_strip_target(self) -> None:
+
+    def get_stripped_files_for_target(
+      *, source_paths: Optional[List[str]], type_alias: Optional[str] = None,
+    ) -> List[str]:
+      adaptor = Mock()
+      adaptor.type_alias = type_alias
+
+      if source_paths is None:
+        del adaptor.sources
+        return self.get_stripped_files(
+          HydratedTarget(address=Mock(), adaptor=adaptor, dependencies=()),
+        )
+
+      adaptor.sources = Mock()
+      adaptor.sources.snapshot = self.make_snapshot({fp: "" for fp in source_paths})
+
+      return self.get_stripped_files(
+        HydratedTarget(address=Mock(), adaptor=adaptor, dependencies=()),
+      )
+
+    # normal target
+    assert get_stripped_files_for_target(
+      source_paths=["src/python/project/f1.py", "src/python/project/f2.py"]
+    ) == sorted(["project/f1.py", "project/f2.py"])
+
+    # empty target
+    assert get_stripped_files_for_target(source_paths=None) == []
+
+    # files targets are not stripped
+    assert get_stripped_files_for_target(
+      source_paths=["src/python/project/f1.py"], type_alias=Files.alias(),
+    ) == ["src/python/project/f1.py"]

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -26,6 +26,10 @@ class SourceRoot:
   category: str
 
 
+class NoSourceRootError(Exception):
+  """Indicates we failed to map a source file to a source root."""
+
+
 class AllSourceRoots(Collection[SourceRoot]):
   pass
 
@@ -97,6 +101,12 @@ class SourceRoots:
     # If no source root is found, use the path directly.
     # TODO: Remove this logic. It should be an error to have no matching source root.
     return SourceRoot(path, (), SourceRootCategories.UNKNOWN)
+
+  # TODO: this is how find_by_path should behave. Figure out how to deprecate the behavior of
+  # find_by_path so that this method becomes redundant.
+  def safe_find_by_path(self, path: str) -> Optional[SourceRoot]:
+    """Find the source root for the given path, if any."""
+    return self._trie.find(path)
 
   def traverse(self) -> Set[str]:
     return self._trie.traverse()


### PR DESCRIPTION
### Problem

Currently, we only have a rule to strip source roots given a `HydratedTarget`. The rule will strip everything belonging to `target_adaptor.sources.snapshot`.

For precise file args—where `./pants test foo.py` only runs over the specified file rather than the whole owning target—we will need a way to strip source roots for a given `Snapshot`, rather than `target_adaptor.sources`. Specifically, to generate the CLI args for tools like Pytest, we need to strip the source roots for the files coming from a `FilesystemResolvedSpec`. 

### Solution

Add a new rule `strip_source_roots_from_snapshot` to go from `SnapshotToStrip -> SourceRootStrippedSources`.

Also, this now properly handles when there is no source root for a path:
 * If `--source-unmatched=create`, strip the parent directory, whereas currently we strip the full path
 * If `--source-unmatched=error`, actually fail. Earlier we would strip the parent directory (which is how `--source-unmatched=create` is supposed to behave).