### PR TITLE
Enable zinc to log diagnostics for jvm languages

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -22,7 +22,8 @@ jar_library(name='args4j',
 jar_library(name='guava',
             jars=[
               jar('com.google.guava', 'guava', '18.0',
-                  apidocs='http://google.github.io/guava/releases/18.0/api/docs/')
+                  apidocs='http://google.github.io/guava/releases/18.0/api/docs/',
+                  force=True)
             ])
 
 jar_library(name='jansi',

--- a/3rdparty/jvm/com/google/code/gson/BUILD
+++ b/3rdparty/jvm/com/google/code/gson/BUILD
@@ -1,0 +1,10 @@
+jar_library(
+    name = "gson",
+    jars = [
+          jar(
+                  org = "com.google.code.gson",
+                  name = "gson",
+                  rev = "2.8.6"
+          ),
+    ],
+)

--- a/3rdparty/jvm/org/eclipse/lsp4j/BUILD
+++ b/3rdparty/jvm/org/eclipse/lsp4j/BUILD
@@ -1,0 +1,5 @@
+jar_library(name="lsp4j",
+  jars=[
+    jar(org="org.eclipse.lsp4j", name="org.eclipse.lsp4j", rev="0.9.0.M3"),
+  ],
+)

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -13,7 +13,9 @@ scala_library(
   ),
   dependencies=[
     '3rdparty/jvm/com/github/scopt',
+    '3rdparty/jvm/com/google/code/gson',
     '3rdparty/jvm/com/martiansoftware:nailgun-server',
+    '3rdparty/jvm/org/eclipse/lsp4j',
     '3rdparty/jvm/org/scala-lang/modules:scala-java8-compat',
     '3rdparty/jvm/org/scala-sbt:io',
     '3rdparty/jvm/org/scala-sbt:util-logging',

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -3,20 +3,28 @@
   */
 package org.pantsbuild.zinc.compiler
 
-import java.io.File
+import java.io.{File, PrintWriter}
 import java.nio.file.Paths
 import scala.collection.JavaConverters._
-
+import scala.compat.java8.OptionConverters._
 import sbt.internal.inc.IncrementalCompilerImpl
 import sbt.internal.util.{BasicLogger, ConsoleLogger, ConsoleOut, StackTrace}
 import sbt.io.IO
 import sbt.util.{ControlEvent, Level, LogEvent, Logger}
 import xsbti.CompileFailed
-
+import xsbti.compile.Inputs
+import xsbti.{Problem, Severity}
 import com.martiansoftware.nailgun.NGContext
+import com.google.gson.Gson
 import com.google.common.base.Charsets
 import com.google.common.io.Files
-
+import org.eclipse.lsp4j.{
+  Diagnostic,
+  DiagnosticSeverity,
+  Position,
+  PublishDiagnosticsParams,
+  Range
+}
 import org.pantsbuild.zinc.analysis.AnalysisMap
 import org.pantsbuild.zinc.util.Util
 
@@ -111,10 +119,8 @@ object Main {
     System.setProperty("sbt.log.format", "true")
 
     def mkConsoleLogger(level: Level.Value, color: Boolean): ConsoleLogger = {
-      val cl = ConsoleLogger(
-        out = ConsoleOut.systemOut,
-        ansiCodesSupported = color
-      )
+      val cl =
+        ConsoleLogger(out = ConsoleOut.systemOut, ansiCodesSupported = color)
       cl.setLevel(level)
       cl
     }
@@ -176,9 +182,13 @@ object Main {
         }
       }
 
-    mainImpl(settings.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile),
-             startTime,
-             n => sys.exit(1))
+    val workingDirectory = Paths.get(".").toAbsolutePath.toFile
+    mainImpl(
+      settings.withAbsolutePaths(workingDirectory),
+      startTime,
+      n => sys.exit(1),
+      workingDirectory
+    )
   }
 
   def nailMain(context: NGContext): Unit = {
@@ -187,10 +197,13 @@ object Main {
     Settings.SettingsParser
       .parse(preprocessArgs(context.getArgs), Settings()) match {
       case Some(settings) =>
+        val workingDirectory = new File(context.getWorkingDirectory)
         mainImpl(
-          settings.withAbsolutePaths(new File(context.getWorkingDirectory)),
+          settings.withAbsolutePaths(workingDirectory),
           startTime,
-          n => context.exit(n))
+          n => context.exit(n),
+          workingDirectory
+        )
       case None => {
         println("See zinc-compiler --help for information about options")
         context.exit(1)
@@ -198,7 +211,73 @@ object Main {
     }
   }
 
-  def mainImpl(settings: Settings, startTime: Long, exit: Int => Unit): Unit = {
+  def toLsp(severity: Severity): DiagnosticSeverity = {
+    severity match {
+      case Severity.Error => DiagnosticSeverity.Error
+      case Severity.Warn  => DiagnosticSeverity.Warning
+      case Severity.Info  => DiagnosticSeverity.Information
+      // Note: DiagnosticSeverity also has a Hint level, but we won't use it here as xsbti doesn't go that far
+    }
+  }
+  def toZeroBased(x: Int): Int = {
+    x - 1
+  }
+  def toLsp(problems: List[Problem],
+            workingDirectory: File): List[PublishDiagnosticsParams] = {
+    problems
+      .groupBy(problem => problem.position.sourcePath)
+      .map {
+        case (file, problems) => {
+          // By using a relative path here as opposed to an actual URI, we diverge slightly from
+          // the precise definition of the Language Server Protocol; but this is necessary if we
+          // want to be able to cache this data in heterogeneous environments.
+          val uri: String = "buildroot://" + file.asScala
+            .map(file => Util.relativize(workingDirectory, new File(file)))
+            .getOrElse("")
+
+          val diagnostics =
+            problems
+              .map(problem => {
+                val position =
+                  new Position(
+                    // xsbti uses one-based values for line and "pointer" (i.e: character index)
+                    // the Language ServerProtocol requires one-based values
+                    toZeroBased(problem.position.line.orElse(0)),
+                    toZeroBased(problem.position.pointer.orElse(0))
+                  )
+
+                val range = new Range(position, position)
+                val severity = toLsp(problem.severity)
+                val code = problem.category()
+                new Diagnostic(range, problem.message(), severity, "zinc", code)
+              })
+          new PublishDiagnosticsParams(uri, diagnostics.asJava)
+        }
+      }
+      .toList
+  }
+
+  def dumpDiagnostics(settings: Settings,
+                      inputs: Inputs,
+                      workingDirectory: File): Unit = {
+    val problems = inputs.setup.reporter.problems.toList
+    val serializer = new Gson()
+    val serialized = serializer.toJson(toLsp(problems, workingDirectory))
+    settings.diagnosticsOut.map(diagnosticsFile => {
+      val log = mkLogger(settings)
+      log.debug(
+        "Writing diagnostics report to file: " + diagnosticsFile.toString
+      )
+      val writer = new PrintWriter(diagnosticsFile)
+      writer.write(serialized)
+      writer.close()
+    })
+  }
+
+  def mainImpl(settings: Settings,
+               startTime: Long,
+               exit: Int => Unit,
+               workingDirectory: File): Unit = {
     val log = mkLogger(settings)
     val isDebug = settings.consoleLog.logLevel <= Level.Debug
 
@@ -224,8 +303,10 @@ object Main {
 
       // post compile merge dir
       if (settings.postCompileMergeDir.isDefined) {
-        IO.copyDirectory(new File(settings.postCompileMergeDir.get.toURI),
-                         new File(settings.classesDirectory.toURI))
+        IO.copyDirectory(
+          new File(settings.postCompileMergeDir.get.toURI),
+          new File(settings.classesDirectory.toURI)
+        )
       }
 
       // Store the output if the result changed.
@@ -236,9 +317,8 @@ object Main {
             .ConcreteAnalysisContents(result.analysis, result.setup)
         )
       }
-
+      dumpDiagnostics(settings, inputs, workingDirectory)
       log.info("Compile success " + Util.timing(startTime))
-
       // if compile is successful, jar the contents of classesDirectory and copy to outputJar
       if (settings.outputJar.isDefined) {
         val outputJarPath = settings.outputJar.get.toPath
@@ -251,6 +331,7 @@ object Main {
       }
     } catch {
       case e: CompileFailed =>
+        dumpDiagnostics(settings, inputs, workingDirectory)
         log.error("Compile failed " + Util.timing(startTime))
         exit(1)
       case e: Exception =>

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -34,6 +34,7 @@ case class Settings(
     _postCompileMergeDir: Option[File] = None,
     outputJar: Option[File] = None,
     scala: ScalaLocation = ScalaLocation(),
+    diagnosticsOut: Option[File] = None,
     scalacOptions: Seq[String] = Seq.empty,
     javaHome: Option[File] = None,
     javaOnly: Boolean = false,
@@ -84,6 +85,7 @@ case class Settings(
       _classesDirectory = normaliseOpt(_classesDirectory),
       outputJar = normaliseOpt(outputJar),
       scala = scala.withAbsolutePaths(relativeTo),
+      diagnosticsOut = normaliseOpt(diagnosticsOut),
       javaHome = normaliseOpt(javaHome),
       _incOptions = _incOptions.withAbsolutePaths(relativeTo),
       analysis = analysis.withAbsolutePaths(relativeTo),
@@ -358,6 +360,10 @@ object Settings {
       .valueName("<path>")
       .action((x, c) => c.copy(scala = c.scala.copy(extra = x)))
       .text("Specify extra Scala jars directly")
+    opt[File]("diagnostics-out")
+      .abbr("diag")
+      .action((x, c) => c.copy(diagnosticsOut = Some(x)))
+      .text("File where the report of compilation errors and warnings will be written")
 
     opt[File]("java-home")
       .abbr("java-home")


### PR DESCRIPTION
### Problem

We are interested in monitoring the number of warnings and errors per
target for any given jvm language (java and scala).

The first step in this effort is to ensure that the zinc wrapper has the
ability of storing  this data.

### Solution

Add a "diagnostics-out" flag to  zinc with a path to a file. If
provided, warnings and errors will be output in that file as a json
formatted List[PublishDiagnosticsParams].
This is the Language Server Protocol representation of a list of
diagnostics (compilation errors or warnings).
See the schema here:
https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_publishDiagnostics
Liberty is taken to express the URIs to code files in terms of relative
paths to avoid remote cache invalidation.

### Result

This will serve our immediate purpose of aggregating information about
the number of errors and warnings in code built by pants; but could also
have wider applications, such as reporting warnings in case of a cache
hit as the diagnostics file can be dumped in the build cache where it
will be cached as any other compilation artifact.

This PR is currently a no-op from pants' point of view as a new version
of zinc will have to be published and consumed from the python consuming
side before changes take effect.