### PR TITLE
Stop defaulting to `--transitive` and remove the option when it no-ops

### DIFF
--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/test_python_eval.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/test_python_eval.py
@@ -164,7 +164,7 @@ class PythonEvalTest(PythonTaskTestBase):
         self.assertEqual([self.c_library], compiled)
 
     def test_compile_fail_missing_build_dep(self):
-        python_eval = self._create_task(target_roots=[self.b_library, self.a_library])
+        python_eval = self._create_task(target_roots=[self.b_library])
 
         with self.assertRaises(python_eval.Error) as e:
             python_eval.execute()

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -14,6 +14,8 @@ from pants.util.contextutil import temporary_dir
 class CountLinesOfCode(ConsoleTask):
     """Print counts of lines of code."""
 
+    _register_console_transitivity_option = False
+
     @classmethod
     def subsystem_dependencies(cls):
         return super().subsystem_dependencies() + (ClocBinary,)
@@ -26,6 +28,19 @@ class CountLinesOfCode(ConsoleTask):
             type=bool,
             fingerprint=True,
             help="Show information about files ignored by cloc.",
+        )
+        register(
+            "--transitive",
+            type=bool,
+            default=False,
+            fingerprint=True,
+            removal_version="1.29.0.dev0",
+            removal_hint=(
+                "This feature is going away. Instead of relying on the `--transitive` flag, "
+                "directly specify on the command line every target that you want to format or "
+                "lint.",
+            ),
+            help="If True, use all targets in the build graph, else use only target roots.",
         )
 
     def console_output(self, targets):

--- a/src/python/pants/backend/graph_info/tasks/filemap.py
+++ b/src/python/pants/backend/graph_info/tasks/filemap.py
@@ -9,19 +9,6 @@ class Filemap(ConsoleTask):
 
     _register_console_transitivity_option = False
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `filemap`.",
-        )
-
     def console_output(self, _):
         visited = set()
         for target in self.determine_target_roots("filemap"):

--- a/src/python/pants/backend/graph_info/tasks/filter.py
+++ b/src/python/pants/backend/graph_info/tasks/filter.py
@@ -56,15 +56,6 @@ class Filter(TargetFilterTaskMixin, ConsoleTask):
             metavar="[+-]regex1,regex2,...",
             help="Filter on targets with tags matching these regexes.",
         )
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `filter`.",
-        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/graph_info/tasks/minimal_cover.py
+++ b/src/python/pants/backend/graph_info/tasks/minimal_cover.py
@@ -14,19 +14,6 @@ class MinimalCover(ConsoleTask):
 
     _register_console_transitivity_option = False
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `minimize`.",
-        )
-
     def console_output(self, _):
         internal_deps = self._collect_internal_deps(self.context.target_roots)
 

--- a/src/python/pants/backend/graph_info/tasks/paths.py
+++ b/src/python/pants/backend/graph_info/tasks/paths.py
@@ -54,19 +54,6 @@ class PathFinder(ConsoleTask):
 
     _register_console_transitivity_option = False
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goals `path` and `paths`.",
-        )
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.log = self.context.log

--- a/src/python/pants/backend/graph_info/tasks/sort_targets.py
+++ b/src/python/pants/backend/graph_info/tasks/sort_targets.py
@@ -14,15 +14,6 @@ class SortTargets(ConsoleTask):
     def register_options(cls, register):
         super().register_options(register)
         register("--reverse", type=bool, help="Sort least-dependent to most-dependent.")
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `sort`.",
-        )
 
     def console_output(self, targets):
         sorted_targets = sort_targets(targets)

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -15,6 +15,10 @@ from pants.util.ordered_set import OrderedSet
 class Dependencies(ConsoleTask):
     """Print the target's dependencies."""
 
+    # TODO: In 1.28.0.dev0, once we default to `--no-transitive`, remove this and go back to using
+    # ConsoleTask's implementation of `--transitive`.
+    _register_console_transitivity_option = False
+
     @staticmethod
     def _is_jvm(target):
         return isinstance(target, (JarLibrary, JvmTarget, JvmApp))
