### PR TITLE
Revert "Update version of cargo-ensure-prefix to fix error while inst…

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -4,7 +4,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cargo="${REPO_ROOT}/build-support/bin/native/cargo"
 
-"${cargo}" ensure-installed --package cargo-ensure-prefix --version 0.1.5
+"${cargo}" ensure-installed --package cargo-ensure-prefix --version 0.1.3
 
 if ! out="$("${cargo}" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \


### PR DESCRIPTION
This reverts commit 2b82c7936b2018a6ffe80d2200bc930bf7a71d14 (Pull Request 9240).

Quoth @pierrechevalier83 :

"Breaking news: 2 things happened about above thread: the problem was fixed and the workaround was broken (because quote 1.0.2 was pulled out. See https://users.rust-lang.org/t/failure-derive-compilation-error/39062
This means CI is back to broken because of this. Moving back to cargo_ensure_prefix 0.1.4 should do the trick."

(I assume that's a typo for 0.1.3, which was the original version before the commit that this commit reverts).
