### PR TITLE
Respect precise file arguments with V2 `./pants test`

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -18,11 +18,12 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
+from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
-from pants.engine.legacy.structs import PythonTestsAdaptor
+from pants.engine.legacy.structs import PythonTestsAdaptor, PythonTestsAdaptorWithOrigin
 from pants.engine.rules import RootRule, subsystem_rule
 from pants.engine.selectors import Params
 from pants.python.python_requirement import PythonRequirement
@@ -47,7 +48,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
 
   def write_file(self, file_content: FileContent) -> None:
     self.create_file(
-      relpath=str(PurePath(self.source_root, file_content.path)),
+      relpath=PurePath(self.source_root, file_content.path).as_posix(),
       contents=file_content.content.decode(),
     )
 
@@ -117,10 +118,12 @@ class PythonTestRunnerIntegrationTest(TestBase):
       *strip_source_roots.rules(),
       *subprocess_environment.rules(),
       subsystem_rule(TestOptions),
-      RootRule(PythonTestsAdaptor),
+      RootRule(PythonTestsAdaptorWithOrigin),
     )
 
-  def run_pytest(self, *, passthrough_args: Optional[str] = None) -> TestResult:
+  def run_pytest(
+    self, *, passthrough_args: Optional[str] = None, origin: Optional[OriginSpec] = None,
+  ) -> TestResult:
     args = [
       "--backend-packages2=pants.backend.python",
       # pin to lower versions so that we can run Python 2 tests
@@ -130,7 +133,11 @@ class PythonTestRunnerIntegrationTest(TestBase):
     if passthrough_args:
       args.append(f"--pytest-args='{passthrough_args}'")
     options_bootstrapper = create_options_bootstrapper(args=args)
-    target = PythonTestsAdaptor(address=Address.parse(f"{self.source_root}:target"))
+    adaptor = PythonTestsAdaptor(address=Address.parse(f"{self.source_root}:target"))
+    if origin is None:
+      origin = SingleAddress(directory=self.source_root, name="target")
+    # TODO: get this working.
+    target = PythonTestsAdaptorWithOrigin(adaptor, origin)
     test_result = self.request_single_product(TestResult, Params(target, options_bootstrapper))
     debug_request = self.request_single_product(
       TestDebugRequest, Params(target, options_bootstrapper),
@@ -160,6 +167,14 @@ class PythonTestRunnerIntegrationTest(TestBase):
     assert result.status == Status.FAILURE
     assert "test_good.py ." in result.stdout
     assert "test_bad.py F" in result.stdout
+
+  def test_precise_file_args(self) -> None:
+    self.create_python_test_target([self.good_source, self.bad_source])
+    file_arg = FilesystemLiteralSpec(PurePath(self.source_root, self.good_source.path).as_posix())
+    result = self.run_pytest(origin=file_arg)
+    assert result.status == Status.SUCCESS
+    assert "test_good.py ." in result.stdout
+    assert "test_bad.py F" not in result.stdout
 
   def test_absolute_import(self) -> None:
     self.create_basic_library()

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -134,6 +134,10 @@ class PythonTestRunnerIntegrationTest(TestBase):
     options_bootstrapper = create_options_bootstrapper(args=args)
     if origin is None:
       origin = SingleAddress(directory=self.source_root, name="target")
+    # TODO: We must use the V1 target's `_sources_field.sources` field to set the TargetAdaptor's
+    # sources attribute. The adaptor will not auto-populate this field. However, it will
+    # auto-populate things like `dependencies` and this was not necessary before using
+    # PythonTestsAdaptorWithOrigin. Why is this necessary in test code?
     v1_target = self.target(f"{self.source_root}:target")
     adaptor = PythonTestsAdaptor(
       address=v1_target.address.to_address(), sources=v1_target._sources_field.sources,

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -442,3 +442,6 @@ class Specs:
       if self.filesystem_specs.dependencies
       else self.address_specs
     )
+
+
+OriginSpec = Union[AddressSpec, FilesystemResolvedSpec]

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,7 +5,7 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from functools import update_wrapper
-from typing import Any, Set, Tuple, Type, Union
+from typing import Any, Sequence, Set, Tuple, Type, Union
 
 from pants.base.exceptions import ResolveError
 from pants.base.specs import AddressSpec, FilesystemResolvedSpec
@@ -14,17 +14,21 @@ from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
 
 
+def _assert_single_address(addresses: Sequence[Address]) -> None:
+  """Assert that exactly one address must be contained in the collection."""
+  if len(addresses) == 0:
+    raise ResolveError("No targets were matched.")
+  if len(addresses) > 1:
+    output = '\n  * '.join(address.spec for address in addresses)
+    raise ResolveError(
+      "Expected a single target, but was given multiple targets.\n\n"
+      f"Did you mean one of:\n  * {output}"
+    )
+
+
 class Addresses(Collection[Address]):
   def expect_single(self) -> Address:
-    """Assert that exactly one Address must be contained in the collection, then return it."""
-    if len(self.dependencies) == 0:
-      raise ResolveError("No targets were matched.")
-    if len(self.dependencies) > 1:
-      output = '\n  * '.join(address.spec for address in self.dependencies)
-      raise ResolveError(
-        "Expected a single target, but was given multiple targets.\n\n"
-        f"Did you mean one of:\n  * {output}"
-      )
+    _assert_single_address(self.dependencies)
     return self.dependencies[0]
 
 
@@ -36,7 +40,11 @@ class AddressWithOrigin:
 
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):
-  pass
+  def expect_single(self) -> AddressWithOrigin:
+    _assert_single_address(
+      [address_with_origin.address for address_with_origin in self.dependencies]
+    )
+    return self.dependencies[0]
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,10 +5,10 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from functools import update_wrapper
-from typing import Any, Sequence, Set, Tuple, Type, Union
+from typing import Any, Sequence, Set, Tuple, Type
 
 from pants.base.exceptions import ResolveError
-from pants.base.specs import AddressSpec, FilesystemResolvedSpec
+from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
@@ -36,7 +36,7 @@ class Addresses(Collection[Address]):
 class AddressWithOrigin:
   """A BuildFileAddress along with the cmd-line spec it was generated from."""
   address: Address
-  origin: Union[AddressSpec, FilesystemResolvedSpec]
+  origin: OriginSpec
 
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -321,5 +321,6 @@ def create_graph_rules(address_mapper: AddressMapper):
     address_origin_map,
     # Root rules representing parameters that might be provided via root subjects.
     RootRule(Address),
+    RootRule(AddressWithOrigin),
     RootRule(AddressSpecs),
   ]

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -412,6 +412,8 @@ class LegacyTransitiveHydratedTargets:
   closure: OrderedSet  # TODO: this is an OrderedSet[LegacyHydratedTarget]
 
 
