### PR TITLE
Simplify `fmt2` grouping of formatters per language

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/register.py
+++ b/src/python/pants/backend/python/lint/bandit/register.py
@@ -1,13 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.bandit import rules as bandit_rules
 
 
 def rules():
-    return (
-        *bandit_rules.rules(),
-        *python_linter.rules(),
-    )
+    return bandit_rules.rules()

--- a/src/python/pants/backend/python/lint/black/register.py
+++ b/src/python/pants/backend/python/lint/black/register.py
@@ -1,14 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from pants.backend.python.lint import python_formatter, python_linter
+from pants.backend.python.lint import python_formatter
 from pants.backend.python.lint.black import rules as black_rules
 
 
 def rules():
-    return (
-        *black_rules.rules(),
-        *python_formatter.rules(),
-        *python_linter.rules(),
-    )
+    return (*black_rules.rules(), *python_formatter.rules())

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
-from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
+from pants.backend.python.lint.python_formatter import PythonFormatter
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -173,7 +173,7 @@ def rules():
         fmt,
         lint,
         subsystem_rule(Black),
-        UnionRule(PythonFormatTarget, BlackFormatter),
+        UnionRule(PythonFormatter, BlackFormatter),
         UnionRule(Linter, BlackFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/docformatter/register.py
+++ b/src/python/pants/backend/python/lint/docformatter/register.py
@@ -1,14 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from pants.backend.python.lint import python_formatter, python_linter
+from pants.backend.python.lint import python_formatter
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 
 
 def rules():
-    return (
-        *docformatter_rules(),
-        *python_formatter.rules(),
-        *python_linter.rules(),
-    )
+    return (*docformatter_rules(), *python_formatter.rules())

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
-from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
+from pants.backend.python.lint.python_formatter import PythonFormatter
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -150,7 +150,7 @@ def rules():
         fmt,
         lint,
         subsystem_rule(Docformatter),
-        UnionRule(PythonFormatTarget, DocformatterFormatter),
+        UnionRule(PythonFormatter, DocformatterFormatter),
         UnionRule(Linter, DocformatterFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/flake8/register.py
+++ b/src/python/pants/backend/python/lint/flake8/register.py
@@ -1,13 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.flake8 import rules as flake8_rules
 
 
 def rules():
-    return (
-        *flake8_rules.rules(),
-        *python_linter.rules(),
-    )
+    return flake8_rules.rules()

--- a/src/python/pants/backend/python/lint/isort/register.py
+++ b/src/python/pants/backend/python/lint/isort/register.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.lint import python_formatter, python_linter
+from pants.backend.python.lint import python_formatter
 from pants.backend.python.lint.isort import rules as isort_rules
 from pants.backend.python.lint.isort.isort_prep import IsortPrep
 from pants.backend.python.lint.isort.isort_run import IsortRun
@@ -9,11 +9,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def rules():
-    return (
-        *isort_rules.rules(),
-        *python_formatter.rules(),
-        *python_linter.rules(),
-    )
+    return (*isort_rules.rules(), *python_formatter.rules())
 
 
 def register_goals():

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
-from pants.backend.python.lint.python_formatter import PythonFormatTarget, PythonFormatter
+from pants.backend.python.lint.python_formatter import PythonFormatter
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -166,7 +166,7 @@ def rules():
         fmt,
         lint,
         subsystem_rule(Isort),
-        UnionRule(PythonFormatTarget, IsortFormatter),
+        UnionRule(PythonFormatter, IsortFormatter),
         UnionRule(Linter, IsortFormatter),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/pylint/register.py
+++ b/src/python/pants/backend/python/lint/pylint/register.py
@@ -1,13 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from pants.backend.python.lint import python_linter
 from pants.backend.python.lint.pylint import rules as pylint_rules
 
 
 def rules():
-    return (
-        *pylint_rules.rules(),
-        *python_linter.rules(),
-    )
+    return pylint_rules.rules()

--- a/src/python/pants/backend/python/lint/python_formatter.py
+++ b/src/python/pants/backend/python/lint/python_formatter.py
@@ -3,90 +3,50 @@
 
 from abc import ABCMeta
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Iterable, List, Optional, Type
 
 from pants.backend.python.lint.python_linter import PYTHON_TARGET_TYPES, PythonLinter
 from pants.engine.fs import Digest, Snapshot
-from pants.engine.legacy.structs import (
-    PantsPluginAdaptorWithOrigin,
-    PythonAppAdaptorWithOrigin,
-    PythonBinaryAdaptorWithOrigin,
-    PythonTargetAdaptorWithOrigin,
-    PythonTestsAdaptorWithOrigin,
-    TargetAdaptorWithOrigin,
-)
+from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
-from pants.engine.rules import RootRule, UnionMembership, UnionRule, rule
+from pants.engine.rules import UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get
-from pants.rules.core.fmt import AggregatedFmtResults, FmtResult, FormatTarget, Formatter
+from pants.rules.core.fmt import FmtResult, Formatter, LanguageFmtResults, LanguageFormatters
 
 
 @union
-@dataclass(frozen=True)
-class PythonFormatTarget:
-    adaptor_with_origin: TargetAdaptorWithOrigin
-
-
 @dataclass(frozen=True)
 class PythonFormatter(Formatter, PythonLinter, metaclass=ABCMeta):
     prior_formatter_result: Optional[Snapshot] = None
 
 
+@dataclass(frozen=True)
+class PythonFormatters(LanguageFormatters):
+    @staticmethod
+    def belongs_to_language(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+        return isinstance(adaptor_with_origin, PYTHON_TARGET_TYPES)
+
+
 @rule
 async def format_python_target(
-    target: PythonFormatTarget, union_membership: UnionMembership
-) -> AggregatedFmtResults:
-    """This aggregator allows us to have multiple formatters safely operate over the same Python
-    targets, even if they modify the same files."""
-    adaptor_with_origin = target.adaptor_with_origin
+    python_formatters: PythonFormatters, union_membership: UnionMembership
+) -> LanguageFmtResults:
+    adaptor_with_origin = python_formatters.adaptors_with_origins[0]
     prior_formatter_result = adaptor_with_origin.adaptor.sources.snapshot
     results: List[FmtResult] = []
-    for formatter in union_membership.union_rules[PythonFormatTarget]:
+    formatters: Iterable[Type[PythonFormatter]] = union_membership.union_rules[PythonFormatter]
+    for formatter in formatters:
         result = await Get[FmtResult](
-            PythonFormatTarget,
+            PythonFormatter,
             formatter((adaptor_with_origin,), prior_formatter_result=prior_formatter_result),
         )
         results.append(result)
         if result != FmtResult.noop():
             prior_formatter_result = await Get[Snapshot](Digest, result.digest)
-    return AggregatedFmtResults(
+    return LanguageFmtResults(
         tuple(results), combined_digest=prior_formatter_result.directory_digest
     )
 
 
-@rule
-def target_adaptor(adaptor_with_origin: PythonTargetAdaptorWithOrigin) -> PythonFormatTarget:
-    return PythonFormatTarget(adaptor_with_origin)
-
-
-@rule
-def app_adaptor(adaptor_with_origin: PythonAppAdaptorWithOrigin) -> PythonFormatTarget:
-    return PythonFormatTarget(adaptor_with_origin)
-
-
-@rule
-def binary_adaptor(adaptor_with_origin: PythonBinaryAdaptorWithOrigin) -> PythonFormatTarget:
-    return PythonFormatTarget(adaptor_with_origin)
-
-
-@rule
-def tests_adaptor(adaptor_with_origin: PythonTestsAdaptorWithOrigin) -> PythonFormatTarget:
-    return PythonFormatTarget(adaptor_with_origin)
-
-
-@rule
-def plugin_adaptor(adaptor_with_origin: PantsPluginAdaptorWithOrigin) -> PythonFormatTarget:
-    return PythonFormatTarget(adaptor_with_origin)
-
-
 def rules():
-    return [
-        format_python_target,
-        target_adaptor,
-        app_adaptor,
-        binary_adaptor,
-        tests_adaptor,
-        plugin_adaptor,
-        *(RootRule(target_type) for target_type in PYTHON_TARGET_TYPES),
-        *(UnionRule(FormatTarget, target_type) for target_type in PYTHON_TARGET_TYPES),
-    ]
+    return [format_python_target, UnionRule(LanguageFormatters, PythonFormatters)]

--- a/src/python/pants/backend/python/lint/python_linter.py
+++ b/src/python/pants/backend/python/lint/python_linter.py
@@ -12,7 +12,6 @@ from pants.engine.legacy.structs import (
     PythonTestsAdaptorWithOrigin,
     TargetAdaptorWithOrigin,
 )
-from pants.engine.rules import RootRule
 from pants.rules.core.lint import Linter
 
 
@@ -30,7 +29,3 @@ PYTHON_TARGET_TYPES = (
     PythonTestsAdaptorWithOrigin,
     PantsPluginAdaptorWithOrigin,
 )
-
-
-def rules():
-    return [RootRule(target_type) for target_type in PYTHON_TARGET_TYPES]

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -1,43 +1,97 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from pathlib import Path
-from typing import List, Tuple, Type
+from typing import List, Type, cast
+from unittest.mock import Mock
 
 from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
-from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
-    Digest,
-    DirectoriesToMerge,
-    FileContent,
-    InputFilesContent,
-    Snapshot,
-    Workspace,
-)
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, DirectoriesToMerge, Workspace
 from pants.engine.legacy.graph import (
     HydratedTarget,
     HydratedTargetsWithOrigins,
     HydratedTargetWithOrigin,
 )
 from pants.engine.legacy.structs import (
-    JvmAppAdaptor,
+    JvmBinaryAdaptor,
     PythonTargetAdaptor,
-    PythonTargetAdaptorWithOrigin,
     TargetAdaptor,
+    TargetAdaptorWithOrigin,
 )
 from pants.engine.rules import UnionMembership
-from pants.rules.core.fmt import AggregatedFmtResults, Fmt, FmtResult, FormatTarget, fmt
-from pants.source.wrapped_globs import EagerFilesetWithSpec
+from pants.rules.core.fmt import Fmt, FmtResult, LanguageFmtResults, LanguageFormatters, fmt
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
+from pants.util.ordered_set import OrderedSet
+
+PYTHON_FILE = Path("formatted.py")
+PYTHON_CONTENT = "print('So Pythonic now!')\n"
+PYTHON_DIGEST = Digest(
+    fingerprint="ad01e45511ca88c6449a8d86f04226d5763ffe5de82df71f91599a85b04b6982",
+    serialized_bytes_length=86,
+)
+
+JAVA_FILE = Path("formatted.java")
+JAVA_CONTENT = "System.out.println('Yay pretty verbosity!')\n"
+
+MERGED_DIGEST = Digest(
+    fingerprint="32a24a86de5c8adf8a5c40f8a3c8dace542089abbeefff3d091f4fedf1df5ba5",
+    serialized_bytes_length=174,
+)
+
+
+class MockLanguageFormatters(LanguageFormatters, metaclass=ABCMeta):
+    @staticmethod
+    @abstractmethod
+    def stdout(_: Address) -> str:
+        pass
+
+    @property
+    def language_fmt_results(self) -> LanguageFmtResults:
+        address = self.adaptors_with_origins[0].adaptor.address
+        # NB: Due to mocking `await Get[Digest](DirectoriesToMerge), the digest we use here does
+        # not matter.
+        digest = EMPTY_DIRECTORY_DIGEST
+        return LanguageFmtResults(
+            (FmtResult(digest=digest, stdout=self.stdout(address), stderr=""),),
+            combined_digest=digest,
+        )
+
+
+class PythonFormatters(MockLanguageFormatters):
+    @staticmethod
+    def belongs_to_language(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+        return isinstance(adaptor_with_origin.adaptor, PythonTargetAdaptor)
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Python formatters: formatted {address}"
+
+
+class JavaFormatters(MockLanguageFormatters):
+    @staticmethod
+    def belongs_to_language(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+        return isinstance(adaptor_with_origin.adaptor, JvmBinaryAdaptor)
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Java formatters: formatted {address}"
+
+
+class InvalidFormatters(MockLanguageFormatters):
+    @staticmethod
+    def belongs_to_language(_: TargetAdaptorWithOrigin) -> bool:
+        return False
+
+    @staticmethod
+    def stdout(address: Address) -> str:
+        return f"Invalid formatters: should not have formatted {address}..."
 
 
 class FmtTest(TestBase):
-
-    formatted_file = Path("formatted.txt")
-    formatted_content = "I'm so pretty now!\n"
-
     @staticmethod
     def make_hydrated_target_with_origin(
         *,
@@ -45,38 +99,28 @@ class FmtTest(TestBase):
         adaptor_type: Type[TargetAdaptor] = PythonTargetAdaptor,
         include_sources: bool = True,
     ) -> HydratedTargetWithOrigin:
-        mocked_snapshot = Snapshot(
-            # TODO: this is not robust to set as an empty digest. Add a test util that provides
-            #  some premade snapshots and possibly a generalized make_hydrated_target_with_origin function.
-            directory_digest=EMPTY_DIRECTORY_DIGEST,
-            files=tuple(["formatted.txt", "fake.txt"] if include_sources else []),
-            dirs=(),
-        )
-        address = Address.parse(f"src/python:{name}")
+        sources = Mock()
+        sources.snapshot = Mock()
+        sources.snapshot.files = ("f1",) if include_sources else ()
+        address = Address.parse(f"//:{name}")
         ht = HydratedTarget(
             address=address,
-            adaptor=adaptor_type(
-                sources=EagerFilesetWithSpec("src/python", {"globs": []}, snapshot=mocked_snapshot),
-                name=name,
-                address=address,
-            ),
+            adaptor=adaptor_type(sources=sources, address=address),
             dependencies=(),
         )
-        return HydratedTargetWithOrigin(ht, SingleAddress(directory="src/python", name=name))
+        return HydratedTargetWithOrigin(ht, SingleAddress(directory="", name=name))
 
-    def run_fmt_rule(self, *, targets: List[HydratedTargetWithOrigin]) -> Tuple[int, str]:
-        result_digest = self.request_single_product(
-            Digest,
-            InputFilesContent(
-                [
-                    FileContent(
-                        path=self.formatted_file.as_posix(), content=self.formatted_content.encode()
-                    )
-                ]
-            ),
-        )
+    def run_fmt_rule(
+        self,
+        *,
+        language_formatters: List[Type[LanguageFormatters]],
+        targets: List[HydratedTargetWithOrigin],
+        result_digest: Digest,
+    ) -> str:
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership({FormatTarget: [PythonTargetAdaptorWithOrigin]})
+        union_membership = UnionMembership(
+            OrderedDict({LanguageFormatters: OrderedSet(language_formatters)})
+        )
         result: Fmt = run_rule(
             fmt,
             rule_args=[
@@ -87,18 +131,9 @@ class FmtTest(TestBase):
             ],
             mock_gets=[
                 MockGet(
-                    product_type=AggregatedFmtResults,
-                    subject_type=FormatTarget,
-                    mock=lambda adaptor_with_origin: AggregatedFmtResults(
-                        (
-                            FmtResult(
-                                digest=result_digest,
-                                stdout=f"Formatted `{adaptor_with_origin.adaptor.name}`",
-                                stderr="",
-                            ),
-                        ),
-                        combined_digest=result_digest,
-                    ),
+                    product_type=LanguageFmtResults,
+                    subject_type=LanguageFormatters,
+                    mock=lambda language_formatters: language_formatters.language_fmt_results,
                 ),
                 MockGet(
                     product_type=Digest,
@@ -108,48 +143,103 @@ class FmtTest(TestBase):
             ],
             union_membership=union_membership,
         )
-        return result.exit_code, console.stdout.getvalue()
+        assert result.exit_code == 0
+        return cast(str, console.stdout.getvalue())
 
-    def assert_workspace_modified(self, *, modified: bool = True) -> None:
-        formatted_file = Path(self.build_root, self.formatted_file)
-        if not modified:
-            assert not formatted_file.is_file()
-            return
-        assert formatted_file.is_file()
-        assert formatted_file.read_text() == self.formatted_content
-
-    def test_non_union_member_noops(self) -> None:
-        exit_code, stdout = self.run_fmt_rule(
-            targets=[self.make_hydrated_target_with_origin(adaptor_type=JvmAppAdaptor)]
-        )
-        assert exit_code == 0
-        assert stdout.strip() == ""
-        self.assert_workspace_modified(modified=False)
+    def assert_workspace_modified(self, *, python_formatted: bool, java_formatted: bool) -> None:
+        python_file = Path(self.build_root, PYTHON_FILE)
+        java_file = Path(self.build_root, JAVA_FILE)
+        if python_formatted:
+            assert python_file.is_file()
+            assert python_file.read_text() == PYTHON_CONTENT
+        if java_formatted:
+            assert java_file.is_file()
+            assert java_file.read_text() == JAVA_CONTENT
 
     def test_empty_target_noops(self) -> None:
-        exit_code, stdout = self.run_fmt_rule(
-            targets=[self.make_hydrated_target_with_origin(include_sources=False)]
+        stdout = self.run_fmt_rule(
+            language_formatters=[PythonFormatters],
+            targets=[self.make_hydrated_target_with_origin(include_sources=False)],
+            result_digest=PYTHON_DIGEST,
         )
-        assert exit_code == 0
         assert stdout.strip() == ""
-        self.assert_workspace_modified(modified=False)
+        self.assert_workspace_modified(python_formatted=False, java_formatted=False)
 
-    def test_single_target(self) -> None:
-        exit_code, stdout = self.run_fmt_rule(targets=[self.make_hydrated_target_with_origin()])
-        assert exit_code == 0
-        assert stdout.strip() == "Formatted `target`"
-        self.assert_workspace_modified()
-
-    def test_multiple_targets(self) -> None:
-        # NB: we do not test the case where AggregatedFmtResults have conflicting changes, as that
-        # logic is handled by DirectoriesToMerge and is avoided by each language having its own
-        # aggregator rule.
-        exit_code, stdout = self.run_fmt_rule(
-            targets=[
-                self.make_hydrated_target_with_origin(name="t1"),
-                self.make_hydrated_target_with_origin(name="t2"),
-            ]
+    def test_invalid_target_noops(self) -> None:
+        stdout = self.run_fmt_rule(
+            language_formatters=[InvalidFormatters],
+            targets=[self.make_hydrated_target_with_origin()],
+            result_digest=PYTHON_DIGEST,
         )
-        assert exit_code == 0
-        assert stdout.splitlines() == ["Formatted `t1`", "Formatted `t2`"]
-        self.assert_workspace_modified()
+        assert stdout.strip() == ""
+        self.assert_workspace_modified(python_formatted=False, java_formatted=False)
+
+    def test_single_language_with_single_target(self) -> None:
+        target_with_origin = self.make_hydrated_target_with_origin()
+        stdout = self.run_fmt_rule(
+            language_formatters=[PythonFormatters],
+            targets=[target_with_origin],
+            result_digest=PYTHON_DIGEST,
+        )
+        assert stdout.strip() == PythonFormatters.stdout(target_with_origin.target.adaptor.address)
+        self.assert_workspace_modified(python_formatted=True, java_formatted=False)
+
+    def test_single_language_with_multiple_targets(self) -> None:
+        targets_with_origins = [
+            self.make_hydrated_target_with_origin(name="t1"),
+            self.make_hydrated_target_with_origin(name="t2"),
+        ]
+        stdout = self.run_fmt_rule(
+            language_formatters=[PythonFormatters],
+            targets=targets_with_origins,
+            result_digest=PYTHON_DIGEST,
+        )
+        assert stdout.splitlines() == [
+            PythonFormatters.stdout(target_with_origin.target.adaptor.address)
+            for target_with_origin in targets_with_origins
+        ]
+        self.assert_workspace_modified(python_formatted=True, java_formatted=False)
+
+    def test_multiple_languages_with_single_targets(self) -> None:
+        python_target = self.make_hydrated_target_with_origin(
+            name="py", adaptor_type=PythonTargetAdaptor
+        )
+        java_target = self.make_hydrated_target_with_origin(
+            name="java", adaptor_type=JvmBinaryAdaptor
+        )
+        stdout = self.run_fmt_rule(
+            language_formatters=[PythonFormatters, JavaFormatters],
+            targets=[python_target, java_target],
+            result_digest=MERGED_DIGEST,
+        )
+        assert stdout.splitlines() == [
+            PythonFormatters.stdout(python_target.target.adaptor.address),
+            JavaFormatters.stdout(java_target.target.adaptor.address),
+        ]
+        self.assert_workspace_modified(python_formatted=True, java_formatted=True)
+
+    def test_multiple_languages_with_multiple_targets(self) -> None:
+        python_targets = [
+            self.make_hydrated_target_with_origin(name="py1", adaptor_type=PythonTargetAdaptor),
+            self.make_hydrated_target_with_origin(name="py2", adaptor_type=PythonTargetAdaptor),
+        ]
+        java_targets = [
+            self.make_hydrated_target_with_origin(name="java1", adaptor_type=JvmBinaryAdaptor),
+            self.make_hydrated_target_with_origin(name="java2", adaptor_type=JvmBinaryAdaptor),
+        ]
+        stdout = self.run_fmt_rule(
+            language_formatters=[PythonFormatters, JavaFormatters],
+            targets=[*python_targets, *java_targets],
+            result_digest=MERGED_DIGEST,
+        )
+        assert stdout.splitlines() == [
+            *(
+                PythonFormatters.stdout(target_with_origin.target.adaptor.address)
+                for target_with_origin in python_targets
+            ),
+            *(
+                JavaFormatters.stdout(target_with_origin.target.adaptor.address)
+                for target_with_origin in java_targets
+            ),
+        ]
+        self.assert_workspace_modified(python_formatted=True, java_formatted=True)

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -118,6 +118,8 @@ class FmtTest(TestBase):
         result_digest: Digest,
     ) -> str:
         console = MockConsole(use_colors=False)
+        # NB: This ensures that the hardcoded digests can actually be found.
+        self.make_snapshot({PYTHON_FILE: PYTHON_CONTENT, JAVA_FILE: JAVA_CONTENT})
         union_membership = UnionMembership(
             OrderedDict({LanguageFormatters: OrderedSet(language_formatters)})
         )

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -43,7 +43,7 @@ class Linter(ABC):
 
     @staticmethod
     @abstractmethod
-    def is_valid_target(adaptor_with_origin: TargetAdaptorWithOrigin) -> bool:
+    def is_valid_target(_: TargetAdaptorWithOrigin) -> bool:
         """Return True if the linter can meaningfully operate on this target type."""
 
 


### PR DESCRIPTION
### Problem

Unlike with `lint`, which can safely run every linter in parallel, formatters must be run sequentially so that they do not overwrite each other. As a performance improvement, we can group formatters by language family: while all Python linters must run sequentially, Scala formatters are not going to touch the same files so those can run sequentially at the same time as Python, and so on.

We previously achieved this grouping by having the concrete class `AggregatedFmtResults` and the union type `FormatTarget`. Each language was expected to give back a single `AggregatedFmtResults` for each target, which stored all the `FmtResult`s for each formatter for that target. `FormatTarget` was a union with members like `PythonTestsAdaptorWithOrigin` and `PythonLibraryAdaptorWithOrigin`. Rules would then convert those target adaptors to an intermediate `PythonFormatTarget`, which was itself a union with members like `IsortTarget`.

This implementation worked but was not as clear as possible.

More importantly, this design makes it challenging to batch multiple targets, as it operates on a per-target basis.

### Solution

Replace `FormatTarget`, `PythonFormatTarget`, and `AggregatedFmtResults` with `LanguageFormatters`, `LanguageFmtResults`, `PythonFormatters`. Rather than `await Get[AggregatedFmtResults](FormatTarget, python_target_adaptor)`, we have `await Get[LanguageFmtResults](LanguageFormatters, PythonFormatters(python_target_adaptor))`. `PythonFormatters` has a rule that runs all union members of `PythonFormatter` and combines them into a result.

Each `LanguageFormatters` subclass defines a `belongs_to_language()` static method to determine whether a target should be run for that language's formatters or not.

### Result

`fmt.py` and `python_formatter.py` are hopefully easier to understand. They are also more closely aligned to `lint.py`.

We can now add the option `--fmt-per-target-caching` to batch multiple targets.