### PR TITLE
Update version of cargo-ensure-prefix to fix error while installing

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -4,7 +4,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cargo="${REPO_ROOT}/build-support/bin/native/cargo"
 
-"${cargo}" ensure-installed --package cargo-ensure-prefix --version 0.1.3
+"${cargo}" ensure-installed --package cargo-ensure-prefix --version 0.1.5
 
 if ! out="$("${cargo}" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \


### PR DESCRIPTION
### Problem

We are getting CI failures such as this one: https://travis-ci.com/pantsbuild/pants/jobs/294858778

This is the relevant part of the log
```
error[E0433]: failed to resolve: could not find `__rt` in `quote`
   --> /home/travis/.cache/pants/rust/cargo/registry/src/github.com-1ecc6299db9ec823/failure_derive-0.1.6/src/lib.rs:107:70
    |
107 | fn display_body(s: &synstructure::Structure) -> Result<Option<quote::__rt::TokenStream>, Error> {
    |                                                                      ^^^^ could not find `__rt` in `quote`
error: aborting due to previous error
For more information about this error, try `rustc --explain E0433`.
error: could not compile `failure_derive`.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-ensure-prefix v0.1.3`, intermediate artifacts can be found at `/tmp/cargo-installsLc2vk`
```

As explained here: https://users.rust-lang.org/t/failure-derive-compilation-error/39062,
The quick workaround is to add:
quote = "=1.0.2"
to Cargo.toml dependencies (anywhere in the project, Cargo will figure it out).
The problem is caused by an incompatibility between failure_derive (which used a private-ish name) and quote 1.0.3 (which renamed it).

### Solution

For this reason, we need to get the version of cargo_ensure_prefix which contains this change: 
https://github.com/illicitonion/cargo-ensure-prefix/pull/1

### Result

CI should go green again (or be closer to green: this problem could manifest itself somewhere else too, in which case we will need to do something similar to address that)