### PR TITLE
Upgrade to Pex 2.1.5.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==2.1.4
+pex==2.1.5
 psutil==5.6.3
 Pygments==2.3.1
 pyopenssl==17.3.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -37,16 +37,16 @@ class DownloadedPexBin(HermeticPex):
     class Factory(Script):
         options_scope = "download-pex-bin"
         name = "pex"
-        default_version = "v2.1.4"
+        default_version = "v2.1.5"
 
         # Note: You can compute the digest and size using:
         # curl -L $URL | tee >(wc -c) >(shasum -a 256) >/dev/null
         default_versions_and_digests = {
             PlatformConstraint.none: ToolForPlatform(
                 digest=Digest(
-                    "6c5ae1f6b9aa40c97bd26a154849044b49f4d698a6abb9ac58ce006bda9cbd4a", 2614246
+                    "7b3db839742dde51da8517335d924d5360f7accf97fc6eb0d7d2b74aaa798c6d", 2614381
                 ),
-                version=ToolVersion("v2.1.4"),
+                version=ToolVersion("v2.1.5"),
             ),
         }
 


### PR DESCRIPTION
This upgrade silences Pip warning about python 2.7 and allows resolving
a greater variety of distributions. Previously Pex - via Pip - choked on
distributions that had data_files in top-level directories matching
source code top-level directories. Pip would replace the top-level
source directory with the data directory when installing the
distribution most often leading to data (importable code) loss.
