### PR TITLE
Tweak `TargetAdaptor.dependencies` to be a tuple rather than a list

### DIFF
--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -296,9 +296,9 @@ class AddressableSequence(AddressableDescriptor):
 
     def _resolve_value(self, instance, value):
         return (
-            [super(AddressableSequence, self)._resolve_value(instance, v) for v in value]
+            tuple(super(AddressableSequence, self)._resolve_value(instance, v) for v in value)
             if value
-            else []
+            else ()
         )
 
 

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -95,7 +95,7 @@ class AddressableDescriptor:
        else a type constraint class can be given if the type constraint should apply to the type of
        the enclosing class.  This is useful for declaring an addressable property in a baseclass that
        should be type-constrained based on the type of the derived class.
-    2. Decorators for addressables (see `addressable`, `addressable_list` and `addressable_dict`)
+    2. Decorators for addressables (see `addressable`, `addressable_sequence` and `addressable_dict`)
        allow wrapping of either class functions - typical - or @property descriptors.  The property
        descriptor case sets up an idiom for recursive addressables.  The idiom looks like:
 
@@ -281,7 +281,7 @@ def addressable(type_constraint):
     return _addressable_wrapper(AddressableDescriptor, type_constraint)
 
 
-class AddressableList(AddressableDescriptor):
+class AddressableSequence(AddressableDescriptor):
     def _checked_value(self, instance, value):
         if value is None:
             return None
@@ -292,20 +292,20 @@ class AddressableList(AddressableDescriptor):
                     self._name, instance, value, type(value).__name__
                 )
             )
-        return [super(AddressableList, self)._checked_value(instance, v) for v in value]
+        return [super(AddressableSequence, self)._checked_value(instance, v) for v in value]
 
     def _resolve_value(self, instance, value):
         return (
-            [super(AddressableList, self)._resolve_value(instance, v) for v in value]
+            [super(AddressableSequence, self)._resolve_value(instance, v) for v in value]
             if value
             else []
         )
 
 
-def addressable_list(type_constraint):
-    """Marks a list's values as satisfying a given type constraint.
+def addressable_sequence(type_constraint):
+    """Marks a sequence's values as satisfying a given type constraint.
 
-    Some (or all) elements of the list may be :class:`pants.engine.objects.Resolvable` elements
+    Some (or all) elements of the sequence may be :class:`pants.engine.objects.Resolvable` elements
     to resolve later.
 
     See :class:`AddressableDescriptor` for more details.
