### PR TITLE
Register `goal2` as `goal` if in v2-exclusive mode.

### DIFF
--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Tuple, Type
 
 from pants.cache.cache_setup import CacheSetup
 from pants.option.optionable import Optionable
+from pants.option.options_bootstrapper import is_v2_exclusive
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.meta import classproperty
@@ -53,9 +54,22 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
         """
         return None
 
+    @classmethod
+    def conflict_free_name(cls):
+        # v2 goal names ending in '2' are assumed to be so-named to avoid conflict with a v1 goal.
+        # If we're in v2-exclusivce mode, strip off the '2', so we can use the more natural name.
+        # Note that this implies a change of options scope when changing to v2-only mode: options
+        # on the foo2 scope will need to be moved to the foo scope. But we already expect options
+        # changes when switching to v2-exclusive mode (e.g., some v1 options aren't even registered
+        # in that mode), so this is in keeping with existing expectations. And this provides
+        # a much better experience to new users who never encountered v1 anyway.
+        if is_v2_exclusive and cls.name.endswith("2"):
+            return cls.name[:-1]
+        return cls.name
+
     @classproperty
     def options_scope(cls):
-        return cls.name
+        return cls.conflict_free_name()
 
     @classmethod
     def subsystem_dependencies(cls):
@@ -112,7 +126,7 @@ class Goal:
 
     @classproperty
     def name(cls):
-        return cls.subsystem_cls.name
+        return cls.subsystem_cls.conflict_free_name()
 
 
 class Outputting:


### PR DESCRIPTION
Requires a little hackery, but provides a much better experience
to users who don't have the v1 baggage.

Note that "v2 exclusive" means that `--v2 --no-v1` 
*AND* `backend_packages==[]`. So mixed-mode use is unaffected. 
E.g., setting `--no-v1` if you still have anything in your `backend_packages`
will not trigger this.

Therefore this should only affect repos that have no v1 legacy at all.

Note: Requires https://github.com/pantsbuild/pants/pull/9162 