### PR TITLE
Mute the path scrub warning when running from sources.

### DIFF
--- a/pants
+++ b/pants
@@ -87,7 +87,7 @@ function exec_pants_bare() {
   # Redirect activation and native bootstrap to ensure that they don't interfere with stdout.
   activate_pants_venv 1>&2
   bootstrap_native_code 1>&2
-  PYTHONPATH="${PANTS_SRCPATH_STR}:${PYTHONPATH}" \
+  PYTHONPATH="${PANTS_SRCPATH_STR}:${PYTHONPATH}" RUNNING_PANTS_FROM_SOURCES=1 \
     exec python "${PANTS_EXE}" "$@"
 }
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -64,11 +64,13 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
     @staticmethod
     def scrub_pythonpath() -> None:
-        # If PYTHONPATH was used to set up the Pants runtime environment, its entries are now on our
-        # `sys.path` allowing us to run. Do not propagate any of these Pants-specific sys.path entries
-        # forward to our subprocesses.
+        # Do not propagate any PYTHONPATH that happens to have been set in our environment
+        # to our subprocesses.
+        # Note that don't warn (but still scrub) if RUNNING_PANTS_FROM_SOURCES is set. This allows
+        # scripts that run pants directly from sources, and therefore must set PYTHONPATH, to mute
+        # this warning.
         pythonpath = os.environ.pop("PYTHONPATH", None)
-        if pythonpath:
+        if pythonpath and not os.environ.pop("RUNNING_PANTS_FROM_SOURCES", None):
             logger.warning(f"Scrubbed PYTHONPATH={pythonpath} from the environment.")
 
     def run(self):


### PR DESCRIPTION
Normally, if PYTHONPATH is set we warn that we're scrubbing it,
so that users don't expect Pants subprocesses to acknowledge
that PYTHONPATH.

However when running from sources we must set PYTHONPATH to the
pants source tree, so this warning is not helpful, and can be
grating.

This change uses another env var to conditionally mute the warning,
and sets that var in the custom "from sources" `./pants` script
in the pants repo.
