### PR TITLE
Revert "Load the bootstrapped zinc compiler from the zinc server's cl…

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -40,13 +40,10 @@ object InputUtils {
   ): Inputs = {
     import settings._
 
-    val scalaJars = Defaults.scalaJars
-    log.debug(s"Selected scala jars: $scalaJars")
+    val scalaJars = InputUtils.selectScalaJars(settings.scala)
 
     val instance = ScalaUtils.scalaInstance(scalaJars.compiler, scalaJars.extra, scalaJars.library)
-    val compiledBridgeJar = Defaults.compiledBridgeJar.get
-    log.debug(s"Selected CompiledBridgeJar $compiledBridgeJar")
-    val compilers = ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, settings.javaHome, newScalaCompiler(instance, compiledBridgeJar))
+    val compilers = ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, settings.javaHome, newScalaCompiler(instance, settings.compiledBridgeJar.get))
 
     // TODO: Remove duplication once on Scala 2.12.x.
     val positionMapper =
@@ -149,12 +146,25 @@ object InputUtils {
   }
 
   /**
+   * Select the scala jars.
+   *
+   * Prefer the explicit scala-compiler, scala-library, and scala-extra settings,
+   * then the scala-path setting, then the scala-home setting. Default to bundled scala.
+   */
+  def selectScalaJars(scala: ScalaLocation): ScalaJars = {
+    val jars = splitScala(scala.path) getOrElse Defaults.scalaJars
+    ScalaJars(
+      scala.compiler getOrElse jars.compiler,
+      scala.library getOrElse jars.library,
+      scala.extra ++ jars.extra
+    )
+  }
+
+  /**
    * Distinguish the compiler and library jars.
    */
   def splitScala(jars: Seq[File], excluded: Set[String] = Set.empty): Option[ScalaJars] = {
-    var  filtered = jars filterNot (excluded contains _.getName)
-    // Added because the jars can be the entire classpath if using the default value.
-    filtered = filtered filter (_.getName matches ".*scala.*")
+    val filtered = jars filterNot (excluded contains _.getName)
     val (compiler, other) = filtered partition (_.getName matches ScalaCompiler.pattern)
     val (library, extra) = other partition (_.getName matches ScalaLibrary.pattern)
     if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(compiler(0), library(0), extra)) else None
@@ -167,20 +177,15 @@ object InputUtils {
   val ScalaCompiler            = JarFile("scala-compiler")
   val ScalaLibrary             = JarFile("scala-library")
   val ScalaReflect             = JarFile("scala-reflect")
-  val ScalaCompilerBridge      = JarFile("scala-compiler-bridge")
 
-  // Scala jars default to jars matching the JarFile patterns on the jvm classpath.
+  // TODO: The default jar locations here are definitely not helpful, but the existence
+  // of "some" value for each of these is assumed in a few places. Should remove and make
+  // them optional to more cleanly support Java-only compiles.
   object Defaults {
-
-    val classpath = IO.parseClasspath(System.getProperty("java.class.path"))
-    val (maybeCompiledBridgeJar, other) = classpath partition (_.getName matches ScalaCompilerBridge.pattern)
-    val compiledBridgeJar = if (maybeCompiledBridgeJar.nonEmpty) Some(maybeCompiledBridgeJar(0)) else None
-    // try to locate scala jars from the current classpath.
-    val classpathScalaJars   = splitScala(other)
     val scalaCompiler        = ScalaCompiler.default
     val scalaLibrary         = ScalaLibrary.default
     val scalaExtra           = Seq(ScalaReflect.default)
-    val scalaJars            = classpathScalaJars getOrElse ScalaJars(scalaCompiler, scalaLibrary, scalaExtra)
+    val scalaJars            = ScalaJars(scalaCompiler, scalaLibrary, scalaExtra)
     val scalaExcluded = Set("jansi.jar", "jline.jar", "scala-partest.jar", "scala-swing.jar", "scalacheck.jar", "scalap.jar")
   }
 

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -123,10 +123,10 @@ object Main {
     }
   }
 
-  def preprocessArgs(rawArgs: Array[String], nailMainCWD: Option[File]): Array[String] = {
+  def preprocessArgs(rawArgs: Array[String]): Array[String] = {
     val (argFiles, partialArgs) = rawArgs.partition(_.startsWith("@"))
     val args = partialArgs ++ argFiles.flatMap { f =>
-      Files.readLines(Util.normalizeIfExists(nailMainCWD)(new File(f.drop(1))), Charsets.UTF_8).asScala
+      Files.readLines(new File(f.drop(1)), Charsets.UTF_8).asScala
     }
     val fixedArgs = args.flatMap { arg =>
       arg match {
@@ -164,7 +164,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     val startTime = System.currentTimeMillis
 
-    val settings = Settings.SettingsParser.parse(preprocessArgs(args, None), Settings()) match {
+    val settings = Settings.SettingsParser.parse(preprocessArgs(args), Settings()) match {
       case Some(settings) => settings
       case None => {
         println("See zinc-compiler --help for information about options")
@@ -178,10 +178,9 @@ object Main {
   def nailMain(context: NGContext): Unit = {
     val startTime = System.currentTimeMillis
 
-    Settings.SettingsParser.parse(preprocessArgs(context.getArgs, Some(new File(context.getWorkingDirectory))), Settings()) match {
+    Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
       case Some(settings) =>
-        var settingsWithAbsPath = settings.withAbsolutePaths(new File(context.getWorkingDirectory))
-        mainImpl(settingsWithAbsPath, startTime, n => context.exit(n))
+        mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)), startTime, n => context.exit(n))
       case None => {
         println("See zinc-compiler --help for information about options")
         context.exit(1)

--- a/src/scala/org/pantsbuild/zinc/util/Util.scala
+++ b/src/scala/org/pantsbuild/zinc/util/Util.scala
@@ -85,17 +85,6 @@ object Util {
   }
 
   /**
-   * Normalize the files to CWD if the normalized path exists
-   */
-  def normalizeIfExists(cwd: Option[File])(file: File): File = {
-    if (cwd.isDefined) {
-      val normed = normalise(cwd)(file)
-      if (normed.exists()) normed else file
-    }
-    else file
-  }
-
-  /**
    * Fully relativize a path, relative to any other base.
    */
   def relativize(base: File, path: File): String = {


### PR DESCRIPTION
This reverts commit 9c72c1367db31ed37353e5d700d453de3d519441.

### Problem
The code in our zinc wrapper is in an inconsistent state with the latest published version (`0.0.17`).

This means that **one does not simply** publish a local jar for zinc with the following steps:
* Publish the jar to one's local m2 repository
```
./pants publish.jar --named-snapshot=master  --local-snapshot --publish-jar-local=~/.m2/repository --no-dryrun --no-prompt src/scala/org/pantsbuild/zinc/compiler
```
* Update the `_ZINC_COMPILER_VERSION` in `src/python/pants/backend/jvm/subsystems/zinc.py` to "master"
* Compile some jvm code

without incurring ~the wrath of Sauron~ this zinc error:
```
See zinc-compiler --help for information about options
Error: Unknown option -compiled-bridge-jar
Error: Unknown option -scala-path
Try --help for more information.
```

### Solution

Revert the change to zinc that added these two options but wasn't fully followed through until it is time to follow through.

### Result

I am able to iterate on the zinc code and test my changes.