### PR TITLE
Specify actually-used platform in ExecuteProcessResult

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -14,7 +14,9 @@ python_tests(
   dependencies = [
     ':console',
     ':goal',
+    ':platform',
     ':rules',
+    'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/engine:util',
   ],
 )

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
-from pants.engine.platform import PlatformConstraint
+from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, rule
 from pants.util.meta import frozen_after_init
 
@@ -118,6 +118,7 @@ class ExecuteProcessResult:
     stdout: bytes
     stderr: bytes
     output_directory_digest: Digest
+    platform: Platform
 
 
 @dataclass(frozen=True)
@@ -131,6 +132,7 @@ class FallibleExecuteProcessResult:
     stderr: bytes
     exit_code: int
     output_directory_digest: Digest
+    platform: Platform
 
 
 class ProcessExecutionFailure(Exception):
@@ -185,7 +187,10 @@ def fallible_to_exec_result_or_raise(
 
     if fallible_result.exit_code == 0:
         return ExecuteProcessResult(
-            fallible_result.stdout, fallible_result.stderr, fallible_result.output_directory_digest
+            fallible_result.stdout,
+            fallible_result.stderr,
+            fallible_result.output_directory_digest,
+            fallible_result.platform,
         )
     else:
         raise ProcessExecutionFailure(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -38,6 +38,7 @@ from pants.engine.isolated_process import (
     MultiPlatformExecuteProcessRequest,
 )
 from pants.engine.objects import union
+from pants.engine.platform import Platform
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
@@ -588,6 +589,7 @@ class EngineTypes(NamedTuple):
     interactive_process_request: TypeId
     interactive_process_result: TypeId
     snapshot_subset: TypeId
+    construct_platform: Function
 
 
 class PyResult(NamedTuple):
@@ -966,6 +968,7 @@ class Native(metaclass=SingletonMetaclass):
             interactive_process_request=ti(InteractiveProcessRequest),
             interactive_process_result=ti(InteractiveProcessResult),
             snapshot_subset=ti(SnapshotSubset),
+            construct_platform=func(Platform),
         )
 
         scheduler_result = self.lib.scheduler_create(

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.platform import Platform
+from pants.testutil.test_base import TestBase
+
+
+class PlatformTest(TestBase):
+    def test_platform_on_epr_result(self) -> None:
+
+        this_platform = Platform.current
+
+        req = ExecuteProcessRequest(
+            argv=("/usr/bin/ls", "--version"),
+            input_files=EMPTY_DIRECTORY_DIGEST,
+            description="Run some program that will exit cleanly.",
+        )
+        result = self.request_single_product(ExecuteProcessResult, req)
+        assert this_platform == result.platform

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest,
+  MultiPlatformExecuteProcessRequest, Platform,
 };
 use std::sync::Arc;
 
@@ -100,6 +100,7 @@ impl CommandRunner {
             execute_response,
             vec![],
             context.workunit_store,
+            Platform::Linux, //TODO lol this is definitely wrong - check maybe_execute_response!
           )
           .map(Some)
           .to_boxed()

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -2,6 +2,7 @@ use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
   MultiPlatformExecuteProcessRequest, Platform,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -11,15 +12,40 @@ use protobuf::Message;
 
 use boxfuture::{BoxFuture, Boxable};
 use hashing::Fingerprint;
+use parking_lot::Mutex;
 use sharded_lmdb::ShardedLmdb;
 use store::Store;
 
 #[derive(Clone)]
 pub struct CommandRunner {
-  pub underlying: Arc<dyn crate::CommandRunner>,
-  pub process_execution_store: ShardedLmdb,
-  pub file_store: Store,
-  pub metadata: ExecuteProcessRequestMetadata,
+  underlying: Arc<dyn crate::CommandRunner>,
+  process_execution_store: ShardedLmdb,
+  platform_map: Arc<Mutex<HashMap<Fingerprint, Platform>>>,
+  file_store: Store,
+  metadata: ExecuteProcessRequestMetadata,
+}
+
+impl CommandRunner {
+  pub fn new(
+    underlying: Arc<dyn crate::CommandRunner>,
+    process_execution_store: ShardedLmdb,
+    file_store: Store,
+    metadata: ExecuteProcessRequestMetadata,
+  ) -> CommandRunner {
+    CommandRunner {
+      underlying,
+      process_execution_store,
+      platform_map: Arc::new(Mutex::new(HashMap::new())),
+      file_store,
+      metadata,
+    }
+  }
+
+  #[allow(dead_code)]
+  fn do_thing(&self) {
+    let _x = &self.process_execution_store;
+    panic!("foo");
+  }
 }
 
 impl crate::CommandRunner for CommandRunner {
@@ -83,27 +109,39 @@ impl CommandRunner {
     fingerprint: Fingerprint,
     context: Context,
   ) -> impl Future<Item = Option<FallibleExecuteProcessResult>, Error = String> {
+    use bazel_protos::remote_execution::ExecuteResponse;
     let file_store = self.file_store.clone();
+
+    let platform_lookup_result = self
+      .platform_map
+      .lock()
+      .get(&fingerprint)
+      .cloned()
+      .ok_or_else(|| "Execution platform not found in store".to_string());
+
     self
       .process_execution_store
       .load_bytes_with(fingerprint, |bytes| {
-        let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
+        let mut execute_response = ExecuteResponse::new();
         execute_response
           .merge_from_bytes(&bytes)
           .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
         Ok(execute_response)
       })
-      .and_then(move |maybe_execute_response| {
+      .and_then(move |maybe_execute_response: Option<ExecuteResponse>| {
         if let Some(execute_response) = maybe_execute_response {
-          crate::remote::populate_fallible_execution_result(
-            file_store,
-            execute_response,
-            vec![],
-            context.workunit_store,
-            Platform::Linux, //TODO lol this is definitely wrong - check maybe_execute_response!
-          )
-          .map(Some)
-          .to_boxed()
+          futures01::future::result(platform_lookup_result)
+            .and_then(|platform: Platform| {
+              crate::remote::populate_fallible_execution_result(
+                file_store,
+                execute_response,
+                vec![],
+                context.workunit_store,
+                platform,
+              )
+              .map(Some)
+            })
+            .to_boxed()
         } else {
           future::ok(None).to_boxed()
         }
@@ -129,6 +167,13 @@ impl CommandRunner {
     // TODO: Should probably have a configurable lease time which is larger than default.
     // (This isn't super urgent because we don't ever actually GC this store. So also...)
     // TODO: GC the local process execution cache.
+    //
+
+    self
+      .platform_map
+      .lock()
+      .insert(fingerprint, result.platform);
+
     self
       .file_store
       .store_file_bytes(result.stdout.clone(), true)

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, PlatformConstraint, RelativePath,
+  FallibleExecuteProcessResult, Platform, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -43,6 +43,7 @@ fn stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -73,6 +74,7 @@ fn stdout_and_stderr_and_exit_code() {
       exit_code: 1,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -104,6 +106,7 @@ fn capture_exit_code_signal() {
       exit_code: -15,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -220,6 +223,7 @@ fn output_files_none() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -253,6 +257,7 @@ fn output_files_one() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -291,6 +296,7 @@ fn output_dirs() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -330,6 +336,7 @@ fn output_files_many() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -367,6 +374,7 @@ fn output_files_execution_failure() {
       exit_code: 1,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -402,6 +410,7 @@ fn output_files_partial_output() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -435,6 +444,7 @@ fn output_overlapping_file_and_dir() {
       exit_code: 0,
       output_directory: TestDirectory::nested().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -467,6 +477,7 @@ fn jdk_symlink() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   )
 }
@@ -583,6 +594,7 @@ fn all_containing_directories_for_outputs_are_created() {
       exit_code: 0,
       output_directory: TestDirectory::nested_dir_and_file().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -616,6 +628,7 @@ fn output_empty_dir() {
       exit_code: 0,
       output_directory: TestDirectory::containing_falcons_dir().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -669,6 +682,7 @@ fn local_only_scratch_files_materialized() {
       exit_code: 0,
       output_directory: roland_directory_digest,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -749,6 +763,7 @@ fn working_directory() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -17,7 +17,7 @@ use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -194,6 +194,7 @@ impl super::CommandRunner for CommandRunner {
       executor,
       true,
       &workdir_for_this_nailgun,
+      Platform::current().unwrap(),
     )
   }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -18,7 +18,7 @@ use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOr
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, MultiPlatformExecuteProcessRequest,
-  PlatformConstraint,
+  Platform, PlatformConstraint,
 };
 use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;
@@ -626,6 +626,7 @@ fn successful_execution_after_one_getoperation() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -673,6 +674,7 @@ fn retries_retriable_errors() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -775,7 +777,7 @@ pub fn sends_headers() {
       String::from("cat") => String::from("roland"),
     },
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -849,6 +851,7 @@ fn extract_response_with_digest_stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -878,6 +881,7 @@ fn extract_response_with_digest_stderr() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -939,7 +943,7 @@ fn ensure_inline_stdio_is_stored() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -957,6 +961,7 @@ fn ensure_inline_stdio_is_stored() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -1031,6 +1036,7 @@ fn successful_execution_after_four_getoperations() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1147,6 +1153,7 @@ fn dropped_request_cancels() {
     exit_code: 0,
     output_directory: EMPTY_DIGEST,
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let run_future = command_runner.run(execute_request.into(), Context::default());
@@ -1214,6 +1221,7 @@ fn retry_for_cancelled_channel() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1477,7 +1485,7 @@ fn execute_missing_file_uploads_if_known() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1496,6 +1504,7 @@ fn execute_missing_file_uploads_if_known() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
   {
@@ -1584,7 +1593,7 @@ fn execute_missing_file_uploads_if_known_status() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1601,6 +1610,7 @@ fn execute_missing_file_uploads_if_known_status() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   );
   {
@@ -1664,7 +1674,7 @@ fn execute_missing_file_errors_if_unknown() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1708,6 +1718,7 @@ fn extract_execute_response_success() {
     exit_code: 17,
     output_directory: TestDirectory::nested().digest(),
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let mut output_file = bazel_protos::remote_execution::OutputFile::new();
@@ -2492,7 +2503,7 @@ fn create_command_runner(
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime,
     Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -2,7 +2,7 @@ use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
   CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -158,6 +158,7 @@ fn make_delayed_command_runner(
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   };
   DelayedCommandRunner::new(

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -32,7 +32,9 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
-use process_execution::{Context, ExecuteProcessRequestMetadata, PlatformConstraint, RelativePath};
+use process_execution::{
+  Context, ExecuteProcessRequestMetadata, Platform, PlatformConstraint, RelativePath,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
@@ -371,7 +373,7 @@ fn main() {
           oauth_bearer_token,
           headers,
           store.clone(),
-          PlatformConstraint::Linux,
+          Platform::Linux,
           executor,
           std::time::Duration::from_secs(160),
           std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -211,12 +211,12 @@ impl Core {
         executor.clone(),
       )
       .map_err(|err| format!("Could not initialize store for process cache: {:?}", err))?;
-      command_runner = Box::new(process_execution::cache::CommandRunner {
-        underlying: command_runner.into(),
+      command_runner = Box::new(process_execution::cache::CommandRunner::new(
+        command_runner.into(),
         process_execution_store,
-        file_store: store.clone(),
-        metadata: process_execution_metadata,
-      })
+        store.clone(),
+        process_execution_metadata,
+      ));
     }
 
     let http_client = reqwest::r#async::Client::new();

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -21,7 +21,7 @@ use fs::{safe_create_dir_all_ioerror, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
   self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ExecuteProcessRequestMetadata,
-  PlatformConstraint,
+  Platform,
 };
 use rand::seq::SliceRandom;
 use reqwest;
@@ -180,7 +180,7 @@ impl Core {
             store.clone(),
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
-            PlatformConstraint::Linux,
+            Platform::Linux,
             executor.clone(),
             std::time::Duration::from_secs(160),
             std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -55,6 +55,7 @@ fn multi_platform_process_request_to_process_result(
   }))
   .and_then(move |process_request| context.get(process_request))
   .map(move |result| {
+    let platform_name: String = result.0.platform.into();
     externs::unsafe_call(
       &core.types.construct_process_result,
       &[
@@ -62,6 +63,10 @@ fn multi_platform_process_request_to_process_result(
         externs::store_bytes(&result.0.stderr),
         externs::store_i64(result.0.exit_code.into()),
         Snapshot::store_directory(&core, &result.0.output_directory),
+        externs::unsafe_call(
+          &core.types.construct_platform,
+          &[externs::store_utf8(&platform_name)],
+        ),
       ],
     )
   })

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -33,4 +33,5 @@ pub struct Types {
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
   pub snapshot_subset: TypeId,
+  pub construct_platform: Function,
 }


### PR DESCRIPTION
### Problem

TODO - we need to be able to get the platform that an `ExecuteProcessResult` actually executed on because this is relevant to making sure certain build outputs remain compatible.

### Solution

Add a `Platform` type and use it.

### Result

TODO