### PR TITLE
Allow mocking unions in `testutil.engine.util.run_rule()`

### DIFF
--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -62,7 +62,7 @@ class FmtTest(TestBase):
         )
         return HydratedTargetWithOrigin(ht, SingleAddress(directory="src", name=name))
 
-    def run_fmt_rule(self, *, targets: List[HydratedTargetWithOrigin]) -> Tuple[Fmt, str]:
+    def run_fmt_rule(self, *, targets: List[HydratedTargetWithOrigin]) -> Tuple[int, str]:
         result_digest = self.request_single_product(
             Digest,
             InputFilesContent(
@@ -106,7 +106,7 @@ class FmtTest(TestBase):
             ],
             union_membership=union_membership,
         )
-        return result, console.stdout.getvalue()
+        return result.exit_code, console.stdout.getvalue()
 
     def assert_workspace_modified(self, *, modified: bool = True) -> None:
         formatted_file = Path(self.build_root, self.formatted_file)
@@ -117,24 +117,24 @@ class FmtTest(TestBase):
         assert formatted_file.read_text() == self.formatted_content
 
     def test_non_union_member_noops(self) -> None:
-        result, stdout = self.run_fmt_rule(
+        exit_code, stdout = self.run_fmt_rule(
             targets=[self.make_hydrated_target_with_origin(adaptor_type=JvmAppAdaptor)]
         )
-        assert result.exit_code == 0
+        assert exit_code == 0
         assert stdout.strip() == ""
         self.assert_workspace_modified(modified=False)
 
     def test_empty_target_noops(self) -> None:
-        result, stdout = self.run_fmt_rule(
+        exit_code, stdout = self.run_fmt_rule(
             targets=[self.make_hydrated_target_with_origin(include_sources=False)]
         )
-        assert result.exit_code == 0
+        assert exit_code == 0
         assert stdout.strip() == ""
         self.assert_workspace_modified(modified=False)
 
     def test_single_target(self) -> None:
-        result, stdout = self.run_fmt_rule(targets=[self.make_hydrated_target_with_origin()])
-        assert result.exit_code == 0
+        exit_code, stdout = self.run_fmt_rule(targets=[self.make_hydrated_target_with_origin()])
+        assert exit_code == 0
         assert stdout.strip() == "Formatted `target`"
         self.assert_workspace_modified()
 
@@ -142,12 +142,12 @@ class FmtTest(TestBase):
         # NB: we do not test the case where AggregatedFmtResults have conflicting changes, as that
         # logic is handled by DirectoriesToMerge and is avoided by each language having its own
         # aggregator rule.
-        result, stdout = self.run_fmt_rule(
+        exit_code, stdout = self.run_fmt_rule(
             targets=[
                 self.make_hydrated_target_with_origin(name="t1"),
                 self.make_hydrated_target_with_origin(name="t2"),
             ]
         )
-        assert result.exit_code == 0
+        assert exit_code == 0
         assert stdout.splitlines() == ["Formatted `t1`", "Formatted `t2`"]
         self.assert_workspace_modified()

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -74,18 +74,19 @@ class FmtTest(TestBase):
             ),
         )
         console = MockConsole(use_colors=False)
+        union_membership = UnionMembership({FormatTarget: [PythonTargetAdaptorWithOrigin]})
         result: Fmt = run_rule(
             fmt,
             rule_args=[
                 console,
                 HydratedTargetsWithOrigins(targets),
                 Workspace(self.scheduler),
-                UnionMembership({FormatTarget: [PythonTargetAdaptorWithOrigin]}),
+                union_membership,
             ],
             mock_gets=[
                 MockGet(
                     product_type=AggregatedFmtResults,
-                    subject_type=PythonTargetAdaptorWithOrigin,
+                    subject_type=FormatTarget,
                     mock=lambda adaptor_with_origin: AggregatedFmtResults(
                         (
                             FmtResult(
@@ -103,6 +104,7 @@ class FmtTest(TestBase):
                     mock=lambda _: result_digest,
                 ),
             ],
+            union_membership=union_membership,
         )
         return result, console.stdout.getvalue()
 

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -30,20 +30,14 @@ class LintTest(TestBase):
                 ]
             )
         console = MockConsole(use_colors=False)
+        union_membership = UnionMembership({LintTarget: [PythonTargetAdaptorWithOrigin]})
         result: Lint = run_rule(
             lint,
-            rule_args=[
-                console,
-                HydratedTargetsWithOrigins(targets),
-                UnionMembership({LintTarget: [PythonTargetAdaptorWithOrigin]}),
-            ],
+            rule_args=[console, HydratedTargetsWithOrigins(targets), union_membership],
             mock_gets=[
-                MockGet(
-                    product_type=LintResults,
-                    subject_type=PythonTargetAdaptorWithOrigin,
-                    mock=mock_linters,
-                ),
+                MockGet(product_type=LintResults, subject_type=LintTarget, mock=mock_linters),
             ],
+            union_membership=union_membership,
         )
         return result, console.stdout.getvalue()
 

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -18,7 +18,7 @@ class LintTest(TestBase):
         *,
         targets: List[HydratedTargetWithOrigin],
         mock_linters: Optional[Callable[[PythonTargetAdaptorWithOrigin], LintResults]] = None,
-    ) -> Tuple[Lint, str]:
+    ) -> Tuple[int, str]:
         if mock_linters is None:
             mock_linters = lambda adaptor_with_origin: LintResults(
                 [
@@ -39,25 +39,25 @@ class LintTest(TestBase):
             ],
             union_membership=union_membership,
         )
