### PR TITLE
Add support for precise file arguments to `fmt2` and `lint2`

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/BUILD
+++ b/src/python/pants/backend/python/lint/bandit/BUILD
@@ -36,5 +36,4 @@ python_tests(
     'src/python/pants/testutil/subsystem',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 210,
 )

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
-from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
+from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -27,21 +27,21 @@ from pants.rules.core.lint import LintResult
 
 @dataclass(frozen=True)
 class BanditTarget:
-  target: TargetAdaptor
+  adaptor_with_origin: TargetAdaptorWithOrigin
 
 
-def generate_args(wrapped_target: BanditTarget, bandit: Bandit) -> Tuple[str, ...]:
+def generate_args(bandit_target: BanditTarget, bandit: Bandit) -> Tuple[str, ...]:
   args = []
   if bandit.options.config is not None:
     args.append(f"--config={bandit.options.config}")
   args.extend(bandit.options.args)
-  args.extend(sorted(wrapped_target.target.sources.snapshot.files))
+  args.extend(sorted(bandit_target.adaptor_with_origin.adaptor.sources.snapshot.files))
   return tuple(args)
 
 
 @rule(name="Lint using Bandit")
 async def lint(
-  wrapped_target: BanditTarget,
+  bandit_target: BanditTarget,
   bandit: Bandit,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -49,13 +49,14 @@ async def lint(
   if bandit.options.skip:
     return LintResult.noop()
 
-  target = wrapped_target.target
+  adaptor_with_origin = bandit_target.adaptor_with_origin
+  adaptor = adaptor_with_origin.adaptor
 
   # NB: Bandit output depends upon which Python interpreter version it's run with. We ensure that
   # each target runs with its own interpreter constraints. See
   # https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit.
   interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
-    adaptors=[target] if isinstance(target, PythonTargetAdaptor) else [],
+    adaptors=[adaptor] if isinstance(adaptor, PythonTargetAdaptor) else [],
     python_setup=python_setup
   )
 
@@ -79,7 +80,7 @@ async def lint(
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        target.sources.snapshot.directory_digest,
+        adaptor.sources.snapshot.directory_digest,
         requirements_pex.directory_digest,
         config_snapshot.directory_digest,
       )
@@ -89,9 +90,9 @@ async def lint(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path=f'./bandit.pex',
-    pex_args=generate_args(wrapped_target, bandit),
+    pex_args=generate_args(bandit_target, bandit),
     input_files=merged_input_files,
-    description=f'Run Bandit for {target.address.reference()}',
+    description=f'Run Bandit for {adaptor.address.reference()}',
   )
   result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
   return LintResult.from_fallible_execute_process_result(result)

--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -35,5 +35,4 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 120,
 )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -3,7 +3,7 @@
 
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import PurePath
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
@@ -29,6 +29,11 @@ from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
+from pants.rules.core import find_target_source_files, strip_source_roots
+from pants.rules.core.find_target_source_files import (
+  FindTargetSourceFilesRequest,
+  TargetSourceFiles,
+)
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
 
@@ -40,23 +45,46 @@ class BlackTarget:
 
 
 @dataclass(frozen=True)
-class BlackSetup:
-  requirements_pex: Pex
-  config_snapshot: Snapshot
-  passthrough_args: Optional[Tuple[str, ...]]
-  skip: bool
+class SetupRequest:
+  target: BlackTarget
+  check_only: bool
+
+
+@dataclass(frozen=True)
+class Setup:
+  process_request: ExecuteProcessRequest
+
+
+def generate_args(
+  *, source_files: TargetSourceFiles, black: Black, check_only: bool,
+) -> Tuple[str, ...]:
+  args = []
+  if check_only:
+    args.append("--check")
+  if black.options.config is not None:
+    args.extend(["--config", black.options.config])
+  args.extend(black.options.args)
+  # NB: For some reason, Black's --exclude option only works on recursive invocations, meaning
+  # calling Black on a directory(s) and letting it auto-discover files. However, we don't want
+  # Black to run over everything recursively under the directory of our target, as Black should
+  # only touch files directly specified. We can use `--include` to ensure that Black only
+  # operates on the files we actually care about.
+  files = sorted(source_files.snapshot.files)
+  args.extend(["--include", "|".join(re.escape(f) for f in files)])
+  args.extend(PurePath(f).parent.as_posix() for f in files)
+  return tuple(args)
 
 
 @rule
-async def setup_black(black: Black) -> BlackSetup:
-  config_path: Optional[str] = black.options.config
-  config_snapshot = await Get[Snapshot](
-    PathGlobs(
-      globs=tuple([config_path] if config_path else []),
-      glob_match_error_behavior=GlobMatchErrorBehavior.error,
-      description_of_origin="the option `--black-config`",
-    )
-  )
+async def setup(
+  request: SetupRequest,
+  black: Black,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+) -> Setup:
+  adaptor_with_origin = request.target.adaptor_with_origin
+  adaptor = adaptor_with_origin.adaptor
+
   requirements_pex = await Get[Pex](
     CreatePex(
       output_filename="black.pex",
@@ -67,101 +95,81 @@ async def setup_black(black: Black) -> BlackSetup:
       entry_point=black.get_entry_point(),
     )
   )
