### PR TITLE
Replace Twitter Common's `maybe_list()` with `pants.util.collections.ensure_list()`

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -1,3 +1,2 @@
-twitter.common.collections>=0.3.11,<0.4
 twitter.common.confluence>=0.3.11,<0.4
 twitter.common.dirutil>=0.3.11,<0.4

--- a/contrib/avro/src/python/pants/contrib/avro/tasks/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/tasks/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'contrib/avro/src/python/pants/contrib/avro/targets',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:nailgun_task',

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
@@ -19,7 +18,6 @@ python_tests(
   name='cpp_toolchain',
   sources=['test_cpp_toolchain.py'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
     'contrib/cpp:examples_directory',
     'src/python/pants/util:contextutil',

--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:shader',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:nailgun_task',

--- a/src/python/pants/backend/codegen/thrift/java/BUILD
+++ b/src/python/pants/backend/codegen/thrift/java/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/codegen/thrift/lib',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -363,7 +363,6 @@ python_library(
   name = 'jar_task',
   sources = ['jar_task.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':classpath_util',
     ':nailgun_task',
     'src/python/pants/backend/jvm:argfile',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -430,7 +430,6 @@ python_library(
   name = 'jvm_binary_task',
   sources = ['jvm_binary_task.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':classpath_products',
     ':jar_task',
     'src/python/pants/backend/jvm/subsystems:shader',
@@ -441,6 +440,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:fileutil',
     'src/python/pants/util:memo',
+    'src/python/pants/util:ordered_set',
   ],
   tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -7,8 +7,6 @@ import tempfile
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.jvm.argfile import safe_args
 from pants.backend.jvm.subsystems.jar_tool import JarTool
 from pants.backend.jvm.targets.java_agent import JavaAgent
@@ -18,6 +16,7 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.java.jar.manifest import Manifest
 from pants.java.util import relativize_classpath
+from pants.util.collections import ensure_str_list
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdtemp
 
@@ -149,7 +148,7 @@ class Jar:
 
         :param iterable classpath: a list of paths
         """
-        self._classpath = self._classpath + maybe_list(classpath)
+        self._classpath = self._classpath + ensure_str_list(classpath)
 
     def write(self, src, dest=None):
         """Schedules a write of the file at ``src`` to the ``dest`` path in this jar.

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -4,8 +4,6 @@
 import os
 from contextlib import contextmanager
 
-from twitter.common.collections.orderedset import OrderedSet
-
 from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jar_task import JarBuilderTask
@@ -15,6 +13,7 @@ from pants.java.util import execute_runner
 from pants.util.contextutil import temporary_dir
 from pants.util.fileutil import atomic_copy
 from pants.util.memo import memoized_property
+from pants.util.ordered_set import OrderedSet
 
 
 class JvmBinaryTask(JarBuilderTask):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:shader',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -1,6 +1,8 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:dataclasses',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:scala_platform',

--- a/src/python/pants/backend/python/targets/BUILD
+++ b/src/python/pants/backend/python/targets/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
     'src/python/pants/python',
+    'src/python/pants/util:collections',
     'src/python/pants/util:ordered_set',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -4,13 +4,13 @@
 import os
 
 from pex.pex_info import PexInfo
-from twitter.common.collections import maybe_list
 
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.subsystem.subsystem import Subsystem
+from pants.util.collections import ensure_str_list
 
 
 class PythonBinary(PythonTarget):
@@ -109,10 +109,10 @@ class PythonBinary(PythonTarget):
                 "inherit_path": PrimitiveField(inherit_path),
                 "zip_safe": PrimitiveField(bool(zip_safe)),
                 "always_write_cache": PrimitiveField(bool(always_write_cache)),
-                "repositories": PrimitiveField(maybe_list(repositories or [])),
-                "indices": PrimitiveField(maybe_list(indices or [])),
+                "repositories": PrimitiveField(ensure_str_list(repositories or [])),
+                "indices": PrimitiveField(ensure_str_list(indices or [])),
                 "ignore_errors": PrimitiveField(bool(ignore_errors)),
-                "platforms": PrimitiveField(tuple(maybe_list(platforms or []))),
+                "platforms": PrimitiveField(tuple(ensure_str_list(platforms or []))),
                 "shebang": PrimitiveField(shebang),
                 "emit_warnings": PrimitiveField(self.Defaults.should_emit_warnings(emit_warnings)),
             }

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -1,12 +1,11 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
+from pants.util.collections import ensure_str_list
 
 
 class PythonDistribution(PythonTarget):
@@ -40,7 +39,9 @@ class PythonDistribution(PythonTarget):
             )
 
         payload = payload or Payload()
-        payload.add_fields({"setup_requires": PrimitiveField(maybe_list(setup_requires or ()))})
+        payload.add_fields(
+            {"setup_requires": PrimitiveField(ensure_str_list(setup_requires or ()))}
+        )
         super().__init__(address=address, payload=payload, sources=sources, **kwargs)
 
     @property

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -3,7 +3,6 @@
 
 
 from pex.interpreter import PythonIdentity
-from twitter.common.collections import maybe_list
 
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.base.exceptions import TargetDefinitionException
@@ -12,6 +11,7 @@ from pants.base.payload_field import PrimitiveField
 from pants.build_graph.address import Address
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
+from pants.util.collections import ensure_str_list
 
 
 class PythonTarget(Target):
@@ -49,7 +49,7 @@ class PythonTarget(Target):
             {
                 "sources": self.create_sources_field(sources, address.spec_path, key_arg="sources"),
                 "provides": provides,
-                "compatibility": PrimitiveField(maybe_list(compatibility or ())),
+                "compatibility": PrimitiveField(ensure_str_list(compatibility or ())),
             }
         )
         super().__init__(address=address, payload=payload, **kwargs)

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -1,9 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.python.targets.python_target import PythonTarget
+from pants.util.collections import ensure_str_list
 
 
 class PythonTests(PythonTarget):
@@ -26,7 +25,7 @@ class PythonTests(PythonTarget):
         :param int timeout: A timeout (in seconds) which covers the total runtime of all tests in this
           target. Only applied if `--test-pytest-timeouts` is set to True.
         """
-        self._coverage = maybe_list(coverage) if coverage is not None else []
+        self._coverage = ensure_str_list(coverage) if coverage is not None else []
         self._timeout = timeout
         super().__init__(**kwargs)
 

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -3,13 +3,12 @@
 
 import logging
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.python.targets.import_wheels_mixin import ImportWheelsMixin
 from pants.base.deprecated import deprecated_conditional
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
+from pants.util.collections import ensure_str_list
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +79,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
                 "module_name": PrimitiveField(module_name),
                 "include_patterns": PrimitiveField(include_patterns or ()),
                 "exclude_patterns": PrimitiveField(exclude_patterns or ()),
-                "compatibility": PrimitiveField(maybe_list(compatibility or ())),
+                "compatibility": PrimitiveField(ensure_str_list(compatibility or ())),
                 "within_data_subdir": PrimitiveField(within_data_subdir),
                 # TODO: consider supporting transitive deps like UnpackedJars!
                 # TODO: consider supporting `platforms` as in PythonBinary!

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -180,7 +180,6 @@ python_library(
   name = 'cmd_line_spec_parser',
   sources = ['cmd_line_spec_parser.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':build_file',
     ':specs',
     'src/python/pants/build_graph',

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:setproctitle',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -147,7 +147,6 @@ python_library(
   name='nodes',
   sources=['nodes.py'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:dataclasses',
     ':addressable',
     ':fs',
@@ -216,7 +215,6 @@ python_library(
   name='scheduler',
   sources=['scheduler.py'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:dataclasses',
     ':fs',
     ':isolated_process',

--- a/src/python/pants/ivy/BUILD
+++ b/src/python/pants/ivy/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
@@ -11,6 +10,7 @@ python_library(
     'src/python/pants/net',
     'src/python/pants/process',
     'src/python/pants/subsystem',
+    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -4,12 +4,11 @@
 import os.path
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
 from pants.java import util
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import Executor, SubprocessExecutor
 from pants.process.lock import OwnerPrintingInterProcessFileLock
+from pants.util.collections import ensure_str_list
 from pants.util.dirutil import safe_mkdir
 
 
@@ -32,7 +31,7 @@ class Ivy:
         :param ivy_resolution_cache_dir: path to store downloaded ivy artifacts
         :param extra_jvm_options: list of strings to add to command line when invoking Ivy
         """
-        self._classpath = maybe_list(classpath)
+        self._classpath = ensure_str_list(classpath)
         self._ivy_settings = ivy_settings
         if self._ivy_settings and not isinstance(self._ivy_settings, str):
             raise ValueError(

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -5,8 +5,8 @@ python_library(
   name = 'executor',
   sources = ['executor.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
+    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],
@@ -54,9 +54,9 @@ python_library(
   dependencies = [
     ':executor',
     ':nailgun_client',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/pantsd:process_manager',
+    'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -8,8 +8,7 @@ import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
+from pants.util.collections import ensure_str_list
 from pants.util.contextutil import environment_as
 
 logger = logging.getLogger(__name__)
@@ -23,11 +22,11 @@ class Executor(ABC):
 
     @staticmethod
     def _scrub_args(classpath, main, jvm_options, args):
-        classpath = maybe_list(classpath)
+        classpath = ensure_str_list(classpath)
         if not isinstance(main, str) or not main:
             raise ValueError("A non-empty main classname is required, given: {}".format(main))
-        jvm_options = maybe_list(jvm_options or ())
-        args = maybe_list(args or ())
+        jvm_options = ensure_str_list(jvm_options or ())
+        args = ensure_str_list(args or ())
         return classpath, main, jvm_options, args
 
     class Error(Exception):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -10,12 +10,11 @@ import threading
 import time
 from contextlib import closing
 
-from twitter.common.collections import maybe_list
-
 from pants.base.build_environment import get_buildroot
 from pants.java.executor import Executor, SubprocessExecutor
 from pants.java.nailgun_client import NailgunClient
 from pants.pantsd.process_manager import FingerprintedProcessManager, ProcessGroup
+from pants.util.collections import ensure_str_list
 from pants.util.dirutil import read_file, safe_file_dump, safe_open
 from pants.util.memo import memoized_classproperty
 
@@ -107,7 +106,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
         self._workdir = workdir
         self._ng_stdout = os.path.join(workdir, "stdout")
         self._ng_stderr = os.path.join(workdir, "stderr")
-        self._nailgun_classpath = maybe_list(nailgun_classpath)
+        self._nailgun_classpath = ensure_str_list(nailgun_classpath)
         self._startup_timeout = startup_timeout
         self._connect_timeout = connect_timeout
         self._connect_attempts = connect_attempts

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -10,7 +10,6 @@ python_library(
     '3rdparty/python:setuptools',
     '3rdparty/python:toml',
     '3rdparty/python:typing-extensions',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/testutil/base/BUILD
+++ b/src/python/pants/testutil/base/BUILD
@@ -5,7 +5,6 @@ python_library(
   name = 'context_utils',
   sources = ['context_utils.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:workunit',
     'src/python/pants/build_graph',
     'src/python/pants/goal:context',

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -5,12 +5,11 @@ import logging
 import sys
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
 from pants.base.workunit import WorkUnit
 from pants.build_graph.target import Target
 from pants.goal.context import Context
 from pants.goal.run_tracker import RunTrackerLogger
+from pants.util.collections import ensure_list
 
 
 class TestContext(Context):
@@ -134,7 +133,7 @@ def create_context_from_options(
     Other params are as for ``Context``.
     """
     run_tracker = TestContext.DummyRunTracker()
-    target_roots = maybe_list(target_roots, Target) if target_roots else []
+    target_roots = ensure_list(target_roots, expected_type=Target) if target_roots else []
     return TestContext(
         options=options,
         run_tracker=run_tracker,

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections
-from typing import Callable, DefaultDict, Iterable, MutableMapping, TypeVar
+import collections.abc
+from typing import Any, Callable, DefaultDict, Iterable, List, MutableMapping, Type, TypeVar, Union
 
 _K = TypeVar("_K")
 _V = TypeVar("_V")
@@ -64,3 +65,32 @@ def assert_single_element(iterable: Iterable[_T]) -> _T:
         return first_item
 
     raise ValueError(f"iterable {iterable!r} has more than one element.")
+
+
+def ensure_list(val: Union[Any, Iterable[Any]], *, expected_type: Type[_T]) -> List[_T]:
+    """Given either a single value or an iterable of values, always return a list.
+
+    This performs runtime type checking to ensure that every element of the list is the expected
+    type.
+    """
+    if isinstance(val, expected_type):
+        return [val]
+    if not isinstance(val, collections.abc.Iterable):
+        raise ValueError(
+            f"The value {val} (type {type(val)}) did not have the expected type {expected_type} "
+            "nor was it an iterable."
+        )
+    result: List[_T] = []
+    for i, x in enumerate(val):
+        if not isinstance(x, expected_type):
+            raise ValueError(
+                f"Not all elements of the iterable have type {expected_type}. Encountered the "
+                f"element {x} of type {type(x)} at index {i}."
+            )
+        result.append(x)
+    return result
+
+
+def ensure_str_list(val: Union[str, Iterable[str]]) -> List[str]:
+    """Given either a single string or an iterable of strings, always return a list."""
+    return ensure_list(val, expected_type=str)

--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -5,7 +5,6 @@
 python_tests(
   sources = ['*.py', '!*_integration.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:parameterized',
     'src/python/pants/backend/codegen/wire/java',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -422,7 +422,6 @@ python_tests(
   name = 'jar_task',
   sources = ['test_jar_task.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_task',

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -299,7 +299,6 @@ python_tests(
   name = 'coursier_resolve',
   sources = ['test_coursier_resolve.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -6,13 +6,12 @@ import re
 from contextlib import contextmanager
 from textwrap import dedent
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jar_task import JarBuilderTask, JarTask
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.testutil.jvm.jar_task_test_base import JarTaskTestBase
+from pants.util.collections import ensure_str_list
 from pants.util.contextutil import open_zip, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 
@@ -173,7 +172,7 @@ class JarTaskTest(BaseJarTaskTest):
                     + "Class-Path: {}\r\n"
                     + "Created-By: org.pantsbuild.tools.jar.JarBuilder\r\n\r\n"
                 )
-                .format(" ".join(maybe_list(classpath)))
+                .format(" ".join(ensure_str_list(classpath)))
                 .encode()
             )
 

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -77,7 +77,6 @@ python_tests(
   name = 'export_integration',
   sources = ['test_export_integration.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/scala/org/pantsbuild/example:scala_with_java_sources_directory',
     'examples/tests/java/org/pantsbuild/example:usethrift_directory',
@@ -85,6 +84,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/ivy',
     'src/python/pants/java/distribution',
+    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:int-test',

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -5,11 +5,10 @@ import json
 import os
 import re
 
-from twitter.common.collections import maybe_list
-
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.intermediate_target_factory import hash_target
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest, ensure_resolver
+from pants.util.collections import ensure_str_list
 from pants_test.backend.project_info.tasks.resolve_jars_test_mixin import ResolveJarsTestMixin
 
 
@@ -34,7 +33,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         :rtype: dict
         """
         export_out_file = os.path.join(workdir, "export_out.txt")
-        args = ["export", f"--output-file={export_out_file}"] + maybe_list(test_target)
+        args = ["export", f"--output-file={export_out_file}", *ensure_str_list(test_target)]
         libs_args = ["--no-export-libraries"] if not load_libs else self._confs_args
         if load_libs and only_default:
             libs_args = []

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -39,7 +39,6 @@ python_tests(
   name = 'cmd_line_spec_parser',
   sources = ['test_cmd_line_spec_parser.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -155,7 +155,6 @@ python_tests(
   sources=['test_rules.py'],
   coverage=['pants.engine.rules'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':scheduler_test_base',
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:console',

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -4,9 +4,9 @@
 python_tests(
   sources = ['test_distribution.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:revision',
     'src/python/pants/java/distribution',
+    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/subsystem',
@@ -19,7 +19,6 @@ python_tests(
   name = 'distribution_integration',
   sources = ['test_distribution_integration.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/java/distribution',
     'src/python/pants/util:osutil',
     'src/python/pants/testutil:int-test',

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -7,8 +7,6 @@ import textwrap
 import unittest
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
 from pants.base.revision import Revision
 from pants.java.distribution.distribution import (
     Distribution,
@@ -20,6 +18,7 @@ from pants.java.distribution.distribution import (
     _UnknownEnvironment,
 )
 from pants.testutil.subsystem.util import global_subsystem_instance
+from pants.util.collections import ensure_list, ensure_str_list
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_open, touch
 
@@ -53,9 +52,9 @@ class EXE:
 @contextmanager
 def distribution(files=None, executables=None, java_home=None):
     with temporary_dir() as dist_root:
-        for f in maybe_list(files or ()):
+        for f in ensure_str_list(files or ()):
             touch(os.path.join(dist_root, f))
-        for executable in maybe_list(executables or (), expected_type=EXE):
+        for executable in ensure_list(executables or (), expected_type=EXE):
             path = os.path.join(dist_root, executable.relpath)
             with safe_open(path, "w") as fp:
                 java_home = os.path.join(dist_root, java_home) if java_home else dist_root


### PR DESCRIPTION
### Problem

`maybe_list` allows you to pass either a single value or an iterable and always get back a list, e.g. `maybe_list("hello")` returns `["hello"]`. It will also do a runtime type check on each element.

We need to start using this functionality in V2 to fix how we handle Python interpreter constraints, but `maybe_list` has some issues:

1. Twitter Commons is now archived.
2. `maybe_list` does not work with type hints.
3. `maybe_list` is more complex than we want, such as parametrizing what type of exception to raise. We never actually used this.
4. `maybe_list` is not as clear as it could be. 
   * It defaults to expecting `str`, which is not obvious from its name. 
   * The parameter `expected_type` can be passed as a positional arg, which is confusing. It should always be a kwarg.
   * The name `maybe_list` is ambiguous in what `maybe` means. Is the parameter `maybe` or is the return type `maybe`?

### Solution

Add `pants.util.collections.ensure_list()`. The functionality is the same, but the API is more explicit and this works with type hints. 

We also add `ensure_str_list()` as an alias for `ensure_list(val, expected_type=str)` because 95% of our uses of `maybe_list` expect a `str`.

### Result

We can completely remove `twitter.common.collections` from our codebase.