### PR TITLE
Specify Platform in ExecuteProcessResult output

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
-from pants.engine.platform import PlatformConstraint
+from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, rule
 from pants.util.meta import frozen_after_init
 
@@ -118,6 +118,7 @@ class ExecuteProcessResult:
     stdout: bytes
     stderr: bytes
     output_directory_digest: Digest
+    platform: Platform
 
 
 @dataclass(frozen=True)
@@ -131,6 +132,7 @@ class FallibleExecuteProcessResult:
     stderr: bytes
     exit_code: int
     output_directory_digest: Digest
+    platform: Platform
 
 
 class ProcessExecutionFailure(Exception):
@@ -185,7 +187,10 @@ def fallible_to_exec_result_or_raise(
 
     if fallible_result.exit_code == 0:
         return ExecuteProcessResult(
-            fallible_result.stdout, fallible_result.stderr, fallible_result.output_directory_digest
+            fallible_result.stdout,
+            fallible_result.stderr,
+            fallible_result.output_directory_digest,
+            fallible_result.platform,
         )
     else:
         raise ProcessExecutionFailure(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -38,6 +38,7 @@ from pants.engine.isolated_process import (
     MultiPlatformExecuteProcessRequest,
 )
 from pants.engine.objects import union
+from pants.engine.platform import Platform
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
@@ -588,6 +589,7 @@ class EngineTypes(NamedTuple):
     interactive_process_request: TypeId
     interactive_process_result: TypeId
     snapshot_subset: TypeId
+    construct_platform: Function
 
 
 class PyResult(NamedTuple):
@@ -966,6 +968,7 @@ class Native(metaclass=SingletonMetaclass):
             interactive_process_request=ti(InteractiveProcessRequest),
             interactive_process_result=ti(InteractiveProcessResult),
             snapshot_subset=ti(SnapshotSubset),
+            construct_platform=func(Platform),
         )
 
         scheduler_result = self.lib.scheduler_create(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -34,7 +34,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.isolated_process import (
-    FallibleExecuteProcessResult,
+    FallibleExecuteProcessResultWithPlatform,
     MultiPlatformExecuteProcessRequest,
 )
 from pants.engine.objects import union
@@ -946,7 +946,7 @@ class Native(metaclass=SingletonMetaclass):
             construct_file_content=func(FileContent),
             construct_files_content=func(FilesContent),
             files_content=ti(FilesContent),
-            construct_process_result=func(FallibleExecuteProcessResult),
+            construct_process_result=func(FallibleExecuteProcessResultWithPlatform),
             construct_materialize_directories_results=func(MaterializeDirectoriesResult),
             construct_materialize_directory_result=func(MaterializeDirectoryResult),
             address=ti(Address),
@@ -959,7 +959,7 @@ class Native(metaclass=SingletonMetaclass):
             file=ti(File),
             link=ti(Link),
             multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
-            process_result=ti(FallibleExecuteProcessResult),
+            process_result=ti(FallibleExecuteProcessResultWithPlatform),
             coroutine=ti(CoroutineType),
             url_to_fetch=ti(UrlToFetch),
             string=ti(str),

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest,
+  MultiPlatformExecuteProcessRequest, Platform,
 };
 use std::sync::Arc;
 
@@ -100,6 +100,7 @@ impl CommandRunner {
             execute_response,
             vec![],
             context.workunit_store,
+            Platform::Linux, //TODO this is incorrect and will be fixed in a follow-up PR
           )
           .map(Some)
           .to_boxed()

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
-  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform,
+  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
+  FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
 };
 use std::sync::Arc;
 
@@ -35,7 +35,7 @@ impl crate::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let digest = crate::digest(req.clone(), &self.metadata);
     let key = digest.0;
 
