### PR TITLE
Remove deprecated `--fmt-skip` and `--lint-skip`

### DIFF
--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -53,7 +53,7 @@ echo "* Checking shell scripts via our custom linter"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking formatting of Python files"
-  ./pants --changed-parent="${MERGE_BASE}" lint2 || die "To fix formatting, run \`./pants fmt2 ::\`"
+  ./pants --changed-parent="${MERGE_BASE}" lint2 || die "To fix formatting, run \`./pants --changed-since=master fmt2\`"
 
   # TODO(CMLivingston) Make lint use `-q` option again after addressing proper workunit labeling:
   # https://github.com/pantsbuild/pants/issues/6633

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -4,6 +4,7 @@
 from pants.base.exceptions import TaskError
 from pants.task.lint_task_mixin import LintTaskMixin
 
+from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
@@ -12,7 +13,7 @@ class GoCheckstyle(LintTaskMixin, GoFmtTaskBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="lint-go")
+        return Gofmt.global_instance().options.skip
 
     def execute(self):
         with self.go_fmt_invalid_targets(["-d"]) as output:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
@@ -3,6 +3,7 @@
 
 from pants.task.fmt_task_mixin import FmtTaskMixin
 
+from pants.contrib.go.subsystems.gofmt import Gofmt
 from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
@@ -11,7 +12,7 @@ class GoFmt(FmtTaskMixin, GoFmtTaskBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="fmt-go")
+        return super().determine_if_skipped(formatter_subsystem=Gofmt.global_instance())
 
     def execute(self):
         with self.go_fmt_invalid_targets(["-w"]) as output:

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -81,6 +81,6 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
             pants_run = self.run_pants(args)
             self.assert_failure(pants_run)
 
