### PR TITLE
Fix options reference page on pantsbuild.org

### DIFF
--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -11,8 +11,8 @@ from pants.help.help_info_extracter import OptionHelpInfo
 class OptionHelpFormatterTest(unittest.TestCase):
   def format_help_for_foo(self, **kwargs):
     ohi = OptionHelpInfo(registering_class=type(None), display_args=['--foo'],
-                         scoped_cmd_line_args=['--foo'], unscoped_cmd_line_args=['--foo'],
-                         typ=bool, default=None, help='help for foo',
+                         comma_separated_display_args='--foo', scoped_cmd_line_args=['--foo'],
+                         unscoped_cmd_line_args=['--foo'], typ=bool, default=None, help='help for foo',
                          deprecated_message=None, removal_version=None, removal_hint=None,
                          choices=None)
     ohi = replace(ohi, **kwargs)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -17,6 +17,8 @@ class OptionHelpInfo:
   registering_class: The type that registered the option.
   display_args: Arg strings suitable for display in help text, including value examples
                 (e.g., [-f, --[no]-foo-bar, --baz=<metavar>].)
+  comma_separated_display_args: Display args as a comma-delimited string, used in
+                                reference documentation.
   scoped_cmd_line_args: The explicitly scoped raw flag names allowed anywhere on the cmd line,
                         (e.g., [--scope-baz, --no-scope-baz, --scope-qux])
   unscoped_cmd_line_args: The unscoped raw flag names allowed on the cmd line in this option's
@@ -32,6 +34,7 @@ class OptionHelpInfo:
   """
   registering_class: Type
   display_args: List[str]
+  comma_separated_display_args: str
   scoped_cmd_line_args: List[str]
   unscoped_cmd_line_args: List[str]
   typ: Type
@@ -41,9 +44,6 @@ class OptionHelpInfo:
   removal_version: Optional[str]
   removal_hint: Optional[str]
   choices: Optional[str]
-
-  def comma_separated_display_args(self):
-    return ', '.join(self.display_args)
 
 
 @dataclass(frozen=True)
@@ -198,6 +198,7 @@ class HelpInfoExtracter:
 
     ret = OptionHelpInfo(registering_class=kwargs.get('registering_class', type(None)),
                          display_args=display_args,
+                         comma_separated_display_args=', '.join(display_args),
                          scoped_cmd_line_args=scoped_cmd_line_args,
                          unscoped_cmd_line_args=unscoped_cmd_line_args,
                          typ=typ,


### PR DESCRIPTION
### Problem

The [option reference page of pantsbuild.org](https://www.pantsbuild.org/options_reference.html) is missing display arguments for associated options.

It appears the introduction of `dataclasses.asdict` in https://github.com/pantsbuild/pants/pull/8853 meant that the `comma_separated_display_args` no longer rendered as expected by the template. 

### Solution

Move the comma-delimited display args to a dataclass field so that `asdict` returns the correct fields used by template (`single_option.html.mustashe`). 

### Result

Docsite displays correct args for options.