### PR TITLE
add type-checked get_field() method to TargetAdaptor and consume v1 target payloads

### DIFF
--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -88,7 +88,7 @@ class Page(Target):
         """
         payload = payload or Payload()
         if not format:
-            if sources.files[0].lower().endswith(".rst"):
+            if sources and sources.files[0].lower().endswith(".rst"):
                 format = "rst"
             else:
                 format = "md"

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -7,7 +7,6 @@ from typing import Iterable, Type
 
 import pytest
 
-from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.rules.run_setup_py import (
     AmbiguousOwnerError,
     AncestorInitPyFiles,
@@ -31,37 +30,23 @@ from pants.backend.python.rules.run_setup_py import (
     get_sources,
     validate_args,
 )
-from pants.build_graph.address import Address
-from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.backend.python.rules.testutil import PythonTestBase
 from pants.engine.fs import Snapshot
-from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
+from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
-from pants.python.python_requirement import PythonRequirement
 from pants.rules.core.strip_source_roots import (
     strip_source_roots_from_snapshot,
     strip_source_roots_from_target,
 )
 from pants.source.source_root import SourceRootConfig
 from pants.testutil.subsystem.util import init_subsystem
-from pants.testutil.test_base import TestBase
 
 _namespace_decl = "__import__('pkg_resources').declare_namespace(__name__)"
 
 
-class TestSetupPyBase(TestBase):
-    @classmethod
-    def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(
-            objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact,}
-        )
-
-    def tgt(self, addr: str) -> HydratedTarget:
-        return self.request_single_product(HydratedTarget, Params(Address.parse(addr)))
-
-
-class TestGenerateChroot(TestSetupPyBase):
+class TestGenerateChroot(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [
@@ -185,7 +170,7 @@ class TestGenerateChroot(TestSetupPyBase):
         self.assert_error("src/python/invalid_binary:invalid_bin2", InvalidEntryPoint)
 
 
-class TestGetSources(TestSetupPyBase):
+class TestGetSources(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [
@@ -303,7 +288,7 @@ class TestGetSources(TestSetupPyBase):
         )
 
 
-class TestGetRequirements(TestSetupPyBase):
+class TestGetRequirements(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [
@@ -367,7 +352,7 @@ class TestGetRequirements(TestSetupPyBase):
         self.assert_requirements(["ext3==0.0.1", "bar==9.8.7"], "src/python/foo/corge")
 
 
-class TestGetAncestorInitPy(TestSetupPyBase):
+class TestGetAncestorInitPy(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [
@@ -436,7 +421,7 @@ class TestGetAncestorInitPy(TestSetupPyBase):
         )
 
 
-class TestGetOwnedDependencies(TestSetupPyBase):
+class TestGetOwnedDependencies(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [
@@ -501,7 +486,7 @@ class TestGetOwnedDependencies(TestSetupPyBase):
         )
 
 
-class TestGetExportingOwner(TestSetupPyBase):
+class TestGetExportingOwner(PythonTestBase):
     @classmethod
     def rules(cls):
         return super().rules() + [

--- a/src/python/pants/backend/python/rules/testutil.py
+++ b/src/python/pants/backend/python/rules/testutil.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.python_artifact import PythonArtifact
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.build_graph.address import Address
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.selectors import Params
+from pants.python.python_requirement import PythonRequirement
+from pants.testutil.subsystem.util import init_subsystem
+from pants.testutil.test_base import TestBase
+
+
+class PythonTestBase(TestBase):
+    @classmethod
+    def alias_groups(cls) -> BuildFileAliases:
+        return BuildFileAliases(
+            objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact,}
+        )
+
+    def tgt(self, addr: str) -> HydratedTarget:
+        return self.request_single_product(HydratedTarget, Params(Address.parse(addr)))
+
+    def setUp(self):
+        super().setUp()
+        init_subsystem(PythonBinary.Defaults)

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -120,7 +120,7 @@ class PythonBinary(PythonTarget):
 
         super().__init__(sources=sources, payload=payload, **kwargs)
 
-        if (not sources or not sources.files) and entry_point is None:
+        if not self.is_in_v2_mode and (not sources or not sources.files) and entry_point is None:
             raise TargetDefinitionException(
                 self, "A python binary target must specify either a single source or entry_point."
             )
@@ -128,7 +128,7 @@ class PythonBinary(PythonTarget):
         if not isinstance(platforms, (list, tuple)) and not isinstance(platforms, str):
             raise TargetDefinitionException(self, "platforms must be a list, tuple or str.")
 
-        if sources and sources.files and entry_point:
+        if not self.is_in_v2_mode and sources and sources.files and entry_point:
             entry_point_module = entry_point.split(":", 1)[0]
             entry_source = list(self.sources_relative_to_source_root())[0]
             source_entry_point = self.translate_source_path_to_py_module_specifier(entry_source)

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -12,7 +12,7 @@ def assert_list(
     can_be_none=True,
     default=(),
     key_arg=None,
-    allowable=(list, Fileset, OrderedSet, set, tuple),
+    allowable=(list, Fileset, OrderedSet, frozenset, set, tuple),
     raise_type=ValueError,
 ):
     """This function is used to ensure that parameters set by users in BUILD files are of acceptable

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -14,6 +14,7 @@ from pants.base.specs import Specs
 from pants.base.workunit import WorkUnit
 from pants.bin.goal_runner import GoalRunner
 from pants.build_graph.build_configuration import BuildConfiguration
