### PR TITLE
Deprecate `--build-file-imports` and remove its deprecated value `allow`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -89,8 +89,6 @@ pants_ignore.add = [
   "/build-support/bin/native/src",
 ]
 
-build_file_imports = "error"
-
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.
 # It is explicitly re-enabled below for [cache.bootstrap] only.

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -168,10 +168,7 @@ class LegacyPythonCallbacksParser(Parser):
         # Note that this is incredibly poor sandboxing. There are many ways to get around it.
         # But it's sufficient to tell most users who aren't being actively malicious that they're doing
         # something wrong, and it has a low performance overhead.
-        if "globs" in python or (
-            self._build_file_imports_behavior != BuildFileImportsBehavior.allow
-            and "import" in python
-        ):
+        if "globs" in python or "import" in python:
             io_wrapped_python = StringIO(python)
             for token in tokenize.generate_tokens(io_wrapped_python.readline):
                 token_str = token[1]
@@ -180,9 +177,7 @@ class LegacyPythonCallbacksParser(Parser):
                 self.check_for_deprecated_globs_usage(token_str, filepath, lineno)
 
                 if token_str == "import":
-                    if self._build_file_imports_behavior == BuildFileImportsBehavior.allow:
-                        continue
-                    elif self._build_file_imports_behavior == BuildFileImportsBehavior.warn:
+                    if self._build_file_imports_behavior == BuildFileImportsBehavior.warn:
                         logger.warning(
                             f"Import used in {filepath} at line {lineno}. Import statements should "
                             f"be avoided in BUILD files because they can easily break Pants caching and lead to "

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -14,7 +14,6 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
 from pants.binaries.binary_tool import rules as binary_tool_rules
@@ -316,38 +315,6 @@ class EngineInitializer:
             if files_not_found_behavior_configured
             else bootstrap_options.glob_expansion_failure
         )
-
-        deprecated_conditional(
-            lambda: cast(
-                bool, bootstrap_options.build_file_imports == BuildFileImportsBehavior.allow
-            ),
-            removal_version="1.27.0.dev0",
-            entity_description="Using `--build-file-imports=allow`",
-            hint_message=(
-                "Import statements should be avoided in BUILD files because they can easily break Pants "
-                "caching and lead to stale results. It is not safe to ignore warnings of imports, so the "
-                "`allow` option is being removed.\n\nTo prepare for this change, either set "
-                "`--build-file-imports=warn` or `--build-file-imports=error` (we recommend using `error`)."
-                "\n\nIf you still need to keep the functionality you have from the import statement, "
-                "consider rewriting your code into a Pants plugin: "
-                "https://www.pantsbuild.org/howto_plugin.html"
-            ),
-        )
-        deprecated_conditional(
-            lambda: bootstrap_options.is_default("build_file_imports"),
-            removal_version="1.27.0.dev0",
-            entity_description="Defaulting to `--build-file-imports=warn`",
-            hint_message=(
-                "Import statements should be avoided in BUILD files because they can easily break Pants "
-                "caching and lead to stale results. The default behavior will change from warning to "
-                "erroring in 1.27.0.dev0, and the option will be removed in 1.29.0.dev0.\n\nTo prepare for "
-                "this change, please explicitly set the option `--build-file-imports=warn` or "
-                "`--build-file-imports=error` (we recommend using `error`).\n\nIf you still need to keep "
-                "the functionality you have from import statements, consider rewriting your code into a "
-                "Pants plugin: https://www.pantsbuild.org/howto_plugin.html"
-            ),
-        )
-
         return EngineInitializer.setup_legacy_graph_extended(
             OptionsInitializer.compute_pants_ignore(build_root, bootstrap_options),
             bootstrap_options.local_store_dir,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -66,7 +66,6 @@ class OwnersNotFoundBehavior(Enum):
 
 
 class BuildFileImportsBehavior(Enum):
-    allow = "allow"
     warn = "warn"
     error = "error"
 
@@ -735,8 +734,15 @@ class GlobalOptions(Subsystem):
         register(
             "--build-file-imports",
             type=BuildFileImportsBehavior,
-            default=BuildFileImportsBehavior.warn,
+            default=BuildFileImportsBehavior.error,
             advanced=True,
+            removal_version="1.29.0.dev0",
+            removal_hint=(
+                "Import statements should be avoided in BUILD files because they can easily break "
+                "Pants caching and lead to stale results. If you still need to keep the "
+                "functionality you have from import statements, consider rewriting your code into "
+                "a Pants plugin: https://www.pantsbuild.org/howto_plugin.html."
+            ),
             help="Whether to allow import statements in BUILD files",
         )
 

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -51,15 +51,3 @@ class BuildGraphIntegrationTest(PantsRunIntegrationTest):
             self.assert_success(pants_run)
             assert "Hello\n" in pants_run.stdout_data
             assert f"Import used in {dir}/BUILD at line" in pants_run.stderr_data
-
-    def test_allowed_module_import(self):
-        self.allowed_import("testprojects/src/python/build_file_imports_module")
-
-    def test_allowed_function_import(self):
-        self.allowed_import("testprojects/src/python/build_file_imports_function")
-
-    def allowed_import(self, dir):
-        with self.file_renamed(dir, "TEST_BUILD", "BUILD"):
-            pants_run = self.run_pants(["--build-file-imports=allow", "run", f"{dir}:hello",])
-        self.assert_success(pants_run)
-        self.assertIn("Hello\n", pants_run.stdout_data)


### PR DESCRIPTION
Build file imports are not safe to allow. As previously planned, in this PR we take the final step to deprecate any support for build file imports.