### PR TITLE
Remove `--test-fast` to always have better test caching

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -63,22 +63,12 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
         }
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
-
-            def iter_partitions():
-                for test_target in test_targets:
-                    partition = (test_target,)
-                    args = (self._generate_args_for_targets([test_target]),)
-                    yield partition, args
-
-        else:
-
-            def iter_partitions():
-                if test_targets:
-                    partition = tuple(test_targets)
-                    args = (self._generate_args_for_targets(test_targets),)
-                    yield partition, args
+    def partitions(self, all_targets, test_targets):
+        def iter_partitions():
+            for test_target in test_targets:
+                partition = (test_target,)
+                args = (self._generate_args_for_targets([test_target]),)
+                yield partition, args
 
         yield iter_partitions
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -44,8 +44,8 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
         self.assertIn("=== RUN   TestAdd", pants_run.stdout_data)
         self.assertIn("PASS", pants_run.stdout_data)
 
-    def test_no_fast(self):
-        args = ["test.go", "--no-fast", "contrib/go/examples/src/go/libA"]
+    def test_partitioned_per_target(self):
+        args = ["test.go", "contrib/go/examples/src/go/libA"]
         pants_run = self.run_pants(args)
         self.assert_success(pants_run)
         # libA depends on libB, so both tests should be run.

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -571,28 +571,19 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         return list(files_iter())
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
+    def partitions(self, all_targets, test_targets):
         complete_test_registry = self._collect_test_targets(test_targets)
-        with self._isolation(per_target, all_targets) as (output_dir, reports, coverage):
-            if per_target:
+        with self._isolation(all_targets) as (output_dir, reports, coverage):
 
-                def iter_partitions():
-                    for test_target in test_targets:
-                        partition = (test_target,)
-                        args = (
-                            os.path.join(output_dir, test_target.id),
-                            coverage,
-                            complete_test_registry,
-                        )
-                        yield partition, args
-
-            else:
-
-                def iter_partitions():
-                    if test_targets:
-                        partition = tuple(test_targets)
-                        args = (output_dir, coverage, complete_test_registry)
-                        yield partition, args
+            def iter_partitions():
+                for test_target in test_targets:
+                    partition = (test_target,)
+                    args = (
+                        os.path.join(output_dir, test_target.id),
+                        coverage,
+                        complete_test_registry,
+                    )
+                    yield partition, args
 
             try:
                 yield iter_partitions
@@ -620,9 +611,9 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                     raise TaskError(e)
 
     @contextmanager
-    def _isolation(self, per_target, all_targets):
+    def _isolation(self, all_targets):
         run_dir = "_runs"
