### PR TITLE
Fix flaky `options_bootstrapper_test.py`

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -5,7 +5,7 @@ import copy
 import re
 import sys
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import ArgSplitter, HelpRequest
@@ -19,6 +19,7 @@ from pants.option.parser_hierarchy import ParserHierarchy, all_enclosing_scopes,
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
 class Options:
@@ -73,16 +74,16 @@ class Options:
         """More than one registration occurred for the same scope."""
 
     @classmethod
-    def complete_scopes(cls, scope_infos: Iterable[ScopeInfo]) -> Set[ScopeInfo]:
+    def complete_scopes(cls, scope_infos: Iterable[ScopeInfo]) -> FrozenOrderedSet[ScopeInfo]:
         """Expand a set of scopes to include all enclosing scopes.
 
         E.g., if the set contains `foo.bar.baz`, ensure that it also contains `foo.bar` and `foo`.
 
         Also adds any deprecated scopes.
         """
-        ret = {GlobalOptionsRegistrar.get_scope_info()}
+        ret = OrderedSet([GlobalOptionsRegistrar.get_scope_info()])
         original_scopes: Dict[str, ScopeInfo] = {}
-        for si in scope_infos:
+        for si in sorted(scope_infos, key=lambda si: si.scope):
             ret.add(si)
             if si.scope in original_scopes:
                 raise cls.DuplicateScopeError(
@@ -102,7 +103,7 @@ class Options:
             for scope in all_enclosing_scopes(si.scope, allow_global=False):
                 if scope not in original_scopes:
                     ret.add(ScopeInfo(scope, ScopeInfo.INTERMEDIATE))
-        return ret
+        return FrozenOrderedSet(ret)
 
     @classmethod
     def create(

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -7,8 +7,6 @@ from functools import partial
 from textwrap import dedent
 from typing import Dict, List, Optional
 
-import pytest
-
 from pants.base.build_environment import get_buildroot
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -247,7 +245,6 @@ class OptionsBootstrapperTest(unittest.TestCase):
             opts_single_config.register("resolver", "--resolver")
             self.assertEqual("coursier", opts_single_config.for_scope("resolver").resolver)
 
-    @pytest.mark.flaky(retries=2)
     def test_full_options_caching(self) -> None:
         with temporary_file_path() as config:
             args = self._config_path(config)

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1195,15 +1195,19 @@ class OptionsTest(TestBase):
         _global = GlobalOptionsRegistrar.get_scope_info()
         self.assertEqual(
             {_global, intermediate("foo"), intermediate("foo.bar"), task("foo.bar.baz")},
-            Options.complete_scopes({task("foo.bar.baz")}),
+            set(Options.complete_scopes({task("foo.bar.baz")})),
         )
         self.assertEqual(
             {_global, intermediate("foo"), intermediate("foo.bar"), task("foo.bar.baz")},
-            Options.complete_scopes({GlobalOptionsRegistrar.get_scope_info(), task("foo.bar.baz")}),
+            set(
+                Options.complete_scopes(
+                    {GlobalOptionsRegistrar.get_scope_info(), task("foo.bar.baz")}
+                )
+            ),
         )
         self.assertEqual(
             {_global, intermediate("foo"), intermediate("foo.bar"), task("foo.bar.baz")},
-            Options.complete_scopes({intermediate("foo"), task("foo.bar.baz")}),
+            set(Options.complete_scopes({intermediate("foo"), task("foo.bar.baz")})),
         )
         self.assertEqual(
             {
@@ -1214,7 +1218,7 @@ class OptionsTest(TestBase):
                 intermediate("qux"),
                 task("qux.quux"),
             },
-            Options.complete_scopes({task("foo.bar.baz"), task("qux.quux")}),
+            set(Options.complete_scopes({task("foo.bar.baz"), task("qux.quux")})),
         )
 
     def test_get_fingerprintable_for_scope_ignore_passthru(self) -> None:


### PR DESCRIPTION
`test_full_options_caching` would frequently flake because we were using sets internally in the `Options` and `OptionsBootstrapper` types. Sets have unstable ordering, so sometimes the test would pass and sometimes it would fail.

We fix this by using our `OrderedSet` and `FrozenOrderedSet` types, with sorting before passing to those constructors.