### PR TITLE
Make the platform a remote execution happened on available to `@rule`s.

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -14,7 +14,9 @@ python_tests(
   dependencies = [
     ':console',
     ':goal',
+    ':platform',
     ':rules',
+    'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/engine:util',
   ],
 )

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
-from pants.engine.platform import PlatformConstraint
+from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, rule
 from pants.util.meta import frozen_after_init
 
@@ -118,6 +118,7 @@ class ExecuteProcessResult:
     stdout: bytes
     stderr: bytes
     output_directory_digest: Digest
+    platform: Platform
 
 
 @dataclass(frozen=True)
@@ -131,6 +132,7 @@ class FallibleExecuteProcessResult:
     stderr: bytes
     exit_code: int
     output_directory_digest: Digest
+    platform: Platform
 
 
 class ProcessExecutionFailure(Exception):
@@ -185,7 +187,10 @@ def fallible_to_exec_result_or_raise(
 
     if fallible_result.exit_code == 0:
         return ExecuteProcessResult(
-            fallible_result.stdout, fallible_result.stderr, fallible_result.output_directory_digest
+            fallible_result.stdout,
+            fallible_result.stderr,
+            fallible_result.output_directory_digest,
+            fallible_result.platform,
         )
     else:
         raise ProcessExecutionFailure(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -38,6 +38,7 @@ from pants.engine.isolated_process import (
     MultiPlatformExecuteProcessRequest,
 )
 from pants.engine.objects import union
+from pants.engine.platform import Platform
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
@@ -588,6 +589,7 @@ class EngineTypes(NamedTuple):
     interactive_process_request: TypeId
     interactive_process_result: TypeId
     snapshot_subset: TypeId
+    construct_platform: Function
 
 
 class PyResult(NamedTuple):
@@ -966,6 +968,7 @@ class Native(metaclass=SingletonMetaclass):
             interactive_process_request=ti(InteractiveProcessRequest),
             interactive_process_result=ti(InteractiveProcessResult),
             snapshot_subset=ti(SnapshotSubset),
+            construct_platform=func(Platform),
         )
 
         scheduler_result = self.lib.scheduler_create(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -34,7 +34,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.isolated_process import (
-    FallibleExecuteProcessResult,
+    FallibleExecuteProcessResultWithPlatform,
     MultiPlatformExecuteProcessRequest,
 )
 from pants.engine.objects import union
@@ -946,7 +946,7 @@ class Native(metaclass=SingletonMetaclass):
             construct_file_content=func(FileContent),
             construct_files_content=func(FilesContent),
             files_content=ti(FilesContent),
-            construct_process_result=func(FallibleExecuteProcessResult),
+            construct_process_result=func(FallibleExecuteProcessResultWithPlatform),
             construct_materialize_directories_results=func(MaterializeDirectoriesResult),
             construct_materialize_directory_result=func(MaterializeDirectoryResult),
             address=ti(Address),
@@ -959,7 +959,7 @@ class Native(metaclass=SingletonMetaclass):
             file=ti(File),
             link=ti(Link),
             multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
-            process_result=ti(FallibleExecuteProcessResult),
+            process_result=ti(FallibleExecuteProcessResultWithPlatform),
             coroutine=ti(CoroutineType),
             url_to_fetch=ti(UrlToFetch),
             string=ti(str),

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
+from pants.engine.isolated_process import (
+    ExecuteProcessRequest,
+    FallibleExecuteProcessResultWithPlatform,
+)
+from pants.engine.platform import Platform
+from pants.testutil.test_base import TestBase
+
+
+class PlatformTest(TestBase):
+    def test_platform_on_local_epr_result(self) -> None:
+
+        this_platform = Platform.current
+
+        req = ExecuteProcessRequest(
+            argv=("/bin/echo", "test"),
+            input_files=EMPTY_DIRECTORY_DIGEST,
+            description="Run some program that will exit cleanly.",
+        )
+        result = self.request_single_product(FallibleExecuteProcessResultWithPlatform, req)
+        assert result.exit_code == 0
+        assert result.platform == this_platform

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -128,6 +128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +1991,7 @@ version = "0.0.1"
 dependencies = [
  "async_semaphore 0.0.1",
  "bazel_protos 0.0.1",
+ "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "concrete_time 0.0.1",
@@ -2003,6 +2013,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sharded_lmdb 0.0.1",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3687,6 +3698,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -39,6 +39,8 @@ regex = "1.3.1"
 lazy_static = "1"
 parking_lot = "0.6"
 itertools = "0.8.0"
+serde = "1.0.104"
+bincode = "1.2.1"
 
 [dev-dependencies]
 maplit = "1.0.1"

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -2,9 +2,9 @@ use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
   FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
 };
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use bincode;
 use bytes::Bytes;
 use futures01::{future, Future};
 use log::{debug, warn};
@@ -12,15 +12,21 @@ use protobuf::Message;
 
 use boxfuture::{BoxFuture, Boxable};
 use hashing::Fingerprint;
-use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use sharded_lmdb::ShardedLmdb;
 use store::Store;
+
+#[allow(dead_code)]
+#[derive(Serialize, Deserialize)]
+struct PlatformAndResponseBytes {
+  platform: Platform,
+  response_bytes: Vec<u8>,
+}
 
 #[derive(Clone)]
 pub struct CommandRunner {
   underlying: Arc<dyn crate::CommandRunner>,
   process_execution_store: ShardedLmdb,
-  platform_map: Arc<Mutex<HashMap<Fingerprint, Platform>>>,
   file_store: Store,
   metadata: ExecuteProcessRequestMetadata,
 }
@@ -35,7 +41,6 @@ impl CommandRunner {
     CommandRunner {
       underlying,
       process_execution_store,
-      platform_map: Arc::new(Mutex::new(HashMap::new())),
       file_store,
       metadata,
     }
@@ -106,23 +111,20 @@ impl CommandRunner {
     use bazel_protos::remote_execution::ExecuteResponse;
     let file_store = self.file_store.clone();
 
-    let platform_map = self.platform_map.clone();
-
     self
       .process_execution_store
       .load_bytes_with(fingerprint.clone(), move |bytes| {
+        let decoded: PlatformAndResponseBytes = bincode::deserialize(&bytes[..])
+          .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
+
+        let platform = decoded.platform;
+
         let mut execute_response = ExecuteResponse::new();
         execute_response
-          .merge_from_bytes(&bytes)
+          .merge_from_bytes(&decoded.response_bytes)
           .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
 
-        let platform_lookup_result = platform_map
-          .lock()
-          .get(&fingerprint)
-          .cloned()
-          .ok_or_else(|| "Execution platform not found in store".to_string())?;
-
-        Ok((execute_response, platform_lookup_result))
+        Ok((execute_response, platform))
       })
       .and_then(
         move |maybe_execute_response: Option<(ExecuteResponse, Platform)>| {
@@ -164,10 +166,7 @@ impl CommandRunner {
     // TODO: GC the local process execution cache.
     //
 
-    self
-      .platform_map
-      .lock()
-      .insert(fingerprint, result.platform);
+    let platform = result.platform;
 
     self
       .file_store
@@ -183,9 +182,22 @@ impl CommandRunner {
         action_result.set_stderr_digest((&stderr_digest).into());
         execute_response
           .write_to_bytes()
-          .map(Bytes::from)
           .map_err(|err| format!("Error serializing execute process result to cache: {}", err))
       })
-      .and_then(move |bytes| process_execution_store.store_bytes(fingerprint, bytes, false))
+      .and_then(move |response_bytes: Vec<u8>| {
+        let bytes_to_store = bincode::serialize(&PlatformAndResponseBytes {
+          platform,
+          response_bytes,
+        })
+        .map(Bytes::from)
+        .map_err(|err| {
+          format!(
+            "Error serializing platform and execute process result: {}",
+            err
+          )
+        });
+        future::result(bytes_to_store)
+      })
+      .and_then(move |bytes: Bytes| process_execution_store.store_bytes(fingerprint, bytes, false))
   }
 }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -40,12 +40,6 @@ impl CommandRunner {
       metadata,
     }
   }
-
-  #[allow(dead_code)]
-  fn do_thing(&self) {
-    let _x = &self.process_execution_store;
-    panic!("foo");
-  }
 }
 
 impl crate::CommandRunner for CommandRunner {

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest,
+  MultiPlatformExecuteProcessRequest, Platform,
 };
 use std::sync::Arc;
 
@@ -100,6 +100,7 @@ impl CommandRunner {
             execute_response,
             vec![],
             context.workunit_store,
+            Platform::Linux, //TODO this is incorrect and will be fixed in a follow-up PR
           )
           .map(Some)
           .to_boxed()

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
-  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform,
+  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
+  FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
 };
 use std::sync::Arc;
 
@@ -35,7 +35,7 @@ impl crate::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let digest = crate::digest(req.clone(), &self.metadata);
     let key = digest.0;
 
@@ -82,7 +82,7 @@ impl CommandRunner {
     &self,
     fingerprint: Fingerprint,
     context: Context,
-  ) -> impl Future<Item = Option<FallibleExecuteProcessResult>, Error = String> {
+  ) -> impl Future<Item = Option<FallibleExecuteProcessResultWithPlatform>, Error = String> {
     let file_store = self.file_store.clone();
     self
       .process_execution_store
@@ -113,7 +113,7 @@ impl CommandRunner {
   fn store(
     &self,
     fingerprint: Fingerprint,
-    result: &FallibleExecuteProcessResult,
+    result: &FallibleExecuteProcessResultWithPlatform,
   ) -> impl Future<Item = (), Error = String> {
     let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
     execute_response.set_cached_result(true);

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -100,7 +100,7 @@ impl CommandRunner {
             execute_response,
             vec![],
             context.workunit_store,
-            Platform::Linux, //TODO this is incorrect and will be fixed in a follow-up PR
+            Platform::current().unwrap(), //TODO this is incorrect and will be fixed in a follow-up PR
           )
           .map(Some)
           .to_boxed()

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -65,13 +65,10 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   let local_result = runtime.block_on(local.run(request.clone().into(), Context::default()));
 
   let cache_dir = TempDir::new().unwrap();
+  let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
 
-  let process_execution_store = ShardedLmdb::new(
-    cache_dir.path().to_owned(),
-    50 * 1024 * 1024,
-    runtime.clone(),
-  )
-  .unwrap();
+  let process_execution_store =
+    ShardedLmdb::new(cache_dir.path().to_owned(), max_lmdb_size, runtime.clone()).unwrap();
 
   let metadata = ExecuteProcessRequestMetadata {
     instance_name: None,

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, PlatformConstraint,
+  ExecuteProcessRequestMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
 };
 use hashing::EMPTY_DIGEST;
 use sharded_lmdb::ShardedLmdb;
@@ -14,8 +14,8 @@ use tempfile::TempDir;
 use testutil::data::TestData;
 
 struct RoundtripResults {
-  uncached: Result<FallibleExecuteProcessResult, String>,
-  maybe_cached: Result<FallibleExecuteProcessResult, String>,
+  uncached: Result<FallibleExecuteProcessResultWithPlatform, String>,
+  maybe_cached: Result<FallibleExecuteProcessResultWithPlatform, String>,
 }
 
 fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -30,6 +30,7 @@ extern crate derivative;
 
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::ops::AddAssign;
@@ -65,7 +66,7 @@ pub mod nailgun;
 
 extern crate uname;
 
-#[derive(PartialOrd, Ord, Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(PartialOrd, Ord, Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Platform {
   Darwin,
   Linux,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -307,7 +307,7 @@ pub struct ExecuteProcessRequestMetadata {
 /// The result of running a process.
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FallibleExecuteProcessResult {
+pub struct FallibleExecuteProcessResultWithPlatform {
   pub stdout: Bytes,
   pub stderr: Bytes,
   pub exit_code: i32,
@@ -321,7 +321,7 @@ pub struct FallibleExecuteProcessResult {
 }
 
 #[cfg(test)]
-impl FallibleExecuteProcessResult {
+impl FallibleExecuteProcessResultWithPlatform {
   pub fn without_execution_attempts(mut self) -> Self {
     self.execution_attempts = vec![];
     self
@@ -363,7 +363,7 @@ pub trait CommandRunner: Send + Sync {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String>;
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String>;
 
   ///
   /// Given a multi platform request which may have some platform
@@ -429,7 +429,7 @@ impl CommandRunner for BoundedCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let inner = self.inner.clone();
     self
       .inner

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -129,7 +129,7 @@ impl From<Platform> for String {
   fn from(platform: Platform) -> String {
     match platform {
       Platform::Linux => "linux".to_string(),
-      Platform::Darwin => "osx".to_string(),
+      Platform::Darwin => "darwin".to_string(),
     }
   }
 }
@@ -138,7 +138,7 @@ impl From<PlatformConstraint> for String {
   fn from(platform: PlatformConstraint) -> String {
     match platform {
       PlatformConstraint::Linux => "linux".to_string(),
-      PlatformConstraint::Darwin => "osx".to_string(),
+      PlatformConstraint::Darwin => "darwin".to_string(),
       PlatformConstraint::None => "none".to_string(),
     }
   }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, Platform, PlatformConstraint, RelativePath,
+  FallibleExecuteProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -37,7 +37,7 @@ fn stdout() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -68,7 +68,7 @@ fn stdout_and_stderr_and_exit_code() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes("bar"),
       exit_code: 1,
@@ -100,7 +100,7 @@ fn capture_exit_code_signal() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: -15,
@@ -217,7 +217,7 @@ fn output_files_none() {
   });
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -251,7 +251,7 @@ fn output_files_one() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -290,7 +290,7 @@ fn output_dirs() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -330,7 +330,7 @@ fn output_files_many() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -368,7 +368,7 @@ fn output_files_execution_failure() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 1,
@@ -404,7 +404,7 @@ fn output_files_partial_output() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -438,7 +438,7 @@ fn output_overlapping_file_and_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -471,7 +471,7 @@ fn jdk_symlink() {
   });
   assert_eq!(
     result,
-    Ok(FallibleExecuteProcessResult {
+    Ok(FallibleExecuteProcessResultWithPlatform {
       stdout: roland,
       stderr: as_bytes(""),
       exit_code: 0,
@@ -588,7 +588,7 @@ fn all_containing_directories_for_outputs_are_created() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -622,7 +622,7 @@ fn output_empty_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -676,7 +676,7 @@ fn local_only_scratch_files_materialized() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -757,7 +757,7 @@ fn working_directory() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResult {
+    FallibleExecuteProcessResultWithPlatform {
       stdout: as_bytes("roland\n"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -768,7 +768,9 @@ fn working_directory() {
   );
 }
 
-fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProcessResult, String> {
+fn run_command_locally(
+  req: ExecuteProcessRequest,
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let work_dir = TempDir::new().unwrap();
   run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned())
 }
@@ -776,7 +778,7 @@ fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProc
 fn run_command_locally_in_dir_with_cleanup(
   req: ExecuteProcessRequest,
   dir: PathBuf,
-) -> Result<FallibleExecuteProcessResult, String> {
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   run_command_locally_in_dir(req, dir, true, None, None)
 }
 
@@ -786,7 +788,7 @@ fn run_command_locally_in_dir(
   cleanup: bool,
   store: Option<Store>,
   executor: Option<task_executor::Executor>,
-) -> Result<FallibleExecuteProcessResult, String> {
+) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
   let store_dir = TempDir::new().unwrap();
   let executor = executor.unwrap_or_else(task_executor::Executor::new);
   let store =

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, PlatformConstraint, RelativePath,
+  FallibleExecuteProcessResult, Platform, PlatformConstraint, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -43,6 +43,7 @@ fn stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -73,6 +74,7 @@ fn stdout_and_stderr_and_exit_code() {
       exit_code: 1,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -104,6 +106,7 @@ fn capture_exit_code_signal() {
       exit_code: -15,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -220,6 +223,7 @@ fn output_files_none() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -253,6 +257,7 @@ fn output_files_one() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -291,6 +296,7 @@ fn output_dirs() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -330,6 +336,7 @@ fn output_files_many() {
       exit_code: 0,
       output_directory: TestDirectory::recursive().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -367,6 +374,7 @@ fn output_files_execution_failure() {
       exit_code: 1,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -402,6 +410,7 @@ fn output_files_partial_output() {
       exit_code: 0,
       output_directory: TestDirectory::containing_roland().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -435,6 +444,7 @@ fn output_overlapping_file_and_dir() {
       exit_code: 0,
       output_directory: TestDirectory::nested().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -467,6 +477,7 @@ fn jdk_symlink() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   )
 }
@@ -583,6 +594,7 @@ fn all_containing_directories_for_outputs_are_created() {
       exit_code: 0,
       output_directory: TestDirectory::nested_dir_and_file().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -616,6 +628,7 @@ fn output_empty_dir() {
       exit_code: 0,
       output_directory: TestDirectory::containing_falcons_dir().digest(),
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   )
 }
@@ -669,6 +682,7 @@ fn local_only_scratch_files_materialized() {
       exit_code: 0,
       output_directory: roland_directory_digest,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -749,6 +763,7 @@ fn working_directory() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -17,7 +17,7 @@ use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
   Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -194,6 +194,7 @@ impl super::CommandRunner for CommandRunner {
       executor,
       true,
       &workdir_for_this_nailgun,
+      Platform::current().unwrap(),
     )
   }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -16,8 +16,9 @@ use tokio::net::TcpStream;
 use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
-  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
+  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
+  FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
+  PlatformConstraint,
 };
 
 #[cfg(test)]
@@ -168,7 +169,7 @@ impl super::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let original_request = self.extract_compatible_request(&req).unwrap();
 
     if !original_request.is_nailgunnable {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -626,7 +626,7 @@ fn successful_execution_after_one_getoperation() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 
@@ -674,7 +674,7 @@ fn retries_retriable_errors() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 
@@ -841,7 +841,8 @@ fn extract_response_with_digest_stdout() {
       )
       .op
       .unwrap()
-      .unwrap()
+      .unwrap(),
+      Platform::Linux,
     )
     .unwrap()
     .without_execution_attempts(),
@@ -851,7 +852,7 @@ fn extract_response_with_digest_stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 }
@@ -871,7 +872,8 @@ fn extract_response_with_digest_stderr() {
       )
       .op
       .unwrap()
-      .unwrap()
+      .unwrap(),
+      Platform::Linux,
     )
     .unwrap()
     .without_execution_attempts(),
@@ -881,7 +883,38 @@ fn extract_response_with_digest_stderr() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
+    }
+  );
+}
+
+#[test]
+fn extract_response_with_digest_stdout_osx_remote() {
+  let op_name = "gimme-foo".to_string();
+  let testdata = TestData::roland();
+  let testdata_empty = TestData::empty();
+  assert_eq!(
+    extract_execute_response(
+      make_successful_operation(
+        &op_name,
+        StdoutType::Digest(testdata.digest()),
+        StderrType::Raw(testdata_empty.string()),
+        0,
+      )
+      .op
+      .unwrap()
+      .unwrap(),
+      Platform::Darwin
+    )
+    .unwrap()
+    .without_execution_attempts(),
+    FallibleExecuteProcessResultWithPlatform {
+      stdout: testdata.bytes(),
+      stderr: testdata_empty.bytes(),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Darwin,
     }
   );
 }
@@ -961,7 +994,7 @@ fn ensure_inline_stdio_is_stored() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 
@@ -1036,7 +1069,7 @@ fn successful_execution_after_four_getoperations() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 }
@@ -1144,6 +1177,7 @@ fn dropped_request_cancels() {
     &cas,
     Duration::from_millis(0),
     Duration::from_secs(0),
+    Platform::Linux,
   );
   let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
@@ -1153,7 +1187,7 @@ fn dropped_request_cancels() {
     exit_code: 0,
     output_directory: EMPTY_DIGEST,
     execution_attempts: vec![],
-    platform: Platform::current().unwrap(),
+    platform: Platform::Linux,
   };
 
   let run_future = command_runner.run(execute_request.into(), Context::default());
@@ -1221,7 +1255,7 @@ fn retry_for_cancelled_channel() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
 }
@@ -1504,7 +1538,7 @@ fn execute_missing_file_uploads_if_known() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     }
   );
   {
@@ -1610,7 +1644,7 @@ fn execute_missing_file_uploads_if_known_status() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
-      platform: Platform::current().unwrap(),
+      platform: Platform::Linux,
     })
   );
   {
@@ -1718,7 +1752,7 @@ fn extract_execute_response_success() {
     exit_code: 17,
     output_directory: TestDirectory::nested().digest(),
     execution_attempts: vec![],
-    platform: Platform::current().unwrap(),
+    platform: Platform::Linux,
   };
 
   let mut output_file = bazel_protos::remote_execution::OutputFile::new();
@@ -1745,7 +1779,7 @@ fn extract_execute_response_success() {
   }));
 
   assert_eq!(
-    extract_execute_response(operation)
+    extract_execute_response(operation, Platform::Linux)
       .unwrap()
       .without_execution_attempts(),
     want_result
@@ -1760,7 +1794,7 @@ fn extract_execute_response_pending() {
   operation.set_done(false);
 
   assert_eq!(
-    extract_execute_response(operation),
+    extract_execute_response(operation, Platform::Linux),
     Err(ExecutionError::NotFinished(operation_name))
   );
 }
@@ -1783,7 +1817,7 @@ fn extract_execute_response_missing_digests() {
     .unwrap();
 
   assert_eq!(
-    extract_execute_response(operation),
+    extract_execute_response(operation, Platform::Linux),
     Err(ExecutionError::MissingDigests(missing_files))
   );
 }
@@ -1805,7 +1839,7 @@ fn extract_execute_response_missing_other_things() {
     .unwrap()
     .unwrap();
 
-  match extract_execute_response(operation) {
+  match extract_execute_response(operation, Platform::Linux) {
     Err(ExecutionError::Fatal(err)) => assert_contains(&err, "monkeys"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
@@ -1824,7 +1858,7 @@ fn extract_execute_response_other_failed_precondition() {
     .unwrap()
     .unwrap();
 
-  match extract_execute_response(operation) {
+  match extract_execute_response(operation, Platform::Linux) {
     Err(ExecutionError::Fatal(err)) => assert_contains(&err, "OUT_OF_CAPACITY"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
@@ -1839,7 +1873,7 @@ fn extract_execute_response_missing_without_list() {
     .unwrap()
     .unwrap();
 
-  match extract_execute_response(operation) {
+  match extract_execute_response(operation, Platform::Linux) {
     Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_lowercase(), "precondition"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
@@ -1860,7 +1894,7 @@ fn extract_execute_response_other_status() {
     response
   }));
 
-  match extract_execute_response(operation) {
+  match extract_execute_response(operation, Platform::Linux) {
     Err(ExecutionError::Fatal(err)) => assert_contains(&err, "PermissionDenied"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
@@ -1926,6 +1960,7 @@ fn wait_between_request_1_retry() {
       &cas,
       Duration::from_millis(100),
       Duration::from_secs(1),
+      Platform::Linux,
     );
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime
@@ -1982,6 +2017,7 @@ fn wait_between_request_3_retry() {
       &cas,
       Duration::from_millis(50),
       Duration::from_secs(5),
+      Platform::Linux,
     );
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime
@@ -2224,6 +2260,7 @@ fn remote_workunits_are_stored() {
     &cas,
     std::time::Duration::from_millis(0),
     std::time::Duration::from_secs(0),
+    Platform::Linux,
   );
 
   let mut runtime = tokio::runtime::Runtime::new().unwrap();
@@ -2482,6 +2519,7 @@ fn run_command_remote(
     &cas,
     Duration::from_millis(0),
     Duration::from_secs(0),
+    Platform::Linux,
   );
   let mut runtime = tokio::runtime::Runtime::new().unwrap();
   runtime.block_on(command_runner.run(request, Context::default()))
@@ -2492,6 +2530,7 @@ fn create_command_runner(
   cas: &mock::StubCAS,
   backoff_incremental_wait: Duration,
   backoff_max_wait: Duration,
+  platform: Platform,
 ) -> CommandRunner {
   let runtime = task_executor::Executor::new();
   let store_dir = TempDir::new().unwrap();
@@ -2503,7 +2542,7 @@ fn create_command_runner(
     None,
     BTreeMap::new(),
     store,
-    Platform::Linux,
+    platform,
     runtime,
     Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,
@@ -2532,6 +2571,7 @@ fn make_store(store_dir: &Path, cas: &mock::StubCAS, executor: task_executor::Ex
 
 fn extract_execute_response(
   operation: bazel_protos::operations::Operation,
+  remote_platform: Platform,
 ) -> Result<FallibleExecuteProcessResultWithPlatform, ExecutionError> {
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
@@ -2542,6 +2582,7 @@ fn extract_execute_response(
     &cas,
     Duration::from_millis(0),
     Duration::from_secs(0),
+    remote_platform,
   );
 
   let mut runtime = tokio::runtime::Runtime::new().unwrap();

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -18,7 +18,7 @@ use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOr
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
   ExecuteProcessRequestMetadata, FallibleExecuteProcessResult, MultiPlatformExecuteProcessRequest,
-  PlatformConstraint,
+  Platform, PlatformConstraint,
 };
 use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;
@@ -626,6 +626,7 @@ fn successful_execution_after_one_getoperation() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -673,6 +674,7 @@ fn retries_retriable_errors() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -775,7 +777,7 @@ pub fn sends_headers() {
       String::from("cat") => String::from("roland"),
     },
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -849,6 +851,7 @@ fn extract_response_with_digest_stdout() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -878,6 +881,7 @@ fn extract_response_with_digest_stderr() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -939,7 +943,7 @@ fn ensure_inline_stdio_is_stored() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -957,6 +961,7 @@ fn ensure_inline_stdio_is_stored() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 
@@ -1031,6 +1036,7 @@ fn successful_execution_after_four_getoperations() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1147,6 +1153,7 @@ fn dropped_request_cancels() {
     exit_code: 0,
     output_directory: EMPTY_DIGEST,
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let run_future = command_runner.run(execute_request.into(), Context::default());
@@ -1214,6 +1221,7 @@ fn retry_for_cancelled_channel() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
 }
@@ -1477,7 +1485,7 @@ fn execute_missing_file_uploads_if_known() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1496,6 +1504,7 @@ fn execute_missing_file_uploads_if_known() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     }
   );
   {
@@ -1584,7 +1593,7 @@ fn execute_missing_file_uploads_if_known_status() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1601,6 +1610,7 @@ fn execute_missing_file_uploads_if_known_status() {
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   );
   {
@@ -1664,7 +1674,7 @@ fn execute_missing_file_errors_if_unknown() {
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime.clone(),
     Duration::from_secs(0),
     Duration::from_millis(0),
@@ -1708,6 +1718,7 @@ fn extract_execute_response_success() {
     exit_code: 17,
     output_directory: TestDirectory::nested().digest(),
     execution_attempts: vec![],
+    platform: Platform::current().unwrap(),
   };
 
   let mut output_file = bazel_protos::remote_execution::OutputFile::new();
@@ -2492,7 +2503,7 @@ fn create_command_runner(
     None,
     BTreeMap::new(),
     store,
-    PlatformConstraint::Linux,
+    Platform::Linux,
     runtime,
     Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -1,5 +1,5 @@
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
+  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
   MultiPlatformExecuteProcessRequest,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -33,7 +33,7 @@ impl SpeculatingCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = Delay::new(Instant::now() + self.speculation_timeout);
     let req2 = req.clone();
     trace!(
@@ -57,11 +57,12 @@ impl SpeculatingCommandRunner {
         Ok(either_success) => {
           // .split() takes out the homogeneous success type for either primary or
           // secondary successes.
-          ok::<FallibleExecuteProcessResult, String>(either_success.split().0).to_boxed()
+          ok::<FallibleExecuteProcessResultWithPlatform, String>(either_success.split().0)
+            .to_boxed()
         }
         Err(Either::A((failed_primary_res, _))) => {
           debug!("primary request FAILED, aborting");
-          err::<FallibleExecuteProcessResult, String>(failed_primary_res).to_boxed()
+          err::<FallibleExecuteProcessResultWithPlatform, String>(failed_primary_res).to_boxed()
         }
         // We handle the case of the secondary failing specially. We only want to show
         // a failure to the user if the primary execution source fails. This maintains
@@ -103,7 +104,7 @@ impl CommandRunner for SpeculatingCommandRunner {
     &self,
     req: MultiPlatformExecuteProcessRequest,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     match (
       self.primary.extract_compatible_request(&req),
       self.secondary.extract_compatible_request(&req),

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -1,7 +1,7 @@
 use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
+  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
   MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -104,7 +104,7 @@ fn run_speculation_test(
   r1_is_compatible: bool,
   r2_is_compatible: bool,
 ) -> (
-  Result<FallibleExecuteProcessResult, String>,
+  Result<FallibleExecuteProcessResultWithPlatform, String>,
   Arc<Mutex<u32>>,
   Arc<Mutex<u32>>,
 ) {
@@ -152,7 +152,7 @@ fn make_delayed_command_runner(
   let result = if is_err {
     Err(msg.into())
   } else {
-    Ok(FallibleExecuteProcessResult {
+    Ok(FallibleExecuteProcessResultWithPlatform {
       stdout: msg.into(),
       stderr: "".into(),
       exit_code: 0,
@@ -173,7 +173,7 @@ fn make_delayed_command_runner(
 #[derive(Clone)]
 struct DelayedCommandRunner {
   delay: Duration,
-  result: Result<FallibleExecuteProcessResult, String>,
+  result: Result<FallibleExecuteProcessResultWithPlatform, String>,
   is_compatible: bool,
   call_counter: Arc<Mutex<u32>>,
   finished_counter: Arc<Mutex<u32>>,
@@ -182,7 +182,7 @@ struct DelayedCommandRunner {
 impl DelayedCommandRunner {
   pub fn new(
     delay: Duration,
-    result: Result<FallibleExecuteProcessResult, String>,
+    result: Result<FallibleExecuteProcessResultWithPlatform, String>,
     is_compatible: bool,
     call_counter: Arc<Mutex<u32>>,
     finished_counter: Arc<Mutex<u32>>,
@@ -210,7 +210,7 @@ impl CommandRunner for DelayedCommandRunner {
     &self,
     _req: MultiPlatformExecuteProcessRequest,
     _context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = Delay::new(Instant::now() + self.delay);
     let exec_result = self.result.clone();
     let command_runner = self.clone();

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -2,7 +2,7 @@ use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
   CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResult,
-  MultiPlatformExecuteProcessRequest, PlatformConstraint,
+  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -158,6 +158,7 @@ fn make_delayed_command_runner(
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],
+      platform: Platform::current().unwrap(),
     })
   };
   DelayedCommandRunner::new(

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -32,7 +32,9 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
-use process_execution::{Context, ExecuteProcessRequestMetadata, PlatformConstraint, RelativePath};
+use process_execution::{
+  Context, ExecuteProcessRequestMetadata, Platform, PlatformConstraint, RelativePath,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
@@ -371,7 +373,7 @@ fn main() {
           oauth_bearer_token,
           headers,
           store.clone(),
-          PlatformConstraint::Linux,
+          Platform::Linux,
           executor,
           std::time::Duration::from_secs(300),
           std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -211,12 +211,12 @@ impl Core {
         executor.clone(),
       )
       .map_err(|err| format!("Could not initialize store for process cache: {:?}", err))?;
-      command_runner = Box::new(process_execution::cache::CommandRunner {
-        underlying: command_runner.into(),
+      command_runner = Box::new(process_execution::cache::CommandRunner::new(
+        command_runner.into(),
         process_execution_store,
-        file_store: store.clone(),
-        metadata: process_execution_metadata,
-      })
+        store.clone(),
+        process_execution_metadata,
+      ));
     }
 
     let http_client = reqwest::r#async::Client::new();

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -21,7 +21,7 @@ use fs::{safe_create_dir_all_ioerror, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
   self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ExecuteProcessRequestMetadata,
-  PlatformConstraint,
+  Platform,
 };
 use rand::seq::SliceRandom;
 use reqwest;
@@ -180,7 +180,7 @@ impl Core {
             store.clone(),
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
-            PlatformConstraint::Linux,
+            Platform::Linux,
             executor.clone(),
             std::time::Duration::from_secs(300),
             std::time::Duration::from_millis(500),

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -55,6 +55,7 @@ fn multi_platform_process_request_to_process_result(
   }))
   .and_then(move |process_request| context.get(process_request))
   .map(move |result| {
+    let platform_name: String = result.0.platform.into();
     externs::unsafe_call(
       &core.types.construct_process_result,
       &[
@@ -62,6 +63,10 @@ fn multi_platform_process_request_to_process_result(
         externs::store_bytes(&result.0.stderr),
         externs::store_i64(result.0.exit_code.into()),
         Snapshot::store_directory(&core, &result.0.output_directory),
+        externs::unsafe_call(
+          &core.types.construct_platform,
+          &[externs::store_utf8(&platform_name)],
+        ),
       ],
     )
   })

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -364,7 +364,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProcessResult(pub process_execution::FallibleExecuteProcessResult);
+pub struct ProcessResult(pub process_execution::FallibleExecuteProcessResultWithPlatform);
 
 ///
 /// A Node that represents reading the destination of a symlink (non-recursively).

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -33,4 +33,5 @@ pub struct Types {
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
   pub snapshot_subset: TypeId,
+  pub construct_platform: Function,
 }


### PR DESCRIPTION
Note to reviewers: This is a follow-up to https://github.com/pantsbuild/pants/pull/9197 that fixes the issue with pulling the correct Platform out of the cache. Only the top three commits are new 

### Problem

We want to be able to track the actual Platform that an external process was ran on in as a field of a new type `FallibleExecuteProcessResultWithPlatform`. This is important for ensuring that some cross platform workflows (such as, a user running pants on a Mac remoting on a build farm with Linux build machines) work correctly. 

### Solution

This commit creates several new types:
- a Rust `Platform` type analogous to the Python `Platform` type and distinct from the `PlatformConstraint` type that already existed in Rust.
-a new pair of identically-named Python/Rust types meant to be passed over the FFI called `FallibleExecuteProcessResultWithPlatform` which has a new parameter `platform` representing the type of the remote platform, and otherwise contains the fields of the existing `FallibleExecuteProcessResult` type

And rewrites a bunch of `process_execution` code (including test code) to make use of these new types in place of the old `FallibleExecutePlatformResult` type (that is, much of the content of this commit is boilerplate). There are some substantive changes to `cache.rs` to handle correctly storing and reading the Platform of a cached `FallibleExecuteProcessResultWithPlatform`. Finally, this commit renames the string representation of the OSX Platform from "osx" to "darwin", to match what the Python code assumes.

### Result

Rule-authors can request a `FallibleExecuteProcessResultWithPlatform` which has the data representing the remote platform. The existing `FallibleExecuteProcessResult` and `ExecuteProcessResult` types work the same way as they previously did, but are now ultimately derived from `FallibleExecuteProcessResultWithPlatform` by dropping the platform information.