### PR TITLE
Get rid of the GlobalOptions wrapper class.

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -30,7 +30,7 @@ from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptorWithOrigin
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.rules.core.test import TestDebugRequest, TestOptions, TestResult, TestTarget
@@ -202,12 +202,11 @@ async def run_python_test(
     test_setup: TestTargetSetup,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-    global_options: GlobalOptions,
+    global_options: GlobalOptionsRegistrar,
     test_options: TestOptions,
 ) -> TestResult:
     """Runs pytest for one target."""
-    colors = global_options.colors
-    env = {"PYTEST_ADDOPTS": f"--color={'yes' if colors else 'no'}"}
+    env = {"PYTEST_ADDOPTS": f"--color={'yes' if global_options.options.colors else 'no'}"}
     run_coverage = test_options.values.run_coverage
     request = test_setup.test_runner_pex.create_execute_request(
         python_setup=python_setup,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -45,7 +45,7 @@ from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import (
-    GlobalOptions,
+    GlobalOptionsRegistrar,
     GlobMatchErrorBehavior,
     OwnersNotFoundBehavior,
 )
@@ -809,7 +809,7 @@ async def sources_snapshots_from_filesystem_specs(
 
 @rule
 async def addresses_with_origins_from_filesystem_specs(
-    filesystem_specs: FilesystemSpecs, global_options: GlobalOptions,
+    filesystem_specs: FilesystemSpecs, global_options: GlobalOptionsRegistrar,
 ) -> AddressesWithOrigins:
     """Find the owner(s) for each FilesystemSpec while preserving the original FilesystemSpec those
     owners come from.
@@ -833,7 +833,7 @@ async def addresses_with_origins_from_filesystem_specs(
         filesystem_specs.includes, snapshot_per_include, owners_per_include
     ):
         if (
-            global_options.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
+            global_options.options.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
             and isinstance(spec, FilesystemLiteralSpec)
             and not owners.addresses
         ):
@@ -843,7 +843,7 @@ async def addresses_with_origins_from_filesystem_specs(
                 f"that there is a BUILD file in `{file_path.parent}` with a target whose `sources` field "
                 f"includes `{file_path}`. See https://www.pantsbuild.org/build_files.html."
             )
-            if global_options.owners_not_found_behavior == OwnersNotFoundBehavior.warn:
+            if global_options.options.owners_not_found_behavior == OwnersNotFoundBehavior.warn:
                 logger.warning(msg)
             else:
                 raise ResolveError(msg)

--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.global_options import GlobalOptions, GlobalOptionsRegistrar
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
@@ -34,16 +34,10 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
     return ScopedOptions(scope, options.options.for_scope(scope.scope))
 
 
-@rule
-def global_options(gor: GlobalOptionsRegistrar) -> GlobalOptions:
-    return GlobalOptions(_inner=gor.options)
-
-
 def create_options_parsing_rules():
     return [
         scope_options,
         parse_options,
-        global_options,
         subsystem_rule(GlobalOptionsRegistrar),
         RootRule(Scope),
         RootRule(OptionsBootstrapper),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -18,18 +18,8 @@ from pants.base.build_environment import (
 from pants.base.deprecated import deprecated_conditional
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
-from pants.option.option_value_container import OptionValueContainer
-from pants.option.optionable import Optionable
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem import Subsystem
-
-
-@dataclass(frozen=True)
-class GlobalOptions(Optionable):
-    _inner: OptionValueContainer
-
-    def __getattr__(self, key):
-        return self._inner.__getattr__(key)
 
 
 class GlobMatchErrorBehavior(Enum):

--- a/src/python/pants/rules/core/repl.py
+++ b/src/python/pants/rules/core/repl.py
@@ -14,7 +14,7 @@ from pants.engine.interactive_runner import InteractiveProcessRequest, Interacti
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.util.contextutil import temporary_dir
 
 
@@ -64,7 +64,7 @@ async def run_repl(
     addresses: Addresses,
     build_root: BuildRoot,
     union_membership: UnionMembership,
-    global_options: GlobalOptions,
+    global_options: GlobalOptionsRegistrar,
 ) -> Repl:
 
     # We can guarantee that we will only even enter this `goal_rule` if there exists an implementer
@@ -86,7 +86,7 @@ async def run_repl(
 
     repl_binary = await Get[ReplBinary](ReplImplementation, repl_implementation(addresses))
 
-    with temporary_dir(root_dir=global_options.pants_workdir, cleanup=False) as tmpdir:
+    with temporary_dir(root_dir=global_options.options.pants_workdir, cleanup=False) as tmpdir:
         path_relative_to_build_root = PurePath(tmpdir).relative_to(build_root.path).as_posix()
         workspace.materialize_directory(
             DirectoryToMaterialize(repl_binary.digest, path_prefix=path_relative_to_build_root)


### PR DESCRIPTION
GlobalOptionsRegistrar is now a subsystem and can be
consumed directly.

A followup change will rename GlobalOptionsRegistrar
to GlobalOptions, for clarity.
