### PR TITLE
Fix plugin resolver cache compatibility.

### DIFF
--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import site
 import uuid
-from typing import Iterable, Iterator, List, Optional, Tuple, Type, TypeVar, cast
+from typing import Iterable, Iterator, List, Optional, Type, TypeVar, cast
 
 from pex import resolver
 from pex.interpreter import PythonInterpreter
@@ -178,7 +178,7 @@ class PluginResolver:
         # Subsystem facility is wired up.  As a result PluginResolver is not itself a Subsystem with
         # PythonRepos as a dependency.  Instead it does the minimum possible work to hand-roll
         # bootstrapping of the Subsystems it needs.
-        optionables: Tuple[Type[Optionable], ...] = (GlobalOptionsRegistrar, PythonRepos)
+        optionables: Iterable[Type[Optionable]] = (GlobalOptionsRegistrar, PythonRepos)
         known_scope_infos: List[ScopeInfo] = [
             ksi for optionable in optionables for ksi in optionable.known_scope_infos()
         ]


### PR DESCRIPTION
The cache between Pants on Pex 1.x and Pants on Pex 2.x was incompatible
(in particular the contents of plugins-<hash>.txt file) leading to
errors when upgrading or downgrading pants that forced either clearing
the plugins cache or else modifying its location via setting the global
`plugin_cache_dir` option.

This change fixes the plugin cache to be divorced from the results of
Pex resolves by copying Pex resolved distributions to a location
controlled by the plugin system that is backwards compatible with older
versions of Pants.