@@ -82,7 +82,7 @@ impl CommandRunner {
     &self,
     fingerprint: Fingerprint,
     context: Context,
-  ) -> impl Future<Item = Option<FallibleExecuteProcessResult>, Error = String> {
+  ) -> impl Future<Item = Option<FallibleExecuteProcessResultWithPlatform>, Error = String> {
     let file_store = self.file_store.clone();
     self
       .process_execution_store
@@ -113,7 +113,7 @@ impl CommandRunner {
   fn store(
     &self,
     fingerprint: Fingerprint,
-    result: &FallibleExecuteProcessResult,
+    result: &FallibleExecuteProcessResultWithPlatform,
   ) -> impl Future<Item = (), Error = String> {
     let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
     execute_response.set_cached_result(true);

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -100,7 +100,7 @@ impl CommandRunner {
             execute_response,
             vec![],
             context.workunit_store,
-            Platform::Linux, //TODO this is incorrect and will be fixed in a follow-up PR
+            Platform::current().unwrap(), //TODO this is incorrect and will be fixed in a follow-up PR
           )
           .map(Some)
           .to_boxed()

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, PlatformConstraint,
+  ExecuteProcessRequestMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
 };
 use hashing::EMPTY_DIGEST;
 use sharded_lmdb::ShardedLmdb;
@@ -14,8 +14,8 @@ use tempfile::TempDir;
 use testutil::data::TestData;
 
 struct RoundtripResults {
-  uncached: Result<FallibleExecuteProcessResult, String>,
-  maybe_cached: Result<FallibleExecuteProcessResult, String>,
+  uncached: Result<FallibleExecuteProcessResultWithPlatform, String>,
+  maybe_cached: Result<FallibleExecuteProcessResultWithPlatform, String>,
 }
 
 fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -307,7 +307,7 @@ pub struct ExecuteProcessRequestMetadata {
 /// The result of running a process.
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FallibleExecuteProcessResult {
+pub struct FallibleExecuteProcessResultWithPlatform {
   pub stdout: Bytes,
   pub stderr: Bytes,
   pub exit_code: i32,
@@ -321,7 +321,7 @@ pub struct FallibleExecuteProcessResult {
 }
 
 #[cfg(test)]
-impl FallibleExecuteProcessResult {
+impl FallibleExecuteProcessResultWithPlatform {
   pub fn without_execution_attempts(mut self) -> Self {
     self.execution_attempts = vec![];
     self
@@ -363,7 +363,7 @@ pub trait CommandRunner: Send + Sync {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String>;
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String>;
 
   ///
   /// Given a multi platform request which may have some platform
@@ -429,7 +429,7 @@ impl CommandRunner for BoundedCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let inner = self.inner.clone();
     self
       .inner

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -129,7 +129,7 @@ impl From<Platform> for String {
   fn from(platform: Platform) -> String {
     match platform {
       Platform::Linux => "linux".to_string(),
-      Platform::Darwin => "osx".to_string(),
+      Platform::Darwin => "darwin".to_string(),
     }
   }
 }
@@ -138,7 +138,7 @@ impl From<PlatformConstraint> for String {
   fn from(platform: PlatformConstraint) -> String {
     match platform {
       PlatformConstraint::Linux => "linux".to_string(),
-      PlatformConstraint::Darwin => "osx".to_string(),
+      PlatformConstraint::Darwin => "darwin".to_string(),
       PlatformConstraint::None => "none".to_string(),
     }
   }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, Platform, PlatformConstraint, RelativePath,
+  FallibleExecuteProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -37,7 +37,7 @@ fn stdout() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -68,7 +68,7 @@ fn stdout_and_stderr_and_exit_code() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes("bar"),
       exit_code: 1,
@@ -100,7 +100,7 @@ fn capture_exit_code_signal() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: -15,
@@ -217,7 +217,7 @@ fn output_files_none() {
   });
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -251,7 +251,7 @@ fn output_files_one() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -290,7 +290,7 @@ fn output_dirs() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -330,7 +330,7 @@ fn output_files_many() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -368,7 +368,7 @@ fn output_files_execution_failure() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 1,
@@ -404,7 +404,7 @@ fn output_files_partial_output() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -438,7 +438,7 @@ fn output_overlapping_file_and_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -471,7 +471,7 @@ fn jdk_symlink() {
   });
   assert_eq!(
     result,
-    Ok(FallibleExecuteProcessResult {
+    Ok(FallibleExecuteProcessResultWithPlatform {
       stdout: roland,
       stderr: as_bytes(""),
       exit_code: 0,
@@ -588,7 +588,7 @@ fn all_containing_directories_for_outputs_are_created() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -622,7 +622,7 @@ fn output_empty_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -676,7 +676,7 @@ fn local_only_scratch_files_materialized() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -757,7 +757,7 @@ fn working_directory() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("roland\n"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -768,7 +768,9 @@ fn working_directory() {
   );
 }
 
-fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProcessResult, String> {
+fn run_command_locally(
+  req: ExecuteProcessRequest,
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let work_dir = TempDir::new().unwrap();
   run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned())
 }
@@ -776,7 +778,7 @@ fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProc
 fn run_command_locally_in_dir_with_cleanup(
   req: ExecuteProcessRequest,
   dir: PathBuf,
-) -> Result<FallibleExecuteProcessResult, String> {
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   run_command_locally_in_dir(req, dir, true, None, None)
 }
 
@@ -786,7 +788,7 @@ fn run_command_locally_in_dir(
   cleanup: bool,
   store: Option<Store>,
   executor: Option<task_executor::Executor>,
-) -> Result<FallibleExecuteProcessResult, String> {
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let store_dir = TempDir::new().unwrap();
   let executor = executor.unwrap_or_else(task_executor::Executor::new);
   let store =

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, PlatformConstraint, RelativePath,
+  FallibleExecuteProcessResult, Platform, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -43,6 +43,7 @@ fn stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -73,6 +74,7 @@ fn stdout_and_stderr_and_exit_code() {
       exit_code: 1,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -104,6 +106,7 @@ fn capture_exit_code_signal() {
       exit_code: -15,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -220,6 +223,7 @@ fn output_files_none() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -253,6 +257,7 @@ fn output_files_one() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -291,6 +296,7 @@ fn output_dirs() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -330,6 +336,7 @@ fn output_files_many() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -367,6 +374,7 @@ fn output_files_execution_failure() {
       exit_code: 1,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -402,6 +410,7 @@ fn output_files_partial_output() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -435,6 +444,7 @@ fn output_overlapping_file_and_dir() {
       exit_code: 0,
       output_directory: TestDirectory::nested().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -467,6 +477,7 @@ fn jdk_symlink() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   )
 }
@@ -583,6 +594,7 @@ fn all_containing_directories_for_outputs_are_created() {
       exit_code: 0,
       output_directory: TestDirectory::nested_dir_and_file().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -616,6 +628,7 @@ fn output_empty_dir() {
       exit_code: 0,
       output_directory: TestDirectory::containing_falcons_dir().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -669,6 +682,7 @@ fn local_only_scratch_files_materialized() {
       exit_code: 0,
       output_directory: roland_directory_digest,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -749,6 +763,7 @@ fn working_directory() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -17,7 +17,7 @@ use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -194,6 +194,7 @@ impl super::CommandRunner for CommandRunner {
       executor,
       true,
       &workdir_for_this_nailgun,
+      Platform::current().unwrap(),
     )
   }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -16,8 +16,9 @@ use tokio::net::TcpStream;
 use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
-  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
+  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
+  FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
+  PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -168,7 +169,7 @@ impl super::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let original_request = self.extract_compatible_request(&req).unwrap();
 
     if !original_request.is_nailgunnable {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -18,7 +18,7 @@ use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOr
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, MultiPlatformExecuteProcessRequest,
-  PlatformConstraint,
+  Platform, PlatformConstraint,
 };
 use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;
@@ -626,6 +626,7 @@ fn successful_execution_after_one_getoperation() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -673,6 +674,7 @@ fn retries_retriable_errors() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -775,7 +777,7 @@ pub fn sends_headers() {
       String::from("cat") => String::from("roland"),
     },
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -849,6 +851,7 @@ fn extract_response_with_digest_stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -878,6 +881,7 @@ fn extract_response_with_digest_stderr() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -939,7 +943,7 @@ fn ensure_inline_stdio_is_stored() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -957,6 +961,7 @@ fn ensure_inline_stdio_is_stored() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -1031,6 +1036,7 @@ fn successful_execution_after_four_getoperations() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1147,6 +1153,7 @@ fn dropped_request_cancels() {
     exit_code: 0,
     output_directory: EMPTY_DIGEST,
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let run_future = command_runner.run(execute_request.into(), Context::default());
@@ -1214,6 +1221,7 @@ fn retry_for_cancelled_channel() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1477,7 +1485,7 @@ fn execute_missing_file_uploads_if_known() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1496,6 +1504,7 @@ fn execute_missing_file_uploads_if_known() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
   {
@@ -1584,7 +1593,7 @@ fn execute_missing_file_uploads_if_known_status() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1601,6 +1610,7 @@ fn execute_missing_file_uploads_if_known_status() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   );
   {
@@ -1664,7 +1674,7 @@ fn execute_missing_file_errors_if_unknown() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1708,6 +1718,7 @@ fn extract_execute_response_success() {
     exit_code: 17,
     output_directory: TestDirectory::nested().digest(),
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let mut output_file = bazel_protos::remote_execution::OutputFile::new();
@@ -2492,7 +2503,7 @@ fn create_command_runner(
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime,
     Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -1,5 +1,5 @@
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
+  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
   MultiPlatformExecuteProcessRequest,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -33,7 +33,7 @@ impl SpeculatingCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = Delay::new(Instant::now() + self.speculation_timeout);
     let req2 = req.clone();
     trace!(
@@ -57,11 +57,12 @@ impl SpeculatingCommandRunner {
         Ok(either_success) => {
           // .split() takes out the homogeneous success type for either primary or
           // secondary successes.
-          ok::<FallibleExecuteProcessResult, String>(either_success.split().0).to_boxed()
+          ok::<FallibleExecuteProcessResultWithPlatform, String>(either_success.split().0)
+            .to_boxed()
         }
         Err(Either::A((failed_primary_res, _))) => {
           debug!("primary request FAILED, aborting");
-          err::<FallibleExecuteProcessResult, String>(failed_primary_res).to_boxed()
+          err::<FallibleExecuteProcessResultWithPlatform, String>(failed_primary_res).to_boxed()
         }
         // We handle the case of the secondary failing specially. We only want to show
         // a failure to the user if the primary execution source fails. This maintains
@@ -103,7 +104,7 @@ impl CommandRunner for SpeculatingCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     match (
       self.primary.extract_compatible_request(&req),
       self.secondary.extract_compatible_request(&req),

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -1,7 +1,7 @@
 use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
+  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
   MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -104,7 +104,7 @@ fn run_speculation_test(
   r1_is_compatible: bool,
   r2_is_compatible: bool,
 ) -> (
-  Result<FallibleExecuteProcessResult, String>,
+  Result<FallibleExecuteProcessResultWithPlatform, String>,
   Arc<Mutex<u32>>,
   Arc<Mutex<u32>>,
 ) {
@@ -152,7 +152,7 @@ fn make_delayed_command_runner(
   let result = if is_err {
     Err(msg.into())
   } else {
-    Ok(FallibleExecuteProcessResult {
+    Ok(FallibleExecuteProcessResultWithPlatform {
       stdout: msg.into(),
       stderr: "".into(),
       exit_code: 0,
@@ -173,7 +173,7 @@ fn make_delayed_command_runner(
 #[derive(Clone)]
 struct DelayedCommandRunner {
   delay: Duration,
-  result: Result<FallibleExecuteProcessResult, String>,
+  result: Result<FallibleExecuteProcessResultWithPlatform, String>,
   is_compatible: bool,
   call_counter: Arc<Mutex<u32>>,
   finished_counter: Arc<Mutex<u32>>,
@@ -182,7 +182,7 @@ struct DelayedCommandRunner {
 impl DelayedCommandRunner {
   pub fn new(
     delay: Duration,
-    result: Result<FallibleExecuteProcessResult, String>,
+    result: Result<FallibleExecuteProcessResultWithPlatform, String>,
     is_compatible: bool,
     call_counter: Arc<Mutex<u32>>,
     finished_counter: Arc<Mutex<u32>>,
@@ -210,7 +210,7 @@ impl CommandRunner for DelayedCommandRunner {
     &self,
     _req: MultiPlatformExecuteProcessRequest,
     _context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = Delay::new(Instant::now() + self.delay);
     let exec_result = self.result.clone();
     let command_runner = self.clone();

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -2,7 +2,7 @@ use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
   CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -158,6 +158,7 @@ fn make_delayed_command_runner(
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   };
   DelayedCommandRunner::new(

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -32,7 +32,9 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
-use process_execution::{Context, ExecuteProcessRequestMetadata, PlatformConstraint, RelativePath};
+use process_execution::{
+  Context, ExecuteProcessRequestMetadata, Platform, PlatformConstraint, RelativePath,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
@@ -371,7 +373,7 @@ fn main() {
           oauth_bearer_token,
           headers,
           store.clone(),
-          PlatformConstraint::Linux,
+          Platform::Linux,
           executor,
           std::time::Duration::from_secs(160),
           std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -21,7 +21,7 @@ use fs::{safe_create_dir_all_ioerror, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
   self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ExecuteProcessRequestMetadata,
-  PlatformConstraint,
+  Platform,
 };
 use rand::seq::SliceRandom;
 use reqwest;
@@ -180,7 +180,7 @@ impl Core {
             store.clone(),
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
-            PlatformConstraint::Linux,
+            Platform::Linux,
             executor.clone(),
             std::time::Duration::from_secs(160),
             std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -55,6 +55,7 @@ fn multi_platform_process_request_to_process_result(
   }))
   .and_then(move |process_request| context.get(process_request))
   .map(move |result| {
+    let platform_name: String = result.0.platform.into();
     externs::unsafe_call(
       &core.types.construct_process_result,
       &[
@@ -62,6 +63,10 @@ fn multi_platform_process_request_to_process_result(
         externs::store_bytes(&result.0.stderr),
         externs::store_i64(result.0.exit_code.into()),
         Snapshot::store_directory(&core, &result.0.output_directory),
+        externs::unsafe_call(
+          &core.types.construct_platform,
+          &[externs::store_utf8(&platform_name)],
+        ),
       ],
     )
   })

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -364,7 +364,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProcessResult(pub process_execution::FallibleExecuteProcessResult);
+pub struct ProcessResult(pub process_execution::FallibleExecuteProcessResultWithPlatform);
 
 ///
 /// A Node that represents reading the destination of a symlink (non-recursively).

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -33,4 +33,5 @@ pub struct Types {
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
   pub snapshot_subset: TypeId,
+  pub construct_platform: Function,
 }


### PR DESCRIPTION
### Problem

We want to be able to track the actual Platform that an external process was ran on in as a field of a new type `FallibleExecuteProcessResultWithPlatform`. This is important for ensuring that some cross platform workflows (such as, a user running pants on a Mac remoting on a build farm with Linux build machines) work correctly. 

### Solution

This commit introduces the Rust boilerplate for creating `Platform` type and passing it across the FFI to Python. It is not yet complete - `cache.rs` has not yet been updated to correctly cache the Platform, and will incorrectly always return "Linux" until this is fixed in a follow-up PR. 

It also renames the string representation of the OSX Platform from "osx" to "darwin", to match what the Python code assumes.

### Result

There is now a new type `FallibleExecuteProcessResultWithPlatform` which has a new parameter `platform`, which will (incorrectly) always be the same as the local platform until a follow-up PR fixes this. The existing `FallibleExecuteProcessResult` and `ExecuteProcessResult` types work the same way as they previously did, but are now derived from `FallibleExecuteProcessResultWithPlatform` by dropping the platform information.