### PR TITLE
add back 'ignore' for --files-not-found-behavior

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -212,9 +212,13 @@ def deprecated_conditional(
     """
     validate_deprecation_semver(removal_version, "removal version")
     if predicate():
-        warn_or_error(removal_version, entity_description, hint_message,
-                      deprecation_start_version=deprecation_start_version,
-                      stacklevel=stacklevel)
+        warn_or_error(
+            removal_version,
+            entity_description,
+            hint_message,
+            deprecation_start_version=deprecation_start_version,
+            stacklevel=stacklevel,
+        )
 
 
 def deprecated(

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -195,6 +195,7 @@ def deprecated_conditional(
     removal_version: str,
     entity_description: str,
     hint_message: Optional[str] = None,
+    deprecation_start_version: Optional[str] = None,
     stacklevel: int = 4,
 ) -> None:
     """Marks a certain configuration as deprecated.
@@ -211,7 +212,9 @@ def deprecated_conditional(
     """
     validate_deprecation_semver(removal_version, "removal version")
     if predicate():
-        warn_or_error(removal_version, entity_description, hint_message, stacklevel=stacklevel)
+        warn_or_error(removal_version, entity_description, hint_message,
+                      deprecation_start_version=deprecation_start_version,
+                      stacklevel=stacklevel)
 
 
 def deprecated(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -88,14 +88,21 @@ class PathGlobs:
         self.__post_init__()
 
     def __post_init__(self) -> None:
-        if (
-            not self.description_of_origin
-            and self.glob_match_error_behavior != GlobMatchErrorBehavior.ignore
-        ):
-            raise ValueError(
-                "Please provide a `description_of_origin` so that the error message is more "
-                "helpful to users when their globs fail to match."
-            )
+        if self.glob_match_error_behavior == GlobMatchErrorBehavior.ignore:
+            if self.description_of_origin:
+                raise ValueError(
+                    "You provided a `description_of_origin` value when `glob_match_error_behavior` is set to "
+                    "`ignore`. The `ignore` value means that the engine will never generate an error when "
+                    "the globs are generated, so `description_of_origin` won't end up ever being used. "
+                    "Please either change `glob_match_error_behavior` to `warn` or `error`, or remove "
+                    "`description_of_origin`."
+                )
+        else:
+            if not self.description_of_origin:
+                raise ValueError(
+                    "Please provide a `description_of_origin` so that the error message is more helpful to "
+                    "users when their globs fail to match."
+                )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -55,8 +55,8 @@ class PathGlobs:
 
     The syntax supported is roughly Git's glob syntax.
 
-    NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
-    be aware of any changes to this object's definition.
+    NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need
+    to be aware of any changes to this object's definition.
     """
 
     globs: Tuple[str, ...]
@@ -76,9 +76,9 @@ class PathGlobs:
                       with `!`, e.g. `!ignore.py`.
         :param glob_match_error_behavior: whether to warn or error upon match failures
         :param conjunction: whether all `include`s must match or only at least one must match
-        :param description_of_origin: a human-friendly description of where this PathGlobs request is
-                                      coming from, used to improve the error message for unmatched
-                                      globs. For example, this might be
+        :param description_of_origin: a human-friendly description of where this PathGlobs request
+                                      is coming from, used to improve the error message for
+                                      unmatched globs. For example, this might be the text string
                                       "the option `--isort-config`".
         """
         self.globs = tuple(globs)
@@ -88,21 +88,14 @@ class PathGlobs:
         self.__post_init__()
 
     def __post_init__(self) -> None:
-        if self.glob_match_error_behavior == GlobMatchErrorBehavior.ignore:
-            if self.description_of_origin:
-                raise ValueError(
-                    "You provided a `description_of_origin` value when `glob_match_error_behavior` is set to "
-                    "`ignore`. The `ignore` value means that the engine will never generate an error when "
-                    "the globs are generated, so `description_of_origin` won't end up ever being used. "
-                    "Please either change `glob_match_error_behavior` to `warn` or `error`, or remove "
-                    "`description_of_origin`."
-                )
-        else:
-            if not self.description_of_origin:
-                raise ValueError(
-                    "Please provide a `description_of_origin` so that the error message is more helpful to "
-                    "users when their globs fail to match."
-                )
+        if (
+            not self.description_of_origin
+            and self.glob_match_error_behavior != GlobMatchErrorBehavior.ignore
+        ):
+            raise ValueError(
+                "Please provide a `description_of_origin` so that the error message is more "
+                "helpful to users when their globs fail to match."
+            )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -718,7 +718,11 @@ async def hydrate_sources(
         glob_match_error_behavior=glob_match_error_behavior,
         # TODO(#9012): add line number referring to the sources field. When doing this, we'll likely
         # need to `await Get[BuildFileAddress](Address)`.
-        description_of_origin=f"{address}'s `{sources_field.arg}` field",
+        description_of_origin=(
+            f"{address}'s `{sources_field.arg}` field"
+            if glob_match_error_behavior != GlobMatchErrorBehavior.ignore
+            else None
+        ),
     )
     snapshot = await Get[Snapshot](PathGlobs, path_globs)
     fileset_with_spec = _eager_fileset_with_spec(
@@ -741,7 +745,11 @@ async def hydrate_bundles(
             glob_match_error_behavior=glob_match_error_behavior,
             # TODO(#9012): add line number referring to the bundles field. When doing this, we'll likely
             # need to `await Get[BuildFileAddress](Address)`.
-            description_of_origin=f"{address}'s `bundles` field",
+            description_of_origin=(
+                f"{address}'s `bundles` field"
+                if glob_match_error_behavior != GlobMatchErrorBehavior.ignore
+                else None
+            ),
         )
         for pg in bundles_field.path_globs_list
     ]

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -15,6 +15,7 @@ from pants.base.build_environment import (
     get_pants_configdir,
     pants_version,
 )
+from pants.base.deprecated import deprecated_conditional
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
 from pants.option.option_value_container import OptionValueContainer
@@ -51,6 +52,16 @@ class FileNotFoundBehavior(Enum):
     error = "error"
 
     def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
+        deprecated_conditional(
+            lambda: self == self.ignore,
+            removal_version='1.28.0.dev2',
+            entity_description='--files-not-found-behavior-option=ignore',
+            hint_message="If you currently set `--files-not-found-behavior=ignore`, you will "
+            "need to instead either set `--files-not-found-behavior=warn` (the "
+            "default) or `--files-not-found-behavior=error`. Ignoring when files are "
+            "not found often results in subtle bugs, so we are removing the option.",
+            deprecation_start_version='1.27.0.dev2',
+        )
         return GlobMatchErrorBehavior(self.value)
 
 
@@ -491,11 +502,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
             default=GlobMatchErrorBehavior.warn,
             removal_version="1.27.0.dev0",
             removal_hint="If you currently set `--glob-expansion-failure=error`, instead set "
-            "`--files-not-found-behavior=error`.\n\n"
-            "If you currently set `--glob-expansion-failure=ignore`, you will "
-            "need to instead either set `--files-not-found-behavior=warn` (the "
-            "default) or `--files-not-found-behavior=error`. Ignoring when files are "
-            "not found often results in subtle bugs, so we are removing the option.",
+            "`--files-not-found-behavior=error`.",
             help="What to do when files and globs specified in BUILD files, such as in the "
             "`sources` field, cannot be found. This happens when the files do not exist on "
             "your machine or when they are ignored by the `--pants-ignore` option.",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -53,14 +53,16 @@ class FileNotFoundBehavior(Enum):
 
     def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
         deprecated_conditional(
-            lambda: self == self.ignore,
-            removal_version='1.28.0.dev2',
-            entity_description='--files-not-found-behavior-option=ignore',
-            hint_message="If you currently set `--files-not-found-behavior=ignore`, you will "
-            "need to instead either set `--files-not-found-behavior=warn` (the "
-            "default) or `--files-not-found-behavior=error`. Ignoring when files are "
-            "not found often results in subtle bugs, so we are removing the option.",
-            deprecation_start_version='1.27.0.dev2',
+            lambda: self == type(self).ignore,
+            removal_version="1.29.0.dev2",
+            entity_description="--files-not-found-behavior-option=ignore",
+            hint_message=(
+                "If you currently set `--files-not-found-behavior=ignore`, you will "
+                "need to instead either set `--files-not-found-behavior=warn` (the "
+                "default) or `--files-not-found-behavior=error`. Ignoring when files are "
+                "not found often results in subtle bugs, so we are removing the option."
+            ),
+            deprecation_start_version="1.27.0.dev0",
         )
         return GlobMatchErrorBehavior(self.value)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -46,6 +46,7 @@ class GlobMatchErrorBehavior(Enum):
 class FileNotFoundBehavior(Enum):
     """What to do when globs do not match in BUILD files."""
 
+    ignore = "ignore"
     warn = "warn"
     error = "error"
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -405,9 +405,12 @@ pub enum StrictGlobMatching {
 impl StrictGlobMatching {
   pub fn create(behavior: &str, description_of_origin: Option<String>) -> Result<Self, String> {
     match (behavior, description_of_origin) {
-      ("ignore", _) => Ok(StrictGlobMatching::Ignore),
+      ("ignore", None) => Ok(StrictGlobMatching::Ignore),
       ("warn", Some(origin)) => Ok(StrictGlobMatching::Warn(origin)),
       ("error", Some(origin)) => Ok(StrictGlobMatching::Error(origin)),
+      ("ignore", Some(_)) => {
+        Err("Provided description_of_origin while ignoring glob match errors".to_string())
+      }
       ("warn", None) | ("error", None) => Err(
         "Must provide a description_of_origin when warning or erroring on glob match errors"
           .to_string(),

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -405,12 +405,9 @@ pub enum StrictGlobMatching {
 impl StrictGlobMatching {
   pub fn create(behavior: &str, description_of_origin: Option<String>) -> Result<Self, String> {
     match (behavior, description_of_origin) {
-      ("ignore", None) => Ok(StrictGlobMatching::Ignore),
+      ("ignore", _) => Ok(StrictGlobMatching::Ignore),
       ("warn", Some(origin)) => Ok(StrictGlobMatching::Warn(origin)),
       ("error", Some(origin)) => Ok(StrictGlobMatching::Error(origin)),
-      ("ignore", Some(_)) => {
-        Err("Provided description_of_origin while ignoring glob match errors".to_string())
-      }
       ("warn", None) | ("error", None) => Err(
         "Must provide a description_of_origin when warning or erroring on glob match errors"
           .to_string(),


### PR DESCRIPTION
### Problem

The globs fixing script doesn't fix all usages in our repo and the decision to remove this option value in #9022 doesn't appear to have been motivated for any particular reason.

### Solution

- Add back the `'ignore'` case to `--files-not-found-behavior`, which is converted into a `GlobMatchErrorBehavior` before being injected into the v2 rule graph as a singleton.