### PR TITLE
Format zinc compiler code

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
@@ -1,7 +1,6 @@
 /**
- * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
- */
-
+  * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
+  */
 package org.pantsbuild.zinc.compiler
 
 import java.io.File
@@ -39,12 +38,14 @@ import org.pantsbuild.zinc.util.Util
 object CompilerUtils {
   val JavaClassVersion = System.getProperty("java.class.version")
 
-  private val compilerCacheLimit = Util.intProperty("zinc.compiler.cache.limit", 5)
-  private val residentCacheLimit = Util.intProperty("zinc.resident.cache.limit", 0)
+  private val compilerCacheLimit =
+    Util.intProperty("zinc.compiler.cache.limit", 5)
+  private val residentCacheLimit =
+    Util.intProperty("zinc.resident.cache.limit", 0)
 
   /**
-   * Static cache for resident scala compilers.
-   */
+    * Static cache for resident scala compilers.
+    */
   private val residentCache: GlobalsCache = {
     val maxCompilers = residentCacheLimit
     if (maxCompilers <= 0)
@@ -54,20 +55,21 @@ object CompilerUtils {
   }
 
   /**
-   * Cache of classloaders: see https://github.com/pantsbuild/pants/issues/4744
-   */
+    * Cache of classloaders: see https://github.com/pantsbuild/pants/issues/4744
+    */
   private val classLoaderCache: Option[ClassLoaderCache] =
     Some(new ClassLoaderCache(new URLClassLoader(Array())))
 
   /**
-   * Get the instance of the GlobalsCache.
-   */
+    * Get the instance of the GlobalsCache.
+    */
   def getGlobalsCache = residentCache
 
   /**
-   * Create a new scala compiler.
-   */
-  def newScalaCompiler(instance: XScalaInstance, bridgeJar: File): AnalyzingCompiler =
+    * Create a new scala compiler.
+    */
+  def newScalaCompiler(instance: XScalaInstance,
+                       bridgeJar: File): AnalyzingCompiler =
     new AnalyzingCompiler(
       instance,
       ZincCompilerUtil.constantBridgeProvider(instance, bridgeJar),
@@ -77,8 +79,8 @@ object CompilerUtils {
     )
 
   /**
-   * Create a new classloader with the root loader as parent (to avoid zinc itself being included).
-   */
+    * Create a new classloader with the root loader as parent (to avoid zinc itself being included).
+    */
   def scalaLoader(jars: Seq[File]) =
     new URLClassLoader(
       Path.toURLs(jars),
@@ -86,11 +88,13 @@ object CompilerUtils {
     )
 
   /**
-   * Get the actual scala version from the compiler.properties in a classloader.
-   * The classloader should only contain one version of scala.
-   */
+    * Get the actual scala version from the compiler.properties in a classloader.
+    * The classloader should only contain one version of scala.
+    */
   def scalaVersion(scalaLoader: ClassLoader): Option[String] = {
-    Util.propertyFromResource("compiler.properties", "version.number", scalaLoader)
+    Util.propertyFromResource("compiler.properties",
+                              "version.number",
+                              scalaLoader)
   }
 
 }

--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -1,11 +1,10 @@
 /**
- * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
- */
-
+  * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
+  */
 package org.pantsbuild.zinc.compiler
 
 import java.io.{File}
-import java.util.function.{ Function => JFunction }
+import java.util.function.{Function => JFunction}
 
 import scala.compat.java8.OptionConverters._
 
@@ -29,21 +28,28 @@ import org.pantsbuild.zinc.scalautil.ScalaUtils
 import org.pantsbuild.zinc.compiler.CompilerUtils.newScalaCompiler
 
 object InputUtils {
+
   /**
-   * Create Inputs based on command-line settings.
-   */
+    * Create Inputs based on command-line settings.
+    */
   def create(
-    settings: Settings,
-    analysisMap: AnalysisMap,
-    previousResult: PreviousResult,
-    log: Logger
+      settings: Settings,
+      analysisMap: AnalysisMap,
+      previousResult: PreviousResult,
+      log: Logger
   ): Inputs = {
     import settings._
 
     val scalaJars = InputUtils.selectScalaJars(settings.scala)
 
-    val instance = ScalaUtils.scalaInstance(scalaJars.compiler, scalaJars.extra, scalaJars.library)
-    val compilers = ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, settings.javaHome, newScalaCompiler(instance, settings.compiledBridgeJar.get))
+    val instance = ScalaUtils.scalaInstance(scalaJars.compiler,
+                                            scalaJars.extra,
+                                            scalaJars.library)
+    val compilers = ZincUtil.compilers(
+      instance,
+      ClasspathOptionsUtil.auto,
+      settings.javaHome,
+      newScalaCompiler(instance, settings.compiledBridgeJar.get))
 
     // TODO: Remove duplication once on Scala 2.12.x.
     val positionMapper =
@@ -70,17 +76,18 @@ object InputUtils {
 
     val reporter =
       if (settings.consoleLog.useBarebonesLogger) {
-        ReporterUtil.getReporter(
-          BareBonesLogger(settings.consoleLog.logLevel), ReporterManager.getDefaultReporterConfig)
+        ReporterUtil.getReporter(BareBonesLogger(settings.consoleLog.logLevel),
+                                 ReporterManager.getDefaultReporterConfig)
       } else {
         ReporterUtil.getDefault(
-        ReporterUtil.getDefaultReporterConfig()
-          .withMaximumErrors(Int.MaxValue)
-          .withUseColor(settings.consoleLog.color)
-          .withMsgFilters(settings.consoleLog.msgPredicates.toArray)
-          .withFileFilters(settings.consoleLog.filePredicates.toArray)
-          .withLogLevel(settings.consoleLog.javaLogLevel)
-          .withPositionMapper(positionMapper)
+          ReporterUtil
+            .getDefaultReporterConfig()
+            .withMaximumErrors(Int.MaxValue)
+            .withUseColor(settings.consoleLog.color)
+            .withMsgFilters(settings.consoleLog.msgPredicates.toArray)
+            .withFileFilters(settings.consoleLog.filePredicates.toArray)
+            .withLogLevel(settings.consoleLog.javaLogLevel)
+            .withPositionMapper(positionMapper)
         )
       }
     val setup =
@@ -104,17 +111,18 @@ object InputUtils {
   }
 
   /**
-   * Load the analysis for the destination, creating it if necessary.
-   */
+    * Load the analysis for the destination, creating it if necessary.
+    */
   def loadDestinationAnalysis(
-    settings: Settings,
-    analysisMap: AnalysisMap,
-    log: Logger
+      settings: Settings,
+      analysisMap: AnalysisMap,
+      log: Logger
   ): (AnalysisStore, PreviousResult) = {
     def load() = {
       val analysisStore = analysisMap.cachedStore(settings.analysis.cache)
       analysisStore.get().asScala match {
-        case Some(a) => (analysisStore, Some(a.getAnalysis), Some(a.getMiniSetup))
+        case Some(a) =>
+          (analysisStore, Some(a.getAnalysis), Some(a.getMiniSetup))
         case _ => (analysisStore, None, None)
       }
     }
@@ -126,31 +134,38 @@ object InputUtils {
       } catch {
         case e: Throwable if settings.analysis.clearInvalid =>
           // Remove the corrupted analysis and output directory.
-          log.warn(s"Failed to load analysis from ${settings.analysis.cache} ($e): will execute a clean compile.")
+          log.warn(
+            s"Failed to load analysis from ${settings.analysis.cache} ($e): will execute a clean compile.")
           IO.delete(settings.analysis.cache)
           IO.delete(settings.classesDirectory)
           load()
       }
-    (analysisStore, PreviousResult.create(previousAnalysis.asJava, previousSetup.asJava))
+    (analysisStore,
+     PreviousResult.create(previousAnalysis.asJava, previousSetup.asJava))
   }
 
   /**
-   * Automatically add the output directory and scala library to the classpath.
-   */
-  def autoClasspath(classesDirectory: File, allScalaJars: Seq[File], javaOnly: Boolean, classpath: Seq[File]): Seq[File] = {
+    * Automatically add the output directory and scala library to the classpath.
+    */
+  def autoClasspath(classesDirectory: File,
+                    allScalaJars: Seq[File],
+                    javaOnly: Boolean,
+                    classpath: Seq[File]): Seq[File] = {
     if (javaOnly) classesDirectory +: classpath
-    else splitScala(allScalaJars) match {
-      case Some(scalaJars) => classesDirectory +: scalaJars.library +: classpath
-      case None            => classesDirectory +: classpath
-    }
+    else
+      splitScala(allScalaJars) match {
+        case Some(scalaJars) =>
+          classesDirectory +: scalaJars.library +: classpath
+        case None => classesDirectory +: classpath
+      }
   }
 
   /**
-   * Select the scala jars.
-   *
-   * Prefer the explicit scala-compiler, scala-library, and scala-extra settings,
-   * then the scala-path setting, then the scala-home setting. Default to bundled scala.
-   */
+    * Select the scala jars.
+    *
+    * Prefer the explicit scala-compiler, scala-library, and scala-extra settings,
+    * then the scala-path setting, then the scala-home setting. Default to bundled scala.
+    */
   def selectScalaJars(scala: ScalaLocation): ScalaJars = {
     val jars = splitScala(scala.path) getOrElse Defaults.scalaJars
     ScalaJars(
@@ -161,37 +176,45 @@ object InputUtils {
   }
 
   /**
-   * Distinguish the compiler and library jars.
-   */
-  def splitScala(jars: Seq[File], excluded: Set[String] = Set.empty): Option[ScalaJars] = {
+    * Distinguish the compiler and library jars.
+    */
+  def splitScala(jars: Seq[File],
+                 excluded: Set[String] = Set.empty): Option[ScalaJars] = {
     val filtered = jars filterNot (excluded contains _.getName)
     val (compiler, other) = filtered partition (_.getName matches ScalaCompiler.pattern)
     val (library, extra) = other partition (_.getName matches ScalaLibrary.pattern)
-    if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(compiler(0), library(0), extra)) else None
+    if (compiler.nonEmpty && library.nonEmpty)
+      Some(ScalaJars(compiler(0), library(0), extra))
+    else None
   }
 
   //
   // Default setup
   //
 
-  val ScalaCompiler            = JarFile("scala-compiler")
-  val ScalaLibrary             = JarFile("scala-library")
-  val ScalaReflect             = JarFile("scala-reflect")
+  val ScalaCompiler = JarFile("scala-compiler")
+  val ScalaLibrary = JarFile("scala-library")
+  val ScalaReflect = JarFile("scala-reflect")
 
   // TODO: The default jar locations here are definitely not helpful, but the existence
   // of "some" value for each of these is assumed in a few places. Should remove and make
   // them optional to more cleanly support Java-only compiles.
   object Defaults {
-    val scalaCompiler        = ScalaCompiler.default
-    val scalaLibrary         = ScalaLibrary.default
-    val scalaExtra           = Seq(ScalaReflect.default)
-    val scalaJars            = ScalaJars(scalaCompiler, scalaLibrary, scalaExtra)
-    val scalaExcluded = Set("jansi.jar", "jline.jar", "scala-partest.jar", "scala-swing.jar", "scalacheck.jar", "scalap.jar")
+    val scalaCompiler = ScalaCompiler.default
+    val scalaLibrary = ScalaLibrary.default
+    val scalaExtra = Seq(ScalaReflect.default)
+    val scalaJars = ScalaJars(scalaCompiler, scalaLibrary, scalaExtra)
+    val scalaExcluded = Set("jansi.jar",
+                            "jline.jar",
+                            "scala-partest.jar",
+                            "scala-swing.jar",
+                            "scalacheck.jar",
+                            "scalap.jar")
   }
 
   /**
-   * Jar file description for locating jars.
-   */
+    * Jar file description for locating jars.
+    */
   case class JarFile(name: String, classifier: Option[String] = None) {
     val versionPattern = "(-.*)?"
     val classifierString = classifier map ("-" + _) getOrElse ""
@@ -201,11 +224,12 @@ object InputUtils {
   }
 
   object JarFile {
-    def apply(name: String, classifier: String): JarFile = JarFile(name, Some(classifier))
+    def apply(name: String, classifier: String): JarFile =
+      JarFile(name, Some(classifier))
   }
 
   /**
-   * The scala jars split into compiler, library, and extra.
-   */
+    * The scala jars split into compiler, library, and extra.
+    */
   case class ScalaJars(compiler: File, library: File, extra: Seq[File])
 }

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -1,7 +1,6 @@
 /**
- * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
- */
-
+  * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
+  */
 package org.pantsbuild.zinc.compiler
 
 import java.io.File
@@ -9,9 +8,9 @@ import java.nio.file.Paths
 import scala.collection.JavaConverters._
 
 import sbt.internal.inc.IncrementalCompilerImpl
-import sbt.internal.util.{ BasicLogger, ConsoleLogger, ConsoleOut, StackTrace }
+import sbt.internal.util.{BasicLogger, ConsoleLogger, ConsoleOut, StackTrace}
 import sbt.io.IO
-import sbt.util.{ ControlEvent, Level, LogEvent, Logger }
+import sbt.util.{ControlEvent, Level, LogEvent, Logger}
 import xsbti.CompileFailed
 
 import com.martiansoftware.nailgun.NGContext
@@ -26,11 +25,12 @@ import org.pantsbuild.zinc.util.Util
 // The normal sbt logger takes 5 seconds to start up in a native image. This is intended to be
 // equivalent, while allowing the native image to run immediately.
 case class BareBonesLogger(thisLevel: Level.Value) extends BasicLogger {
-  import scala.Console.{ CYAN, GREEN, RED, YELLOW, RESET }
+  import scala.Console.{CYAN, GREEN, RED, YELLOW, RESET}
 
   val out = System.err
 
-  override def trace(t: => Throwable): Unit = out.println(StackTrace.trimmed(t, getTrace))
+  override def trace(t: => Throwable): Unit =
+    out.println(StackTrace.trimmed(t, getTrace))
 
   override def success(message: => String): Unit = {
     val colored = s"$GREEN[success!] $message$RESET"
@@ -43,14 +43,14 @@ case class BareBonesLogger(thisLevel: Level.Value) extends BasicLogger {
   }
 
   override def log(
-    level: Level.Value,
-    message: => String
+      level: Level.Value,
+      message: => String
   ): Unit = {
     if (level >= thisLevel) {
       val (colorStart, prefix) = level match {
         case Level.Debug => (CYAN, "[debug]")
-        case Level.Info => (GREEN, "[info]")
-        case Level.Warn => (YELLOW, "[warn]")
+        case Level.Info  => (GREEN, "[info]")
+        case Level.Warn  => (YELLOW, "[warn]")
         case Level.Error => (RED, "[error]")
       }
       val colored = s"$colorStart$prefix $message$RESET"
@@ -68,19 +68,21 @@ case class BareBonesLogger(thisLevel: Level.Value) extends BasicLogger {
 }
 
 /**
- * Command-line main class.
- */
+  * Command-line main class.
+  */
 object Main {
+
   /**
-   * Full zinc version info.
-   */
+    * Full zinc version info.
+    */
   case class Version(published: String, timestamp: String, commit: String)
 
   /**
-   * Get the zinc version from a generated properties file.
-   */
+    * Get the zinc version from a generated properties file.
+    */
   lazy val zincVersion: Version = {
-    val props = Util.propertiesFromResource("zinc.version.properties", getClass.getClassLoader)
+    val props = Util.propertiesFromResource("zinc.version.properties",
+                                            getClass.getClassLoader)
     Version(
       props.getProperty("version", "unknown"),
       props.getProperty("timestamp", ""),
@@ -89,11 +91,12 @@ object Main {
   }
 
   /**
-   * For snapshots the zinc version includes timestamp and commit.
-   */
+    * For snapshots the zinc version includes timestamp and commit.
+    */
   lazy val versionString: String = {
     import zincVersion._
-    if (published.endsWith("-SNAPSHOT")) "%s %s-%s" format (published, timestamp, commit take 10)
+    if (published.endsWith("-SNAPSHOT"))
+      "%s %s-%s" format (published, timestamp, commit take 10)
     else published
   }
 
@@ -146,7 +149,7 @@ object Main {
       // Old versions of this binary used :s not ,s as list separators.
       // Accept their input.
       if (fixedArgs(i - 1) == "--classpath" || fixedArgs(i - 1) == "-cp"
-        || fixedArgs(i - 1) == "--scala-path" || fixedArgs(i - 1) == "-scala-path") {
+          || fixedArgs(i - 1) == "--scala-path" || fixedArgs(i - 1) == "-scala-path") {
         fixedArgs(i) = fixedArgs(i).replace(":", ",")
       }
       // Old versions of this binary used :s not =s as map separators.
@@ -159,28 +162,35 @@ object Main {
   }
 
   /**
-   * Run a compile.
-   */
+    * Run a compile.
+    */
   def main(args: Array[String]): Unit = {
     val startTime = System.currentTimeMillis
 
-    val settings = Settings.SettingsParser.parse(preprocessArgs(args), Settings()) match {
-      case Some(settings) => settings
-      case None => {
-        println("See zinc-compiler --help for information about options")
-        sys.exit(1)
+    val settings =
+      Settings.SettingsParser.parse(preprocessArgs(args), Settings()) match {
+        case Some(settings) => settings
+        case None => {
+          println("See zinc-compiler --help for information about options")
+          sys.exit(1)
+        }
       }
-    }
 
-    mainImpl(settings.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile), startTime, n => sys.exit(1))
+    mainImpl(settings.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile),
+             startTime,
+             n => sys.exit(1))
   }
 
   def nailMain(context: NGContext): Unit = {
     val startTime = System.currentTimeMillis
 
-    Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
+    Settings.SettingsParser
+      .parse(preprocessArgs(context.getArgs), Settings()) match {
       case Some(settings) =>
-        mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)), startTime, n => context.exit(n))
+        mainImpl(
+          settings.withAbsolutePaths(new File(context.getWorkingDirectory)),
+          startTime,
+          n => context.exit(n))
       case None => {
         println("See zinc-compiler --help for information about options")
         context.exit(1)
@@ -214,14 +224,16 @@ object Main {
 
       // post compile merge dir
       if (settings.postCompileMergeDir.isDefined) {
-        IO.copyDirectory(new File(settings.postCompileMergeDir.get.toURI), new File(settings.classesDirectory.toURI))
+        IO.copyDirectory(new File(settings.postCompileMergeDir.get.toURI),
+                         new File(settings.classesDirectory.toURI))
       }
 
       // Store the output if the result changed.
       if (result.hasModified) {
         targetAnalysisStore.set(
           // TODO
-          sbt.internal.inc.ConcreteAnalysisContents(result.analysis, result.setup)
+          sbt.internal.inc
+            .ConcreteAnalysisContents(result.analysis, result.setup)
         )
       }
 
@@ -231,8 +243,11 @@ object Main {
       if (settings.outputJar.isDefined) {
         val outputJarPath = settings.outputJar.get.toPath
         val classesDirectory = settings.classesDirectory
-        log.debug("Creating JAR at %s, for files at %s" format (outputJarPath, classesDirectory))
-        OutputUtils.createClassesJar(classesDirectory, outputJarPath, settings.creationTime)
+        log.debug(
+          "Creating JAR at %s, for files at %s" format (outputJarPath, classesDirectory))
+        OutputUtils.createClassesJar(classesDirectory,
+                                     outputJarPath,
+                                     settings.creationTime)
       }
     } catch {
       case e: CompileFailed =>

--- a/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
@@ -1,7 +1,6 @@
 /**
- * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
- */
-
+  * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
+  */
 package org.pantsbuild.zinc.compiler
 
 import java.io.File
@@ -14,21 +13,24 @@ import scala.collection.mutable
 object OutputUtils {
 
   /**
-   * Sort the contents of the `dir` in lexicographic order.
-   *
-   * @param dir File handle containing the contents to sort
-   * @return sorted set of all paths within the `dir`
-   */
+    * Sort the contents of the `dir` in lexicographic order.
+    *
+    * @param dir File handle containing the contents to sort
+    * @return sorted set of all paths within the `dir`
+    */
   def sort(dir: File): mutable.TreeSet[Path] = {
     val sorted = new mutable.TreeSet[Path]()
 
     val fileSortVisitor = new SimpleFileVisitor[Path]() {
-      override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      override def preVisitDirectory(
+          path: Path,
+          attrs: BasicFileAttributes): FileVisitResult = {
         sorted.add(path)
         FileVisitResult.CONTINUE
       }
 
-      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      override def visitFile(path: Path,
+                             attrs: BasicFileAttributes): FileVisitResult = {
         sorted.add(path)
         FileVisitResult.CONTINUE
       }
@@ -39,18 +41,23 @@ object OutputUtils {
   }
 
   def relativize(base: String, path: Path): String = {
-    new File(base.toString).toURI().relativize(new File(path.toString).toURI()).getPath()
+    new File(base.toString)
+      .toURI()
+      .relativize(new File(path.toString).toURI())
+      .getPath()
   }
 
   /**
-   * Create a JAR from the file and directory paths provided.
-   *
-   * @param paths set of all paths to be added to the JAR
-   * @param outputJarPath Absolute Path to the output JAR being created
-   * @param jarEntryTime time to be set for each JAR entry
-   */
-  def createJar(
-    base: String, paths: mutable.TreeSet[Path], outputJarPath: Path, jarEntryTime: Long) {
+    * Create a JAR from the file and directory paths provided.
+    *
+    * @param paths set of all paths to be added to the JAR
+    * @param outputJarPath Absolute Path to the output JAR being created
+    * @param jarEntryTime time to be set for each JAR entry
+    */
+  def createJar(base: String,
+                paths: mutable.TreeSet[Path],
+                outputJarPath: Path,
+                jarEntryTime: Long) {
 
     val target = new JarOutputStream(Files.newOutputStream(outputJarPath))
 
@@ -64,7 +71,8 @@ object OutputUtils {
 
     def addToJar(source: Path, entryName: String) {
       if (source.toFile.isDirectory) {
-        target.putNextEntry(jarEntry(if (entryName.endsWith("/")) entryName else entryName + '/'))
+        target.putNextEntry(
+          jarEntry(if (entryName.endsWith("/")) entryName else entryName + '/'))
       } else {
         target.putNextEntry(jarEntry(entryName))
         Files.copy(source, target)
@@ -72,35 +80,38 @@ object OutputUtils {
       target.closeEntry()
     }
 
-    for (
-      path <- paths;
-      relativePath = relativize(base, path)
-      if relativePath.nonEmpty
-    ) {
+    for (path <- paths;
+         relativePath = relativize(base, path)
+         if relativePath.nonEmpty) {
       addToJar(path, relativePath)
     }
     target.close()
   }
 
   /**
-   * Jar the contents of output classes (settings.classesDirectory) and copy to settings.outputJar
-   *
-   */
-  def createClassesJar(classesDirectory: File, outputJarPath: Path, jarCreationTime: Long) = {
+    * Jar the contents of output classes (settings.classesDirectory) and copy to settings.outputJar
+    *
+    */
+  def createClassesJar(classesDirectory: File,
+                       outputJarPath: Path,
+                       jarCreationTime: Long) = {
 
     // Sort the contents of the classesDirectory for deterministic jar creation
     val sortedClasses = sort(classesDirectory)
 
-    createJar(classesDirectory.toString, sortedClasses, outputJarPath, jarCreationTime)
+    createJar(classesDirectory.toString,
+              sortedClasses,
+              outputJarPath,
+              jarCreationTime)
   }
 
   /**
-   * Determines if a file exists in a JAR provided.
-   *
-   * @param jarPath Absolute Path to the JAR being inspected
-   * @param fileName Name of the file, the existence of which is to be inspected
-   * @return
-   */
+    * Determines if a file exists in a JAR provided.
+    *
+    * @param jarPath Absolute Path to the JAR being inspected
+    * @param fileName Name of the file, the existence of which is to be inspected
+    * @return
+    */
   def existsClass(jarPath: Path, fileName: String): Boolean = {
     var jis: JarInputStream = null
     var found = false

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -1,7 +1,6 @@
 /**
- * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
- */
-
+  * Copyright (C) 2012 Typesafe, Inc. <http://www.typesafe.com>
+  */
 package org.pantsbuild.zinc.compiler
 
 import com.google.common.base.Joiner
@@ -15,32 +14,36 @@ import scala.compat.java8.OptionConverters._
 import scala.util.matching.Regex
 import sbt.io.syntax._
 import sbt.util.{Level, Logger}
-import xsbti.compile.{ClassFileManagerType, CompileOrder, TransactionalManagerType}
+import xsbti.compile.{
+  ClassFileManagerType,
+  CompileOrder,
+  TransactionalManagerType
+}
 import xsbti.compile.{IncOptions => ZincIncOptions}
 import org.pantsbuild.zinc.analysis.AnalysisOptions
 import org.pantsbuild.zinc.util.Util
 
 /**
- * All parsed command-line options.
- */
+  * All parsed command-line options.
+  */
 case class Settings(
-  consoleLog: ConsoleOptions        = ConsoleOptions(),
-  _sources: Seq[File]               = Seq.empty,
-  classpath: Seq[File]              = Seq.empty,
-  _classesDirectory: Option[File]   = None,
-  _postCompileMergeDir: Option[File] = None,
-  outputJar: Option[File]           = None,
-  scala: ScalaLocation              = ScalaLocation(),
-  scalacOptions: Seq[String]        = Seq.empty,
-  javaHome: Option[File]            = None,
-  javaOnly: Boolean                 = false,
-  javacOptions: Seq[String]         = Seq.empty,
-  compileOrder: CompileOrder        = CompileOrder.Mixed,
-  _incOptions: IncOptions           = IncOptions(),
-  analysis: AnalysisOptions         = AnalysisOptions(),
-  creationTime: Long                = 0,
-  compiledBridgeJar: Option[File]   = None,
-  useBarebonesLogger: Boolean       = false
+    consoleLog: ConsoleOptions = ConsoleOptions(),
+    _sources: Seq[File] = Seq.empty,
+    classpath: Seq[File] = Seq.empty,
+    _classesDirectory: Option[File] = None,
+    _postCompileMergeDir: Option[File] = None,
+    outputJar: Option[File] = None,
+    scala: ScalaLocation = ScalaLocation(),
+    scalacOptions: Seq[String] = Seq.empty,
+    javaHome: Option[File] = None,
+    javaOnly: Boolean = false,
+    javacOptions: Seq[String] = Seq.empty,
+    compileOrder: CompileOrder = CompileOrder.Mixed,
+    _incOptions: IncOptions = IncOptions(),
+    analysis: AnalysisOptions = AnalysisOptions(),
+    creationTime: Long = 0,
+    compiledBridgeJar: Option[File] = None,
+    useBarebonesLogger: Boolean = false
 ) {
   import Settings._
 
@@ -49,14 +52,17 @@ case class Settings(
   lazy val classesDirectory: File =
     normalise(_classesDirectory.getOrElse(defaultClassesDirectory()))
 
-  lazy val postCompileMergeDir: Option[File] = _postCompileMergeDir.map(normalise)
+  lazy val postCompileMergeDir: Option[File] =
+    _postCompileMergeDir.map(normalise)
 
   lazy val incOptions: IncOptions = {
     _incOptions.copy(
       apiDumpDirectory = _incOptions.apiDumpDirectory map normalise,
       backup = {
         if (_incOptions.transactional)
-          Some(normalise(_incOptions.backup.getOrElse(defaultBackupLocation(classesDirectory))))
+          Some(
+            normalise(_incOptions.backup.getOrElse(
+              defaultBackupLocation(classesDirectory))))
         else
           None
       }
@@ -64,8 +70,10 @@ case class Settings(
   }
 
   def withAbsolutePaths(relativeTo: File): Settings = {
-    def normaliseSeq(seq: Seq[File]): Seq[File] = Util.normaliseSeq(Some(relativeTo))(seq)
-    def normaliseOpt(opt: Option[File]): Option[File] = Util.normaliseOpt(Some(relativeTo))(opt)
+    def normaliseSeq(seq: Seq[File]): Seq[File] =
+      Util.normaliseSeq(Some(relativeTo))(seq)
+    def normaliseOpt(opt: Option[File]): Option[File] =
+      Util.normaliseOpt(Some(relativeTo))(opt)
 
     // It's a shame that this is manually listing the args which are files, but this doesn't feel
     // high-value enough to fold into the full options parsing
@@ -85,14 +93,14 @@ case class Settings(
 }
 
 /**
- * Console logging options.
- */
+  * Console logging options.
+  */
 case class ConsoleOptions(
-  logLevel: Level.Value      = Level.Info,
-  color: Boolean             = true,
-  fileFilters: Seq[Regex]    = Seq.empty,
-  msgFilters: Seq[Regex]     = Seq.empty,
-  useBarebonesLogger: Boolean= false
+    logLevel: Level.Value = Level.Info,
+    color: Boolean = true,
+    fileFilters: Seq[Regex] = Seq.empty,
+    msgFilters: Seq[Regex] = Seq.empty,
+    useBarebonesLogger: Boolean = false
 ) {
   def javaLogLevel: jlogging.Level = logLevel match {
     case Level.Info =>
@@ -108,9 +116,9 @@ case class ConsoleOptions(
   }
 
   /**
-   * Because filtering Path objects requires first converting to a String, we compose
-   * the regexes into one predicate.
-   */
+    * Because filtering Path objects requires first converting to a String, we compose
+    * the regexes into one predicate.
+    */
   def filePredicates: Seq[JFunction[Path, JBoolean]] =
     Seq(
       new JFunction[Path, JBoolean] {
@@ -130,18 +138,20 @@ case class ConsoleOptions(
 }
 
 /**
- * Alternative ways to locate the scala jars.
- */
+  * Alternative ways to locate the scala jars.
+  */
 case class ScalaLocation(
-  home: Option[File]     = None,
-  path: Seq[File]        = Seq.empty,
-  compiler: Option[File] = None,
-  library: Option[File]  = None,
-  extra: Seq[File]       = Seq.empty
+    home: Option[File] = None,
+    path: Seq[File] = Seq.empty,
+    compiler: Option[File] = None,
+    library: Option[File] = None,
+    extra: Seq[File] = Seq.empty
 ) {
   def withAbsolutePaths(relativeTo: File): ScalaLocation = {
-    def normaliseSeq(seq: Seq[File]): Seq[File] = Util.normaliseSeq(Some(relativeTo))(seq)
-    def normaliseOpt(opt: Option[File]): Option[File] = Util.normaliseOpt(Some(relativeTo))(opt)
+    def normaliseSeq(seq: Seq[File]): Seq[File] =
+      Util.normaliseSeq(Some(relativeTo))(seq)
+    def normaliseOpt(opt: Option[File]): Option[File] =
+      Util.normaliseOpt(Some(relativeTo))(opt)
 
     // It's a shame that this is manually listing the args which are files, but this doesn't feel
     // high-value enough to fold into the full options parsing
@@ -157,50 +167,52 @@ case class ScalaLocation(
 }
 
 object ScalaLocation {
-  /**
-   * Java API for creating ScalaLocation.
-   */
-  def create(
-    home: File,
-    path: JList[File],
-    compiler: File,
-    library: File,
-    extra: JList[File]): ScalaLocation =
-  ScalaLocation(
-    Option(home),
-    path.asScala,
-    Option(compiler),
-    Option(library),
-    extra.asScala
-  )
 
   /**
-   * Java API for creating ScalaLocation with scala home.
-   */
+    * Java API for creating ScalaLocation.
+    */
+  def create(home: File,
+             path: JList[File],
+             compiler: File,
+             library: File,
+             extra: JList[File]): ScalaLocation =
+    ScalaLocation(
+      Option(home),
+      path.asScala,
+      Option(compiler),
+      Option(library),
+      extra.asScala
+    )
+
+  /**
+    * Java API for creating ScalaLocation with scala home.
+    */
   def fromHome(home: File) = ScalaLocation(home = Option(home))
 
   /**
-   * Java API for creating ScalaLocation with scala path.
-   */
+    * Java API for creating ScalaLocation with scala path.
+    */
   def fromPath(path: JList[File]) = ScalaLocation(path = path.asScala)
 }
 
 /**
- * Wrapper around incremental compiler options.
- */
+  * Wrapper around incremental compiler options.
+  */
 case class IncOptions(
-  transitiveStep: Int            = ZincIncOptions.defaultTransitiveStep,
-  recompileAllFraction: Double   = ZincIncOptions.defaultRecompileAllFraction,
-  relationsDebug: Boolean        = ZincIncOptions.defaultRelationsDebug,
-  apiDebug: Boolean              = ZincIncOptions.defaultApiDebug,
-  apiDiffContextSize: Int        = ZincIncOptions.defaultApiDiffContextSize,
-  apiDumpDirectory: Option[File] = ZincIncOptions.defaultApiDumpDirectory.asScala,
-  transactional: Boolean         = false,
-  useZincFileManager: Boolean    = true,
-  backup: Option[File]           = None
+    transitiveStep: Int = ZincIncOptions.defaultTransitiveStep,
+    recompileAllFraction: Double = ZincIncOptions.defaultRecompileAllFraction,
+    relationsDebug: Boolean = ZincIncOptions.defaultRelationsDebug,
+    apiDebug: Boolean = ZincIncOptions.defaultApiDebug,
+    apiDiffContextSize: Int = ZincIncOptions.defaultApiDiffContextSize,
+    apiDumpDirectory: Option[File] =
+      ZincIncOptions.defaultApiDumpDirectory.asScala,
+    transactional: Boolean = false,
+    useZincFileManager: Boolean = true,
+    backup: Option[File] = None
 ) {
   def options(log: Logger): ZincIncOptions =
-    ZincIncOptions.create()
+    ZincIncOptions
+      .create()
       .withTransitiveStep(transitiveStep)
       .withRecompileAllFraction(recompileAllFraction)
       .withRelationsDebug(relationsDebug)
@@ -249,7 +261,8 @@ object Settings {
 
     opt[Unit]("debug")
       .abbr("debug")
-      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.Debug)))
+      .action((x, c) =>
+        c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.Debug)))
       .text("Set log level for stdout to debug")
 
     opt[String]("log-level")
@@ -257,34 +270,44 @@ object Settings {
       .valueName("level")
       // Allow multiple specifiers of this, and always use the last.
       .unbounded()
-      .validate { level => {
-        if (logLevels.contains(level)) success else failure(s"Level must be one of $logLevels.")
-      }}
-      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.withName(x))))
-      .text(s"Set log level for stdout (${Joiner.on('|').join(logLevels.asJava)})")
+      .validate { level =>
+        {
+          if (logLevels.contains(level)) success
+          else failure(s"Level must be one of $logLevels.")
+        }
+      }
+      .action((x, c) =>
+        c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.withName(x))))
+      .text(
+        s"Set log level for stdout (${Joiner.on('|').join(logLevels.asJava)})")
 
     opt[Unit]("no-color")
       .abbr("no-color")
-      .action((x, c) => c.copy(consoleLog =  c.consoleLog.copy(color = false)))
+      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(color = false)))
       .text("No color in logging to stdout")
 
     opt[String]("msg-filter")
       .abbr("msg-filter")
       .valueName("<regex>")
       .unbounded()
-      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(msgFilters = c.consoleLog.msgFilters :+ x.r)))
+      .action((x, c) =>
+        c.copy(consoleLog =
+          c.consoleLog.copy(msgFilters = c.consoleLog.msgFilters :+ x.r)))
       .text("Filter warning messages matching the given regex")
 
     opt[String]("file-filter")
       .abbr("file-filter")
       .valueName("<regex>")
       .unbounded()
-      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(fileFilters = c.consoleLog.fileFilters :+ x.r)))
+      .action((x, c) =>
+        c.copy(consoleLog =
+          c.consoleLog.copy(fileFilters = c.consoleLog.fileFilters :+ x.r)))
       .text("Filter warning messages from filenames matching the given regex")
 
     opt[Unit]("use-barebones-logger")
       .abbr("use-barebones-logger")
-      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(useBarebonesLogger = true)))
+      .action((x, c) =>
+        c.copy(consoleLog = c.consoleLog.copy(useBarebonesLogger = true)))
       .text("Use our custom barebones logger instead of the sbt logger. This is an experimental feature that speeds up native-image startup times considerably.")
 
     opt[Seq[File]]("classpath")
@@ -303,7 +326,7 @@ object Settings {
 
     opt[File]("jar-destination")
       .abbr("jar")
-      .action((x, c) => c.copy(outputJar =  Some(x)))
+      .action((x, c) => c.copy(outputJar = Some(x)))
       .text("Jar destination for compiled classes")
 
     opt[File]("scala-home")
@@ -354,52 +377,64 @@ object Settings {
 
     opt[Int]("transitive-step")
       .abbr("transitive-step")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(transitiveStep = x)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(transitiveStep = x)))
       .text("Steps before transitive closure")
 
     opt[Double]("recompile-all-fraction")
       .abbr("recompile-all-fraction")
-      .validate{ fraction => {
-        if (0 <= fraction && fraction <= 1) success else failure("recompile-all-fraction must be between 0 and 1")
-      }}
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(recompileAllFraction = x)))
+      .validate { fraction =>
+        {
+          if (0 <= fraction && fraction <= 1) success
+          else failure("recompile-all-fraction must be between 0 and 1")
+        }
+      }
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(recompileAllFraction = x)))
       .text("Limit before recompiling all sources")
 
     opt[Unit]("debug-relations")
       .abbr("debug-relations")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(relationsDebug = true)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(relationsDebug = true)))
       .text("Enable debug logging of analysis relations")
 
     opt[Unit]("debug-api")
       .abbr("debug-api")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDebug = true)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(apiDebug = true)))
       .text("Enable analysis API debugging")
 
     opt[File]("api-dump")
       .abbr("api-dump")
       .valueName("directory")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDumpDirectory = Some(x))))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(apiDumpDirectory = Some(x))))
       .text("Destination for analysis API dump")
 
     opt[Int]("api-diff-context-size")
       .abbr("api-diff-context-size")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDiffContextSize = x)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(apiDiffContextSize = x)))
       .text("Diff context size (in lines) for API debug")
 
     opt[Unit]("transactional")
       .abbr("transactional")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(transactional = true)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(transactional = true)))
       .text("Restore previous class files on failure")
 
     opt[Unit]("no-zinc-file-manager")
       .abbr("no-zinc-file-manager")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(useZincFileManager = false)))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(useZincFileManager = false)))
       .text("Disable zinc provided file manager")
 
     opt[File]("backup")
       .abbr("backup")
       .valueName("<directory>")
