### PR TITLE
Fix `file_option` not working with V2 tests

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -3,8 +3,6 @@
 
 from typing import List, Optional
 
-import pytest
-
 from pants.backend.python.lint.bandit.rules import BanditTarget
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -47,7 +45,6 @@ class BanditIntegrationTest(TestBase):
     ) -> LintResult:
         args = ["--backend-packages2=pants.backend.python.lint.bandit"]
         if config:
-            # TODO(#9148): The config file exists but parser.py cannot find it
             self.create_file(relpath=".bandit", contents=config)
             args.append("--bandit-config=.bandit")
         if passthrough_args:
@@ -89,7 +86,6 @@ class BanditIntegrationTest(TestBase):
         assert result.exit_code == 0
         assert "No issues identified." in result.stdout
 
-    @pytest.mark.skip(reason="#9148: The config file exists but parser.py cannot find it")
     def test_respects_config_file(self) -> None:
         result = self.run_bandit([self.bad_source], config="skips: ['B303']\n")
         assert result.exit_code == 0

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -3,8 +3,6 @@
 
 from typing import List, Optional, Tuple
 
-import pytest
-
 from pants.backend.python.lint.black.rules import BlackTarget
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -109,7 +107,6 @@ class BlackIntegrationTest(TestBase):
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
 
-    @pytest.mark.skip(reason="#9148: The config file exists but parser.py cannot find it")
     def test_respects_config_file(self) -> None:
         lint_result, fmt_result = self.run_black(
             [self.needs_config_source], config="[tool.black]\nskip-string-normalization = 'true'\n",

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -3,8 +3,6 @@
 
 from typing import List, Optional
 
-import pytest
-
 from pants.backend.python.lint.flake8.rules import Flake8Target
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -48,7 +46,6 @@ class Flake8IntegrationTest(TestBase):
     ) -> LintResult:
         args = ["--backend-packages2=pants.backend.python.lint.flake8"]
         if config:
-            # TODO(#9148): The config file exists, but parser.py cannot find it
             self.create_file(relpath=".flake8", contents=config)
             args.append("--flake8-config=.flake8")
         if passthrough_args:
@@ -101,7 +98,6 @@ class Flake8IntegrationTest(TestBase):
         assert py3_result.exit_code == 0
         assert py3_result.stdout.strip() == ""
 
-    @pytest.mark.skip(reason="#9148: The config file exists, but parser.py cannot find it")
     def test_respects_config_file(self) -> None:
         result = self.run_flake8([self.bad_source], config="[flake8]\nignore = F401\n")
         assert result.exit_code == 0

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -38,7 +38,7 @@ class PylintTarget:
 def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
     args = []
     if pylint.options.config is not None:
-        args.append(f"--config={pylint.options.config}")
+        args.append(f"--rcfile={pylint.options.config}")
     args.extend(pylint.options.args)
     args.extend(sorted(specified_source_files.snapshot.files))
     return tuple(args)

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -113,7 +113,7 @@ class PylintIntegrationTest(TestBase):
         self.write_file(self.bad_source)
         result = self.run_pylint([self.bad_source], config="[pylint]\ndisable = C0103\n")
         assert result.exit_code == 0
-        assert result.stdout.strip() == ""
+        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
 
     def test_respects_passthrough_args(self) -> None:
         self.create_python_library()

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -5,8 +5,6 @@ from functools import partialmethod
 from textwrap import dedent
 from typing import List, Optional
 
-import pytest
-
 from pants.backend.python.lint.pylint.rules import PylintTarget
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -60,7 +58,6 @@ class PylintIntegrationTest(TestBase):
     ) -> LintResult:
         args = ["--backend-packages2=pants.backend.python.lint.pylint"]
         if config:
-            # TODO(#9148): The config file exists but parser.py cannot find it
             self.create_file(relpath="pylintrc", contents=config)
             args.append("--pylint-config=pylintrc")
         if passthrough_args:
@@ -111,7 +108,6 @@ class PylintIntegrationTest(TestBase):
         assert result.exit_code == 0
         assert "Your code has been rated at 10.00/10" in result.stdout.strip()
 
-    @pytest.mark.skip(reason="#9148: The config file exists but parser.py cannot find it")
     def test_respects_config_file(self) -> None:
         self.create_python_library()
         self.write_file(self.bad_source)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -807,7 +807,7 @@ class Parser:
             if type_arg == file_option:
                 check_file_exists(val)
             if type_arg == dir_option:
-                check_dir_option(val)
+                check_dir_exists(val)
 
         def check_file_exists(val) -> None:
             error_prefix = f"File value `{val}` for option `{dest}` in `{self._scope_str()}`"
@@ -819,7 +819,7 @@ class Parser:
             if not path.is_file() and not path_with_buildroot.is_file():
                 raise ParseError(f"{error_prefix} does not exist.")
 
-        def check_dir_option(val) -> None:
+        def check_dir_exists(val) -> None:
             error_prefix = f"Directory value `{val}` for option `{dest}` in `{self._scope_str()}`"
             try:
                 path = Path(val)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/9148.

`parser.py` calls `Path(value).is_file()` to validate that `file_option`s actually exist. When given a relative path like `.bandit`, Python will see if that file exists in the cwd. This works great in production.

It does not work with tests when using the V2 test runner, however. When running tests with V2, the cwd is the chroot created by the V2 test runner. Our `TestBase` tests don't actually write to that chroot, though; they use a temporary `self.build_root`. So, when calling something like `self.create_file(".bandit")`, `TestBase` will create the file in the `TestBase` chroot rather than the V2 test runner chroot. This means that `parser.py` cannot find the value, even though it does exist where it's supposed to belong.

We fix this by checking first if the raw value exists, then falling back to seeing if it exists when prefixed by the build root.