### PR TITLE
Simplify `sources` code now that `globs()` is removed

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -671,7 +671,9 @@ async def hydrate_sources(
     )
     snapshot = await Get[Snapshot](PathGlobs, path_globs)
     fileset_with_spec = _eager_fileset_with_spec(
-        spec_path=address.spec_path, filespec=sources_field.filespecs, snapshot=snapshot,
+        spec_path=address.spec_path,
+        filespec=sources_field.source_globs.filespecs,
+        snapshot=snapshot,
     )
     sources_field.validate_fn(fileset_with_spec)
     return HydratedField(sources_field.arg, fileset_with_spec)

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -3,7 +3,6 @@
 
 import logging
 import os.path
-from abc import ABCMeta, abstractmethod
 from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
@@ -72,17 +71,16 @@ class TargetAdaptor(StructWithDeps):
         if sources is None:
             if self.default_sources_globs is None:
                 return None
-            default_globs = Files(
+            default_sources = SourceGlobs(
                 *(
                     *self.default_sources_globs,
                     *(f"!{glob}" for glob in self.default_sources_exclude_globs or []),
                 ),
-                spec_path=self.address.spec_path,
             )
-            return GlobsWithConjunction(default_globs, GlobExpansionConjunction.any_match)
+            return GlobsWithConjunction(default_sources, GlobExpansionConjunction.any_match)
 
-        globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
-        return GlobsWithConjunction(globs, GlobExpansionConjunction.all_match)
+        source_globs = SourceGlobs.from_sources_field(sources)
+        return GlobsWithConjunction(source_globs, GlobExpansionConjunction.all_match)
 
     @property
     def field_adaptors(self) -> Tuple:
@@ -92,21 +90,16 @@ class TargetAdaptor(StructWithDeps):
             if conjunction_globs is None:
                 return tuple()
 
-            sources = conjunction_globs.non_path_globs
+            sources = conjunction_globs.globs
             if not sources:
                 return tuple()
 
-            base_globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
-            path_globs = base_globs.to_path_globs(
-                self.address.spec_path, conjunction_globs.conjunction
-            )
             sources_field = SourcesField(
-                self.address,
-                "sources",
-                base_globs.filespecs,
-                base_globs,
-                path_globs,
-                self.validate_sources,
+                address=self.address,
+                arg="sources",
+                source_globs=sources,
+                conjunction=conjunction_globs.conjunction,
+                validate_fn=self.validate_sources,
             )
             return (sources_field,)
 
@@ -167,18 +160,21 @@ class SourcesField:
 
     address: Address
     arg: str
-    filespecs: wrapped_globs.Filespec
-    base_globs: "BaseGlobs"
-    path_globs: PathGlobs
-    validate_fn: Callable
+    source_globs: "SourceGlobs"
+    conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match
+    validate_fn: Callable = lambda _: None
+
+    @property
+    def path_globs(self) -> PathGlobs:
+        return self.source_globs.to_path_globs(
+            relpath=self.address.spec_path, conjunction=self.conjunction
+        )
 
     def __hash__(self):
         return hash((self.address, self.arg))
 
-    def __repr__(self):
-        return "{}(address={}, input_globs={}, arg={}, filespecs={!r})".format(
-            type(self).__name__, self.address, self.base_globs, self.arg, self.filespecs
-        )
+    def __str__(self):
+        return f"{self.address}({self.arg}={self.source_globs})"
 
 
 class JvmBinaryAdaptor(TargetAdaptor):
@@ -259,13 +255,13 @@ class AppAdaptor(TargetAdaptor):
             # set to that rel_path.
             rel_root = getattr(bundle, "rel_path", self.address.spec_path)
 
-            base_globs = BaseGlobs.from_sources_field(bundle.fileset, rel_root)
-            path_globs = base_globs.to_path_globs(rel_root, GlobExpansionConjunction.all_match)
+            source_globs = SourceGlobs.from_sources_field(bundle.fileset)
+            path_globs = source_globs.to_path_globs(rel_root, GlobExpansionConjunction.all_match)
 
-            filespecs_list.append(base_globs.filespecs)
+            filespecs_list.append(source_globs.filespecs)
             path_globs_list.append(path_globs)
 
-        return BundlesField(self.address, self.bundles, filespecs_list, path_globs_list,)
+        return BundlesField(self.address, self.bundles, filespecs_list, path_globs_list)
 
 
 class JvmAppAdaptor(AppAdaptor):
@@ -297,17 +293,12 @@ class PythonTargetAdaptor(TargetAdaptor):
             field_adaptors = super().field_adaptors
             if getattr(self, "resources", None) is None:
                 return field_adaptors
-            base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
-            path_globs = base_globs.to_path_globs(
-                self.address.spec_path, GlobExpansionConjunction.all_match
-            )
+            source_globs = SourceGlobs.from_sources_field(self.resources)
             sources_field = SourcesField(
-                self.address,
-                "resources",
-                base_globs.filespecs,
-                base_globs,
-                path_globs,
-                lambda _: None,
+                address=self.address,
+                arg="resources",
+                source_globs=source_globs,
+                conjunction=GlobExpansionConjunction.all_match,
             )
             return (*field_adaptors, sources_field)
 
@@ -345,7 +336,7 @@ class PythonRequirementLibraryAdaptor(TargetAdaptor):
 
 class PantsPluginAdaptor(PythonTargetAdaptor):
     def get_sources(self) -> "GlobsWithConjunction":
-        return GlobsWithConjunction.for_literal_files(["register.py"], self.address.spec_path)
+        return GlobsWithConjunction.for_literal_files(["register.py"])
 
 
 # TODO(#7490): Remove this once we have multiple params support so that rules can do something
@@ -441,134 +432,67 @@ class PantsPluginAdaptorWithOrigin(TargetAdaptorWithOrigin):
     adaptor: PantsPluginAdaptor
 
 
-# TODO: Consolidate this with `Files`
-class BaseGlobs(Locatable, metaclass=ABCMeta):
-    """An adaptor class to allow BUILD file parsing from ContextAwareObjectFactories."""
+class SourceGlobs(Locatable):
+    """A light wrapper around a target's `sources`.
+
+    This allows BUILD file parsing from ContextAwareObjectFactories.
+    """
 
     @staticmethod
-    def from_sources_field(
-        sources: Union[None, str, Iterable[str], "BaseGlobs"], spec_path: str,
-    ) -> "BaseGlobs":
+    def from_sources_field(sources: Union[None, str, Iterable[str]]) -> "SourceGlobs":
         """Return a BaseGlobs for the given sources field."""
         if sources is None:
-            return Files(spec_path=spec_path)
-        if isinstance(sources, BaseGlobs):
-            return sources
+            return SourceGlobs()
         if isinstance(sources, str):
-            return Files(sources, spec_path=spec_path)
+            return SourceGlobs(sources)
         if isinstance(sources, (MutableSet, MutableSequence, tuple)) and all(
             isinstance(s, str) for s in sources
         ):
-            return Files(*sources, spec_path=spec_path)
-        raise ValueError(f"Expected a list of literal sources and globs. Got: {sources}")
+            return SourceGlobs(*sources)
+        raise ValueError(f"Expected a list of literal source files and globs. Got: {sources}.")
 
-    @property
-    @abstractmethod
-    def path_globs_kwarg(self) -> str:
-        """The name of the `PathGlobs` parameter corresponding to this BaseGlobs instance."""
-
-    @property
-    @abstractmethod
-    def legacy_globs_class(self) -> Type[wrapped_globs.FilesetRelPathWrapper]:
-        """The corresponding `wrapped_globs` class for this BaseGlobs."""
-
-    # TODO: stop accepting an `exclude` argument once we remove `globs` et al.
-    def __init__(
-        self, *patterns: str, spec_path: str, exclude: Optional[List[str]] = None, **kwargs,
-    ) -> None:
+    def __init__(self, *patterns: str) -> None:
         self._patterns = patterns
-        self._spec_path = spec_path
-        self._raw_exclude = exclude
-
-        if isinstance(exclude, str):
-            raise ValueError(f"Excludes should be a list of strings. Got: {exclude!r}")
-        if kwargs:
-            raise ValueError(f"kwargs not supported. Got: {kwargs}")
-
-        # TODO: once we remove `globs`, `rglobs`, and `zglobs`, we should change as follows:
-        #  * Stop setting `self._parsed_include` and `self._parsed_exclude`. Only save `self._patterns`.
-        #    All the below code should be deleted. For now, we must have these values to ensure that we
-        #    properly parse the `globs()` function.
-        #  * `to_path_globs()` will still need to strip the leading `!` from the exclude pattern, call
-        #    `os.path.join`, and then prepend it back with `!`. But, it will do that when traversing
-        #     over `self._patterns`, rather than `self._parsed_exclude`. We have a new unit test to
-        #     ensure that we don't break this.
-        #  * `filespecs()` must still need to split out the includes from excludes to maintain backwards
-        #     compatibility. The below for loop splitting out the `self._patterns` should be moved
-        #     into `filespecs()`. We have a new unit test to ensure that we don't break this.
-        self._parsed_include: List[str] = []
-        self._parsed_exclude: List[str] = []
-        if isinstance(self, Files):
-            for glob in self._patterns:
-                if glob.startswith("!"):
-                    self._parsed_exclude.append(glob[1:])
-                else:
-                    self._parsed_include.append(glob)
-        else:
-            self._parsed_include = self.legacy_globs_class.to_filespec(patterns)["globs"]
-            self._parsed_exclude = self._parse_exclude(exclude or [])
 
     @property
     def filespecs(self) -> wrapped_globs.Filespec:
         """Return a filespecs dict representing both globs and excludes."""
-        filespecs: wrapped_globs.Filespec = {"globs": self._parsed_include}
-        if self._parsed_exclude:
-            filespecs["exclude"] = [{"globs": self._parsed_exclude}]
+        includes = []
+        excludes = []
+        for glob in self._patterns:
+            if glob.startswith("!"):
+                excludes.append(glob[1:])
+            else:
+                includes.append(glob)
+        filespecs: wrapped_globs.Filespec = {"globs": includes}
+        if excludes:
+            filespecs["exclude"] = [{"globs": excludes}]
         return filespecs
 
     def to_path_globs(self, relpath: str, conjunction: GlobExpansionConjunction) -> PathGlobs:
         """Return a PathGlobs representing the included and excluded Files for these patterns."""
+
+        def join_with_relpath(glob: str) -> str:
+            if glob.startswith("!"):
+                return f"!{os.path.join(relpath, glob[1:])}"
+            return os.path.join(relpath, glob)
+
         return PathGlobs(
-            globs=(
-                *(os.path.join(relpath, glob) for glob in self._parsed_include),
-                *(f"!{os.path.join(relpath, glob)}" for glob in self._parsed_exclude),
-            ),
-            conjunction=conjunction,
+            globs=(join_with_relpath(glob) for glob in self._patterns), conjunction=conjunction,
         )
 
-    def _parse_exclude(self, raw_exclude: List[str]) -> List[str]:
-        excluded_patterns: List[str] = []
-        for raw_element in raw_exclude:
-            exclude_filespecs = BaseGlobs.from_sources_field(raw_element, self._spec_path).filespecs
-            if exclude_filespecs.get("exclude"):
-                raise ValueError("Nested excludes are not supported: got {}".format(raw_element))
-            excluded_patterns.extend(exclude_filespecs["globs"])
-        return excluded_patterns
-
-    def _gen_init_args_str(self) -> str:
-        all_arg_strs = []
-        positional_args = ", ".join(repr(p) for p in self._patterns)
-        if positional_args:
-            all_arg_strs.append(positional_args)
-        all_arg_strs.append(f"spec_path={self._spec_path}")
-        if self._raw_exclude:
-            all_arg_strs.append(f"exclude={self._raw_exclude}")
-        return ", ".join(all_arg_strs)
-
     def __repr__(self) -> str:
-        # TODO: remove this once we finish deprecating `globs` et al. Use the __str__ implementation.
-        return f"{type(self).__name__}({self._gen_init_args_str()})"
-
-    def __str__(self) -> str:
-        return f"{self.path_globs_kwarg}({self._gen_init_args_str()})"
-
-
-class Files(BaseGlobs):
-    path_globs_kwarg = "files"
-    legacy_globs_class = wrapped_globs.Globs
-
-    def __str__(self) -> str:
         return f"[{', '.join(repr(p) for p in self._patterns)}]"
 
 
 @dataclass(frozen=True)
 class GlobsWithConjunction:
-    non_path_globs: BaseGlobs
+    globs: SourceGlobs
     conjunction: GlobExpansionConjunction
 
     @classmethod
-    def for_literal_files(cls, file_paths: Sequence[str], spec_path: str) -> "GlobsWithConjunction":
-        return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction.all_match)
+    def for_literal_files(cls, file_paths: Sequence[str]) -> "GlobsWithConjunction":
+        return cls(SourceGlobs(*file_paths), GlobExpansionConjunction.all_match)
 
 
 def rules():

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -23,7 +23,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot, Snapshot
 from pants.engine.legacy.graph import HydratedField