-        return result, console.stdout.getvalue()
+        return result.exit_code, console.stdout.getvalue()
 
     def test_non_union_member_noops(self) -> None:
-        result, stdout = self.run_lint_rule(
+        exit_code, stdout = self.run_lint_rule(
             targets=[FmtTest.make_hydrated_target_with_origin(adaptor_type=JvmAppAdaptor)],
         )
-        assert result.exit_code == 0
+        assert exit_code == 0
         assert stdout == ""
 
     def test_empty_target_noops(self) -> None:
-        result, stdout = self.run_lint_rule(
+        exit_code, stdout = self.run_lint_rule(
             targets=[FmtTest.make_hydrated_target_with_origin(include_sources=False)],
         )
-        assert result.exit_code == 0
+        assert exit_code == 0
         assert stdout == ""
 
     def test_single_target_with_one_linter(self) -> None:
-        result, stdout = self.run_lint_rule(targets=[FmtTest.make_hydrated_target_with_origin()])
-        assert result.exit_code == 1
+        exit_code, stdout = self.run_lint_rule(targets=[FmtTest.make_hydrated_target_with_origin()])
+        assert exit_code == 1
         assert stdout.strip() == "Linted `target`"
 
     def test_single_target_with_multiple_linters(self) -> None:
@@ -69,10 +69,10 @@ class LintTest(TestBase):
                 ]
             )
 
-        result, stdout = self.run_lint_rule(
+        exit_code, stdout = self.run_lint_rule(
             targets=[FmtTest.make_hydrated_target_with_origin()], mock_linters=mock_linters,
         )
-        assert result.exit_code == 1
+        assert exit_code == 1
         assert stdout.splitlines() == ["Linter 1", "Linter 2"]
 
     def test_multiple_targets_with_one_linter(self) -> None:
@@ -85,14 +85,14 @@ class LintTest(TestBase):
                 )
             return LintResults([LintResult(exit_code=0, stdout=f"`{name}` passed", stderr="")])
 
-        result, stdout = self.run_lint_rule(
+        exit_code, stdout = self.run_lint_rule(
             targets=[
                 FmtTest.make_hydrated_target_with_origin(name="good"),
                 FmtTest.make_hydrated_target_with_origin(name="bad"),
             ],
             mock_linters=mock_linters,
         )
-        assert result.exit_code == 127
+        assert exit_code == 127
         assert stdout.splitlines() == ["`good` passed", "`bad` failed"]
 
     def test_multiple_targets_with_multiple_linters(self) -> None:
@@ -114,14 +114,14 @@ class LintTest(TestBase):
                 ]
             )
 
