### PR TITLE
Fix interpreter constraints with V2 to AND multiple targets

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import DefaultDict, Iterable, List, Optional, Tuple
+from typing import Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+from pkg_resources import Requirement
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex
@@ -56,6 +57,20 @@ class PexRequirements:
         return PexRequirements(all_target_requirements)
 
 
+Spec = Tuple[str, str]  # e.g. (">=", "3.6")
+
+
+class ParsedConstraint(NamedTuple):
+    interpreter: str
+    specs: Set[Spec]
+
+    def __str__(self) -> str:
+        specs = ",".join(
+            f"{op}{version}" for op, version in sorted(self.specs, key=lambda spec: spec[1])
+        )
+        return f"{self.interpreter}{specs}"
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class PexInterpreterConstraints:
@@ -64,31 +79,78 @@ class PexInterpreterConstraints:
     def __init__(self, constraints: Optional[Iterable[str]] = None) -> None:
         self.constraints = FrozenOrderedSet(sorted(constraints or ()))
 
-    def generate_pex_arg_list(self) -> List[str]:
-        args = []
-        for constraint in sorted(self.constraints):
-            args.extend(["--interpreter-constraint", constraint])
-        return args
+    @staticmethod
+    def merge_constraint_sets(constraint_sets: Iterable[Iterable[str]]) -> List[str]:
+        """Given a collection of constraints sets, merge by ORing within each individual constraint
+        set and ANDing across each distinct constraint set.
+
+        For example, given `[["CPython>=2.7", "CPython<=3"], ["CPython==3.6.*"]]`, return
+        `["CPython>=2.7,==3.6.*", "CPython<=3,==3.6.*"]`.
+        """
+        # Each element (a List[ParsedConstraint) will get ANDed.
+        parsed_constraint_sets: List[List[ParsedConstraint]] = []
+        for constraint_set in constraint_sets:
+            # Each element (a ParsedConstraint) will get ORed.
+            parsed_constraint_set: List[ParsedConstraint] = []
+            for constraint in constraint_set:
+                try:
+                    parsed_requirement = Requirement.parse(constraint)
+                except ValueError:
+                    # We allow the shorthand `>=3.7`, which gets expanded to `CPython>=3.7`. See
+                    # Pex's interpreter.py's `parse_requirement()`.
+                    parsed_requirement = Requirement.parse(f"CPython{constraint}")
+                interpreter = parsed_requirement.project_name
+                specs = set(parsed_requirement.specs)
+                parsed_constraint_set.append(ParsedConstraint(interpreter, specs))
+            parsed_constraint_sets.append(parsed_constraint_set)
+
+        def and_constraints(parsed_constraints: Sequence[ParsedConstraint]) -> ParsedConstraint:
+            merged_specs = set()
+            expected_interpreter = parsed_constraints[0][0]
+            for parsed_constraint in parsed_constraints:
+                if parsed_constraint.interpreter != expected_interpreter:
+                    attempted_interpreters = {
+                        interpreter: [
+                            str(parsed_constraint) for parsed_constraint in parsed_constraints
+                        ]
+                        for interpreter, parsed_constraints in itertools.groupby(
+                            parsed_constraints,
+                            key=lambda parsed_constraint: parsed_constraint.interpreter,
+                        )
+                    }
+                    raise ValueError(
+                        "Tried ANDing Python interpreter constraints with different interpreters. "
+                        f"Please use only one interpreter. Got {attempted_interpreters}."
+                    )
+                merged_specs.update(parsed_constraint.specs)
+            return ParsedConstraint(expected_interpreter, merged_specs)
+
+        return sorted(
+            {
+                str(and_constraints(constraints_product))
+                for constraints_product in itertools.product(*parsed_constraint_sets)
+            }
+        )
 
     @classmethod
     def create_from_adaptors(
         cls, adaptors: Iterable[TargetAdaptor], python_setup: PythonSetup
     ) -> "PexInterpreterConstraints":
-        constraints_to_adaptors: DefaultDict[
-            Tuple[str, ...], List[PythonTargetAdaptor]
-        ] = defaultdict(list)
+        constraint_sets: Set[Iterable[str]] = set()
         for adaptor in adaptors:
             if not isinstance(adaptor, PythonTargetAdaptor):
                 continue
