### PR TITLE
Add `TargetAdaptor.has_sources()`

### DIFF
--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -123,6 +123,17 @@ class TargetAdaptor(StructWithDeps):
         :param sources EagerFilesetWithSpec resolved sources.
         """
 
+    # TODO: do we want to support the `extension` parameter from Target.has_sources()? In V1,
+    # it's used to distinguish between Java vs. Scala files. For now, we should leave it off to
+    # keep things as simple as possible, but we may want to add it in the future.
+    def has_sources(self) -> bool:
+        """Return True if the target has `sources` defined with resolved entries.
+
+        This checks after the sources have been resolved, e.g. after any globs have been expanded
+        and any ignores have been applied.
+        """
+        return hasattr(self, "sources") and bool(self.sources.snapshot.files)
+
 
 @union
 class HydrateableField:

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -63,7 +63,7 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
         input_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
     else:
         input_snapshots = (
-            adaptor.sources.snapshot for adaptor in request.adaptors if hasattr(adaptor, "sources")
+            adaptor.sources.snapshot for adaptor in request.adaptors if adaptor.has_sources()
         )
     result = await Get[Snapshot](
         DirectoriesToMerge(tuple(snapshot.directory_digest for snapshot in input_snapshots))
@@ -98,7 +98,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
     snapshot_subset_requests = {}
     for adaptor_with_origin in request.adaptors_with_origins:
         adaptor = adaptor_with_origin.adaptor
-        if not hasattr(adaptor, "sources"):
+        if not adaptor.has_sources():
             continue
         result = determine_specified_sources_for_target(adaptor_with_origin)
         if isinstance(result, Snapshot):

--- a/src/python/pants/rules/core/determine_source_files_test.py
+++ b/src/python/pants/rules/core/determine_source_files_test.py
@@ -16,7 +16,7 @@ from pants.base.specs import (
 )
 from pants.build_graph.address import Address
 from pants.build_graph.files import Files
-from pants.engine.legacy.structs import TargetAdaptorWithOrigin
+from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.rules.core.determine_source_files import (
@@ -62,16 +62,15 @@ class DetermineSourceFilesTest(TestBase):
         include_sources: bool = True,
         type_alias: Optional[str] = None,
     ) -> TargetAdaptorWithOrigin:
-        adaptor = Mock()
-        adaptor.type_alias = type_alias
-        adaptor.sources = Mock()
-        adaptor.address = Address.parse(f"{sources.source_root}:lib")
-        adaptor.sources = Mock()
-        adaptor.sources.snapshot = self.make_snapshot(
-            {fp: "" for fp in sources.source_file_absolute_paths}
+        sources_field = Mock()
+        sources_field.snapshot = self.make_snapshot(
+            {fp: "" for fp in (sources.source_file_absolute_paths if include_sources else [])}
         )
-        if not include_sources:
-            del adaptor.sources
+        adaptor = TargetAdaptor(
+            address=Address.parse(f"{sources.source_root}:lib"),
+            type_alias=type_alias,
+            sources=sources_field,
+        )
         if origin is None:
             origin = SiblingAddresses(sources.source_root)
         return TargetAdaptorWithOrigin(adaptor, origin)

--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -59,7 +59,7 @@ async def file_deps(
     ):
         unique_rel_paths.add(build_file_address.rel_path)
         adaptor = hydrated_target.adaptor
-        if hasattr(adaptor, "sources"):
+        if adaptor.has_sources():
             sources_paths = (
                 adaptor.sources.snapshot.files
                 if not options.values.globs

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -67,10 +67,7 @@ class FormatTarget:
         adaptor_with_origin: TargetAdaptorWithOrigin, *, union_membership: UnionMembership,
     ) -> bool:
         is_fmt_target = union_membership.is_member(FormatTarget, adaptor_with_origin)
-        has_sources = hasattr(adaptor_with_origin.adaptor, "sources") and bool(
-            adaptor_with_origin.adaptor.sources.snapshot.files
-        )
-        return has_sources and is_fmt_target
+        return adaptor_with_origin.adaptor.has_sources() and is_fmt_target
 
 
 class FmtOptions(GoalSubsystem):

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -51,10 +51,7 @@ class LintTarget:
         adaptor_with_origin: TargetAdaptorWithOrigin, *, union_membership: UnionMembership
     ) -> bool:
         is_lint_target = union_membership.is_member(LintTarget, adaptor_with_origin)
-        has_sources = hasattr(adaptor_with_origin.adaptor, "sources") and bool(
-            adaptor_with_origin.adaptor.sources.snapshot.files
-        )
-        return has_sources and is_lint_target
+        return adaptor_with_origin.adaptor.has_sources() and is_lint_target
 
 
 class LintOptions(GoalSubsystem):

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -117,9 +117,7 @@ async def strip_source_roots_from_target(request: StripTargetRequest,) -> Source
     `pants/util/strutil.py`."""
     target_adaptor = request.adaptor
 
-    # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
-    # simplify the hasattr() checks here!
-    if not hasattr(target_adaptor, "sources"):
+    if not target_adaptor.has_sources():
         return SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
 
     sources_snapshot = request.specified_files_snapshot or target_adaptor.sources.snapshot

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -107,10 +107,7 @@ class AddressAndTestResult:
         is_not_a_glob = isinstance(
             adaptor_with_origin.origin, (SingleAddress, FilesystemLiteralSpec)
         )
-        has_sources = hasattr(adaptor_with_origin.adaptor, "sources") and bool(
-            adaptor_with_origin.adaptor.sources.snapshot.files
-        )
-        return has_sources and (is_test_target or is_not_a_glob)
+        return adaptor_with_origin.adaptor.has_sources() and (is_test_target or is_not_a_glob)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The idiom to check if a V2 `TargetAdaptor` has sources keeps popping up. The implementation differs between these usages; sometimes we only check for `sources`, other times we also check that `sources` actually has values.