-  return BlackSetup(
-    requirements_pex=requirements_pex,
-    config_snapshot=config_snapshot,
-    passthrough_args=tuple(black.options.args),
-    skip=black.options.skip,
+
+  config_path: Optional[str] = black.options.config
+  config_snapshot = await Get[Snapshot](
+    PathGlobs(
+      globs=tuple([config_path] if config_path else []),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      description_of_origin="the option `--black-config`",
+    )
   )
 
+  # NB: We populate the chroot with every source file belonging to the target, but possibly only
+  # tell Black to run over some of those files when given file arguments.
+  full_sources_digest = (
+    request.target.prior_formatter_result_digest or adaptor.sources.snapshot.directory_digest
+  )
+  specified_source_files = await Get[TargetSourceFiles](
+    FindTargetSourceFilesRequest(adaptor_with_origin)
+  )
 
-@dataclass(frozen=True)
-class BlackArgs:
-  args: Tuple[str, ...]
-
-  @staticmethod
-  def create(
-    *, black_target: BlackTarget, black_setup: BlackSetup, check_only: bool,
-  ) -> "BlackArgs":
-    files = black_target.adaptor_with_origin.adaptor.sources.snapshot.files
-    pex_args = []
-    if check_only:
-      pex_args.append("--check")
-    if black_setup.config_snapshot.files:
-      pex_args.extend(["--config", black_setup.config_snapshot.files[0]])
-    if black_setup.passthrough_args:
-      pex_args.extend(black_setup.passthrough_args)
-    # NB: For some reason, Black's --exclude option only works on recursive invocations, meaning
-    # calling Black on a directory(s) and letting it auto-discover files. However, we don't want
-    # Black to run over everything recursively under the directory of our target, as Black should
-    # only touch files in the target's `sources`. We can use `--include` to ensure that Black only
-    # operates on the files we actually care about.
-    pex_args.extend(["--include", "|".join(re.escape(f) for f in files)])
-    pex_args.extend(str(Path(f).parent) for f in files)
-    return BlackArgs(tuple(pex_args))
-
-
-@rule
-async def create_black_request(
-  black_target: BlackTarget,
-  black_args: BlackArgs,
-  black_setup: BlackSetup,
-  python_setup: PythonSetup,
-  subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> ExecuteProcessRequest:
-  adaptor = black_target.adaptor_with_origin.adaptor
-  sources_digest = black_target.prior_formatter_result_digest or adaptor.sources.snapshot.directory_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        sources_digest,
-        black_setup.requirements_pex.directory_digest,
-        black_setup.config_snapshot.directory_digest,
+        full_sources_digest,
+        requirements_pex.directory_digest,
+        config_snapshot.directory_digest,
       )
     ),
   )
-  return black_setup.requirements_pex.create_execute_request(
-      python_setup=python_setup,
-      subprocess_encoding_environment=subprocess_encoding_environment,
-      pex_path="./black.pex",
-      pex_args=black_args.args,
-      input_files=merged_input_files,
-      output_files=adaptor.sources.snapshot.files,
-      description=f'Run Black for {adaptor.address.reference()}',
+
+  process_request = requirements_pex.create_execute_request(
+    python_setup=python_setup,
+    subprocess_encoding_environment=subprocess_encoding_environment,
+    pex_path="./black.pex",
+    pex_args=generate_args(
+      source_files=specified_source_files, black=black, check_only=request.check_only,
+    ),
+    input_files=merged_input_files,
+    # NB: Even if the user specified to only run on certain files belonging to the target, we
+    # still capture in the output all of the source files.
+    output_files=adaptor.sources.snapshot.files,
+    description=f'Run black for {adaptor.address.reference()}',
   )
+  return Setup(process_request)
 
 
 @rule(name="Format using Black")
-async def fmt(black_target: BlackTarget, black_setup: BlackSetup) -> FmtResult:
-  if black_setup.skip:
+async def fmt(black_target: BlackTarget, black: Black) -> FmtResult:
+  if black.options.skip:
     return FmtResult.noop()
-  args = BlackArgs.create(black_setup=black_setup, black_target=black_target, check_only=False)
-  request = await Get[ExecuteProcessRequest](BlackArgs, args)
-  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+  setup = await Get[Setup](SetupRequest(black_target, check_only=False))
+  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
   return FmtResult.from_execute_process_result(result)
 
 
 @rule(name="Lint using Black")
-async def lint(black_target: BlackTarget, black_setup: BlackSetup) -> LintResult:
-  if black_setup.skip:
+async def lint(black_target: BlackTarget, black: Black) -> LintResult:
+  if black.options.skip:
     return LintResult.noop()
-  args = BlackArgs.create(black_setup=black_setup, black_target=black_target, check_only=True)
-  request = await Get[ExecuteProcessRequest](BlackArgs, args)
-  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+  setup = await Get[Setup](SetupRequest(black_target, check_only=True))
+  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
   return LintResult.from_fallible_execute_process_result(result)
 
 
 def rules():
   return [
-    setup_black,
-    create_black_request,
+    setup,
     fmt,
     lint,
     subsystem_rule(Black),
     UnionRule(PythonFormatTarget, BlackTarget),
     UnionRule(PythonLintTarget, BlackTarget),
     *download_pex_bin.rules(),
+    *find_target_source_files.rules(),
     *pex.rules(),
     *python_native_code.rules(),
+    *strip_source_roots.rules(),
     *subprocess_environment.rules(),
   ]

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -7,11 +7,11 @@ import pytest
 
 from pants.backend.python.lint.black.rules import BlackTarget
 from pants.backend.python.lint.black.rules import rules as black_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.rules import download_pex_bin
+from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
-from pants.engine.legacy.structs import TargetAdaptor
+from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.rules.core.fmt import FmtResult
@@ -41,9 +41,6 @@ class BlackIntegrationTest(TestBase):
       *super().rules(),
       *black_rules(),
       download_pex_bin.download_pex_bin,
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
       RootRule(BlackTarget),
       RootRule(download_pex_bin.DownloadedPexBin.Factory),
     )
