### PR TITLE
Fix warnings filtering under pantsd

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -4,7 +4,6 @@
 import logging
 import os
 import sys
-import warnings
 from typing import List, Mapping, Optional
 
 from pants.base.exception_sink import ExceptionSink
@@ -89,9 +88,6 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
     ExceptionSink.reset_should_print_backtrace_to_terminal(global_bootstrap_options.print_exception_stacktrace)
     ExceptionSink.reset_log_location(global_bootstrap_options.pants_workdir)
-
-    for message_regexp in global_bootstrap_options.ignore_pants_warnings:
-      warnings.filterwarnings(action='ignore', message=message_regexp)
 
     # TODO https://github.com/pantsbuild/pants/issues/7205
     if self._should_run_with_pantsd(global_bootstrap_options):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -316,7 +316,13 @@ class PantsDaemon(FingerprintedProcessManager):
     with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
       # Reinitialize logging for the daemon context.
       init_rust_logger(self._log_level, self._log_show_rust_3rdparty)
-      result = setup_logging(self._log_level, log_dir=self._log_dir, log_name=self.LOG_NAME, native=self._native)
+      result = setup_logging(
+        self._log_level,
+        log_dir=self._log_dir,
+        log_name=self.LOG_NAME,
+        native=self._native,
+        warnings_filter_regexes=self._bootstrap_options.for_global_scope(),
+      )
       self._native.override_thread_logging_destination_to_just_pantsd()
 
       # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -50,7 +50,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
   class UninitializedSubsystemError(SubsystemError):
     def __init__(self, class_name, scope):
       super().__init__(
-        f'Subsystem "{class_name}" not initialized for scope "{scope}". Is subsystem missing'
+        f'Subsystem "{class_name}" not initialized for scope "{scope}". Is subsystem missing '
         'from subsystem_dependencies() in a task? '
       )
 


### PR DESCRIPTION
### Problem

The warnings-filtering facility provided by `--ignore-pants-warnings` was not being enabled in the pantsd subprocess, meaning that warnings were not filtered while pantsd was in use.

### Solution

Move warnings filtering into `setup_logging` to ensure that it is executed in all relevant contexts. 

### Result

Warnings are properly filtered with/without pantsd. 