-from pants.engine.legacy.structs import Files, SourcesField
+from pants.engine.legacy.structs import SourceGlobs, SourcesField
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import SchedulerSession
 from pants.engine.selectors import Params
@@ -276,12 +276,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
                 rel_path=os.path.join(package_dir, "BUILD"), target_name="_bogus_target_for_test",
             ),
             arg="sources",
-            filespecs={"globs": package_relative_path_globs},
-            base_globs=Files(spec_path=package_dir),
-            path_globs=PathGlobs(
-                tuple(os.path.join(package_dir, path) for path in package_relative_path_globs),
-            ),
-            validate_fn=lambda _: True,
+            source_globs=SourceGlobs(*package_relative_path_globs),
         )
         field = self.scheduler.product_request(HydratedField, [sources_field])[0]
         return cast(EagerFilesetWithSpec, field.value)

--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -2,14 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.engine.fs import PathGlobs
-from pants.engine.legacy.structs import Files
+from pants.engine.legacy.structs import SourceGlobs
 from pants.option.custom_types import GlobExpansionConjunction
 
 
 def test_ignore_globs_parsed_correctly() -> None:
-    files = Files("foo.py", "!ignore.py", "!**/*", spec_path="")
-    assert files.to_path_globs(
+    sources = SourceGlobs("foo.py", "!ignore.py", "!**/*")
+    assert sources.to_path_globs(
         relpath="src/python", conjunction=GlobExpansionConjunction.any_match,
     ) == PathGlobs(["src/python/foo.py", "!src/python/ignore.py", "!src/python/**/*"])
     # Check that we maintain backwards compatibility with the `filespecs` property used by V1.
-    assert files.filespecs == {"globs": ["foo.py"], "exclude": [{"globs": ["ignore.py", "**/*"]}]}
+    assert sources.filespecs == {"globs": ["foo.py"], "exclude": [{"globs": ["ignore.py", "**/*"]}]}


### PR DESCRIPTION
We no longer need several abstractions like `BaseGlobs` vs. `Files`. This gets merged into `SourceFiles`.

`SourceFiles` (previously `BaseGlobs`) no longer takes the kwargs `spec_path` and `exclude` because these were both never used and were impossible to trigger, as now `sources` must be a list of files, rather than a function call like `globs()`.

We also simplify the constructor for `SourcesField` to stop duplicating as much information in each call site.