### PR TITLE
Simplify `lint2` to stop grouping by languages

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/register.py
+++ b/src/python/pants/backend/python/lint/bandit/register.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.lint import python_lint_target
+from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.bandit import rules as bandit_rules
 
 
 def rules():
     return (
         *bandit_rules.rules(),
-        *python_lint_target.rules(),
+        *python_linter.rules(),
     )

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit
-from pants.backend.python.lint.python_linter import PythonLinter, PythonLintTarget
+from pants.backend.python.lint.python_linter import PythonLinter
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -27,7 +27,7 @@ from pants.rules.core.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,7 @@ def rules():
     return [
         lint,
         subsystem_rule(Bandit),
-        UnionRule(PythonLintTarget, BanditLinter),
+        UnionRule(Linter, BanditLinter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.bandit.rules import BanditTargets
+from pants.backend.python.lint.bandit.rules import BanditLinter
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -31,7 +31,7 @@ class BanditIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *bandit_rules(), RootRule(BanditTargets))
+        return (*super().rules(), *bandit_rules(), RootRule(BanditLinter))
 
     def make_target_with_origin(
         self,
@@ -68,7 +68,7 @@ class BanditIntegrationTest(TestBase):
             args.append(f"--bandit-skip")
         return self.request_single_product(
             LintResult,
-            Params(BanditTargets(tuple(targets)), create_options_bootstrapper(args=args)),
+            Params(BanditLinter(tuple(targets)), create_options_bootstrapper(args=args)),
         )
 
     def test_passing_source(self) -> None:

--- a/src/python/pants/backend/python/lint/black/register.py
+++ b/src/python/pants/backend/python/lint/black/register.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.lint import python_format_target, python_lint_target
+from pants.backend.python.lint import python_formatter, python_linter
 from pants.backend.python.lint.black import rules as black_rules
 
 
 def rules():
     return (
         *black_rules.rules(),
-        *python_format_target.rules(),
-        *python_lint_target.rules(),
+        *python_formatter.rules(),
+        *python_linter.rules(),
     )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
-from pants.backend.python.lint.python_linter import PythonLintTarget
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -35,7 +34,7 @@ from pants.rules.core.determine_source_files import (
     SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -175,7 +174,7 @@ def rules():
         lint,
         subsystem_rule(Black),
         UnionRule(PythonFormatTarget, BlackFormatter),
-        UnionRule(PythonLintTarget, BlackFormatter),
+        UnionRule(Linter, BlackFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -7,8 +7,8 @@ from pathlib import PurePath
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
-from pants.backend.python.lint.python_format_target import PythonFormatTarget
-from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
+from pants.backend.python.lint.python_linter import PythonLintTarget
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -24,7 +24,6 @@ from pants.engine.isolated_process import (
     ExecuteProcessResult,
     FallibleExecuteProcessResult,
 )
-from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -40,14 +39,13 @@ from pants.rules.core.lint import LintResult
 
 
 @dataclass(frozen=True)
-class BlackTargets:
-    adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
-    prior_formatter_result: Optional[Snapshot] = None  # unused by `lint`
+class BlackFormatter(PythonFormatter):
+    pass
 
 
 @dataclass(frozen=True)
 class SetupRequest:
-    targets: BlackTargets
+    formatter: BlackFormatter
     check_only: bool
 
 
@@ -83,7 +81,7 @@ async def setup(
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> Setup:
-    adaptors_with_origins = request.targets.adaptors_with_origins
+    adaptors_with_origins = request.formatter.adaptors_with_origins
 
     requirements_pex = await Get[Pex](
         CreatePex(
@@ -105,7 +103,7 @@ async def setup(
         )
     )
 
-    if request.targets.prior_formatter_result is None:
+    if request.formatter.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
             AllSourceFilesRequest(
                 adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
@@ -113,7 +111,7 @@ async def setup(
         )
         all_source_files_snapshot = all_source_files.snapshot
     else:
-        all_source_files_snapshot = request.targets.prior_formatter_result
+        all_source_files_snapshot = request.formatter.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
         SpecifiedSourceFilesRequest(adaptors_with_origins)
@@ -153,19 +151,19 @@ async def setup(
 
 
 @rule(name="Format using Black")
-async def fmt(targets: BlackTargets, black: Black) -> FmtResult:
+async def fmt(formatter: BlackFormatter, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
-    setup = await Get[Setup](SetupRequest(targets, check_only=False))
+    setup = await Get[Setup](SetupRequest(formatter, check_only=False))
     result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
 @rule(name="Lint using Black")
-async def lint(targets: BlackTargets, black: Black) -> LintResult:
+async def lint(formatter: BlackFormatter, black: Black) -> LintResult:
     if black.options.skip:
         return LintResult.noop()
-    setup = await Get[Setup](SetupRequest(targets, check_only=True))
+    setup = await Get[Setup](SetupRequest(formatter, check_only=True))
     result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
@@ -176,8 +174,8 @@ def rules():
         fmt,
         lint,
         subsystem_rule(Black),
-        UnionRule(PythonFormatTarget, BlackTargets),
-        UnionRule(PythonLintTarget, BlackTargets),
+        UnionRule(PythonFormatTarget, BlackFormatter),
+        UnionRule(PythonLintTarget, BlackFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional, Tuple
 
-from pants.backend.python.lint.black.rules import BlackTargets
+from pants.backend.python.lint.black.rules import BlackFormatter
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -29,7 +29,7 @@ class BlackIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *black_rules(), RootRule(BlackTargets))
+        return (*super().rules(), *black_rules(), RootRule(BlackFormatter))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
@@ -61,7 +61,7 @@ class BlackIntegrationTest(TestBase):
             args.append(f"--black-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         lint_result = self.request_single_product(
-            LintResult, Params(BlackTargets(tuple(targets)), options_bootstrapper)
+            LintResult, Params(BlackFormatter(tuple(targets)), options_bootstrapper)
         )
         input_snapshot = self.request_single_product(
             Snapshot,
@@ -72,7 +72,7 @@ class BlackIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                BlackTargets(tuple(targets), prior_formatter_result=input_snapshot),
+                BlackFormatter(tuple(targets), prior_formatter_result=input_snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/docformatter/register.py
+++ b/src/python/pants/backend/python/lint/docformatter/register.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.lint import python_format_target, python_lint_target
+from pants.backend.python.lint import python_formatter, python_linter
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 
 
 def rules():
     return (
         *docformatter_rules(),
-        *python_format_target.rules(),
-        *python_lint_target.rules(),
+        *python_formatter.rules(),
+        *python_linter.rules(),
     )

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -6,7 +6,6 @@ from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
-from pants.backend.python.lint.python_linter import PythonLintTarget
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -32,7 +31,7 @@ from pants.rules.core.determine_source_files import (
     SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -152,7 +151,7 @@ def rules():
         lint,
         subsystem_rule(Docformatter),
         UnionRule(PythonFormatTarget, DocformatterFormatter),
-        UnionRule(PythonLintTarget, DocformatterFormatter),
+        UnionRule(Linter, DocformatterFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional, Tuple
 
-from pants.backend.python.lint.docformatter.rules import DocformatterTargets
+from pants.backend.python.lint.docformatter.rules import DocformatterFormatter
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -26,7 +26,7 @@ class DocformatterIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *docformatter_rules(), RootRule(DocformatterTargets))
+        return (*super().rules(), *docformatter_rules(), RootRule(DocformatterFormatter))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
@@ -54,7 +54,7 @@ class DocformatterIntegrationTest(TestBase):
             args.append(f"--docformatter-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         lint_result = self.request_single_product(
-            LintResult, Params(DocformatterTargets(tuple(targets)), options_bootstrapper)
+            LintResult, Params(DocformatterFormatter(tuple(targets)), options_bootstrapper)
         )
         input_snapshot = self.request_single_product(
             Snapshot,
@@ -65,7 +65,7 @@ class DocformatterIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                DocformatterTargets(tuple(targets), prior_formatter_result=input_snapshot),
+                DocformatterFormatter(tuple(targets), prior_formatter_result=input_snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/flake8/register.py
+++ b/src/python/pants/backend/python/lint/flake8/register.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.lint import python_lint_target
+from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.flake8 import rules as flake8_rules
 
 
 def rules():
     return (
         *flake8_rules.rules(),
-        *python_lint_target.rules(),
+        *python_linter.rules(),
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
-from pants.backend.python.lint.python_linter import PythonLinter, PythonLintTarget
+from pants.backend.python.lint.python_linter import PythonLinter
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -27,7 +27,7 @@ from pants.rules.core.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,7 @@ def rules():
     return [
         lint,
         subsystem_rule(Flake8),
-        UnionRule(PythonLintTarget, Flake8Linter),
+        UnionRule(Linter, Flake8Linter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.flake8.rules import Flake8Targets
+from pants.backend.python.lint.flake8.rules import Flake8Linter
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -32,7 +32,7 @@ class Flake8IntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *flake8_rules(), RootRule(Flake8Targets))
+        return (*super().rules(), *flake8_rules(), RootRule(Flake8Linter))
 
     def make_target_with_origin(
         self,
@@ -69,7 +69,7 @@ class Flake8IntegrationTest(TestBase):
             args.append(f"--flake8-skip")
         return self.request_single_product(
             LintResult,
-            Params(Flake8Targets(tuple(targets)), create_options_bootstrapper(args=args)),
+            Params(Flake8Linter(tuple(targets)), create_options_bootstrapper(args=args)),
         )
 
     def test_passing_source(self) -> None:

--- a/src/python/pants/backend/python/lint/isort/register.py
+++ b/src/python/pants/backend/python/lint/isort/register.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.lint import python_format_target, python_lint_target
+from pants.backend.python.lint import python_formatter, python_linter
 from pants.backend.python.lint.isort import rules as isort_rules
 from pants.backend.python.lint.isort.isort_prep import IsortPrep
 from pants.backend.python.lint.isort.isort_run import IsortRun
@@ -11,8 +11,8 @@ from pants.goal.task_registrar import TaskRegistrar as task
 def rules():
     return (
         *isort_rules.rules(),
-        *python_format_target.rules(),
-        *python_lint_target.rules(),
+        *python_formatter.rules(),
+        *python_linter.rules(),
     )
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -6,7 +6,6 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
-from pants.backend.python.lint.python_linter import PythonLintTarget
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -34,7 +33,7 @@ from pants.rules.core.determine_source_files import (
     SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -168,7 +167,7 @@ def rules():
         lint,
         subsystem_rule(Isort),
         UnionRule(PythonFormatTarget, IsortFormatter),
-        UnionRule(PythonLintTarget, IsortFormatter),
+        UnionRule(Linter, IsortFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional, Tuple
 
-from pants.backend.python.lint.isort.rules import IsortTargets
+from pants.backend.python.lint.isort.rules import IsortFormatter
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -36,7 +36,7 @@ class IsortIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *isort_rules(), RootRule(IsortTargets))
+        return (*super().rules(), *isort_rules(), RootRule(IsortFormatter))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
@@ -68,7 +68,7 @@ class IsortIntegrationTest(TestBase):
             args.append(f"--isort-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         lint_result = self.request_single_product(
-            LintResult, Params(IsortTargets(tuple(targets)), options_bootstrapper)
+            LintResult, Params(IsortFormatter(tuple(targets)), options_bootstrapper)
         )
         input_snapshot = self.request_single_product(
             Snapshot,
@@ -79,7 +79,7 @@ class IsortIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                IsortTargets(tuple(targets), prior_formatter_result=input_snapshot),
+                IsortFormatter(tuple(targets), prior_formatter_result=input_snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/pylint/register.py
+++ b/src/python/pants/backend/python/lint/pylint/register.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.lint import python_lint_target
+from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.pylint import rules as pylint_rules
 
 
 def rules():
     return (
         *pylint_rules.rules(),
-        *python_lint_target.rules(),
+        *python_linter.rules(),
     )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
-from pants.backend.python.lint.python_linter import PythonLinter, PythonLintTarget
+from pants.backend.python.lint.python_linter import PythonLinter
 from pants.backend.python.rules import download_pex_bin, pex, prepare_chrooted_python_sources
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -27,7 +27,7 @@ from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
-from pants.rules.core.lint import LintResult
+from pants.rules.core.lint import Linter, LintResult
 
 
 @dataclass(frozen=True)
@@ -135,7 +135,7 @@ def rules():
     return [
         lint,
         subsystem_rule(Pylint),
-        UnionRule(PythonLintTarget, PylintLinter),
+        UnionRule(Linter, PylintLinter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
-from pants.backend.python.lint.python_lint_target import PythonLintTarget
+from pants.backend.python.lint.python_linter import PythonLinter, PythonLintTarget
 from pants.backend.python.rules import download_pex_bin, pex, prepare_chrooted_python_sources
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -21,7 +21,6 @@ from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
-from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -32,8 +31,8 @@ from pants.rules.core.lint import LintResult
 
 
 @dataclass(frozen=True)
-class PylintTargets:
-    adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
+class PylintLinter(PythonLinter):
+    pass
 
 
 def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
@@ -47,7 +46,7 @@ def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tup
 
 @rule(name="Lint using Pylint")
 async def lint(
-    targets: PylintTargets,
+    linter: PylintLinter,
     pylint: Pylint,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -55,7 +54,7 @@ async def lint(
     if pylint.options.skip:
         return LintResult.noop()
 
-    adaptors_with_origins = targets.adaptors_with_origins
+    adaptors_with_origins = linter.adaptors_with_origins
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
@@ -136,7 +135,7 @@ def rules():
     return [
         lint,
         subsystem_rule(Pylint),
-        UnionRule(PythonLintTarget, PylintTargets),
+        UnionRule(PythonLintTarget, PylintLinter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -5,7 +5,7 @@ from functools import partialmethod
 from textwrap import dedent
 from typing import List, Optional
 
-from pants.backend.python.lint.pylint.rules import PylintTargets
+from pants.backend.python.lint.pylint.rules import PylintLinter
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -41,7 +41,7 @@ class PylintIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *pylint_rules(), RootRule(PylintTargets))
+        return (*super().rules(), *pylint_rules(), RootRule(PylintLinter))
 
     def write_file(self, file_content: FileContent) -> None:
         self.create_file(relpath=file_content.path, contents=file_content.content.decode())
@@ -81,7 +81,7 @@ class PylintIntegrationTest(TestBase):
             args.append(f"--pylint-skip")
         return self.request_single_product(
             LintResult,
-            Params(PylintTargets(tuple(targets)), create_options_bootstrapper(args=args)),
+            Params(PylintLinter(tuple(targets)), create_options_bootstrapper(args=args)),
         )
 
     def test_passing_source(self) -> None:

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -20,24 +20,19 @@ from pants.engine.selectors import Get
 from pants.rules.core.fmt import AggregatedFmtResults, FmtResult, FormatTarget
 
 
-# TODO: Change this to be multiple targets.
 @union
-class PythonFormatTarget:
-    pass
-
-
 @dataclass(frozen=True)
-class _ConcretePythonFormatTarget:
+class PythonFormatTarget:
     adaptor_with_origin: TargetAdaptorWithOrigin
 
 
 @rule
 async def format_python_target(
-    concrete_target: _ConcretePythonFormatTarget, union_membership: UnionMembership
+    target: PythonFormatTarget, union_membership: UnionMembership
 ) -> AggregatedFmtResults:
     """This aggregator allows us to have multiple formatters safely operate over the same Python
     targets, even if they modify the same files."""
-    adaptor_with_origin = concrete_target.adaptor_with_origin
+    adaptor_with_origin = target.adaptor_with_origin
     prior_formatter_result = adaptor_with_origin.adaptor.sources.snapshot
     results: List[FmtResult] = []
     for member in union_membership.union_rules[PythonFormatTarget]:
@@ -54,34 +49,28 @@ async def format_python_target(
 
 
 @rule
-def target_adaptor(
-    adaptor_with_origin: PythonTargetAdaptorWithOrigin,
-) -> _ConcretePythonFormatTarget:
-    return _ConcretePythonFormatTarget(adaptor_with_origin)
+def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> PythonFormatTarget:
+    return PythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
-    return _ConcretePythonFormatTarget(adaptor_with_origin)
+def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> PythonFormatTarget:
+    return PythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def binary_adaptor(
-    adaptor_with_origin: PythonBinaryAdaptorWithOrigin,
-) -> _ConcretePythonFormatTarget:
-    return _ConcretePythonFormatTarget(adaptor_with_origin)
+def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> PythonFormatTarget:
+    return PythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> _ConcretePythonFormatTarget:
-    return _ConcretePythonFormatTarget(adaptor_with_origin)
+def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> PythonFormatTarget:
+    return PythonFormatTarget(adaptor_with_origin)
 
 
 @rule
-def plugin_adaptor(
-    adaptor_with_origin: PantsPluginAdaptorWithOrigin,
-) -> _ConcretePythonFormatTarget:
-    return _ConcretePythonFormatTarget(adaptor_with_origin)
+def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> PythonFormatTarget:
+    return PythonFormatTarget(adaptor_with_origin)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/python_format_target_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_format_target_integration_test.py
@@ -7,10 +7,7 @@ from pants.backend.python.lint.black.rules import BlackTargets
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.isort.rules import IsortTargets
 from pants.backend.python.lint.isort.rules import rules as isort_rules
-from pants.backend.python.lint.python_format_target import (
-    _ConcretePythonFormatTarget,
-    format_python_target,
-)
+from pants.backend.python.lint.python_format_target import PythonFormatTarget, format_python_target
 from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
@@ -31,7 +28,7 @@ class PythonFormatTargetIntegrationTest(TestBase):
             format_python_target,
             *black_rules(),
             *isort_rules(),
-            RootRule(_ConcretePythonFormatTarget),
+            RootRule(PythonFormatTarget),
             RootRule(BlackTargets),
             RootRule(IsortTargets),
         )
@@ -45,7 +42,7 @@ class PythonFormatTargetIntegrationTest(TestBase):
             address=Address.parse("test:target"),
         )
         origin = SingleAddress(directory="test", name="target")
-        target = _ConcretePythonFormatTarget(TargetAdaptorWithOrigin(adaptor, origin))
+        target = PythonFormatTarget(TargetAdaptorWithOrigin(adaptor, origin))
         args = [
             "--backend-packages2=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
             *(extra_args or []),

--- a/src/python/pants/backend/python/lint/python_formatter_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_formatter_integration_test.py
@@ -3,11 +3,11 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.black.rules import BlackTargets
+from pants.backend.python.lint.black.rules import BlackFormatter
 from pants.backend.python.lint.black.rules import rules as black_rules
-from pants.backend.python.lint.isort.rules import IsortTargets
+from pants.backend.python.lint.isort.rules import IsortFormatter
 from pants.backend.python.lint.isort.rules import rules as isort_rules
-from pants.backend.python.lint.python_format_target import PythonFormatTarget, format_python_target
+from pants.backend.python.lint.python_formatter import PythonFormatTarget, format_python_target
 from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
@@ -20,7 +20,7 @@ from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
 
-class PythonFormatTargetIntegrationTest(TestBase):
+class PythonFormatterIntegrationTest(TestBase):
     @classmethod
     def rules(cls):
         return (
@@ -29,8 +29,8 @@ class PythonFormatTargetIntegrationTest(TestBase):
             *black_rules(),
             *isort_rules(),
             RootRule(PythonFormatTarget),
-            RootRule(BlackTargets),
-            RootRule(IsortTargets),
+            RootRule(BlackFormatter),
+            RootRule(IsortFormatter),
         )
 
     def run_black_and_isort(

--- a/src/python/pants/backend/python/lint/python_lint_target.py
+++ b/src/python/pants/backend/python/lint/python_lint_target.py
@@ -18,62 +18,58 @@ from pants.rules.core.lint import LintResult, LintResults, LintTarget
 
 
 @union
-class PythonLintTarget:
-    pass
-
-
 @dataclass(frozen=True)
-class _ConcretePythonLintTarget:
+class PythonLintTarget:
     adaptor_with_origin: TargetAdaptorWithOrigin
 
 
 @rule
 async def lint_python_target(
-    concrete_target: _ConcretePythonLintTarget, union_membership: UnionMembership,
+    target: PythonLintTarget, union_membership: UnionMembership
 ) -> LintResults:
     """This aggregator allows us to have multiple linters operate over the same Python targets.
 
     We do not care if linters overlap in their execution as linters have no side-effects.
     """
     results = await MultiGet(
-        Get[LintResult](PythonLintTarget, member((concrete_target.adaptor_with_origin,)))
+        Get[LintResult](PythonLintTarget, member((target.adaptor_with_origin,)))
         for member in union_membership.union_rules[PythonLintTarget]
     )
     return LintResults(results)
 
 
-PYTHON_TARGET_TYPES = [
+PYTHON_TARGET_TYPES = (
     PythonAppAdaptorWithOrigin,
     PythonBinaryAdaptorWithOrigin,
     PythonTargetAdaptorWithOrigin,
     PythonTestsAdaptorWithOrigin,
     PantsPluginAdaptorWithOrigin,
-]
+)
 
 
 @rule
-def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> _ConcretePythonLintTarget:
-    return _ConcretePythonLintTarget(adaptor_with_origin)
+def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> PythonLintTarget:
+    return PythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> _ConcretePythonLintTarget:
-    return _ConcretePythonLintTarget(adaptor_with_origin)
+def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> PythonLintTarget:
+    return PythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> _ConcretePythonLintTarget:
-    return _ConcretePythonLintTarget(adaptor_with_origin)
+def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> PythonLintTarget:
+    return PythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> _ConcretePythonLintTarget:
-    return _ConcretePythonLintTarget(adaptor_with_origin)
+def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> PythonLintTarget:
+    return PythonLintTarget(adaptor_with_origin)
 
 
 @rule
-def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> _ConcretePythonLintTarget:
-    return _ConcretePythonLintTarget(adaptor_with_origin)
+def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> PythonLintTarget:
+    return PythonLintTarget(adaptor_with_origin)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/python_linter.py
+++ b/src/python/pants/backend/python/lint/python_linter.py
@@ -12,36 +12,15 @@ from pants.engine.legacy.structs import (
     PythonTestsAdaptorWithOrigin,
     TargetAdaptorWithOrigin,
 )
-from pants.engine.objects import union
-from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
-from pants.engine.selectors import Get, MultiGet
-from pants.rules.core.lint import Linter, LintResult, LintResults, LintTarget
-
-
-@union
-@dataclass(frozen=True)
-class PythonLintTarget:
-    adaptor_with_origin: TargetAdaptorWithOrigin
+from pants.engine.rules import RootRule
+from pants.rules.core.lint import Linter
 
 
 @dataclass(frozen=True)
 class PythonLinter(Linter, metaclass=ABCMeta):
-    pass
-
-
-@rule
-async def lint_python_target(
-    target: PythonLintTarget, union_membership: UnionMembership
-) -> LintResults:
-    """This aggregator allows us to have multiple linters operate over the same Python targets.
-
-    We do not care if linters overlap in their execution as linters have no side-effects.
-    """
-    results = await MultiGet(
-        Get[LintResult](PythonLintTarget, linter((target.adaptor_with_origin,)))
-        for linter in union_membership.union_rules[PythonLintTarget]
-    )
-    return LintResults(results)
+    @staticmethod
+    def is_valid_target(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+        return isinstance(adaptor_with_origin, PYTHON_TARGET_TYPES)
 
 
 PYTHON_TARGET_TYPES = (
@@ -53,39 +32,5 @@ PYTHON_TARGET_TYPES = (
 )
 
 
-@rule
-def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> PythonLintTarget:
-    return PythonLintTarget(adaptor_with_origin)
-
-
-@rule
-def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> PythonLintTarget:
-    return PythonLintTarget(adaptor_with_origin)
-
-
-@rule
-def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> PythonLintTarget:
-    return PythonLintTarget(adaptor_with_origin)
-
-
-@rule
-def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> PythonLintTarget:
-    return PythonLintTarget(adaptor_with_origin)
-
-
-@rule
-def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> PythonLintTarget:
-    return PythonLintTarget(adaptor_with_origin)
-
-
 def rules():
-    return [
-        lint_python_target,
-        target_adaptor,
-        app_adaptor,
-        binary_adaptor,
-        tests_adaptor,
-        plugin_adaptor,
-        *(RootRule(target_type) for target_type in PYTHON_TARGET_TYPES),
-        *(UnionRule(LintTarget, target_type) for target_type in PYTHON_TARGET_TYPES),
-    ]
+    return [RootRule(target_type) for target_type in PYTHON_TARGET_TYPES]

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -57,7 +57,7 @@ class AggregatedFmtResults:
     combined_digest: Digest
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class Formatter(Linter, metaclass=ABCMeta):
     adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
 

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+from abc import ABCMeta
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -20,6 +21,7 @@ from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get, MultiGet
+from pants.rules.core.lint import Linter
 
 
 @dataclass(frozen=True)
@@ -53,6 +55,11 @@ class AggregatedFmtResults:
 
     results: Tuple[FmtResult, ...]
     combined_digest: Digest
+
+
+@dataclass(frozen=True)
+class Formatter(Linter, metaclass=ABCMeta):
+    adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
 
 
 @union

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -52,15 +52,17 @@ class FmtTest(TestBase):
             files=tuple(["formatted.txt", "fake.txt"] if include_sources else []),
             dirs=(),
         )
+        address = Address.parse(f"src/python:{name}")
         ht = HydratedTarget(
-            address=Address.parse(f"src:{name}"),
+            address=address,
             adaptor=adaptor_type(
-                sources=EagerFilesetWithSpec("src", {"globs": []}, snapshot=mocked_snapshot),
+                sources=EagerFilesetWithSpec("src/python", {"globs": []}, snapshot=mocked_snapshot),
                 name=name,
+                address=address,
             ),
             dependencies=(),
         )
-        return HydratedTargetWithOrigin(ht, SingleAddress(directory="src", name=name))
+        return HydratedTargetWithOrigin(ht, SingleAddress(directory="src/python", name=name))
 
     def run_fmt_rule(self, *, targets: List[HydratedTargetWithOrigin]) -> Tuple[int, str]:
         result_digest = self.request_single_product(

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -1,17 +1,16 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable, Tuple, Type
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargetsWithOrigins
 from pants.engine.legacy.structs import TargetAdaptorWithOrigin
-from pants.engine.objects import Collection, union
+from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get, MultiGet
 
@@ -37,28 +36,15 @@ class LintResult:
         )
 
 
-class LintResults(Collection[LintResult]):
-    """This collection allows us to aggregate multiple `LintResult`s for a language."""
-
-
-@dataclass(frozen=True)
+@union
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class Linter(ABC):
     adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
 
-
-@union
-class LintTarget:
-    """A union for registration of a lintable target type.
-
-    The union members should be subclasses of TargetAdaptorWithOrigin.
-    """
-
     @staticmethod
-    def is_lintable(
-        adaptor_with_origin: TargetAdaptorWithOrigin, *, union_membership: UnionMembership
-    ) -> bool:
-        is_lint_target = union_membership.is_member(LintTarget, adaptor_with_origin)
-        return adaptor_with_origin.adaptor.has_sources() and is_lint_target
+    @abstractmethod
+    def is_valid_target(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+        """Return True if the linter can meaningfully operate on this target type."""
 
 
 class LintOptions(GoalSubsystem):
@@ -68,7 +54,7 @@ class LintOptions(GoalSubsystem):
     # Blocked on https://github.com/pantsbuild/pants/issues/8351
     name = "lint2"
 
-    required_union_implementations = (LintTarget,)
+    required_union_implementations = (Linter,)
 
 
 class Lint(Goal):
@@ -85,12 +71,14 @@ async def lint(
         TargetAdaptorWithOrigin.create(target_with_origin.target.adaptor, target_with_origin.origin)
         for target_with_origin in targets_with_origins
     ]
-    nested_results = await MultiGet(
-        Get[LintResults](LintTarget, adaptor_with_origin)
+
+    linters: Iterable[Type[Linter]] = union_membership.union_rules[Linter]
+    results = await MultiGet(
+        Get[LintResult](Linter, linter((adaptor_with_origin,)))
         for adaptor_with_origin in adaptors_with_origins
-        if LintTarget.is_lintable(adaptor_with_origin, union_membership=union_membership)
+        for linter in linters
+        if adaptor_with_origin.adaptor.has_sources() and linter.is_valid_target(adaptor_with_origin)
     )
-    results = list(itertools.chain.from_iterable(nested_results))
 
     if not results:
         return Lint(exit_code=0)

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+from abc import ABC
 from dataclasses import dataclass
+from typing import Tuple
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
@@ -37,6 +39,11 @@ class LintResult:
 
 class LintResults(Collection[LintResult]):
     """This collection allows us to aggregate multiple `LintResult`s for a language."""
+
+
+@dataclass(frozen=True)
+class Linter(ABC):
+    adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
 
 
 @union

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -1,130 +1,170 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Callable, List, Optional, Tuple
+from abc import ABCMeta, abstractmethod
+from typing import List, Tuple, Type
 
+from pants.build_graph.address import Address
 from pants.engine.legacy.graph import HydratedTargetsWithOrigins, HydratedTargetWithOrigin
-from pants.engine.legacy.structs import JvmAppAdaptor, PythonTargetAdaptorWithOrigin
+from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.rules import UnionMembership
 from pants.rules.core.fmt_test import FmtTest
-from pants.rules.core.lint import Lint, LintResult, LintResults, LintTarget, lint
+from pants.rules.core.lint import Lint, Linter, LintResult, lint
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
+
+
+class MockLinter(Linter, metaclass=ABCMeta):
+    @staticmethod
+    def is_valid_target(_: TargetAdaptorWithOrigin) -> bool:
+        return True
+
+    @staticmethod
+    @abstractmethod
+    def exit_code(_: Address) -> int:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def stdout(_: Address) -> str:
+        pass
+
+    @property
+    def target_address(self) -> Address:
+        return self.adaptors_with_origins[0].adaptor.address
+
+    @property
+    def lint_result(self) -> LintResult:
+        return LintResult(self.exit_code(self.target_address), self.stdout(self.target_address), "")
+
+
+class SuccessfulLinter(MockLinter):
+    @staticmethod
+    def exit_code(_: Address) -> int:
+        return 0
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Successful linter: {address} was good."
+
+
+class FailingLinter(MockLinter):
+    @staticmethod
+    def exit_code(_: Address) -> int:
+        return 1
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Failing linter: {address} was bad."
+
+
+class ConditionallySucceedsLinter(MockLinter):
+    @staticmethod
+    def exit_code(address: Address) -> int:
+        if address.target_name == "bad":
+            return 127
+        return 0
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        if address.target_name == "bad":
+            return f"Conditionally succeeds linter: {address} was bad."
+        return f"Conditionally succeeds linter: {address} was good."
+
+
+class InvalidTargetLinter(MockLinter):
+    @staticmethod
+    def exit_code(_: Address) -> int:
+        return -1
+
+    @staticmethod
+    def is_valid_target(_: TargetAdaptorWithOrigin) -> bool:
+        return False
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Invalid target linter: {address} should not have run..."
 
 
 class LintTest(TestBase):
     @staticmethod
     def run_lint_rule(
-        *,
-        targets: List[HydratedTargetWithOrigin],
-        mock_linters: Optional[Callable[[PythonTargetAdaptorWithOrigin], LintResults]] = None,
+        *, linters: List[Type[Linter]], targets: List[HydratedTargetWithOrigin],
     ) -> Tuple[int, str]:
-        if mock_linters is None:
-            mock_linters = lambda adaptor_with_origin: LintResults(
-                [
-                    LintResult(
-                        exit_code=1,
-                        stdout=f"Linted `{adaptor_with_origin.adaptor.name}`",
-                        stderr="",
-                    )
-                ]
-            )
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership({LintTarget: [PythonTargetAdaptorWithOrigin]})
+        union_membership = UnionMembership({Linter: linters})
         result: Lint = run_rule(
             lint,
             rule_args=[console, HydratedTargetsWithOrigins(targets), union_membership],
             mock_gets=[
-                MockGet(product_type=LintResults, subject_type=LintTarget, mock=mock_linters),
+                MockGet(
+                    product_type=LintResult,
+                    subject_type=Linter,
+                    mock=lambda linter: linter.lint_result,
+                ),
             ],
             union_membership=union_membership,
         )
         return result.exit_code, console.stdout.getvalue()
 
-    def test_non_union_member_noops(self) -> None:
-        exit_code, stdout = self.run_lint_rule(
-            targets=[FmtTest.make_hydrated_target_with_origin(adaptor_type=JvmAppAdaptor)],
-        )
-        assert exit_code == 0
-        assert stdout == ""
-
     def test_empty_target_noops(self) -> None:
         exit_code, stdout = self.run_lint_rule(
+            linters=[FailingLinter],
             targets=[FmtTest.make_hydrated_target_with_origin(include_sources=False)],
         )
         assert exit_code == 0
         assert stdout == ""
 
+    def test_invalid_target_noops(self) -> None:
+        exit_code, stdout = self.run_lint_rule(
+            linters=[InvalidTargetLinter], targets=[FmtTest.make_hydrated_target_with_origin()],
+        )
+        assert exit_code == 0
+        assert stdout == ""
+
     def test_single_target_with_one_linter(self) -> None:
-        exit_code, stdout = self.run_lint_rule(targets=[FmtTest.make_hydrated_target_with_origin()])
-        assert exit_code == 1
-        assert stdout.strip() == "Linted `target`"
+        target_with_origin = FmtTest.make_hydrated_target_with_origin()
+        address = target_with_origin.target.adaptor.address
+        exit_code, stdout = self.run_lint_rule(
+            linters=[FailingLinter], targets=[target_with_origin]
+        )
+        assert exit_code == FailingLinter.exit_code(address)
+        assert stdout.strip() == FailingLinter.stdout(address)
 
     def test_single_target_with_multiple_linters(self) -> None:
-        def mock_linters(_: PythonTargetAdaptorWithOrigin) -> LintResults:
-            return LintResults(
-                [
-                    LintResult(exit_code=0, stdout=f"Linter 1", stderr=""),
-                    LintResult(exit_code=1, stdout=f"Linter 2", stderr=""),
-                ]
-            )
-
+        target_with_origin = FmtTest.make_hydrated_target_with_origin()
+        address = target_with_origin.target.adaptor.address
         exit_code, stdout = self.run_lint_rule(
-            targets=[FmtTest.make_hydrated_target_with_origin()], mock_linters=mock_linters,
+            linters=[SuccessfulLinter, FailingLinter], targets=[target_with_origin],
         )
-        assert exit_code == 1
-        assert stdout.splitlines() == ["Linter 1", "Linter 2"]
+        assert exit_code == FailingLinter.exit_code(address)
+        assert stdout.splitlines() == [
+            SuccessfulLinter.stdout(address),
+            FailingLinter.stdout(address),
+        ]
 
     def test_multiple_targets_with_one_linter(self) -> None:
-        # If any single target fails, the error code should propagate to the whole run.
-        def mock_linters(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> LintResults:
-            name = adaptor_with_origin.adaptor.name
-            if name == "bad":
-                return LintResults(
-                    [LintResult(exit_code=127, stdout=f"`{name}` failed", stderr="")]
-                )
-            return LintResults([LintResult(exit_code=0, stdout=f"`{name}` passed", stderr="")])
-
+        good_target = FmtTest.make_hydrated_target_with_origin(name="good")
+        bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
         exit_code, stdout = self.run_lint_rule(
-            targets=[
-                FmtTest.make_hydrated_target_with_origin(name="good"),
-                FmtTest.make_hydrated_target_with_origin(name="bad"),
-            ],
-            mock_linters=mock_linters,
+            linters=[ConditionallySucceedsLinter], targets=[good_target, bad_target],
         )
-        assert exit_code == 127
-        assert stdout.splitlines() == ["`good` passed", "`bad` failed"]
+        assert exit_code == ConditionallySucceedsLinter.exit_code(bad_target.target.adaptor.address)
+        assert stdout.splitlines() == [
+            ConditionallySucceedsLinter.stdout(target_with_origin.target.adaptor.address)
+            for target_with_origin in [good_target, bad_target]
+        ]
 
     def test_multiple_targets_with_multiple_linters(self) -> None:
-        def mock_linters(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> LintResults:
-            name = adaptor_with_origin.adaptor.name
-            if name == "bad":
-                return LintResults(
-                    [
-                        LintResult(exit_code=0, stdout=f"Linter 1 passed for `{name}`", stderr=""),
-                        LintResult(
-                            exit_code=127, stdout=f"Linter 2 failed for `{name}`", stderr=""
-                        ),
-                    ]
-                )
-            return LintResults(
-                [
-                    LintResult(exit_code=0, stdout=f"Linter 1 passed for `{name}`", stderr=""),
-                    LintResult(exit_code=0, stdout=f"Linter 2 passed for `{name}`", stderr=""),
-                ]
-            )
-
+        good_target = FmtTest.make_hydrated_target_with_origin(name="good")
+        bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
         exit_code, stdout = self.run_lint_rule(
-            targets=[
-                FmtTest.make_hydrated_target_with_origin(name="good"),
-                FmtTest.make_hydrated_target_with_origin(name="bad"),
-            ],
-            mock_linters=mock_linters,
+            linters=[ConditionallySucceedsLinter, SuccessfulLinter],
+            targets=[good_target, bad_target],
         )
-        assert exit_code == 127
+        assert exit_code == ConditionallySucceedsLinter.exit_code(bad_target.target.adaptor.address)
         assert stdout.splitlines() == [
-            "Linter 1 passed for `good`",
-            "Linter 2 passed for `good`",
-            "Linter 1 passed for `bad`",
-            "Linter 2 failed for `bad`",
+            linter.stdout(target_with_origin.target.adaptor.address)
+            for target_with_origin in [good_target, bad_target]
+            for linter in [ConditionallySucceedsLinter, SuccessfulLinter]
         ]


### PR DESCRIPTION
### Problem

In https://github.com/pantsbuild/pants/pull/8801, we came up with a solution for graph ambiguity when using multiple linters. https://github.com/pantsbuild/pants/pull/8823 followed this up by fixing the problem of `fmt2` when multiple formatters overwrite the same file.

Currently, both `lint2` and `fmt2` operate by grouping linters by language. There may be several Python linters/formatters, several Java linters/formatters, etc. The `lint` and `fmt` `@goal_rule`s will call `await Get[LintResult](LintTarget, target_adaptor)`. That `target_adaptor` will then get passed to the corresponding language implementation, like `python_lint_target.py`, then, there, that target will be run against all registered Python linters and the results will be grouped together into a collection of Python results. `lint.py` will get back that collection of Python results, along with the collection of Java results, etc, and will flatten the list of lists of individual `LintResult`s.

Why do this language grouping? For formatters, it's a performance win. With formatters, we must run every formatter sequentially and pipe the result of one formatter into the next so that they don't overwrite each other. But, if we group by language, then we can at least have Python formatters run at the same time as Scala formatters. Within the Scala formatters, only one will run at a time, but a Python formatter might be running at the same time.

But, it turns out there is no reason to group by languages for linters. With linters, they by definition do not mutate the workspace. So, it is safe to run every linter in parallel. Grouping by languages is a good performance hack with `fmt`, but only complicates things and results in worse performance for `lint`.

### Solution

Redesign `lint.py` to no longer have a union of `LintTarget` but to instead have a union of `Linter`. 

Previously, we expected a union like `{LintTarget: [PythonTargetAdaptorWIthOrigin, PythonTestsAdaptorWithOrigin]}`. `await Get[LintResult](LintTarget, target_adaptor)` would then result in something like a `PythonTargetAdaptorWithOrigin` getting converted into another union `PythonLintTarget`, which then would get passed to each of the linters via `BanditTarget`, `BlackTarget`, `Flake8Target`, etc.

Instead, we now have a union like `{Linter: [BanditLinter, BlackFormatter, Flake8Linter]}`. Each of these linters is a subclass of `Linter` (which is both a union and an abstract dataclass). In `lint.py`, we explicitly grab all registered linters and explicitly call their constructors to pass the target to run on, e.g. calling `BanditLinter(target)` and `BlackFormatter(target)`. This allows us to still call every linter like before, but to no longer need to group by language.

To filter out irrelevant targets—e.g. that Flake8 cannot operate on Java targets—we no longer check the `UnionMemership` to see if that target type belongs to `LintTarget`, but we instead have a static method `Linter.is_valid_target()`. Each linter implements this method to indicate if it can meaningfully operate on the target type. If it can't, we skip that linter for the target.

### Result

`lint.py` should be much easier to understand now. It likely has better performance (not benchmarked).

We can now add `--no-lint-per-target-caching` in a follow-up to batch multiple targets.

This does not touch `fmt.py` much, beyond introducing the `Formatter` abstract class to complement the `Linter` abstract class. `fmt.py` will be simplified in a followup, as it does still need to keep support for grouping by languages.