### PR TITLE
Update docs to use `pants.toml`

### DIFF
--- a/build-support/bin/bootstrap_pants_pex.sh
+++ b/build-support/bin/bootstrap_pants_pex.sh
@@ -48,7 +48,7 @@ function calculate_pants_pex_current_hash() {
      "${REPO_ROOT}/BUILD" \
      "${REPO_ROOT}/BUILD.tools" \
      "${REPO_ROOT}/BUILD_ROOT" \
-     "${REPO_ROOT}/pants.ini" \
+     "${REPO_ROOT}/pants.toml" \
      "${REPO_ROOT}/3rdparty" \
      "${REPO_ROOT}/build-support/checkstyle" \
      "${REPO_ROOT}/build-support/eslint" \

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -130,7 +130,7 @@ REQUIREMENTS_3RDPARTY_FILES=(
 
 # When we do (dry-run) testing, we need to run the packaged pants.
 # It doesn't have internal backend plugins so when we execute it
-# at the repo build root, the root pants.ini will ask it to load
+# at the repo build root, the root pants.toml will ask it to load
 # internal backend packages and their dependencies which it doesn't have,
 # and it'll fail. To solve that problem, we load the internal backend package
 # dependencies into the pantsbuild.pants venv.

--- a/build-support/ivy/BUILD.netrc
+++ b/build-support/ivy/BUILD.netrc
@@ -1,6 +1,6 @@
 # Enable ~/.netrc for credentials management of jvm publishing.
 
-# These credentials are used by our 'public' publish repo defined in [publish]repos in `pants.ini`
+# These credentials are used by our 'public' publish repo defined in [publish]repos in `pants.toml`
 # and the username and password here are templated in to a credentials configuration for
 # oss.sonatype.org in `build-support/ivy/publish.ivysettings.xml`.  This setup is complex, but
 # documented well here: http://pantsbuild.org/setup_repo.html#enabling-pants-publish

--- a/build-support/ivy/publish.ivysettings.xml
+++ b/build-support/ivy/publish.ivysettings.xml
@@ -15,7 +15,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
   <!-- The ${login} and ${password} values below come from a credentials() object,
        which is fed by '~/.netrc'.  There must be a '~/.netrc' machine entry which
-       matches a resolver in the "[publish]repos" object in 'pants.ini', which also
+       matches a resolver in the "[publish]repos" object in 'pants.toml', which also
        matches the 'host' in this XML block. -->
   <credentials host="oss.sonatype.org"
                realm="Sonatype Nexus Repository Manager"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -43,7 +43,7 @@ Contrib plugins should generally follow 3 basic setup steps:
    pythonpath = [
      "%(buildroot)s/pants-plugins/src/python",
      "%(buildroot)s/contrib/example/src/python",  # 1
-    ]
+   ]
 
    backend_packages = [
      "internal_backend.repositories",

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -35,26 +35,22 @@ Contrib plugins should generally follow 3 basic setup steps:
    ```
 
 2. Make the local pants aware of your plugin
-   This involves 2 edits to `pants.ini`.  You'll need to add one entry in each of the
+   This involves 2 edits to `pants.toml`.  You'll need to add one entry in each of the
    `pythonpath` and `backend_packages` lists:
-   ```ini
+   ```toml
    [GLOBAL]
    # Enable our own custom loose-source plugins as well as contribs.
-   pythonpath: [
-       "%(buildroot)s/pants-plugins/src/python",
-       ...
-       "%(buildroot)s/contrib/example/src/python",  # 1
-       ...
-     ]
+   pythonpath = [
+     "%(buildroot)s/pants-plugins/src/python",
+     "%(buildroot)s/contrib/example/src/python",  # 1
+    ]
 
-   backend_packages: [
-       "internal_backend.repositories",
-       "internal_backend.sitegen",
-       "internal_backend.utilities",
-       ...
-       "pants.contrib.example",  # 2
-       ...
-     ]
+   backend_packages = [
+     "internal_backend.repositories",
+     "internal_backend.sitegen",
+     "internal_backend.utilities",
+     "pants.contrib.example",  # 2
+   ]
    ```
 
 3. When you're ready for your plugin to be distributed, convert your main `python_library` plugin

--- a/contrib/errorprone/README.md
+++ b/contrib/errorprone/README.md
@@ -13,20 +13,20 @@ One notable difference between this plugin and other Error Prone integrations is
 Error Prone support is provided by a plugin distributed to [pypi]
 (https://pypi.org/pypi/pantsbuild.pants.contrib.errorprone).
 Assuming you have already [installed pants](http://www.pantsbuild.org/install.html), you'll need to
-add the Error Prone plugin in your `pants.ini`, like so:
-```ini
+add the Error Prone plugin in your `pants.toml`, like so:
+```toml
 [GLOBAL]
-pants_version: 1.3.0
+pants_version = "1.26.0"
 
-plugins: [
-    'pantsbuild.pants.contrib.errorprone==%(pants_version)s',
-  ]
+plugins = [
+  'pantsbuild.pants.contrib.errorprone==%(pants_version)s',
+]
 ```
 
 The version of Error Prone used by the plugin requires Java 8 to run.  If you want to run Error Prone with Java 7 you will need to use version 2.0.5 or earlier. Using Java 7 may require changes to the bootclasspath to override certain classes from `rt.jar`.  See [this github issue](https://github.com/google/error-prone/issues/287) for more details.
 
 You can override the version of Error Prone by adding the following to the `BUILD.tools` file
-```ini
+```python
 # Override the default version of Error Prone shipped with Pants
 jar_library(name = 'errorprone',
   jars = [
@@ -56,16 +56,16 @@ When you run `./pants compile` Error Prone is executed after the compile step an
 
 You can exclude targets with `--compile-errorprone-exclude-patterns` and globally suppress specific Error Prone checks with `--compile-errorprone-command-line-options`.
 
-Here are example `pants.ini` settings that exclude several test targets and disable the `DefaultCharset` bug pattern.
+Here are example `pants.toml` settings that exclude several test targets and disable the `DefaultCharset` bug pattern.
 
-```ini
+```toml
 [compile.errorprone]
-command_line_options: [
-    # See http://errorprone.info/bugpatterns for all patterns
-    '-Xep:DefaultCharset:OFF'
-  ]
-exclude_patterns: [
-    'tests/java/org/pantsbuild/tools/junit/.*',
-    'testprojects/src/java/org/pantsbuild/testproject/annotation/main:main'
-  ]
+command_line_options = [
+  # See http://errorprone.info/bugpatterns for all patterns
+  '-Xep:DefaultCharset:OFF',
+]
+exclude_patterns = [
+  'tests/java/org/pantsbuild/tools/junit/.*',
+  'testprojects/src/java/org/pantsbuild/testproject/annotation/main:main',
+]
 ```

--- a/contrib/findbugs/README.md
+++ b/contrib/findbugs/README.md
@@ -13,14 +13,14 @@ This plugin uses FindBugs 3.0.1 which requires Java 1.7.0 or later to run.
 FindBugs support is provided by a plugin distributed to [pypi]
 (https://pypi.org/pypi/pantsbuild.pants.contrib.findbugs).
 Assuming you have already [installed pants](http://www.pantsbuild.org/install.html), you'll need to
-add the FindBugs plugin in your `pants.ini`, like so:
-```ini
+add the FindBugs plugin in your `pants.toml`, like so:
+```toml
 [GLOBAL]
-pants_version: 1.0.0
+pants_version = "1.26.0"
 
-plugins: [
-    'pantsbuild.pants.contrib.findbugs==%(pants_version)s',
-  ]
+plugins = [
+  'pantsbuild.pants.contrib.findbugs==%(pants_version)s',
+]
 ```
 
 ## Running
@@ -77,11 +77,11 @@ to filter out specific bug reports.  The format of the exclude file is documente
 
 Here are example settings that fail the build only for highly ranked bugs and exclude all test files
 
-```ini
+```toml
 [compile.findbugs]
-max_rank: 4
-fail_on_error: True
-exclude_patterns: [".*/tests/java/.*"]
+max_rank = 4
+fail_on_error = true
+exclude_patterns = [".*/tests/java/.*"]
 ```
 
 ## Reporting

--- a/contrib/go/README.md
+++ b/contrib/go/README.md
@@ -9,17 +9,17 @@ tooling easier.
 Go support is provided by a plugin distributed to
 [pypi](https://pypi.org/pypi/pantsbuild.pants.contrib.go).
 Assuming you have already [installed pants](http://www.pantsbuild.org/install.html), you'll need to
-add the Go plugin in your `pants.ini`, like so:
-```ini
+add the Go plugin in your `pants.toml`, like so:
+```toml
 [GLOBAL]
-pants_version: 1.0.0
+pants_version = "1.26.0"
 
-plugins: [
-    'pantsbuild.pants.contrib.go==%(pants_version)s',
-  ]
+plugins = [
+  'pantsbuild.pants.contrib.go==%(pants_version)s',
+]
 
 [go-distribution]
-version: 1.10
+version = "1.10"
 ```
 
 On your next run of `./pants` the plugin will be installed and you'll find these new goals:
@@ -71,13 +71,11 @@ Pants corrects for this in the case of its default patterns: It will correctly d
 that `src/go/src` and `src/main/go/src` are the possible source roots for Go.
 
 But if your Go code does not live in one of these locations then you'll need to tell Pants where
-to find it, e.g., by adding this to `pants.ini`:
+to find it, e.g., by adding this to `pants.toml`:
 
-```ini
+```toml
 [source]
-source_roots: {
-    'my/custom/path/go/src': ['go']
-  }
+source_roots = "{'my/custom/path/go/src': ['go']}"
 ```
 
 This tells pants that the `src/go/src` source root houses one type of code, Go code.
@@ -248,16 +246,16 @@ At this point the generated BUILD files can be checked in.
 
 When new packages are added or existing packages' dependencies are modified a similar seeding (only
 needed if the packages are new roots), buildgen and compilation can be cycled through. To simplify
-the process it's recommended the flags be made defaults for the repo by editing your pants init to
+the process it's recommended the flags be made defaults for the repo by editing your `pants.toml` to
 include the following section:
-```ini
+```toml
 [buildgen.go]
 # We always want buildgen to materialize BUILD files on disk as well as handle seeding remotes
 # when new ones are encountered.  We also never want to allow FLOATING revs, they should be pinned
 # right away.
-materialize: True
-remote: True
-fail_floating: True
+materialize = true
+remote = true
+fail_floating = true
 ```
 Now running buildgen is just `./pants buildgen`.
 
@@ -307,9 +305,9 @@ In Go, we can import and use the protobuf generated code as it were regular Go c
 To select the version of the go protobuf runtime your generated code depends on, set option `import_target`
 in scope `gen.go-protobuf` to point to an appropriate target address. E.g.,
 
-```ini
+```toml
 [gen.go-protobuf]
-import_target: 3rdparty/go/github.com/golang/protobuf/proto
+import_target = "3rdparty/go/github.com/golang/protobuf/proto"
 ```
 
 (Where 3rdparty/go/github.com/golang/protobuf/proto was presumably created by the buildgen process
@@ -322,12 +320,12 @@ by adding  the `protoc_plugins=['grpc']` argument. See, e.g.,
 [`contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD`](https://github.com/pantsbuild/pants/blob/master/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD)
 
 You can also activate it for all `go_protobuf_library` targets in your repo, using the `protoc_plugins`
-option in scope `gen.go-protobuf`. E.g., add this to your `pants.ini`:
+option in scope `gen.go-protobuf`. E.g., add this to your `pants.toml`:
 
-```ini
+```toml
 [gen.go-protobuf]
-protoc_plugins=["grpc"]
-import_target: src/protobuf:grpc-deps
+protoc_plugins = ["grpc"]
+import_target = "src/protobuf:grpc-deps"
 ```
 
 Note that we also modify `import_target`, as your code must now depend on the gRPC runtime.

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -86,7 +86,7 @@ class GoCompile(GoWorkspaceTask):
     def _get_build_flags(cls, build_flags_from_option, is_flagged, target):
         """Merge build flags with global < target < command-line order.
 
-        Build flags can be defined as globals (in `pants.ini`), as arguments to a Target, and via
+        Build flags can be defined as globals (in `pants.toml`), as arguments to a Target, and via
         the command-line.
         """
         # If self.get_options().build_flags returns a quoted string, remove the outer quotes,

--- a/contrib/jax_ws/README.md
+++ b/contrib/jax_ws/README.md
@@ -8,14 +8,14 @@ Web Services Description Language (WSDL) file for calling a JAX-WS web service.
 JAX-WS support is provided by a plugin distributed to [pypi]
 (https://pypi.org/pypi/pantsbuild.pants.contrib.jax_ws).
 Assuming you have already [installed pants](http://www.pantsbuild.org/install.html), you'll need to
-add the JAX-WS plugin in your `pants.ini`, like so:
-```ini
+add the JAX-WS plugin in your `pants.toml`, like so:
+```toml
 [GLOBAL]
-pants_version: 1.0.0
+pants_version = "1.26.0"
 
-plugins: [
-    'pantsbuild.pants.contrib.jax_ws==%(pants_version)s',
-  ]
+plugins = [
+  'pantsbuild.pants.contrib.jax_ws==%(pants_version)s',
+]
 ```
 
 ## Target Example
@@ -35,12 +35,12 @@ and service stubs will be generated for you when you `gen` this target
 $ ./pants gen myproject/src/main/jax_ws:hello-service
 ```
 
-Common jvm_options for jax-rs can be included in your pants.ini file
-```ini
+Common jvm_options for jax-rs can be included in your `pants.toml` file
+```toml
 [gen.jax-ws]
-jvm_options: [
-    '-Djavax.xml.accessExternalSchema=all'
-  ]
+jvm_options = [
+  '-Djavax.xml.accessExternalSchema=all'
+]
 ```
 
 ## Options

--- a/contrib/node/README.md
+++ b/contrib/node/README.md
@@ -53,7 +53,7 @@ See the examples directory for real examples.
 Pants will bootstrap itself with its own copy of Node.js, NPM, and Yarn package manager and use them to run commands.
 It runs those commands with the bootstrapped Node's bin directory at the front of the PATH.
 
-Distribution versions can be modified in `pants.ini`.
+Distribution versions can be modified in `pants.toml`.
 
 ## Package Management
 

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -104,7 +104,7 @@ class Checkstyle(LintTaskMixin, Task):
             type=list,
             help="A list of interpreter constraints for which matching targets will be linted "
             "in addition to targets that match the global interpreter constraints "
-            "(either from defaults or pants.ini). If the user supplies an empty list, "
+            "(either from defaults or pants.toml). If the user supplies an empty list, "
             "Pants will lint all targets in the target set, irrespective of the working "
             "set of compatibility constraints.",
         )

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -65,9 +65,9 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
             "Pylint. Pants currently provides a wrapper around MyPy and will soon add "
             "Pylint. (To install MyPy, add "
             "`pantsbuild.pants.contrib.mypy==%(pants_version)s` to your `plugins` list.)"
-            "\n\nTo prepare, set `skip: True` in your `pants.ini` under the section "
-            "`python-eval`. If you still need to use this tool, set `skip: False`. In "
-            "Pants 1.27.0.dev0, the default will change from `skip: False` to `skip: True`, "
+            "\n\nTo prepare, set `skip = true` in your `pants.toml` under the section "
+            "`python-eval`. If you still need to use this tool, set `skip = false`. In "
+            "Pants 1.27.0.dev0, the default will change from `skip = false` to `skip = true`, "
             "and in Pants 1.29.0.dev0, the module will be removed.",
         )
         return self.resolve_conflicting_skip_options(

--- a/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
+++ b/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
@@ -210,11 +210,11 @@ You can set up your `3rdparty/BUILD` file like so:
       ],
     )
 
-And in `pants.ini`, add:
+And in `pants.toml`, add:
 
     :::ini
     [jar-dependency-management]
-    default_target: 3rdparty:management
+    default_target = "3rdparty:management"
 
 This will force all `jar_library` targets in your repository to use the
 versions of `commons-io` and `jersey-core` referenced by the `management`

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -228,26 +228,26 @@ eventually.
 
 ##### For Pants >= 1.7.x
 
-    :::ini
+    :::toml
     # This will turn on coursier and turn off ivy.
     [resolver]
-    resolver: coursier
+    resolver = "coursier"
 
     [resolve.coursier]
     # jvm option in case of large resolves
-    jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
+    jvm_options = ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
 
     [export]
     # Same if needed for large resolves
-    jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
+    jvm_options = ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
 
     [coursier]
-    repos: ['https://repo1.maven.org/maven2', 'https://dl.google.com/dl/android/maven2/']
+    repos = ['https://repo1.maven.org/maven2', 'https://dl.google.com/dl/android/maven2/']
 
     # Change the following if you choose to [build coursier jar from scratch](https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants)
     # or to fetch from different location.
-    bootstrap_jar_url: <url>
-    version: <version>
+    bootstrap_jar_url = "<url>"
+    version = "<version>"
 
 * To inspect the resolve result, specify `--resolver-coursier-report`
 * To show coursier command line invocation, use `-ldebug`
@@ -256,6 +256,8 @@ eventually.
         ./pants --resolver-resolver=coursier resolve.coursier --report examples/tests/scala/org/pantsbuild/example/hello/welcome -ldebug
 
 ##### For Pants <= 1.6.x
+
+Note that this uses `pants.ini` rather than `pants.toml`.
 
     :::ini
     # This will turn on coursier and turn off ivy.
@@ -304,38 +306,42 @@ compilation for Java and Scala.
 Java9 vs Java8, Which Java
 --------------------------
 
-Pants first looks through any JDKs specified by the `paths` map in pants.ini's jvm-distributions
+Pants first looks through any JDKs specified by the `paths` map in pants.toml's jvm-distributions
 section, eg:
 
-    :::ini
+    :::toml
     [jvm-distributions]
-    paths = {
-        'macos': [
-          '/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk',
-          '/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk',
-        ],
-        'linux': [
-          '/usr/java/jdk1.8.0_152',
-        ]
-      }
+    paths = """
+    {
+      'macos': [
+        '/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk',
+        '/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk',
+      ],
+      'linux': [
+        '/usr/java/jdk1.8.0_152',
+      ]
+    }
+    """
 
 If no JVMs are found there, Pants uses the first Java it finds in `JDK_HOME`, `JAVA_HOME`,
-or `PATH`. If no `paths` are specified in pants.ini, you can use JDK_HOME to set the Java version
+or `PATH`. If no `paths` are specified in pants.toml, you can use JDK_HOME to set the Java version
 for just one pants invocation:
 
     :::bash
     $ JDK_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./pants ...
 
 If you sometimes need to compile some code in Java 8 and sometimes Java 9, you can define
-jvm-platforms in pants.ini, and set what targets use which platforms. For example, in pants.ini:
+jvm-platforms in pants.toml, and set what targets use which platforms. For example, in pants.toml:
 
-    :::ini
+    :::toml
     [jvm-platform]
-    default_platform: java8
-    platforms: {
-        'java8': {'source': '8', 'target': '8', 'args': [] },
-        java9': {'source': '9', 'target': '9', 'args': [] },
-      }
+    default_platform = "java8"
+    platforms = """
+    {
+      'java8': {'source': '8', 'target': '8', 'args': [] },
+      'java9': {'source': '9', 'target': '9', 'args': [] },
+    }
+    """
 
 And then in a BUILD file:
 
@@ -354,12 +360,13 @@ If you want to set the `-bootclasspath` (or `-Xbootclasspath`) to use the
 appropriate java distribution, you can use the `$JAVA_HOME` symbol in the
 `args` list. For example:
 
-    :::ini
+    :::toml
     [jvm-platform]
-    default_platform: java8
-    platforms: {
-        'java8': {'source': '8', 'target': '8', 'args': ["-C-bootclasspath:$JAVA_HOME/jre/lib/resources.jar:$JAVA_HOME/jre/lib/rt.jar:$JAVA_HOME/jre/lib/sunrsasign.jar:$JAVA_HOME/jre/lib/jsse.jar:$JAVA_HOME/jre/lib/jce.jar:$JAVA_HOME/jre/lib/charsets.jar:$JAVA_HOME/jre/lib/jfr.jar:$JAVA_HOME/jre/classes"] },
-      }
+    default_platform = "java8"
+    platforms = """
+    {
+      'java8': {'source': '8', 'target': '8', 'args': ["-C-bootclasspath:$JAVA_HOME/jre/lib/resources.jar:$JAVA_HOME/jre/lib/rt.jar:$JAVA_HOME/jre/lib/sunrsasign.jar:$JAVA_HOME/jre/lib/jsse.jar:$JAVA_HOME/jre/lib/jce.jar:$JAVA_HOME/jre/lib/charsets.jar:$JAVA_HOME/jre/lib/jfr.jar:$JAVA_HOME/jre/classes"] },
+    }
 
 Your `-bootclasspath` should be designed to work with any compatible version of
 the JVM that might be used. If you make use of `[jvm-distributions]` and have

--- a/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
+++ b/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
@@ -46,16 +46,16 @@ Using javac plugins
 
 Plugins can be integrated in one of two ways:
 
-- Global plugins: specified in `pants.ini` and used on all Java code.
+- Global plugins: specified in `pants.toml` and used on all Java code.
 - Per-target plugins: specified on a Java target and used only when compiling that target.
 
 #### Global plugins
 
-Global plugins are specified using the `javac_plugins` key in the `compile.rsc` section of `pants.ini`:
+Global plugins are specified using the `javac_plugins` key in the `compile.rsc` section of `pants.toml`:
 
 ```
 [compile.rsc]
-javac_plugins: ['simple_javac_plugin']
+javac_plugins = ['simple_javac_plugin']
 
 ```
 
@@ -63,10 +63,8 @@ Plugins can optionally take arguments, specified like this:
 
 ```
 [compile.rsc]
-javac_plugins: ['simple_javac_plugin]
-javac_plugin_args: {
-    'simple_javac_plugin': ['arg1', 'arg2']
-  }
+javac_plugins = ['simple_javac_plugin]
+javac_plugin_args = "{'simple_javac_plugin': ['arg1', 'arg2']}"
 ```
 
 

--- a/examples/src/java/org/pantsbuild/example/page.md
+++ b/examples/src/java/org/pantsbuild/example/page.md
@@ -200,8 +200,8 @@ plugin, install a goal that subclasses `ConfluencePublish`:
       # ...
       task(name='confluence', action=ArchieConfluence, dependencies=['markdown']).install()
 
-In your `pants.ini` file, add a section with the url of your wiki server. E.g., if your server
+In your `pants.toml` file, add a section with the url of your wiki server. E.g., if your server
 is at wiki.archie.org, it would look like:
 
     [confluence]
-    url: https://wiki.archie.org
+    url = "https://wiki.archie.org"

--- a/examples/src/java/org/pantsbuild/example/publish.md
+++ b/examples/src/java/org/pantsbuild/example/publish.md
@@ -54,13 +54,14 @@ refers to the `public` repository defined above. (Notice it's a Python object, n
 If you get an error that the repo name (here, `public`) isn't defined, your plugin didn't register
 with Pants successfully. Make sure you bootstrap Pants in a way that loads your `register.py`.
 
-In your `pants.ini` file, set up a `[publish.jar]` section. In that section,
+In your `pants.toml` file, set up a `[publish.jar]` section. In that section,
 create a `dict` called `repos`. It should contain a section for each `Repository` object that you
 defined in your plugin:
 
-    :::ini
+    :::toml
     [publish.jar]
-    repos: {
+    repos = """
+    {
       'public': {  # must match the name of the `Repository` object that you defined in your plugin.
         'resolver': 'maven.example.com', # must match hostname in ~/.netrc and the <url> parameter
                                          # in your custom ivysettings.xml.
@@ -74,6 +75,7 @@ defined in your plugin:
         'help': 'Configure your ~/.netrc for artifactory.example.com access.'
       },
     }
+    """
 
 If your repository requires authentication, add a `~/.netrc` file. Here is a sample file, that
 matches the `repos` specified above:
@@ -101,7 +103,7 @@ with the additional information needed to publish artifacts. Here is an example 
       <settings defaultResolver="chain-repos"/>
       <!-- The ${login} and ${password} values come from a netrc_credentials() object in a BUILD
            file, which is fed by '~/.netrc'.  There must be a '~/.netrc' machine entry which
-           matches a resolver in the "repos" object in 'pants.ini', which also matches the 'host' in
+           matches a resolver in the "repos" object in 'pants.toml', which also matches the 'host' in
            this XML block.
 
            machine <hostname>
@@ -132,12 +134,12 @@ with the additional information needed to publish artifacts. Here is an example 
       </resolvers>
     </ivysettings>
 
-With this file in place, add a `[publish.jar]` section to `pants.ini`, and tell pants to use
+With this file in place, add a `[publish.jar]` section to `pants.toml`, and tell pants to use
 the custom Ivy settings when publishing:
 
-    :::ini
+    :::toml
     [publish.jar]
-    ivy_settings: %(pants_supportdir)s/ivy/ivysettings_for_publishing.xml
+    ivy_settings = "%(pants_supportdir)s/ivy/ivysettings_for_publishing.xml"
 
 <a pantsmark="setup_publish_restrict_branch"> </a>
 
@@ -146,7 +148,7 @@ the custom Ivy settings when publishing:
 Your organization might have a notion of a special "release branch": you want publishing
 to happen on this source control branch, which you maintain extra-carefully.
 You can set this branch using the `restrict_push_branches` option in the
-`[publish.jar]` section of your `pants.ini` file.
+`[publish.jar]` section of your `pants.toml` file.
 
 ### Task to Publish "Extra" Artifacts
 

--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -85,7 +85,7 @@ target if set for both itself and its dependencies, or will otherwise fall back 
 
 Pants will look for those files in the location specified in the
 [[`python-repos`|pants('src/docs:setup_repo')#redirecting-python-requirements-to-other-servers]] field
-in pants.ini. It can understand either a simple local directory of .whl files or a "find links"-friendly
+in pants.toml. It can understand either a simple local directory of .whl files or a "find links"-friendly
 webpage of links formatted like so:
 
 ```

--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -65,11 +65,11 @@ an interpreter (e.g.: `CPython`, `PyPy`) and version constraint, and that a list
 may be specified.
 
 The most common approach is to configure interpreter constraints for your whole repo.
-For example, to use python3 for the whole repo, update `pants.ini` as follows:
+For example, to use python3 for the whole repo, update `pants.toml` as follows:
 
-```ini
+```toml
 [python-setup]
-interpreter_constraints: ["CPython>=3.5"]
+interpreter_constraints = ["CPython>=3.5"]
 ```
 
 If you require more granularity, the `compatibility` parameter may be specified on

--- a/examples/src/python/example/pants_publish_plugin/extra_test_jar_example.py
+++ b/examples/src/python/example/pants_publish_plugin/extra_test_jar_example.py
@@ -46,7 +46,7 @@ class ExtraTestJarExample(JarTask):
 
             # Create a jar file to be published along with other artifacts for this target.
             # In principle, any extra file type could be created here, and published.
-            # Options in pants.ini allow specifying the file extension.
+            # Options in pants.toml allow specifying the file extension.
             with self.open_jar(jar_path, overwrite=True, compressed=True) as open_jar:
                 # Write the sample file to the jar.
                 open_jar.write(os.path.join(self.workdir, example_file_name), "example.txt")
@@ -54,7 +54,7 @@ class ExtraTestJarExample(JarTask):
             # For this target, add the path to the newly created jar to the product map, under the
             # 'extra_test_jar_example key.
             #
-            # IMPORTANT: this string *must* match the string that you have set in pants.ini. Otherwise,
+            # IMPORTANT: this string *must* match the string that you have set in pants.toml. Otherwise,
             # the code in 'jar_publish.py' won't be able to find this addition to the product map.
             self.context.products.get("extra_test_jar_example").add(target, self.workdir).append(
                 jar_name

--- a/examples/src/python/example/tensorflow_custom_op/README.md
+++ b/examples/src/python/example/tensorflow_custom_op/README.md
@@ -14,4 +14,4 @@ Note that due to a current limitation (see [#6848](https://github.com/pantsbuild
 ./pants --native-build-step-toolchain-variant=llvm test examples/tests/python/example_test/tensorflow_custom_op:: -- -vs
 ```
 
-or by setting the toolchain variant [option in `pants.ini`](https://www.pantsbuild.org/options.html).
+or by setting the toolchain variant [option in `pants.toml`](https://www.pantsbuild.org/options.html).

--- a/examples/src/scala/org/pantsbuild/example/README.md
+++ b/examples/src/scala/org/pantsbuild/example/README.md
@@ -188,24 +188,24 @@ In a `BUILD` file at the root of the repo, define the `semanticdb` compiler plug
 
 Note that the explicit full scala version string (`2.11.12`) is required for the semanticdb jar we use here, which is why we can't just use <a pantsref="bdict_jar">`scala_jar`</a> (which would just append e.g. `_2.12` to the name).
 
-Then, reference it from `pants.ini` to load the plugin, and enable semantic rewrites to require
+Then, reference it from `pants.toml` to load the plugin, and enable semantic rewrites to require
 compilation for `fmt` and `lint`:
 
-    :::ini
+    :::toml
     [compile.rsc]
-    args: [
-        # The `-S` prefix here indicates that zinc should pass this option to scalac rather than
-        # to javac (`-C` prefix).
-        '-S-Yrangepos',
-      ]
+    args = [
+      # The `-S` prefix here indicates that zinc should pass this option to scalac rather than
+      # to javac (`-C` prefix).
+      '-S-Yrangepos',
+    ]
 
     [scala]
-    scalac_plugins: [
-        'semanticdb',
-      ]
+    scalac_plugins = [
+      'semanticdb',
+    ]
 
     [lint.scalafix]
-    semantic: True
+    semantic = true
 
     [fmt.scalafix]
-    semantic: True
+    semantic = true

--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
@@ -45,27 +45,25 @@ Using scalac plugins
 
 Plugins can be integrated in one of two ways:
 
-- Global plugins: specified in `pants.ini` and used on all Scala code.
+- Global plugins: specified in `pants.toml` and used on all Scala code.
 - Per-target plugins: specified on a Scala target and used only when compiling that target.
 
 #### Global plugins
 
-Global plugins are specified using the `scalac_plugins` key in the `scala` section of `pants.ini`:
+Global plugins are specified using the `scalac_plugins` key in the `scala` section of `pants.toml`:
 
-```
+```toml
 [scala]
-scalac_plugins: ['simple_scalac_plugin']
+scalac_plugins = ['simple_scalac_plugin']
 
 ```
 
 Plugins can optionally take arguments, specified like this:
 
-```
+```toml
 [scala]
-scalac_plugins: ['simple_scalac_plugin']
-scalac_plugin_args: {
-    'simple_scalac_plugin': ['arg1', 'arg2']
-  }
+scalac_plugins = ['simple_scalac_plugin']
+scalac_plugin_args = "{'simple_scalac_plugin': ['arg1', 'arg2']}"
 ```
 
 

--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -6,7 +6,7 @@
 #     --remote-oauth-bearer-token-path=<(gcloud auth application-default print-access-token | perl -p -e 'chomp if eof')
 #     --no-v1 --v2 test tests/python/pants_test/util:strutil
 #
-# Remoting does not work for every goal, so you should not permanently point to this ini file, e.g.
+# Remoting does not work for every goal, so you should not permanently point to this TOML file, e.g.
 # via an env var; only point to it when you want to remote a specific invocation.
 
 [GLOBAL]

--- a/src/docs/build_files.md
+++ b/src/docs/build_files.md
@@ -105,17 +105,19 @@ Tags are a set of strings used to describe or categorize targets. They can be in
 
 Tags can be configured for targets in three ways:
 - Directly in the `BUILD` file (`tags={'common'}` in the example above)
-- In `pants.ini`:
+- In `pants.toml`:
 
-```ini
+```toml
 [target-tag-assignments]
-tag_targets_mappings: {
-    'tag1': ['path/to/target:', 'path/to/another/target:bar'],
-    'tag2': ['path/to/another/target:bar']
-  }
+tag_targets_mappings = """
+{
+  'tag1': ['path/to/target:', 'path/to/another/target:bar'],
+  'tag2': ['path/to/another/target:bar']
+}
+"""
 ```
 
-- In a `JSON` file, [[referenced from the `pants.ini` or command line|pants('src/docs:options')]], for example:
+- In a `JSON` file, [[referenced from the `pants.toml` or command line|pants('src/docs:options')]], for example:
 
 ```bash
 ./pants list src/python/pants/base:exceptions --target-tag-assignments-tag-targets-mappings=@/path/to/target_tag_definitions.json

--- a/src/docs/common_tasks/login.md
+++ b/src/docs/common_tasks/login.md
@@ -33,13 +33,15 @@ bypass `.netrc` altogether.
 
 ## Required Configuration
 
-The named provider must be configured. E.g., in `pants.ini` you'd have:
+The named provider must be configured. E.g., in `pants.toml` you'd have:
 
-```ini
+```toml
 [basic_auth]
-providers = {
-    'myauthprovider': {
-      'url': 'https://myauthprovider.com/path/to/authentication/endpoint'
-    }
+providers = """
+{
+  'myauthprovider': {
+    'url': 'https://myauthprovider.com/path/to/authentication/endpoint'
   }
+}
+"""
 ```

--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -136,7 +136,7 @@ class method and call the passed-in `register` function:
 Option values are available via `self.get_options()`:
 
     :::python
-    # Did user pass in the --my-option CLI flag (or set it in pants.ini)?
+    # Did user pass in the --my-option CLI flag (or set it in pants.toml)?
     if self.get_options().my_option:
 
 ### Scopes
@@ -150,7 +150,7 @@ The scope is used to set options values. E.g., the value of `self.get_options().
 task with scope `scope` is set by, in this order:
   - The value of the cmd-line flag `--scope-my-option`.
   - The value of the environment variable `PANTS_SCOPE_MY_OPTION`.
-  - The value of the pants.ini var `my_option` in section `scope`.
+  - The value of the pants.toml var `my_option` in section `scope`.
 
 Note that if the task being run is specified explicitly on the command line, you can omit the
 scope from the cmd-line flag name. For example, instead of
@@ -167,7 +167,7 @@ will affect the behaviour of the registered option. The most common parameters a
   If not specified, the option will be a string.
 - `default`: Sets a default value that will be used if the option is not specified by the user.
 - `advanced`: Indicates that an option is intended either for use by power users, or for use in
-  only in pants.ini, rather than from the command-line. By default, advanced options are not displayed in `./pants help`.
+  only in pants.toml, rather than from the command-line. By default, advanced options are not displayed in `./pants help`.
 - `fingerprint`: Indicates that the value of the registered option affects the products
   of the task, such that changing the option would result in different products. When `True`,
   changing the option will cause targets built by the task to be invalidated and rebuilt.
@@ -219,7 +219,7 @@ shows some useful idioms for JVM tasks.
 -   Inherit `NailgunTask` to avoid starting up a new JVM.
 -   Specify the tool executable as a Pants `jar`; Pants knows how to
     download and run those.
--   Let organizations/users override the jar in `pants.ini`; it makes it
+-   Let organizations/users override the jar in `pants.toml`; it makes it
     easy to use/test a new version.
 
 Enabling Artifact Caching For Tasks

--- a/src/docs/dev_tasks_publish_extras.md
+++ b/src/docs/dev_tasks_publish_extras.md
@@ -9,32 +9,34 @@ that contains some metadata -- code coverage info, source git
 repository, java version that created the jar, etc. To accomplish this,
 you'll first need to write a custom task, which creates any additional
 files (jar or otherwise) that you would like to publish. Next, you'll
-create a `publish_extras` section under `[publish.jar]` in pants.ini,
+create a `publish_extras` section under `[publish.jar]` in pants.toml,
 and add a key for the new product type. Your custom task will create the
 extra file(s) that you want to publish, and write the path to the
-products map under the key that you have defined in pants.ini. The
-publishing code will loop over all keys found in pants.ini, and consult
+products map under the key that you have defined in pants.toml. The
+publishing code will loop over all keys found in pants.toml, and consult
 the product map. If pants finds a file for the current key, it will
 gather it up, and bundle it in with the rest of the files being
 published.
 
 An example of a custom task is supplied in the
 `examples/src/python/example/pants_publish_plugin` directory. To use it,
-add the following to your pants.ini:
+add the following to your pants.toml:
 
     [publish.jar]
-    publish_extras: {
-        'extra_test_jar_example': {
-          'override_name': '{target_provides_name}-extra_example',
-          'classifier': 'classy',
-          'extension': 'jar',
-        },
-      }
+    publish_extras = """
+    {
+      'extra_test_jar_example': {
+        'override_name': '{target_provides_name}-extra_example',
+        'classifier': 'classy',
+        'extension': 'jar',
+      },
+    }
+    """
 
     [GLOBAL]
-    backend_packages: [
-        'example.pants_publish_plugin',
-      ]
+    backend_packages = [
+      'example.pants_publish_plugin',
+    ]
 
 In the above configuration example, the string
 `'extra_test_jar_example'` is a key into the product map. In this case,
@@ -53,7 +55,7 @@ By default, pants uses the following scheme when publishing artifacts:
 The pants plugin publishing system allows a customization of the
 artifact identifier, classifier, and file extension. To customize the
 name of your extra object, you can supply some extra parameters in the
-`pants.ini` file:
+`pants.toml` file:
 
 +   `override_name` -- allows customization of the name (`artifactId`)
     of the additional file published. Specifying a string will
@@ -67,7 +69,7 @@ name of your extra object, you can supply some extra parameters in the
 
 **Note:** You must supply a non-default value for at least one of the
 above parameters, otherwise your extra publish artifact won't have a
-unique name. With the above config in your pants.ini, invoke pants like
+unique name. With the above config in your pants.toml, invoke pants like
 this, to do a test publish:
 
     :::bash

--- a/src/docs/first_tutorial.md
+++ b/src/docs/first_tutorial.md
@@ -209,20 +209,20 @@ If you want help diagnosing some strange Pants behavior, you might want verbose 
 To get this, instead of just invoking `./pants`, set some environment variables and request
 more logging: `PEX_VERBOSE=5 ./pants -ldebug`.
 
-### pants.ini
+### pants.toml
 
 Pants allows you to also specify options in a config file. If you want to always run pants
-with a particular option, you can configure it in a file at the root of the repo named `pants.ini`
+with a particular option, you can configure it in a file at the root of the repo named `pants.toml`
 
-    :::ini
+    :::toml
     [default]
-    jvm_options: ["-Xmx1g", "-Dfile.encoding=UTF8"]
+    jvm_options = ["-Xmx1g", "-Dfile.encoding=UTF8"]
 
     [test.junit]
-    fail-fast: True
+    fail-fast = true
 
-For more information on the `pants.ini` file format, see
-[[Invoking Pants|pants('src/docs:invoking')]].
+For more information on the `pants.toml` file format, see
+[[Options|pants('src/docs:options')]].
 
 BUILD Files
 -----------

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -11,13 +11,13 @@ These instructions assume you've already
 Running from sources
 --------------------
 
-As pants is implemented in python it can be run directly from sources.
+As Pants is implemented in Python it can be run directly from sources.
 
     :::bash
     $ ./pants goals
     <remainder of output omitted for brevity>
 
-If you want to run pants from sources, but in another repo to test changes before a release, you
+If you want to run Pants from sources, but in another repo to test changes before a release, you
 can run it like so:
 
     :::bash
@@ -37,13 +37,13 @@ also be run from pants sources. Explaining each environment variable:
 + `PANTS_PLUGINS`: This should always be as-shown, ie: an empty list.
 + `PANTS_PYTHONPATH`: This is a comma-separated list of PYTHONPATH elements. Note the plus symbol
   before the list - this indicates the given elements should be appended to the PYTHONPATH.
-  The values can be taken from the pants repo pants.ini. You'll need one path per plugin your other
+  The values can be taken from the Pants repo's `pants.toml`. You'll need one path per plugin your other
   repo uses.
 + `PANTS_BACKEND_PACKAGES`: This is a comma-separated list of plugin package names. Note the plus
   symbol before the list - this indicates the given elements should be appended to the PYTHONPATH.
-  These values can also be taken from the pants repo pants.ini. You'll need one package name per
+  These values can also be taken from the Pants repo's `pants.toml`. You'll need one package name per
   plugin your other repo uses.
-+ `PANTS_VERSION`: The version of pants required by the repo.
++ `PANTS_VERSION`: The version of Pants required by the repo.
 
 If your other repo uses plugins but you don't use this environment variable technique, or you do use
 it but miss one or more plugins, pants will still run, but the result can be confusing since the
@@ -95,16 +95,16 @@ You'll need to setup some files one-time in your own repo:
       ]
     )
 
-    $ cat pants-production.ini
+    $ cat pants-production.toml
     [python-repos]
     # You should replace these repos with your own housing pre-built eggs or wheels for the
     # platforms you support.
-    repos: [
-        "https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html",
-        "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
-      ]
+    repos = [
+      "https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html",
+      "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
+    ]
 
-    indexes: ["https://pypi.org/simple/"]
+    indexes = ["https://pypi.org/simple/"]
 
 To (re-)generate a `pants.pex` you then run these 2 commands:
 
@@ -116,7 +116,7 @@ To (re-)generate a `pants.pex` you then run these 2 commands:
 2. In your own repo the following command will create a locally built `pants.pex` for all platforms:
 
         :::bash
-        $ /tmp/pantsbuild/pants --pants-config-files=pants-production.ini clean-all binary //:pants
+        $ /tmp/pantsbuild/pants --pants-config-files=pants-production.toml clean-all binary //:pants
 
 The resulting `pants.pex` will be in the `dist/` directory:
 
@@ -301,20 +301,20 @@ dependency found on the local filesystem:
     )
 
 For debugging, append JVM args to turn on the debugger for the appropriate tool in
-`pants.ini`:
+`pants.toml`:
 
-    :::ini
+    :::toml
     [jar-tool]
-    jvm_options: ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
+    jvm_options = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"]
 
 Note that most tools run under nailgun by default. The easiest way to
 debug them is to disable nailgun by specifying the command line option
-`--execution-strategy=subprocess` or setting `execution_strategy: subprocess` in the specific tool
-section or in the `[DEFAULT]` section of `pants.ini`.
+`--execution-strategy=subprocess` or setting `execution_strategy = "subprocess"` in the specific tool
+section or in the `[DEFAULT]` section of `pants.toml`.
 
     :::ini
     [DEFAULT]
-    execution_strategy: subprocess
+    execution_strategy = "subprocess"
 
 ###JVM Tool Development Tips
 

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -312,7 +312,7 @@ debug them is to disable nailgun by specifying the command line option
 `--execution-strategy=subprocess` or setting `execution_strategy = "subprocess"` in the specific tool
 section or in the `[DEFAULT]` section of `pants.toml`.
 
-    :::ini
+    :::toml
     [DEFAULT]
     execution_strategy = "subprocess"
 

--- a/src/docs/howto_plugin.md
+++ b/src/docs/howto_plugin.md
@@ -25,7 +25,7 @@ This "Hello World" plugin example shows how to register a plugin with Pants. It 
 `hello-world` goal with two tasks. Here's how to create it:
 
 - If you don't have an existing Pants project to work with, create one. Locate its config file,
- typically `pants.ini` in the repo root.
+ typically `pants.toml` in the repo root.
 
 - Create a directory for your plugins. In this example we will use the `plugins/` directory in 
 the repo root, but there is no convention, and you can put them wherever you like.
@@ -74,13 +74,13 @@ the repo root, but there is no convention, and you can put them wherever you lik
  This creates a new goal named `hello-world`, and registers the two tasks to it.
 
 
-- In `pants.ini` place the following content:
+- In `pants.toml` place the following content:
   
-        :::ini
+        :::toml
         [GLOBAL]
-        pants_version: 1.9.0
-        pythonpath: ["%(buildroot)s/plugins"]
-        backend_packages: ["hello"]     
+        pants_version = "1.26.0"
+        pythonpath = ["%(buildroot)s/plugins"]
+        backend_packages = ["hello"]     
 
 `backend_packages` defines which plugins you want to use in your project.
 
@@ -111,23 +111,23 @@ Now you can use your plugin by typing `./pants hello-world`:
 Note that to consume the custom plugin as a published artifact (say on PyPI), instead of 
 directly from the repo, then instead of `backend_packages` and `pythonpath` you would set `plugins`:
 
-        :::ini
+        :::toml
         [GLOBAL]
-        pants_version: 1.9.0
-        plugins: ["myorg.hello==1.7.6"]
+        pants_version = "1.26.0"
+        plugins = ["myorg.hello==1.7.6"]
 
 Similarly, if your custom plugin is consumed directly from the repo, but has dependencies on 
 published artifacts, then you list those in `plugins`:
      
-        :::ini
+        :::toml
         [GLOBAL]
-        pants_version: 1.9.0
-        pythonpath: ["%(buildroot)s/plugins"]
-        backend_packages: ["hello"]
-        plugins: ["some.dependency==4.5.11"]
+        pants_version = "1.26.0"
+        pythonpath = ["%(buildroot)s/plugins"]
+        backend_packages = ["hello"]
+        plugins = ["some.dependency==4.5.11"]
 
 See below for more details. 
-  
+
      
 Simple Configuration
 --------------------
@@ -178,20 +178,16 @@ can consume it specifically but disregard regular `JvmBinary` instances (using `
           )
 
 
-- In `pants.ini`, add your new plugin package to the list of backends to load when pants starts.
+- In `pants.toml`, add your new plugin package to the list of backends to load when pants starts.
   This instructs pants to load a module named `hadoop.register`.
 
-        :::ini
+        :::toml
         [GLOBAL]
-        pythonpath: [
-            '%(buildroot)s/plugins',
-          ]
-        backend_packages: [
-            'hadoop',
-          ]
+        pythonpath = ['%(buildroot)s/plugins']
+        backend_packages = ['hadoop']
 
 Note that you can also set the PYTHONPATH in your `./pants` wrapper script, instead of in
-`pants.ini`, if you have other reasons to do so. Either way, pants will look for a `register.py`
+`pants.toml`, if you have other reasons to do so. Either way, pants will look for a `register.py`
 file for each backend package you list by prefixing that package with the python path; ie roughly
 `pythonpath + backend package + register.py` is tried for each pythonpath prefix until a
 `register.py` is found, in this example `plugins/hadoop/register.py`.
@@ -203,7 +199,7 @@ For an example of a code repo with plugins to add features to Pants when buildin
 take a look at [`twitter/commons`](https://github.com/twitter/commons), especially its
 [`pants-plugins` directory](https://github.com/twitter/commons/tree/32011ab5351fea23e8c70e24e752540b06d1389f/pants-plugins).
 
-The repo's [`pants.ini` file](https://github.com/twitter/commons/blob/32011ab5351fea23e8c70e24e752540b06d1389f/pants.ini) has a
+The repo's [`pants.ini` file](https://github.com/twitter/commons/blob/32011ab5351fea23e8c70e24e752540b06d1389f/pants.ini) (the format used before `pants.toml`) has a
 `backend_packages` entry listing the plugin packages (packages with `register.py` files):
 
     :::ini

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -28,29 +28,25 @@ To verify that Pants bootstraps correctly, run:
     :::bash
     ./pants --version
 
-Now, run this command to create an initial `pants.ini` config file:
+Now, run this command to create an initial `pants.toml` config file:
 
     :::bash
-    printf "[GLOBAL]\npants_version: $(./pants --version)\n" > pants.ini
+    printf "[GLOBAL]\npants_version = \"$(./pants --version)\"\n" > pants.toml
 
-This config pins the `pants_version`. When you'd like to upgrade Pants, edit the version in `pants.ini` and `./pants` will self-update on the next run.
+This config pins the `pants_version`. When you'd like to upgrade Pants, edit the version in `pants.toml` and `./pants` will self-update on the next run.
 
 To use Pants plugins published to PyPI, add them to a `plugins` list, like so:
 
-    :::ini
+    :::toml
     [GLOBAL]
-    pants_version: ...
+    pants_version = ...
 
     plugins: [
-        'pantsbuild.pants.contrib.go==%(pants_version)s',
-        'pantsbuild.pants.contrib.scrooge==%(pants_version)s',
-      ]
+      "pantsbuild.pants.contrib.go==%(pants_version)s",
+      "pantsbuild.pants.contrib.scrooge==%(pants_version)s",
+    ]
 
 Pants will notice you changed your plugins and will install them the next time you run `./pants`.
-
-Note that the formatting of the plugins list is important; all lines below the `plugins:` line must be
-indented by at least one white space to form logical continuation lines. This is standard for Python
-ini files. See [[Options|pants('src/docs:options')]] for a guide on modifying your `pants.ini`.
 
 The ./pants Runner Script
 -------------------------
@@ -69,10 +65,10 @@ PEX-based Installation
 The virtualenv-based method is the recommended way of installing Pants.
 However in cases where you can't depend on a local pants installation (e.g., your machines
 prohibit software installation), some sites fetch a pre-built executable `pants.pex` using
-the `pants_version` defined in `pants.ini`.  To upgrade pants, they generate a `pants.pex`
+the `pants_version` defined in `pants.toml`.  To upgrade pants, they generate a `pants.pex`
 and upload it to a file server at a location computable  from the version number.
 They then write their own `./pants` script that checks the `pants_version` in
-`pants.ini` and download the appropriate pex from the file server to the correct spot.
+`pants.toml` and download the appropriate pex from the file server to the correct spot.
 
 Troubleshooting
 ---------------

--- a/src/docs/internals.md
+++ b/src/docs/internals.md
@@ -53,7 +53,7 @@ Engine](https://groups.google.com/forum/#!topic/pants-devel/uHGpR2K6FBI)
 
 **Context**<br>
 An API to the state of the world. A Task uses this to find out things
-like the flags the user set on the command line, pants.ini config, and
+like the flags the user set on the command line, pants.toml config, and
 the state of the build cache. The task uses context.products to
 communicate results and requests for build results.
 

--- a/src/docs/invoking.md
+++ b/src/docs/invoking.md
@@ -134,7 +134,7 @@ As of `1.4.0`, there is one remaining set of caveats to using the daemon:
 
 ### Usage
 
-To enable the daemon, turn on the `--enable-pantsd` global option via CLI arg, environment variable, or `pants.ini` (see [[Options|pants('src/docs:options')]]).
+To enable the daemon, turn on the `--enable-pantsd` global option via CLI arg, environment variable, or `pants.toml` (see [[Options|pants('src/docs:options')]]).
 
 #### Killing the Daemon
 

--- a/src/docs/options.md
+++ b/src/docs/options.md
@@ -125,7 +125,7 @@ Removes take precedence over adds, so you cannot "add something back in":
 
 ### Dict Options
 
-Dict option values are Python-style dict literals: `--foo='{"a": 1,"b": 2}'`.
+Dict option values are Python-style dict literals embedded in a string, e.g: `--foo='{"a": 1,"b": 2}'`.
 
 In `pants.toml`, it often helps to use multiline strings for readability, e.g.:
 
@@ -318,4 +318,6 @@ When in doubt, the scope is described in the heading for each option in the help
 
 ### Validate the TOML
 
-Most editors will warn when you have invalid TOML. Another useful resource is the website [www.toml-lint.com](https://www.toml-lint.com).
+Most editors will warn when you have invalid TOML. For many editors, such as IntelliJ/Pycharm, you must first install a TOML plugin. 
+
+Pants will also provide a useful error message if it fails to parse the TOML file.

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -88,7 +88,7 @@ from master the release manager may also need to do a release from a stable bran
        _For example if you were releasing `1.2.0rc0` you would need to
        create `src/python/pants/notes/1.2.x.rst` and include all `1.2.0.devX` release notes._
      * Create a new page() in `src/python/pants/notes/BUILD` corresponding to the new notes.
-     * Add the file to pants.ini in the branch_notes section.
+     * Add the file to pants.toml in the branch_notes section.
      * Add the new notes file to `src/docs/docsite.json` in a few places.
      * Check that the new notes are visible on the docsite by previewing it using
        the [docs reference](http://www.pantsbuild.org/docs#generating-the-site) instructions.

--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -64,11 +64,11 @@ of targets in a special BUILD file named `BUILD.tools` in the repo root.
 
 Pants uses `Ivy` to fetch JVM-based tools.  Ivy requires an XML configuration file.
 By default, pants uses the configuration that ships with Ivy,
-but if you need to change Ivy settings you can specify your own in `pants.ini`:
+but if you need to change Ivy settings you can specify your own in `pants.toml`:
 
     [ivy]
-    ivy_settings: %(pants_supportdir)s/ivy/ivysettings.xml
-    cache_dir: ~/.ivy2/pants
+    ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
+    cache_dir = "~/.ivy2/pants"
 
 For more information on Ivy settings, see the [Ivy documentation](http://ant.apache.org/ivy/)
 
@@ -79,11 +79,11 @@ Build Cache
 -----------
 
 Pants automatically caches its work locally. But most organizations will want to set up a shared
-remote build cache. To do so, set `cache` options in `pants.ini`:
+remote build cache. To do so, set `cache` options in `pants.toml`:
 
     [cache]
-    read_from: ['https://myserver.co/pantscache']
-    write_to: ['https://myserver.co/pantscache']
+    read_from = ['https://myserver.co/pantscache']
+    write_to = ['https://myserver.co/pantscache']
 
 Note that the read and write cache locations are separate options: you may, for example, only want
 your CI machines, not individual developer builds, to populate the shared cache.
@@ -122,13 +122,11 @@ If you you work with a large engineering organization, you might want to
 gather this information in one place, so it can inform decisions about how
 to improve everybody's build times.
 
-To upload these stats to a server for future analysis set the following option in `pants.ini`:
+To upload these stats to a server for future analysis set the following option in `pants.toml`:
 
-    :::ini
+    :::toml
     [run-tracker]
-    stats_upload_urls: {
-      'http://myorg.org/pantsstats': 'authprovider'
-    }
+    stats_upload_urls = "{'http://myorg.org/pantsstats': 'authprovider'}"
 
 Pants will `POST` JSON data to each key URL.  The `authprovider` is the name of the provider the
 user must auth against in order to post to the corresponding URL.
@@ -198,11 +196,11 @@ export REQUESTS_CA_BUNDLE=/etc/certs/latest.pem
 
 Pants fetches the Ivy tool with an initial manual bootstrapping step using the Python requests library.
 If you do not want to use `HTTP_PROXY` or `HTTPS_PROXY` as described above, you can re-redirect
-this initial download to another URL with a setting in `pants.ini`:
+this initial download to another URL with a setting in `pants.toml`:
 
-    :::ini
+    :::toml
     [ivy]
-    bootstrap_jar_url: https://proxy.corp.example.com/content/groups/public/org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar
+    bootstrap_jar_url = "https://proxy.corp.example.com/content/groups/public/org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar"
 
 You may also encounter issues downloading this .jar file if you are using self-signed SSL certificates.
 See the section on Configuring the Python requests library above.
@@ -213,7 +211,7 @@ See the section on Configuring the Python requests library above.
 If your site uses Sonatype Nexus or another reverse proxy for
 artifacts, you do not need to use a separate HTTP proxy.  Contact the
 reverse proxy administrator to setup a proxy for the sites listed in
-`build-support/ivy/settings.xml` and `pants.ini`.  By default these
+`build-support/ivy/settings.xml` and `pants.toml`.  By default these
 are `https://repo1.maven.org/maven2/` and `https://dl.bintray.com/pantsbuild/maven/`:
 
 Here is an excerpt of a modified ivysettings.xml with some possible configurations:
@@ -239,30 +237,30 @@ For the binary support tools like protoc, you will need to setup a
 proxy for the `dl.bintray.com` repo, or create your own repo of build
 tools:
 
-    :::ini
+    :::toml
     binaries_baseurls = [
-        "https://nexus.example.com/content/repositories/dl.bintray.com/pantsbuild/bin/build-support"
-      ]
+      "https://nexus.example.com/content/repositories/dl.bintray.com/pantsbuild/bin/build-support",
+    ]
 
 ### Redirecting python requirements to other servers
 
-For python repos, you need to override the following settings in pants.ini:
+For Python repos, you need to override the following settings in `pants.toml`:
 
-    :::ini
+    :::toml
     [python-repos]
-    repos: [
-        "https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html",
-        "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
-      ]
+    repos = [
+      "https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html",
+      "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html",
+    ]
 
-    indexes: [
-        "https://pypi.org/simple/"
-      ]
+    indexes = [
+      "https://pypi.org/simple/",
+    ]
 
 You can also reference a local repo relative to your project's build root with this pattern:
 
-    :::ini
+    :::toml
     [python-repos]
-    repos: [
-        "%(buildroot)s/repo_path"
-      ]
+    repos = [
+      "%(buildroot)s/repo_path",
+    ]

--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -81,30 +81,30 @@ $ cat ./ivy-with-commons-httpclient.xml
 </ivy-module>
 ```
 
-Then, reference your modified ivy profile from pants.ini and flip on
+Then, reference your modified ivy profile from pants.toml and flip on
 some extra logging in the commons-httpclient by setting some system properties:
 
-```ini
+```toml
 [ivy]
-ivy_profile: ivy-with-commons-httpclient.xml
+ivy_profile = "ivy-with-commons-httpclient.xml"
 
 # Enable httpcommons debugging when bootstrapping tools
 [bootstrap.bootstrap-jvm-tools]
-jvm_options: [
-    "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog",
-    "-Dorg.apache.commons.logging.simplelog.showdatetime=true",
-    "-Dorg.apache.commons.logging.simplelog.log.httpclient.wire.header=debug",
-    "-Dorg.apache.commons.logging.simplelog.log.org.apache.commons.httpclient=debug",
-  ]
+jvm_options = [
+  "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog",
+  "-Dorg.apache.commons.logging.simplelog.showdatetime=true",
+  "-Dorg.apache.commons.logging.simplelog.log.httpclient.wire.header=debug",
+  "-Dorg.apache.commons.logging.simplelog.log.org.apache.commons.httpclient=debug",
+]
 
 # Enable httpcommons debugging when resolving 3rdparty libraries
 [resolve.ivy]
-jvm_options: [
-    "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog",
-    "-Dorg.apache.commons.logging.simplelog.showdatetime=true",
-    "-Dorg.apache.commons.logging.simplelog.log.httpclient.wire.header=debug",
-    "-Dorg.apache.commons.logging.simplelog.log.org.apache.commons.httpclient=debug",
-	]
+jvm_options = [
+  "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog",
+  "-Dorg.apache.commons.logging.simplelog.showdatetime=true",
+  "-Dorg.apache.commons.logging.simplelog.log.httpclient.wire.header=debug",
+  "-Dorg.apache.commons.logging.simplelog.log.org.apache.commons.httpclient=debug",
+]
 ```
 
 You'll be able to see the output in the pants reporting server output

--- a/src/python/pants/backend/docgen/tasks/templates/reference/pants_reference_body.html.mustache
+++ b/src/python/pants/backend/docgen/tasks/templates/reference/pants_reference_body.html.mustache
@@ -61,7 +61,7 @@
 <h2>Options and Scopes</h2>
 <p>
   Tasks and subsystems can be configured using <em>options</em>. Option values may be specified
-  using command line flags, environment variables or the <code>pants.ini</code> config file.
+  using command line flags, environment variables or the <code>pants.toml</code> config file.
 </p>
 <p>
   Pants has many tasks and subsystems, and therefore it has many options. For organizational
@@ -89,7 +89,7 @@
 </p>
 <ul>
   <li>
-    Set the value of key <code>foo</code> in section <code>bar.baz</code> in pants.ini:
+    Set the value of key <code>foo</code> in section <code>bar.baz</code> in pants.toml:
     <pre>
       [bar.baz]
       foo = 42</pre>

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -39,7 +39,7 @@ class JvmPlatform(Subsystem):
             if not platforms_by_name:
                 messages.append(
                     "In fact, no platforms are defined under {0}. These should typically be"
-                    " specified in [{0}] in pants.ini.".format(scope_name)
+                    " specified in [{0}] in pants.toml.".format(scope_name)
                 )
             else:
                 messages.append(
@@ -48,7 +48,7 @@ class JvmPlatform(Subsystem):
                     )
                 )
                 messages.append(
-                    "\nThese are typically defined under [{}] in pants.ini.".format(scope_name)
+                    "\nThese are typically defined under [{}] in pants.toml.".format(scope_name)
                 )
             super(JvmPlatform.UndefinedJvmPlatform, self).__init__(" ".join(messages))
 
@@ -148,7 +148,7 @@ class JvmPlatform(Subsystem):
         if name not in platforms_by_name:
             raise self.IllegalDefaultPlatform(
                 "The default platform was set to '{0}', but no platform by that name has been "
-                "defined. Typically, this should be defined under [{1}] in pants.ini.".format(
+                "defined. Typically, this should be defined under [{1}] in pants.toml.".format(
                     name, self.options_scope
                 )
             )
@@ -163,7 +163,7 @@ class JvmPlatform(Subsystem):
         if name not in platforms_by_name:
             raise self.IllegalDefaultPlatform(
                 "The default runtime platform was set to '{0}', but no platform by that name has been "
-                "defined. Typically, this should be defined under [{1}] in pants.ini.".format(
+                "defined. Typically, this should be defined under [{1}] in pants.toml.".format(
                     name, self.options_scope
                 )
             )

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -36,12 +36,12 @@ class JvmToolMixin:
                 raise ValueError(
                     dedent(
                         """\
-          JVM tool configuration now expects a single target address, use the
-          following in pants.ini:
+                        JVM tool configuration now expects a single target address, use the
+                        following in pants.toml:
 
-          [{scope}]
-          {key}: //tool/classpath:address
-          """.format(
+                        [{scope}]
+                        {key} = "//tool/classpath:address"
+                        """.format(
                             scope=self.scope, key=self.key
                         )
                     )

--- a/src/python/pants/backend/jvm/targets/credentials.py
+++ b/src/python/pants/backend/jvm/targets/credentials.py
@@ -13,7 +13,7 @@ from pants.util.netrc import Netrc
 class Credentials(Target, metaclass=ABCMeta):
     """Credentials for a maven repository.
 
-    The `publish.jar` section of your `pants.ini` file can refer to one or more of these.
+    The `publish.jar` section of your `pants.toml` file can refer to one or more of these.
     """
 
     @abstractmethod

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -165,12 +165,12 @@ class BootstrapJvmTools(IvyTaskMixin, CoursierMixin, JarTask):  # type: ignore[m
 
                                     This target has a default classpath configured, so you can simply remove:
                                       [{scope}]
-                                      {option}: {tool}
-                                    from pants.ini (or any other config file) to use the default tool.
+                                      {option} = "{tool}"
+                                    from pants.toml (or any other config file) to use the default tool.
 
                                     The default classpath is: {default_classpath}
 
-                                    Note that tool target addresses in pants.ini should be specified *without* quotes.
+                                    Note that tool target addresses in pants.toml should be specified *without* quotes.
                                     """
                                 )
                                 .strip()

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -42,7 +42,7 @@ class BundleCreate(BundleMixin, JvmBinaryTask):
             "the bundle's root dir. If unset, all jars will go into the bundle's libs "
             "directory, the root will only contain a synthetic jar with its manifest's "
             "Class-Path set to those jars. This option is also defined in jvm_app target. "
-            "Precedence is CLI option > target option > pants.ini option.",
+            "Precedence is CLI option > target option > pants.toml option.",
         )
 
     @classmethod

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -250,7 +250,7 @@ class JarPublish(HasTransitiveOptionMixin, ScmPublishMixin, JarTask):
     publish artifacts to Maven-style repositories. Pants performs prerequisite
     tasks like compiling, creating jars, and generating ``pom.xml`` files then
     invokes Ivy to actually publish the artifacts, so publishing is largely
-    configured in ``ivysettings.xml``. ``BUILD`` and ``pants.ini`` files
+    configured in ``ivysettings.xml``. ``BUILD`` and ``pants.toml`` files
     primarily provide linkage between publishable targets and the
     Ivy ``resolvers`` used to publish them.
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -455,7 +455,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         self._targets_to_compile_settings = None
 
         # TODO: self._jvm_options doesn't seem to record changes from `--<scope>-jvm-options` on the
-        # command line (but this might work in pants.ini?)!
+        # command line (but this might work in pants.toml?)!
         # JVM options for running the compiler.
         self._jvm_options = self.get_options().jvm_options
 

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -76,8 +76,8 @@ class Dependencies(ConsoleTask):
             hint_message="Currently, Pants defaults to `--dependencies-transitive`, which means that it "
             "will find all transitive dependencies for the target, rather than only direct "
             "dependencies. This is a useful feature, but surprising to be the default."
-            "\n\nTo prepare for this change to the default value, set in `pants.ini` under "
-            "the section `dependencies` the value `transitive: False`. In Pants 1.28.0, "
+            "\n\nTo prepare for this change to the default value, set in `pants.toml` under "
+            "the section `dependencies` the value `transitive = false`. In Pants 1.28.0, "
             "you can safely remove the setting.",
         )
         return self.get_options().transitive

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -42,8 +42,8 @@ class FileDeps(ConsoleTask):
             hint_message="Currently, Pants defaults to `--filedeps-transitive`, which means that it "
             "will find all transitive files used by the target, rather than only direct "
             "file dependencies. This is a useful feature, but surprising to be the default."
-            "\n\nTo prepare for this change to the default value, set in `pants.ini` under "
-            "the section `filedeps` the value `transitive: False`. In Pants 1.28.0, "
+            "\n\nTo prepare for this change to the default value, set in `pants.toml` under "
+            "the section `filedeps` the value `transitive = false`. In Pants 1.28.0, "
             "you can safely remove the setting.",
         )
         return self.get_options().transitive

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -182,7 +182,7 @@ class BinaryToolBase(Subsystem):
             type=dict,
             default={
                 # "Serialize" the default value dict into "basic" types that can be easily specified
-                # in pants.ini.
+                # in pants.toml.
                 platform_constraint.value: tool.into_tuple()
                 for platform_constraint, tool in cls.default_versions_and_digests.items()
             },

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -302,7 +302,7 @@ class BinaryUtil:
         pass
 
     class NoBaseUrlsError(TaskError):
-        """Indicates that no urls were specified in pants.ini."""
+        """Indicates that no URLs were specified in pants.toml."""
 
         pass
 

--- a/src/python/pants/build_graph/bundle_mixin.py
+++ b/src/python/pants/build_graph/bundle_mixin.py
@@ -23,7 +23,7 @@ class BundleMixin(TaskBase):
             fingerprint=True,
             help="Create an archive of this type from the bundle. "
             "This option is also defined in app target. "
-            "Precedence is CLI option > target option > pants.ini option.",
+            "Precedence is CLI option > target option > pants.toml option.",
         )
         # `target.id` ensures global uniqueness, this flag is provided primarily for
         # backward compatibility.
@@ -46,7 +46,7 @@ class BundleMixin(TaskBase):
     def resolved_option(options, target, key):
         """Get value for option "key".
 
-        Resolution precedence is CLI option > target option > pants.ini option.
+        Resolution precedence is CLI option > target option > pants.toml option.
 
         :param options: Options returned by `task.get_option()`
         :param target: Target

--- a/src/python/pants/build_graph/mirrored_target_option_mixin.py
+++ b/src/python/pants/build_graph/mirrored_target_option_mixin.py
@@ -47,7 +47,7 @@ class MirroredTargetOptionDeclaration:
         if target_setting is not None:
             return target_setting
 
-        # Otherwise, retrieve the value from the environment/pants.ini/hardcoded default.
+        # Otherwise, retrieve the value from the environment/pants.toml/hardcoded default.
         return self.option_value
 
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -29,7 +29,7 @@ from pants.source.source_root import SourceRootConfig
 class Context:
     """Contains the context for a single run of pants.
 
-    Task implementations can access configuration data from pants.ini and any flags they have exposed
+    Task implementations can access configuration data from pants.toml and any flags they have exposed
     here as well as information about the targets involved in the run.
 
     Advanced uses of the context include adding new targets to it for upstream or downstream goals to

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -118,7 +118,7 @@ class PluginResolver:
 
         # Ignore command line flags since we'd blow up on any we don't understand (most of them).
         # If someone wants to bootstrap plugins in a one-off custom way they'll need to use env vars
-        # or a --pants-config-files pointing to a custom pants.ini snippet.
+        # or a --pants-config-files pointing to a custom pants.toml snippet.
         defaulted_only_options = options.drop_flag_values()
 
         # Finally, construct the Subsystem.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -250,7 +250,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
             help="Use this pants version. Note Pants code only uses this to verify that you are "
             "using the requested version, as Pants cannot dynamically change the version it "
             "is using once the program is already running. This option is useful to set in "
-            "your pants.ini, however, and then you can grep the value to select which "
+            "your pants.toml, however, and then you can grep the value to select which "
             "version to use for setup scripts (e.g. `./pants`), runner scripts, IDE plugins, "
             "etc. For example, the setup script we distribute at https://www.pantsbuild.org/install.html#recommended-installation "
             "uses this value to determine which Python version to run with. You may find the "

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -33,7 +33,7 @@ class Options:
       - The value of the --foo-bar flag in global scope.
       - The value of the PANTS_GLOBAL_FOO_BAR environment variable.
       - The value of the PANTS_FOO_BAR environment variable.
-      - The value of the foo_bar key in the [GLOBAL] section of pants.ini.
+      - The value of the foo_bar key in the [GLOBAL] section of pants.toml.
       - The hard-coded value provided at registration time.
       - None.
 
@@ -46,9 +46,9 @@ class Options:
       - The value of the PANTS_COMPILE_FOO_BAR environment variable.
       - The value of the PANTS_GLOBAL_FOO_BAR environment variable.
       - The value of the PANTS_FOO_BAR environment variable.
-      - The value of the foo_bar key in the [compile.java] section of pants.ini.
-      - The value of the foo_bar key in the [compile] section of pants.ini.
-      - The value of the foo_bar key in the [GLOBAL] section of pants.ini.
+      - The value of the foo_bar key in the [compile.java] section of pants.toml.
+      - The value of the foo_bar key in the [compile] section of pants.toml.
+      - The value of the foo_bar key in the [GLOBAL] section of pants.toml.
       - The hard-coded value provided at registration time.
       - None.
 
@@ -58,9 +58,9 @@ class Options:
       - The value of the --foo-bar flag in scope 'compile'.
       - The value of the PANTS_COMPILE_JAVA_FOO_BAR environment variable.
       - The value of the PANTS_COMPILE_FOO_BAR environment variable.
-      - The value of the foo_bar key in the [compile.java] section of pants.ini.
-      - The value of the foo_bar key in the [compile] section of pants.ini.
-      - The value of the foo_bar key in the [GLOBAL] section of pants.ini
+      - The value of the foo_bar key in the [compile.java] section of pants.toml.
+      - The value of the foo_bar key in the [compile] section of pants.toml.
+      - The value of the foo_bar key in the [GLOBAL] section of pants.toml
         (because of automatic config file fallback to that section).
       - The hard-coded value provided at registration time.
       - None.

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -151,7 +151,7 @@ class OptionsBootstrapper:
         bootstrap_option_values = initial_bootstrap_options.for_global_scope()
 
         # Now re-read the config, post-bootstrapping. Note the order: First whatever we bootstrapped
-        # from (typically pants.ini), then config override, then rcfiles.
+        # from (typically pants.toml), then config override, then rcfiles.
         full_config_paths = pre_bootstrap_config.sources()
         if bootstrap_option_values.pantsrc:
             rcfiles = [

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -54,8 +54,8 @@ class ConsoleTask(QuietTaskMixin, Task):
                 "command line, rather than only the targets you specify. This is often useful, "
                 "such as running `./pants dependencies --transitive`, but it is surprising "
                 "to have this behavior by default.\n\nTo prepare for this change to the default "
-                f"value, set in `pants.ini` under the section `{self.options_scope}` the value "
-                "`transitive: False`. In Pants 1.27.0, you can safely remove the setting.",
+                f"value, set in `pants.toml` under the section `{self.options_scope}` the value "
+                "`transitive = false`. In Pants 1.27.0, you can safely remove the setting.",
             )
             return self.get_options().transitive
         # `Task` defaults to returning `True` in `act_transitively`, so we keep that default value.

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -420,8 +420,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
         """Runs pants in a subprocess.
 
         :param list command: A list of command line arguments coming after `./pants`.
-        :param config: Optional data for a generated ini file. A map of <section-name> ->
-        map of key -> value. If order in the ini file matters, this should be an OrderedDict.
+        :param config: Optional data for a generated TOML file. A map of <section-name> ->
+        map of key -> value.
         :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
         """
         with self.temporary_workdir() as workdir:
@@ -435,8 +435,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
         callers a chance to do any necessary validations on the workdir.
 
         :param list command: A list of command line arguments coming after `./pants`.
-        :param config: Optional data for a generated ini file. A map of <section-name> ->
-        map of key -> value. If order in the ini file matters, this should be an OrderedDict.
+        :param config: Optional data for a generated TOML file. A map of <section-name> ->
+        map of key -> value.
         :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
         :returns a PantsResult instance.
         """

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -97,7 +97,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
             current_root = get_buildroot()
         files_to_copy = set(files_to_copy)
         files_to_copy.update(
-            f for f in os.listdir(current_root) if f.endswith(".ini") or f.startswith("BUILD")
+            f for f in os.listdir(current_root) if f.endswith(".toml") or f.startswith("BUILD")
         )
         files_to_copy.update(
             (


### PR DESCRIPTION
As decided in https://github.com/pantsbuild/pants/pull/9052, TOML brings several benefits over INI config files (despite some weirdness around things like dict values).

This updates our docs to refer to `pants.toml`. A followup will deprecate `pants.ini`.