### PR TITLE
Add back `inject_init` rule

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,6 +6,7 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
     download_pex_bin,
+    inject_init,
     pex,
     pex_from_target_closure,
     prepare_chrooted_python_sources,
@@ -92,6 +93,7 @@ def register_goals():
 def rules():
     return (
         *download_pex_bin.rules(),
+        *inject_init.rules(),
         *prepare_chrooted_python_sources.rules(),
         *pex.rules(),
         *pex_from_target_closure.rules(),

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent, Snapshot
+from pants.engine.rules import RootRule, rule
+from pants.engine.selectors import Get
+from pants.python.pex_build_util import identify_missing_init_files
+
+
+# NB: Needed due to graph ambiguity.
+@dataclass(frozen=True)
+class InjectInitRequest:
+    snapshot: Snapshot
+
+
+@dataclass(frozen=True)
+class InitInjectedSnapshot:
+    snapshot: Snapshot
+
+
+@rule
+async def inject_missing_init_files(request: InjectInitRequest) -> InitInjectedSnapshot:
+    """Ensure that every package has an `__init__.py` file in it.
+
+    This will preserve any `__init__.py` files already in the input snapshot.
+    """
+    snapshot = request.snapshot
+    missing_init_files = sorted(identify_missing_init_files(snapshot.files))
+    if not missing_init_files:
+        return InitInjectedSnapshot(snapshot)
+    generated_inits_digest = await Get[Digest](
+        InputFilesContent(FileContent(path=fp, content=b"") for fp in missing_init_files)
+    )
+    result = await Get[Snapshot](
+        DirectoriesToMerge((snapshot.directory_digest, generated_inits_digest))
+    )
+    return InitInjectedSnapshot(result)
+
+
+def rules():
+    return [inject_missing_init_files, RootRule(InjectInitRequest)]

--- a/src/python/pants/backend/python/rules/inject_init_test.py
+++ b/src/python/pants/backend/python/rules/inject_init_test.py
@@ -1,0 +1,74 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+from pants.backend.python.rules.inject_init import (
+    InitInjectedSnapshot,
+    InjectInitRequest,
+    inject_missing_init_files,
+)
+from pants.engine.fs import Digest, FilesContent
+from pants.engine.rules import RootRule
+from pants.testutil.test_base import TestBase
+
+
+class InjectInitTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            inject_missing_init_files,
+            RootRule(InjectInitRequest),
+            RootRule(Digest),
+        )
+
+    def assert_injected(self, *, original_files: List[str], expected_added: List[str]) -> None:
+        request = InjectInitRequest(
+            self.make_snapshot({fp: "# python code" for fp in original_files})
+        )
+        result = self.request_single_product(InitInjectedSnapshot, request).snapshot
+        assert sorted(result.files) == sorted([*original_files, *expected_added])
+        # Ensure all original `__init__.py` are preserved with their original content.
+        materialized_original_inits = [
+            fc
+            for fc in self.request_single_product(FilesContent, result.directory_digest)
+            if fc.path in original_files and fc.path.endswith("__init__.py")
+        ]
+        for original_init in materialized_original_inits:
+            assert (
+                original_init.content == b"# python code"
+            ), f"{original_init} does not have its original content preserved."
+
+    def test_no_inits_present(self) -> None:
+        self.assert_injected(
+            original_files=["lib.py", "subdir/lib.py"], expected_added=["subdir/__init__.py"],
+        )
+        self.assert_injected(
+            original_files=["src/python/lib.py", "src/python/subdir/lib.py"],
+            expected_added=[
+                "src/__init__.py",
+                "src/python/__init__.py",
+                "src/python/subdir/__init__.py",
+            ],
+        )
+
+    def test_preserves_original_inits(self) -> None:
+        self.assert_injected(
+            original_files=["lib.py", "__init__.py", "subdir/lib.py"],
+            expected_added=["subdir/__init__.py"],
+        )
+        self.assert_injected(
+            original_files=[
+                "src/python/lib.py",
+                "src/python/__init__.py",
+                "src/python/subdir/lib.py",
+                "src/python/subdir/__init__.py",
+            ],
+            expected_added=["src/__init__.py"],
+        )
+        # No missing `__init__.py` files
+        self.assert_injected(
+            original_files=["lib.py", "__init__.py", "subdir/lib.py", "subdir/__init__.py"],
+            expected_added=[],
+        )

--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources_test.py
@@ -5,9 +5,9 @@ from pathlib import PurePath
 from typing import List, Optional
 from unittest.mock import Mock
 
+from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.backend.python.rules.prepare_chrooted_python_sources import (
-    ChrootedPythonSources,
-    prepare_chrooted_python_sources,
+    rules as prepare_chrooted_python_sources_rules,
 )
 from pants.build_graph.address import Address
 from pants.build_graph.files import Files
@@ -25,7 +25,7 @@ class PrepareChrootedPythonSourcesTest(TestBase):
         return (
             *super().rules(),
             *strip_source_roots.rules(),
-            prepare_chrooted_python_sources,
+            *prepare_chrooted_python_sources_rules(),
             RootRule(HydratedTargets),
         )
 


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/9115 inlined `inject_init.py` into `prepare_chrooted_python_sources.py` because it was the only call site at the time.

Turns out, V2 coverage has a use case for `inject_init`.

This makes several enhancements over the original `inject_init` implementation:

* Uses `InputFilesContent` instead of `ExecuteProcessRequest`
* The result merges the original with new `__init__.py`s, rather than returning only the newly added `__init__.py`s.
* Returns a `Snapshot`, rather than `Digest`, which is more ergonomic.
* More comprehensive tests, e.g. ensuring we aren't overriding the original `__init__.py`.