### PR TITLE
make CLI target spec glob failure behavior into --unmatched-address-spec-behavior

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -226,8 +226,8 @@ class UnmatchedTargetAddressError(ResolveError):
 @rule
 async def addresses_with_origins_from_address_families(
   address_mapper: AddressMapper,
-    address_specs: AddressSpecs,
-    unmatched_behavior: UnmatchedAddressSpecBehavior,
+  address_specs: AddressSpecs,
+  unmatched_behavior: UnmatchedAddressSpecBehavior,
 ) -> AddressesWithOrigins:
   """Given an AddressMapper and list of AddressSpecs, return matching AddressesWithOrigins.
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -62,6 +62,7 @@ from pants.option.global_options import (
   BuildFileImportsBehavior,
   ExecutionOptions,
   GlobMatchErrorBehavior,
+  UnmatchedAddressSpecBehavior,
 )
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -417,6 +418,10 @@ class EngineInitializer:
       return glob_match_error_behavior
 
     @rule
+    def unmatched_address_spec_behavior_singleton() -> UnmatchedAddressSpecBehavior:
+      return UnmatchedAddressSpecBehavior(bootstrap_options.unmatched_address_spec_behavior)
+
+    @rule
     def build_configuration_singleton() -> BuildConfiguration:
       return build_configuration
 
@@ -438,6 +443,7 @@ class EngineInitializer:
       *(
         RootRule(Console),
         glob_match_error_behavior_singleton,
+        unmatched_address_spec_behavior_singleton,
         build_configuration_singleton,
         symbol_table_singleton,
         union_membership_singleton,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -58,6 +58,11 @@ class OwnersNotFoundBehavior(Enum):
   error = "error"
 
 
+class UnmatchedAddressSpecBehavior(Enum):
+  ErrorOnAnyUnmatched = 'error-on-any-unmatched'
+  NoErrorOnUnmatchedGlobs = 'no-error-on-unmatched-globs'
+
+
 class BuildFileImportsBehavior(Enum):
   allow = "allow"
   warn = "warn"
@@ -338,6 +343,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help="What to do when files and globs specified in BUILD files, such as in the "
                   "`sources` field, cannot be found. This happens when the files do not exist on "
                   "your machine or when they are ignored by the `--pants-ignore` option.")
+    register('--unmatched-address-spec-behavior',
+             type=UnmatchedAddressSpecBehavior, default=UnmatchedAddressSpecBehavior.ErrorOnAnyUnmatched,
+             help='What to do when an address spec on the command-line fails to match any target.')
 
     # TODO(#7203): make a regexp option type!
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,


### PR DESCRIPTION
### Problem

[Pants accepts `:` and `::` as target globs on the command line](https://www.pantsbuild.org/target_addresses.html). When they fail to match a target, pants raises an error. Since we've made it possible to avoid failing on glob matching with `--owners-not-found-behavior`, it seems reasonable to extend the idea to target globs.

### Solution

This PR was made to demonstrate how an alternative solution to #9130 which uses `::` would work, but I actually like #9130 a lot now, so this is instead just an extension of glob failure options to target specs.

- First, create the global `--unmatched-address-spec-behavior` global option, which has the `ErrorOnAnyUnmatched` and `NoErrorOnUnmatchedGlobs` modes. When `--unmatched-address-spec-behavior=no-error-on-unmatched-globs`, `:` and `::` will not error if they fail to match any source files.
  - This enables running `./pants buildgen ::` and `./pants list ::` immediately after one another, for example.

### Result

It's possible to write idempotent pants scripts that just warn if provided no input targets instead of erroring!