### PR TITLE
Bump process execution timeout from 2m40s to 5 mins

### DIFF
--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -373,7 +373,7 @@ fn main() {
           store.clone(),
           PlatformConstraint::Linux,
           executor,
-          std::time::Duration::from_secs(160),
+          std::time::Duration::from_secs(300),
           std::time::Duration::from_millis(500),
           std::time::Duration::from_secs(5),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -182,7 +182,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             PlatformConstraint::Linux,
             executor.clone(),
-            std::time::Duration::from_secs(160),
+            std::time::Duration::from_secs(300),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?),


### PR DESCRIPTION
### Problem

There was a slow-down in pants somewhere between 1.26.0.dev0 and 1.26.0.dev2 that makes CI consistently timeout; at least in my recent experience, trying to merge a few PRs.

### Solution

Bump the queue buffer time hardcoded in Rust, which gets added to the test’s timeout value. This has the benefit of applying to every remoted test.

### Result

If all goes according to plan, CI passes on this PR and it becomes easier to merge other PRs until the root cause of the slow down is identified and fixed.
At that point in time, reverting this PR is recommended.

Note: I resisted the urge to create a constant for this magic number because this PR is designed to be reverted later. Probably worth a follow-up, though.