+from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.native import Native
 from pants.engine.rules import UnionMembership
 from pants.engine.scheduler import SchedulerSession
@@ -315,6 +316,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
         if not v1_goals and not ambiguous_goals:
             return PANTS_SUCCEEDED_EXIT_CODE
+
+        TargetAdaptor._use_v1_targets = False
 
         # Setup and run GoalRunner.
         return (

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -51,7 +51,7 @@ class _OptionalFieldExtractor(Generic[_T]):
         ret = self.value
         if ret is None:
             return None
-        assert isinstance(ret, self.typ), f"{self=}, {ret=}"
+        assert isinstance(ret, self.typ), f"{ret} was not an instance of {self.typ}!"
         return ret
 
 
@@ -67,7 +67,7 @@ class TargetAdaptor(StructWithDeps):
     def _make_v1_target(self, **kwargs) -> Target:
         merged_kwargs = dict(build_graph=None, sources=None)
         merged_kwargs.update(**kwargs)
-        return self._v1_target_class(**merged_kwargs)
+        return self._v1_target_class(**merged_kwargs)  # type: ignore[misc]
 
     def get_field(self, name: str, typ: Type[_T]) -> _OptionalFieldExtractor[_T]:
         maybe_value = self.kwargs().get(name, None)

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -341,6 +341,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         self._build_configuration = self.build_config()
         self._inited_target = False
         subsystem_util.init_subsystem(Target.TagAssignments)
+        subsystem_util.init_subsystem(Target.Arguments)
 
     def buildroot_files(self, relpath=None):
         """Returns the set of all files under the test build root.


### PR DESCRIPTION
### Problem

One possible attempt to address the *migration to v2 `TargetAdaptor`s*, in conjunction with #9153. The `get_field()` method makes progress towards #4535.

This implements the strategy from #8760, much more cleanly and efficiently.

### Solution

- For several `TargetAdaptor` subclasses (such as `PythonBinaryAdaptor`), assign a v1 `Target` subclass (such as `PythonBinary`) to the `_v1_target_class` class field in `engine_initializer.py`.
- When such a `TargetAdaptor` is accessed, create an instance of `self._v1_target_class` with `build_graph=None` and `sources=None`.
- Add all payload fields from the constructed v1 `Target` to the `TargetAdaptor`'s `kwargs()`.
- Add the `get_field()` method to `TargetAdaptor` to access its kwargs while checking types.

### Result

If a v2 `TargetAdaptor` has declared a `_v1_target_class` field, it will have access to that target's payload fields when created. This allows re-use of logic written in v1 target classes, while allowing a smooth eventual migration to v2 `TargetAdaptor`s. Along with #9153, this is a first step in addressing #4535.