### PR TITLE
Use `FrozenOrderedSet` with `PexRequirements` and `PexInterpreterConstraints`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -79,7 +79,7 @@ async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
             output_filename="lambdex.pex",
             requirements=PexRequirements(lambdex.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(lambdex.default_interpreter_constraints)
+                lambdex.default_interpreter_constraints
             ),
             entry_point=lambdex.get_entry_point(),
         )

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -77,7 +77,7 @@ async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="lambdex.pex",
-            requirements=PexRequirements(requirements=tuple(lambdex.get_requirement_specs())),
+            requirements=PexRequirements(lambdex.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(lambdex.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -66,7 +66,7 @@ async def lint(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="bandit.pex",
-            requirements=PexRequirements(requirements=tuple(bandit.get_requirement_specs())),
+            requirements=PexRequirements(bandit.get_requirement_specs()),
             interpreter_constraints=interpreter_constraints,
             entry_point=bandit.get_entry_point(),
         )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -85,7 +85,7 @@ async def setup(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="black.pex",
-            requirements=PexRequirements(requirements=tuple(black.get_requirement_specs())),
+            requirements=PexRequirements(black.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(black.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -87,7 +87,7 @@ async def setup(
             output_filename="black.pex",
             requirements=PexRequirements(black.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(black.default_interpreter_constraints)
+                black.default_interpreter_constraints
             ),
             entry_point=black.get_entry_point(),
         )

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -72,7 +72,7 @@ async def setup(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="docformatter.pex",
-            requirements=PexRequirements(requirements=tuple(docformatter.get_requirement_specs())),
+            requirements=PexRequirements(docformatter.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(docformatter.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -74,7 +74,7 @@ async def setup(
             output_filename="docformatter.pex",
             requirements=PexRequirements(docformatter.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(docformatter.default_interpreter_constraints)
+                docformatter.default_interpreter_constraints
             ),
             entry_point=docformatter.get_entry_point(),
         )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -66,7 +66,7 @@ async def lint(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="flake8.pex",
-            requirements=PexRequirements(requirements=tuple(flake8.get_requirement_specs())),
+            requirements=PexRequirements(flake8.get_requirement_specs()),
             interpreter_constraints=interpreter_constraints,
             entry_point=flake8.get_entry_point(),
         )

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -79,7 +79,7 @@ async def setup(
             output_filename="isort.pex",
             requirements=PexRequirements(isort.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(isort.default_interpreter_constraints)
+                isort.default_interpreter_constraints
             ),
             entry_point=isort.get_entry_point(),
         )

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -77,7 +77,7 @@ async def setup(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="isort.pex",
-            requirements=PexRequirements(requirements=tuple(isort.get_requirement_specs())),
+            requirements=PexRequirements(isort.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(isort.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -81,7 +81,7 @@ async def lint(
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="pylint.pex",
-            requirements=PexRequirements(requirements=tuple(pylint.get_requirement_specs())),
+            requirements=PexRequirements(pylint.get_requirement_specs()),
             interpreter_constraints=interpreter_constraints,
             entry_point=pylint.get_entry_point(),
         )

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -25,11 +25,17 @@ from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
+from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class PexRequirements:
-    requirements: Tuple[str, ...] = ()
+    requirements: FrozenOrderedSet[str]
+
+    def __init__(self, requirements: Optional[Iterable[str]] = None) -> None:
+        self.requirements = FrozenOrderedSet(sorted(requirements or ()))
 
     @classmethod
     def create_from_adaptors(
@@ -45,7 +51,7 @@ class PexRequirements:
                 for py_req in maybe_python_req_lib.requirements:
                     all_target_requirements.add(str(py_req.requirement))
         all_target_requirements.update(additional_requirements)
-        return PexRequirements(requirements=tuple(sorted(all_target_requirements)))
+        return PexRequirements(all_target_requirements)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -126,9 +126,7 @@ class PexTest(TestBase):
         self.assertEqual(result.stdout, b"from main\n")
 
     def test_resolves_dependencies(self) -> None:
-        requirements = PexRequirements(
-            requirements=("six==1.12.0", "jsonschema==2.6.0", "requests==2.23.0")
-        )
+        requirements = PexRequirements(["six==1.12.0", "jsonschema==2.6.0", "requests==2.23.0"])
         pex_info = self.create_pex_and_get_pex_info(requirements=requirements)
         # NB: We do not check for transitive dependencies, which PEX-INFO will include. We only check
         # that at least the dependencies we requested are included.
@@ -147,7 +145,7 @@ class PexTest(TestBase):
         self.create_file("constraints.txt", "\n".join(constraints))
 
         pex_info = self.create_pex_and_get_pex_info(
-            requirements=PexRequirements((direct_dep,)),
+            requirements=PexRequirements([direct_dep]),
             additional_pants_args=("--python-setup-requirement-constraints=constraints.txt",),
         )
         assert set(pex_info["requirements"]) == set(constraints)

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -156,9 +156,9 @@ class PexTest(TestBase):
         assert pex_info["entry_point"] == entry_point
 
     def test_interpreter_constraints(self) -> None:
-        constraints = PexInterpreterConstraints(constraint_set=("CPython>=2.7,<3", "CPython>=3.6"))
+        constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
         pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
-        assert set(pex_info["interpreter_constraints"]) == set(constraints.constraint_set)
+        assert set(pex_info["interpreter_constraints"]) == set(constraints.constraints)
 
     def test_additional_args(self) -> None:
         pex_info = self.create_pex_and_get_pex_info(additional_pex_args=("--not-zip-safe",))

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -251,7 +251,7 @@ async def setup_coverage(coverage: PytestCoverage) -> CoverageSetup:
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename=output_pex_filename,
-            requirements=PexRequirements(requirements=tuple(coverage.get_requirement_specs())),
+            requirements=PexRequirements(coverage.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(coverage.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -253,7 +253,7 @@ async def setup_coverage(coverage: PytestCoverage) -> CoverageSetup:
             output_filename=output_pex_filename,
             requirements=PexRequirements(coverage.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(coverage.default_interpreter_constraints)
+                coverage.default_interpreter_constraints
             ),
             entry_point=coverage.get_entry_point(),
             input_files_digest=plugin_file_digest,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -112,7 +112,7 @@ async def setup_pytest_for_target(
         CreatePex,
         create_pex(
             output_filename="pytest.pex",
-            requirements=PexRequirements(requirements=pytest.get_requirement_strings()),
+            requirements=PexRequirements(pytest.get_requirement_strings()),
             additional_args=additional_args_for_pytest,
             input_files_digest=plugin_file_digest,
         ),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -657,7 +657,7 @@ async def setup_setuptools(setuptools: Setuptools) -> SetuptoolsSetup:
     requirements_pex = await Get[Pex](
         CreatePex(
             output_filename="setuptools.pex",
-            requirements=PexRequirements(requirements=tuple(setuptools.get_requirement_specs())),
+            requirements=PexRequirements(setuptools.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
                 constraint_set=tuple(setuptools.default_interpreter_constraints)
             ),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -659,7 +659,7 @@ async def setup_setuptools(setuptools: Setuptools) -> SetuptoolsSetup:
             output_filename="setuptools.pex",
             requirements=PexRequirements(setuptools.get_requirement_specs()),
             interpreter_constraints=PexInterpreterConstraints(
-                constraint_set=tuple(setuptools.default_interpreter_constraints)
+                setuptools.default_interpreter_constraints
             ),
         )
     )


### PR DESCRIPTION
For both `PexRequirements` and `PexInterpreterConstraints`—which are both collections of `str`s—we desire these properties:

1. Must be hashable.
2. Should be immutable.
3. Must have consistent ordering, otherwise, we get very few cache hits.
4. Must de-duplicate all elements.

We previously achieved this by using `tuple(sorted(set(elements)))` because at the time that was the best we could do now. Now, we can simply use `FrozenOrderedSet(sorted(elements))` to get all 4 properties.

`FrozenOrderedSet` is both more ergonomic and better expresses the intent of what we're doing.

--

We also provide custom constructors for both types to allow accepting a flexible `Iterable[str]`, rather than something specific like `Tuple[str, ...]`. This makes for cleaner call sites. More importantly, it allows us to move the sorting into the constructor, rather than expecting the call sites to have been pre-sorted.