@@ -65,20 +62,22 @@ class BlackIntegrationTest(TestBase):
     if skip:
       args.append(f"--black-skip")
     input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-    target_adaptor = TargetAdaptor(
+    adaptor = TargetAdaptor(
       sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
       address=Address.parse("test:target"),
     )
-    lint_target = BlackTarget(target_adaptor)
-    fmt_target = BlackTarget(target_adaptor, prior_formatter_result_digest=input_snapshot.directory_digest)
+    origin = SingleAddress(directory="test", name="target")
+    adaptor_with_origin = TargetAdaptorWithOrigin(adaptor, origin)
     options_bootstrapper = create_options_bootstrapper(args=args)
     lint_result = self.request_single_product(LintResult, Params(
-      lint_target,
+      BlackTarget(adaptor_with_origin),
       options_bootstrapper,
       download_pex_bin.DownloadedPexBin.Factory.global_instance(),
     ))
     fmt_result = self.request_single_product(FmtResult, Params(
-      fmt_target,
+      BlackTarget(
+        adaptor_with_origin, prior_formatter_result_digest=input_snapshot.directory_digest,
+      ),
       options_bootstrapper,
       download_pex_bin.DownloadedPexBin.Factory.global_instance(),
     ))

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -8,7 +8,7 @@ import pytest
 from pants.backend.python.lint.black.rules import BlackTarget
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.rules import download_pex_bin
-from pants.base.specs import SingleAddress
+from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
 from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
@@ -52,6 +52,7 @@ class BlackIntegrationTest(TestBase):
     config: Optional[str] = None,
     passthrough_args: Optional[str] = None,
     skip: bool = False,
+    origin: Optional[OriginSpec] = None,
   ) -> Tuple[LintResult, FmtResult]:
     args = ["--backend-packages2=pants.backend.python.lint.black"]
     if config is not None:
@@ -66,7 +67,8 @@ class BlackIntegrationTest(TestBase):
       sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
       address=Address.parse("test:target"),
     )
-    origin = SingleAddress(directory="test", name="target")
+    if origin is None:
+      origin = SingleAddress(directory="test", name="target")
     adaptor_with_origin = TargetAdaptorWithOrigin(adaptor, origin)
     options_bootstrapper = create_options_bootstrapper(args=args)
     lint_result = self.request_single_product(LintResult, Params(
@@ -106,6 +108,14 @@ class BlackIntegrationTest(TestBase):
     self.assertIn("1 file would be reformatted, 1 file would be left unchanged", lint_result.stderr)
     self.assertIn("1 file reformatted, 1 file left unchanged", fmt_result.stderr)
     self.assertEqual(fmt_result.digest, self.get_digest([self.good_source, self.fixed_bad_source]))
+
+  def test_precise_file_args(self) -> None:
+    file_arg = FilesystemLiteralSpec(self.good_source.path)
+    lint_result, fmt_result = self.run_black([self.good_source, self.bad_source], origin=file_arg)
+    assert lint_result.exit_code == 0
+    assert "1 file would be left unchanged" in lint_result.stderr
+    assert "1 file left unchanged" in fmt_result.stderr
+    assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
 
   @pytest.mark.skip(reason="Get config file creation to work with options parsing")
   def test_respects_config_file(self) -> None:

--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -36,5 +36,4 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 210,
 )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -22,6 +22,11 @@ from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
+from pants.rules.core import find_target_source_files, strip_source_roots
+from pants.rules.core.find_target_source_files import (
+  FindTargetSourceFilesRequest,
+  TargetSourceFiles,
+)
 from pants.rules.core.lint import LintResult
 
 
@@ -30,12 +35,12 @@ class Flake8Target:
   adaptor_with_origin: TargetAdaptorWithOrigin
 
 
-def generate_args(flake8_target: Flake8Target, flake8: Flake8) -> Tuple[str, ...]:
+def generate_args(*, source_files: TargetSourceFiles, flake8: Flake8) -> Tuple[str, ...]:
   args = []
   if flake8.options.config is not None:
     args.append(f"--config={flake8.options.config}")
   args.extend(flake8.options.args)
-  args.extend(sorted(flake8_target.adaptor_with_origin.adaptor.sources.snapshot.files))
+  args.extend(sorted(source_files.snapshot.files))
   return tuple(args)
 
 
@@ -49,7 +54,8 @@ async def lint(
   if flake8.options.skip:
     return LintResult.noop()
 
-  adaptor = flake8_target.adaptor_with_origin.adaptor
+  adaptor_with_origin = flake8_target.adaptor_with_origin
+  adaptor = adaptor_with_origin.adaptor
 
   # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
   # each target runs with its own interpreter constraints. See
@@ -58,6 +64,14 @@ async def lint(
     adaptors=[adaptor] if isinstance(adaptor, PythonTargetAdaptor) else [],
     python_setup=python_setup
   )
+  requirements_pex = await Get[Pex](
+    CreatePex(
+      output_filename="flake8.pex",
+      requirements=PexRequirements(requirements=tuple(flake8.get_requirement_specs())),
+      interpreter_constraints=interpreter_constraints,
+      entry_point=flake8.get_entry_point(),
+    )
+  )
 
   config_path: Optional[str] = flake8.options.config
   config_snapshot = await Get[Snapshot](
@@ -65,14 +79,6 @@ async def lint(
       globs=tuple([config_path] if config_path else []),
       glob_match_error_behavior=GlobMatchErrorBehavior.error,
       description_of_origin="the option `--flake8-config`",
-    )
-  )
-  requirements_pex = await Get[Pex](
-    CreatePex(
-      output_filename="flake8.pex",
-      requirements=PexRequirements(requirements=tuple(flake8.get_requirement_specs())),
-      interpreter_constraints=interpreter_constraints,
-      entry_point=flake8.get_entry_point(),
     )
   )
 
@@ -85,11 +91,14 @@ async def lint(
       )
     ),
   )
+
+  source_files = await Get[TargetSourceFiles](FindTargetSourceFilesRequest(adaptor_with_origin))
+
   request = requirements_pex.create_execute_request(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path=f'./flake8.pex',
-    pex_args=generate_args(flake8_target, flake8),
+    pex_args=generate_args(source_files=source_files, flake8=flake8),
     input_files=merged_input_files,
     description=f'Run Flake8 for {adaptor.address.reference()}',
   )
@@ -103,7 +112,9 @@ def rules():
     subsystem_rule(Flake8),
     UnionRule(PythonLintTarget, Flake8Target),
     *download_pex_bin.rules(),
