### PR TITLE
Fix setuptools's Python 2 deprecation warning with Python linters

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -8,8 +8,8 @@ from pants.option.custom_types import file_option, shell_str
 
 class Bandit(PythonToolBase):
   options_scope = 'bandit'
-  default_version = 'bandit'
-  default_extra_requirements = ['setuptools']
+  default_version = 'bandit>=1.6.2,<1.7'
+  default_extra_requirements = ['setuptools<45']  # `<45` is for Python 2 support
   default_entry_point = 'bandit'
   default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.0"]
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -7,7 +7,7 @@ from pants.option.custom_types import file_option, shell_str
 
 class Black(PythonToolBase):
   options_scope = 'black'
-  default_version = 'black==19.3b0'
+  default_version = 'black==19.10b0'
   default_extra_requirements = ['setuptools']
   default_entry_point = 'black:patched_main'
   default_interpreter_constraints = ["CPython>=3.6"]

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -7,8 +7,8 @@ from pants.option.custom_types import file_option, shell_str
 
 class Flake8(PythonToolBase):
   options_scope = 'flake8'
-  default_version = 'flake8'
-  default_extra_requirements = ['setuptools']
+  default_version = 'flake8>=3.7.9,<3.8'
+  default_extra_requirements = ['setuptools<45']  # `<45` is for Python 2 support
   default_entry_point = 'flake8'
   default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -7,9 +7,10 @@ from pants.option.custom_types import file_option, shell_str
 
 class Isort(PythonToolBase):
   options_scope = 'isort'
-  default_version = 'isort==4.3.20'
+  default_version = 'isort>=4.3.21,<4.4'
   default_extra_requirements = ['setuptools']
   default_entry_point = 'isort.main'
+  default_interpreter_constraints = ["CPython>=3.6"]
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -8,9 +8,8 @@ from pants.option.custom_types import file_option, shell_str
 class Isort(PythonToolBase):
   options_scope = 'isort'
   default_version = 'isort>=4.3.21,<4.4'
-  default_extra_requirements = ['setuptools']
+  default_extra_requirements = ['setuptools<45']  # NB: `<45` is for Python 2 support
   default_entry_point = 'isort.main'
-  default_interpreter_constraints = ["CPython>=3.6"]
 
   @classmethod
   def register_options(cls, register):


### PR DESCRIPTION
Setuptools 45.x is the last to support Python 2. It has an incredibly noisy stderr message to make sure users are aware of this:

```
/private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionUnBXvi/pex_root/install/setuptools-45.2.0-py2-none-any.whl.91f9e7e571716e18411266133f3db5a0212dfa92/setuptools-45.2.0-py2-none-any.whl/pkg_resources/py2_warn.py:22: UserWarning: Setuptools will stop working on Python 2
************************************************************
You are running Setuptools on Python 2, which is no longer
supported and
>>> SETUPTOOLS WILL STOP WORKING <<<
in a subsequent release (no sooner than 2020-04-20).
Please ensure you are installing
Setuptools using pip 9.x or later or pin to `setuptools<45`
in your environment.
If you have done those things and are still encountering
this message, please comment in
https://github.com/pypa/setuptools/issues/1458
about the steps that led to this unsupported combination.
************************************************************
  sys.version_info < (3,) and warnings.warn(pre + "*" * 60 + msg + "*" * 60)
```

By tweaking our default versions, we can make sure our users don't get this noise when running `./pants fmt2` and `./pants lint2`.