### PR TITLE
[export-dep-as-jar] Make library ordering deterministic

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -160,15 +160,15 @@ class ExportDepAsJar(ConsoleTask):
     return f
 
   def _dependencies_to_include_in_libraries(self, t, modulizable_target_set):
-    dependencies_to_include = []
+    dependencies_to_include = set([])
     self.context.build_graph.walk_transitive_dependency_graph(
       [direct_dep.address for direct_dep in t.dependencies],
       # NB: Dependency graph between modulizable targets is represented with modules,
       #     so we don't need to expand those branches of the dep graph.
       predicate=lambda dep: dep not in modulizable_target_set,
-      work=lambda dep: dependencies_to_include.append(dep),
+      work=lambda dep: dependencies_to_include.add(dep),
     )
-    return dependencies_to_include
+    return list(sorted(dependencies_to_include))
 
   def _extract_compiler_args_from_zinc_args(self, args):
     scalac_option_prefix = '-S'

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -160,13 +160,13 @@ class ExportDepAsJar(ConsoleTask):
     return f
 
   def _dependencies_to_include_in_libraries(self, t, modulizable_target_set):
-    dependencies_to_include = set([])
+    dependencies_to_include = []
     self.context.build_graph.walk_transitive_dependency_graph(
       [direct_dep.address for direct_dep in t.dependencies],
       # NB: Dependency graph between modulizable targets is represented with modules,
       #     so we don't need to expand those branches of the dep graph.
       predicate=lambda dep: dep not in modulizable_target_set,
-      work=lambda dep: dependencies_to_include.add(dep),
+      work=lambda dep: dependencies_to_include.append(dep),
     )
     return dependencies_to_include
 


### PR DESCRIPTION
### Problem

The ordering of the `libraries` field in individual targets was not deterministic, causing flakiness.

### Solution

Replace the implementation of the field from a `set` to a `list`. Since this depends on a deterministic graph traversal, it should be deterministic now.
