### PR TITLE
Don't use ProjectTree in Scheduler

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -75,6 +75,7 @@ class Scheduler:
         execution_options: ExecutionOptions,
         include_trace_on_error: bool = True,
         visualize_to_dir: Optional[str] = None,
+        validate: bool = True,
     ):
         """
         :param native: An instance of engine.native.Native.
@@ -88,6 +89,7 @@ class Scheduler:
         :param execution_options: Execution options for (remote) processes.
         :param include_trace_on_error: Include the trace through the graph upon encountering errors.
         :type include_trace_on_error: bool
+        :param validate: True to assert that the ruleset is valid.
         """
         self._native = native
         self.include_trace_on_error = include_trace_on_error
@@ -116,7 +118,8 @@ class Scheduler:
             rule_graph_name = "rule_graph.dot"
             self.visualize_rule_graph_to_file(os.path.join(self._visualize_to_dir, rule_graph_name))
 
-        self._assert_ruleset_valid()
+        if validate:
+            self._assert_ruleset_valid()
 
     def _root_type_ids(self):
         return self._to_ids_buf(self._root_subject_types)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 import logging
 import multiprocessing
 import os

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -3,7 +3,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional, Tuple, cast
+from typing import Any, Iterable, List, Optional, Tuple, cast
 
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -366,7 +366,7 @@ class EngineInitializer:
 
     @staticmethod
     def setup_legacy_graph_extended(
-        pants_ignore_patterns,
+        pants_ignore_patterns: List[str],
         local_store_dir,
         build_file_imports_behavior: BuildFileImportsBehavior,
         options_bootstrapper: OptionsBootstrapper,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -16,7 +16,6 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
-from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.specs import Specs
 from pants.binaries.binary_tool import rules as binary_tool_rules
 from pants.binaries.binary_util import rules as binary_util_rules
@@ -383,8 +382,6 @@ class EngineInitializer:
     ) -> LegacyGraphScheduler:
         """Construct and return the components necessary for LegacyBuildGraph construction.
 
-        :param list pants_ignore_patterns: A list of path ignore patterns for FileSystemProjectTree,
-                                           usually taken from the '--pants-ignore' global option.
         :param local_store_dir: The directory to use for storing the engine's LMDB store in.
         :param build_file_imports_behavior: How to behave if a BUILD file being parsed tries to use
                                             import statements.
@@ -414,8 +411,6 @@ class EngineInitializer:
         rules = build_configuration.rules()
 
         symbol_table = _legacy_symbol_table(build_file_aliases)
-
-        project_tree = FileSystemProjectTree(build_root, pants_ignore_patterns)
 
         execution_options = execution_options or DEFAULT_EXECUTION_OPTIONS
 
@@ -478,12 +473,13 @@ class EngineInitializer:
         union_rules = build_configuration.union_rules()
 
         scheduler = Scheduler(
-            native,
-            project_tree,
-            local_store_dir,
-            rules,
-            union_rules,
-            execution_options,
+            native=native,
+            ignore_patterns=pants_ignore_patterns,
+            build_root=build_root,
+            local_store_dir=local_store_dir,
+            rules=rules,
+            union_rules=union_rules,
+            execution_options=execution_options,
             include_trace_on_error=include_trace_on_error,
             visualize_to_dir=bootstrap_options.native_engine_visualize_to,
         )

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -147,12 +147,14 @@ def init_native():
 def create_scheduler(rules, union_rules=None, validate=True, native=None):
     """Create a Scheduler."""
     native = native or init_native()
+    tree = FileSystemProjectTree(os.getcwd())
     return Scheduler(
-        native,
-        FileSystemProjectTree(os.getcwd()),
-        "./.pants.d",
-        rules,
-        union_rules,
+        native=native,
+        ignore_patterns=tree.ignore_patterns,
+        build_root=tree.build_root,
+        local_store_dir="./.pants.d",
+        rules=rules,
+        union_rules=union_rules,
         execution_options=DEFAULT_EXECUTION_OPTIONS,
         validate=validate,
     )

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -411,7 +411,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         # NB: This uses the long form of initialization because it needs to directly specify
         # `cls.alias_groups` rather than having them be provided by bootstrap options.
         graph_session = EngineInitializer.setup_legacy_graph_extended(
-            pants_ignore_patterns=None,
+            pants_ignore_patterns=[],
             local_store_dir=local_store_dir,
             build_file_imports_behavior=BuildFileImportsBehavior.error,
             native=init_native(),

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -55,12 +55,13 @@ class SchedulerTestBase:
         project_tree = project_tree or self.mk_fs_tree(work_dir=work_dir)
         local_store_dir = os.path.realpath(safe_mkdtemp())
         scheduler = Scheduler(
-            self._native,
-            project_tree,
-            local_store_dir,
-            rules,
-            union_rules,
-            DEFAULT_EXECUTION_OPTIONS,
+            native=self._native,
+            ignore_patterns=project_tree.ignore_patterns,
+            build_root=project_tree.build_root,
+            local_store_dir=local_store_dir,
+            rules=rules,
+            union_rules=union_rules,
+            execution_options=DEFAULT_EXECUTION_OPTIONS,
             include_trace_on_error=include_trace_on_error,
         )
         return scheduler.new_session(


### PR DESCRIPTION
The only reason the `Scheduler` requires a `ProjectTree` as input is to pass along the `build_root` and `ignore_patterns` to the native scheduler over the FFI. Since no other functionality of `Scheduler` relies on a `ProjectTree` being passed in, it makes sense to just pass in these two parameters separately, without requiring a `ProjectTree`. This will also make more sense when we support passing an option to the engine to respect `.gitignore` files, via a similar mechanism to how `ignore_patterns` is passed to the engine. 