### PR TITLE
Remove `--glob-expansion-failure` and deprecate `--files-not-found-behavior=ignore`

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -297,24 +297,6 @@ class EngineInitializer:
         """Construct and return the components necessary for LegacyBuildGraph construction."""
         build_root = get_buildroot()
         bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
-
-        glob_expansion_failure_configured = not bootstrap_options.is_default(
-            "glob_expansion_failure"
-        )
-        files_not_found_behavior_configured = not bootstrap_options.is_default(
-            "files_not_found_behavior"
-        )
-        if glob_expansion_failure_configured and files_not_found_behavior_configured:
-            raise ValueError(
-                "Conflicting options used. You used the new, preferred `--files-not-found-behavior`, but "
-                "also used the deprecated `--glob-expansion-failure`.\n\nPlease "
-                "specify only one of these (preferably `--files-not-found-behavior`)."
-            )
-        glob_match_error_behavior = (
-            bootstrap_options.files_not_found_behavior.to_glob_match_error_behavior()
-            if files_not_found_behavior_configured
-            else bootstrap_options.glob_expansion_failure
-        )
         return EngineInitializer.setup_legacy_graph_extended(
             OptionsInitializer.compute_pants_ignore(build_root, bootstrap_options),
             bootstrap_options.local_store_dir,
@@ -323,7 +305,9 @@ class EngineInitializer:
             build_configuration,
             build_root=build_root,
             native=native,
-            glob_match_error_behavior=glob_match_error_behavior,
+            glob_match_error_behavior=(
+                bootstrap_options.files_not_found_behavior.to_glob_match_error_behavior()
+            ),
             build_ignore_patterns=bootstrap_options.build_ignore,
             exclude_target_regexps=bootstrap_options.exclude_target_regexp,
             subproject_roots=bootstrap_options.subproject_roots,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -52,7 +52,6 @@ class FileNotFoundBehavior(Enum):
                 "default) or `--files-not-found-behavior=error`. Ignoring when files are "
                 "not found often results in subtle bugs, so we are removing the option."
             ),
-            deprecation_start_version="1.27.0.dev0",
         )
         return GlobMatchErrorBehavior(self.value)
 
@@ -442,18 +441,6 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=FileNotFoundBehavior,
             default=FileNotFoundBehavior.warn,
-            help="What to do when files and globs specified in BUILD files, such as in the "
-            "`sources` field, cannot be found. This happens when the files do not exist on "
-            "your machine or when they are ignored by the `--pants-ignore` option.",
-        )
-        register(
-            "--glob-expansion-failure",
-            advanced=True,
-            type=GlobMatchErrorBehavior,
-            default=GlobMatchErrorBehavior.warn,
-            removal_version="1.27.0.dev0",
-            removal_hint="If you currently set `--glob-expansion-failure=error`, instead set "
-            "`--files-not-found-behavior=error`.",
             help="What to do when files and globs specified in BUILD files, such as in the "
             "`sources` field, cannot be found. This happens when the files do not exist on "
             "your machine or when they are ignored by the `--pants-ignore` option.",


### PR DESCRIPTION
`--glob-expansion-failure` was renamed to `--files-not-found-behavior`.

We also deprecate `--files-not-found-behavior=ignore`, as originally scheduled, because it is not safe to ignore unmatched globs in BUILD files. (We originally had made this deprecation, but delayed the deprecation until 1.27.x)