@@ -44,6 +48,13 @@ class Dependencies(ConsoleTask):
             "(only external jars).",
             removal_version="1.27.0.dev0",
             removal_hint="Use `--dependencies-type=3rdparty` instead.",
+        )
+        register(
+            "--transitive",
+            type=bool,
+            default=True,
+            fingerprint=True,
+            help="If True, use all targets in the build graph, else use only target roots.",
         )
 
     def __init__(self, *args, **kwargs):

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -65,15 +65,6 @@ class Depmap(ConsoleTask):
             help="Specifies the separator to use between the org/name/rev components of a "
             "dependency's fully qualified name.",
         )
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `depmap`.",
-        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -472,24 +472,9 @@ class Export(ExportTask, ConsoleTask):  # type: ignore[misc]
 
     _register_console_transitivity_option = False
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="`export` should always act transitively, which is the default. This option "
-            "will be going away to ensure that Pants always does the right thing.",
-        )
-
     @property
     def act_transitively(self):
-        # NB: `export` should always act transitively
-        return self.get_options().transitive
+        return True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -67,22 +67,10 @@ class ExportDepAsJar(ConsoleTask):
             type=bool,
             help="Causes 3rdparty libraries with javadocs to be output.",
         )
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="`export-dep-as-jar` should always act transitively, which is the default. "
-            "This option will be going away to ensure that Pants always does the right "
-            "thing.",
-        )
 
     @property
     def act_transitively(self):
-        # NB: `export-dep-as-jar` should always act transitively
-        return self.get_options().transitive
+        return True
 
     @classmethod
     def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -17,6 +17,10 @@ class FileDeps(ConsoleTask):
     transitive closure of targets are also included.
     """
 
+    # TODO: In 1.28.0.dev0, once we default to `--no-transitive`, remove this and go back to using
+    # ConsoleTask's implementation of `--transitive`.
+    _register_console_transitivity_option = False
+
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -30,6 +34,13 @@ class FileDeps(ConsoleTask):
             type=bool,
             default=True,
             help="If True output with absolute path, else output with path relative to the build root",
+        )
+        register(
+            "--transitive",
+            type=bool,
+            default=True,
+            fingerprint=True,
+            help="If True, use all targets in the build graph, else use only target roots.",
         )
 
     @property

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -108,16 +108,6 @@ class IdeaPluginGen(ConsoleTask):
             help="Sets the java language and jdk used to compile the project's java sources.",
         )
         register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="`idea-plugin` should always act transitively, which is the default. This option "
-            "will be going away to ensure that Pants always does the right thing.",
-        )
-        register(
             "--possible-paths",
             type=list,
             default=["/Applications/IntelliJ IDEA CE.app", "/Applications/IntelliJ IDEA.app"],
@@ -126,8 +116,7 @@ class IdeaPluginGen(ConsoleTask):
 
     @property
     def act_transitively(self):
-        # NB: `idea-plugin` should always act transitively
-        return self.get_options().transitive
+        return True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python/pants/core_tasks/bash_completion.py
+++ b/src/python/pants/core_tasks/bash_completion.py
@@ -20,19 +20,6 @@ class BashCompletion(ConsoleTask):
 
     _register_console_transitivity_option = False
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `bash-completion`.",
-        )
-
     @staticmethod
     def _get_all_cmd_line_scopes():
         """Return all scopes that may be explicitly specified on the cmd line, in no particular

--- a/src/python/pants/core_tasks/explain_options_task.py
+++ b/src/python/pants/core_tasks/explain_options_task.py
@@ -51,15 +51,6 @@ class ExplainOptionsTask(ConsoleTask):
             default="text",
             help="Specify the format options will be printed.",
         )
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            help="If True, use all targets in the build graph, else use only target roots.",
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `options`.",
-        )
 
     def _scope_filter(self, scope):
         pattern = self.get_options().scope

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -35,14 +35,6 @@ class Login(ConsoleTask):
             "could here use the option `--login-to=prod` to login at "
             "`https://app.pantsbuild.org/auth`.",
         )
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `login`.",
-        )
 
     def console_output(self, targets):
         if targets:

--- a/src/python/pants/core_tasks/targets_help.py
+++ b/src/python/pants/core_tasks/targets_help.py
@@ -17,14 +17,6 @@ class TargetsHelp(ConsoleTask):
     def register_options(cls, register):
         super().register_options(register)
         register("--details", help="Show details about this target type.")
-        register(
-            "--transitive",
-            type=bool,
-            default=True,
-            fingerprint=True,
-            removal_version="1.27.0.dev0",
-            removal_hint="This option has no impact on the goal `targets`.",
-        )
 
     def console_output(self, targets):
         buildfile_aliases = self.context.build_configuration.registered_aliases()

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -5,7 +5,6 @@ import errno
 import os
 from contextlib import contextmanager
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.task.task import QuietTaskMixin, Task
 from pants.util.dirutil import safe_open
@@ -37,27 +36,13 @@ class ConsoleTask(QuietTaskMixin, Task):
             register(
                 "--transitive",
                 type=bool,
-                default=True,
+                default=False,
                 fingerprint=True,
                 help="If True, use all targets in the build graph, else use only target roots.",
             )
 
     @property
     def act_transitively(self):
-        if self._register_console_transitivity_option:
-            deprecated_conditional(
-                lambda: self.get_options().is_default("transitive"),
-                entity_description=f"Pants defaulting to `--transitive` for `{self.options_scope}`",
-                removal_version="1.27.0.dev0",
-                hint_message="Currently, Pants defaults to `--transitive`, which means that it "
-                "will run against transitive dependencies for the targets you specify on the "
-                "command line, rather than only the targets you specify. This is often useful, "
-                "such as running `./pants dependencies --transitive`, but it is surprising "
-                "to have this behavior by default.\n\nTo prepare for this change to the default "
-                f"value, set in `pants.toml` under the section `{self.options_scope}` the value "
-                "`transitive = false`. In Pants 1.27.0, you can safely remove the setting.",
-            )
-            return self.get_options().transitive
         # `Task` defaults to returning `True` in `act_transitively`, so we keep that default value.
         return self.get_options().get("transitive", True)
 

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -3,7 +3,7 @@
 
 from pants.task.target_restriction_mixins import (
     DeprecatedSkipGoalOptionsRegistrar,
-    HasSkipOptionMixin,
+    HasSkipGoalOptionMixin,
 )
 
 
@@ -22,7 +22,7 @@ class FmtGoalRegistrar(DeprecatedSkipGoalOptionsRegistrar):
         )
 
 
-class FmtTaskMixin(HasSkipOptionMixin):
+class FmtTaskMixin(HasSkipGoalOptionMixin):
     """A mixin to combine with code formatting tasks."""
 
     goal_options_registrar_cls = FmtGoalRegistrar

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.task.target_restriction_mixins import (
-    DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar,
-    HasSkipAndTransitiveGoalOptionsMixin,
+    DeprecatedSkipGoalOptionsRegistrar,
+    HasSkipOptionMixin,
 )
 
 
-class FmtGoalRegistrar(DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar):
+class FmtGoalRegistrar(DeprecatedSkipGoalOptionsRegistrar):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -22,8 +22,12 @@ class FmtGoalRegistrar(DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
         )
 
 
-class FmtTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
+class FmtTaskMixin(HasSkipOptionMixin):
     """A mixin to combine with code formatting tasks."""
 
     goal_options_registrar_cls = FmtGoalRegistrar
     target_filtering_enabled = True
+
+    @property
+    def act_transitively(self):
+        return False

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -3,11 +3,11 @@
 
 from pants.task.target_restriction_mixins import (
     DeprecatedSkipGoalOptionsRegistrar,
-    HasSkipOptionMixin,
+    HasSkipGoalOptionMixin,
 )
 
 