-        result, stdout = self.run_lint_rule(
+        exit_code, stdout = self.run_lint_rule(
             targets=[
                 FmtTest.make_hydrated_target_with_origin(name="good"),
                 FmtTest.make_hydrated_target_with_origin(name="bad"),
             ],
             mock_linters=mock_linters,
         )
-        assert result.exit_code == 127
+        assert exit_code == 127
         assert stdout.splitlines() == [
             "Linter 1 passed for `good`",
             "Linter 2 passed for `good`",

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -265,24 +265,28 @@ class TestTest(TestBase):
             if test_target_type
             else PythonBinaryAdaptor(type_alias="python_binary", sources=mocked_fileset)
         )
+        union_membership = UnionMembership(union_rules={TestTarget: [PythonTestsAdaptorWithOrigin]})
         with self.captured_logging(logging.INFO):
             result: AddressAndTestResult = run_rule(
                 coordinator_of_tests,
                 rule_args=[
                     HydratedTargetWithOrigin(
                         target=HydratedTarget(address, target_adaptor, ()),
-                        origin=origin
-                        or SingleAddress(directory=address.spec_path, name=address.target_name),
+                        origin=(
+                            origin
+                            or SingleAddress(directory=address.spec_path, name=address.target_name)
+                        ),
                     ),
-                    UnionMembership(union_rules={TestTarget: [PythonTestsAdaptorWithOrigin]}),
+                    union_membership,
                 ],
                 mock_gets=[
                     MockGet(
                         product_type=TestResult,
-                        subject_type=PythonTestsAdaptorWithOrigin,
+                        subject_type=TestTarget,
                         mock=lambda _: TestResult(status=Status.SUCCESS, stdout="foo", stderr=""),
                     ),
                 ],
+                union_membership=union_membership,
             )
         return result
 

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -14,6 +14,7 @@ from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.addressable import addressable_list
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
+from pants.engine.rules import UnionMembership
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.struct import Struct
@@ -35,11 +36,13 @@ def run_rule(
     *,
     rule_args: Optional[Sequence[Any]] = None,
     mock_gets: Optional[Sequence[MockGet]] = None,
+    union_membership: Optional[UnionMembership] = None,
 ):
     """A test helper function that runs an @rule with a set of arguments and mocked Get providers.
 
     An @rule named `my_rule` that takes one argument and makes no `Get` requests can be invoked
     like so (although you could also just invoke it directly):
+
     ```
     return_value = run_rule(my_rule, rule_args=[arg1])
     ```
@@ -51,6 +54,7 @@ def run_rule(
 
     So in the case of an @rule named `my_co_rule` that takes one argument and makes Get requests
     for a product type `Listing` with subject type `Dir`, the invoke might look like:
+
     ```
     return_value = run_rule(
       my_co_rule,
@@ -64,6 +68,11 @@ def run_rule(
       ],
     )
     ```
+
+    If any of the @rule's Get requests involve union members, you should pass a `UnionMembership`
+    mapping the union base to any union members you'd like to test. For example, if your rule has
+    `await Get[TestResult](TargetAdaptor, target_adaptor)`, you may pass
+    `UnionMembership({TargetAdaptor: PythonTestsTargetAdaptor})` to this function.
 
     :returns: The return value of the completed @rule.
     """
@@ -95,7 +104,14 @@ def run_rule(
             (
                 mock_get.mock
                 for mock_get in mock_gets
-                if mock_get.product_type == product and mock_get.subject_type == type(subject)
+                if mock_get.product_type == product
+                and (
+                    mock_get.subject_type == type(subject)
+                    or (
+                        union_membership
+                        and union_membership.is_member(mock_get.subject_type, subject)
+                    )
+                )
             ),
             None,
         )


### PR DESCRIPTION
### Problem

The implementation in `run_rule()` requires `type(mock.subject) == mock.subject_type)`. That is, with:

```
await Get[A](B, b)
```

`b` must have exactly the type `B`, regardless of it's a union. This is not how the engine actually works. We allow for either the exact type or for union members.

### Result

The `rules/core` tests now properly mirror their src code rules.