### PR TITLE
Rename `fmt2` to `fmt` and `lint2` to `lint`

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -417,11 +417,10 @@ def run_lint(*, oauth_token_path: Optional[str] = None) -> None:
     targets = ["contrib::", "examples::", "src::", "tests::", "zinc::"]
     command_prefix = ["./pants.pex", "--tag=-nolint"]
 
-    v2_command_prefix = [*command_prefix, "--no-v1", "--v2"]
     v2_command = (
-        [*v2_command_prefix, "lint", *targets]
+        ["--no-v1", "--v2", "lint", *targets]
         if oauth_token_path is None
-        else [*v2_command_prefix, *_use_remote_execution(oauth_token_path), "lint", *targets]
+        else [*command_prefix, *_use_remote_execution(oauth_token_path), "lint", *targets]
     )
     _run_command(
         v2_command,

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -417,10 +417,11 @@ def run_lint(*, oauth_token_path: Optional[str] = None) -> None:
     targets = ["contrib::", "examples::", "src::", "tests::", "zinc::"]
     command_prefix = ["./pants.pex", "--tag=-nolint"]
 
+    v2_command_prefix = [*command_prefix, "--no-v1", "--v2"]
     v2_command = (
-        [*command_prefix, "lint2", *targets]
+        [*v2_command_prefix, "lint", *targets]
         if oauth_token_path is None
-        else [*command_prefix, *_use_remote_execution(oauth_token_path), "lint2", *targets]
+        else [*v2_command_prefix, *_use_remote_execution(oauth_token_path), "lint", *targets]
     )
     _run_command(
         v2_command,

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -53,7 +53,7 @@ echo "* Checking shell scripts via our custom linter"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking formatting of Python files"
-  ./pants --changed-parent="${MERGE_BASE}" lint2 || die "To fix formatting, run \`./pants --changed-since=master fmt2\`"
+  ./v2 --changed-parent="${MERGE_BASE}" lint || die "To fix formatting, run \`./v2 --changed-since=master fmt\`"
 
   # TODO(CMLivingston) Make lint use `-q` option again after addressing proper workunit labeling:
   # https://github.com/pantsbuild/pants/issues/6633

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
@@ -60,6 +60,7 @@ class GoogleJavaFormatTests(TestBase):
             target_type=JavaLibrary,
             sources=["MyClass.java"],
         )
+        self.set_options(only=None)
         context = self.context(target_roots=[target])
         self.execute(context)
         with open(javafile, "r") as fh:

--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -53,8 +53,8 @@ interpreter_search_paths = [
 ld_flags = []
 cpp_flags = []
 
-[fmt2]
+[fmt]
 per_target_caching = true
 
-[lint2]
+[lint]
 per_target_caching = true

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -19,7 +19,6 @@ from pants.core_tasks.substitute_aliased_targets import SubstituteAliasedTargets
 from pants.core_tasks.targets_help import TargetsHelp
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
-from pants.task.fmt_task_mixin import FmtTaskMixin
 
 
 def register_goals():
@@ -43,7 +42,7 @@ def register_goals():
     Goal.register("publish", "Publish a build artifact.")
     Goal.register("dep-usage", "Collect target dependency usage data.")
     Goal.register("lint", "Find formatting errors in source code.")
-    Goal.register("fmt", "Autoformat source code.", FmtTaskMixin.goal_options_registrar_cls)
+    Goal.register("fmt", "Autoformat source code.")
     Goal.register("buildozer", "Manipulate BUILD files.")
 
     # Register tasks.

--- a/src/python/pants/help/list_goals_integration_test.py
+++ b/src/python/pants/help/list_goals_integration_test.py
@@ -17,7 +17,7 @@ class TestListGoalsIntegration(PantsRunIntegrationTest):
     def test_only_show_implemented_goals(self) -> None:
         # Some core goals, such as `./pants test`, require downstream implementations to work
         # properly. We should only show those goals when an implementation is provided.
-        goals_that_need_implementation = ["binary", "fmt2", "lint2", "run", "test"]
+        goals_that_need_implementation = ["binary", "fmt", "lint", "run", "test"]
         command = ["--pants-config-files=[]", "--no-v1", "--v2", "goals"]
 
         not_implemented_run = self.run_pants(command)

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -76,15 +76,24 @@ class LanguageFormatters(ABC):
 class FmtOptions(GoalSubsystem):
     """Autoformat source code."""
 
-    # TODO: make this "fmt"
-    # Blocked on https://github.com/pantsbuild/pants/issues/8351
-    name = "fmt2"
+    name = "fmt"
 
     required_union_implementations = (LanguageFormatters,)
 
     @classmethod
     def register_options(cls, register) -> None:
         super().register_options(register)
+        register(
+            "--only",
+            type=str,
+            default=None,
+            fingerprint=True,
+            advanced=True,
+            help=(
+                "Only run the specified formatter. Currently the only accepted values are "
+                "`scalafix` or not setting any value."
+            ),
+        )
         register(
             "--per-target-caching",
             advanced=True,

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -50,9 +50,7 @@ class Linter(ABC):
 class LintOptions(GoalSubsystem):
     """Lint source code."""
 
-    # TODO: make this "lint"
-    # Blocked on https://github.com/pantsbuild/pants/issues/8351
-    name = "lint2"
+    name = "lint"
 
     required_union_implementations = (Linter,)
 

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -4,30 +4,11 @@
 from typing import cast
 
 from pants.subsystem.subsystem import Subsystem
-from pants.task.goal_options_mixin import GoalOptionsMixin, GoalOptionsRegistrar
 
 
-class FmtGoalRegistrar(GoalOptionsRegistrar):
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--only",
-            type=str,
-            default=None,
-            fingerprint=True,
-            advanced=True,
-            help=(
-                "Only run the specified formatter. Currently the only accepted values are "
-                "`scalafix` or not setting any value."
-            ),
-        )
-
-
-class FmtTaskMixin(GoalOptionsMixin):
+class FmtTaskMixin:
     """A mixin to combine with code formatting tasks."""
 
-    goal_options_registrar_cls = FmtGoalRegistrar
     target_filtering_enabled = True
 
     @property
@@ -37,7 +18,6 @@ class FmtTaskMixin(GoalOptionsMixin):
     def determine_if_skipped(self, *, formatter_subsystem: Subsystem) -> bool:
         # TODO: generalize this to work with every formatter, not only scalafix.
         # TODO: expand this to `--lint-only`.
-        # TODO: move this implementation to the V2 GoalSubsystem once `fmt2` is renamed to `fmt`.
         skipped = cast(bool, formatter_subsystem.options.skip)
         only = self.get_options().only  # type: ignore
         is_scalafix = self.__class__.__name__.startswith("ScalaFix")

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -16,7 +16,8 @@ class FmtTaskMixin:
         return False
 
     def determine_if_skipped(self, *, formatter_subsystem: Subsystem) -> bool:
-        # TODO: generalize this to work with every formatter, not only scalafix.
+        # TODO: generalize this to work with every formatter, not only scalafix. When doing this,
+        # change the `help` description in `fmt.py`.
         # TODO: expand this to `--lint-only`.
         skipped = cast(bool, formatter_subsystem.options.skip)
         only = self.get_options().only  # type: ignore

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -101,6 +101,10 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
     def task_type(cls):
         return ScalaFmtCheckFormat
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_options(only=None)
+
     def test_scalafmt_fail_default_config(self):
         context = self.context(target_roots=self.library)
         with self.assertRaises(TaskError):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -101,10 +101,6 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
     def task_type(cls):
         return ScalaFmtCheckFormat
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.set_options(only=None)
-
     def test_scalafmt_fail_default_config(self):
         context = self.context(target_roots=self.library)
         with self.assertRaises(TaskError):
@@ -131,6 +127,10 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
     def task_type(cls):
         return ScalaFmtFormat
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_options(only=None)
+
     def test_scalafmt_format_default_config(self):
         self.format_file_and_verify_fmt()
 
@@ -138,12 +138,10 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
         self.set_options_for_scope(Scalafmt.options_scope, config=self.config)
         self.format_file_and_verify_fmt()
 
-    def format_file_and_verify_fmt(self, **options):
-        self.set_options(**options)
-
+    def format_file_and_verify_fmt(self):
         lint_options_scope = "sfcf"
         check_fmt_task_type = self.synthesize_task_subtype(ScalaFmtCheckFormat, lint_options_scope)
-        self.set_options_for_scope(lint_options_scope, **options)
+        self.set_options_for_scope(lint_options_scope)
 
         # format an incorrectly formatted file.
         context = self.context(for_task_types=[check_fmt_task_type], target_roots=self.library)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/8351.

It's safe to make this change, even with us defaulting to `--v2` for users, because we default to no V2 linters being enabled and the V2 goal no-ops in this case. 

It's also safe to have both V1 and V2 linters run at the same time (mixed mode). They won't run at the same time, so there's no risk of formatters conflicting with each other.

In a followup, we can now deprecate V1 isort for the V2 implementation.