### PR TITLE
Remove deprecated passthrough args for `login`, `lint.mypy`, and `fmt.isort`

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -15,7 +15,7 @@ from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.base import hash_utils
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
@@ -86,10 +86,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
              help='Tag name to identify Python targets to execute MyPy')
     register('--verbose', type=bool, default=False,
              help='Extra detail showing non-whitelisted targets')
-
-  @classmethod
-  def supports_passthru_args(cls):
-    return True
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -265,20 +261,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
       config = self._resolve_conflicting_options(old_option='config_file', new_option='config')
       if config:
         cmd.append(f'--config-file={os.path.join(get_buildroot(), config)}')
-      deprecated_conditional(
-        lambda: self.get_passthru_args(),
-        removal_version='1.26.0.dev1',
-        entity_description='Using the old style of passthrough args for MyPy',
-        hint_message="You passed arguments to MyPy through either the "
-                     "`--lint-mypy-passthrough-args` option or the style "
-                     "`./pants lint.mypy -- --python-version 3.7 --disallow-any-expr`. Instead, "
-                     "pass any arguments to MyPy like this: "
-                     "`./pants lint :: --mypy-args='--python-version 3.7 --disallow-any-expr'`.\n\n"
-                     "This change is meant to reduce confusion in how option scopes work with "
-                     "passthrough args and to prepare for MyPy eventually exclusively using the "
-                     "V2 implementation, which only supports `--mypy-args`.",
-      )
-      cmd.extend(self.get_passthru_args())
       cmd.extend(self._mypy_subsystem.options.args)
       cmd.append(f'@{sources_list_path}')
 

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -11,7 +11,6 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.fmt_task_mixin import FmtTaskMixin
@@ -52,22 +51,7 @@ class IsortRun(FmtTaskMixin, Task):
 
       isort = self.context.products.get_data(IsortPrep.tool_instance_cls)
       isort_subsystem = Isort.global_instance()
-      deprecated_conditional(
-        lambda: self.get_passthru_args(),
-        removal_version='1.26.0.dev1',
-        entity_description='Using the old style of passthrough args for isort',
-        hint_message="You passed arguments to isort through either the "
-                     "`--fmt-isort-passthrough-args` option or the style "
-                     "`./pants fmt.isort -- --case-sensitive --trailing-comma`. Instead, pass any "
-                     "arguments to isort like this: `./pants fmt :: "
-                     "--isort-args='--case-sensitive --trailing-comma'`.\n\n"
-                     "This change is meant to reduce confusion in how option scopes work with "
-                     "passthrough args and to prepare for isort eventually exclusively using the "
-                     "V2 implementation, which only supports `--isort-args`.",
-      )
-      args = [
-        *self.get_passthru_args(), *isort_subsystem.options.args, '--filter-files', *sources,
-      ]
+      args = [*isort_subsystem.options.args, '--filter-files', *sources]
 
       # NB: We execute isort out of process to avoid unwanted side-effects from importing it:
       #   https://github.com/timothycrosley/isort/issues/456
@@ -96,10 +80,6 @@ class IsortRun(FmtTaskMixin, Task):
   def is_non_synthetic_python_target(target):
     return (not target.is_synthetic
             and isinstance(target, (PythonLibrary, PythonBinary, PythonTests)))
-
-  @classmethod
-  def supports_passthru_args(cls):
-    return True
 
   @property
   def skip_execution(self):

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -6,7 +6,6 @@ import getpass
 from colors import cyan, green, red
 
 from pants.auth.basic_auth import BasicAuth, BasicAuthCreds, Challenged
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.task.console_task import ConsoleTask
 
@@ -22,10 +21,6 @@ class Login(ConsoleTask):
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (BasicAuth,)
-
-  @classmethod
-  def supports_passthru_args(cls):
-    return True
 
   @classmethod
   def register_options(cls, register):
@@ -47,21 +42,7 @@ class Login(ConsoleTask):
   def console_output(self, targets):
     if targets:
       raise TaskError('The login task does not take any target arguments.')
-
-    deprecated_conditional(
-      lambda: self.get_passthru_args(),
-      removal_version='1.26.0.dev1',
-      entity_description='Using passthrough args with `./pants login`',
-      hint_message="Instead of passing the provider through `--login-passthrough-args` or the "
-                   "style `./pants login -- prod`, use the option `--login-to`, such as "
-                   "`./pants login --to=prod`.",
-    )
-
-    # TODO: When we have other auth methods (e.g., OAuth2), select one by provider name.
-    requested_providers = list(filter(None, [self.get_options().to] + self.get_passthru_args()))
-    if len(requested_providers) != 1:
-      raise TaskError('Must specify exactly one provider.')
-    provider = requested_providers[0]
+    provider = self.get_options().to
     try:
       BasicAuth.global_instance().authenticate(provider)
       return ['', 'Logged in successfully using .netrc credentials.']

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -43,6 +43,11 @@ class Login(ConsoleTask):
     if targets:
       raise TaskError('The login task does not take any target arguments.')
     provider = self.get_options().to
+    if provider is None:
+      raise TaskError(
+        "Please give the provider with `./pants login --to`. (Run "
+        "`./pants help login` to see what this option expects.)"
+      )
     try:
       BasicAuth.global_instance().authenticate(provider)
       return ['', 'Logged in successfully using .netrc credentials.']

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -582,10 +582,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Output a timing report at the end of the run.')
     register('-e', '--explain', type=bool, passive=no_v1,
              help='Explain the execution of goals.')
-    register('-t', '--timeout', advanced=True, type=int, metavar='<seconds>', passive=no_v1,
-             removal_version="1.26.0.dev1",
-             removal_hint="This option is not used and may be removed with no change in behavior. ",
-             help='Number of seconds to wait for http connections.')
     # TODO: After moving to the new options system these abstraction leaks can go away.
     register('-k', '--kill-nailguns', advanced=True, type=bool, passive=no_v1,
              help='Kill nailguns before exiting')

--- a/tests/python/pants_test/backend/python/tasks/test_isort_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_isort_run.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 
 from pytest import fail
 
+from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.backend.python.tasks.isort_run import IsortRun
 from pants.base.exceptions import TaskError
@@ -73,10 +74,12 @@ class PythonIsortTest(PythonTaskTestBase):
     if options:
       self.set_options(**options)
 
+    if passthru_args:
+      self.set_options_for_scope(Isort.options_scope, args=passthru_args)
+
     isort_prep_task_type = self.synthesize_task_subtype(IsortPrep, 'ip')
     context = self.context(for_task_types=[isort_prep_task_type],
-                           target_roots=target_roots,
-                           passthru_args=passthru_args)
+                           target_roots=target_roots)
 
     isort_prep = isort_prep_task_type(context, os.path.join(self.pants_workdir, 'ip'))
     isort_prep.execute()


### PR DESCRIPTION
This also removes the global option `--timeout`, which was not used by anything and polluted the option namespace.