-        mode_dir = "isolated" if per_target else "combined"
+        mode_dir = "isolated"
         batch_dir = str(self._batch_size) if self._batched else "all"
         output_dir = os.path.join(
             self.workdir, run_dir, Target.identify(all_targets), mode_dir, batch_dir

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -605,17 +605,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         return relsrc_to_target.get(relsrc)
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
-
-            def iter_partitions():
-                for test_target in test_targets:
-                    yield (test_target,)
-
-        else:
-
-            def iter_partitions():
-                yield tuple(test_targets)
+    def partitions(self, all_targets, test_targets):
+        def iter_partitions():
+            for test_target in test_targets:
+                yield (test_target,)
 
         workdir = self.workdir
 

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -407,10 +407,9 @@ class TestRunnerTaskMixin:
 
 
 class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
-    """A mixin for test tasks that support running tests over both individual targets and batches.
+    """A mixin for test tasks that support running tests over individual targets.
 
-    Provides support for partitioning via `--fast` (batches) and `--no-fast` (per target) options and
-    helps ensure correct caching behavior in either mode.
+    This will partition tests per target and will help to ensure correct caching.
 
     It's expected that mixees implement proper chrooting (see `run_tests_in_chroot`) to support
     correct successful test result caching.
@@ -423,22 +422,6 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         # TODO(John Sirois): Implement sanity checks on options wrt caching:
         # https://github.com/pantsbuild/pants/issues/5073
 
-        register(
-            "--fast",
-            type=bool,
-            default=False,
-            fingerprint=True,
-            removal_version="1.27.0.dev0",
-            removal_hint="This option is going away for better isolation of tests and in "
-            "preparation for switching to the V2 test implementation, which provides "
-            "much better caching and concurrency.\n\n"
-            "We recommend running a full CI suite with `no-fast` (the default now) "
-            "to see if any tests fail. If any fail, this likely signals shared state "
-            "between your test targets.",
-            help="Run all tests in a single invocation. If turned off, each test target "
-            "will run in its own invocation, which will be slower, but isolates "
-            "tests from process-wide state created by tests in other targets.",
-        )
         register(
             "--chroot",
             advanced=True,
@@ -454,9 +437,8 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         return VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
 
     def check_artifact_cache_for(self, invalidation_check):
-        # Tests generate artifacts, namely junit.xml and coverage reports, that cover the full target
-        # set whether that is all targets in the context (`--fast`) or each target individually
-        # (`--no-fast`).
+        # Tests generate artifacts, namely junit.xml and coverage reports, that cover the full
+        # target set.
         return [self._vts_for_partition(invalidation_check)]
 
     @property
@@ -500,12 +482,11 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
 
         self.context.release_lock()
 
-        per_target = not self.get_options().fast
         fail_fast = self.get_options().fail_fast
 
         results = {}
         failure = False
-        with self.partitions(per_target, all_targets, test_targets) as partitions:
+        with self.partitions(all_targets, test_targets) as partitions:
             for (partition, args) in partitions():
                 try:
                     rv = self._run_partition(fail_fast, partition, *args)
@@ -547,40 +528,17 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
                 # A low-level test execution failure occurred before tests were run.
                 raise TaskError()
 
-    # Some notes on invalidation vs caching as used in `run_partition` below. Here invalidation
-    # refers to executing task work in `Task.invalidated` blocks against invalid targets. Caching
-    # refers to storing the results of that work in the artifact cache using
+    # Here invalidation refers to executing task work in `Task.invalidated` blocks against invalid
+    # targets. Caching refers to storing the results of that work in the artifact cache using
     # `VersionedTargetSet.results_dir`. One further bit of terminology is partition, which is the
-    # name for the set of targets passed to the `Task.invalidated` block:
+    # name for the set of targets passed to the `Task.invalidated` block. A partition used to
+    # sometimes be multiple targets, but now it always corresponds to one target as we removed the
+    # `--fast` option.
     #
-    # + Caching results for len(partition) > 1: This is trivial iff we always run all targets in
-    #   the partition, but running just invalid targets in the partition is a nicer experience (you
-    #   can whittle away at failures in a loop of `::`-style runs). Running just invalid though
-    #   requires being able to merge prior results for the partition; ie: knowing the details of
-    #   junit xml, coverage data, or using tools that do, to merge data files. The alternative is
-    #   to always run all targets in a partition if even 1 target is invalid. In this way data files
-    #   corresponding to the full partition are always generated, and so on a green partition, the
-    #   cached data files will always represent the full green run.
-    #
-    # The compromise taken here is to only cache when `all_vts == invalid_vts`; ie when the partition
-    # goes green and the run was against the full partition. A common scenario would then be:
-    #
-    # 1. Mary makes changes / adds new code and iterates `./pants test tests/python/stuff::`
-    #    gradually getting greener until finally all test targets in the `tests/python/stuff::` set
-    #    pass. She commits the green change, but there is no cached result for it since green state
-    #    for the partition was approached incrementally.
-    # 2. Jake pulls in Mary's green change and runs `./pants test tests/python/stuff::`. There is a
-    #    cache miss and he does a full local run, but since `tests/python/stuff::` is green,
-    #    `all_vts == invalid_vts` and the result is now cached for others.
-    #
-    # In this scenario, Jake will likely be a CI process, in which case human others will see a
-    # cached result from Mary's commit. It's important to note, that the CI process must run the same
-    # partition as the end user for that end user to benefit and hit the cache. This is unlikely since
-    # the only natural partitions under CI are single target ones (`--no-fast` or all targets
-    # `--fast ::`. Its unlikely an end user in a large repo will want to run `--fast ::` since `::`
-    # is probably a much wider swath of code than they're working on. As such, although `--fast`
-    # caching is supported, its unlikely to be effective. Caching is best utilized when CI and users
-    # run `--no-fast`.
+    # The below implementation originally had to handle the case where partitions had more than one
+    # target. This raised issues when some targets in the partition were successful but others were
+    # not, which we tried to mitigate by distinguishing between invalidation vs. caching. We get
+    # much better caching now because a partition is always one single target.
     def _run_partition(self, fail_fast, test_targets, *args):
         with self.invalidated(
             targets=test_targets,
@@ -644,7 +602,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         return None
 
     @abstractmethod
-    def partitions(self, per_target, all_targets, test_targets):
+    def partitions(self, all_targets, test_targets):
         """Return a context manager that can be called to iterate of target partitions.
 
         The iterator should return a 2-tuple with the partitions targets in the first slot and a tuple

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -111,7 +111,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
             self.assertIn("Welcome.scala", html_report_string)
 
     def test_junit_run_with_coverage_succeeds_scoverage(self):
-        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot", "--fast"])
+        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot"])
 
     def do_test_junit_run_with_coverage_succeeds_cobertura(self, tests=(), args=()):
         html_path = (
@@ -214,11 +214,10 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
         self.assert_failure(pants_run)
         self.assertIn("No target found for test specifier", pants_run.stdout_data)
 
-    def test_junit_run_no_fast_multi(self):
+    def test_junit_run_multiple_targets(self):
         pants_run = self.run_pants(
             [
                 "test.junit",
-                "--no-fast",
                 "--test=PassingTest",
                 "testprojects/tests/java/org/pantsbuild/testproject/dummies:passing_target",
                 "testprojects/tests/java/org/pantsbuild/testproject/matcher",

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -514,10 +514,6 @@ python_tests(
     def test_green(self):
         self.run_tests(targets=[self.green])
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_caches_greens_fast(self):
-        self.run_tests(targets=[self.green, self.green2, self.green3], fast=True)
-
     @ensure_cached(PytestRun, expected_num_artifacts=3)
     def test_cache_greens(self):
         self.run_tests(targets=[self.green, self.green2, self.green3])
@@ -529,10 +525,6 @@ python_tests(
             timeout_default=3,
         )
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_out_of_band_deselect_fast_success(self):
-        self.run_tests([self.green, self.red], "-kno_tests_should_match_at_all", fast=True)
-
     # NB: Both red and green are cached. Red because its skipped via deselect and so runs (noops)
     # successfully. This is OK since the -k passthru is part of the task fingerprinting.
     @ensure_cached(PytestRun, expected_num_artifacts=2)
@@ -542,15 +534,6 @@ python_tests(
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_red(self):
         self.run_failing_tests(targets=[self.red], failed_targets=[self.red])
-
-    @ensure_cached(PytestRun, expected_num_artifacts=0)
-    def test_fail_fast_skips_second_red_test_with_single_chroot(self):
-        self.run_failing_tests(
-            targets=[self.red, self.red_in_class],
-            failed_targets=[self.red],
-            fail_fast=True,
-            fast=True,
-        )
 
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_fail_fast_skips_second_red_test(self):


### PR DESCRIPTION
This gives users better caching by default (per-target caching) and prepares them for V2.

In a followup, we likely want to deprecate the `--chroot` option to always chroot. Then, there will be theoretically no blockers for users upgrading to the V2 test runner.