### PR TITLE
Ide 254

### DIFF
--- a/examples/src/thrift/org/pantsbuild/example/distance/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/distance/BUILD
@@ -9,6 +9,7 @@ java_thrift_library(name='distance-java',
   provides = artifact(org='org.pantsbuild.example',
                       name='distance-thrift-java',
                       repo=public),
+  dependencies = ['examples/src/scala/org/pantsbuild/example/hello/welcome']
 )
 
 python_thrift_library(name='distance-python',

--- a/examples/src/thrift/org/pantsbuild/example/distance/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/distance/BUILD
@@ -9,7 +9,6 @@ java_thrift_library(name='distance-java',
   provides = artifact(org='org.pantsbuild.example',
                       name='distance-thrift-java',
                       repo=public),
-  dependencies = ['examples/src/scala/org/pantsbuild/example/hello/welcome']
 )
 
 python_thrift_library(name='distance-python',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -7,7 +7,6 @@ from enum import Enum
 from multiprocessing import cpu_count
 from typing import Optional
 
-from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -244,6 +243,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   def select_source(self, source_file_path):
     raise NotImplementedError()
 
+  def product_types(cls):
+    return super(JvmCompile, cls).product_types() + ['jvm_modulizable_targets']
+
   def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, compiler_option_sets, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
@@ -455,6 +457,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
       relevant_targets = list(set(relevant_targets) - modulizable_targets)
       self.create_extra_products_for_targets(modulizable_targets)
+      self.context.products.get_data('jvm_modulizable_targets', set).update(modulizable_targets)
 
     if relevant_targets:
       # Note, JVM targets are validated (`vts.update()`) as they succeed.  As a result,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -484,6 +484,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   def calculate_jvm_modulizable_targets(self):
     relevant_targets = list(self.context.targets(predicate=self.select))
+    # import pdb
+    # pdb.set_trace()
     target_roots_in_play = set(relevant_targets) & set(self.context.target_roots)
     target_roots_minus_thrift = set(filter(lambda x: not x.is_synthetic, target_roots_in_play))
     modulizable_targets = set(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -14,6 +14,7 @@ from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.zinc import Zinc
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.javac_plugin import JavacPlugin
+from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
@@ -486,7 +487,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   def calculate_jvm_modulizable_targets(self):
     def is_jvm_or_resource_target(t):
-      return not t.is_synthetic and isinstance(t, (JvmTarget, Resources))
+      return isinstance(t, (JvmTarget, JvmApp, Resources))
 
     jvm_and_resources_target_roots = set(
       filter(is_jvm_or_resource_target, self.context.target_roots))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -769,7 +769,7 @@ class ZincCompile(BaseZincCompile):
 
   @classmethod
   def product_types(cls):
-    return ['runtime_classpath', 'export_dep_as_jar_signal', 'zinc_analysis', 'zinc_args']
+    return super().product_types(cls) + ['runtime_classpath', 'export_dep_as_jar_signal', 'zinc_analysis', 'zinc_args']
 
   @staticmethod
   def select(target):

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -320,12 +320,12 @@ class ExportDepAsJar(ConsoleTask):
     return set(targets)
 
   def _get_targets_to_make_into_modules(self, target_roots_set, resource_target_map, runtime_classpath):
-    target_root_addresses = [t.address for t in target_roots_set]
-    dependees_of_target_roots = [
-      t for t in self.context.build_graph.transitive_dependees_of_addresses(target_root_addresses)
+    jvm_modulizable_targets = self.context.products.get_data('jvm_modulizable_targets')
+    non_generated_resource_jvm_modulizable_targets = [
+      t for t in jvm_modulizable_targets
       if self._get_target_type(t, resource_target_map, runtime_classpath) is not SourceRootTypes.RESOURCE_GENERATED
     ]
-    return dependees_of_target_roots
+    return non_generated_resource_jvm_modulizable_targets
 
   def _make_libraries_entry(self, target, resource_target_map, runtime_classpath):
     # Using resolved path in preparation for VCFS.
@@ -404,8 +404,6 @@ class ExportDepAsJar(ConsoleTask):
     return graph_info
 
   def console_output(self, targets):
-    print('modules!!!')
-    print(self.context.products.get_data('jvm_modulizable_targets'))
     zinc_args_for_all_targets = self.context.products.get_data('zinc_args')
 
     if zinc_args_for_all_targets is None:

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -69,6 +69,7 @@ class ExportDepAsJar(ConsoleTask):
     round_manager.require_data('zinc_args')
     round_manager.require_data('runtime_classpath')
     round_manager.require_data('export_dep_as_jar_signal')
+    round_manager.require_data('jvm_modulizable_targets')
 
   @property
   def _output_folder(self):
@@ -403,6 +404,8 @@ class ExportDepAsJar(ConsoleTask):
     return graph_info
 
   def console_output(self, targets):
+    print('modules!!!')
+    print(self.context.products.get_data('jvm_modulizable_targets'))
     zinc_args_for_all_targets = self.context.products.get_data('zinc_args')
 
     if zinc_args_for_all_targets is None:

--- a/src/python/pants/testutil/task_test_base.py
+++ b/src/python/pants/testutil/task_test_base.py
@@ -173,6 +173,7 @@ class TaskTestBase(TestBase):
       last_target = self.make_target(
         f'project_info:{name}',
         dependencies=[] if last_target is None else [last_target],
+        sources = ['x.scala'],
         **additional_target_args,
       )
       graph[name] = last_target

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -386,7 +386,8 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
                           'project_info/this/is/a/source/Bar.scala']},
       'libraries': sorted([
         'org.apache:apache-jar:12.12.2012',
-        'org.scala-lang:scala-library:2.10.5'
+        'org.scala-lang:scala-library:2.10.5',
+        'project_info.jvm_target_b',
       ]),
       'id': 'project_info.jvm_target',
       # 'is_code_gen': False,

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -236,7 +236,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         'project_info:target_type',
         target_type=ScalaLibrary,
         dependencies=[jvm_binary, src_resource],
-        sources=[],
+        sources=['x.scala'],
     )
 
     self.make_target(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -153,7 +153,6 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     self.make_target(
       'project_info:first',
       target_type=JvmTarget,
-      sources=['a.scala']
     )
 
     jar_lib = self.make_target(
@@ -225,7 +224,6 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       'project_info:top_dependency',
       target_type=JvmTarget,
       dependencies=[jvm_binary],
-      sources=['x.scala'],
     )
 
     self.create_file('project_info/a_resource', contents='a')
@@ -241,7 +239,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         'project_info:target_type',
         target_type=ScalaLibrary,
         dependencies=[jvm_binary, src_resource],
-        sources=['x.scala'],
+        sources=[],
     )
 
     self.make_target(
@@ -253,7 +251,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       'project_info:scala_with_source_dep',
       target_type=ScalaLibrary,
       dependencies=[self.jvm_target_with_sources],
-      sources=['x.scala'],
+      sources=[],
     )
 
     self.linear_build_graph = self.make_linear_graph(['a', 'b', 'c', 'd', 'e'], target_type=ScalaLibrary)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -153,7 +153,8 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
 
     self.make_target(
       'project_info:first',
-      target_type=Target,
+      target_type=JvmTarget,
+      sources=['a.scala']
     )
 
     jar_lib = self.make_target(
@@ -291,6 +292,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     }
     options.update(options_overrides)
 
+    # We are only initializing ZincCompile to access the instance method `calculate_jvm_modulizable_targets`
     ZincCompile.options_scope = 'compile.rsc'
     BootstrapJvmTools.options_scope = 'bootstrap-jvm-tools'
     context = self.context(options=options, target_roots=[self.target(spec) for spec in specs],
@@ -303,8 +305,9 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
 
     context.products.safe_create_data('zinc_args', init_func=lambda: MagicMock())
 
+    # This simulates ZincCompile creates the product.
     zinc_compile_task = ZincCompile(context, self.pants_workdir)
-    context.products.safe_create_data('jvm_modulizable_targets', init_func=lambda: zinc_compile_task.calculate_jvm_modulizable_targets())
+    context.products.get_data('jvm_modulizable_targets', init_func=zinc_compile_task.calculate_jvm_modulizable_targets)
 
     bootstrap_task = BootstrapJvmTools(context, self.pants_workdir)
     bootstrap_task.execute()


### PR DESCRIPTION
### Problem

When `export-dep-as-jar`, code generated targets are treated as editable code (modules) when they are target roots, causing
* more modules exported than necessary, hence unnecessary compiles in the IDE
* the thrift file changes requires a re-import to in order for IDE to pick up the newly generated code, so the generated code in essence never changes with the IDE. Making the thrift files editable gives out the wrong impression to users the changes will reflect immediately within the IDE without a re-import.

So code generated targets should be treated as libraries.

### Solution

Calculate `modulizable_targets` by
1. first filtering away thrift targets
2. expand to dependees of the filtered list

#### Examples
A -> B -> C -> D (all source targets):
1. export A C: A B C are modules, D is lib

A -> B (thrift) -> C -> D:
1. export A: A is module, BCD are libs
1. export A C: Illegal because B cannot depend on source targets. i.e. dependees(target roots - thrift targets) contains thrift targets
2. export A B: A is module, BCD are libs

A -> B -> C -> D (thrift) -> E,  A -> F -> C
1. export A C. ABCF are modules
2. export A D. A is module

so the final modulizable targets, M = depeedees(targets_roots - thrift_targets). Error out if M contains any thrift targets.

### Result

- [ ]  Tests to add that correspond to the examples above

### Other changes
1. This consolidates the logic of calculating `modulizable_targets` between `ZincCompile` and `export-dep-as-jar`, so the work is not duplicated anymore by having `ZincCompile` saves `modulizable_targets` as its product.
2. It removes the predicate of `self.select(..)` when computing `modulizable_targets` because it introduces inconsistency depending on the whether there is any source defined in the target. https://github.com/pantsbuild/pants/blob/master/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py#L922-L928. I can imagine it was a good optimization for compile's logic, but for IDE use cases, a consistent result of export should be more desired.