@@ -313,7 +313,7 @@ def addressable_list(type_constraint):
     :param type_constraint: The type constraint the list's values must all satisfy.
     :type type_constraint: :class:`TypeConstraint`
     """
-    return _addressable_wrapper(AddressableList, type_constraint)
+    return _addressable_wrapper(AddressableSequence, type_constraint)
 
 
 class AddressableDict(AddressableDescriptor):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import inspect
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import update_wrapper
 from typing import Any, Sequence, Set, Tuple, Type
@@ -286,9 +286,9 @@ class AddressableSequence(AddressableDescriptor):
         if value is None:
             return None
 
-        if not isinstance(value, MutableSequence):
+        if not isinstance(value, (list, tuple)):
             raise TypeError(
-                "The {} property of {} must be a list, given {} of type {}".format(
+                "The {} property of {} must be a tuple or list, given {} of type {}".format(
                     self._name, instance, value, type(value).__name__
                 )
             )
@@ -321,7 +321,7 @@ class AddressableDict(AddressableDescriptor):
         if value is None:
             return None
 
-        if not isinstance(value, MutableMapping):
+        if not isinstance(value, Mapping):
             raise TypeError(
                 "The {} property of {} must be a dict, given {} of type {}".format(
                     self._name, instance, value, type(value).__name__

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -145,7 +145,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
     hydrated_inline_dependencies = await MultiGet(
         Get[HydratedStruct](Address, a) for a in inline_dependencies
     )
-    dependencies = [d.value for d in hydrated_inline_dependencies]
+    dependencies = tuple(d.value for d in hydrated_inline_dependencies)
 
     def maybe_consume(outer_key, value):
         if isinstance(value, str):
@@ -182,7 +182,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
                     k: maybe_consume(key, v) for k, v in sorted(value.items(), key=_key_func)
                 }
             elif isinstance(value, (list, tuple)):
-                hydrated_args[key] = list(maybe_consume(key, v) for v in value)
+                hydrated_args[key] = tuple(maybe_consume(key, v) for v in value)
             else:
                 hydrated_args[key] = maybe_consume(key, value)
         return _hydrate(type(item), address.spec_path, **hydrated_args)

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import Mapping
 from typing import Dict
 
 from twitter.common.collections import OrderedSet
@@ -129,10 +129,10 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
         for key, value in sorted(item._asdict().items(), key=_key_func):
             if not AddressableDescriptor.is_addressable(item, key):
                 continue
-            if isinstance(value, MutableMapping):
+            if isinstance(value, Mapping):
                 for _, v in sorted(value.items(), key=_key_func):
                     maybe_append(key, v)
-            elif isinstance(value, MutableSequence):
+            elif isinstance(value, (list, tuple)):
                 for v in value:
                     maybe_append(key, v)
             else:
@@ -177,14 +177,12 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
                 hydrated_args[key] = value
                 continue
 
-            if isinstance(value, MutableMapping):
-                container_type = type(value)
-                hydrated_args[key] = container_type(
-                    (k, maybe_consume(key, v)) for k, v in sorted(value.items(), key=_key_func)
-                )
-            elif isinstance(value, MutableSequence):
-                container_type = type(value)
-                hydrated_args[key] = container_type(maybe_consume(key, v) for v in value)
+            if isinstance(value, Mapping):
+                hydrated_args[key] = {
+                    k: maybe_consume(key, v) for k, v in sorted(value.items(), key=_key_func)
+                }
+            elif isinstance(value, (list, tuple)):
+                hydrated_args[key] = list(maybe_consume(key, v) for v in value)
             else:
                 hydrated_args[key] = maybe_consume(key, value)
         return _hydrate(type(item), address.spec_path, **hydrated_args)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -661,7 +661,7 @@ async def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
     return HydratedTarget(
         address=target_adaptor.address,
         adaptor=type(target_adaptor)(**kwargs),
-        dependencies=tuple(target_adaptor.dependencies),
+        dependencies=target_adaptor.dependencies,
     )
 
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Typ
 from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
-from pants.engine.addressable import addressable_list
+from pants.engine.addressable import addressable_sequence
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
 from pants.engine.objects import Locatable, union
 from pants.engine.rules import UnionRule
@@ -218,7 +218,7 @@ class AppAdaptor(TargetAdaptor):
         super().__init__(**kwargs)
         self.bundles = bundles
 
-    @addressable_list(Exactly(BundleAdaptor))
+    @addressable_sequence(Exactly(BundleAdaptor))
     def bundles(self):
         """The BundleAdaptors for this JvmApp."""
         return self.bundles

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -30,6 +30,12 @@ class TargetAdaptor(StructWithDeps):
     Extends StructWithDeps to add a `dependencies` field marked Addressable.
     """
 
+    # NB: This overridden `__init__()` is weird. We solely have it so that MyPy can infer
+    # `TargetAdaptor.dependencies` as `Tuple[Address, ...]`.
+    def __init__(self, dependencies=None, **kwargs) -> None:
+        super().__init__(dependencies, **kwargs)
+        self.dependencies: Tuple[Address, ...]
+
     @property
     def address(self) -> Address:
         # TODO: this isn't actually safe to override as not being Optional. There are

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -5,7 +5,7 @@ from collections.abc import MutableMapping, MutableSequence
 from typing import Any, Dict, Iterable, Optional, cast
 
 from pants.build_graph.address import Address
-from pants.engine.addressable import addressable, addressable_list
+from pants.engine.addressable import addressable, addressable_sequence
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
 from pants.util.objects import SubclassesOf, SuperclassesOf
 
@@ -162,11 +162,11 @@ class Struct(Serializable, SerializableFactory, Validatable):
         :rtype: :class:`Serializable`
         """
 
-    @addressable_list(SuperclassesOf)
+    @addressable_sequence(SuperclassesOf)
     def merges(self):
         """Return the objects this object merges in, if any.
 
-        :rtype: list of :class:`Serializable`
+        :rtype: tuple of :class:`Serializable`
         """
 
     def _asdict(self) -> Dict[str, Any]:
@@ -304,9 +304,9 @@ class StructWithDeps(Struct):
         super().__init__(**kwargs)
         self.dependencies = dependencies
 
-    @addressable_list(SubclassesOf(Struct))
+    @addressable_sequence(SubclassesOf(Struct))
     def dependencies(self):
         """The direct dependencies of this target.
 
