### PR TITLE
Set up infrastructure for generating coverage reports in V2 `./pants test`

### DIFF
--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -33,7 +33,12 @@ class Status(Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
 
+
 class CoverageData(ABC):
+    """Base class for inputs to a coverage report.
+
+    Subclasses should add whichever fields they require - snapshots of coverage output or xml files, etc.
+    """
     @property
     @abstractmethod
     def batch_cls(self) -> Type["CoverageDataBatch"]:

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -1,17 +1,21 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
 import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from pathlib import PurePath
+
+from typing import Optional, Type, Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import FilesystemLiteralSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin
 from pants.engine.console import Console
-from pants.engine.fs import Digest
+from pants.engine.fs import DirectoryToMaterialize, Workspace, Digest
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.isolated_process import FallibleExecuteProcessResult
@@ -29,15 +33,19 @@ class Status(Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
 
+class CoverageData(ABC):
+    @property
+    @abstractmethod
+    def batch_cls(self) -> Type["CoverageDataBatch"]:
+        pass
+
 
 @dataclass(frozen=True)
 class TestResult:
     status: Status
     stdout: str
     stderr: str
-    # TODO: We need a more generic way to handle coverage output across languages.
-    # See #8915 for proposed improvements.
-    _python_sqlite_coverage_file: Optional[Digest] = None
+    coverage_data: Optional[CoverageData] = None
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -45,12 +53,14 @@ class TestResult:
     @staticmethod
     def from_fallible_execute_process_result(
         process_result: FallibleExecuteProcessResult,
+        *,
+        coverage_data: Optional[CoverageData] = None,
     ) -> "TestResult":
         return TestResult(
             status=Status.SUCCESS if process_result.exit_code == 0 else Status.FAILURE,
             stdout=process_result.stdout.decode(),
             stderr=process_result.stderr.decode(),
-            _python_sqlite_coverage_file=process_result.output_directory_digest,
+            coverage_data=coverage_data,
         )
 
 
@@ -79,6 +89,7 @@ class TestTarget:
         return None
 
 
+
 @dataclass(frozen=True)
 class AddressAndTestResult:
     address: Address
@@ -103,13 +114,23 @@ class AddressAndDebugRequest:
     address: Address
     request: TestDebugRequest
 
+@union
+@dataclass(frozen=True)
+class CoverageDataBatch:
+    addresses_and_test_results: Tuple[AddressAndTestResult, ...]
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    result_digest: Digest
+    directory_to_materialize_to: PurePath
 
 class TestOptions(GoalSubsystem):
     """Runs tests."""
 
     name = "test"
 
-    required_union_implementations = (TestTarget,)
+    required_union_implementations = (TestTarget, CoverageDataBatch)
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -142,6 +163,7 @@ async def run_tests(
     options: TestOptions,
     runner: InteractiveRunner,
     addresses_with_origins: AddressesWithOrigins,
+    workspace: Workspace,
 ) -> Test:
     if options.values.debug:
         address_with_origin = addresses_with_origins.expect_single()
@@ -155,9 +177,35 @@ async def run_tests(
         Get[AddressAndTestResult](AddressWithOrigin, address_with_origin)
         for address_with_origin in addresses_with_origins
     )
+
+    if options.values.run_coverage:
+        results_with_coverage = [
+            x
+            for x in results
+            if x.test_result is not None and x.test_result.coverage_data is not None
+        ]
+        coverage_data_collections = itertools.groupby(
+            results_with_coverage,
+            lambda address_and_test_result: address_and_test_result.test_result.coverage_data.batch_cls,  # type: ignore[union-attr]
+        )
+
+        coverage_reports = await MultiGet(
+            Get[CoverageReport](
+                CoverageDataBatch, coverage_batch_cls(tuple(addresses_and_test_results))
+            )
+            for coverage_batch_cls, addresses_and_test_results in coverage_data_collections
+        )
+        for report in coverage_reports:
+            workspace.materialize_directory(
+                DirectoryToMaterialize(
+                    report.result_digest,
+                    path_prefix=report.directory_to_materialize_to.as_posix(),
+                )
+            )
+            console.print_stdout(f"Wrote coverage report to `{report.directory_to_materialize_to}`")
+
     did_any_fail = False
     filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
-
     for address, test_result in filtered_results:
         if test_result.status == Status.FAILURE:
             did_any_fail = True

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -5,11 +5,11 @@ import logging
 from textwrap import dedent
 from typing import Optional
 from unittest.mock import Mock
-
+from pathlib import PurePath
 from pants.base.specs import DescendantAddresses, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargetWithOrigin
 from pants.engine.legacy.structs import (
@@ -27,6 +27,8 @@ from pants.rules.core.test import (
     TestTarget,
     coordinator_of_tests,
     run_tests,
+    CoverageReport,
+    CoverageDataBatch,
 )
 from pants.source.wrapped_globs import EagerFilesetWithSpec
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
@@ -71,12 +73,13 @@ class TestTest(TestBase):
 
     def single_target_test(self, result, expected_console_output, success=True, debug=False):
         console = MockConsole(use_colors=False)
-        options = MockOptions(debug=debug)
+        options = MockOptions(debug=debug, run_coverage=False)
         runner = InteractiveRunner(self.scheduler)
+        workspace = Workspace(self.scheduler)
         addr = Address.parse("some/target")
         res = run_rule(
             run_tests,
-            rule_args=[console, options, runner, self.make_addresses_with_origins(addr)],
+            rule_args=[console, options, runner, self.make_addresses_with_origins(addr), workspace],
             mock_gets=[
                 MockGet(
                     product_type=AddressAndTestResult,
@@ -92,6 +95,14 @@ class TestTest(TestBase):
                             ipr=self.make_successful_ipr() if success else self.make_failure_ipr()
                         ),
                     ),
+                ),
+                MockGet(
+                    product_type=CoverageReport,
+                    subject_type=CoverageDataBatch,
+                    mock=lambda _: CoverageReport(
+                        result_digest=EMPTY_DIRECTORY_DIGEST,
+                        directory_to_materialize_to=PurePath('mockety/mock'),
+                    )
                 ),
             ],
         )
@@ -131,8 +142,9 @@ class TestTest(TestBase):
 
     def test_output_mixed(self) -> None:
         console = MockConsole(use_colors=False)
-        options = MockOptions(debug=False)
+        options = MockOptions(debug=False, run_coverage=False)
         runner = InteractiveRunner(self.scheduler)
+        workspace = Workspace(self.scheduler)
         address1 = Address.parse("testprojects/tests/python/pants/passes")
         address2 = Address.parse("testprojects/tests/python/pants/fails")
 
@@ -160,6 +172,7 @@ class TestTest(TestBase):
                 options,
                 runner,
                 self.make_addresses_with_origins(address1, address2),
+                workspace,
             ],
             mock_gets=[
                 MockGet(
@@ -171,6 +184,14 @@ class TestTest(TestBase):
                     product_type=AddressAndDebugRequest,
                     subject_type=AddressWithOrigin,
                     mock=make_debug_request,
+                ),
+                MockGet(
+                    product_type=CoverageReport,
+                    subject_type=CoverageDataBatch,
+                    mock=lambda _: CoverageReport(
+                        result_digest=EMPTY_DIRECTORY_DIGEST,
+                        directory_to_materialize_to=PurePath('mockety/mock')
+                    ),
                 ),
             ],
         )

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -2,14 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from pathlib import PurePath
 from textwrap import dedent
 from typing import Optional
 from unittest.mock import Mock
