### PR TITLE
Add `./pants .` shorthand to operate on all watched files

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -67,6 +67,8 @@ class CmdLineSpecParser:
     """
     if spec == ".":
       return FilesystemGlobSpec("**/*")
+    if spec.endswith("/."):
+      return FilesystemGlobSpec(f"{spec[:-len('.')]}**/*")
     if spec.endswith('::'):
       spec_path = spec[:-len('::')]
       return DescendantAddresses(directory=self._normalize_spec_path(spec_path))

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -65,6 +65,8 @@ class CmdLineSpecParser:
 
     :raises: CmdLineSpecParser.BadSpecError if the address selector could not be parsed.
     """
+    if spec == ".":
+      return FilesystemGlobSpec("**/*")
     if spec.endswith('::'):
       spec_path = spec[:-len('::')]
       return DescendantAddresses(directory=self._normalize_spec_path(spec_path))

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -93,6 +93,12 @@ class CmdLineSpecParserTest(TestBase):
 
   def test_dot_glob(self) -> None:
     self.assert_filesystem_spec_parsed(".", glob("**/*"))
+    self.assert_filesystem_spec_parsed("a/b/.", glob("a/b/**/*"))
+    # We don't expand `.` in any other context to preserve command line accordances and to avoid
+    # ambiguity. We can tweak the grammar later if we find a need.
+    self.assert_address_spec_parsed("a/b/c.", single("a/b/c.", "c."))
+    self.assert_address_spec_parsed("a/./b", single("a/b", "b"))
+    self.assert_address_spec_parsed("a/./", single("a", "a"))
 
   def test_excludes(self) -> None:
     for glob_str in ["!", "!a/b/", "!/a/b/*"]:

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -91,6 +91,9 @@ class CmdLineSpecParserTest(TestBase):
     for glob_str in ["*", "**/*", "a/b/*", "a/b/test_*.py", "a/b/**/test_*"]:
       self.assert_filesystem_spec_parsed(glob_str, glob(glob_str))
 
+  def test_dot_glob(self) -> None:
+    self.assert_filesystem_spec_parsed(".", glob("**/*"))
+
   def test_excludes(self) -> None:
     for glob_str in ["!", "!a/b/", "!/a/b/*"]:
       self.assert_filesystem_spec_parsed(glob_str, ignore(glob_str[1:]))


### PR DESCRIPTION
Before:

```bash
$ ./pants buildgen '**/*'   # note the quotes
```

After:

```bash
$ ./pants buildgen .
```

We also expand `a/b/.` to mean `a/b/**/*` for consistency and convenience, although we do not expand every `.` we see such as not expanding `a/./b`.

This aligns with Git conventions, such as `git add .` and `git checkout -- .`. Generally, our `PathGlobs` syntax aligns closely with Git, such as using `!` for excludes, so this further alignment is desirable.

Beyond alignment with Git, Toolchain users very frequently run `./pants buildgen '**/*'` (not `./pants buildgen ::` because BUILD files might not yet exist), and this greatly improves the ergonomics of this every-day command.