### PR TITLE
Fix V2 handling of `compatibility` when it's a string rather than list

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -41,14 +41,15 @@ class BanditIntegrationTest(TestBase):
         origin: Optional[OriginSpec] = None,
     ) -> PythonTargetAdaptorWithOrigin:
         input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-        adaptor = PythonTargetAdaptor(
+        adaptor_kwargs = dict(
             sources=EagerFilesetWithSpec("test", {"globs": []}, snapshot=input_snapshot),
             address=Address.parse("test:target"),
-            compatibility=[interpreter_constraints] if interpreter_constraints else None,
         )
+        if interpreter_constraints:
+            adaptor_kwargs["compatibility"] = interpreter_constraints
         if origin is None:
             origin = SingleAddress(directory="test", name="target")
-        return PythonTargetAdaptorWithOrigin(adaptor, origin)
+        return PythonTargetAdaptorWithOrigin(PythonTargetAdaptor(**adaptor_kwargs), origin)
 
     def run_bandit(
         self,

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -42,14 +42,15 @@ class Flake8IntegrationTest(TestBase):
         origin: Optional[OriginSpec] = None,
     ) -> PythonTargetAdaptorWithOrigin:
         input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-        adaptor = PythonTargetAdaptor(
+        adaptor_kwargs = dict(
             sources=EagerFilesetWithSpec("test", {"globs": []}, snapshot=input_snapshot),
             address=Address.parse("test:target"),
-            compatibility=[interpreter_constraints] if interpreter_constraints else None,
         )
+        if interpreter_constraints:
+            adaptor_kwargs["compatibility"] = interpreter_constraints
         if origin is None:
             origin = SingleAddress(directory="test", name="target")
-        return PythonTargetAdaptorWithOrigin(adaptor, origin)
+        return PythonTargetAdaptorWithOrigin(PythonTargetAdaptor(**adaptor_kwargs), origin)
 
     def run_flake8(
         self,

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -55,15 +55,16 @@ class PylintIntegrationTest(TestBase):
         dependencies: Optional[List[Address]] = None,
     ) -> PythonTargetAdaptorWithOrigin:
         input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-        adaptor = PythonTargetAdaptor(
+        adaptor_kwargs = dict(
             sources=EagerFilesetWithSpec(self.source_root, {"globs": []}, snapshot=input_snapshot),
             address=Address.parse(f"{self.source_root}:target"),
-            compatibility=[interpreter_constraints] if interpreter_constraints else None,
             dependencies=dependencies or [],
         )
+        if interpreter_constraints:
+            adaptor_kwargs["compatibility"] = interpreter_constraints
         if origin is None:
             origin = SingleAddress(directory=self.source_root, name="target")
-        return PythonTargetAdaptorWithOrigin(adaptor, origin)
+        return PythonTargetAdaptorWithOrigin(PythonTargetAdaptor(**adaptor_kwargs), origin)
 
     def run_pylint(
         self,

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -1,8 +1,10 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Tuple
+from typing import DefaultDict, Iterable, List, Optional, Tuple
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex
@@ -72,15 +74,21 @@ class PexInterpreterConstraints:
     def create_from_adaptors(
         cls, adaptors: Iterable[TargetAdaptor], python_setup: PythonSetup
     ) -> "PexInterpreterConstraints":
-        constraints = {
-            constraint
-            for target_adaptor in adaptors
-            for constraint in python_setup.compatibility_or_constraints(
-                target_adaptor.compatibility
-            )
-            if isinstance(target_adaptor, PythonTargetAdaptor)
-        }
-        return PexInterpreterConstraints(constraints)
+        constraints_to_adaptors: DefaultDict[
+            Tuple[str, ...], List[PythonTargetAdaptor]
+        ] = defaultdict(list)
+        for adaptor in adaptors:
+            if not isinstance(adaptor, PythonTargetAdaptor):
+                continue
+            constraints = python_setup.compatibility_or_constraints(adaptor.compatibility)
+            constraints_to_adaptors[constraints].append(adaptor)
+        # TODO(Pex#914): AND between distinct targets, but OR within targets. Right now, we flatten
+        # every constraint and OR everything. When doing this, use static analysis to produce the
+        # minimum constraints, e.g. simplify `CPython==3.6 AND (CPython==3.6 OR CPython==3.7)`
+        # to `CPython==3.6`.
+        return PexInterpreterConstraints(
+            itertools.chain.from_iterable(constraints_to_adaptors.keys())
+        )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -76,7 +76,7 @@ class PexInterpreterConstraints:
             constraint
             for target_adaptor in adaptors
             for constraint in python_setup.compatibility_or_constraints(
-                getattr(target_adaptor, "compatibility", None)
+                target_adaptor.compatibility
             )
             if isinstance(target_adaptor, PythonTargetAdaptor)
         }

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -295,8 +295,9 @@ async def run_setup_pys(
 
     py2 = is_python2(
         (
-            getattr(target_with_origin.target.adaptor, "compatibility", None)
+            target_with_origin.target.adaptor.compatibility
             for target_with_origin in targets_with_origins
+            if isinstance(target_with_origin.target.adaptor, PythonTargetAdaptor)
         ),
         python_setup,
     )

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -17,6 +17,7 @@ from pants.engine.objects import Locatable, union
 from pants.engine.rules import UnionRule
 from pants.engine.struct import Struct, StructWithDeps
 from pants.source import wrapped_globs
+from pants.util.collections import ensure_str_list
 from pants.util.contextutil import exception_logging
 from pants.util.meta import classproperty
 from pants.util.objects import Exactly
@@ -309,6 +310,13 @@ class PythonTargetAdaptor(TargetAdaptor):
                 lambda _: None,
             )
             return (*field_adaptors, sources_field)
+
+    # TODO(#4535): remove this once its superseded by the target API.
+    @property
+    def compatibility(self) -> Optional[List[str]]:
+        if "compatibility" not in self._kwargs:
+            return None
+        return ensure_str_list(self._kwargs["compatibility"])
 
 
 class PythonBinaryAdaptor(PythonTargetAdaptor):


### PR DESCRIPTION
### Problem

We allow `compatibility` to be either a list of strings (ORed) or a single value.

```python
# This works
python_library(
  name="lib",
  compatibility=['CPython==3.7.*']
)

# This should work too, but doesn't
python_library(
  name="lib",
  compatibility='CPython==3.7.*'
)
```

In V2, we assumed it was always a list so a single string value would cause Pants to fail to find an interpreter.

### Solution

Add a typed property `compatibility` to `PythonTargetAdaptor` (and thus its subclasses). In the property, use `ensure_str_list` to handle both single strings and lists of strings.

This design will almost certainly change with the Target API, but it provides a light-weight way to get the functionality we need without committing to any bigger design.

### Result

Interpreter constraints still don't work properly in V2 (https://github.com/pantsbuild/pants/issues/9210), but one of the 3 issues is now resolved.