### PR TITLE
Add Python `docformatter` auto-formatter

### DIFF
--- a/src/python/pants/backend/python/lint/docformatter/BUILD
+++ b/src/python/pants/backend/python/lint/docformatter/BUILD
@@ -1,0 +1,38 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    '3rdparty/python:dataclasses',
+    'src/python/pants/backend/python/lint',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/rules',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:isolated_process',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/option',
+    'src/python/pants/python',
+    'src/python/pants/rules/core',
+  ],
+  tags = {"partially_type_checked"},
+)
+
+python_tests(
+  name='integration',
+  sources=['*_integration_test.py'],
+  dependencies=[
+    ':docformatter',
+    'src/python/pants/backend/python/lint',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/engine/legacy:structs',
+    'src/python/pants/rules/core',
+    'src/python/pants/source',
+    'src/python/pants/testutil:test_base',
+    'src/python/pants/testutil/option',
+  ],
+  tags = {'integration', 'partially_type_checked'},
+)

--- a/src/python/pants/backend/python/lint/docformatter/register.py
+++ b/src/python/pants/backend/python/lint/docformatter/register.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+from pants.backend.python.lint import python_format_target, python_lint_target
+from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
+
+
+def rules():
+  return (
+    *docformatter_rules(),
+    *python_format_target.rules(),
+    *python_lint_target.rules(),
+  )

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -1,0 +1,147 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from pants.backend.python.lint.docformatter.subsystem import Docformatter
+from pants.backend.python.lint.python_format_target import PythonFormatTarget
+from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.pex import (
+  CreatePex,
+  Pex,
+  PexInterpreterConstraints,
+  PexRequirements,
+)
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.engine.fs import Digest, DirectoriesToMerge
+from pants.engine.isolated_process import (
+  ExecuteProcessRequest,
+  ExecuteProcessResult,
+  FallibleExecuteProcessResult,
+)
+from pants.engine.legacy.structs import TargetAdaptorWithOrigin
+from pants.engine.rules import UnionRule, rule, subsystem_rule
+from pants.engine.selectors import Get
+from pants.python.python_setup import PythonSetup
+from pants.rules.core import find_target_source_files, strip_source_roots
+from pants.rules.core.find_target_source_files import (
+  FindTargetSourceFilesRequest,
+  TargetSourceFiles,
+)
+from pants.rules.core.fmt import FmtResult
+from pants.rules.core.lint import LintResult
+
+
+@dataclass(frozen=True)
+class DocformatterTarget:
+  adaptor_with_origin: TargetAdaptorWithOrigin
+  prior_formatter_result_digest: Optional[Digest] = None  # unused by `lint`
+
+
+@dataclass(frozen=True)
+class SetupRequest:
+  target: DocformatterTarget
+  check_only: bool
+
+
+@dataclass(frozen=True)
+class Setup:
+  process_request: ExecuteProcessRequest
+
+
+def generate_args(
+  *, source_files: TargetSourceFiles, docformatter: Docformatter, check_only: bool,
+) -> Tuple[str, ...]:
+  return (
+    "--check" if check_only else "--in-place",
+    *docformatter.options.args,
+    *sorted(source_files.snapshot.files),
+  )
+
+
+@rule
+async def setup(
+  request: SetupRequest,
+  docformatter: Docformatter,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+) -> Setup:
+  adaptor_with_origin = request.target.adaptor_with_origin
+  adaptor = adaptor_with_origin.adaptor
+
+  requirements_pex = await Get[Pex](
+    CreatePex(
+      output_filename="docformatter.pex",
+      requirements=PexRequirements(requirements=tuple(docformatter.get_requirement_specs())),
+      interpreter_constraints=PexInterpreterConstraints(
+        constraint_set=tuple(docformatter.default_interpreter_constraints)
+      ),
+      entry_point=docformatter.get_entry_point(),
+    )
+  )
+
+  # NB: We populate the chroot with every source file belonging to the target, but possibly only
+  # tell Docformatter to run over some of those files when given file arguments.
+  full_sources_digest = (
+    request.target.prior_formatter_result_digest or adaptor.sources.snapshot.directory_digest
+  )
+  specified_source_files = await Get[TargetSourceFiles](
+    FindTargetSourceFilesRequest(adaptor_with_origin)
+  )
+
+  merged_input_files = await Get[Digest](
+    DirectoriesToMerge(directories=(full_sources_digest, requirements_pex.directory_digest)),
+  )
+
+  process_request = requirements_pex.create_execute_request(
+    python_setup=python_setup,
+    subprocess_encoding_environment=subprocess_encoding_environment,
+    pex_path="./docformatter.pex",
+    pex_args=generate_args(
+      source_files=specified_source_files, docformatter=docformatter, check_only=request.check_only,
+    ),
+    input_files=merged_input_files,
+    # NB: Even if the user specified to only run on certain files belonging to the target, we
+    # still capture in the output all of the source files.
+    output_files=adaptor.sources.snapshot.files,
+    description=f'Run docformatter for {adaptor.address.reference()}',
+  )
+  return Setup(process_request)
+
+
+@rule(name="Format Python docstrings with docformatter")
+async def fmt(docformatter_target: DocformatterTarget, docformatter: Docformatter) -> FmtResult:
+  if docformatter.options.skip:
+    return FmtResult.noop()
+  setup = await Get[Setup](SetupRequest(docformatter_target, check_only=False))
+  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+  return FmtResult.from_execute_process_result(result)
+
+
+@rule(name="Lint Python docstrings with docformatter")
+async def lint(docformatter_target: DocformatterTarget, docformatter: Docformatter) -> LintResult:
+  if docformatter.options.skip:
+    return LintResult.noop()
+  setup = await Get[Setup](SetupRequest(docformatter_target, check_only=True))
+  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+  return LintResult.from_fallible_execute_process_result(result)
+
+
+def rules():
+  return [
+    setup,
+    fmt,
+    lint,
+    subsystem_rule(Docformatter),
+    UnionRule(PythonFormatTarget, DocformatterTarget),
+    UnionRule(PythonLintTarget, DocformatterTarget),
+    *download_pex_bin.rules(),
+    *find_target_source_files.rules(),
+    *pex.rules(),
+    *python_native_code.rules(),
+    *strip_source_roots.rules(),
+    *subprocess_environment.rules(),
+  ]

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -1,0 +1,121 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List, Optional, Tuple
+
+from pants.backend.python.lint.docformatter.rules import DocformatterTarget
+from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
+from pants.backend.python.rules import download_pex_bin
+from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
+from pants.build_graph.address import Address
+from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
+from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
+from pants.engine.rules import RootRule
+from pants.engine.selectors import Params
+from pants.rules.core.fmt import FmtResult
+from pants.rules.core.lint import LintResult
+from pants.source.wrapped_globs import EagerFilesetWithSpec
+from pants.testutil.option.util import create_options_bootstrapper
+from pants.testutil.subsystem.util import init_subsystems
+from pants.testutil.test_base import TestBase
+
+
+class BlackIntegrationTest(TestBase):
+
+  def setUp(self):
+    super().setUp()
+    init_subsystems([download_pex_bin.DownloadedPexBin.Factory])
+
+  good_source = FileContent(path="test/good.py", content=b'"""Good docstring."""\n')
+  bad_source = FileContent(path="test/bad.py", content=b'"""Oops, missing a period"""\n')
+  fixed_bad_source = FileContent(path="test/bad.py", content=b'"""Oops, missing a period."""\n')
+
+  @classmethod
+  def rules(cls):
+    return (
+      *super().rules(),
+      *docformatter_rules(),
+      download_pex_bin.download_pex_bin,
+      RootRule(DocformatterTarget),
+      RootRule(download_pex_bin.DownloadedPexBin.Factory),
+    )
+
+  def run_docformatter(
+    self,
+    source_files: List[FileContent],
+    *,
+    passthrough_args: Optional[str] = None,
+    skip: bool = False,
+    origin: Optional[OriginSpec] = None,
+  ) -> Tuple[LintResult, FmtResult]:
+    args = ["--backend-packages2=pants.backend.python.lint.docformatter"]
+    if passthrough_args:
+      args.append(f"--docformatter-args='{passthrough_args}'")
+    if skip:
+      args.append(f"--docformatter-skip")
+    input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
+    adaptor = TargetAdaptor(
+      sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
+      address=Address.parse("test:target"),
+    )
+    if origin is None:
+      origin = SingleAddress(directory="test", name="target")
+    adaptor_with_origin = TargetAdaptorWithOrigin(adaptor, origin)
+    options_bootstrapper = create_options_bootstrapper(args=args)
+    lint_result = self.request_single_product(LintResult, Params(
+      DocformatterTarget(adaptor_with_origin),
+      options_bootstrapper,
+      download_pex_bin.DownloadedPexBin.Factory.global_instance(),
+    ))
+    fmt_result = self.request_single_product(FmtResult, Params(
+      DocformatterTarget(
+        adaptor_with_origin, prior_formatter_result_digest=input_snapshot.directory_digest,
+      ),
+      options_bootstrapper,
+      download_pex_bin.DownloadedPexBin.Factory.global_instance(),
+    ))
+    return lint_result, fmt_result
+
+  def get_digest(self, source_files: List[FileContent]) -> Digest:
+    return self.request_single_product(Digest, InputFilesContent(source_files))
+
+  def test_single_passing_source(self) -> None:
+    lint_result, fmt_result = self.run_docformatter([self.good_source])
+    assert lint_result == LintResult.noop()
+    assert fmt_result.digest == self.get_digest([self.good_source])
+
+  def test_single_failing_source(self) -> None:
+    lint_result, fmt_result = self.run_docformatter([self.bad_source])
+    assert lint_result.exit_code == 3
+    assert lint_result.stderr.strip() == self.bad_source.path
+    assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+
+  def test_multiple_mixed_sources(self) -> None:
+    lint_result, fmt_result = self.run_docformatter([self.good_source, self.bad_source])
+    assert lint_result.exit_code == 3
+    assert lint_result.stderr.strip() == self.bad_source.path
+    assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+
+  def test_precise_file_args(self) -> None:
+    file_arg = FilesystemLiteralSpec(self.good_source.path)
+    lint_result, fmt_result = self.run_docformatter(
+      [self.good_source, self.bad_source], origin=file_arg
+    )
+    assert lint_result == LintResult.noop()
+    assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+
+  def test_respects_passthrough_args(self) -> None:
+    needs_config = FileContent(
+      path="test/config.py",
+      content=b'"""\nOne line docstring acting like it\'s multiline.\n"""\n',
+    )
+    lint_result, fmt_result = self.run_docformatter(
+      [needs_config], passthrough_args="--make-summary-multi-line",
+    )
+    assert lint_result == LintResult.noop()
+    assert fmt_result.digest == self.get_digest([needs_config])
+
+  def test_skip(self) -> None:
+    lint_result, fmt_result = self.run_docformatter([self.bad_source], skip=True)
+    assert lint_result == LintResult.noop()
+    assert fmt_result == FmtResult.noop()

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.option.custom_types import shell_str
+
+
+class Docformatter(PythonToolBase):
+  options_scope = 'docformatter'
+  default_version = 'docformatter>=1.3.1,<1.4'
+  default_entry_point = 'docformatter:main'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--skip', type=bool, default=False,
+      help="Don't use docformatter when running `./pants fmt` and `./pants lint`."
+    )
+    register(
+      '--args', type=list, member_type=shell_str,
+      help="Arguments to pass directly to docformatter, e.g. "
+           "`--docformatter-args=\"--wrap-summaries=100 --pre-summary-newline\"`.",
+    )


### PR DESCRIPTION
`docformatter` is like `scalafmt` or `Black` but for docstrings. It enforces PEP 257 conventions.