### PR TITLE
Add `--no-fmt-per-target-caching` to run V2 formatters with batched targets

### DIFF
--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -53,5 +53,8 @@ interpreter_search_paths = [
 ld_flags = []
 cpp_flags = []
 
+[fmt2]
+per_target_caching = true
+
 [lint2]
 per_target_caching = true

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -52,7 +52,7 @@ class SuccessfulLinter(MockLinter):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return "\n".join(f"Successful linter: {address} was good." for address in addresses)
+        return f"Successful linter: {', '.join(str(address) for address in addresses)}"
 
 
 class FailingLinter(MockLinter):
@@ -62,7 +62,7 @@ class FailingLinter(MockLinter):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return "\n".join(f"Failing linter: {address} was bad." for address in addresses)
+        return f"Failing linter: {', '.join(str(address) for address in addresses)}"
 
 
 class ConditionallySucceedsLinter(MockLinter):
@@ -74,10 +74,7 @@ class ConditionallySucceedsLinter(MockLinter):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return "\n".join(
-            f"Conditionally succeeds linter: {address} was {address.target_name}."
-            for address in addresses
-        )
+        return f"Conditionally succeeds linter: {', '.join(str(address) for address in addresses)}"
 
 
 class InvalidTargetLinter(MockLinter):
@@ -91,9 +88,7 @@ class InvalidTargetLinter(MockLinter):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return "\n".join(
-            f"Invalid target linter: {address} should not have run..." for address in addresses
-        )
+        return f"Invalid target linter: {', '.join(str(address) for address in addresses)}"
 
 
 class LintTest(TestBase):
@@ -102,7 +97,7 @@ class LintTest(TestBase):
         *,
         linters: List[Type[Linter]],
         targets: List[HydratedTargetWithOrigin],
-        per_target_caching: bool = False,
+        per_target_caching: bool,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
         union_membership = UnionMembership({Linter: linters})
@@ -187,34 +182,57 @@ class LintTest(TestBase):
     def test_multiple_targets_with_one_linter(self) -> None:
         good_target = FmtTest.make_hydrated_target_with_origin(name="good")
         bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
+        addresses = [
+            target_with_origin.target.adaptor.address
+            for target_with_origin in (good_target, bad_target)
+        ]
 
-        exit_code, stdout = self.run_lint_rule(
-            linters=[ConditionallySucceedsLinter],
-            targets=[good_target, bad_target],
-            per_target_caching=True,
-        )
-        assert exit_code == ConditionallySucceedsLinter.exit_code(
-            [bad_target.target.adaptor.address]
-        )
+        def get_stdout(*, per_target_caching: bool) -> str:
+            exit_code, stdout = self.run_lint_rule(
+                linters=[ConditionallySucceedsLinter],
+                targets=[good_target, bad_target],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == ConditionallySucceedsLinter.exit_code(
+                [bad_target.target.adaptor.address]
+            )
+            return stdout
+
+        stdout = get_stdout(per_target_caching=False)
+        assert stdout.strip() == ConditionallySucceedsLinter.stdout(addresses)
+
+        stdout = get_stdout(per_target_caching=True)
         assert stdout.splitlines() == [
-            ConditionallySucceedsLinter.stdout([target_with_origin.target.adaptor.address])
-            for target_with_origin in [good_target, bad_target]
+            ConditionallySucceedsLinter.stdout([address]) for address in addresses
         ]
 
     def test_multiple_targets_with_multiple_linters(self) -> None:
         good_target = FmtTest.make_hydrated_target_with_origin(name="good")
         bad_target = FmtTest.make_hydrated_target_with_origin(name="bad")
+        addresses = [
+            target_with_origin.target.adaptor.address
+            for target_with_origin in (good_target, bad_target)
+        ]
 
-        exit_code, stdout = self.run_lint_rule(
-            linters=[ConditionallySucceedsLinter, SuccessfulLinter],
-            targets=[good_target, bad_target],
-            per_target_caching=True,
-        )
-        assert exit_code == ConditionallySucceedsLinter.exit_code(
-            [bad_target.target.adaptor.address]
-        )
+        def get_stdout(*, per_target_caching: bool) -> str:
+            exit_code, stdout = self.run_lint_rule(
+                linters=[ConditionallySucceedsLinter, SuccessfulLinter],
+                targets=[good_target, bad_target],
+                per_target_caching=per_target_caching,
+            )
+            assert exit_code == ConditionallySucceedsLinter.exit_code(
+                [bad_target.target.adaptor.address]
+            )
+            return stdout
+
+        stdout = get_stdout(per_target_caching=False)
         assert stdout.splitlines() == [
-            linter.stdout([target_with_origin.target.adaptor.address])
-            for target_with_origin in [good_target, bad_target]
+            linter.stdout(addresses) for linter in [ConditionallySucceedsLinter, SuccessfulLinter]
+        ]
+
+        stdout = get_stdout(per_target_caching=True)
+        assert stdout.splitlines() == [
+            linter.stdout([address])
+            for address in addresses
             for linter in [ConditionallySucceedsLinter, SuccessfulLinter]
         ]


### PR DESCRIPTION
Per https://docs.google.com/document/d/1Tdof6jx9aVaOGeIQeI9Gn-8x7nd6LfjnJ0QrbLFBbgc/edit, we found that formatters have substantial startup overhead but have little cost to add an additional file. On a completely cold cache, it is 5-30x slower to run our 3 Python formatters once-per-file rather than in a batch.

https://github.com/pantsbuild/pants/pull/9209 solved this problem for linters by adding `--no-lint-per-target-caching` as an option. Here, we add `--no-fmt-per-target-caching`.

We keep this as an option because it's easy to do that and when remote caching is used it is likely faster to use `--per-target-caching` because there are so many cache hits.