### PR TITLE
Fix TOML config files interpolating options from the same section

### DIFF
--- a/build-support/migration-support/migrate_to_toml_config.py
+++ b/build-support/migration-support/migrate_to_toml_config.py
@@ -83,7 +83,7 @@ def generate_new_config(config: Path) -> List[str]:
   for i, line in enumerate(original_text_lines):
     option_regex = r"(?P<option>[a-zA-Z0-9_]+)"
     before_value_regex = rf"\s*{option_regex}\s*[:=]\s*"
-    valid_value_characters = r"a-zA-Z0-9_.@!:%\=\>\<\-\(\)\/"
+    valid_value_characters = r"a-zA-Z0-9_.@!:%\*\=\>\<\-\(\)\/"
     value_regex = rf"(?P<value>[{valid_value_characters}]+)"
     parsed_line = re.match(
       rf"{before_value_regex}{value_regex}\s*$", line,

--- a/build-support/migration-support/migrate_to_toml_config_test.py
+++ b/build-support/migration-support/migrate_to_toml_config_test.py
@@ -33,6 +33,7 @@ def test_fully_automatable_config() -> None:
       version: isort>=4.8
       target: src/python:example
       path: /usr/bin/test.txt
+      glob: *.txt
       fromfile: @build-support/example.txt
       interpolation: %(foo)s/example
       """
@@ -50,6 +51,7 @@ def test_fully_automatable_config() -> None:
       version = "isort>=4.8"
       target = "src/python:example"
       path = "/usr/bin/test.txt"
+      glob = "*.txt"
       fromfile = "@build-support/example.txt"
       interpolation = "%(foo)s/example"
       """


### PR DESCRIPTION
According to [`configparser`'s docs](https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation), basic interpolation should work when referring to an option either from `DEFAULT` _or_ from the same section. We were not supporting the latter case of referring to an option from the same section, solely due to an oversight.

This meant that a config like this would fail:

```toml
[GLOBAL]
pants_version = "1.26.0.dev0"
plugins = [
  "pantsbuild.pants.contrib.awslambda-python==%(pants_version)s",
]
```

This fixes the issue and also improves the error message when string interpolation fails.

Finally, this tweaks `migrate_to_toml_config.py` to recognize `*` as a valid character in option values so that options like `glob: *.txt` are automatically converted.