-      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(backup = Some(x))))
+      .action((x, c) =>
+        c.copy(_incOptions = c._incOptions.copy(backup = Some(x))))
       .text("Backup location (if transactional)")
 
     opt[File]("analysis-cache")
@@ -420,7 +455,8 @@ object Settings {
 
     opt[Unit]("no-clear-invalid-analysis")
       .abbr("no-clear-invalid-analysis")
-      .action((x, c) => c.copy(analysis = c.analysis.copy(clearInvalid = false)))
+      .action(
+        (x, c) => c.copy(analysis = c.analysis.copy(clearInvalid = false)))
       .text("If set, zinc will fail rather than purging illegal analysis.")
 
     opt[String]("scalac-option")
@@ -444,39 +480,41 @@ object Settings {
   }
 
   /**
-   * Create a CompileOrder value based on string input.
-   */
+    * Create a CompileOrder value based on string input.
+    */
   def compileOrder(order: String): CompileOrder = {
     order.toLowerCase match {
-      case "mixed"                                       => CompileOrder.Mixed
-      case "java"  | "java-then-scala" | "javathenscala" => CompileOrder.JavaThenScala
-      case "scala" | "scala-then-java" | "scalathenjava" => CompileOrder.ScalaThenJava
+      case "mixed" => CompileOrder.Mixed
+      case "java" | "java-then-scala" | "javathenscala" =>
+        CompileOrder.JavaThenScala
+      case "scala" | "scala-then-java" | "scalathenjava" =>
+        CompileOrder.ScalaThenJava
     }
   }
 
   /**
-   * Normalise all relative paths to absolute paths.
-   */
+    * Normalise all relative paths to absolute paths.
+    */
   def normalise(f: File): File = f.getAbsoluteFile
 
   /**
-   * By default the cache location is relative to the classes directory (for example, target/classes/../cache/classes).
-   */
+    * By default the cache location is relative to the classes directory (for example, target/classes/../cache/classes).
+    */
   def defaultCacheLocation(classesDir: File) = {
     classesDir.getParentFile / "cache" / classesDir.getName
   }
 
   /**
-   * By default the backup location is relative to the classes directory (for example, target/classes/../backup/classes).
-   */
+    * By default the backup location is relative to the classes directory (for example, target/classes/../backup/classes).
+    */
   def defaultBackupLocation(classesDir: File): File = {
     classesDir.getParentFile / "backup" / classesDir.getName
   }
 
   /**
-   * If a settings.classesDirectory option isnt specified, create a temporary directory for output
-   * classes to be written to.
-   */
+    * If a settings.classesDirectory option isnt specified, create a temporary directory for output
+    * classes to be written to.
+    */
   def defaultClassesDirectory(): File = {
     Files.createTempDirectory("temp-zinc-classes").toFile
   }


### PR DESCRIPTION
### Problem

I am preparing work in the scala code for the zinc compiler wrapper.
Currently, the formatting is inconsistent and I prefer working in a formatted codebase so I don't have to mix formatting changes with semantic changes.

### Solution

Format the zinc code with
```
./pants fmt src/scala/org/pantsbuild/zinc/compiler/Main.scala --scalafmt-skip=False
```

Note: I'm making this its own PR to simplify reverts of the semantic PRs if needed.

### Result

The zinc code is formatted and I can follow up with purely semantic changes.