### PR TITLE
Refactor `strip_source_roots` to use `TargetAdaptor` rather than `HydratedTarget`

### DIFF
--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
 from pants.engine.fs import DirectoriesToMerge, Snapshot
-from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
+from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripTargetRequest
 
 
 @dataclass(frozen=True)
@@ -29,7 +29,7 @@ async def prepare_chrooted_python_sources(
     stripping source roots.
     """
     source_root_stripped_sources = await MultiGet(
-        Get[SourceRootStrippedSources](HydratedTarget, hydrated_target)
+        Get[SourceRootStrippedSources](StripTargetRequest(hydrated_target.adaptor))
         for hydrated_target in hydrated_targets
     )
     sources_snapshot = await Get[Snapshot](

--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources_test.py
@@ -39,6 +39,7 @@ class PrepareChrootedPythonSourcesTest(TestBase):
         address = Address(
             spec_path=PurePath(source_paths[0]).parent.as_posix(), target_name="target"
         )
+        adaptor.address = address
         return HydratedTarget(address=address, adaptor=adaptor, dependencies=())
 
     def test_adds_missing_inits_and_strips_source_roots(self) -> None:

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -4,29 +4,29 @@
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
-from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripTargetRequest
 
 
 @rule
 async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> CreatedBinary:
     # TODO(#8420) This way of calculating the entry point works but is a bit hackish.
-    entry_point = None
     if hasattr(python_binary_adaptor, "entry_point"):
         entry_point = python_binary_adaptor.entry_point
     else:
         sources_snapshot = python_binary_adaptor.sources.snapshot
-        if len(sources_snapshot.files) == 1:
-            target = await Get[HydratedTarget](Address, python_binary_adaptor.address)
-            output = await Get[SourceRootStrippedSources](HydratedTarget, target)
-            root_filename = output.snapshot.files[0]
-            entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
+        # NB: A `python_binary` may have either 0 or 1 source files. This is validated by
+        # `PythonBinaryAdaptor`.
+        if not sources_snapshot.files:
+            entry_point = None
+        else:
+            output = await Get[SourceRootStrippedSources](StripTargetRequest(python_binary_adaptor))
+            module_name = output.snapshot.files[0]
+            entry_point = PythonBinary.translate_source_path_to_py_module_specifier(module_name)
 
     request = CreatePexFromTargetClosure(
         addresses=Addresses((python_binary_adaptor.address,)),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -55,7 +55,7 @@ from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.distdir import DistDir
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripTargetRequest
 from pants.source.source_root import SourceRootConfig
 
 logger = logging.getLogger(__name__)
@@ -446,7 +446,7 @@ async def get_sources(
 ) -> SetupPySources:
     targets = request.hydrated_targets
     stripped_srcs_list = await MultiGet(
-        Get[SourceRootStrippedSources](HydratedTarget, target) for target in targets
+        Get[SourceRootStrippedSources](StripTargetRequest(target.adaptor)) for target in targets
     )
 
     # Create a chroot with all the sources, and any ancestor __init__.py files that might be needed

--- a/src/python/pants/rules/core/find_target_source_files.py
+++ b/src/python/pants/rules/core/find_target_source_files.py
@@ -9,7 +9,7 @@ from pants.engine.fs import PathGlobs, Snapshot, SnapshotSubset
 from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSourceRootsRequest
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
 
 
 @dataclass(frozen=True)
@@ -45,7 +45,7 @@ async def find_target_source_files(request: FindTargetSourceFilesRequest) -> Tar
     if not request.strip_source_roots:
         return TargetSourceFiles(resulting_snapshot)
     stripped = await Get[SourceRootStrippedSources](
-        StripSourceRootsRequest(
+        StripSnapshotRequest(
             resulting_snapshot,
             # TODO: simply pass `address.spec_path` once `--source-unmatched` is removed.
             representative_path=PurePath(adaptor.address.spec_path, "BUILD").as_posix(),


### PR DESCRIPTION
### Problem

The rule `strip_source_roots_from_target` currently expects a `HydratedTarget`, but it doesn't actually need that much information/hydration. All it needs is the underlying `TargetAdaptor`.

Requiring `HydratedTarget` makes the API less ergonomic than possible as it requires call-sites that have a `TargetAdaptor` to first `await Get[HydratedTarget](Address, adaptor.address)` (which also has a performance hit).

This is getting in the way of generalizing the `determine_source_files` rules.

### Solution

Add `StripTargetRequest` to complement `StripSnapshotRequest`.