-        :rtype: list
+        :rtype: tuple
         """

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, get_typ
 from colors import blue, green, red
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
-from pants.engine.addressable import addressable_list
+from pants.engine.addressable import addressable_sequence
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import Scheduler
@@ -147,7 +147,7 @@ class Target(Struct):
         super().__init__(name=name, **kwargs)
         self.configurations = configurations
 
-    @addressable_list(SubclassesOf(Struct))
+    @addressable_sequence(SubclassesOf(Struct))
     def configurations(self):
         pass
 

--- a/tests/python/pants_test/engine/examples/README.md
+++ b/tests/python/pants_test/engine/examples/README.md
@@ -65,7 +65,7 @@ modelled flexibly via an [`AddressableDescriptor`](https://github.com/pantsbuild
 that has associated decorators for one to one edges
 ([`@addressable`](https://github.com/pantsbuild/pants/blob/3bd6d75949c253e2e11dfece7e593a7e5fdf0908/src/python/pants/engine/exp/addressable.py#L299)),
 and one to many edges
-([`@addressable_list`](https://github.com/pantsbuild/pants/blob/3bd6d75949c253e2e11dfece7e593a7e5fdf0908/src/python/pants/engine/exp/addressable.py#L341)
+([`@addressable_sequence`](https://github.com/pantsbuild/pants/blob/3bd6d75949c253e2e11dfece7e593a7e5fdf0908/src/python/pants/engine/exp/addressable.py#L341)
 and [`@addressable_dict`](https://github.com/pantsbuild/pants/blob/3bd6d75949c253e2e11dfece7e593a7e5fdf0908/src/python/pants/engine/exp/addressable.py#L370)).
 There are two important outgrowths from the flexible edge-schema model:
 

--- a/tests/python/pants_test/engine/test_addressable.py
+++ b/tests/python/pants_test/engine/test_addressable.py
@@ -8,7 +8,7 @@ from pants.engine.addressable import (
     NotSerializableError,
     addressable,
     addressable_dict,
-    addressable_list,
+    addressable_sequence,
 )
 from pants.engine.objects import Resolvable, Serializable
 from pants.util.objects import Exactly, TypeConstraintError
@@ -121,11 +121,11 @@ class AddressableListTest(unittest.TestCase):
             super(AddressableListTest.Series, self).__init__()
             self.values = values
 
-        @addressable_list(Exactly(int, float))
+        @addressable_sequence(Exactly(int, float))
         def values(self):
             """Return this series' values.
 
-            :rtype list of int or float
+            :rtype tuple of int or float
             """
 
     def test_none(self):

--- a/tests/python/pants_test/engine/test_addressable.py
+++ b/tests/python/pants_test/engine/test_addressable.py
@@ -131,23 +131,23 @@ class AddressableListTest(unittest.TestCase):
     def test_none(self):
         series = self.Series(None)
 
-        self.assertEqual([], series.values)
+        self.assertEqual((), series.values)
 
     def test_values(self):
         series = self.Series([42, 1 / 137.0])
 
-        self.assertEqual([42, 1 / 137.0], series.values)
+        self.assertEqual((42, 1 / 137.0,), series.values)
 
     def test_addresses(self):
         series = self.Series(["//:meaning-of-life"])
 
-        self.assertEqual(["//:meaning-of-life"], series.values)
+        self.assertEqual(("//:meaning-of-life",), series.values)
 
     def test_resolvables(self):
         resolvable_value = CountingResolvable("//:fine-structure-constant", 1 / 137.0)
         series = self.Series([resolvable_value])
 
-        self.assertEqual([1 / 137.0], series.values)
+        self.assertEqual((1 / 137.0,), series.values)
         self.assertEqual(1, resolvable_value.resolutions)
 
         self.assertEqual(1 / 137.0, series.values[0])
@@ -159,7 +159,7 @@ class AddressableListTest(unittest.TestCase):
 
         self.assertEqual(0, resolvable_value.resolutions)
 
-        self.assertEqual([42, "//:meaning-of-life", 1 / 137.0], series.values)
+        self.assertEqual((42, "//:meaning-of-life", 1 / 137.0), series.values)
         self.assertEqual(1, resolvable_value.resolutions)
 
         self.assertEqual(1 / 137.0, series.values[2])


### PR DESCRIPTION
### Problem

`TargetAdaptor` and `HydratedTarget` duplicate information - they both have `address` and `dependencies` fields that are almost identical, outside of `TargetAdaptor` using a list rather than a tuple of `Address` instances for the `dependencies` field.

@jsirois explained that there was no particular reason to use lists, rather than tuples, with this `Struct` code from the very first days of the engine. Recently, we've defaulted to always using tuples instead of lists because they are immutable and hashable, but this is not a common idiom in Python so we had used lists in 2015.

### Solution

Rename `@addressable_list` to `@addressable_sequence` (`@addressable_tuple` sounded wrong because that makes it sound like a 2-tuple, 3-tuple, etc). 

Tweak `addressable.py` and `build_files.py` to stop expecting a `MutableSequence` and instead work with either `tuple` or `list`. We don't enforce it gets `list` because we don't want to waste time trying to update all call sites. Then, we cast everything to a `tuple`, unlike previously using a `list`.

Finally, we use a hacky `__init__()` to get MyPy to understand that `TargetAdaptor.dependencies` is a `Tuple[Address, ...]`.

### Result

We'll be able to remove `HydratedTarget.address` and `HydratedTarget.dependencies` as fields because they're both contained within `TargetAdaptor`.

This is sort of prework for the Target API.