+# TODO(#7490): Remove this once we have multiple params support so that rules can do something
+# like `await Get[TestResult](Params(Address(..), Origin(..)))`.
 @dataclass(frozen=True)
 class HydratedTargetWithOrigin:
   """A wrapper around HydratedTarget that preserves the original spec used to resolve the target.

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -21,6 +21,7 @@ from pants.base.specs import (
   FilesystemLiteralSpec,
   FilesystemResolvedGlobSpec,
   FilesystemSpecs,
+  OriginSpec,
   SingleAddress,
 )
 from pants.build_graph.address import Address, BuildFileAddress
@@ -412,6 +413,17 @@ class LegacyTransitiveHydratedTargets:
 
 
 @dataclass(frozen=True)
+class HydratedTargetWithOrigin:
+  """A wrapper around HydratedTarget that preserves the original spec used to resolve the target.
+
+  This is useful for precise file arguments, where a goal like `./pants test` runs over only the
+  specified file arguments rather than the whole target.
+  """
+  target: HydratedTarget
+  origin: OriginSpec
+
+
+@dataclass(frozen=True)
 class SourcesSnapshot:
   """Sources matched by command line specs, either directly via FilesystemSpecs or indirectly via
   AddressSpecs.
@@ -631,6 +643,14 @@ async def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
   )
 
 
+@rule
+async def hydrate_target_with_origin(
+  address_with_origin: AddressWithOrigin
+) -> HydratedTargetWithOrigin:
+  ht = await Get[HydratedTarget](Address, address_with_origin.address)
+  return HydratedTargetWithOrigin(target=ht, origin=address_with_origin.origin)
+
+
 def _eager_fileset_with_spec(
   spec_path: str, filespec: Filespec, snapshot: Snapshot, include_dirs: bool = False,
 ) -> EagerFilesetWithSpec:
@@ -797,6 +817,7 @@ def create_legacy_graph_tasks():
     legacy_transitive_hydrated_targets,
     hydrated_targets,
     hydrate_target,
+    hydrate_target_with_origin,
     find_owners,
     hydrate_sources,
     hydrate_bundles,

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -311,10 +311,86 @@ class PantsPluginAdaptor(PythonTargetAdaptor):
     return GlobsWithConjunction.for_literal_files(['register.py'], self.address.spec_path)
 
 
+# TODO(#4535): Find a less clunky solution for precise file args as part of the Target API. The
+# trick here is that we must have some way to preserve the OriginSpec while also having a distinct
+# type for each target so that unions work properly.
 @dataclass(frozen=True)
-class PythonTestsAdaptorWithOrigin:
-  adaptor: PythonTestsAdaptor
+class TargetAdaptorWithOrigin:
+  adaptor: TargetAdaptor
   origin: OriginSpec
+
+  @staticmethod
+  def create(adaptor: TargetAdaptor, origin: OriginSpec) -> "TargetAdaptorWithOrigin":
+    adaptor_with_origin_cls: Type["TargetAdaptorWithOrigin"] = {
+      TargetAdaptor: TargetAdaptorWithOrigin,
+      AppAdaptor: AppAdaptorWithOrigin,
+      JvmAppAdaptor: JvmAppAdaptorWithOrigin,
+      PythonAppAdaptor: PythonAppAdaptorWithOrigin,
+      ResourcesAdaptor: ResourcesAdaptorWithOrigin,
+      RemoteSourcesAdaptor: RemoteSourcesAdaptorWithOrigin,
+      PythonTargetAdaptor: PythonTargetAdaptorWithOrigin,
+      PythonBinaryAdaptor: PythonBinaryAdaptorWithOrigin,
+      PythonTestsAdaptor: PythonTestsAdaptorWithOrigin,
+      PythonAWSLambdaAdaptor: PythonAWSLambdaAdaptorWithOrigin,
+      PythonRequirementLibraryAdaptor: PythonRequirementLibraryAdaptorWithOrigin,
+      PantsPluginAdaptor: PantsPluginAdaptorWithOrigin,
+    }[type(adaptor)]
+    return adaptor_with_origin_cls(adaptor, origin)
+
+
+@dataclass(frozen=True)
+class AppAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: AppAdaptor
+
+
+@dataclass(frozen=True)
+class JvmAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: JvmAppAdaptor
+
+
+@dataclass(frozen=True)
+class PythonAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonAppAdaptor
+
+
+@dataclass(frozen=True)
+class ResourcesAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: ResourcesAdaptor
+
+
+@dataclass(frozen=True)
+class RemoteSourcesAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: RemoteSourcesAdaptor
+
+
+@dataclass(frozen=True)
+class PythonTargetAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonTargetAdaptor
+
+
+@dataclass(frozen=True)
+class PythonBinaryAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonBinaryAdaptor
+
+
+@dataclass(frozen=True)
+class PythonTestsAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonTestsAdaptor
+
+
+@dataclass(frozen=True)
+class PythonAWSLambdaAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonAWSLambdaAdaptor
+
+
+@dataclass(frozen=True)
+class PythonRequirementLibraryAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PythonRequirementLibraryAdaptor
+
+
+@dataclass(frozen=True)
+class PantsPluginAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PantsPluginAdaptor
 
 
 # TODO: Remove all the subclasses once we remove globs et al. The only remaining subclass would be

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -8,6 +8,7 @@ from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 
+from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_list
@@ -308,6 +309,12 @@ class PythonRequirementLibraryAdaptor(TargetAdaptor): pass
 class PantsPluginAdaptor(PythonTargetAdaptor):
   def get_sources(self) -> "GlobsWithConjunction":
     return GlobsWithConjunction.for_literal_files(['register.py'], self.address.spec_path)
+
+
+@dataclass(frozen=True)
+class PythonTestsAdaptorWithOrigin:
+  adaptor: PythonTestsAdaptor
+  origin: OriginSpec
 
 
 # TODO: Remove all the subclasses once we remove globs et al. The only remaining subclass would be

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -311,9 +311,8 @@ class PantsPluginAdaptor(PythonTargetAdaptor):
     return GlobsWithConjunction.for_literal_files(['register.py'], self.address.spec_path)
 
 