-from pathlib import PurePath
+
 from pants.base.specs import DescendantAddresses, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import AddressesWithOrigins, AddressWithOrigin
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, InputFilesContent, Snapshot, Workspace
+from pants.engine.fs import (
+    EMPTY_DIRECTORY_DIGEST,
+    Digest,
+    FileContent,
+    InputFilesContent,
+    Snapshot,
+    Workspace,
+)
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargetWithOrigin
 from pants.engine.legacy.structs import (
@@ -21,14 +29,14 @@ from pants.engine.rules import UnionMembership
 from pants.rules.core.test import (
     AddressAndDebugRequest,
     AddressAndTestResult,
+    CoverageDataBatch,
+    CoverageReport,
     Status,
     TestDebugRequest,
     TestResult,
     TestTarget,
     coordinator_of_tests,
     run_tests,
-    CoverageReport,
-    CoverageDataBatch,
 )
 from pants.source.wrapped_globs import EagerFilesetWithSpec
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
@@ -101,8 +109,8 @@ class TestTest(TestBase):
                     subject_type=CoverageDataBatch,
                     mock=lambda _: CoverageReport(
                         result_digest=EMPTY_DIRECTORY_DIGEST,
-                        directory_to_materialize_to=PurePath('mockety/mock'),
-                    )
+                        directory_to_materialize_to=PurePath("mockety/mock"),
+                    ),
                 ),
             ],
         )
@@ -190,7 +198,7 @@ class TestTest(TestBase):
                     subject_type=CoverageDataBatch,
                     mock=lambda _: CoverageReport(
                         result_digest=EMPTY_DIRECTORY_DIGEST,
-                        directory_to_materialize_to=PurePath('mockety/mock')
+                        directory_to_materialize_to=PurePath("mockety/mock"),
                     ),
                 ),
             ],


### PR DESCRIPTION
### Problem

in #8978 I added coverage support for pytest in V2 but discovered it induced a dep from the generic test runner to the python backend. This adds a generic CoverageReport to test.py and lays the groundwork for finishing the pytest coverage work without inducing the unwanted backend dependency.

Huge thanks to Stu and Eric for helping me figure this bit out! You guys are the best!