### PR TITLE
Enforce keyword args in TestBase.create_library()

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -33,7 +33,10 @@ class ThriftLinterTest(TaskTestBase):
             )
 
         thrift_target = self.create_library(
-            "src/thrift/tweet", "java_thrift_library", "a", ["A.thrift"]
+            path="src/thrift/tweet",
+            target_type="java_thrift_library",
+            name="a",
+            sources=["A.thrift"],
         )
         task = self.create_task(self.context(target_roots=thrift_target))
         self._prepare_mocks(task)
@@ -66,9 +69,18 @@ class ThriftLinterTest(TaskTestBase):
                 self.context().options.for_global_scope()
             )
 
-        self.create_library("src/thrift/tweet", "java_thrift_library", "a", ["A.thrift"])
+        self.create_library(
+            path="src/thrift/tweet",
+            target_type="java_thrift_library",
+            name="a",
+            sources=["A.thrift"],
+        )
         target_b = self.create_library(
-            "src/thrift/tweet", "java_thrift_library", "b", ["B.thrift"], dependencies=[":a"]
+            path="src/thrift/tweet",
+            target_type="java_thrift_library",
+            name="b",
+            sources=["B.thrift"],
+            dependencies=[":a"],
         )
         task = self.create_task(self.context(target_roots=target_b))
         self._prepare_mocks(task)

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -608,6 +608,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
     def create_library(
         self,
+        *,
         path: str,
         target_type: str,
         name: str,
@@ -666,7 +667,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         """
         :API: public
         """
-        return self.create_library(path, "resources", name, sources)
+        return self.create_library(path=path, target_type="resources", name=name, sources=sources,)
 
     def assertUnorderedPrefixEqual(self, expected, actual_iter):
         """Consumes len(expected) items from the given iter, and asserts that they match, unordered.

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_create.py
@@ -63,11 +63,23 @@ class JarCreateMiscTest(JarCreateTestBase):
 
 
 class JarCreateExecuteTest(JarCreateTestBase):
-    def java_library(self, path, name, sources, **kwargs):
-        return self.create_library(path, "java_library", name, sources, **kwargs)
+    def java_library(self, path, name, sources, dependencies=None):
+        return self.create_library(
+            path=path,
+            target_type="java_library",
+            name=name,
+            sources=sources,
+            dependencies=dependencies,
+        )
 
-    def scala_library(self, path, name, sources, **kwargs):
-        return self.create_library(path, "scala_library", name, sources, **kwargs)
+    def scala_library(self, path, name, sources, java_sources=None):
+        return self.create_library(
+            path=path,
+            target_type="scala_library",
+            name=name,
+            sources=sources,
+            java_sources=java_sources,
+        )
 
     def jvm_binary(self, path, name, source=None, dependencies=None):
         self.create_files(path, [source])
@@ -86,7 +98,9 @@ class JarCreateExecuteTest(JarCreateTestBase):
         return self.target(f"{path}:{name}")
 
     def java_thrift_library(self, path, name, *sources):
-        return self.create_library(path, "java_thrift_library", name, sources)
+        return self.create_library(
+            path=path, target_type="java_thrift_library", name=name, sources=sources
+        )
 
     def setUp(self):
         super().setUp()

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -57,10 +57,10 @@ class JarPublishTest(NailgunTaskTestBase):
         targets.append(nail_target)
 
         shoe_target = self.create_library(
-            "b",
-            "java_library",
-            "b",
-            ["B.java"],
+            path="b",
+            target_type="java_library",
+            name="b",
+            sources=["B.java"],
             provides="artifact(org='com.example', name='shoe', repo=internal)",
             dependencies=[nail_target.address.reference()],
         )
@@ -69,17 +69,19 @@ class JarPublishTest(NailgunTaskTestBase):
         shoe_address = shoe_target.address.reference()
         if with_alias:
             # add an alias target between c and b
-            alias_target = self.create_library("z", "target", "z", dependencies=[shoe_address])
+            alias_target = self.create_library(
+                path="z", target_type="target", name="z", dependencies=[shoe_address]
+            )
             targets.append(alias_target)
             horse_deps = [alias_target.address.reference()]
         else:
             horse_deps = [shoe_address]
 
         horse_target = self.create_library(
-            "c",
-            "java_library",
-            "c",
-            ["C.java"],
+            path="c",
+            target_type="java_library",
+            name="c",
+            sources=["C.java"],
             provides="artifact(org='com.example', name='horse', repo=internal)",
             dependencies=horse_deps,
         )
@@ -88,20 +90,20 @@ class JarPublishTest(NailgunTaskTestBase):
 
     def _create_nail_target(self):
         return self.create_library(
-            "a",
-            "java_library",
-            "a",
-            ["A.java"],
+            path="a",
+            target_type="java_library",
+            name="a",
+            sources=["A.java"],
             provides="artifact(org='com.example', name='nail', repo=internal)",
         )
 
     def _prepare_targets_with_duplicates(self):
         targets = list(self._prepare_for_publishing())
         conflict = self.create_library(
-            "conflict",
-            "java_library",
-            "conflict",
-            ["Conflict.java"],
+            path="conflict",
+            target_type="java_library",
+            name="conflict",
+            sources=["Conflict.java"],
             provides="artifact(org='com.example', name='nail', repo=internal)",
         )
         targets.append(conflict)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -175,7 +175,12 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
         if target_name:
             target = self.target(target_name)
         else:
-            target = self.create_library(test_rel_path, "junit_tests", "foo_test", ["FooTest.java"])
+            target = self.create_library(
+                path=test_rel_path,
+                target_type="junit_tests",
+                name="foo_test",
+                sources=["FooTest.java"],
+            )
 
         target_roots = []
         if create_some_resources:
@@ -571,11 +576,11 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
                   @Test
                   public void testFoo() {{
                     assertTrue(new File("target_cwd_sentinel").exists());
-        
+
                     // We declare a Files dependency on this file, but since we run in a CWD not in a
                     // chroot and not in the build root, we can't find it at the expected relative path.
                     assertFalse(new File("config/org/pantsbuild/foo/files_dep_sentinel").exists());
-        
+
                     // As a sanity check, it is at the expected absolute path though.
                     File buildRoot = new File("{}");
                     assertTrue(new File(buildRoot,

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -75,8 +75,8 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
                 "lib.py": dedent(
                     """
                     import os
-                
-                
+
+
                     def main():
                       os.getcwd()
                     """
@@ -90,7 +90,9 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
         self._assert_pex(binary)
 
     def test_deployable_archive_products_files_deps(self):
-        self.create_library("src/things", "files", "things", sources=["loose_file"])
+        self.create_library(
+            path="src/things", target_type="files", name="things", sources=["loose_file"]
+        )
         self.create_file("src/things/loose_file", "data!")
         self.create_python_library(
             "src/python/lib",
@@ -101,8 +103,8 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
                     import io
                     import os
                     import sys
-                
-                
+
+
                     def main():
                       here = os.path.dirname(__file__)
                       loose_file = os.path.join(here, '../src/things/loose_file')

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -42,10 +42,15 @@ class SourceMapperTest(TestBase):
 
     def test_joint_ownership(self):
         # A simple target with two sources.
-        self.create_library("lib/rpc", "java_library", "rpc", ["err.py", "http.py"])
+        self.create_library(
+            path="lib/rpc", target_type="java_library", name="rpc", sources=["err.py", "http.py"]
+        )
         # Another target with sources but also claims one already owned from above.
         self.create_library(
-            "lib", "java_library", "lib", ["a.py", "b.py", "rpc/net.py", "rpc/err.py"]
+            path="lib",
+            target_type="java_library",
+            name="lib",
+            sources=["a.py", "b.py", "rpc/net.py", "rpc/err.py"],
         )
 
         # Sole ownership of new files.
@@ -61,7 +66,12 @@ class SourceMapperTest(TestBase):
 
     def test_nested(self):
         # A root-level BUILD file's sources are found or not correctly.
-        self.create_library("date", "java_library", "date", ["day.py", "time/unit/hour.py"])
+        self.create_library(
+            path="date",
+            target_type="java_library",
+            name="date",
+            sources=["day.py", "time/unit/hour.py"],
+        )
         self.create_file("date/time/unit/minute.py")
         # Shallow, simple source still works.
         self.owner(["date:date"], "date/day.py")
@@ -71,10 +81,27 @@ class SourceMapperTest(TestBase):
         self.owner([], "date/time/unit/minute.py")
 
     def test_with_root_level_build(self):
-        self.create_library("", "java_library", "top", ["foo.py", "text/common/const/emoji.py"])
-        self.create_library("text", "java_library", "text", ["localize.py"])
-        self.create_library("text/common/const", "java_library", "const", ["emoji.py", "ascii.py"])
-        self.create_library("text/common/helper", "java_library", "helper", ["trunc.py"])
+        self.create_library(
+            path="",
+            target_type="java_library",
+            name="top",
+            sources=["foo.py", "text/common/const/emoji.py"],
+        )
+        self.create_library(
+            path="text", target_type="java_library", name="text", sources=["localize.py"]
+        )
+        self.create_library(
+            path="text/common/const",
+            target_type="java_library",
+            name="const",
+            sources=["emoji.py", "ascii.py"],
+        )
+        self.create_library(
+            path="text/common/helper",
+            target_type="java_library",
+            name="helper",
+            sources=["trunc.py"],
+        )
         self.create_file("bar.py")
 
         self.owner(["text/common/helper:helper"], "text/common/helper/trunc.py")

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -41,8 +41,8 @@ class GraphTest(TestBase):
         )
 
     def test_with_missing_target_in_existing_build_file(self) -> None:
-        self.create_library("3rdparty/python", "target", "Markdown")
-        self.create_library("3rdparty/python", "target", "Pygments")
+        self.create_library(path="3rdparty/python", target_type="target", name="Markdown")
+        self.create_library(path="3rdparty/python", target_type="target", name="Pygments")
         # When a target is missing,
         #  the suggestions should be in order
         #  and there should only be one copy of the error if tracing is off.
@@ -63,7 +63,7 @@ class GraphTest(TestBase):
 
     def test_invalidate_fsnode(self) -> None:
         # NB: Invalidation is now more directly tested in unit tests in the `graph` crate.
-        self.create_library("src/example", "target", "things")
+        self.create_library(path="src/example", target_type="target", name="things")
         self.targets("src/example::")
         invalidated_count = self.invalidate_for("src/example/BUILD")
         self.assertGreater(invalidated_count, 0)
@@ -71,7 +71,9 @@ class GraphTest(TestBase):
     def test_sources_ordering(self) -> None:
         input_sources = ["p", "a", "n", "t", "s", "b", "u", "i", "l", "d"]
         expected_sources = sorted(input_sources)
-        self.create_library("src/example", "files", "things", sources=input_sources)
+        self.create_library(
+            path="src/example", target_type="files", name="things", sources=input_sources
+        )
 
         target = self.target("src/example:things")
         sources = [os.path.basename(s) for s in target.sources_relative_to_buildroot()]
@@ -84,6 +86,6 @@ class GraphTest(TestBase):
         definitions.
         """
 
-        files = self.create_library("src/example", "tagged_files", "things")
+        files = self.create_library(path="src/example", target_type="tagged_files", name="things")
         self.assertIn(self._TAG, files.tags)
         self.assertEqual(type(files), Files)


### PR DESCRIPTION
Minor refactor after #9249  to enforce the use of key word args.