### PR TITLE
Fix `--skip` option for V2 formatters when multiple formatters enabled

### DIFF
--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -46,7 +46,8 @@ async def format_python_target(
             ),
         )
         results.append(result)
-        prior_formatter_result_digest = result.digest
+        if result != FmtResult.noop():
+            prior_formatter_result_digest = result.digest
     return AggregatedFmtResults(tuple(results), combined_digest=prior_formatter_result_digest)
 
 


### PR DESCRIPTION
### Problem

Running `./v2 --black-skip fmt2 path/to/file.py` fails in our codebase (where we also have isort and docformatter enabled) because of how V2 formatters run sequentially and pass their output digest on to the next formatter:

https://github.com/pantsbuild/pants/blob/29cf9fc8b25a540f32e4a9e0aeeaaa6ea4dcc48f/src/python/pants/backend/python/lint/python_format_target.py#L39-L49

When skipped, the rule returns `FmtResult.noop()`, which has an `EMPTY_DIRECTORY_DIGEST`, so the subsequent formatters end up with an empty input digest to format and fail to run.

### Solution

Only update the `prior_formatter_result_digest ` if the linter was not skipped.

Also, add a test for this use case.