### PR TITLE
Deprecate V1 isort implementation in favor of improved V2 implementation

### DIFF
--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -3,9 +3,11 @@
 
 import importlib
 import traceback
+from typing import Dict, List
 
-from pkg_resources import Requirement
+from pkg_resources import Requirement, WorkingSet
 
+from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import BackendConfigurationError
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.util.ordered_set import FrozenOrderedSet
@@ -24,24 +26,59 @@ class PluginLoadOrderError(PluginLoadingError):
 
 
 def load_backends_and_plugins(
-    plugins1, plugins2, working_set, backends1, backends2, build_configuration
-):
+    plugins1: List[str],
+    plugins2: List[str],
+    working_set: WorkingSet,
+    backends1: List[str],
+    backends2: List[str],
+    build_configuration: BuildConfiguration,
+) -> BuildConfiguration:
     """Load named plugins and source backends.
 
-    :param list<str> plugins1: v1 plugins to load.
-    :param list<str> plugins2: v2 plugins to load.
-    :param WorkingSet working_set: A pkg_resources.WorkingSet to load plugins from.
-    :param list<str> backends1: v1 backends to load.
-    :param list<str> backends2: v2 backends to load.
-    :param BuildConfiguration build_configuration: The BuildConfiguration (for adding aliases).
+    :param plugins1: v1 plugins to load.
+    :param plugins2: v2 plugins to load.
+    :param working_set: A pkg_resources.WorkingSet to load plugins from.
+    :param backends1: v1 backends to load.
+    :param backends2: v2 backends to load.
+    :param build_configuration: The BuildConfiguration (for adding aliases).
     """
+    if "pants.backend.python.lint.isort" in backends1:
+        warn_or_error(
+            deprecated_entity_description="The V1 isort implementation",
+            removal_version="1.29.0.dev0",
+            hint=(
+                "The original isort implementation is being replaced by an improved implementation "
+                "made possible by the V2 engine. This new implementation brings these benefits:\n\n"
+                "\t1) Avoids unnecessary prework. This new implementation should be faster to "
+                "run.\n"
+                "\t2) Has less verbose output. Pants will now only show what isort itself outputs. "
+                "(Use `--v2-ui` if you want to see the work Pants is doing behind-the-scenes.)\n"
+                "\t3) Works with `./pants lint` automatically. When you run `./pants lint`, Pants "
+                "will run isort in check-only mode.\n"
+                "\t4) Works with precise file arguments. If you say `./pants fmt f1.py`, Pants "
+                "will only run over the file `f1.py`, whereas the old implementation would run "
+                "over every file belonging to the target that owns `f1.py`."
+                "\n\nTo prepare for this change, add to the `GLOBAL` section in your `pants.toml` "
+                "the line `backend_packages.remove = ['pants.backend.python.lint.isort']` "
+                "(or `backend_packages = -['pants.backend.python.lint.isort']` to your "
+                "`pants.ini`). Then, if you still want to use isort, add "
+                "`backend_packages2.add = ['pants.backend.python.lint.isort']` to `pants.toml` or "
+                "`backend_packages2 = +['pants.backend.python.lint.isort']` to your `pants.ini`. "
+                "Ensure that you have `--v2` enabled (the default value)."
+            ),
+        )
     load_build_configuration_from_source(build_configuration, backends1, backends2)
     load_plugins(build_configuration, plugins1, working_set, is_v1_plugin=True)
     load_plugins(build_configuration, plugins2, working_set, is_v1_plugin=False)
     return build_configuration
 
 
-def load_plugins(build_configuration, plugins, working_set, is_v1_plugin):
+def load_plugins(
+    build_configuration: BuildConfiguration,
+    plugins: List[str],
+    working_set: WorkingSet,
+    is_v1_plugin: bool,
+) -> None:
     """Load named plugins from the current working_set into the supplied build_configuration.
 
     "Loading" a plugin here refers to calling registration methods -- it is assumed each plugin
@@ -60,13 +97,13 @@ def load_plugins(build_configuration, plugins, working_set, is_v1_plugin):
     can be loaded. This does not change the order or what plugins are loaded in any way -- it is
     purely an assertion to guard against misconfiguration.
 
-    :param BuildConfiguration build_configuration: The BuildConfiguration (for adding aliases).
-    :param list<str> plugins: A list of plugin names optionally with versions, in requirement format.
+    :param build_configuration: The BuildConfiguration (for adding aliases).
+    :param plugins: A list of plugin names optionally with versions, in requirement format.
                               eg ['widgetpublish', 'widgetgen==1.2'].
-    :param WorkingSet working_set: A pkg_resources.WorkingSet to load plugins from.
-    :param bool is_v1_plugin: Whether this is a v1 or v2 plugin.
+    :param working_set: A pkg_resources.WorkingSet to load plugins from.
+    :param is_v1_plugin: Whether this is a v1 or v2 plugin.
     """
