### PR TITLE
Add support for ipython

### DIFF
--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -103,6 +103,9 @@ class Subsystem(SubsystemClientMixin, Optionable):
         :API: public
 
         :returns: The global subsystem instance.
+
+        Note that `global_instance` is a v1-idiom only. v2 rules should always request a subsystem as a rule input, rather than
+        trying to call <subsystem>.global_instance() in the body of an `@rule`.
         """
         return cls._instance_for_scope(cls.options_scope)  # type: ignore[arg-type]  # MyPy is treating cls.options_scope as a Callable, rather than `str`
 

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -38,6 +38,7 @@ class GoalRuleTestBase(TestBase):
     def execute_rule(
         self,
         args: Optional[Iterable[str]] = None,
+        global_args: Optional[Iterable[str]] = None,
         env: Optional[Dict[str, str]] = None,
         exit_code: int = 0,
         additional_params: Optional[Iterable[Any]] = None,
@@ -50,7 +51,7 @@ class GoalRuleTestBase(TestBase):
         """
         # Create an OptionsBootstrapper for these args/env, and a captured Console instance.
         options_bootstrapper = create_options_bootstrapper(
-            args=(self.goal_cls.name, *(args or [])), env=env,
+            args=(*(global_args or []), self.goal_cls.name, *(args or [])), env=env,
         )
         BuildConfigInitializer.get(options_bootstrapper)
         full_options = options_bootstrapper.get_full_options(


### PR DESCRIPTION
This commit adds support for running an `ipython` repl rather than a `python` one. The repl to run is determined by a new option `--shell` registered on the `repl` goal.