### PR TITLE
Add `OrderedSet` and `FrozenOrderedSet`

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -1,6 +1,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_tests(
+  name='tests',
+  dependencies=[
+    ':ordered_set',
+  ],
+  tags = {'type_checked'},
+)
+
 python_library(
   name = 'argutil',
   sources = ['argutil.py'],
@@ -98,6 +106,12 @@ python_library(
   name = 'objects',
   sources = ['objects.py'],
   tags = {'partially_type_checked'},
+)
+
+python_library(
+  name = 'ordered_set',
+  sources = ['ordered_set.py'],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -1,0 +1,368 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""An OrderedSet is a set that remembers its insertion order, and a FrozenOrderedSet is one that is
+also immutable.
+
+Based on the library `ordered-set` developed by Robyn Speer and released under the MIT license:
+https://github.com/LuminosoInsight/ordered-set.
+
+The library `ordered-set` is itself originally based on a recipe originally posted to ActivateState
+Recipes by Raymond Hettiger and released under the MIT license:
+http://code.activestate.com/recipes/576694/.
+"""
+
+import itertools
+from abc import ABC, abstractmethod
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    MutableSet,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+
+T = TypeVar("T")
+
+
+class _AbstractOrderedSet(ABC, AbstractSet[T], Sequence[T]):
+    """Common functionality shared between OrderedSet and FrozenOrderedSet."""
+
+    @abstractmethod
+    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
+        pass
+
+    @property
+    @abstractmethod
+    def _items(self) -> Sequence[T]:
+        """This stores the de-duplicated elements in order."""
+
+    @property
+    @abstractmethod
+    def _map(self) -> Dict[T, int]:
+        """This maps the elements to their index for O(1) time complexity with .index() and
+        __contains__()."""
+
+    def __len__(self) -> int:
+        """Returns the number of unique elements in the set."""
+        return len(self._items)
+
+    def copy(self) -> "_AbstractOrderedSet[T]":
+        """Return a shallow copy of this object."""
+        return self.__class__(self)
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "_AbstractOrderedSet[T]":
+        ...
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[T, "_AbstractOrderedSet[T]"]:  # noqa: F811
+        """Get the item at a given index.
+
+        If `index` is a slice, you will get back that slice of items, as a new OrderedSet.
+        """
+        if isinstance(index, slice):
+            return self.__class__(self._items[index])
+        return self._items[index]
+
+    def __contains__(self, key: Any) -> bool:
+        """Test if the item is in this ordered set."""
+        return key in self._map
+
+    def index(self, key: T, start: int = 0, stop: Optional[int] = None) -> int:
+        """Get the index of a given entry, raising a ValueError if it's not present."""
+        not_found_error = ValueError(f"{key} is not in {self.__class__.__name__}.")
+        try:
+            result = self._map[key]
+        except KeyError:
+            raise not_found_error
+        if result < start or (stop and result >= stop):
+            raise not_found_error
+        return result
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._items)
+
+    def __reversed__(self) -> Iterator[T]:
+        return reversed(self._items)
+
+    def __repr__(self) -> str:
+        name = self.__class__.__name__
+        if not self:
+            return f"{name}()"
+        return f"{name}({list(self)!r})"
+
+    def __eq__(self, other: Any) -> bool:
+        """Returns True if other is the same type with the same elements and same order."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._items == other._items
+
+    def union(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Combines all unique items.
+
+        Each item's order is defined by its first appearance.
+        """
+        merged_iterables = itertools.chain([self], others)
+        return self.__class__(itertools.chain.from_iterable(merged_iterables))
+
+    def __and__(self, other: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        # The parent class's implementation of this is backwards.
+        return self.intersection(other)
+
+    def intersection(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Returns elements in common between all sets.
+
+        Order is defined only by the first set.
+        """
+        cls = self.__class__
+        if not others:
+            return cls(self)
+        common = set.intersection(*(set(other) for other in others))
+        return cls(item for item in self if item in common)
+
+    def difference(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Returns all elements that are in this set but not the others."""
+        cls = self.__class__
+        if not others:
+            return cls(self)
+        other = set.union(*(set(other) for other in others))
+        return cls(item for item in self if item not in other)
+
+    def issubset(self, other: Iterable[T]) -> bool:
+        """Report whether another set contains this set."""
+        try:
+            # Fast check for obvious cases
+            if len(self) > len(other):  # type: ignore[arg-type]
+                return False
+        except AttributeError:
+            pass
+        return all(item in other for item in self)
+
+    def issuperset(self, other: Iterable[T]) -> bool:
+        """Report whether this set contains another set."""
+        try:
+            # Fast check for obvious cases
+            if len(self) < len(other):  # type: ignore[arg-type]
+                return False
+        except AttributeError:
+            pass
+        return all(item in self for item in other)
+
+    def symmetric_difference(self, other: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Return the symmetric difference of this OrderedSet and another set as a new OrderedSet.
+        That is, the new set will contain all elements that are in exactly one of the sets.
+
+        Their order will be preserved, with elements from `self` preceding elements from `other`.
+        """
+        cls = self.__class__
+        diff1 = cls(self).difference(other)
+        diff2 = cls(other).difference(self)
+        return diff1.union(diff2)
+
+
+class OrderedSet(_AbstractOrderedSet[T], MutableSet[T]):
+    """A mutable set that retains its order.
+
+    This is not safe to use with the V2 engine.
+    """
+
+    def __init__(self, iterable: Optional[Iterable[T]] = None):
+        self._items_buffer: List[T] = []
+        self._map_buffer: Dict[T, int] = {}
+        if iterable is not None:
+            # MyPy complains about our use of augmented assignment operators, mostly because
+            # AbstractClass expects the value to be another AbstractClass, even though we allow it
+            # to be any Iterable.
+            self |= iterable  # type: ignore[arg-type, misc]
+
+    @property
+    def _items(self) -> List[T]:
+        return self._items_buffer
+
+    @_items.setter
+    def _items(self, new_items: List[T]) -> None:
+        self._items_buffer = new_items
+
+    @property
+    def _map(self) -> Dict[T, int]:
+        return self._map_buffer
+
+    @_map.setter
+    def _map(self, new_map: Dict[T, int]) -> None:
+        self._map_buffer = new_map
+
+    def copy(self) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().copy())
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "OrderedSet[T]":
+        ...
+
+    def __getitem__(self, index: Union[int, slice]) -> Union[T, "OrderedSet[T]"]:  # noqa: F811
+        return cast(Union[T, OrderedSet[T]], super().__getitem__(index))
+
+    def union(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().union(*others))
+
+    def __and__(self, other: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().__and__(other))
+
+    def intersection(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().intersection(*others))
+
+    def difference(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().difference(*others))
+
+    def symmetric_difference(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().symmetric_difference(*others))
+
+    def add(self, key: T) -> None:
+        """Add `key` as an item to this OrderedSet."""
+        if key in self._map:
+            return
+        self._map[key] = len(self._items)
+        self._items.append(key)
+
+    append = add
+
+    def update(self, iterable: Iterable[T]) -> None:
+        """Update the set with the given iterable sequence."""
+        for item in iterable:
+            self.add(item)
+
+    extend = update
+
+    def pop(self) -> T:
+        """Remove and return the last element from the set.
+
+        Raises KeyError if the set is empty.
+        """
+        if not self._items:
+            raise KeyError("Set is empty")
+
+        elem = self._items[-1]
+        del self._items[-1]
+        del self._map[elem]
+        return elem
+
+    def discard(self, key: T) -> None:
+        """Remove an element.  Do not raise an exception if absent.
+
+        The MutableSet mixin uses this to implement the .remove() method, which
+        *does* raise an error when asked to remove a non-existent item.
+        """
+        if key not in self:
+            return
+        i = self._map[key]
+        del self._items[i]
+        del self._map[key]
+        for k, v in self._map.items():
+            if v >= i:
+                self._map[k] = v - 1
+
+    def clear(self) -> None:
+        """Remove all items from this OrderedSet."""
+        del self._items[:]
+        self._map.clear()
+
+    def _update_items(self, items: Iterable[T]) -> None:
+        """Replace the 'items' list of this OrderedSet with a new one, updating self.map
+        accordingly."""
+        self._items = list(items)
+        self._map = {v: i for i, v in enumerate(self._items)}
+
+    def difference_update(self, *others: Iterable[T]) -> None:
+        """Update this OrderedSet to remove items from one or more other sets."""
+        items_to_remove: Set[T] = set()
+        for other in others:
+            items_as_set = set(other)
+            items_to_remove |= items_as_set
+        self._update_items(item for item in self._items if item not in items_to_remove)
+
+    def intersection_update(self, other: Iterable[T]) -> None:
+        """Update this OrderedSet to keep only items in another set, preserving their order in this
+        set."""
+        other = set(other)
+        self._update_items(item for item in self._items if item in other)
+
+    def symmetric_difference_update(self, other: Iterable[T]) -> None:
+        """Update this OrderedSet to remove items from another set, then add items from the other
+        set that were not present in this set."""
+        items_to_add = [item for item in other if item not in self]
+        items_to_remove = cast(Set[T], set(other))
+        self._update_items(
+            [item for item in self._items if item not in items_to_remove] + items_to_add
+        )
+
+
+class FrozenOrderedSet(_AbstractOrderedSet[T]):
+    """A frozen (i.e. immutable) set that retains its order.
+
+    This is safe to use with the V2 engine.
+    """
+
+    def __init__(self, iterable: Optional[Iterable[T]] = None):
+        self._items_buffer = tuple(OrderedSet(iterable))
+        self._map_buffer = {v: i for i, v in enumerate(self._items)}
+
+    @property
+    def _items(self) -> Tuple[T, ...]:
+        return self._items_buffer
+
+    @property
+    def _map(self) -> Dict[T, int]:
+        return self._map_buffer
+
+    def copy(self) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().copy())
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "FrozenOrderedSet[T]":
+        ...
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[T, "FrozenOrderedSet[T]"]:  # noqa: F811
+        return cast(Union[T, FrozenOrderedSet[T]], super().__getitem__(index))
+
+    def union(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().union(*others))
+
+    def __and__(self, other: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().__and__(other))
+
+    def intersection(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().intersection(*others))
+
+    def difference(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().difference(*others))
+
+    def symmetric_difference(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().symmetric_difference(*others))
+
+    def __hash__(self) -> int:
+        return hash(self._items)

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -72,9 +72,9 @@ def test_find_index(cls: OrderedSetCls) -> None:
     with pytest.raises(ValueError):
         set1.index("a", start=1)
     with pytest.raises(ValueError):
-        set1.index("c", stop=2)
+        set1.index("c", end=2)
     with pytest.raises(ValueError):
-        set1.index("b", start=1, stop=1)
+        set1.index("b", start=1, end=1)
 
 
 @pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -1,0 +1,358 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import random
+from typing import AbstractSet, Iterator, Sequence, Tuple, Type, Union
+
+import pytest
+
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+
+OrderedSetInstance = Union[OrderedSet, FrozenOrderedSet]
+OrderedSetCls = Union[Type[OrderedSet], Type[FrozenOrderedSet]]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_stable_order(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert len(set1) == 5
+    assert list(set1) == ["a", "b", "r", "c", "d"]
+    assert list(reversed(set1)) == ["d", "c", "r", "b", "a"]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_contains(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert "a" in set1
+    assert "r" in set1
+    assert "z" not in set1
+    assert 0 not in set1
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_copy(cls: OrderedSetCls) -> None:
+    set1 = cls("abc")
+    set2 = set1.copy()
+    assert set1 == set2
+    assert set1 is set1
+    assert set2 is set2
+    assert set1 is not set2
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_get_by_index(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert set1[0] == "a"
+    assert set1[1] == "b"
+    assert set1[2] == "r"
+    assert set1[3] == "c"
+    assert set1[4] == "d"
+    with pytest.raises(IndexError):
+        set1[5]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_slices(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert set1[:] == set1
+    assert set1[:] is not set1
+    assert set1[1:3] == cls(["b", "r"])
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_find_index(cls: OrderedSetCls) -> None:
+    set1 = cls("abc")
+    assert set1.index("a") == 0
+    assert set1.index("b") == 1
+    assert set1.index("c") == 2
+
+    with pytest.raises(ValueError):
+        set1.index("z")
+    with pytest.raises(ValueError):
+        set1.index("a", start=1)
+    with pytest.raises(ValueError):
+        set1.index("c", stop=2)
+    with pytest.raises(ValueError):
+        set1.index("b", start=1, stop=1)
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_tuples(cls: OrderedSetCls) -> None:
+    tup = ("tuple", 1)
+    set1 = OrderedSet([tup])
+    assert set1.index(tup) == 0
+    assert set1[0] == tup
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_repr(cls: OrderedSetCls) -> None:
+    set1 = cls()
+    assert repr(set1) == f"{cls.__name__}()"
+
+    set2 = cls("abcabc")
+    assert repr(set2) == f"{cls.__name__}(['a', 'b', 'c'])"
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_equality(cls: OrderedSetCls) -> None:
+    set1 = cls([1, 2])
+
+    assert set1 == cls([1, 2])
+    assert set1 == cls([1, 1, 2, 2])
+
+    assert set1 != cls([2, 1])
+    assert set1 != [2, 1]
+    assert set1 != [2, 1, 1]
+
+    assert set1 != [1, 2]
+    assert set1 != (1, 2)
+    assert set1 != {1, 2}
+    assert set1 != {1: None, 2: None}
+
+    # We are strict in enforcing that FrozenOrderedSet != OrderedSet. This is important for the
+    # engine, where we should never use OrderedSet.
+    other_cls = FrozenOrderedSet if cls == OrderedSet else OrderedSet
+    assert set1 != other_cls([1, 2])
+
+
+def test_frozen_is_hashable() -> None:
+    set1 = FrozenOrderedSet("abcabc")
+    assert hash(set1) == hash(set1.copy())
+    assert hash(set1) == hash(("a", "b", "c"))
+
+    set2 = FrozenOrderedSet("abcd")
+    assert hash(set1) != hash(set2)
+    assert hash(set1) != hash(("a", "b", "c", "d"))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_binary_operations(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    set2 = cls("simsalabim")
+    assert set1 != set2
+
+    assert set1 & set2 == cls(["a", "b"])
+    assert set1 | set2 == cls(["a", "b", "r", "c", "d", "s", "i", "m", "l"])
+    assert set1 - set2 == cls(["r", "c", "d"])
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_comparisons(cls: OrderedSetCls) -> None:
+    # Comparison operators on sets actually test for subset and superset.
+    assert cls([1, 2]) < cls([1, 2, 3])
+    assert cls([1, 2]) > cls([1])
+
+
+def test_add() -> None:
+    set1: OrderedSet[str] = OrderedSet()
+
+    set1.add("a")
+    assert set1 == OrderedSet("a")
+
+    set1.add("b")
+    assert set1 == OrderedSet("ab")
+
+    set1.add("a")
+    assert set1 == OrderedSet("ab")
+
+
+def test_update() -> None:
+    set1 = OrderedSet("abcd")
+    set1.update("efgh")
+
+    assert len(set1) == 8
+    assert "".join(set1) == "abcdefgh"
+
+    set2 = OrderedSet("abcd")
+    set2.update("cdef")
+    assert len(set2) == 6
+    assert "".join(set2) == "abcdef"
+
+
+def test_remove() -> None:
+    set1 = OrderedSet("abracadabra")
+
+    set1.remove("a")
+    set1.remove("b")
+
+    assert set1 == OrderedSet("rcd")
+    assert set1[0] == "r"
+    assert set1[1] == "c"
+    assert set1[2] == "d"
+
+    assert set1.index("r") == 0
+    assert set1.index("c") == 1
+    assert set1.index("d") == 2
+
+    assert "a" not in set1
+    assert "b" not in set1
+    assert "r" in set1
+
+    # Make sure we can .discard() something that's already gone, plus something that was never
+    # there.
+    set1.discard("a")
+    set1.discard("a")
+
+    # If we .remove() an element that's not there, we get a KeyError.
+    with pytest.raises(KeyError):
+        set1.remove("z")
+
+
+def test_pop() -> None:
+    set1 = OrderedSet("ab")
+    elem = set1.pop()
+
+    assert elem == "b"
+    assert set1 == OrderedSet("a")
+    elem = set1.pop()
+
+    assert elem == "a"
+    assert set1 == OrderedSet()
+
+    with pytest.raises(KeyError):
+        set1.pop()
+
+
+def test_clear() -> None:
+    set1 = OrderedSet("abracadabra")
+    set1.clear()
+
+    assert len(set1) == 0
+    assert set1 == OrderedSet()
+
+
+def assert_results_are_the_same(
+    results: Union[Sequence[AbstractSet], Sequence[bool]],
+    *,
+    sets: Tuple[OrderedSetInstance, OrderedSetInstance],
+) -> None:
+    """Check that all results have the same value, but are different items."""
+    assert all(
+        result == results[0] for result in results
+    ), f"Not all results are the same.\nResults: {results}\nTest data: {sets}"
+    for a, b in itertools.combinations(results, r=2):
+        if isinstance(a, bool):
+            continue
+        assert a is not b, (
+            "The results should all be distinct OrderedSet or FrozenOrderedSet instances. "
+            f"{a} is the same object as {b}."
+        )
+
+
+def generate_testdata(
+    cls: OrderedSetCls,
+) -> Iterator[Tuple[OrderedSetInstance, OrderedSetInstance]]:
+    data1 = cls([5, 3, 1, 4])
+    data2 = cls([1, 4])
+    yield data1, data2
+
+    # First set is empty
+    data1 = cls([])
+    data2 = cls([3, 1, 2])
+    yield data1, data2
+
+    # Second set is empty
+    data1 = cls([3, 1, 2])
+    data2 = cls([])
+    yield data1, data2
+
+    # Both sets are empty
+    data1 = cls([])
+    data2 = cls([])
+    yield data1, data2
+
+    # Random test cases
+    rng = random.Random(0)
+    a, b = 20, 20
+    for _ in range(10):
+        data1 = cls(rng.randint(0, a) for _ in range(b))
+        data2 = cls(rng.randint(0, a) for _ in range(b))
+        yield data1, data2
+        yield data2, data1
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_intersection(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 & set2, set1.intersection(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.intersection_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 &= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_difference(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 - set2, set1.difference(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.difference_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 -= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_xor(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 ^ set2, set1.symmetric_difference(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.symmetric_difference_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 ^= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_union(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 | set2, set1.union(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 |= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_subset(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1 <= set2
+        result2 = set1.issubset(set2)
+        result3 = set(set1).issubset(set(set2))
+        assert_results_are_the_same([result1, result2, result3], sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_superset(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1 >= set2
+        result2 = set1.issuperset(set2)
+        result3 = set(set1).issuperset(set(set2))
+        assert_results_are_the_same([result1, result2, result3], sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_disjoint(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1.isdisjoint(set2)
+        result2 = len(set1.intersection(set2)) == 0
+        assert_results_are_the_same([result1, result2], sets=(set1, set2))


### PR DESCRIPTION
### Problem

We currently rely on Twitter Common's `OrderdedSet` implementation from https://github.com/twitter-archive/commons/blob/master/src/python/twitter/common/collections/orderedset.py.

This implementation has three problems:
1. Twitter Commons is now archived and will have no more updates.
1. `OrderedSet` does not work with type hints. It is impossible to say `OrderedSet[str]` and you can only say `OrderedSet`.
   * This makes our V2 code—which is type-driven—harder to work with.
1. There is no immutable implementation.
   * `OrderedSet()` is not hashable.
   * Mutability is dangerous with the engine. We must rely on programmer discipline to not break the caching scheme.

### Solution

Add `pants.util.ordered_set` with two classes `OrderedSet[T]` and `FrozenOrderedSet[T]`.

#### Rejected alternative: tweaking Twitter Commons

Twitter and the original recipe from Raymond Hettiger use a doubly-linked list. In contrast, the popular [`ordered-set` library](https://github.com/LuminosoInsight/ordered-set) uses both a list and dictionary. As described in their [README](https://github.com/LuminosoInsight/ordered-set#comparisons), using a list results in faster index lookups of O(1) rather than O(n); as a consequence, deletions go from O(1) to O(n) with this alternative approach. We don't expect to use deletions frequently, particularly with `FrozenOrderedSet` never allowing deletions, so we would rather optimize for index lookups.

The `ordered-set` library also provides a much more robust foundation to build off of, such as already having type hints. It's easier to port `ordered-set` than Twitter Commons to our uses.

#### Rejected alternative: using the `ordered-set` library.

Originally, the plan was to use the aforementioned [`ordered-set` library](https://github.com/LuminosoInsight/ordered-set) directly instead of Twitter commons. In fact, I even put up a PR to add `FrozenOrderedSet`: https://github.com/LuminosoInsight/ordered-set/pull/63.

However, I realized that the library fundamentally is not a good fit for Pants because it is more expansive than we'd like.

For example, they define `__eq__` such that `OrderedSet([1, 2]) == [1, 2]`. In contrast, the std lib sets `[1, 2] != (1, 2)`. They used this looser equality for NumPy and Pandas applications; here, we want the strictness that a `FrozenOrderedSet` will only ever equal another `FrozenOrderedSet` so that we can be confident the engine works correctly.

They make other affordances for scientific computing, like allowing indexing multiple elements with `OrderedSet(["a", "b", "c"])[0, 1]`, which we do not want to support.

--

Finally, we are able to make several simplifications to the implementation thanks to the fact that we don't care about <Python 3.6. Dictionaries are ordered in Python 3.6+, which we now use to handle deduplication. This allows us to have `OrderedSet` simply wrap `list` and `FrozenOrderedSet` simply wrap `tuple`, unlike `ordered-set` also storing both a `list` and `dict` in the data structure. 

Technically, `__contains__` is now `O(n)` rather than `O(1)`, which does slow the implementation of `OrderedSet.add()`. But, a benchmark showed that `__contains__` was only 0.0001 seconds slower for a list of 10_000 numbers, so the code simplifications and reduced space complexity (no longer storing a `dict`) seem like the right tradeoff.

#### Rejected alternative: fork

Pants does not want the maintenance overhead of maintaining a fork indefinitely. Nor does Pants want to rely on a fork maintained by a personal commiter like myself.

### Result

We now have a mutable `OrderedSet` that works with MyPy (and generally is more robust than Twitter Common's implementation), and we have a `FrozenOrderedSet` that we never had before.

In a followup PR, we will replace Twitter Commons with these new classes.