+    *find_target_source_files.rules(),
     *pex.rules(),
     *python_native_code.rules(),
+    *strip_source_roots.rules(),
     *subprocess_environment.rules(),
   ]

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
-from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
+from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -27,21 +27,21 @@ from pants.rules.core.lint import LintResult
 
 @dataclass(frozen=True)
 class Flake8Target:
-  target: TargetAdaptor
+  adaptor_with_origin: TargetAdaptorWithOrigin
 
 
-def generate_args(wrapped_target: Flake8Target, flake8: Flake8) -> Tuple[str, ...]:
+def generate_args(flake8_target: Flake8Target, flake8: Flake8) -> Tuple[str, ...]:
   args = []
   if flake8.options.config is not None:
     args.append(f"--config={flake8.options.config}")
   args.extend(flake8.options.args)
-  args.extend(sorted(wrapped_target.target.sources.snapshot.files))
+  args.extend(sorted(flake8_target.adaptor_with_origin.adaptor.sources.snapshot.files))
   return tuple(args)
 
 
 @rule(name="Lint using Flake8")
 async def lint(
-  wrapped_target: Flake8Target,
+  flake8_target: Flake8Target,
   flake8: Flake8,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -49,13 +49,13 @@ async def lint(
   if flake8.options.skip:
     return LintResult.noop()
 
-  target = wrapped_target.target
+  adaptor = flake8_target.adaptor_with_origin.adaptor
 
   # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
   # each target runs with its own interpreter constraints. See
   # http://flake8.pycqa.org/en/latest/user/invocation.html.
   interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
-    adaptors=[target] if isinstance(target, PythonTargetAdaptor) else [],
+    adaptors=[adaptor] if isinstance(adaptor, PythonTargetAdaptor) else [],
     python_setup=python_setup
   )
 
@@ -79,7 +79,7 @@ async def lint(
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        target.sources.snapshot.directory_digest,
+        adaptor.sources.snapshot.directory_digest,
         requirements_pex.directory_digest,
         config_snapshot.directory_digest,
       )
@@ -89,9 +89,9 @@ async def lint(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path=f'./flake8.pex',
-    pex_args=generate_args(wrapped_target, flake8),
+    pex_args=generate_args(flake8_target, flake8),
     input_files=merged_input_files,
-    description=f'Run Flake8 for {target.address.reference()}',
+    description=f'Run Flake8 for {adaptor.address.reference()}',
   )
   result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
   return LintResult.from_fallible_execute_process_result(result)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -28,6 +28,11 @@ from pants.engine.selectors import Get
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
+from pants.rules.core import find_target_source_files, strip_source_roots
+from pants.rules.core.find_target_source_files import (
+  FindTargetSourceFilesRequest,
+  TargetSourceFiles,
+)
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
 
@@ -39,24 +44,39 @@ class IsortTarget:
 
 
 @dataclass(frozen=True)
-class IsortSetup:
-  requirements_pex: Pex
-  config_snapshot: Snapshot
-  passthrough_args: Tuple[str, ...]
-  skip: bool
+class SetupRequest:
+  target: IsortTarget
+  check_only: bool
+
+
+@dataclass(frozen=True)
+class Setup:
+  process_request: ExecuteProcessRequest
+
+
+def generate_args(
+  *, source_files: TargetSourceFiles, isort: Isort, check_only: bool,
+) -> Tuple[str, ...]:
+  # NB: isort auto-discovers config files. There is no way to hardcode them via command line
+  # flags. So long as the files are in the Pex's input files, isort will use the config.
+  args = []
+  if check_only:
+    args.append("--check-only")
+  args.extend(isort.options.args)
+  args.extend(sorted(source_files.snapshot.files))
+  return tuple(args)
 
 
 @rule
-async def setup_isort(isort: Isort) -> IsortSetup:
-  config_path: Optional[List[str]] = isort.options.config
-  config_snapshot = await Get[Snapshot](
-    PathGlobs(
-      globs=config_path or (),
-      glob_match_error_behavior=GlobMatchErrorBehavior.error,
-      conjunction=GlobExpansionConjunction.all_match,
-      description_of_origin="the option `--isort-config`",
-    )
-  )
+async def setup(
+  request: SetupRequest,
+  isort: Isort,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+) -> Setup:
+  adaptor_with_origin = request.target.adaptor_with_origin
+  adaptor = adaptor_with_origin.adaptor
+
   requirements_pex = await Get[Pex](
     CreatePex(
       output_filename="isort.pex",
@@ -67,97 +87,82 @@ async def setup_isort(isort: Isort) -> IsortSetup:
       entry_point=isort.get_entry_point(),
     )
   )
-  return IsortSetup(
-    requirements_pex=requirements_pex,
-    config_snapshot=config_snapshot,
-    passthrough_args=tuple(isort.options.args),
-    skip=isort.options.skip,
+
+  config_path: Optional[List[str]] = isort.options.config
+  config_snapshot = await Get[Snapshot](
+    PathGlobs(
+      globs=config_path or (),
+      glob_match_error_behavior=GlobMatchErrorBehavior.error,
+      conjunction=GlobExpansionConjunction.all_match,
+      description_of_origin="the option `--isort-config`",
+    )
   )
 
-
-@dataclass(frozen=True)
-class IsortArgs:
-  args: Tuple[str, ...]
-
-  @staticmethod
-  def create(
-    *, isort_target: IsortTarget, isort_setup: IsortSetup, check_only: bool,
-  ) -> "IsortArgs":
-    # NB: isort auto-discovers config files. There is no way to hardcode them via command line
-    # flags. So long as the files are in the Pex's input files, isort will use the config.
-    files = isort_target.adaptor_with_origin.adaptor.sources.snapshot.files
-    pex_args = []
-    if check_only:
-      pex_args.append("--check-only")
-    if isort_setup.passthrough_args:
-      pex_args.extend(isort_setup.passthrough_args)
-    pex_args.extend(files)
-    return IsortArgs(tuple(pex_args))
-
-
-@rule
-async def create_isort_request(
-  isort_target: IsortTarget,
-  isort_args: IsortArgs,
-  isort_setup: IsortSetup,
-  python_setup: PythonSetup,
-  subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> ExecuteProcessRequest:
-  adaptor = isort_target.adaptor_with_origin.adaptor
-  sources_digest = (
-    isort_target.prior_formatter_result_digest or adaptor.sources.snapshot.directory_digest
+  # NB: We populate the chroot with every source file belonging to the target, but possibly only
+  # tell isort to run over some of those files when given file arguments.
+  full_sources_digest = (
+    request.target.prior_formatter_result_digest or adaptor.sources.snapshot.directory_digest
   )
+  specified_source_files = await Get[TargetSourceFiles](
+    FindTargetSourceFilesRequest(adaptor_with_origin)
+  )
+
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        sources_digest,
-        isort_setup.requirements_pex.directory_digest,
-        isort_setup.config_snapshot.directory_digest,
+        full_sources_digest,
+        requirements_pex.directory_digest,
+        config_snapshot.directory_digest,
       )
     ),
   )
-  return isort_setup.requirements_pex.create_execute_request(
+
+  process_request = requirements_pex.create_execute_request(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path="./isort.pex",
-    pex_args=isort_args.args,
+    pex_args=generate_args(
+      source_files=specified_source_files, isort=isort, check_only=request.check_only,
+    ),
     input_files=merged_input_files,
+    # NB: Even if the user specified to only run on certain files belonging to the target, we
+    # still capture in the output all of the source files.
     output_files=adaptor.sources.snapshot.files,
     description=f'Run isort for {adaptor.address.reference()}',
   )
+  return Setup(process_request)
 
 
 @rule(name="Format using isort")
-async def fmt(isort_target: IsortTarget, isort_setup: IsortSetup) -> FmtResult:
-  if isort_setup.skip:
+async def fmt(isort_target: IsortTarget, isort: Isort) -> FmtResult:
+  if isort.options.skip:
     return FmtResult.noop()
-  args = IsortArgs.create(isort_target=isort_target, isort_setup=isort_setup, check_only=False)
-  request = await Get[ExecuteProcessRequest](IsortArgs, args)
-  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+  setup = await Get[Setup](SetupRequest(isort_target, check_only=False))
+  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
   return FmtResult.from_execute_process_result(result)
 
 
 @rule(name="Lint using isort")
-async def lint(isort_target: IsortTarget, isort_setup: IsortSetup) -> LintResult:
-  if isort_setup.skip:
+async def lint(isort_target: IsortTarget, isort: Isort) -> LintResult:
+  if isort.options.skip:
     return LintResult.noop()
-  args = IsortArgs.create(isort_target=isort_target, isort_setup=isort_setup, check_only=True)
-  request = await Get[ExecuteProcessRequest](IsortArgs, args)
-  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+  setup = await Get[Setup](SetupRequest(isort_target, check_only=True))
+  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
   return LintResult.from_fallible_execute_process_result(result)
 
 
 def rules():
   return [
-    setup_isort,
-    create_isort_request,
+    setup,
     fmt,
     lint,
     subsystem_rule(Isort),
     UnionRule(PythonFormatTarget, IsortTarget),
     UnionRule(PythonLintTarget, IsortTarget),
     *download_pex_bin.rules(),
+    *find_target_source_files.rules(),
     *pex.rules(),
     *python_native_code.rules(),
+    *strip_source_roots.rules(),
     *subprocess_environment.rules(),
   ]

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -5,11 +5,11 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.rules import IsortTarget
 from pants.backend.python.lint.isort.rules import rules as isort_rules
-from pants.backend.python.rules import download_pex_bin, pex
-from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.rules import download_pex_bin
+from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
-from pants.engine.legacy.structs import TargetAdaptor
+from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.rules.core.fmt import FmtResult
@@ -47,9 +47,6 @@ class IsortIntegrationTest(TestBase):
       *super().rules(),
       *isort_rules(),
       download_pex_bin.download_pex_bin,
-      *pex.rules(),
-      *python_native_code.rules(),
-      *subprocess_environment.rules(),
       RootRule(IsortTarget),
       RootRule(download_pex_bin.DownloadedPexBin.Factory),
     )
@@ -71,22 +68,22 @@ class IsortIntegrationTest(TestBase):
     if skip:
       args.append(f"--isort-skip")
     input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-    target_adaptor = TargetAdaptor(
+    adaptor = TargetAdaptor(
       sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
       address=Address.parse("test:target"),
     )
-    lint_target = IsortTarget(target_adaptor)
-    fmt_target = IsortTarget(
-      target_adaptor, prior_formatter_result_digest=input_snapshot.directory_digest,
-    )
+    origin = SingleAddress(directory="test", name="target")
+    adaptor_with_origin = TargetAdaptorWithOrigin(adaptor, origin)
     options_bootstrapper = create_options_bootstrapper(args=args)
     lint_result = self.request_single_product(LintResult, Params(
-      lint_target,
+      IsortTarget(adaptor_with_origin),
       options_bootstrapper,
       download_pex_bin.DownloadedPexBin.Factory.global_instance(),
     ))
     fmt_result = self.request_single_product(FmtResult, Params(
-      fmt_target,
+      IsortTarget(
+        adaptor_with_origin, prior_formatter_result_digest=input_snapshot.directory_digest,
+      ),
       options_bootstrapper,
       download_pex_bin.DownloadedPexBin.Factory.global_instance(),
     ))

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -6,12 +6,12 @@ from typing import List
 
 from pants.backend.python.lint.python_lint_target import PYTHON_TARGET_TYPES
 from pants.engine.legacy.structs import (
-  PantsPluginAdaptor,
-  PythonAppAdaptor,
-  PythonBinaryAdaptor,
-  PythonTargetAdaptor,
-  PythonTestsAdaptor,
-  TargetAdaptor,
+  PantsPluginAdaptorWithOrigin,
+  PythonAppAdaptorWithOrigin,
+  PythonBinaryAdaptorWithOrigin,
+  PythonTargetAdaptorWithOrigin,
+  PythonTestsAdaptorWithOrigin,
+  TargetAdaptorWithOrigin,
 )
 from pants.engine.objects import union
 from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
@@ -26,21 +26,23 @@ class PythonFormatTarget:
 
 @dataclass(frozen=True)
 class _ConcretePythonFormatTarget:
-  target: TargetAdaptor
+  adaptor_with_origin: TargetAdaptorWithOrigin
 
 
 @rule
 async def format_python_target(
-  wrapped_target: _ConcretePythonFormatTarget, union_membership: UnionMembership
+  concrete_target: _ConcretePythonFormatTarget, union_membership: UnionMembership
 ) -> AggregatedFmtResults:
   """This aggregator allows us to have multiple formatters safely operate over the same Python
-  targets, even if they modify the same files."""
-  prior_formatter_result_digest = wrapped_target.target.sources.snapshot.directory_digest
+  targets, even if they modify the same files.
+  """
+  adaptor_with_origin = concrete_target.adaptor_with_origin
+  prior_formatter_result_digest = adaptor_with_origin.adaptor.sources.snapshot.directory_digest
   results: List[FmtResult] = []
   for member in union_membership.union_rules[PythonFormatTarget]:
     result = await Get[FmtResult](
       PythonFormatTarget,
-      member(wrapped_target.target, prior_formatter_result_digest=prior_formatter_result_digest),
+      member(adaptor_with_origin, prior_formatter_result_digest=prior_formatter_result_digest),
     )
     results.append(result)
     prior_formatter_result_digest = result.digest
@@ -48,28 +50,28 @@ async def format_python_target(
 
 
 @rule
-def target_adaptor(target: PythonTargetAdaptor) -> _ConcretePythonFormatTarget:
-  return _ConcretePythonFormatTarget(target)
+def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
+  return _ConcretePythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def app_adaptor(target: PythonAppAdaptor) -> _ConcretePythonFormatTarget:
-  return _ConcretePythonFormatTarget(target)
+def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
+  return _ConcretePythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def binary_adaptor(target: PythonBinaryAdaptor) -> _ConcretePythonFormatTarget:
-  return _ConcretePythonFormatTarget(target)
+def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
+  return _ConcretePythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def tests_adaptor(target: PythonTestsAdaptor) -> _ConcretePythonFormatTarget:
-  return _ConcretePythonFormatTarget(target)
+def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
+  return _ConcretePythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def plugin_adaptor(target: PantsPluginAdaptor) -> _ConcretePythonFormatTarget:
-  return _ConcretePythonFormatTarget(target)
+def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
+  return _ConcretePythonFormatTarget(adaptor_with_origin)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/python_lint_target.py
+++ b/src/python/pants/backend/python/lint/python_lint_target.py
@@ -4,12 +4,12 @@
 from dataclasses import dataclass
 
 from pants.engine.legacy.structs import (
-  PantsPluginAdaptor,
-  PythonAppAdaptor,
-  PythonBinaryAdaptor,
-  PythonTargetAdaptor,
-  PythonTestsAdaptor,
-  TargetAdaptor,
+  PantsPluginAdaptorWithOrigin,
+  PythonAppAdaptorWithOrigin,
+  PythonBinaryAdaptorWithOrigin,
+  PythonTargetAdaptorWithOrigin,
+  PythonTestsAdaptorWithOrigin,
+  TargetAdaptorWithOrigin,
 )
 from pants.engine.objects import union
 from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
@@ -24,55 +24,55 @@ class PythonLintTarget:
 
 @dataclass(frozen=True)
 class _ConcretePythonLintTarget:
-  target: TargetAdaptor
+  adaptor_with_origin: TargetAdaptorWithOrigin
 
 
 @rule
 async def lint_python_target(
-  wrapped_target: _ConcretePythonLintTarget, union_membership: UnionMembership
+  concrete_target: _ConcretePythonLintTarget, union_membership: UnionMembership,
 ) -> LintResults:
   """This aggregator allows us to have multiple linters operate over the same Python targets.
 
   We do not care if linters overlap in their execution as linters have no side-effects."""
   results = await MultiGet(
-    Get[LintResult](PythonLintTarget, member(wrapped_target.target))
+    Get[LintResult](PythonLintTarget, member(concrete_target.adaptor_with_origin))
     for member in union_membership.union_rules[PythonLintTarget]
   )
   return LintResults(results)
 
 
 PYTHON_TARGET_TYPES = [
-  PythonAppAdaptor,
-  PythonBinaryAdaptor,
-  PythonTargetAdaptor,
-  PythonTestsAdaptor,
-  PantsPluginAdaptor,
+  PythonAppAdaptorWithOrigin,
+  PythonBinaryAdaptorWithOrigin,
+  PythonTargetAdaptorWithOrigin,
+  PythonTestsAdaptorWithOrigin,
+  PantsPluginAdaptorWithOrigin,
 ]
 
 
 @rule
-def target_adaptor(target: PythonTargetAdaptor) -> _ConcretePythonLintTarget:
-  return _ConcretePythonLintTarget(target)
+def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> _ConcretePythonLintTarget:
+  return _ConcretePythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def app_adaptor(target: PythonAppAdaptor) -> _ConcretePythonLintTarget:
-  return _ConcretePythonLintTarget(target)
+def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> _ConcretePythonLintTarget:
+  return _ConcretePythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def binary_adaptor(target: PythonBinaryAdaptor) -> _ConcretePythonLintTarget:
-  return _ConcretePythonLintTarget(target)
+def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> _ConcretePythonLintTarget:
+  return _ConcretePythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def tests_adaptor(target: PythonTestsAdaptor) -> _ConcretePythonLintTarget:
-  return _ConcretePythonLintTarget(target)
+def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> _ConcretePythonLintTarget:
+  return _ConcretePythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def plugin_adaptor(target: PantsPluginAdaptor) -> _ConcretePythonLintTarget:
-  return _ConcretePythonLintTarget(target)
+def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> _ConcretePythonLintTarget:
+  return _ConcretePythonLintTarget(adaptor_with_origin)
 
 
 def rules():

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -324,8 +324,10 @@ class TargetAdaptorWithOrigin:
       TargetAdaptor: TargetAdaptorWithOrigin,
       AppAdaptor: AppAdaptorWithOrigin,
       JvmAppAdaptor: JvmAppAdaptorWithOrigin,
+      JvmBinaryAdaptor: JvmBinaryAdaptorWithOrigin,
       PythonAppAdaptor: PythonAppAdaptorWithOrigin,
       ResourcesAdaptor: ResourcesAdaptorWithOrigin,
+      PageAdaptor: PageAdaptorWithOrigin,
       RemoteSourcesAdaptor: RemoteSourcesAdaptorWithOrigin,
       PythonTargetAdaptor: PythonTargetAdaptorWithOrigin,
       PythonBinaryAdaptor: PythonBinaryAdaptorWithOrigin,
@@ -333,7 +335,7 @@ class TargetAdaptorWithOrigin:
       PythonAWSLambdaAdaptor: PythonAWSLambdaAdaptorWithOrigin,
       PythonRequirementLibraryAdaptor: PythonRequirementLibraryAdaptorWithOrigin,
       PantsPluginAdaptor: PantsPluginAdaptorWithOrigin,
-    }[type(adaptor)]
+    }.get(type(adaptor), TargetAdaptorWithOrigin)
     return adaptor_with_origin_cls(adaptor, origin)
 
 
@@ -348,6 +350,11 @@ class JvmAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
 
 
 @dataclass(frozen=True)
+class JvmBinaryAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: JvmBinaryAdaptor
+
+
+@dataclass(frozen=True)
 class PythonAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
   adaptor: PythonAppAdaptor
 
@@ -355,6 +362,11 @@ class PythonAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
 @dataclass(frozen=True)
 class ResourcesAdaptorWithOrigin(TargetAdaptorWithOrigin):
   adaptor: ResourcesAdaptor
+
+
+@dataclass(frozen=True)
+class PageAdaptorWithOrigin(TargetAdaptorWithOrigin):
+  adaptor: PageAdaptor
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -14,8 +15,8 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessResult
-from pants.engine.legacy.graph import HydratedTargets
-from pants.engine.legacy.structs import TargetAdaptor
+from pants.engine.legacy.graph import HydratedTargetsWithOrigins
+from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get, MultiGet
@@ -54,19 +55,21 @@ class AggregatedFmtResults:
 
 @union
 class FormatTarget:
-  """A union for registration of a formattable target type."""
+  """A union for registration of a formattable target type.
+
+  The union members should be subclasses of TargetAdaptorWithOrigin.
+  """
 
   @staticmethod
   def is_formattable(
-    target_adaptor: TargetAdaptor, *, union_membership: UnionMembership
+    adaptor_with_origin: TargetAdaptorWithOrigin, *, union_membership: UnionMembership,
   ) -> bool:
-    return (
-      union_membership.is_member(FormatTarget, target_adaptor)
-      # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of
-      #  raising to remove the hasattr() checks here!
-      and hasattr(target_adaptor, "sources")
-      and target_adaptor.sources.snapshot.files  # i.e., sources is not empty
+    is_fmt_target = union_membership.is_member(FormatTarget, adaptor_with_origin)
+    has_sources = (
+      hasattr(adaptor_with_origin.adaptor, "sources")
+      and bool(adaptor_with_origin.adaptor.sources.snapshot.files)
     )
+    return has_sources and is_fmt_target
 
 
 class FmtOptions(GoalSubsystem):
@@ -86,20 +89,24 @@ class Fmt(Goal):
 @goal_rule
 async def fmt(
   console: Console,
-  targets: HydratedTargets,
+  targets_with_origins: HydratedTargetsWithOrigins,
   workspace: Workspace,
   union_membership: UnionMembership
 ) -> Fmt:
-  aggregated_results = await MultiGet(
-    Get[AggregatedFmtResults](FormatTarget, target.adaptor)
-    for target in targets
-    if FormatTarget.is_formattable(target.adaptor, union_membership=union_membership)
-  )
-  individual_results = [
-    result
-    for aggregated_result in aggregated_results
-    for result in aggregated_result.results
+  adaptors_with_origins = [
+    TargetAdaptorWithOrigin.create(target_with_origin.target.adaptor, target_with_origin.origin)
+    for target_with_origin in targets_with_origins
   ]
+  aggregated_results = await MultiGet(
+    Get[AggregatedFmtResults](FormatTarget, adaptor_with_origin)
+    for adaptor_with_origin in adaptors_with_origins
+    if FormatTarget.is_formattable(adaptor_with_origin, union_membership=union_membership)
+  )
+  individual_results = list(
+    itertools.chain.from_iterable(
+      aggregated_result.results for aggregated_result in aggregated_results
+    )
+  )
 
   if not individual_results:
     return Fmt(exit_code=0)
@@ -125,6 +132,4 @@ async def fmt(
 
 
 def rules():
-  return [
-    fmt,
-  ]
+  return [fmt]

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -3,8 +3,8 @@
 
 from typing import Callable, List, Optional, Tuple
 
-from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
-from pants.engine.legacy.structs import JvmAppAdaptor, PythonTargetAdaptor
+from pants.engine.legacy.graph import HydratedTargetsWithOrigins, HydratedTargetWithOrigin
+from pants.engine.legacy.structs import JvmAppAdaptor, PythonTargetAdaptorWithOrigin
 from pants.engine.rules import UnionMembership
 from pants.rules.core.fmt_test import FmtTest
 from pants.rules.core.lint import Lint, LintResult, LintResults, LintTarget, lint
@@ -17,77 +17,82 @@ class LintTest(TestBase):
   @staticmethod
   def run_lint_rule(
     *,
-    targets: List[HydratedTarget],
-    mock_linters: Optional[Callable[[PythonTargetAdaptor], LintResults]] = None,
+    targets: List[HydratedTargetWithOrigin],
+    mock_linters: Optional[Callable[[PythonTargetAdaptorWithOrigin], LintResults]] = None,
   ) -> Tuple[Lint, str]:
     if mock_linters is None:
-      mock_linters = lambda target_adaptor: LintResults([LintResult(
-        exit_code=1, stdout=f"Linted `{target_adaptor.name}`", stderr=""
+      mock_linters = lambda adaptor_with_origin: LintResults([LintResult(
+        exit_code=1, stdout=f"Linted `{adaptor_with_origin.adaptor.name}`", stderr=""
       )])
     console = MockConsole(use_colors=False)
     result: Lint = run_rule(
       lint,
       rule_args=[
         console,
-        HydratedTargets(targets),
-        UnionMembership(union_rules={LintTarget: [PythonTargetAdaptor]})
+        HydratedTargetsWithOrigins(targets),
+        UnionMembership(union_rules={LintTarget: [PythonTargetAdaptorWithOrigin]})
       ],
       mock_gets=[
-        MockGet(product_type=LintResults, subject_type=PythonTargetAdaptor, mock=mock_linters),
+        MockGet(
+          product_type=LintResults, subject_type=PythonTargetAdaptorWithOrigin, mock=mock_linters,
+        ),
       ],
     )
     return result, console.stdout.getvalue()
 
   def test_non_union_member_noops(self) -> None:
     result, stdout = self.run_lint_rule(
-      targets=[FmtTest.make_hydrated_target(adaptor_type=JvmAppAdaptor)],
+      targets=[FmtTest.make_hydrated_target_with_origin(adaptor_type=JvmAppAdaptor)],
     )
     assert result.exit_code == 0
     assert stdout == ""
 
   def test_empty_target_noops(self) -> None:
     result, stdout = self.run_lint_rule(
-      targets=[FmtTest.make_hydrated_target(adaptor_type=JvmAppAdaptor)],
+      targets=[FmtTest.make_hydrated_target_with_origin(include_sources=False)],
     )
     assert result.exit_code == 0
     assert stdout == ""
 
   def test_single_target_with_one_linter(self) -> None:
-    result, stdout = self.run_lint_rule(targets=[FmtTest.make_hydrated_target()])
+    result, stdout = self.run_lint_rule(targets=[FmtTest.make_hydrated_target_with_origin()])
     assert result.exit_code == 1
     assert stdout.strip() == "Linted `target`"
 
   def test_single_target_with_multiple_linters(self) -> None:
-    def mock_linters(_: PythonTargetAdaptor) -> LintResults:
+    def mock_linters(_: PythonTargetAdaptorWithOrigin) -> LintResults:
       return LintResults([
         LintResult(exit_code=0, stdout=f"Linter 1", stderr=""),
         LintResult(exit_code=1, stdout=f"Linter 2", stderr=""),
       ])
 
     result, stdout = self.run_lint_rule(
-      targets=[FmtTest.make_hydrated_target()], mock_linters=mock_linters,
+      targets=[FmtTest.make_hydrated_target_with_origin()], mock_linters=mock_linters,
     )
     assert result.exit_code == 1
     assert stdout.splitlines() == ["Linter 1", "Linter 2"]
 
   def test_multiple_targets_with_one_linter(self) -> None:
     # If any single target fails, the error code should propagate to the whole run.
-    def mock_linters(adaptor: PythonTargetAdaptor) -> LintResults:
-      name = adaptor.name
+    def mock_linters(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> LintResults:
+      name = adaptor_with_origin.adaptor.name
       if name == "bad":
         return LintResults([LintResult(exit_code=127, stdout=f"`{name}` failed", stderr="")])
       return LintResults([LintResult(exit_code=0, stdout=f"`{name}` passed", stderr="")])
 
     result, stdout = self.run_lint_rule(
-      targets=[FmtTest.make_hydrated_target(name="good"), FmtTest.make_hydrated_target(name="bad")],
+      targets=[
+        FmtTest.make_hydrated_target_with_origin(name="good"),
+        FmtTest.make_hydrated_target_with_origin(name="bad"),
+      ],
       mock_linters=mock_linters,
     )
     assert result.exit_code == 127
     assert stdout.splitlines() == ["`good` passed", "`bad` failed"]
 
   def test_multiple_targets_with_multiple_linters(self) -> None:
-    def mock_linters(adaptor: PythonTargetAdaptor) -> LintResults:
-      name = adaptor.name
+    def mock_linters(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> LintResults:
+      name = adaptor_with_origin.adaptor.name
       if name == "bad":
         return LintResults([
           LintResult(exit_code=0, stdout=f"Linter 1 passed for `{name}`", stderr=""),
@@ -99,7 +104,10 @@ class LintTest(TestBase):
       ])
 
     result, stdout = self.run_lint_rule(
-      targets=[FmtTest.make_hydrated_target(name="good"), FmtTest.make_hydrated_target(name="bad")],
+      targets=[
+        FmtTest.make_hydrated_target_with_origin(name="good"),
+        FmtTest.make_hydrated_target_with_origin(name="bad"),
+      ],
       mock_linters=mock_linters,
     )
     assert result.exit_code == 127


### PR DESCRIPTION
Now, running `./pants fmt2 lint2 src/python/pants/rules/core/run.py` will only run on `run.py` rather than the whole `rules/core:core` target.