### PR TITLE
Introduce a notion of schema to lmdb

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -8,7 +8,7 @@ use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use lmdb::Error::NotFound;
 use lmdb::{self, Cursor, Database, RwTransaction, Transaction, WriteFlags};
 use sha2::Sha256;
-use sharded_lmdb::ShardedLmdb;
+use sharded_lmdb::{ShardedLmdb, VersionedFingerprint};
 use std;
 use std::collections::BinaryHeap;
 use std::path::Path;
@@ -63,12 +63,13 @@ impl ByteStore {
       // it _can_ be a Directory.
       return Ok(Some(EntryType::Directory));
     }
+    let effective_key = VersionedFingerprint::new(*fingerprint, ShardedLmdb::schema_version());
     {
       let (env, directory_database, _) = self.inner.directory_dbs.clone()?.get(fingerprint);
       let txn = env
         .begin_ro_txn()
         .map_err(|err| format!("Failed to begin read transaction: {:?}", err))?;
-      match txn.get(directory_database, &fingerprint.as_ref()) {
+      match txn.get(directory_database, &effective_key) {
         Ok(_) => return Ok(Some(EntryType::Directory)),
         Err(NotFound) => {}
         Err(err) => {
@@ -83,7 +84,7 @@ impl ByteStore {
     let txn = env
       .begin_ro_txn()
       .map_err(|err| format!("Failed to begin read transaction: {}", err))?;
-    match txn.get(file_database, &fingerprint.as_ref()) {
+    match txn.get(file_database, &effective_key) {
       Ok(_) => return Ok(Some(EntryType::File)),
       Err(NotFound) => {}
       Err(err) => {
@@ -175,10 +176,14 @@ impl ByteStore {
         env
           .begin_rw_txn()
           .and_then(|mut txn| {
-            txn.del(database, &aged_fingerprint.fingerprint.as_ref(), None)?;
+            let key = VersionedFingerprint::new(
+              aged_fingerprint.fingerprint,
+              ShardedLmdb::schema_version(),
+            );
+            txn.del(database, &key, None)?;
 
             txn
-              .del(lease_database, &aged_fingerprint.fingerprint.as_ref(), None)
+              .del(lease_database, &key, None)
               .or_else(|err| match err {
                 NotFound => Ok(()),
                 err => Err(err),
@@ -242,9 +247,11 @@ impl ByteStore {
           // 0 indicates unleased.
           .unwrap_or(0);
 
+        let v = VersionedFingerprint::from_bytes_unsafe(key);
+        let fingerprint = v.get_fingerprint();
         fingerprints_by_expired_ago.push(AgedFingerprint {
           expired_seconds_ago: expired_seconds_ago,
-          fingerprint: Fingerprint::from_bytes_unsafe(key),
+          fingerprint,
           size_bytes: bytes.len(),
           entry_type: entry_type,
         });
@@ -323,7 +330,9 @@ impl ByteStore {
         .open_ro_cursor(*database)
         .map_err(|err| format!("Failed to open lmdb read cursor: {}", err))?;
       for (key, bytes) in cursor.iter() {
-        digests.push(Digest(Fingerprint::from_bytes_unsafe(key), bytes.len()));
+        let v = VersionedFingerprint::from_bytes_unsafe(key);
+        let fingerprint = v.get_fingerprint();
+        digests.push(Digest(fingerprint, bytes.len()));
       }
     }
     Ok(digests)

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -44,7 +44,7 @@ pub const EMPTY_FINGERPRINT: Fingerprint = Fingerprint([
 ]);
 pub const EMPTY_DIGEST: Digest = Digest(EMPTY_FINGERPRINT, 0);
 
-const FINGERPRINT_SIZE: usize = 32;
+pub const FINGERPRINT_SIZE: usize = 32;
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Fingerprint(pub [u8; FINGERPRINT_SIZE]);

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -27,7 +27,7 @@
 
 use bytes::Bytes;
 use futures01::{future, Future};
-use hashing::Fingerprint;
+use hashing::{Fingerprint, FINGERPRINT_SIZE};
 use lmdb::{
   self, Database, DatabaseFlags, Environment, EnvironmentCopyFlags, EnvironmentFlags,
   RwTransaction, Transaction, WriteFlags,
@@ -39,6 +39,55 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time;
 use tempfile::TempDir;
+
+const VERSIONED_FINGERPRINT_SIZE: usize = FINGERPRINT_SIZE + 1;
+
+/// VersionedFingerprint is a byte buffer one longer than the number of bytes stored in a
+/// Fingerprint. It is just the byte pattern of a Fingerprint with the version number concatenated
+/// onto the end of it.
+pub struct VersionedFingerprint([u8; VERSIONED_FINGERPRINT_SIZE]);
+
+impl VersionedFingerprint {
+  pub fn new(fingerprint: Fingerprint, version: u8) -> VersionedFingerprint {
+    let mut buf = [0; VERSIONED_FINGERPRINT_SIZE];
+    buf[0..FINGERPRINT_SIZE].copy_from_slice(&fingerprint.0[..]);
+    buf[FINGERPRINT_SIZE] = version;
+    VersionedFingerprint(buf)
+  }
+
+  pub fn get_fingerprint(&self) -> Fingerprint {
+    let mut buf = [0; FINGERPRINT_SIZE];
+    buf.copy_from_slice(&self.0[0..FINGERPRINT_SIZE]);
+    Fingerprint(buf)
+  }
+
+  pub fn from_bytes_unsafe(bytes: &[u8]) -> VersionedFingerprint {
+    if bytes.len() != VERSIONED_FINGERPRINT_SIZE {
+      panic!(
+        "Input value was not a versioned fingerprint; had length: {}",
+        bytes.len()
+      );
+    }
+
+    let mut buf = [0; VERSIONED_FINGERPRINT_SIZE];
+    buf.clone_from_slice(&bytes[0..VERSIONED_FINGERPRINT_SIZE]);
+    VersionedFingerprint(buf)
+  }
+
+  pub fn to_hex(&self) -> String {
+    let mut s = String::new();
+    for byte in 0..VERSIONED_FINGERPRINT_SIZE {
+      fmt::Write::write_fmt(&mut s, format_args!("{:02x}", byte)).unwrap();
+    }
+    s
+  }
+}
+
+impl AsRef<[u8]> for VersionedFingerprint {
+  fn as_ref(&self) -> &[u8] {
+    &self.0[..]
+  }
+}
 
 // Each LMDB directory can have at most one concurrent writer.
 // We use this type to shard storage into 16 LMDB directories, based on the first 4 bits of the
@@ -53,6 +102,16 @@ pub struct ShardedLmdb {
 }
 
 impl ShardedLmdb {
+  // Whenever we change the byte format of data stored in lmdb, we will
+  // need to increment this schema version. This schema version will
+  // be appended to the Fingerprint-derived keys to create the key
+  // we actually store in the database. This way, data stored with a version
+  // of pants on one schema version will not conflict with data stored
+  // with a different version of pants on a different schema version.
+  pub fn schema_version() -> u8 {
+    1
+  }
+
   // max_size is the maximum size the databases together will be allowed to grow to.
   // When calling this function, we will attempt to allocate that much virtual (not resident) memory
   // for the mmap; in theory it should be possible not to bound this, but in practice we see travis
@@ -69,7 +128,7 @@ impl ShardedLmdb {
     for (env, dir, fingerprint_prefix) in ShardedLmdb::envs(&root_path, max_size)? {
       trace!("Making ShardedLmdb content database for {:?}", dir);
       let content_database = env
-        .create_db(Some("content"), DatabaseFlags::empty())
+        .create_db(Some("content-versioned"), DatabaseFlags::empty())
         .map_err(|e| {
           format!(
             "Error creating/opening content database at {:?}: {}",
@@ -79,7 +138,7 @@ impl ShardedLmdb {
 
       trace!("Making ShardedLmdb lease database for {:?}", dir);
       let lease_database = env
-        .create_db(Some("leases"), DatabaseFlags::empty())
+        .create_db(Some("leases-versioned"), DatabaseFlags::empty())
         .map_err(|e| {
           format!(
             "Error creating/opening content database at {:?}: {}",
@@ -171,19 +230,20 @@ impl ShardedLmdb {
 
   pub fn store_bytes(
     &self,
-    key: Fingerprint,
+    fingerprint: Fingerprint,
     bytes: Bytes,
     initial_lease: bool,
   ) -> impl Future<Item = (), Error = String> {
     let store = self.clone();
     self.executor.spawn_on_io_pool(future::lazy(move || {
-      let (env, db, lease_database) = store.get(&key);
+      let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::schema_version());
+      let (env, db, lease_database) = store.get(&fingerprint);
       let put_res = env.begin_rw_txn().and_then(|mut txn| {
-        txn.put(db, &key, &bytes, WriteFlags::NO_OVERWRITE)?;
+        txn.put(db, &effective_key, &bytes, WriteFlags::NO_OVERWRITE)?;
         if initial_lease {
           store.lease(
             lease_database,
-            &key,
+            &effective_key,
             Self::default_lease_until_secs_since_epoch(),
             &mut txn,
           )?;
@@ -194,7 +254,11 @@ impl ShardedLmdb {
       match put_res {
         Ok(()) => Ok(()),
         Err(lmdb::Error::KeyExist) => Ok(()),
-        Err(err) => Err(format!("Error storing key {:?}: {}", key.to_hex(), err)),
+        Err(err) => Err(format!(
+          "Error storing versioned key {:?}: {}",
+          effective_key.to_hex(),
+          err
+        )),
       }
     }))
   }
@@ -202,13 +266,13 @@ impl ShardedLmdb {
   fn lease(
     &self,
     database: Database,
-    fingerprint: &Fingerprint,
+    versioned_fingerprint: &VersionedFingerprint,
     until_secs_since_epoch: u64,
     txn: &mut RwTransaction<'_>,
   ) -> Result<(), lmdb::Error> {
     txn.put(
       database,
-      &fingerprint.as_ref(),
+      &versioned_fingerprint.as_ref(),
       &until_secs_since_epoch.to_le_bytes(),
       WriteFlags::empty(),
     )
@@ -230,17 +294,18 @@ impl ShardedLmdb {
     f: F,
   ) -> impl Future<Item = Option<T>, Error = String> {
     let store = self.clone();
+    let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::schema_version());
     self.executor.spawn_on_io_pool(future::lazy(move || {
       let (env, db, _) = store.get(&fingerprint);
       let ro_txn = env
         .begin_ro_txn()
         .map_err(|err| format!("Failed to begin read transaction: {}", err));
-      ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
+      ro_txn.and_then(|txn| match txn.get(db, &effective_key) {
         Ok(bytes) => f(Bytes::from(bytes)).map(Some),
         Err(lmdb::Error::NotFound) => Ok(None),
         Err(err) => Err(format!(
-          "Error loading fingerprint {:?}: {}",
-          fingerprint.to_hex(),
+          "Error loading versioned key {:?}: {}",
+          effective_key.to_hex(),
           err,
         )),
       })


### PR DESCRIPTION
### Problem

In order to implement https://github.com/pantsbuild/pants/pull/9198 , which stores the Platform a remote process executed on in lmdb, we need to change the way that bytes we store to/load from lmdb are (de)serialized to rust data structures. This is fundamentally a database schema change, which we don't currently have a way to do gracefully.

### Solution

This commit introduces a new type `VersionedFingerprint`, which is a simple concatenation of the existing `Fingerprint` type and a one-byte schema version tag. From here on out, if we ever need to change the way we store a type in lmdb, we can bump the schema version (and add an additional byte if we ever need to do this more than 255 times), which will make existing `Fingerprint`s stored in the database no longer map to the same effective keys they did previously. This will make it so that when pants upgrades (or downgrades),  pants won't find a value stored in lmdb under a different data model and try to deserialize it incorrectly.

This commit also renames the currently-existing instantiations of lmdb, which on a one-time basis with this commit will effectively invalidate all existing cache entries.