### PR TITLE
Delay removing `--test-fast` from 1.27.0.dev0 to 1.28.0.dev0

### DIFF
--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -428,13 +428,14 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
             type=bool,
             default=False,
             fingerprint=True,
-            removal_version="1.27.0.dev0",
-            removal_hint="This option is going away for better isolation of tests and in "
-            "preparation for switching to the V2 test implementation, which provides "
-            "much better caching and concurrency.\n\n"
-            "We recommend running a full CI suite with `no-fast` (the default now) "
-            "to see if any tests fail. If any fail, this likely signals shared state "
-            "between your test targets.",
+            removal_version="1.28.0.dev0",
+            removal_hint=(
+                "This option is going away for better isolation of tests, which provides "
+                "better caching. This also prepares for upgrading to the V2 test implementation,"
+                "which provides even better caching and parallelism.\n\nWe recommend running a "
+                "full CI suite with `no-fast` (the default now) to see if any tests fail. If any "
+                "fail, this likely signals shared state between your test targets."
+            ),
             help="Run all tests in a single invocation. If turned off, each test target "
             "will run in its own invocation, which will be slower, but isolates "
             "tests from process-wide state created by tests in other targets.",


### PR DESCRIPTION
Some users (Twitter) requested more time before we remove `--test-fast`. It's reasonable to push this back for the following reasons:

1. We already deprecated _a lot_ in 1.25.0.dev0. Distributing the deprecations makes for a better experience for users.
2. The code is not very expensive to support for `--fast`. Instead, this deprecation was entirely meant to get users to start preparing for the V2 test runner. We don't need to be aggressive in getting them there. 