### PR TITLE
Compiler option sets can be lists or sets

### DIFF
--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -70,7 +70,8 @@ class ScalaLibrary(ExportableJvmLibrary):
 
         scalac_plugins = scalac_plugins or []
         scalac_plugin_args = scalac_plugin_args or {}
-        compiler_option_sets = compiler_option_sets or set()
+        # Allow lists as well as sets in BUILD files:
+        compiler_option_sets = set(compiler_option_sets) if compiler_option_sets else set()
 
         # Modify these options in case scoverage is enabled.
         if ScoveragePlatform.global_instance().get_options().enable_scoverage:


### PR DESCRIPTION
### Problem

Some people use list literals in BUILD files for compiler_option_sets. Currently this errors.

### Solution

Convert the value in the BUILD file to a set if needed.

### Result

Both list and set values work fine.