### PR TITLE
Make GlobalOptions rule provide full options.

### DIFF
--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pants.engine.rules import RootRule, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptions, GlobalOptionsRegistrar
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -36,7 +36,9 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 
 @rule
 def global_options(options_bootstrapper: OptionsBootstrapper) -> GlobalOptions:
-    global_options = options_bootstrapper.bootstrap_options.for_global_scope()
+    global_options = options_bootstrapper.get_full_options(
+        GlobalOptionsRegistrar.known_scope_infos()
+    ).for_global_scope()
     return GlobalOptions(_inner=global_options)
 
 

--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import GlobalOptions, GlobalOptionsRegistrar
 from pants.option.options import Options
@@ -35,11 +35,8 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 
 
 @rule
-def global_options(options_bootstrapper: OptionsBootstrapper) -> GlobalOptions:
-    global_options = options_bootstrapper.get_full_options(
-        GlobalOptionsRegistrar.known_scope_infos()
-    ).for_global_scope()
-    return GlobalOptions(_inner=global_options)
+def global_options(gor: GlobalOptionsRegistrar) -> GlobalOptions:
+    return GlobalOptions(_inner=gor.options)
 
 
 def create_options_parsing_rules():
@@ -47,6 +44,7 @@ def create_options_parsing_rules():
         scope_options,
         parse_options,
         global_options,
+        subsystem_rule(GlobalOptionsRegistrar),
         RootRule(Scope),
         RootRule(OptionsBootstrapper),
     ]

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -194,17 +194,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
             help="Set the logging level.",
         )
 
-        # TODO: Move these to regular bootstrap options after addressing
-        # https://github.com/pantsbuild/pants/issues/9212
-        register(
-            "--colors",
-            type=bool,
-            default=sys.stdout.isatty(),
-            recursive=True,
-            daemon=False,
-            help="Set whether log messages are displayed in color.",
-        )
-
         register(
             "--log-show-rust-3rdparty",
             type=bool,
@@ -219,6 +208,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
         register(
             "--v1", advanced=True, type=bool, default=True, help="Enables execution of v1 Tasks."
         )
+
         register(
             "--v2",
             advanced=True,
@@ -934,6 +924,15 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
         # won't choke on them on the command line, and also so we can access their values as regular
         # global-scope options, for convenience.
         cls.register_bootstrap_options(register)
+
+        register(
+            "--colors",
+            type=bool,
+            default=sys.stdout.isatty(),
+            recursive=True,
+            daemon=False,
+            help="Set whether log messages are displayed in color.",
+        )
 
         register(
             "--tag",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -4,10 +4,9 @@
 import multiprocessing
 import os
 import sys
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-
-from dataclasses import dataclass
 
 from pants.base.build_environment import (
     get_buildroot,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -25,7 +25,7 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 
 @dataclass(frozen=True)
-class GlobalOptions:
+class GlobalOptions(Optionable):
     _inner: OptionValueContainer
 
     def __getattr__(self, key):
@@ -1088,3 +1088,14 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                 "The `--remote-execution-server` option requires also setting "
                 "`--remote-store-server`. Often these have the same value."
             )
+
+    # TODO: It's possible that global options could just be a Subsystem!
+
+    def __init__(self, scope: str, scoped_options: OptionValueContainer) -> None:
+        super().__init__()
+        self._scope = scope
+        self._scoped_options = scoped_options
+
+    @property
+    def options(self) -> OptionValueContainer:
+        return self._scoped_options

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -4,9 +4,10 @@
 import multiprocessing
 import os
 import sys
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+
+from dataclasses import dataclass
 
 from pants.base.build_environment import (
     get_buildroot,
@@ -21,7 +22,7 @@ from pants.option.errors import OptionsError
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
-from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
+from pants.subsystem.subsystem import Subsystem
 
 
 @dataclass(frozen=True)
@@ -163,7 +164,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
 )
 
 
-class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
+class GlobalOptionsRegistrar(Subsystem):
     options_scope = GLOBAL_SCOPE
     options_scope_category = ScopeInfo.GLOBAL
 
@@ -1088,14 +1089,3 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                 "The `--remote-execution-server` option requires also setting "
                 "`--remote-store-server`. Often these have the same value."
             )
-
-    # TODO: It's possible that global options could just be a Subsystem!
-
-    def __init__(self, scope: str, scoped_options: OptionValueContainer) -> None:
-        super().__init__()
-        self._scope = scope
-        self._scoped_options = scoped_options
-
-    @property
-    def options(self) -> OptionValueContainer:
-        return self._scoped_options

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -85,7 +85,7 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
 
     @classmethod
     def is_valid_scope_name_component(cls, s: str) -> bool:
-        return s == '' or cls._scope_name_component_re.match(s) is not None
+        return s == "" or cls._scope_name_component_re.match(s) is not None
 
     @classmethod
     def validate_scope_name_component(cls, s: str) -> None:

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -85,7 +85,7 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
 
     @classmethod
     def is_valid_scope_name_component(cls, s: str) -> bool:
-        return cls._scope_name_component_re.match(s) is not None
+        return s == '' or cls._scope_name_component_re.match(s) is not None
 
     @classmethod
     def validate_scope_name_component(cls, s: str) -> None:

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -46,6 +46,7 @@ class OptionableTest(unittest.TestCase):
         def check_false(s: str) -> None:
             self.assertFalse(Optionable.is_valid_scope_name_component(s))
 
+        check_true("")
         check_true("foo")
         check_true("foo-bar0")
         check_true("foo-bar0-1ba22z")

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -10,7 +10,6 @@ from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import ArgSplitter, HelpRequest
 from pants.option.config import Config
-from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer
@@ -80,7 +79,7 @@ class Options:
 
         Also adds any deprecated scopes.
         """
-        ret = {GlobalOptionsRegistrar.get_scope_info()}
+        ret = set()
         original_scopes: Dict[str, ScopeInfo] = {}
         for si in scope_infos:
             ret.add(si)

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -10,6 +10,7 @@ from pants.engine.goal import Goal
 from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.init.specs_calculator import SpecsCalculator
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 from pants.util.meta import classproperty
@@ -55,7 +56,10 @@ class GoalRuleTestBase(TestBase):
         )
         BuildConfigInitializer.get(options_bootstrapper)
         full_options = options_bootstrapper.get_full_options(
-            list(self.goal_cls.subsystem_cls.known_scope_infos())
+            [
+                *GlobalOptionsRegistrar.known_scope_infos(),
+                *self.goal_cls.subsystem_cls.known_scope_infos(),
+            ]
         )
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr)


### PR DESCRIPTION
Previously GlobalOptionsRegistrar was just a bag of classmethods for registration.  Actually getting hold of a set of global option values was a little convoluted, especially in the v2 world.

This change makes GlobalOptionsRegistrar a subsystem, so it can actually be instantiated via a subsystem_rule, like any other subsystem.  This makes it straightforward to get hold of global option values without special-case handling via OptionsBootstrapper.

As a result, the GlobalOptions rule now provides full options, where previously it only provided bootstrap options, as proven by moving the `--colors` option from bootstrap to regular options.

Fixes #9212.

Note that this means that in v2 every Optionable is a Subsystem. So when we're fully on v2 we'll be able to greatly simplify the conceptual landscape.
