### PR TITLE
External deps

### DIFF
--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -7,9 +7,10 @@ from typing import Set
 from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
+from pants.engine.legacy.graph import HydratedTarget, HydratedTargets, TransitiveHydratedTargets
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
+from pants.engine.legacy.structs import PythonRequirementLibraryAdaptor
 
 
 class DependencyType(Enum):
@@ -78,12 +79,20 @@ async def dependencies(
   options: DependenciesOptions,
 ) -> Dependencies:
   addresses: Set[str] = set()
+  third_party_targets: Set[HydratedTarget] = set()
   if options.values.transitive:
     transitive_targets = await Get[TransitiveHydratedTargets](
       BuildFileAddresses, build_file_addresses,
     )
     transitive_dependencies = transitive_targets.closure - set(transitive_targets.roots)
-    addresses.update(hydrated_target.address.spec for hydrated_target in transitive_dependencies)
+    for hydrated_target in transitive_dependencies:
+      address = hydrated_target.address.spec
+      if address.startswith('3rdparty'):
+        third_party_targets.add(hydrated_target)
+      else:
+        addresses.add(address)
+    # targets.update(transitive_dependencies)
+    # addresses.update(hydrated_target.address.spec for hydrated_target in transitive_dependencies)
   else:
     hydrated_targets = await Get[HydratedTargets](BuildFileAddresses, build_file_addresses)
     addresses.update(
@@ -99,6 +108,12 @@ async def dependencies(
   if options.values.type in [DependencyType.THIRD_PARTY, DependencyType.SOURCE_AND_THIRD_PARTY]:
     # TODO(John Sirois): We need an external payload abstraction at which point knowledge
     # of jar and requirement payloads can go and this hairball will be untangled.
+
+    for hydrated_target in third_party_targets:
+      if isinstance(hydrated_target.adaptor, PythonRequirementLibraryAdaptor):
+        for requirement in hydrated_target.adaptor.requirements:
+          with options.line_oriented(console) as print_stdout:
+            print_stdout(requirement.requirement)
     import pdb; pdb.set_trace()
     # if isinstance(tgt.payload.get_field('requirements'), PythonRequirementsField):
     #   for requirement in tgt.payload.requirements:

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -7,10 +7,10 @@ from typing import Set
 from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.legacy.graph import HydratedTarget, HydratedTargets, TransitiveHydratedTargets
+from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
+from pants.engine.legacy.structs import PythonRequirementLibraryAdaptor
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
-from pants.engine.legacy.structs import PythonRequirementLibraryAdaptor
 
 
 class DependencyType(Enum):
@@ -50,82 +50,42 @@ class Dependencies(Goal):
 
 @goal_rule
 async def dependencies(
-<<<<<<< HEAD
     console: Console, addresses: Addresses, options: DependenciesOptions,
 ) -> Dependencies:
     address_strings: Set[str] = set()
+    third_party_requirements: Set[str] = set()
+
     if options.values.transitive:
         transitive_targets = await Get[TransitiveHydratedTargets](Addresses, addresses)
-        transitive_dependencies = transitive_targets.closure - set(transitive_targets.roots)
-        address_strings.update(
-            hydrated_target.adaptor.address.spec for hydrated_target in transitive_dependencies
+        hydrated_targets = HydratedTargets(
+            transitive_targets.closure - set(transitive_targets.roots)
         )
     else:
         hydrated_targets = await Get[HydratedTargets](Addresses, addresses)
-        address_strings.update(
-            dep.spec
-            for hydrated_target in hydrated_targets
-            for dep in hydrated_target.adaptor.dependencies
-        )
 
-    with options.line_oriented(console) as print_stdout:
-        for address in sorted(address_strings):
-            print_stdout(address)
+    for target in hydrated_targets:
+        address_string = target.address.spec
+        if address_string.startswith("3rdparty"):
+            if isinstance(target.adaptor, PythonRequirementLibraryAdaptor):
+                third_party_requirements.update(
+                    str(requirement.requirement) for requirement in target.adaptor.requirements
+                )
+            # TODO: Support jvm third party deps when there is some sort of JarLibraryAdaptor.
+        else:
+            address_strings.update(
+                hydrated_target.address.spec for hydrated_target in hydrated_targets
+            )
 
+    if options.values.type in [DependencyType.SOURCE, DependencyType.SOURCE_AND_THIRD_PARTY]:
+        with options.line_oriented(console) as print_stdout:
+            for address in sorted(address_strings):
+                print_stdout(address)
+
+    if options.values.type in [DependencyType.THIRD_PARTY, DependencyType.SOURCE_AND_THIRD_PARTY]:
+        with options.line_oriented(console) as print_stdout:
+            for requirement_string in sorted(third_party_requirements):
+                print_stdout(requirement_string)
     return Dependencies(exit_code=0)
-=======
-  console: Console,
-  build_file_addresses: BuildFileAddresses,
-  options: DependenciesOptions,
-) -> Dependencies:
-  addresses: Set[str] = set()
-  third_party_targets: Set[HydratedTarget] = set()
-  if options.values.transitive:
-    transitive_targets = await Get[TransitiveHydratedTargets](
-      BuildFileAddresses, build_file_addresses,
-    )
-    transitive_dependencies = transitive_targets.closure - set(transitive_targets.roots)
-    for hydrated_target in transitive_dependencies:
-      address = hydrated_target.address.spec
-      if address.startswith('3rdparty'):
-        third_party_targets.add(hydrated_target)
-      else:
-        addresses.add(address)
-    # targets.update(transitive_dependencies)
-    # addresses.update(hydrated_target.address.spec for hydrated_target in transitive_dependencies)
-  else:
-    hydrated_targets = await Get[HydratedTargets](BuildFileAddresses, build_file_addresses)
-    addresses.update(
-      dep.spec
-      for hydrated_target in hydrated_targets
-      for dep in hydrated_target.dependencies
-    )
-
-  if options.values.type in [DependencyType.SOURCE, DependencyType.SOURCE_AND_THIRD_PARTY]:
-    with options.line_oriented(console) as print_stdout:
-      for address in sorted(addresses):
-        print_stdout(address)
-  if options.values.type in [DependencyType.THIRD_PARTY, DependencyType.SOURCE_AND_THIRD_PARTY]:
-    # TODO(John Sirois): We need an external payload abstraction at which point knowledge
-    # of jar and requirement payloads can go and this hairball will be untangled.
-
-    for hydrated_target in third_party_targets:
-      if isinstance(hydrated_target.adaptor, PythonRequirementLibraryAdaptor):
-        for requirement in hydrated_target.adaptor.requirements:
-          with options.line_oriented(console) as print_stdout:
-            print_stdout(requirement.requirement)
-    import pdb; pdb.set_trace()
-    # if isinstance(tgt.payload.get_field('requirements'), PythonRequirementsField):
-    #   for requirement in tgt.payload.requirements:
-    #     yield str(requirement.requirement)
-    # elif isinstance(tgt.payload.get_field('jars'), JarsField):
-    #   for jar in tgt.payload.jars:
-    #     data = dict(org=jar.org, name=jar.name, rev=jar.rev)
-    #     yield (f'{jar.org}:{jar.name}:{jar.rev}' if jar.rev else f'{jar.org}:{jar.name}')
-
-
-  return Dependencies(exit_code=0)
->>>>>>> begin external deps
 
 
 def rules():

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -49,6 +49,7 @@ class Dependencies(Goal):
 
 @goal_rule
 async def dependencies(
+<<<<<<< HEAD
     console: Console, addresses: Addresses, options: DependenciesOptions,
 ) -> Dependencies:
     address_strings: Set[str] = set()
@@ -71,6 +72,45 @@ async def dependencies(
             print_stdout(address)
 
     return Dependencies(exit_code=0)
+=======
+  console: Console,
+  build_file_addresses: BuildFileAddresses,
+  options: DependenciesOptions,
+) -> Dependencies:
+  addresses: Set[str] = set()
+  if options.values.transitive:
+    transitive_targets = await Get[TransitiveHydratedTargets](
+      BuildFileAddresses, build_file_addresses,
+    )
+    transitive_dependencies = transitive_targets.closure - set(transitive_targets.roots)
+    addresses.update(hydrated_target.address.spec for hydrated_target in transitive_dependencies)
+  else:
+    hydrated_targets = await Get[HydratedTargets](BuildFileAddresses, build_file_addresses)
+    addresses.update(
+      dep.spec
+      for hydrated_target in hydrated_targets
+      for dep in hydrated_target.dependencies
+    )
+
+  if options.values.type in [DependencyType.SOURCE, DependencyType.SOURCE_AND_THIRD_PARTY]:
+    with options.line_oriented(console) as print_stdout:
+      for address in sorted(addresses):
+        print_stdout(address)
+  if options.values.type in [DependencyType.THIRD_PARTY, DependencyType.SOURCE_AND_THIRD_PARTY]:
+    # TODO(John Sirois): We need an external payload abstraction at which point knowledge
+    # of jar and requirement payloads can go and this hairball will be untangled.
+    import pdb; pdb.set_trace()
+    # if isinstance(tgt.payload.get_field('requirements'), PythonRequirementsField):
+    #   for requirement in tgt.payload.requirements:
+    #     yield str(requirement.requirement)
+    # elif isinstance(tgt.payload.get_field('jars'), JarsField):
+    #   for jar in tgt.payload.jars:
+    #     data = dict(org=jar.org, name=jar.name, rev=jar.rev)
+    #     yield (f'{jar.org}:{jar.name}:{jar.rev}' if jar.rev else f'{jar.org}:{jar.name}')
+
+
+  return Dependencies(exit_code=0)
+>>>>>>> begin external deps
 
 
 def rules():

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -70,6 +70,9 @@ async def dependencies(
         DependencyType.SOURCE,
         DependencyType.SOURCE_AND_THIRD_PARTY,
     ]
+    print('TARGETS')
+    for target in hydrated_targets:
+        print(target)
 
     for target in hydrated_targets:
         if should_include_third_party:

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -80,7 +80,9 @@ async def dependencies(
                 # TODO(#8762): Support jvm third party deps when there is some sort of JarLibraryAdaptor.
         if should_include_source:
             address_strings.update(
-                hydrated_target.adaptor.address.spec for hydrated_target in hydrated_targets
+                dep.spec
+                for hydrated_target in hydrated_targets
+                for dep in hydrated_target.adaptor.dependencies
             )
 
     with options.line_oriented(console) as print_stdout:

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -79,11 +79,16 @@ async def dependencies(
                 )
                 # TODO(#8762): Support jvm third party deps when there is some sort of JarLibraryAdaptor.
         if should_include_source:
-            address_strings.update(
-                dep.spec
-                for hydrated_target in hydrated_targets
-                for dep in hydrated_target.adaptor.dependencies
-            )
+            if options.values.transitive:
+                address_strings.update(
+                    target.adaptor.address.spec for hydrated_target in hydrated_targets
+                )
+            else:
+                address_strings.update(
+                    dep.spec
+                    for hydrated_target in hydrated_targets
+                    for dep in hydrated_target.adaptor.dependencies
+                )
 
     with options.line_oriented(console) as print_stdout:
         for address in sorted(address_strings):

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.project_info.rules import dependencies
+from pants.backend.project_info.rules.dependencies import Dependencies, rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -12,7 +12,7 @@ from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
 class DependenciesIntegrationTest(GoalRuleTestBase):
-    goal_cls = dependencies.Dependencies
+    goal_cls = Dependencies
 
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
@@ -26,7 +26,7 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
 
     @classmethod
     def rules(cls):
-        return super().rules() + dependencies.rules()
+        return super().rules() + rules()
 
     def create_python_library(self, path: str, *, dependencies: Optional[List[str]] = None) -> None:
         self.create_library(

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.project_info.rules.dependencies import Dependencies, rules
+from pants.backend.project_info.rules.dependencies import Dependencies, DependencyType, rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -47,20 +47,20 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
         target: str,
         expected: List[str],
         transitive: bool = True,
-        dependency_type: str = "source",
+        dependency_type: DependencyType = DependencyType.SOURCE,
     ) -> None:
         env = {"PANTS_BACKEND_PACKAGES2": "pants.backend.project_info"}
-        args = [f"--type={dependency_type}"]
+        args = [f"--type={dependency_type.value}"]
         if transitive:
             args.append("--transitive")
         self.assert_console_output(*expected, args=[*args, target], env=env)
 
-    def test_no_target(self):
+    def test_no_target(self) -> None:
         self.assert_dependencies(
             target="", expected=[], transitive=False,
         )
 
-    def test_no_dependencies(self):
+    def test_no_dependencies(self) -> None:
         self.create_python_library(path="some/target")
         self.assert_dependencies(
             target="some/target", expected=[], transitive=False,
@@ -69,7 +69,7 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/target", expected=[], transitive=True,
         )
 
-    def test_dependencies_source(self):
+    def test_dependencies_source(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -83,10 +83,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/other/target",
             expected=["3rdparty/bar:bar", "some/target:target"],
             transitive=False,
-            dependency_type="source",
+            dependency_type=DependencyType.SOURCE,
         )
 
-    def test_dependencies_source_transitive(self):
+    def test_dependencies_source_transitive(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -105,10 +105,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
                 "dep/target:target",
             ],
             transitive=True,
-            dependency_type="source",
+            dependency_type=DependencyType.SOURCE,
         )
 
-    def test_dependencies_3rdparty(self):
+    def test_dependencies_3rdparty(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -122,10 +122,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/other/target",
             expected=["bar==1.0.0"],
             transitive=False,
-            dependency_type="3rdparty",
+            dependency_type=DependencyType.THIRD_PARTY,
         )
 
-    def test_dependencies_3rdparty_transitive(self):
+    def test_dependencies_3rdparty_transitive(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -139,10 +139,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/other/target",
             expected=["bar==1.0.0", "foo==1.0.0"],
             transitive=True,
-            dependency_type="3rdparty",
+            dependency_type=DependencyType.THIRD_PARTY,
         )
 
-    def test_dependencies_source_and_3rdparty(self):
+    def test_dependencies_source_and_3rdparty(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -156,10 +156,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/other/target",
             expected=["3rdparty/bar:bar", "some/target:target", "bar==1.0.0"],
             transitive=False,
-            dependency_type="source-and-3rdparty",
+            dependency_type=DependencyType.SOURCE_AND_THIRD_PARTY,
         )
 
-    def test_dependencies_source_and_3rdparty_transitive(self):
+    def test_dependencies_source_and_3rdparty_transitive(self) -> None:
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
@@ -180,5 +180,5 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
                 "bar==1.0.0",
             ],
             transitive=True,
-            dependency_type="source-and-3rdparty",
+            dependency_type=DependencyType.SOURCE_AND_THIRD_PARTY,
         )

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -5,7 +5,9 @@ from typing import List, Optional
 
 from pants.backend.project_info.rules import dependencies
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.python.python_requirement import PythonRequirement
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
@@ -14,7 +16,13 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
 
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(targets={"python_library": PythonLibrary,},)
+        return BuildFileAliases(
+            targets={
+                "python_library": PythonLibrary,
+                "python_requirement_library": PythonRequirementLibrary,
+            },
+            objects={"python_requirement": PythonRequirement,},
+        )
 
     @classmethod
     def rules(cls):
