### PR TITLE
add assertDoesNotRaise contextmanager

### DIFF
--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -676,10 +676,14 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     self.assertIn(error_text, str(cm.exception))
 
   @contextmanager
-  def assertDoesNotRaise(self):
+  def assertDoesNotRaise(self, exc_class: Type[BaseException] = Exception):
+    """Verifies that the block does not raise an exception of the specified type.
+
+    :API: public
+    """
     try:
       yield
-    except Exception as e:
+    except exc_class as e:
       raise AssertionError(f'section should not have raised, but did: {e}') from e
 
   def get_bootstrap_options(self, cli_options=()):

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -675,6 +675,13 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
       yield cm
     self.assertIn(error_text, str(cm.exception))
 
+  @contextmanager
+  def assertDoesNotRaise(self):
+    try:
+      yield
+    except Exception as e:
+      raise AssertionError(f'section should not have raised, but did: {e}') from e
+
   def get_bootstrap_options(self, cli_options=()):
     """Retrieves bootstrap options.
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -221,10 +221,8 @@ class SchedulerTest(TestBase):
 
     # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to the
     # existence of transitive_b_c().
-    result_d = self.request_single_product(D, Params(c))
-    # We don't need the inner B objects to be the same, and we know the arguments are type-checked,
-    # we're just testing transitively resolving products in this file.
-    self.assertTrue(isinstance(result_d, D))
+    with self.assertDoesNotRaise():
+      _ = self.request_single_product(D, Params(c))
 
   @contextmanager
   def _assert_execution_error(self, expected_msg):
@@ -232,11 +230,10 @@ class SchedulerTest(TestBase):
       yield
 
   def test_union_rules(self):
-    a = self.request_single_product(A, Params(UnionWrapper(UnionA())))
-    # TODO: figure out what to assert here!
-    self.assertTrue(isinstance(a, A))
-    a = self.request_single_product(A, Params(UnionWrapper(UnionB())))
-    self.assertTrue(isinstance(a, A))
+    with self.assertDoesNotRaise():
+      _ = self.request_single_product(A, Params(UnionWrapper(UnionA())))
+    with self.assertDoesNotRaise():
+      _ = self.request_single_product(A, Params(UnionWrapper(UnionB())))
     # Fails due to no union relationship from A -> UnionBase.
     with self._assert_execution_error("Type A is not a member of the UnionBase @union"):
       self.request_single_product(A, Params(UnionWrapper(A())))


### PR DESCRIPTION
### Problem

It would be nice to be explicit about the intent when we're trying to make sure something ran without an exception and we *really, really* don't care about, or don't have any meaningful return value.

### Solution

- Add a `self.assertDoesNotRaise()` contextmanager.