-    loaded = {}
+    loaded: Dict = {}
     for plugin in plugins or []:
         req = Requirement.parse(plugin)
         dist = working_set.find(req)
@@ -105,10 +142,12 @@ def load_plugins(build_configuration, plugins, working_set, is_v1_plugin):
         loaded[dist.as_requirement().key] = dist
 
 
-def load_build_configuration_from_source(build_configuration, backends1, backends2):
+def load_build_configuration_from_source(
+    build_configuration: BuildConfiguration, backends1: List[str], backends2: List[str]
+) -> None:
     """Installs pants backend packages to provide BUILD file symbols and cli goals.
 
-    :param BuildConfiguration build_configuration: The BuildConfiguration (for adding aliases).
+    :param build_configuration: The BuildConfiguration (for adding aliases).
     :param backends1: An list of packages to load v1 backends from.
     :param backends2: An list of packages to load v2 backends from.
     :raises: :class:``pants.base.exceptions.BuildConfigurationError`` if there is a problem loading

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -298,18 +298,22 @@ class GlobalOptions(Subsystem):
                 "pants.backend.codegen.wire.java",
                 "pants.backend.project_info",
             ],
-            help="Register v1 tasks from these backends. The backend packages must be present on "
-            "the PYTHONPATH, typically because they are in the pants core dist, in a "
-            "plugin dist, or available as sources in the repo.",
+            help=(
+                "Register v1 tasks from these backends. The backend packages must be present on "
+                "the PYTHONPATH, typically because they are in the Pants core dist, in a "
+                "plugin dist, or available as sources in the repo."
+            ),
         )
         register(
             "--backend-packages2",
             advanced=True,
             type=list,
             default=[],
-            help="Register v2 rules from these backends. The backend packages must be present on "
-            "the PYTHONPATH, typically because they are in the pants core dist, in a "
-            "plugin dist, or available as sources in the repo.",
+            help=(
+                "Register v2 rules from these backends. The backend packages must be present on "
+                "the PYTHONPATH, typically because they are in the Pants core dist, in a "
+                "plugin dist, or available as sources in the repo."
+            ),
         )
 
         register(


### PR DESCRIPTION
As explained in this deprecation message, the V2 isort implementation brings 4 main benefits compared to the V1 implementation:

> ▶ ./pants --v2 fmt src/python/pants/util:strutil
/Users/eric/DocsLocal/code/projects/pants/src/python/pants/init/options_initializer.py:64: DeprecationWarning: DEPRECATED: The V1 isort implementation will be removed in version 1.29.0.dev0.
>  The original isort implementation is being replaced by an improved implementation made possible by the V2 engine. This new implementation brings these benefits:
>
>	1) Avoids unnecessary prework. This new implementation should be faster to run.
>	2) Has less verbose output. Pants will now only show what isort itself outputs. (Use `--v2-ui` if you want to see the work Pants is doing behind-the-scenes.)
>	3) Works with `./pants lint` automatically. When you run `./pants lint`, Pants will run isort in check-only mode.
>	4) Works with precise file arguments. If you say `./pants fmt f1.py`, Pants will only run over the file `f1.py`, whereas the old implementation would run over every file belonging to the target that owns `f1.py`.
>
> To prepare for this change, add to the `GLOBAL` section in your `pants.toml` the line `backend_packages.remove = ['pants.backend.python.lint.isort']` (or `backend_packages = -['pants.backend.python.lint.isort']` to your `pants.ini`). Then, if you still want to use isort, add `backend_packages2.add = ['pants.backend.python.lint.isort']` to `pants.toml` or `backend_packages2 = +['pants.backend.python.lint.isort']` to your `pants.ini`. Ensure that you have `--v2` enabled (the default value).

Important detail: V2 isort will work even without V2 `pants.backend.python` enabled. Also, we now have `--v2` on by default. So, things should work as soon as adding `backend_packages2.add = ['pants.backend.python.lint.isort']`.

Beyond an improved user experience, this reduces the amount of code we need to maintain and means that the majority of Python users will now be using V2!