-class LintTaskMixin(HasSkipOptionMixin):
+class LintTaskMixin(HasSkipGoalOptionMixin):
     """A mixin to combine with lint tasks."""
 
     goal_options_registrar_cls = DeprecatedSkipGoalOptionsRegistrar

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -2,13 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.task.target_restriction_mixins import (
-    DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar,
-    HasSkipAndTransitiveGoalOptionsMixin,
+    DeprecatedSkipGoalOptionsRegistrar,
+    HasSkipOptionMixin,
 )
 
 
-class LintTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
+class LintTaskMixin(HasSkipOptionMixin):
     """A mixin to combine with lint tasks."""
 
-    goal_options_registrar_cls = DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar
+    goal_options_registrar_cls = DeprecatedSkipGoalOptionsRegistrar
     target_filtering_enabled = True
+
+    @property
+    def act_transitively(self):
+        return False

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -118,6 +118,10 @@ class SkipOptionRegistrar:
         )
 
 
+class HasSkipGoalOptionMixin(GoalOptionsMixin, HasSkipOptionMixin):
+    """A mixin for tasks that have a --skip option registered at the goal level."""
+
+
 class HasSkipAndTransitiveOptionsMixin(HasSkipOptionMixin, HasTransitiveOptionMixin):
     """A mixin for tasks that have a --transitive and a --skip option."""
 

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -137,23 +137,10 @@ class SkipAndTransitiveGoalOptionsRegistrar(
     """Registrar of --skip and --transitive at the goal level."""
 
 
-class DeprecatedSkipAndDeprecatedTransitiveGoalOptionsRegistrar(GoalOptionsRegistrar):
+class DeprecatedSkipGoalOptionsRegistrar(GoalOptionsRegistrar):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
-        register(
-            "--transitive",
-            type=bool,
-            default=False,
-            fingerprint=True,
-            recursive=True,
-            removal_version="1.27.0.dev0",
-            removal_hint="This feature is going away. Instead of relying on the `--transitive` flag, "
-            "directly specify on the command line every target that you want to format or "
-            "lint.",
-            help="If false, act only on the targets directly specified on the command line. "
-            "If true, act on the transitive dependency closure of those targets.",
-        )
         deprecated_skip_mapping = {
             "lint-checkstyle": "checkstyle",
             "fmt-javascriptstyle": "eslint",

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -78,7 +78,6 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
             "fmt.scalafix": {
                 "rules": "scala:rsc.rules.RscCompat",
                 "semantic": True,
-                "transitive": True,
                 "scalafix_tool_classpath": f"{TEST_DIR}/rsc_compat:rsc-compat",
             },
         }

--- a/tests/python/pants_test/task/test_console_task.py
+++ b/tests/python/pants_test/task/test_console_task.py
@@ -39,12 +39,13 @@ class ConsoleTaskTest(TaskTestBase):
         b = self.make_target("src:b", dependencies=[a])
 
         s = BytesIO()
+        self.set_options_for_scope("print-targets", transitive=True)
         task_transitive = self.PrintTargets(
             self.context(for_task_types=[self.PrintTargets], console_outstream=s, target_roots=[b]),
             self.test_workdir,
         )
         task_transitive.execute()
-        self.assertEqual(s.getvalue().decode("utf-8"), "src:b\nsrc:a\n")
+        self.assertEqual(s.getvalue().decode(), "src:b\nsrc:a\n")
 
         s = BytesIO()
         self.set_options_for_scope("print-targets", transitive=False)
@@ -53,7 +54,7 @@ class ConsoleTaskTest(TaskTestBase):
             self.test_workdir,
         )
         task_intransitive.execute()
-        self.assertEqual(s.getvalue().decode("utf-8"), "src:b\n")
+        self.assertEqual(s.getvalue().decode(), "src:b\n")
 
     def test_sigpipe(self):
         r, w = os.pipe()


### PR DESCRIPTION
Follows up on https://github.com/pantsbuild/pants/pull/8955. This removes the `--transitive` flag for options where it was ignored or where we should always act transitively. This also changes the default for console tasks to `--no-transitive` (except for `filedeps` and `dependencies`, which have a slower deprecation cycle).

This also adds a new deprecation for `--cloc-transitive`, which is the last blocker to replacing V1 `cloc` with the V2 implementation.