### PR TITLE
Ignore Black and docformatter changes with `git blame`

### DIFF
--- a/.ignored_revisions
+++ b/.ignored_revisions
@@ -1,4 +1,11 @@
-# This revision reformatted all the python code with Black the first time.
+# This commit reformatted all the Python code with Black the first time.
 6c60cf752a6cc150620e8a2437974ae7d16917c5
-# This revision reverted the previous revision as more work and discussions were needed.
+
+# This commit reverted the previous commit as more work and discussions were needed.
 33a6d51db91ea1fe69c39117c8878abcb824cdfb
+
+# This commit ran docformatter over the whole codebase.
+d0998872d8116edd5ebc8231dbdd28779591dc2b
+
+# This commit ran Black over the whole codebase.
+29cf9fc8b25a540f32e4a9e0aeeaaa6ea4dcc48f

--- a/.travis.yml
+++ b/.travis.yml
@@ -381,9 +381,9 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis-wait-enhanced --timeout 60m --interval 9m -- ./build-support/bin/ci.py
+    - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
       --githooks --sanity-checks --doc-gen --python-version 3.6
-    - travis-wait-enhanced --timeout 25m --interval 9m -- ./build-support/bin/ci.py
+    - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
       --remote-execution-enabled --lint --python-version 3.6
     stage: Test Pants
     sudo: required
@@ -444,9 +444,9 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis-wait-enhanced --timeout 60m --interval 9m -- ./build-support/bin/ci.py
+    - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
       --githooks --sanity-checks --doc-gen --python-version 3.7
-    - travis-wait-enhanced --timeout 25m --interval 9m -- ./build-support/bin/ci.py
+    - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
       --remote-execution-enabled --lint --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -500,14 +500,14 @@ def lint(python_version: PythonVersion) -> Dict:
         "name": f"Self-checks and lint (Python {python_version.decimal})",
         "script": [
             (
-                "travis-wait-enhanced --timeout 60m --interval 9m -- ./build-support/bin/ci.py "
+                "travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py "
                 f"--githooks --sanity-checks --doc-gen --python-version {python_version.decimal}"
             ),
             # NB: We split up `--lint` into its own shard because it uses remote execution. The
             # RBE token expires after 60 minutes, so we don't want to generate the token until all
             # local execution has finished.
             (
-                "travis-wait-enhanced --timeout 25m --interval 9m -- ./build-support/bin/ci.py "
+                "travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py "
                 f"--remote-execution-enabled --lint --python-version {python_version.decimal}"
             ),
         ],

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -109,8 +109,7 @@ class PythonInterpreterCache(Subsystem):
                     Possible ways to fix this:
                     * Modify your Python interpreter constraints by following https://www.pantsbuild.org/python_readme.html#configure-the-python-version.
                     * Ensure the targeted Python version is installed and discoverable.
-                    * Modify Pants' interpreter search paths via --pants-setup-interpreter-search-paths.
-                    """.format(
+                    * Modify Pants' interpreter search paths via --pants-setup-interpreter-search-paths.""".format(
                         " && ".join(sorted(unique_compatibilities_strs)),
                         ", ".join(tgts_by_compatibilities_strs),
                         ", ".join(all_interpreter_version_strings),

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -20,7 +20,7 @@ class PythonArtifact(PayloadField):
         """
         :param kwargs: Passed to `setuptools.setup
           <https://pythonhosted.org/setuptools/setuptools.html>`_.
-       """
+        """
         self._kw = kwargs
         self._binaries = {}
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_properties.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_properties.py
@@ -19,12 +19,7 @@ class PropertiesTest(unittest.TestCase):
         self.assertLoaded("", {})
         self.assertLoaded(" ", {})
         self.assertLoaded("\t", {})
-        self.assertLoaded(
-            """
-
-    """,
-            {},
-        )
+        self.assertLoaded("\n", {})
 
     def test_comments(self):
         self.assertLoaded(

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 import unittest
 from typing import Tuple, Type, cast
 
@@ -122,7 +123,9 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         address_family = AddressFamily("root", {"a": ("root/BUILD", TargetAdaptor())})
         address_specs = AddressSpecs([SingleAddress("root", "b"), SingleAddress("root", "a")])
 
-        expected_rx_str = r'"b" was not found in namespace "root". Did you mean one of:\n\s+:a'
+        expected_rx_str = re.escape(
+            '"b" was not found in namespace "root". Did you mean one of:\n  :a'
+        )
         with self.assertRaisesRegex(ResolveError, expected_rx_str):
             self._resolve_addresses(
                 address_specs, address_family, self._snapshot(), self._address_mapper()


### PR DESCRIPTION
This makes `git blame` less noisy. Pants developers must have run `build-support/bin/install_git_hooks.sh` and use a relatively modern version of Git.

This also cleans up some small things from the original Black PR, including increasing the timeout for `ci.py --lint`.