### PR TITLE
Rename Platform -> PlatformConstraint

### DIFF
--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, Platform,
+  ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, PlatformConstraint,
 };
 use hashing::EMPTY_DIGEST;
 use sharded_lmdb::ShardedLmdb;
@@ -58,7 +58,7 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -215,7 +215,7 @@ pub struct ExecuteProcessRequest {
   /// see https://github.com/pantsbuild/pants/issues/6416.
   ///
   pub jdk_home: Option<PathBuf>,
-  pub target_platform: PlatformConstraint, //TODO I don't think we need this attr here
+  pub target_platform: PlatformConstraint,
 
   pub is_nailgunnable: bool,
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -23,7 +23,7 @@ use tokio_process::CommandExt;
 
 use crate::{
   Context, ExecuteProcessRequest, FallibleExecuteProcessResult, MultiPlatformExecuteProcessRequest,
-  Platform,
+  PlatformConstraint,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -35,7 +35,7 @@ pub struct CommandRunner {
   executor: task_executor::Executor,
   work_dir_base: PathBuf,
   cleanup_local_dirs: bool,
-  platform: Platform,
+  platform_constraint: PlatformConstraint,
 }
 
 impl CommandRunner {
@@ -50,7 +50,7 @@ impl CommandRunner {
       executor,
       work_dir_base,
       cleanup_local_dirs,
-      platform: Platform::current_platform().unwrap(),
+      platform_constraint: PlatformConstraint::current_platform_constraint().unwrap(),
     }
   }
 
@@ -215,9 +215,12 @@ impl super::CommandRunner for CommandRunner {
     req: &MultiPlatformExecuteProcessRequest,
   ) -> Option<ExecuteProcessRequest> {
     for compatible_constraint in vec![
-      &(Platform::None, Platform::None),
-      &(self.platform, Platform::None),
-      &(self.platform, Platform::current_platform().unwrap()),
+      &(PlatformConstraint::None, PlatformConstraint::None),
+      &(self.platform_constraint, PlatformConstraint::None),
+      &(
+        self.platform_constraint,
+        PlatformConstraint::current_platform_constraint().unwrap(),
+      ),
     ]
     .iter()
     {

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, Platform, RelativePath,
+  FallibleExecuteProcessResult, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -31,7 +31,7 @@ fn stdout() {
     description: "echo foo".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -61,7 +61,7 @@ fn stdout_and_stderr_and_exit_code() {
     description: "echo foo and fail".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -92,7 +92,7 @@ fn capture_exit_code_signal() {
     description: "kill self".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -126,7 +126,7 @@ fn env() {
     description: "run env".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -166,7 +166,7 @@ fn env_is_deterministic() {
       description: "run env".to_string(),
       unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
-      target_platform: Platform::None,
+      target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
     }
   }
@@ -190,7 +190,7 @@ fn binary_not_found() {
     description: "echo foo".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   })
   .expect_err("Want Err");
@@ -209,7 +209,7 @@ fn output_files_none() {
     description: "bash".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
   assert_eq!(
@@ -241,7 +241,7 @@ fn output_files_one() {
     description: "bash".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -279,7 +279,7 @@ fn output_dirs() {
     description: "bash".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -318,7 +318,7 @@ fn output_files_many() {
     description: "treats-roland".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -355,7 +355,7 @@ fn output_files_execution_failure() {
     description: "echo foo".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -390,7 +390,7 @@ fn output_files_partial_output() {
     description: "echo-roland".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -423,7 +423,7 @@ fn output_overlapping_file_and_dir() {
     description: "bash".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -456,7 +456,7 @@ fn jdk_symlink() {
     description: "cat roland".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: Some(preserved_work_tmpdir.path().to_path_buf()),
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
   assert_eq!(
@@ -492,7 +492,7 @@ fn test_directory_preservation() {
       description: "bash".to_string(),
       unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
-      target_platform: Platform::None,
+      target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
     },
     preserved_work_root.clone(),
@@ -533,7 +533,7 @@ fn test_directory_preservation_error() {
       description: "failing execution".to_string(),
       unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
-      target_platform: Platform::None,
+      target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
     },
     preserved_work_root.clone(),
@@ -571,7 +571,7 @@ fn all_containing_directories_for_outputs_are_created() {
     description: "create nonoverlapping directories and file".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -604,7 +604,7 @@ fn output_empty_dir() {
     description: "bash".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   });
 
@@ -652,7 +652,7 @@ fn local_only_scratch_files_materialized() {
       unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
         roland_directory_digest,
       jdk_home: None,
-      target_platform: Platform::None,
+      target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
     },
     work_dir.path().to_owned(),
@@ -690,7 +690,7 @@ fn timeout() {
     description: "sleepy-cat".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   })
   .unwrap();
@@ -732,7 +732,7 @@ fn working_directory() {
       description: "confused-cat".to_string(),
       unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
-      target_platform: Platform::None,
+      target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
     },
     work_dir.path().to_owned(),

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -17,7 +17,7 @@ use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform,
+  MultiPlatformExecuteProcessRequest, PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -47,7 +47,7 @@ fn construct_nailgun_server_request(
   nailgun_name: &str,
   args_for_the_jvm: Vec<String>,
   jdk: PathBuf,
-  platform: Platform,
+  platform_constraint: PlatformConstraint,
 ) -> ExecuteProcessRequest {
   let mut full_args = args_for_the_jvm;
   full_args.push(NAILGUN_MAIN_CLASS.to_string());
@@ -65,7 +65,7 @@ fn construct_nailgun_server_request(
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: Some(jdk),
-    target_platform: platform,
+    target_platform: platform_constraint,
     is_nailgunnable: true,
   }
 }

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -1,5 +1,5 @@
 use crate::nailgun::{CommandRunner, ARGS_TO_START_NAILGUN, NAILGUN_MAIN_CLASS};
-use crate::{ExecuteProcessRequest, ExecuteProcessRequestMetadata, Platform};
+use crate::{ExecuteProcessRequest, ExecuteProcessRequestMetadata, PlatformConstraint};
 use hashing::EMPTY_DIGEST;
 use std::fs::read_link;
 use std::os::unix::fs::symlink;
@@ -43,7 +43,7 @@ fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> ExecuteProcessRequest
     description: "".to_string(),
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: jdk_home,
-    target_platform: Platform::Darwin,
+    target_platform: PlatformConstraint::Darwin,
     is_nailgunnable: true,
   }
 }
@@ -88,7 +88,7 @@ fn creating_nailgun_server_request_updates_the_cli() {
     &NAILGUN_MAIN_CLASS.to_string(),
     Vec::new(),
     PathBuf::from(""),
-    Platform::None,
+    PlatformConstraint::None,
   );
   assert_eq!(req.argv[0], NAILGUN_MAIN_CLASS);
   assert_eq!(req.argv[1..], ARGS_TO_START_NAILGUN);

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -18,7 +18,7 @@ use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOr
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, MultiPlatformExecuteProcessRequest,
-  Platform,
+  PlatformConstraint,
 };
 use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;
@@ -72,7 +72,7 @@ fn local_only_scratch_files_ignored() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -97,7 +97,7 @@ fn local_only_scratch_files_ignored() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       TestDirectory::containing_falcons_dir().digest(),
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -131,7 +131,7 @@ fn make_execute_request() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -215,7 +215,7 @@ fn make_execute_request_with_instance_name() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -307,7 +307,7 @@ fn make_execute_request_with_cache_key_gen_version() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -395,7 +395,7 @@ fn make_execute_request_with_jdk() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: Some(PathBuf::from("/tmp")),
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -461,7 +461,7 @@ fn make_execute_request_with_jdk_and_extra_platform_properties() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: Some(PathBuf::from("/tmp")),
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -569,7 +569,7 @@ fn server_rejecting_execute_request_gives_error() {
             unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
               hashing::EMPTY_DIGEST,
             jdk_home: None,
-            target_platform: Platform::None,
+            target_platform: PlatformConstraint::None,
             is_nailgunnable: false,
           },
           empty_request_metadata(),
@@ -775,7 +775,7 @@ pub fn sends_headers() {
       String::from("cat") => String::from("roland"),
     },
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -939,7 +939,7 @@ fn ensure_inline_stdio_is_stored() {
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1054,7 +1054,7 @@ fn timeout_after_sufficiently_delayed_getoperations() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -1107,7 +1107,7 @@ fn dropped_request_cancels() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
 
@@ -1477,7 +1477,7 @@ fn execute_missing_file_uploads_if_known() {
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1584,7 +1584,7 @@ fn execute_missing_file_uploads_if_known_status() {
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1664,7 +1664,7 @@ fn execute_missing_file_errors_if_unknown() {
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -2288,7 +2288,7 @@ pub fn echo_foo_request() -> MultiPlatformExecuteProcessRequest {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
   req.into()
@@ -2492,7 +2492,7 @@ fn create_command_runner(
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    PlatformConstraint::Linux,
     runtime,
     Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,
@@ -2602,7 +2602,7 @@ fn cat_roland_request() -> MultiPlatformExecuteProcessRequest {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
   req.into()
@@ -2621,7 +2621,7 @@ fn echo_roland_request() -> MultiPlatformExecuteProcessRequest {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: None,
-    target_platform: Platform::None,
+    target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
   };
   req.into()

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -2,7 +2,7 @@ use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
   CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform,
+  MultiPlatformExecuteProcessRequest, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -234,7 +234,7 @@ impl CommandRunner for DelayedCommandRunner {
       Some(
         req
           .0
-          .get(&(Platform::None, Platform::None))
+          .get(&(PlatformConstraint::None, PlatformConstraint::None))
           .unwrap()
           .clone(),
       )

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ExecuteProcessRequest, Platform, RelativePath};
+use crate::{ExecuteProcessRequest, PlatformConstraint, RelativePath};
 use hashing::{Digest, Fingerprint};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};
@@ -19,7 +19,7 @@ fn execute_process_request_equality() {
             description,
             unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
             jdk_home: None,
-            target_platform: Platform::None,
+            target_platform: PlatformConstraint::None,
             is_nailgunnable: false,
         };
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -32,7 +32,7 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
-use process_execution::{Context, ExecuteProcessRequestMetadata, Platform, RelativePath};
+use process_execution::{Context, ExecuteProcessRequestMetadata, PlatformConstraint, RelativePath};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
@@ -337,8 +337,10 @@ fn main() {
     unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
       hashing::EMPTY_DIGEST,
     jdk_home: args.value_of("jdk").map(PathBuf::from),
-    target_platform: Platform::try_from(&args.value_of("target-platform").unwrap().to_string())
-      .expect("invalid value for `target-platform"),
+    target_platform: PlatformConstraint::try_from(
+      &args.value_of("target-platform").unwrap().to_string(),
+    )
+    .expect("invalid value for `target-platform"),
     is_nailgunnable,
   };
 
@@ -369,7 +371,7 @@ fn main() {
           oauth_bearer_token,
           headers,
           store.clone(),
-          Platform::Linux,
+          PlatformConstraint::Linux,
           executor,
           std::time::Duration::from_secs(160),
           std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -21,7 +21,7 @@ use fs::{safe_create_dir_all_ioerror, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
   self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ExecuteProcessRequestMetadata,
-  Platform,
+  PlatformConstraint,
 };
 use rand::seq::SliceRandom;
 use reqwest;
@@ -180,7 +180,7 @@ impl Core {
             store.clone(),
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
-            Platform::Linux,
+            PlatformConstraint::Linux,
             executor.clone(),
             std::time::Duration::from_secs(160),
             std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -28,7 +28,7 @@ use fs::{
 };
 use hashing;
 use process_execution::{
-  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, Platform, RelativePath,
+  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, PlatformConstraint, RelativePath,
 };
 use rule_graph;
 
@@ -217,7 +217,7 @@ pub struct MultiPlatformExecuteProcess(MultiPlatformExecuteProcessRequest);
 impl MultiPlatformExecuteProcess {
   fn lift_execute_process(
     value: &Value,
-    target_platform: Platform,
+    target_platform: PlatformConstraint,
   ) -> Result<ExecuteProcessRequest, String> {
     let env = externs::project_tuple_encoded_map(&value, "env")?;
 
@@ -297,8 +297,8 @@ impl MultiPlatformExecuteProcess {
       .chunks_exact(2)
       .map(|constraint_key_pair| {
         (
-          Platform::try_from(&constraint_key_pair[0]).unwrap(),
-          Platform::try_from(&constraint_key_pair[1]).unwrap(),
+          PlatformConstraint::try_from(&constraint_key_pair[0]).unwrap(),
+          PlatformConstraint::try_from(&constraint_key_pair[1]).unwrap(),
         )
       })
       .collect();
@@ -311,8 +311,10 @@ impl MultiPlatformExecuteProcess {
       ));
     }
 
-    let mut request_by_constraint: BTreeMap<(Platform, Platform), ExecuteProcessRequest> =
-      BTreeMap::new();
+    let mut request_by_constraint: BTreeMap<
+      (PlatformConstraint, PlatformConstraint),
+      ExecuteProcessRequest,
+    > = BTreeMap::new();
     for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(requests.iter()) {
       let underlying_req =
         MultiPlatformExecuteProcess::lift_execute_process(execute_process, constraint_key.1)?;


### PR DESCRIPTION
### Problem

Python has a pair of enum types `Platform` (with variants "darwin" and "linux"), and `PlatformConstraint` (with variants "none", "darwin" and "linux"). There is also a rust enum  type defined in `process_execution` called `Platform`, but it has three variants like Python `PlatformConstraint` rather than two. This makes it confusing to reason about how the rust and python types correspond.

### Solution

Rename the Rust type to `PlatformConstraint` to indicate that it is analogous to the Python type of that name