### PR TITLE
Fix help printing for v2 goals

### DIFF
--- a/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
+++ b/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
@@ -54,7 +54,7 @@ class GeneratePantsReference(Task):
     def _gen_reference(self):
         def get_scope_data(scope):
             ret = []
-            for si in ScopeInfoIterator(self.context.options.known_scope_to_info).iterate([scope]):
+            for si in ScopeInfoIterator(self.context.options.known_scope_to_info).iterate({scope}):
                 help_info = HelpInfoExtracter(si.scope).get_option_scope_help_info_from_parser(
                     self.context.options.get_parser(si.scope)
                 )

--- a/src/python/pants/help/scope_info_iterator.py
+++ b/src/python/pants/help/scope_info_iterator.py
@@ -10,7 +10,7 @@ from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 
-@dataclass
+@dataclass(frozen=True)
 class ScopeInfoIterator:
     """Provides relevant ScopeInfo instances in a useful order."""
 

--- a/src/python/pants/help/scope_info_iterator_test.py
+++ b/src/python/pants/help/scope_info_iterator_test.py
@@ -51,7 +51,7 @@ class ScopeInfoIteratorTest(unittest.TestCase):
         scope_to_infos = dict((x.scope, x) for x in infos)
 
         it = ScopeInfoIterator(scope_to_infos)
-        actual = list(it.iterate([GLOBAL_SCOPE, "goal1", "goal2.task21", "goal3"]))
+        actual = list(it.iterate({GLOBAL_SCOPE, "goal1", "goal2.task21", "goal3"}))
 
         expected_scopes = [
             GLOBAL_SCOPE,


### PR DESCRIPTION
### Problem

When a user runs `--help` on a v2 goal, pants will current provide help output as if it is a v1 goal - that is, provide help information for the goal and related subystems and v1 tasks. Most of this information is irrelevant in a v2 context and should not be displayed.

### Solution

This commit modifies the help printer to only print help information relevant to v2 if v2 is enabled and v1 is not enabled. 
