### PR TITLE
Stabilize CI lint shard timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -353,6 +353,9 @@ matrix:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
       ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
@@ -378,8 +381,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --githooks --sanity-checks --doc-gen --lint --python-version
-      3.6
+    - travis-wait-enhanced --timeout 40m --interval 9m ./build-support/bin/ci.py --githooks
+      --sanity-checks --doc-gen --lint --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -410,6 +413,9 @@ matrix:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
       ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
@@ -436,8 +442,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --githooks --sanity-checks --doc-gen --lint --python-version
-      3.7
+    - travis-wait-enhanced --timeout 40m --interval 9m ./build-support/bin/ci.py --githooks
+      --sanity-checks --doc-gen --lint --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - before_cache:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -433,11 +433,11 @@ def bootstrap_osx(python_version: PythonVersion) -> Dict:
 
 def lint(python_version: PythonVersion) -> Dict:
   shard = {
-    **linux_shard(python_version=python_version),
+    **linux_shard(python_version=python_version, install_travis_wait=True),
     "name": f"Self-checks and lint (Python {python_version.decimal})",
     "script": [
-      f"./build-support/bin/ci.py --githooks --sanity-checks --doc-gen --lint "
-      f"--python-version {python_version.decimal}"
+      f"travis-wait-enhanced --timeout 40m --interval 9m ./build-support/bin/ci.py --githooks "
+      f"--sanity-checks --doc-gen --lint --python-version {python_version.decimal}"
     ]
   }
   safe_append(shard, "env", f"CACHE_NAME=lint.py{python_version.number}")


### PR DESCRIPTION
Now that we're using both V2 isort and docformatter, we've seen most CI runs time out for the lint shard. This is because we do not cache the V2 results and the V2 linters have atrocious performance when the cache is cold, per https://docs.google.com/document/d/1Tdof6jx9aVaOGeIQeI9Gn-8x7nd6LfjnJ0QrbLFBbgc/edit#.

A followup could use remote execution with the lint shard.