### PR TITLE
Add ipdb for internal Pants tests

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -389,6 +389,7 @@ pytest_plugins.add = [
   # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
   #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
   "setuptools==40.6.3",
+  "ipdb",
 ]
 
 [test.pytest]

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -224,16 +224,16 @@ To run Pants under `pdb` and set a breakpoint, you can typically add
     :::python
     import pdb; pdb.set_trace()
 
-...where you first want to break. If the code is in a test, instead use
+...where you first want to break. If the code is in a test, you can use ipdb for a much nicer debugger
 
     :::python
-    import pytest; pytest.set_trace()
+    import ipdb; ipdb.set_trace()
 
-To run tests and bring up `pdb` for failing tests, you can instead pass `--pdb` to
-`test.pytest --options`:
+To run tests and bring up `pdb` for failing tests, you can pass `--pdb` to
+`--pytest-args`:
 
     :::bash
-    $ ./pants test.pytest --options='--pdb' tests/python/pants_test/tasks:
+    $ ./pants --pytest-args='--pdb' test tests/python/pants_test/tasks:
     ... plenty of test output ...
     tests/python/pants_test/tasks/test_targets_help.py E
     >>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -251,8 +251,7 @@ To run tests and bring up `pdb` for failing tests, you can instead pass `--pdb` 
     -> super().setUpClass()
     (Pdb)
 
-Debug quickly; that test target will time out in a couple of minutes,
-quitting you out.
+When debugging tests, the test might time out. You can turn off timeouts with `--no-pytest-timeouts`.
 
 To start an interactive Python shell that can `import` Pants modules,
 use the usual `./pants repl` on a `python_library` target that builds (or


### PR DESCRIPTION
`ipdb` (based off of ipython) provides a much nicer experience than `pdb` when debugging. For example, `ipdb` has tab-autocomplete:

![example ipdb autocomplete](https://user-images.githubusercontent.com/14852634/74470424-bc845100-4e5b-11ea-80fa-28734ea59f4d.png)

### How to use

Add `import ipdb; ipdb.set_trace()` to some code. Then run `./pants --no-v1 --v2 test --debug path/to:target --pytest-args='-s'`.

The `-s` passthrough arg is necessary to get Pytest to play nicely with ipdb.

### Only adds for tests

While it would be nice to be able to use `ipdb` in any context, such as `./pants run`, that would require adding `ipdb` as a dependency in `3rdparty/python/requirements.txt`, which has an impact on everyone who uses Pants as a library.

Instead, here, we can register `ipdb` with the `pytest` subsystem without impacting any users outside of this internal repo.