### PR TITLE
Fixing scoverage sourcePath to be relative in OSS (duplicate #8132)

### DIFF
--- a/3rdparty/jvm/com/twitter/scoverage/BUILD
+++ b/3rdparty/jvm/com/twitter/scoverage/BUILD
@@ -5,10 +5,11 @@
 # https://github.com/twitter-forks/scalac-scoverage-plugin. PR for the modifications
 # on original scoverage repo here: https://github.com/scoverage/scalac-scoverage-plugin/pull/267.
 # In future, we should ping OSS Scoverage to get that PR merged and consume scoverage directly
-# from there.
+# from there. Version 1.0.2 incorporates the changes in the following PR:
+# https://github.com/scoverage/scalac-scoverage-plugin/pull/275.
 
 jar_library(name='scalac-scoverage-plugin',
   jars=[
-    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.1-twitter'),
+    scala_jar(org='com.twitter.scoverage', name='scalac-scoverage-plugin', rev='1.0.2-twitter'),
     ],
   )

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -49,12 +49,12 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-plugin_2.12",
-                rev="1.0.1-twitter",
+                rev="1.0.2-twitter",
             ),
             JarDependency(
                 org="com.twitter.scoverage",
                 name="scalac-scoverage-runtime_2.12",
-                rev="1.0.1-twitter",
+                rev="1.0.2-twitter",
             ),
         ]
 

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -28,7 +28,7 @@ class Scoverage(CoverageEngine):
 
             def scoverage_jar(name, **kwargs):
                 return JarDependency(
-                    org="com.twitter.scoverage", name=name, rev="1.0.1-twitter", **kwargs
+                    org="com.twitter.scoverage", name=name, rev="1.0.2-twitter", **kwargs
                 )
 
             def slf4j_jar(name):


### PR DESCRIPTION
### Fixing scoverage sourcePath to be relative in OSS (duplicate #8132)

Clone from #8132 to resolve merge conflicts from an intern's branch who's no longer under responsibility to make changes.