### PR TITLE
Make _tasks a local variable on Scheduler constructor

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -99,13 +99,10 @@ class Scheduler:
         self._root_subject_types = [r.output_type for r in rule_index.roots]
 
         # Create the native Scheduler and Session.
-        # TODO: This `_tasks` reference could be a local variable, since it is not used
-        # after construction.
-        self._tasks = native.new_tasks()
-        self._register_rules(rule_index)
+        tasks = self._register_rules(rule_index)
 
         self._scheduler = native.new_scheduler(
-            tasks=self._tasks,
+            tasks=tasks,
             root_subject_types=self._root_subject_types,
             build_root=build_root,
             local_store_dir=local_store_dir,
@@ -166,37 +163,36 @@ class Scheduler:
     def _to_utf8_buf(self, string):
         return self._native.context.utf8_buf(string)
 
-    def _register_rules(self, rule_index):
-        """Record the given RuleIndex on `self._tasks`."""
+    def _register_rules(self, rule_index: RuleIndex) -> Any:
+        """Create a native Tasks object, and record the given RuleIndex on it."""
+
+        tasks = self._native.new_tasks()
         registered = set()
+
         for output_type, rules in rule_index.rules.items():
             for rule in rules:
                 key = (output_type, rule)
-                if key in registered:
-                    continue
                 registered.add(key)
 
                 if type(rule) is TaskRule:
-                    self._register_task(output_type, rule, rule_index.union_rules)
+                    self._register_task(tasks, output_type, rule, rule_index.union_rules)
                 else:
                     raise ValueError("Unexpected Rule type: {}".format(rule))
 
-    def _register_task(self, output_type, rule: TaskRule, union_rules):
+        return tasks
+
+    def _register_task(self, tasks: Any, output_type, rule: TaskRule, union_rules) -> None:
         """Register the given TaskRule with the native scheduler."""
         func = Function(self._to_key(rule.func))
-        self._native.lib.tasks_task_begin(
-            self._tasks, func, self._to_type(output_type), rule.cacheable
-        )
+        self._native.lib.tasks_task_begin(tasks, func, self._to_type(output_type), rule.cacheable)
         for selector in rule.input_selectors:
-            self._native.lib.tasks_add_select(self._tasks, self._to_type(selector))
+            self._native.lib.tasks_add_select(tasks, self._to_type(selector))
 
         if rule.name:
-            self._native.lib.tasks_add_display_info(self._tasks, rule.name.encode())
+            self._native.lib.tasks_add_display_info(tasks, rule.name.encode())
 
         def add_get_edge(product, subject):
-            self._native.lib.tasks_add_get(
-                self._tasks, self._to_type(product), self._to_type(subject)
-            )
+            self._native.lib.tasks_add_get(tasks, self._to_type(product), self._to_type(subject))
 
         for the_get in rule.input_gets:
             if union.is_instance(the_get.subject_declared_type):
@@ -207,7 +203,7 @@ class Scheduler:
                 # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.
                 add_get_edge(the_get.product, the_get.subject_declared_type)
 
-        self._native.lib.tasks_task_end(self._tasks)
+        self._native.lib.tasks_task_end(tasks)
 
     def visualize_graph_to_file(self, session, filename):
         res = self._native.lib.graph_visualize(self._scheduler, session, filename.encode())

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -163,7 +163,7 @@ class Scheduler:
     def _to_utf8_buf(self, string):
         return self._native.context.utf8_buf(string)
 
-    def _register_rules(self, rule_index: RuleIndex) -> Any:
+    def _register_rules(self, rule_index: RuleIndex):
         """Create a native Tasks object, and record the given RuleIndex on it."""
 
         tasks = self._native.new_tasks()
@@ -181,7 +181,9 @@ class Scheduler:
 
         return tasks
 
-    def _register_task(self, tasks: Any, output_type, rule: TaskRule, union_rules) -> None:
+    def _register_task(
+        self, tasks, output_type, rule: TaskRule, union_rules: "OrderedDict[Type, OrderedSet[Type]]"
+    ) -> None:
         """Register the given TaskRule with the native scheduler."""
         func = Function(self._to_key(rule.func))
         self._native.lib.tasks_task_begin(tasks, func, self._to_type(output_type), rule.cacheable)


### PR DESCRIPTION
Minor code reorganization - handle a TODO by removing a class variable that doesn't need to be there.