-            constraints = python_setup.compatibility_or_constraints(adaptor.compatibility)
-            constraints_to_adaptors[constraints].append(adaptor)
-        # TODO(Pex#914): AND between distinct targets, but OR within targets. Right now, we flatten
-        # every constraint and OR everything. When doing this, use static analysis to produce the
-        # minimum constraints, e.g. simplify `CPython==3.6 AND (CPython==3.6 OR CPython==3.7)`
-        # to `CPython==3.6`.
-        return PexInterpreterConstraints(
-            itertools.chain.from_iterable(constraints_to_adaptors.keys())
-        )
+            constraint_set = python_setup.compatibility_or_constraints(adaptor.compatibility)
+            constraint_sets.add(constraint_set)
+        # This will OR within each target and AND across targets.
+        merged_constraints = cls.merge_constraint_sets(constraint_sets)
+        return PexInterpreterConstraints(merged_constraints)
+
+    def generate_pex_arg_list(self) -> List[str]:
+        args = []
+        for constraint in sorted(self.constraints):
+            args.extend(["--interpreter-constraint", constraint])
+        return args
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -110,17 +110,18 @@ class PexInterpreterConstraints:
             for parsed_constraint in parsed_constraints:
                 if parsed_constraint.interpreter != expected_interpreter:
                     attempted_interpreters = {
-                        interpreter: [
+                        interpreter: sorted(
                             str(parsed_constraint) for parsed_constraint in parsed_constraints
-                        ]
+                        )
                         for interpreter, parsed_constraints in itertools.groupby(
                             parsed_constraints,
                             key=lambda parsed_constraint: parsed_constraint.interpreter,
                         )
                     }
                     raise ValueError(
-                        "Tried ANDing Python interpreter constraints with different interpreters. "
-                        f"Please use only one interpreter. Got {attempted_interpreters}."
+                        "Tried ANDing Python interpreter constraints with different interpreter "
+                        "types. Please use only one interpreter type. Got "
+                        f"{attempted_interpreters}."
                     )
                 merged_specs.update(parsed_constraint.specs)
             return ParsedConstraint(expected_interpreter, merged_specs)

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -69,6 +69,24 @@ def test_merge_interpreter_constraints() -> None:
             "CPython>=3.5,==3.7.*",
         ],
     )
+    # A & (B | C | D) & (E | F) & G =>
+    # (A & B & E & G) | (A & B & F & G) | (A & C & E & G) | (A & C & F & G) | (A & D & E & G) | (A & D & F & G)
+    assert_merged(
+        input=[
+            ["CPython==3.6.5"],
+            ["CPython==2.7.14", "CPython==2.7.15", "CPython==2.7.16"],
+            ["CPython>=3.6", "CPython==3.5.10"],
+            ["CPython>3.8"],
+        ],
+        expected=[
+            "CPython==2.7.14,==3.5.10,==3.6.5,>3.8",
+            "CPython==2.7.14,>=3.6,==3.6.5,>3.8",
+            "CPython==2.7.15,==3.5.10,==3.6.5,>3.8",
+            "CPython==2.7.15,>=3.6,==3.6.5,>3.8",
+            "CPython==2.7.16,==3.5.10,==3.6.5,>3.8",
+            "CPython==2.7.16,>=3.6,==3.6.5,>3.8",
+        ],
+    )
 
     # No specifiers
     assert_merged(input=[["CPython"]], expected=["CPython"])


### PR DESCRIPTION
### Problem

With interpreter constraints, PEX allows ANDing interpreter constraints via a comma, e.g. `CPython>=2.7,<3`. PEX also allows ORing constraints by passing `--interpreter-constraint` multiple times, which is useful for disjoint sets like `CPython==2.7.* | CPython>=3.6`.

Currently, in V2, we OR every interpreter constraint encountered. Instead, we should only OR within each individual target and should AND between targets. For example, the below should resolve to needing Python 3.7 because `:dep` requires it, even though `:compat` works with Python 2.7 or 3.6+:

```python
python_library(
  name="dep_global",
  source="test_compat.py",
)

python_library(
  name="dep",
  source="test_compat.py",
  compatibility=['CPython==3.7.*']
)

python_tests(
  name = 'compat',
  source='test_compat.py',
  dependencies=[":dep", ":dep_global"],
  compatibility=['CPython>=2.7,<3', 'CPython>=3.6.*'],
)
```

### Solution

The only way PEX can AND constraints is via commas of multiple specs (e.g. `>=3.5` or `==3.5.*`) in the same requirement string. The only way to say `CPython==2.7.* AND CPython==3.5.*` is to merge it into `CPython==2.7.*,3.5.*`.

So, we add code that will OR within each individual target but AND across targets. We do this by using setuptools' `Requirement.parse()` to get each individual `spec`, then using `itertools.product` to generate every combination of the requirements, and finally merging these into strings understood by Pex. 

### Result

V2 now handles interpreter constraints similar to V1. However, unlike V1 determining the interpreter via Pants code, with V2, Pants will solely pass the constraints to Pex and let Pex handle all runtime interpreter selection.

We eagerly error when trying to AND different interpreters, e.g. `PyPY & CPython`.