### PR TITLE
Don't require V2 test implementations to have coverage support

### DIFF
--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -137,7 +137,7 @@ class TestOptions(GoalSubsystem):
 
     name = "test"
 
-    required_union_implementations = (TestTarget, CoverageDataBatch)
+    required_union_implementations = (TestTarget,)
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -186,6 +186,8 @@ async def run_tests(
     )
 
     if options.values.run_coverage:
+        # TODO: consider warning if a user uses `--coverage` but the language backend does not
+        # provide coverage support. This might be too chatty to be worth doing?
         results_with_coverage = [
             x
             for x in results


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/9170 required `CoverageDataBatch` to be implemented for the V2 `test` goal to work. Otherwise, it would gracefully no-op.

Because we don't yet have `pytest-cov` implemented in V2, this meant that `./v2 test` stopped working.

Generally, we probably don't want to require that test implementations have coverage support to work. Coverage support is an added bonus and it's meaningful to have a test runner even if it doesn't have coverage.