### PR TITLE
Add `--no-lint2-per-target-caching` to run V2 linters with batched targets

### DIFF
--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -52,3 +52,6 @@ interpreter_search_paths = [
 [python-native-code]
 ld_flags = []
 cpp_flags = []
+
+[lint2]
+per_target_caching = true

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -56,6 +56,29 @@ class LintOptions(GoalSubsystem):
 
     required_union_implementations = (Linter,)
 
+    @classmethod
+    def register_options(cls, register) -> None:
+        super().register_options(register)
+        register(
+            "--per-target-caching",
+            advanced=True,
+            type=bool,
+            default=False,
+            help=(
+                "Rather than running all targets in a single batch, run each target as a "
+                "separate process. Why do this? You'll get many more cache hits. Additionally, for "
+                "Python users, if you have some targets that only work with Python 2 and some that "
+                "only work with Python 3, `--per-target-caching` will allow you to use the right "
+                "interpreter for each target. Why not do this? Linters both have substantial "
+                "startup overhead and are cheap to add one additional file to the run. On a cold "
+                "cache, it is much faster to use `--no-per-target-caching`. We only recommend "
+                "using `--per-target-caching` if you "
+                "are using a remote cache, or if you have some Python 2-only targets and "
+                "some Python 3-only targets, or if you have benchmarked that this option will be "
+                "faster than `--no-per-target-caching` for your use case."
+            ),
+        )
+
 
 class Lint(Goal):
     subsystem_cls = LintOptions
@@ -65,20 +88,37 @@ class Lint(Goal):
 async def lint(
     console: Console,
     targets_with_origins: HydratedTargetsWithOrigins,
+    options: LintOptions,
     union_membership: UnionMembership,
 ) -> Lint:
-    adaptors_with_origins = [
+    adaptors_with_origins = tuple(
         TargetAdaptorWithOrigin.create(target_with_origin.target.adaptor, target_with_origin.origin)
         for target_with_origin in targets_with_origins
-    ]
+        if target_with_origin.target.adaptor.has_sources()
+    )
 
     linters: Iterable[Type[Linter]] = union_membership.union_rules[Linter]
-    results = await MultiGet(
-        Get[LintResult](Linter, linter((adaptor_with_origin,)))
-        for adaptor_with_origin in adaptors_with_origins
-        for linter in linters
-        if adaptor_with_origin.adaptor.has_sources() and linter.is_valid_target(adaptor_with_origin)
-    )
+    if options.values.per_target_caching:
+        results = await MultiGet(
+            Get[LintResult](Linter, linter((adaptor_with_origin,)))
+            for adaptor_with_origin in adaptors_with_origins
+            for linter in linters
+            if linter.is_valid_target(adaptor_with_origin)
+        )
+    else:
+        linters_with_valid_targets = {
+            linter: tuple(
+                adaptor_with_origin
+                for adaptor_with_origin in adaptors_with_origins
+                if linter.is_valid_target(adaptor_with_origin)
+            )
+            for linter in linters
+        }
+        results = await MultiGet(
+            Get[LintResult](Linter, linter(valid_targets))
+            for linter, valid_targets in linters_with_valid_targets.items()
+            if valid_targets
+        )
 
     if not results:
         return Lint(exit_code=0)

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABCMeta, abstractmethod
-from typing import List, Tuple, Type
+from typing import Iterable, List, Tuple, Type
+from unittest.mock import Mock
 
 from pants.build_graph.address import Address
 from pants.engine.legacy.graph import HydratedTargetsWithOrigins, HydratedTargetWithOrigin
@@ -14,6 +15,12 @@ from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
 
 
+# TODO(#9141): replace this with a proper util to create `GoalSubsystem`s
+class MockOptions:
+    def __init__(self, **values):
+        self.values = Mock(**values)
+
+
 class MockLinter(Linter, metaclass=ABCMeta):
     @staticmethod
     def is_valid_target(_: TargetAdaptorWithOrigin) -> bool:
@@ -21,60 +28,61 @@ class MockLinter(Linter, metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def exit_code(_: Address) -> int:
+    def exit_code(_: Iterable[Address]) -> int:
         pass
 
     @staticmethod
     @abstractmethod
-    def stdout(_: Address) -> str:
+    def stdout(_: Iterable[Address]) -> str:
         pass
 
     @property
-    def target_address(self) -> Address:
-        return self.adaptors_with_origins[0].adaptor.address
-
-    @property
     def lint_result(self) -> LintResult:
-        return LintResult(self.exit_code(self.target_address), self.stdout(self.target_address), "")
+        addresses = [
+            adaptor_with_origin.adaptor.address
+            for adaptor_with_origin in self.adaptors_with_origins
+        ]
+        return LintResult(self.exit_code(addresses), self.stdout(addresses), "")
 
 
 class SuccessfulLinter(MockLinter):
     @staticmethod
-    def exit_code(_: Address) -> int:
+    def exit_code(_: Iterable[Address]) -> int:
         return 0
 
     @staticmethod
-    def stdout(address: Address) -> str:
-        return f"Successful linter: {address} was good."
+    def stdout(addresses: Iterable[Address]) -> str:
+        return "\n".join(f"Successful linter: {address} was good." for address in addresses)
 
 
 class FailingLinter(MockLinter):
     @staticmethod
-    def exit_code(_: Address) -> int:
+    def exit_code(_: Iterable[Address]) -> int:
         return 1
 
     @staticmethod
-    def stdout(address: Address) -> str:
-        return f"Failing linter: {address} was bad."
+    def stdout(addresses: Iterable[Address]) -> str:
+        return "\n".join(f"Failing linter: {address} was bad." for address in addresses)
 
 
 class ConditionallySucceedsLinter(MockLinter):
     @staticmethod
-    def exit_code(address: Address) -> int:
-        if address.target_name == "bad":
+    def exit_code(addresses: Iterable[Address]) -> int:
+        if any(address.target_name == "bad" for address in addresses):
             return 127
         return 0
 
     @staticmethod
-    def stdout(address: Address) -> str:
-        if address.target_name == "bad":
-            return f"Conditionally succeeds linter: {address} was bad."
-        return f"Conditionally succeeds linter: {address} was good."
+    def stdout(addresses: Iterable[Address]) -> str:
+        return "\n".join(
+            f"Conditionally succeeds linter: {address} was {address.target_name}."
+            for address in addresses
+        )
 
 
 class InvalidTargetLinter(MockLinter):
     @staticmethod
-    def exit_code(_: Address) -> int:
+    def exit_code(_: Iterable[Address]) -> int:
         return -1
 
     @staticmethod
@@ -82,20 +90,30 @@ class InvalidTargetLinter(MockLinter):
         return False
 
     @staticmethod
-    def stdout(address: Address) -> str:
-        return f"Invalid target linter: {address} should not have run..."
+    def stdout(addresses: Iterable[Address]) -> str:
+        return "\n".join(
+            f"Invalid target linter: {address} should not have run..." for address in addresses
+        )
 
 
 class LintTest(TestBase):
     @staticmethod
     def run_lint_rule(
-        *, linters: List[Type[Linter]], targets: List[HydratedTargetWithOrigin],
+        *,
+        linters: List[Type[Linter]],
+        targets: List[HydratedTargetWithOrigin],
+        per_target_caching: bool = False,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
         union_membership = UnionMembership({Linter: linters})
         result: Lint = run_rule(
             lint,
-            rule_args=[console, HydratedTargetsWithOrigins(targets), union_membership],
+            rule_args=[
+                console,
+                HydratedTargetsWithOrigins(targets),
+                MockOptions(per_target_caching=per_target_caching),
+                union_membership,
+            ],
             mock_gets=[
                 MockGet(
                     product_type=LintResult,
@@ -108,63 +126,95 @@ class LintTest(TestBase):
         return result.exit_code, console.stdout.getvalue()
 
     def test_empty_target_noops(self) -> None:
-        exit_code, stdout = self.run_lint_rule(
-            linters=[FailingLinter],
-            targets=[FmtTest.make_hydrated_target_with_origin(include_sources=False)],
-        )
-        assert exit_code == 0
-        assert stdout == ""
+        def assert_noops(per_target_caching: bool) -> None:
+            exit_code, stdout = self.run_lint_rule(
+                linters=[FailingLinter],
+                targets=[FmtTest.make_hydrated_target_with_origin(include_sources=False)],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == 0
+            assert stdout == ""
+
+        assert_noops(per_target_caching=False)
+        assert_noops(per_target_caching=True)
 
     def test_invalid_target_noops(self) -> None:
-        exit_code, stdout = self.run_lint_rule(
-            linters=[InvalidTargetLinter], targets=[FmtTest.make_hydrated_target_with_origin()],
-        )
-        assert exit_code == 0
-        assert stdout == ""
+        def assert_noops(per_target_caching: bool) -> None:
+            exit_code, stdout = self.run_lint_rule(
+                linters=[InvalidTargetLinter],
+                targets=[FmtTest.make_hydrated_target_with_origin()],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == 0
+            assert stdout == ""
+
+        assert_noops(per_target_caching=False)
+        assert_noops(per_target_caching=True)
 
     def test_single_target_with_one_linter(self) -> None:
-        target_with_origin = FmtTest.make_hydrated_target_with_origin()
-        address = target_with_origin.target.adaptor.address
-        exit_code, stdout = self.run_lint_rule(
-            linters=[FailingLinter], targets=[target_with_origin]
-        )
-        assert exit_code == FailingLinter.exit_code(address)
-        assert stdout.strip() == FailingLinter.stdout(address)
+        def assert_expected(per_target_caching: bool) -> None:
+            target_with_origin = FmtTest.make_hydrated_target_with_origin()
+            address = target_with_origin.target.adaptor.address
+            exit_code, stdout = self.run_lint_rule(
+                linters=[FailingLinter],
+                targets=[target_with_origin],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == FailingLinter.exit_code([address])
+            assert stdout.strip() == FailingLinter.stdout([address])
+
+        assert_expected(per_target_caching=False)
+        assert_expected(per_target_caching=True)
 
     def test_single_target_with_multiple_linters(self) -> None:
-        target_with_origin = FmtTest.make_hydrated_target_with_origin()
-        address = target_with_origin.target.adaptor.address
-        exit_code, stdout = self.run_lint_rule(
-            linters=[SuccessfulLinter, FailingLinter], targets=[target_with_origin],
-        )
-        assert exit_code == FailingLinter.exit_code(address)
-        assert stdout.splitlines() == [
-            SuccessfulLinter.stdout(address),
-            FailingLinter.stdout(address),
-        ]
+        def assert_expected(per_target_caching: bool) -> None:
+            target_with_origin = FmtTest.make_hydrated_target_with_origin()
+            address = target_with_origin.target.adaptor.address
+            exit_code, stdout = self.run_lint_rule(
+                linters=[SuccessfulLinter, FailingLinter],
+                targets=[target_with_origin],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == FailingLinter.exit_code([address])
+            assert stdout.splitlines() == [
+                SuccessfulLinter.stdout([address]),
+                FailingLinter.stdout([address]),
+            ]
+
+        assert_expected(per_target_caching=False)
+        assert_expected(per_target_caching=True)
 
     def test_multiple_targets_with_one_linter(self) -> None:
         good_target = FmtTest.make_hydrated_target_with_origin(name="good")
         bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
+
         exit_code, stdout = self.run_lint_rule(
-            linters=[ConditionallySucceedsLinter], targets=[good_target, bad_target],
+            linters=[ConditionallySucceedsLinter],
+            targets=[good_target, bad_target],
+            per_target_caching=True,
         )
-        assert exit_code == ConditionallySucceedsLinter.exit_code(bad_target.target.adaptor.address)
+        assert exit_code == ConditionallySucceedsLinter.exit_code(
+            [bad_target.target.adaptor.address]
+        )
         assert stdout.splitlines() == [
-            ConditionallySucceedsLinter.stdout(target_with_origin.target.adaptor.address)
+            ConditionallySucceedsLinter.stdout([target_with_origin.target.adaptor.address])
             for target_with_origin in [good_target, bad_target]
         ]
 
     def test_multiple_targets_with_multiple_linters(self) -> None:
         good_target = FmtTest.make_hydrated_target_with_origin(name="good")
         bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
+
         exit_code, stdout = self.run_lint_rule(
             linters=[ConditionallySucceedsLinter, SuccessfulLinter],
             targets=[good_target, bad_target],
+            per_target_caching=True,
         )
-        assert exit_code == ConditionallySucceedsLinter.exit_code(bad_target.target.adaptor.address)
+        assert exit_code == ConditionallySucceedsLinter.exit_code(
+            [bad_target.target.adaptor.address]
+        )
         assert stdout.splitlines() == [
-            linter.stdout(target_with_origin.target.adaptor.address)
+            linter.stdout([target_with_origin.target.adaptor.address])
             for target_with_origin in [good_target, bad_target]
             for linter in [ConditionallySucceedsLinter, SuccessfulLinter]
         ]


### PR DESCRIPTION
### Problem

Per https://docs.google.com/document/d/1Tdof6jx9aVaOGeIQeI9Gn-8x7nd6LfjnJ0QrbLFBbgc/edit, we found that linters have substantial startup overhead but have little cost to add an additional file. On a completely cold cache, it is 5-30x slower to run our 6 Python linters once-per-file rather than in a batch.

Further, the output is very wordy for tools like Black when using per-target caching, as it would output a message for every single target.

Still, there are some cases where per-target caching makes sense. In particular, this is useful when:

1. The user has remote caching, so the cache is almost always warm.
2. The user has some Python 2 only targets and some Python 3 only targets, and they want to be able to run `./pants lint2 ::` using the correct interpreter for each target. (With Python, the version used does matter for linters like Flake8 and Bandit, which load the AST).

### Solution

Add `--lint2-per-target-caching` as an advanced option. Default to `--no-lint2-per-target-caching`.

### Result

```bash
▶ ./v2 lint2 --per-target-caching src/python/pants/util:strutil src/python/pants/util:tarutil
Scrubbed PYTHONPATH=/Users/eric/DocsLocal/code/projects/pants/src/python: from the environment.
All done! ✨ 🍰 ✨
1 file would be left unchanged.

All done! ✨ 🍰 ✨
1 file would be left unchanged.

▶ ./v2 lint2 src/python/pants/util:strutil src/python/pants/util:tarutil
Scrubbed PYTHONPATH=/Users/eric/DocsLocal/code/projects/pants/src/python: from the environment.
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```
