### PR TITLE
Refactor TestBase.create_library()

### DIFF
--- a/src/python/pants/rules/core/filedeps_test.py
+++ b/src/python/pants/rules/core/filedeps_test.py
@@ -246,16 +246,11 @@ class FileDepsTest(GoalRuleTestBase):
             target_type="jvm_binary",
             name="bin",
             sources=["main.java"],
-            main="bin.Main",
             dependencies=["src/java/lib"],
         )
         self.create_file("project/config/app.yaml")
         self.create_library(
-            path="project",
-            target_type="jvm_app",
-            name="app",
-            binary="src/java/bin",
-            bundles=["bundle(fileset=['config/app.yaml'])"],
+            path="project", target_type="jvm_app", name="app",
         )
         self.assert_filedeps(
             targets=["project:app"],

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -642,13 +642,15 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
         sources_str = f"sources={repr(sources)}," if sources else ""
         if java_sources is not None:
-            formatted_java_sources = ",".join('"{str_target}"' for str_target in java_sources)
+            formatted_java_sources = ",".join(f'"{str_target}"' for str_target in java_sources)
             java_sources_str = f"java_sources=[{formatted_java_sources}],"
         else:
             java_sources_str = ""
+
         provides_str = f"provides={provides}," if provides is not None else ""
         dependencies_str = f"dependencies={dependencies}," if dependencies is not None else ""
         requirements_str = f"requirements={requirements}," if requirements is not None else ""
+
         self.add_to_build_file(
             path,
             dedent(

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -621,8 +621,8 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
          name: Name of the library target.
          sources: List of source file at the path relative to path.
          **kwargs: Optional attributes that can be set for any library target.
-           Currently it includes support for resources, java_sources, provides
-           and dependencies.
+           Currently it includes support for resources, java_sources, provides,
+           dependencies and requirements.
         """
         if sources:
             self.create_files(path, sources)
@@ -635,6 +635,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             %(java_sources)s
             %(provides)s
             %(dependencies)s
+            %(requirements)s
           )
         """
                 % dict(
@@ -653,6 +654,11 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
                     dependencies=(
                         "dependencies=%s," % kwargs.get("dependencies")
                         if "dependencies" in kwargs
+                        else ""
+                    ),
+                    requirements=(
+                        "requirements=%s," % kwargs.get("requirements")
+                        if "requirements" in kwargs
                         else ""
                     ),
                 )

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -611,57 +611,56 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             targets.append(self.build_graph.get_target(address))
         return targets
 
-    def create_library(self, path, target_type, name, sources=None, **kwargs):
+    def create_library(
+        self,
+        path: str,
+        target_type: str,
+        name: str,
+        sources: Optional[List[str]] = None,
+        java_sources: Optional[List[str]] = None,
+        provides: Optional[str] = None,
+        dependencies: Optional[List[str]] = None,
+        requirements: Optional[str] = None,
+    ):
         """Creates a library target of given type at the BUILD file at path with sources.
 
         :API: public
 
-         path: The relative path to the BUILD file from the build root.
-         target_type: valid pants target type.
-         name: Name of the library target.
-         sources: List of source file at the path relative to path.
-         **kwargs: Optional attributes that can be set for any library target.
-           Currently it includes support for resources, java_sources, provides,
-           dependencies and requirements.
+        path: The relative path to the BUILD file from the build root.
+        target_type: valid pants target type.
+        name: Name of the library target.
+        sources: List of source file at the path relative to path.
+        java_sources: List of java sources.
+        provides: Provides with a format consistent with what should be rendered in the resulting BUILD
+            file, eg: "artifact(org='org.pantsbuild.example', name='hello-greet', repo=public)"
+        dependencies: List of dependencies: [':protobuf-2.4.1']
+        requirements: Python requirements with a format consistent with what should be in the resulting
+            build file, eg: "[python_requirement(foo==1.0.0)]"
         """
         if sources:
             self.create_files(path, sources)
+
+        sources_str = f"sources={repr(sources)}," if sources else ""
+        if java_sources is not None:
+            formatted_java_sources = ",".join('"{str_target}"' for str_target in java_sources)
+            java_sources_str = f"java_sources=[{formatted_java_sources}],"
+        else:
+            java_sources_str = ""
+        provides_str = f"provides={provides}," if provides is not None else ""
+        dependencies_str = f"dependencies={dependencies}," if dependencies is not None else ""
+        requirements_str = f"requirements={requirements}," if requirements is not None else ""
         self.add_to_build_file(
             path,
             dedent(
-                """
-          %(target_type)s(name='%(name)s',
-            %(sources)s
-            %(java_sources)s
-            %(provides)s
-            %(dependencies)s
-            %(requirements)s
-          )
-        """
-                % dict(
-                    target_type=target_type,
-                    name=name,
-                    sources=("sources=%s," % repr(sources) if sources else ""),
-                    java_sources=(
-                        "java_sources=[%s],"
-                        % ",".join('"%s"' % str_target for str_target in kwargs.get("java_sources"))
-                        if "java_sources" in kwargs
-                        else ""
-                    ),
-                    provides=(
-                        "provides=%s," % kwargs.get("provides") if "provides" in kwargs else ""
-                    ),
-                    dependencies=(
-                        "dependencies=%s," % kwargs.get("dependencies")
-                        if "dependencies" in kwargs
-                        else ""
-                    ),
-                    requirements=(
-                        "requirements=%s," % kwargs.get("requirements")
-                        if "requirements" in kwargs
-                        else ""
-                    ),
+                f"""
+                {target_type}(name='{name}',
+                    {sources_str}
+                    {java_sources_str}
+                    {provides_str}
+                    {dependencies_str}
+                    {requirements_str}
                 )
+                """
             ),
         )
         return self.target(f"{path}:{name}")


### PR DESCRIPTION
### Problem

I need `TestBase.create_library()` to support python requirements in order to write tests for V2 dependencies --3rdparty.

### Solution

Added support for requirements, also added types, updated the docstring, ditched `**kwargs` in favor of named keyword arguments, and replaced `%s` string formatting with f strings.

### Result

`TestBase.create_library()` now supports requirements. Found one case in which we were passing kwargs that create_library() was ignoring entirely (`main`, `binary` and `bundles` were never supported.) and removed them. Previously this wasn't an error, it just didn't do anything, which may have been unexpected.