@@ -25,11 +33,26 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             path=path, target_type="python_library", name="target", dependencies=dependencies or []
         )
 
+    def create_python_requirement_library(self, name: str) -> None:
+        self.create_library(
+            path=f"3rdparty/{name}",
+            target_type="python_requirement_library",
+            name=name,
+            requirements=f"[python_requirement('{name}==1.0.0')]",
+        )
+
     def assert_dependencies(
-        self, *, target: str, expected: List[str], transitive: bool = True
+        self,
+        *,
+        target: str,
+        expected: List[str],
+        transitive: bool = True,
+        dependency_type: str = "source",
     ) -> None:
         env = {"PANTS_BACKEND_PACKAGES2": "pants.backend.project_info"}
-        args = ["--transitive"] if transitive else []
+        args = [f"--type={dependency_type}"]
+        if transitive:
+            args.append("--transitive")
         self.assert_console_output(*expected, args=[*args, target], env=env)
 
     def test_no_target(self):
@@ -46,15 +69,123 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             target="some/target", expected=[], transitive=True,
         )
 
-    def test_dependencies(self):
+    def test_dependencies_source(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
-        self.create_python_library(path="some/target", dependencies=["dep/target"])
-        self.create_python_library(path="some/other/target", dependencies=["some/target"])
+        self.create_python_library(path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"])
+        self.create_python_library(path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"])
         self.assert_dependencies(
-            target="some/other/target", expected=["some/target:target"], transitive=False,
+            target="some/other/target",
+            expected=["3rdparty/bar:bar", "some/target:target"],
+            transitive=False,
+            dependency_type="source",
+        )
+
+    def test_dependencies_source_transitive(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
+        self.create_python_library(path="dep/target")
+        self.create_python_library(path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"])
+        self.create_python_library(path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"])
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["3rdparty/bar:bar", "some/target:target", "3rdparty/foo:foo", "dep/target:target"],
+            transitive=True,
+            dependency_type="source",
+        )
+
+
+    def test_dependencies_3rdparty(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
+        self.create_python_library(path="dep/target")
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
         )
         self.assert_dependencies(
             target="some/other/target",
-            expected=["dep/target:target", "some/target:target",],
-            transitive=True,
+            expected=["bar==1.0.0"],
+            transitive=False,
+            dependency_type="3rdparty",
         )
+
+    def test_dependencies_3rdparty_transitive(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
+        self.create_python_library(path="dep/target")
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
+        )
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["bar==1.0.0", "foo==1.0.0"],
+            transitive=True,
+            dependency_type="3rdparty",
+        )
+
+    def test_dependencies_source_and_3rdparty(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
+        self.create_python_library(path="dep/target")
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
+        )
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["3rdparty/bar:bar", "some/target:target", "bar==1.0.0"],
+            transitive=False,
+            dependency_type="source-and-3rdparty",
+        )
+
+    def test_dependencies_source_and_3rdparty_transitive(self):
+        self.create_python_requirement_library(name="foo")
+        self.create_python_requirement_library(name="bar")
+        self.create_python_library(path="dep/target")
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
+        )
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=[
+                "some/target:target",
+                "dep/target:target",
+                "3rdparty/foo:foo",
+                "3rdparty/bar:bar",
+            ],
+            transitive=True,
+            dependency_type="source-and-3rdparty",
+        )
+
+
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["bar==1.0.0"],
+            transitive=False,
+            dependency_type="3rdparty",
+        )
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["3rdparty/bar:bar", "bar==1.0.0"],
+            transitive=False,
+            dependency_type="source-and-3rdparty",
+        )
+        self.assert_dependencies(
+            target="some/other/target",
+            expected=["some/target:target", "3rdparty/bar"],
+            transitive=False,
+            dependency_type="source-and-3rdparty",
+        )
+

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -73,8 +73,12 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
-        self.create_python_library(path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"])
-        self.create_python_library(path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"])
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
+        )
         self.assert_dependencies(
             target="some/other/target",
             expected=["3rdparty/bar:bar", "some/target:target"],
@@ -86,15 +90,23 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
         self.create_python_requirement_library(name="foo")
         self.create_python_requirement_library(name="bar")
         self.create_python_library(path="dep/target")
-        self.create_python_library(path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"])
-        self.create_python_library(path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"])
+        self.create_python_library(
+            path="some/target", dependencies=["dep/target", "3rdparty/foo:foo"]
+        )
+        self.create_python_library(
+            path="some/other/target", dependencies=["some/target", "3rdparty/bar:bar"]
+        )
         self.assert_dependencies(
             target="some/other/target",
-            expected=["3rdparty/bar:bar", "some/target:target", "3rdparty/foo:foo", "dep/target:target"],
+            expected=[
+                "3rdparty/bar:bar",
+                "some/target:target",
+                "3rdparty/foo:foo",
+                "dep/target:target",
+            ],
             transitive=True,
             dependency_type="source",
         )
-
 
     def test_dependencies_3rdparty(self):
         self.create_python_requirement_library(name="foo")
@@ -164,28 +176,9 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
                 "dep/target:target",
                 "3rdparty/foo:foo",
                 "3rdparty/bar:bar",
+                "foo==1.0.0",
+                "bar==1.0.0",
             ],
             transitive=True,
             dependency_type="source-and-3rdparty",
         )
-
-
-        self.assert_dependencies(
-            target="some/other/target",
-            expected=["bar==1.0.0"],
-            transitive=False,
-            dependency_type="3rdparty",
-        )
-        self.assert_dependencies(
-            target="some/other/target",
-            expected=["3rdparty/bar:bar", "bar==1.0.0"],
-            transitive=False,
-            dependency_type="source-and-3rdparty",
-        )
-        self.assert_dependencies(
-            target="some/other/target",
-            expected=["some/target:target", "3rdparty/bar"],
-            transitive=False,
-            dependency_type="source-and-3rdparty",
-        )
-


### PR DESCRIPTION
### Problem

V2 dependencies rule didn't support listing external dependencies. Turns out the `--external` flag was used by at least one pants consumer.

### Solution

Add support for listing external dependencies.

### Result

Running
 ```
./pants dependencies2 --dependencies2-transitive --dependencies2-type=3rdparty src/python/pants/rules/core::
``` 
now prints all external deps of the target. 

```
~/c/pants ❯❯❯ ./pants dependencies2 --dependencies2-transitive --dependencies2-type=3rdparty src/python/pants/rules/core::
Scrubbed PYTHONPATH=/Users/tansypants/code/pants/src/python: from the environment.
Markdown==2.1.1
PyYAML==5.1.2
Pygments==2.3.1
ansicolors==1.1.8
cffi==1.13.2
contextlib2==0.5.5
dataclasses==0.6
docutils==0.14
fasteners==0.15.0
packaging==16.8
pathspec==0.5.9
pex==2.1.5
psutil==5.6.3
py_zipkin==0.18.4
pyopenssl==17.3.0
pystache==0.5.3
python-Levenshtein==0.12.0
pywatchman==1.4.1
requests[security]>=2.20.1
setproctitle==1.1.10
setuptools==44.0.0
toml==0.10.0
twitter.common.collections<0.4,>=0.3.11
twitter.common.confluence<0.4,>=0.3.11
twitter.common.dirutil<0.4,>=0.3.11
typing-extensions==3.7.4
wheel==0.33.6
www-authenticate==0.9.2
```

This is currently only working for python 3rd party deps. As far as I can tell we don't have V2 jvm support, so that remains a TODO. 