-# TODO(#4535): Find a less clunky solution for precise file args as part of the Target API. The
-# trick here is that we must have some way to preserve the OriginSpec while also having a distinct
-# type for each target so that unions work properly.
+# TODO(#7490): Remove this once we have multiple params support so that rules can do something
+# like `await Get[TestResult](Params(Address(..), Origin(..)))`.
 @dataclass(frozen=True)
 class TargetAdaptorWithOrigin:
   adaptor: TargetAdaptor

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -65,7 +65,10 @@ class TestDebugRequest:
 
 @union
 class TestTarget:
-  """A union for registration of a testable target type."""
+  """A union for registration of a testable target type.
+
+  The union members should be subclasses of TargetAdaptorWithOrigin.
+  """
 
   # Prevent this class from being detected by Pytest as a test class.
   __test__ = False
@@ -192,9 +195,9 @@ async def coordinator_of_tests(
   # live TTY, periodically dump heavy hitters to stderr. See
   # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
   logger.info(f"Starting tests: {target.address.reference()}")
-  # NB: This has the effect of "casting" a TargetAdaptor to a member of the TestTarget union.
-  # The adaptor will always be a member because of the union membership check above, but if
-  # it were not it would fail at runtime with a useful error message.
+  # NB: This has the effect of "casting" a TargetAdaptorWithOrigin to a member of the TestTarget
+  # union. If the adaptor is not a member of the union, the engine will fail at runtime with a
+  # useful error message.
   result = await Get[TestResult](TestTarget, adaptor_with_origin)
   logger.info(
     f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.build_graph.address import Address
-from pants.engine.addressable import Addresses
+from pants.engine.addressable import AddressesWithOrigins
 from pants.engine.build_files import AddressOriginMap
 from pants.engine.console import Console
 from pants.engine.fs import Digest
@@ -135,15 +135,21 @@ class AddressAndDebugRequest:
 
 @goal_rule
 async def run_tests(
-  console: Console, options: TestOptions, runner: InteractiveRunner, addresses: Addresses,
+  console: Console,
+  options: TestOptions,
+  runner: InteractiveRunner,
+  addresses_with_origins: AddressesWithOrigins,
 ) -> Test:
   if options.values.debug:
-    address = addresses.expect_single()
-    addr_debug_request = await Get[AddressAndDebugRequest](Address, address)
+    address_with_origin = addresses_with_origins.expect_single()
+    addr_debug_request = await Get[AddressAndDebugRequest](Address, address_with_origin.address)
     result = runner.run_local_interactive_process(addr_debug_request.request.ipr)
     return Test(result.process_exit_code)
 
-  results = await MultiGet(Get[AddressAndTestResult](Address, addr) for addr in addresses)
+  results = await MultiGet(
+    Get[AddressAndTestResult](Address, address_with_origin.address)
+    for address_with_origin in addresses_with_origins
+  )
   did_any_fail = False
   filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
 

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -3,16 +3,15 @@
 
 import logging
 from textwrap import dedent
-from typing import Dict, Optional
+from typing import Optional
 from unittest.mock import Mock
 
-from pants.base.specs import DescendantAddresses, SingleAddress, Spec
+from pants.base.specs import DescendantAddresses, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin
-from pants.engine.build_files import AddressOriginMap
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.legacy.graph import HydratedTarget, HydratedTargetWithOrigin
 from pants.engine.legacy.structs import PythonBinaryAdaptor, PythonTestsAdaptor
 from pants.engine.rules import UnionMembership
 from pants.rules.core.test import (
@@ -75,12 +74,12 @@ class TestTest(TestBase):
       mock_gets=[
         MockGet(
           product_type=AddressAndTestResult,
-          subject_type=Address,
+          subject_type=AddressWithOrigin,
           mock=lambda _: AddressAndTestResult(addr, result),
         ),
         MockGet(
           product_type=AddressAndDebugRequest,
-          subject_type=Address,
+          subject_type=AddressWithOrigin,
           mock=lambda _: AddressAndDebugRequest(
             addr,
             TestDebugRequest(ipr=self.make_successful_ipr() if success else self.make_failure_ipr())
@@ -118,30 +117,38 @@ class TestTest(TestBase):
     console = MockConsole(use_colors=False)
     options = MockOptions(debug=False)
     runner = InteractiveRunner(self.scheduler)
-    target1 = Address.parse("testprojects/tests/python/pants/passes")
-    target2 = Address.parse("testprojects/tests/python/pants/fails")
+    address1 = Address.parse("testprojects/tests/python/pants/passes")
+    address2 = Address.parse("testprojects/tests/python/pants/fails")
 
-    def make_result(target: Address) -> AddressAndTestResult:
-      if target == target1:
+    def make_result(address_with_origin: AddressWithOrigin) -> AddressAndTestResult:
+      address = address_with_origin.address
+      if address == address1:
         tr = TestResult(status=Status.SUCCESS, stdout='I passed\n', stderr='')
-      elif target == target2:
+      elif address == address2:
         tr = TestResult(status=Status.FAILURE, stdout='I failed\n', stderr='')
       else:
         raise Exception("Unrecognised target")
-      return AddressAndTestResult(target, tr)
+      return AddressAndTestResult(address, tr)
 
-    def make_debug_request(target: Address) -> AddressAndDebugRequest:
+    def make_debug_request(address_with_origin: AddressWithOrigin) -> AddressAndDebugRequest:
+      address = address_with_origin.address
       request = TestDebugRequest(
-        ipr=self.make_successful_ipr() if target == target1 else self.make_failure_ipr()
+        ipr=self.make_successful_ipr() if address == address1 else self.make_failure_ipr()
       )
-      return AddressAndDebugRequest(target, request)
+      return AddressAndDebugRequest(address, request)
 
     res = run_rule(
       run_tests,
-      rule_args=[console, options, runner, self.make_addresses_with_origins(target1, target2)],
+      rule_args=[console, options, runner, self.make_addresses_with_origins(address1, address2)],
       mock_gets=[
-        MockGet(product_type=AddressAndTestResult, subject_type=Address, mock=make_result),
-        MockGet(product_type=AddressAndDebugRequest, subject_type=Address, mock=make_debug_request),
+        MockGet(
+          product_type=AddressAndTestResult, subject_type=AddressWithOrigin, mock=make_result
+        ),
+        MockGet(
+          product_type=AddressAndDebugRequest,
+          subject_type=AddressWithOrigin,
+          mock=make_debug_request
+        ),
       ],
     )
 
@@ -182,7 +189,7 @@ class TestTest(TestBase):
     self,
     *,
     address: Address,
-    addr_to_origin: Optional[Dict[Address, Spec]] = None,
+    origin: Optional[OriginSpec] = None,
     test_target_type: bool = True,
     include_sources: bool = True,
   ) -> AddressAndTestResult:
@@ -206,9 +213,11 @@ class TestTest(TestBase):
       result: AddressAndTestResult = run_rule(
         coordinator_of_tests,
         rule_args=[
-          HydratedTarget(address, target_adaptor, ()),
+          HydratedTargetWithOrigin(
+            target=HydratedTarget(address, target_adaptor, ()),
+            origin=origin or SingleAddress(directory=address.spec_path, name=address.target_name),
+          ),
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
-          AddressOriginMap(addr_to_origin=addr_to_origin or {}),
         ],
         mock_gets=[
           MockGet(
@@ -235,7 +244,7 @@ class TestTest(TestBase):
     with self.assertRaisesRegex(AssertionError, r'Rule requested: .* which cannot be satisfied.'):
       self.run_coordinator_of_tests(
         address=addr,
-        addr_to_origin={addr: SingleAddress(directory='some/dir', name='bin')},
+        origin=SingleAddress(directory='some/dir', name='bin'),
         test_target_type=False,
       )
 
@@ -247,8 +256,7 @@ class TestTest(TestBase):
   def test_coordinator_globbed_test_target(self) -> None:
     addr = Address.parse("some/dir:tests")
     result = self.run_coordinator_of_tests(
-      address=addr,
-      addr_to_origin={addr: DescendantAddresses(directory='some/dir')}
+      address=addr, origin=DescendantAddresses(directory='some/dir'),
     )
     assert result == AddressAndTestResult(
       addr, TestResult(status=Status.SUCCESS, stdout='foo', stderr='')
@@ -258,7 +266,7 @@ class TestTest(TestBase):
     addr = Address.parse("some/dir:bin")
     result = self.run_coordinator_of_tests(
       address=addr,
-      addr_to_origin={addr: DescendantAddresses(directory='some/dir')},
+      origin=DescendantAddresses(directory='some/dir'),
       test_target_type=False,
     )
     assert result == AddressAndTestResult(addr, None)

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -12,7 +12,11 @@ from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargetWithOrigin
-from pants.engine.legacy.structs import PythonBinaryAdaptor, PythonTestsAdaptor
+from pants.engine.legacy.structs import (
+  PythonBinaryAdaptor,
+  PythonTestsAdaptor,
+  PythonTestsAdaptorWithOrigin,
+)
 from pants.engine.rules import UnionMembership
 from pants.rules.core.test import (
   AddressAndDebugRequest,
@@ -217,12 +221,12 @@ class TestTest(TestBase):
             target=HydratedTarget(address, target_adaptor, ()),
             origin=origin or SingleAddress(directory=address.spec_path, name=address.target_name),
           ),
-          UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
+          UnionMembership(union_rules={TestTarget: [PythonTestsAdaptorWithOrigin]}),
         ],
         mock_gets=[
           MockGet(
             product_type=TestResult,
-            subject_type=PythonTestsAdaptor,
+            subject_type=PythonTestsAdaptorWithOrigin,
             mock=lambda _: TestResult(status=Status.SUCCESS, stdout='foo', stderr=''),
           ),
         ],


### PR DESCRIPTION
## Problem

When running `./pants test src/python/pants/rules/core/run_test.py`, someone who has never used Pants before would expect Pants to only test `run_test.py`. However, Pants will end up testing all of `rules/core:tests` and users must specify `./pants test src/python/pants/rules/core/run_test.py --pytest-args='-k RunTest'` to get what they want.

At the same time, we must still use the metadata from the owning target in order to prepare the test, such as resolving `dependencies`.

## Solution

Preserve the `OriginSpec` and pass it down all the way to `python_test_runner.py` so that it may pass more precise arguments to Pytest. Previously, we always passed every single file belonging to the `sources` of the target. Now, when given a filesystem spec, we will pass the files explicitly specified (which are a subset of the target's `sources`).

In order to preserve the `OriginSpec`, we make several changes.

**These changes are clunky due to the lack of multiple params in `await Get` (https://github.com/pantsbuild/pants/issues/7490). This PR helps to guide that design, though, while adding a useful feature needed today.**

### `AddressesWithOrigins`

The test `@goal_rule` now requests `AddressesWithOrigins`, rather than `Addresses`, so that we may preserve the original specs.

Here, we add a method to go from `AddressesWithOrigins -> AddressWithOrigin`.

### `HydratedTargetWithOrigin`

This allows us to have a hydrated target without losing the `OriginSpec` information. 

We need to be able to use `HydratedTarget` because this is how we access the underlying `TargetAdaptor` necessary to get the `TestTarget` union working. The original `AddressWithOrigin` from the `@goal_rule` isn't hydrated enough.

### `TargetAdaptorWithOrigin`

Finally, we add `TargetAdaptorWithOrigin`, along with a type for each distinct `TargetAdaptor`, such as `PythonTestsAdaptorWithOrigin`.

We need so many new classes for the union mechanism to work properly. `python_test_runner.py` must have some way to signal that it only works with `python_tests` targets, which we previously did by registering `UnionRule(TestTarget, PythonTestsAdaptor)`. But, we still need to preserve the `OriginSpec`, so we introduce `PythonTestsAdaptorWithOrigin`.

#### Rejected alternative: field on `TargetAdaptor`

One alternative design is to insert the `OriginSpec` proactively on the `TargetAdaptor`. This means that we would not need to introduce any `TargetAdaptorWithOrigin` types.

However, this approach suffers from not being typed. Given the type-driven API of rules, we want some structured way to specify that `python_test_runner.py` _must_ have the `OriginSpec` preserved, rather than checking for some optional field defined on the `TargetAdaptor`.

## Result

`./pants test src/python/pants/rules/core/run_test.py` only runs over `run_test.py` now. 

In a followup, we will add precise file args to `fmt2` and `lint2`.