### PR TITLE
Minor code cleanup involving some uses of Platform

### DIFF
--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import List, Tuple
 
 from pants.backend.native.config.environment import CCompiler, CppCompiler
 from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFileMapper
@@ -34,7 +35,7 @@ class GCC(NativeTool):
     def _file_mapper(self):
         return ArchiveFileMapper.scoped_instance(self)
 
-    def _filemap(self, all_components_list):
+    def _filemap(self, all_components_list: List[Tuple[str, ...]]):
         return self._file_mapper.map_files(self.select(), all_components_list)
 
     @memoized_property
@@ -42,11 +43,17 @@ class GCC(NativeTool):
         return self._filemap([("bin",)])
 
     @memoized_method
-    def _common_lib_dirs(self, platform):
-        lib64_tuples = match(platform, {Platform.darwin: [], Platform.linux: [("lib64",)]})
-        return self._filemap(
-            lib64_tuples + [("lib",), ("lib/gcc",), ("lib/gcc/*", self.version()),]
+    def _common_lib_dirs(self, platform: Platform):
+        lib64_tuples: List[Tuple[str, ...]] = match(
+            platform, {Platform.darwin: [], Platform.linux: [("lib64",)]}
         )
+        files: List[Tuple[str, ...]] = [
+            *lib64_tuples,
+            ("lib",),
+            ("lib/gcc",),
+            ("lib/gcc/*", self.version()),
+        ]
+        return self._filemap(files)
 
     @memoized_property
     def _common_include_dirs(self):

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -77,7 +77,7 @@ class LibcObjects:
 
 
 class LinkerWrapperMixin:
-    def for_compiler(self, compiler, platform):
+    def for_compiler(self, compiler):
         """Return a Linker object which is intended to be compatible with the given `compiler`."""
         return (
             self.linker
@@ -221,7 +221,7 @@ async def select_llvm_c_toolchain(
     working_c_compiler = joined_c_compiler.prepend_field("extra_args", ["-x", "c", "-std=c11",])
 
     llvm_linker_wrapper = await Get[LLVMLinker](NativeToolchain, native_toolchain)
-    working_linker = llvm_linker_wrapper.for_compiler(working_c_compiler, platform)
+    working_linker = llvm_linker_wrapper.for_compiler(working_c_compiler)
 
     return LLVMCToolchain(CToolchain(working_c_compiler, working_linker))
 
@@ -274,7 +274,7 @@ async def select_llvm_cpp_toolchain(
 
     llvm_linker_wrapper = await Get[LLVMLinker](NativeToolchain, native_toolchain)
     working_linker = (
-        llvm_linker_wrapper.for_compiler(working_cpp_compiler, platform)
+        llvm_linker_wrapper.for_compiler(working_cpp_compiler)
         .append_field("linking_library_dirs", extra_llvm_linking_library_dirs)
         .prepend_field("extra_args", linker_extra_args)
     )
@@ -304,7 +304,7 @@ async def select_gcc_c_toolchain(
     )
 
     gcc_linker_wrapper = await Get[GCCLinker](NativeToolchain, native_toolchain)
-    working_linker = gcc_linker_wrapper.for_compiler(working_c_compiler, platform)
+    working_linker = gcc_linker_wrapper.for_compiler(working_c_compiler)
 
     return GCCCToolchain(CToolchain(working_c_compiler, working_linker))
 
@@ -343,7 +343,7 @@ async def select_gcc_cpp_toolchain(
     )
 
     gcc_linker_wrapper = await Get[GCCLinker](NativeToolchain, native_toolchain)
-    working_linker = gcc_linker_wrapper.for_compiler(working_cpp_compiler, platform)
+    working_linker = gcc_linker_wrapper.for_compiler(working_cpp_compiler)
 
     return GCCCppToolchain(CppToolchain(working_cpp_compiler, working_linker))
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -33,8 +33,7 @@ class PlatformConstraint(Enum):
 # which means replacing this singleton rule with a RootRule populated by an option.
 @rule
 def materialize_platform() -> Platform:
-    current: Platform = Platform.current
-    return current
+    return Platform.current
 
 
 def create_platform_rules() -> List[Callable]:


### PR DESCRIPTION
This commit:

- adds type annotations to some of the uses of Platform in the `gcc` subsystem
- removes a needless use of Platform in `native_toolchain`
- makes a line of code more concise in `platform.py`.