-            args = ["compile", "lint", "--lint-go-skip", lib_unstyle_dir]
+            args = ["compile", "lint", "--gofmt-skip", lib_unstyle_dir]
             pants_run = self.run_pants(args)
             self.assert_success(pants_run)

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -99,7 +99,7 @@ class GoogleJavaFormatTask(FmtTaskMixin, GoogleJavaFormatBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="lint-google-java-format")
+        return super().determine_if_skipped(formatter_subsystem=GoogleJavaFormat.global_instance())
 
     def process_result(self, result):
         if result != 0:

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -80,7 +80,7 @@ class GoogleJavaFormatLintTask(LintTaskMixin, GoogleJavaFormatBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="fmt-google-java-format")
+        return GoogleJavaFormat.global_instance().options.skip
 
     def process_result(self, result):
         if result != 0:

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -82,9 +82,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="lint-mypy", new_scope="mypy", subsystem=self._mypy_subsystem,
-        )
+        return self._mypy_subsystem.options.skip
 
     def find_mypy_interpreter(self):
         interpreters = self._interpreter_cache.setup(

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -240,4 +240,4 @@ class JavascriptStyleFmt(FmtTaskMixin, JavascriptStyleBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="fmt-javascriptstyle")
+        return super().determine_if_skipped(formatter_subsystem=ESLint.global_instance())

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -182,10 +182,8 @@ class JavascriptStyleBase(NodeTask):
         if not targets:
             return
         failed_targets = []
-        bootstrap_dir, is_preconfigured = (
-            ESLint.global_instance().supportdir(task_workdir=self.workdir)
-            if ESLint.global_instance().options.setupdir
-            else self.node_distribution.eslint_supportdir(self.workdir)
+        bootstrap_dir, is_preconfigured = ESLint.global_instance().supportdir(
+            task_workdir=self.workdir
         )
         if not is_preconfigured:
             self.context.log.debug("ESLint is not pre-configured, bootstrapping with defaults.")

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -229,7 +229,7 @@ class JavascriptStyleLint(LintTaskMixin, JavascriptStyleBase):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="lint-javascriptstyle")
+        return ESLint.global_instance().options.skip
 
 
 class JavascriptStyleFmt(FmtTaskMixin, JavascriptStyleBase):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -111,9 +111,7 @@ class Checkstyle(LintTaskMixin, Task):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="lint-pythonstyle", new_scope="pycheck", subsystem=Pycheck.global_instance(),
-        )
+        return Pycheck.global_instance().options.skip
 
     def _is_checked(self, target):
         return (

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -14,7 +14,6 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -53,28 +52,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
 
     @property
     def skip_execution(self):
-        task_options = self.get_options()
-        subsystem_options = PythonEvalSubystem.global_instance().options
-        deprecated_conditional(
-            lambda: task_options.is_default("skip") and subsystem_options.is_default("skip"),
-            entity_description="`python-eval` defaulting to being used",
-            removal_version="1.27.0.dev0",
-            hint_message="`python-eval` is scheduled to be removed in Pants 1.29.0.dev0. The Python "
-            "linter landscape has changed since we first created this tool - there are now "
-            "popular linters that dramatically improve upon this one, such as MyPy and "
-            "Pylint. Pants currently provides a wrapper around MyPy and will soon add "
-            "Pylint. (To install MyPy, add "
-            "`pantsbuild.pants.contrib.mypy==%(pants_version)s` to your `plugins` list.)"
-            "\n\nTo prepare, set `skip = true` in your `pants.toml` under the section "
-            "`python-eval`. If you still need to use this tool, set `skip = false`. In "
-            "Pants 1.27.0.dev0, the default will change from `skip = false` to `skip = true`, "
-            "and in Pants 1.29.0.dev0, the module will be removed.",
-        )
-        return self.resolve_conflicting_skip_options(
-            old_scope="lint-python-eval",
-            new_scope="python-eval",
-            subsystem=PythonEvalSubystem.global_instance(),
-        )
+        return PythonEvalSubystem.global_instance().options.skip
 
     @classmethod
     def prepare(cls, options, round_manager):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval_subsystem.py
@@ -14,6 +14,6 @@ class PythonEval(Subsystem):
         register(
             "--skip",
             type=bool,
-            default=False,
+            default=True,
             help="Don't use `python-eval` when running `./pants lint`.",
         )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter_task.py
@@ -67,11 +67,7 @@ class ThriftLinterTask(LintTaskMixin, NailgunTask):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="thrift-linter",
-            new_scope="scrooge-linter",
-            subsystem=ScroogeLinter.global_instance(),
-        )
+        return ScroogeLinter.global_instance().options.skip
 
     @property
     def cache_target_dirs(self):

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -75,11 +75,7 @@ class Checkstyle(LintTaskMixin, NailgunTask):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="lint-checkstyle",
-            new_scope="checkstyle",
-            subsystem=CheckstyleSubsystem.global_instance(),
-        )
+        return CheckstyleSubsystem.global_instance().options.skip
 
     @classmethod
     def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -186,7 +186,7 @@ class ScalaFixCheck(LintTaskMixin, ScalafixTask):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="lint-scalafix")
+        return Scalafix.global_instance().options.skip
 
     def process_result(self, result):
         if result != 0:

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -23,13 +23,6 @@ class ScalafixTask(RewriteBase):
 
     _SCALAFIX_MAIN = "scalafix.cli.Cli"
 
-    def _resolve_conflicting_skip(self, *, old_scope: str):
-        # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
-        # properly.
-        return self.resolve_conflicting_skip_options(  # type: ignore
-            old_scope=old_scope, new_scope="scalafix", subsystem=Scalafix.global_instance(),
-        )
-
     @classmethod
     def subsystem_dependencies(cls):
         return super().subsystem_dependencies() + (Scalafix,)
