### PR TITLE
Improve the error message when no rules are installed that return a type

### DIFF
--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -934,20 +934,20 @@ impl<R: Rule> RuleGraph<R> {
           })
           .collect();
         let suggestions_str = if suggestions.is_empty() {
-          ".".to_string()
+          format!(
+            "return the type {}. Is the @rule that you're expecting to run registered?",
+            product,
+          )
         } else {
           suggestions.sort();
           format!(
-            ", but there were @rules that could compute it using:\n  {}",
+            "can compute {} given input Params({}), but there were @rules that could compute it using:\n  {}",
+            product,
+            params_str(&params),
             suggestions.join("\n  ")
           )
         };
-        Err(format!(
-          "No installed @rules can compute {} for input Params({}){}",
-          product,
-          params_str(&params),
-          suggestions_str,
-        ))
+        Err(format!("No installed @rules {}", suggestions_str,))
       }
       0 => {
         // Some Param(s) were not registered.

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -276,7 +276,10 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(Exception) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing('No installed @rules can compute A for input Params(B).', str(cm.exception))
+    self.assert_equal_with_printing(
+      """No installed @rules return the type A. Is the @rule that you're expecting to run registered?""",
+      str(cm.exception)
+    )
 
   def test_non_existing_root_fails_differently(self):
     rules = [

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -206,7 +206,7 @@ class SchedulerTest(TestBase):
     self.assertEquals(result_str, consumes_a_and_b(a, b))
 
     # But not a subset.
-    expected_msg = ("No installed @rules can compute {} for input Params(A), but"
+    expected_msg = ("No installed @rules can compute {} given input Params(A), but"
                     .format(str.__name__))
     with self.assertRaisesRegex(Exception, re.escape(expected_msg)):
       self.request_single_product(str, Params(a))


### PR DESCRIPTION
### Problem

The error message that is rendered when you attempt to request an output type for which there are _no_ `@rules` installed is confusing, because it is shaped the same as the error message you get when relevant rules _are_ installed, but haven't been given the right parameters.

### Solution

Better differentiate the: "there is no such rule" case from the "there is such a rule, but you didn't give us the right parameters" case.

### Result

Clearer error messages when entering the `RuleGraph`.