### PR TITLE
Only targets in build context can end up as target roots.

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/BUILD
@@ -11,6 +11,7 @@ target(
     ':scalac_directory',
     ':several_scala_targets_directory',
     ':styleissue_directory',
+    ':multiple_roots_with_same_dep',
   ],
 )
 
@@ -60,6 +61,11 @@ files(
 files(
   name = 'several_scala_targets_directory',
   sources = ['several_scala_targets/**/*'],
+)
+
+files(
+  name = 'multiple_roots_with_same_dep',
+  sources = ['multiple_roots_with_same_dep/**/*'],
 )
 
 files(

--- a/examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep/A.scala
+++ b/examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep/A.scala
@@ -1,0 +1,8 @@
+package org.pantsbuild.example.compiler_options
+
+// Unused import
+import scala.collection.Map
+
+object A {
+  private val unused = ???
+}

--- a/examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep/BUILD
@@ -1,0 +1,35 @@
+# A and B are build graph roots, D is a shared dep.
+#       A   B
+#      / \ /
+#     C   D
+#    /
+#   E
+
+
+scala_library(
+  name="A",
+  sources=["*.scala"],
+  dependencies=[":C", ":D"]
+)
+
+scala_library(
+  name="B",
+  sources=["*.scala"],
+  dependencies=[":D"]
+)
+
+scala_library(
+  name="C",
+  sources=["*.scala"],
+  dependencies=[":E"]
+)
+
+scala_library(
+  name="D",
+  sources=["*.scala"],
+)
+
+scala_library(
+  name="E",
+  sources=["*.scala"],
+)

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -407,13 +407,14 @@ class ExportDepAsJar(ConsoleTask):
         return set(targets)
 
     def _get_targets_to_make_into_modules(
-        self, target_roots_set, resource_target_map, runtime_classpath
+        self, target_roots_set, resource_target_map, runtime_classpath, all_targets
     ):
         target_root_addresses = [t.address for t in target_roots_set]
+
         dependees_of_target_roots = [
             t
             for t in self.context.build_graph.transitive_dependees_of_addresses(
-                target_root_addresses
+                target_root_addresses, predicate=lambda t: t in all_targets
             )
             if self._get_target_type(t, resource_target_map, runtime_classpath)
             is not SourceRootTypes.RESOURCE_GENERATED
@@ -480,7 +481,7 @@ class ExportDepAsJar(ConsoleTask):
                     resource_target_map[dep] = t
 
         modulizable_targets = self._get_targets_to_make_into_modules(
-            target_roots_set, resource_target_map, runtime_classpath
+            target_roots_set, resource_target_map, runtime_classpath, all_targets
         )
         non_modulizable_targets = all_targets.difference(modulizable_targets)
 
@@ -519,7 +520,7 @@ class ExportDepAsJar(ConsoleTask):
 
         if zinc_args_for_all_targets is None:
             raise TaskError(
-                "There was an error compiling the targets - There there are no zing argument entries"
+                "There was an error compiling the targets - There there are no zinc argument entries"
             )
 
         runtime_classpath = self.context.products.get_data("runtime_classpath")

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -106,7 +106,8 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala:base_compile_integration_test',
     'testprojects/src/java/org/pantsbuild/testproject:extra_jvm_options_directory',
     'examples/src/java/org/pantsbuild/example:javac_directory',
-    'examples/src/scala/org/pantsbuild/example:several_scala_targets_directory'
+    'examples/src/scala/org/pantsbuild/example:several_scala_targets_directory',
+    'examples/src/scala/org/pantsbuild/example:multiple_roots_with_same_dep',
   ],
   tags = {"integration", "partially_type_checked"},
   timeout = 630,

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -184,3 +184,30 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
                         self.assertIn(conf, entries)
                         for path in entries.values():
                             self.assertTrue(os.path.exists(path), path)
+
+    def test_only_targets_in_build_context_are_exported(self):
+        target_roots = [
+            "examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep:A",
+            "examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep:D",
+        ]
+        with self.temporary_workdir() as workdir:
+            pants_run = self.run_pants_with_workdir(
+                ["export-dep-as-jar"] + target_roots, workdir, {}
+            )
+            self.assert_success(pants_run)
+            export_output = json.loads(pants_run.stdout_data)
+            self.assertIn(
+                "examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep:A",
+                export_output["targets"],
+                export_output,
+            )
+            self.assertIn(
+                "examples.src.scala.org.pantsbuild.example.multiple_roots_with_same_dep.C",
+                export_output["libraries"],
+                export_output,
+            )
+            self.assertNotIn(
+                "examples/src/scala/org/pantsbuild/example/multiple_roots_with_same_dep:B",
+                export_output["targets"],
+                export_output,
+            )


### PR DESCRIPTION
### Problem

Targets that are not part of the build context were ending up in the export-dep-as-jar because of the way we were walking transitive dependees of target roots. These extra targets do not have there dependencies compiled or resolved. Furthermore they don't need to be exported because they are not part of the build context derived from target roots.

### Solution

When walking the dependees graph for target roots, ignore any dependees of target roots that fall outside of the build context.

### Result

Less targets are exported, and only targets in the build context end up as modules in the exported json.