@@ -171,7 +164,7 @@ class ScalaFixFix(FmtTaskMixin, ScalafixTask):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="fmt-scalafix")
+        return super().determine_if_skipped(formatter_subsystem=Scalafix.global_instance())
 
     def process_result(self, result):
         if result != 0:

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -19,13 +19,6 @@ class ScalafmtTask(RewriteBase):
     different scalafmt commands.
     """
 
-    def _resolve_conflicting_skip(self, *, old_scope: str):
-        # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
-        # properly.
-        return self.resolve_conflicting_skip_options(  # type: ignore
-            old_scope=old_scope, new_scope="scalafmt", subsystem=Scalafmt.global_instance(),
-        )
-
     @classmethod
     def subsystem_dependencies(cls):
         return super().subsystem_dependencies() + (Scalafmt,)
@@ -125,7 +118,7 @@ class ScalaFmtFormat(FmtTaskMixin, ScalafmtTask):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="fmt-scalafmt")
+        return super().determine_if_skipped(formatter_subsystem=Scalafmt.global_instance())
 
     def process_result(self, result):
         # Processes the results of running the scalafmt command.

--- a/src/python/pants/backend/jvm/tasks/scalafmt_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt_task.py
@@ -100,7 +100,7 @@ class ScalaFmtCheckFormat(LintTaskMixin, ScalafmtTask):
 
     @property
     def skip_execution(self):
-        return super()._resolve_conflicting_skip(old_scope="lint-scalafmt")
+        return Scalafmt.global_instance().options.skip
 
     def process_result(self, result):
         if result != 0:

--- a/src/python/pants/backend/jvm/tasks/scalastyle_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle_task.py
@@ -108,11 +108,7 @@ class ScalastyleTask(LintTaskMixin, NailgunTask):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="lint-scalastyle",
-            new_scope="scalastyle",
-            subsystem=Scalastyle.global_instance(),
-        )
+        return Scalastyle.global_instance().options.skip
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/python/lint/isort/isort_run.py
+++ b/src/python/pants/backend/python/lint/isort/isort_run.py
@@ -87,6 +87,4 @@ class IsortRun(FmtTaskMixin, Task):
 
     @property
     def skip_execution(self):
-        return self.resolve_conflicting_skip_options(
-            old_scope="fmt-isort", new_scope="isort", subsystem=Isort.global_instance(),
-        )
+        return self.determine_if_skipped(formatter_subsystem=Isort.global_instance())

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -20,7 +20,6 @@ from pants.core_tasks.targets_help import TargetsHelp
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
 from pants.task.fmt_task_mixin import FmtTaskMixin
-from pants.task.lint_task_mixin import LintTaskMixin
 
 
 def register_goals():
@@ -43,9 +42,7 @@ def register_goals():
     Goal.register("doc", "Generate documentation.")
     Goal.register("publish", "Publish a build artifact.")
     Goal.register("dep-usage", "Collect target dependency usage data.")
-    Goal.register(
-        "lint", "Find formatting errors in source code.", LintTaskMixin.goal_options_registrar_cls
-    )
+    Goal.register("lint", "Find formatting errors in source code.")
     Goal.register("fmt", "Autoformat source code.", FmtTaskMixin.goal_options_registrar_cls)
     Goal.register("buildozer", "Manipulate BUILD files.")
 

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -1,13 +1,13 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.task.target_restriction_mixins import (
-    DeprecatedSkipGoalOptionsRegistrar,
-    HasSkipGoalOptionMixin,
-)
+from typing import cast
+
+from pants.subsystem.subsystem import Subsystem
+from pants.task.goal_options_mixin import GoalOptionsMixin, GoalOptionsRegistrar
 
 
-class FmtGoalRegistrar(DeprecatedSkipGoalOptionsRegistrar):
+class FmtGoalRegistrar(GoalOptionsRegistrar):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -17,12 +17,14 @@ class FmtGoalRegistrar(DeprecatedSkipGoalOptionsRegistrar):
             default=None,
             fingerprint=True,
             advanced=True,
-            help="Only run the specified formatter. Currently the only accepted values are "
-            "`scalafix` or not setting any value.",
+            help=(
+                "Only run the specified formatter. Currently the only accepted values are "
+                "`scalafix` or not setting any value."
+            ),
         )
 
 
-class FmtTaskMixin(HasSkipGoalOptionMixin):
+class FmtTaskMixin(GoalOptionsMixin):
     """A mixin to combine with code formatting tasks."""
 
     goal_options_registrar_cls = FmtGoalRegistrar
@@ -31,3 +33,25 @@ class FmtTaskMixin(HasSkipGoalOptionMixin):
     @property
     def act_transitively(self):
         return False
+
+    def determine_if_skipped(self, *, formatter_subsystem: Subsystem) -> bool:
+        # TODO: generalize this to work with every formatter, not only scalafix.
+        # TODO: expand this to `--lint-only`.
+        # TODO: move this implementation to the V2 GoalSubsystem once `fmt2` is renamed to `fmt`.
+        skipped = cast(bool, formatter_subsystem.options.skip)
+        only = self.get_options().only  # type: ignore
+        is_scalafix = self.__class__.__name__.startswith("ScalaFix")
+
+        if only is not None and only != "scalafix":
+            raise ValueError(
+                "Invalid value for `--fmt-only`. It must be `scalafix` or not be set at all."
+            )
+        if is_scalafix and only == "scalafix" and skipped:
+            raise ValueError(
+                f"Invalid flag combination. You cannot both set `--fmt-only=scalafix` and "
+                f"`--scalafix-skip`.",
+            )
+
+        if only == "scalafix" and not is_scalafix:
+            return True
+        return skipped

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -1,16 +1,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.task.target_restriction_mixins import (
-    DeprecatedSkipGoalOptionsRegistrar,
-    HasSkipGoalOptionMixin,
-)
 
-
-class LintTaskMixin(HasSkipGoalOptionMixin):
+class LintTaskMixin:
     """A mixin to combine with lint tasks."""
 
-    goal_options_registrar_cls = DeprecatedSkipGoalOptionsRegistrar
     target_filtering_enabled = True
 
     @property

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import resolve_conflicting_options
-from pants.subsystem.subsystem import Subsystem
 from pants.task.goal_options_mixin import GoalOptionsMixin, GoalOptionsRegistrar
 
 
@@ -56,55 +54,7 @@ class HasSkipOptionMixin:
 
     @property
     def skip_execution(self):
-        return self.resolve_only_as_skip(self.get_options().skip)
-
-    def resolve_only_as_skip(self, skip: bool):
-        # This flag is defined only on fmt, which is done in FmtTaskMixin.
-        # In v2, we expect to have a --only flag on both fmt and lint which will allow individual
-        # formatters to be selected.
-        #
-        # This is a hacky one-off implementation to help Twitter deal with the fact that they have a
-        # custom Goal called scalafix, which does the equivalent of `fmt --fmt-only=scalafix`, as it
-        # provides them with a forward-compatible way of migrating people off of their scalafix goal.
-        #
-        # When the v2 goal is renamed from fmt2 to fmt, this option should be moved to that Goal, and
-        # its implementation broadened to support all v2 formatters, as well as any v1 formatters we
-        # fancy while we keep them around.
-        #
-        # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
-        # properly.
-        options = self.get_options()  # type: ignore
-        if hasattr(options, "only"):
-            only = options.only
-            if only is None:
-                return skip
-            elif only == "scalafix":
-                only_resolved_as_skip = not self.__class__.__name__.startswith("ScalaFix")
-                if skip and not only_resolved_as_skip:
-                    raise ValueError(
-                        f"Invalid flag combination; cannot specify --only={only} if --skip=True",
-                    )
-                return only_resolved_as_skip
-            else:
-                raise ValueError(
-                    "Invalid value for flag --only - must be scalafix or not set at all"
-                )
-        return skip
-
-    def resolve_conflicting_skip_options(
-        self, old_scope: str, new_scope: str, subsystem: Subsystem
-    ):
-        skip = resolve_conflicting_options(
-            old_option="skip",
-            new_option="skip",
-            old_scope=old_scope,
-            new_scope=new_scope,
-            # Skip mypy because this is a temporary hack, and mypy doesn't follow the inheritance chain
-            # properly.
-            old_container=self.get_options(),  # type: ignore
-            new_container=subsystem.options,
-        )
-        return self.resolve_only_as_skip(skip)
+        return self.get_options().skip
 
 
 class SkipOptionRegistrar:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -27,7 +27,7 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
             target_dir, target_name = target.rsplit(":", 1)
             shutil.copytree(target_dir, src_dir)
             with self.temporary_workdir() as workdir:
-                cmd = ["compile", "--lint-scalafmt-skip", f"{src_dir}:{target_name}"]
+                cmd = ["compile", "--scalafmt-skip", f"{src_dir}:{target_name}"]
                 pants_run = self.run_pants_with_workdir(command=cmd, workdir=workdir)
                 self.assert_success(pants_run)
 
@@ -49,7 +49,7 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(
             [
                 "compile",
-                "--lint-scalafmt-skip",
+                "--scalafmt-skip",
                 "testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C",
             ]
         )


### PR DESCRIPTION
Instead, users should use the corresponding subsystem's skip option, e.g. `--isort-skip` and `eslint-skip`.

This unblocks us from renaming `fmt2` to `fmt` and from replacing V1 linter implementations with V2 implementations.