### PR TITLE
[export-dep-as-jar] Include transitive target dependencies in export-dep-as-jar

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -6,6 +6,8 @@ import os
 import zipfile
 from collections import defaultdict
 
+from twitter.common.collections import OrderedSet
+
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -199,6 +201,7 @@ class ExportDepAsJar(ConsoleTask):
     info = {
       # this means 'dependencies'
       'targets': [],
+      'source_dependencies_in_classpath': [],
       'libraries': [],
       'roots': [],
       'id': current_target.id,
@@ -276,6 +279,13 @@ class ExportDepAsJar(ConsoleTask):
       info['platform'] = current_target.platform.name
       if hasattr(current_target, 'runtime_platform'):
         info['runtime_platform'] = current_target.runtime_platform.name
+
+    transitive_targets = OrderedSet([
+      dep.address.spec for dep in dependencies_needed_in_classpath
+      if dep in modulizable_target_set
+    ])
+    transitive_targets.update(info['targets'])
+    info['source_dependencies_in_classpath'] = [dep for dep in transitive_targets]
 
     return info
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -399,6 +399,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
          },
       ],
       'scope' : 'default',
+      'source_dependencies_in_classpath': ['project_info:jvm_target'],
       'target_type': 'SOURCE',
       'transitive' : True,
       'pants_target_type': 'scala_library',
@@ -640,3 +641,15 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
 
     assert transitive_dependency_library_entry in disabled_result['libraries']
     assert transitive_dependency_library_entry not in enabled_result['libraries']
+
+  def test_transitive_targets(self):
+    # Address of the dependency that shouldn't appear in the strict deps case.
+    # It needs to be a root, otherwise it won't be modulizable.
+    dependency_spec = self.jvm_target_with_sources.address.spec
+
+    enabled_spec = self.strict_deps_enabled.address.spec
+    enabled_result = self.execute_export_json(enabled_spec, dependency_spec)['targets'][enabled_spec]
+    disabled_spec = self.strict_deps_disabled.address.spec
+    disabled_result = self.execute_export_json(disabled_spec, dependency_spec)['targets'][disabled_spec]
+    assert dependency_spec not in enabled_result['source_dependencies_in_classpath']
+    assert dependency_spec in disabled_result['source_dependencies_in_classpath']


### PR DESCRIPTION
### Problem

There is currently no way for a tool consuming the output of `export-dep-as-jar` to know whether to traverse the transitive dependency graph of a target or not. The tool shouldn't do that when the target has `strict_deps` enabled.

### Solution

Add a field to the ouput of the target,  "source_dependencies_in_classpath". This field is the intersection between "modulizable targets" and "transitive dependencies", respecting `strict_deps`.

### Result

The output for the target now has that field, called `source_dependencies_in_classpath`. Tools can use this field instead of `targets` when figuring out which targets need including in the classpath. No need to traverse `targets` now. 

- Depends on #9145 