### PR TITLE
[WIP] create a 'target_adaptors' entry in v2 plugins and backends

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -42,6 +42,13 @@ from pants.backend.python.tasks.setup_py import SetupPy
 from pants.backend.python.tasks.unpack_wheels import UnpackWheels
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
+from pants.engine.legacy.structs import (
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonRequirementLibraryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+)
 from pants.goal.task_registrar import TaskRegistrar as task
 from pants.python.python_requirement import PythonRequirement
 
@@ -90,6 +97,16 @@ def register_goals():
   task(name='isort', action=IsortRun).install('fmt')
   task(name='py', action=PythonBundle).install('bundle')
   task(name='unpack-wheels', action=UnpackWheels).install()
+
+
+def target_adaptors():
+  return {
+    'python_library': PythonTargetAdaptor,
+    'python_app': PythonAppAdaptor,
+    'python_tests': PythonTestsAdaptor,
+    'python_binary': PythonBinaryAdaptor,
+    'python_requirement_library': PythonRequirementLibraryAdaptor,
+  }
 
 
 def rules():

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -35,6 +35,7 @@ class BuildConfiguration:
     self._optionables = OrderedSet()
     self._rules = OrderedSet()
     self._union_rules = OrderedDict()
+    self._target_adaptors = OrderedDict()
 
   def registered_aliases(self) -> BuildFileAliases:
     """Return the registered aliases exposed in BUILD files.
@@ -166,6 +167,10 @@ class BuildConfiguration:
                               if rule.dependency_optionables}
     self.register_optionables(dependency_optionables)
 
+  def register_target_adaptors(self, adaptors):
+    # TODO: type annotations and runtime validation?
+    self._target_adaptors.update(adaptors)
+
   def rules(self):
     """Returns the registered rules.
 
@@ -179,6 +184,10 @@ class BuildConfiguration:
     :rtype: OrderedDict
     """
     return self._union_rules
+
+  def target_adaptors(self):
+    """???"""
+    return self._target_adaptors
 
   @memoized_method
   def _get_addressable_factory(self, target_type, alias):

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -98,6 +98,9 @@ def load_plugins(build_configuration, plugins, working_set, is_v1_plugin):
       if 'rules' in entries:
         rules = entries['rules'].load()()
         build_configuration.register_rules(rules)
+      if 'target_adaptors' in entries:
+        target_adaptors = entries['target_adaptors'].load()()
+        build_configuration.register_target_adaptors(target_adaptors)
     loaded[dist.as_requirement().key] = dist
 
 
@@ -170,3 +173,6 @@ def load_backend(build_configuration: BuildConfiguration, backend_package: str,
     rules = invoke_entrypoint('rules')
     if rules:
       build_configuration.register_rules(rules)
+    target_adaptors = invoke_entrypoint('target_adaptors')
+    if target_adaptors:
+      build_configuration.register_target_adaptors(target_adaptors)


### PR DESCRIPTION
### Problem

We would like to be able to consume v2 lint and fmt rules with Black in the Twitter monorepo. Right now this fails because we have many different target names for our python code. I believe this issue is something that will occur for many other repos attempting to switch to using Black with pants as well.

### Solution

- Allow v2 plugins to declare a `def target_adaptors()` function returning a dict mapping BUILD file symbols to `TargetAdaptor` subclasses.

### TODO
- [ ] Expose the mapping of `TargetAdaptorWithOrigin` in `structs.py` to `register.py`s in backends and plugins, the same way we've exposed `target_adaptors()`.
  - Possibly use the `target_adaptors()` endpoint directly for this information?
*See:*
https://github.com/pantsbuild/pants/blob/4e981bc9512ac1cd2b4817f2c86f7c491d3bd6bb/src/python/pants/engine/legacy/structs.py#L321-L322

### Result

Repos which use many different names for targets (e.g. `python3_binary()`, `hadoop_binary()`, etc) are now able to use rules acting on `HydratedTarget`s in the v2 engine!