### PR TITLE
Prevent excessive readlink's when using a symlinked workdir.

### DIFF
--- a/src/python/pants/cache/artifact.py
+++ b/src/python/pants/cache/artifact.py
@@ -81,8 +81,11 @@ class TarballArtifact(Artifact):
 
     # TODO: Expose `dereference` for tasks.
     # https://github.com/pantsbuild/pants/issues/3961
-    def __init__(self, artifact_root, tarfile_, compression=9, dereference=True):
+    def __init__(
+        self, artifact_root, artifact_extraction_root, tarfile_, compression=9, dereference=True
+    ):
         super().__init__(artifact_root)
+        self.artifact_extraction_root = artifact_extraction_root
         self._tarfile = tarfile_
         self._compression = compression
         self._dereference = dereference
@@ -113,7 +116,7 @@ class TarballArtifact(Artifact):
         # after the extraction.
         try:
             self.NATIVE_BINARY.decompress_tarball(
-                self._tarfile.encode(), self._artifact_root.encode()
+                self._tarfile.encode(), self.artifact_extraction_root.encode()
             )
         except Exception as e:
             raise ArtifactError("Extracting artifact failed:\n{}".format(e))

--- a/src/python/pants/cache/artifact_cache.py
+++ b/src/python/pants/cache/artifact_cache.py
@@ -50,12 +50,13 @@ class ArtifactCache:
     Subclasses implement the methods below to provide this functionality.
     """
 
-    def __init__(self, artifact_root):
+    def __init__(self, artifact_root, artifact_extraction_root=None):
         """Create an ArtifactCache.
 
         All artifacts must be under artifact_root.
         """
         self.artifact_root = artifact_root
+        self.artifact_extraction_root = artifact_extraction_root or artifact_root
 
     def prune(self):
         """Prune stale cache files.

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -20,15 +20,23 @@ logger = logging.getLogger(__name__)
 
 
 class BaseLocalArtifactCache(ArtifactCache):
-    def __init__(self, artifact_root, compression, permissions=None, dereference=True):
+    def __init__(
+        self,
+        artifact_root,
+        artifact_extraction_root,
+        compression,
+        permissions=None,
+        dereference=True,
+    ):
         """
         :param str artifact_root: The path under which cacheable products will be read/written.
+        :param str artifact_extraction_root: The path to where we should extract artifacts. Usually a reified artifact_path.
         :param int compression: The gzip compression level for created artifacts.
                                 Valid values are 0-9.
         :param str permissions: File permissions to use when creating artifact files.
         :param bool dereference: Dereference symlinks when creating the cache tarball.
         """
-        super().__init__(artifact_root)
+        super().__init__(artifact_root, artifact_extraction_root)
         self._compression = compression
         self._cache_root = None
         self._permissions = permissions
@@ -36,7 +44,11 @@ class BaseLocalArtifactCache(ArtifactCache):
 
     def _artifact(self, path):
         return TarballArtifact(
-            self.artifact_root, path, self._compression, dereference=self._dereference
+            self.artifact_root,
+            self.artifact_extraction_root,
+            path,
+            self._compression,
+            dereference=self._dereference,
         )
 
     @contextmanager
@@ -101,6 +113,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     def __init__(
         self,
         artifact_root,
+        artifact_extraction_root,
         cache_root,
         compression,
         max_entries_per_target=None,
@@ -109,6 +122,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     ):
         """
         :param str artifact_root: The path under which cacheable products will be read/written.
+        :param str artifact_extraction_root: The path to where we should extract artifacts. Usually a reified artifact_path.
         :param str cache_root: The locally cached files are stored under this directory.
         :param int compression: The gzip compression level for created artifacts (1-9 or false-y).
         :param int max_entries_per_target: The maximum number of old cache files to leave behind on a cache miss.
@@ -117,6 +131,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
         """
         super().__init__(
             artifact_root,
+            artifact_extraction_root,
             compression,
             permissions=int(permissions.strip(), base=8) if permissions else None,
             dereference=dereference,
@@ -192,11 +207,16 @@ class TempLocalArtifactCache(BaseLocalArtifactCache):
     calls, but is useful for handling file IO for a remote cache.
     """
 
-    def __init__(self, artifact_root, compression, permissions=None):
+    def __init__(self, artifact_root, artifact_extraction_root, compression, permissions=None):
         """
         :param str artifact_root: The path under which cacheable products will be read/written.
         """
-        super().__init__(artifact_root, compression=compression, permissions=permissions)
+        super().__init__(
+            artifact_root,
+            artifact_extraction_root,
+            compression=compression,
+            permissions=permissions,
+        )
 
     def _store_tarball(self, cache_key, src):
         return src

--- a/tests/python/pants_test/cache/test_artifact.py
+++ b/tests/python/pants_test/cache/test_artifact.py
@@ -25,7 +25,9 @@ class TarballArtifactTest(TestBase):
 
             file_path = self.touch_file_in(artifact_root)
 
-            artifact = TarballArtifact(artifact_root, os.path.join(cache_root, "some.tar"))
+            artifact = TarballArtifact(
+                artifact_root, artifact_root, os.path.join(cache_root, "some.tar")
+            )
             artifact.collect([file_path])
 
             self.assertEqual([file_path], list(artifact.get_paths()))
@@ -36,7 +38,9 @@ class TarballArtifactTest(TestBase):
             cache_root = os.path.join(tmpdir, "cache")
             safe_mkdir(cache_root)
 
-            artifact = TarballArtifact(artifact_root, os.path.join(cache_root, "some.tar"))
+            artifact = TarballArtifact(
+                artifact_root, artifact_root, os.path.join(cache_root, "some.tar")
+            )
             self.assertFalse(artifact.exists())
 
     def test_exists_true_when_exists(self):
@@ -47,21 +51,27 @@ class TarballArtifactTest(TestBase):
 
             path = self.touch_file_in(artifact_root)
 
-            artifact = TarballArtifact(artifact_root, os.path.join(cache_root, "some.tar"))
+            artifact = TarballArtifact(
+                artifact_root, artifact_root, os.path.join(cache_root, "some.tar")
+            )
             artifact.collect([path])
 
             self.assertTrue(artifact.exists())
 
     def test_non_existent_tarball_extraction(self):
         with temporary_dir() as tmpdir:
-            artifact = TarballArtifact(artifact_root=tmpdir, tarfile_="vapor.tar")
+            artifact = TarballArtifact(
+                artifact_root=tmpdir, artifact_extraction_root=tmpdir, tarfile_="vapor.tar"
+            )
             with self.assertRaises(ArtifactError):
                 artifact.extract()
 
     def test_corrupt_tarball_extraction(self):
         with temporary_dir() as tmpdir:
             path = self.touch_file_in(tmpdir, content="invalid")
-            artifact = TarballArtifact(artifact_root=tmpdir, tarfile_=path)
+            artifact = TarballArtifact(
+                artifact_root=tmpdir, artifact_extraction_root=tmpdir, tarfile_=path
+            )
             with self.assertRaises(ArtifactError):
                 artifact.extract()
 

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -27,10 +27,16 @@ TEST_CONTENT2 = b"kermit"
 
 class TestArtifactCache(TestBase):
     @contextmanager
-    def setup_local_cache(self):
+    def setup_local_cache(self, seperate_extraction_root=False):
         with temporary_dir() as artifact_root:
-            with temporary_dir() as cache_root:
-                yield LocalArtifactCache(artifact_root, cache_root, compression=1)
+            with temporary_dir() as artifact_extraction_root:
+                with temporary_dir() as cache_root:
+                    extraction_root = (
+                        artifact_extraction_root if seperate_extraction_root else artifact_root
+                    )
+                    yield LocalArtifactCache(
+                        artifact_root, extraction_root, cache_root, compression=1
+                    )
 
     @contextmanager
     def setup_server(self, return_failed=False, cache_root=None):
@@ -40,7 +46,7 @@ class TestArtifactCache(TestBase):
     @contextmanager
     def setup_rest_cache(self, local=None, return_failed=False):
         with temporary_dir() as artifact_root:
-            local = local or TempLocalArtifactCache(artifact_root, 0)
+            local = local or TempLocalArtifactCache(artifact_root, artifact_root, 0)
             with self.setup_server(return_failed=return_failed) as server:
                 yield RESTfulArtifactCache(artifact_root, BestUrlSelector([server.url]), local)
 
@@ -63,6 +69,10 @@ class TestArtifactCache(TestBase):
         with self.setup_local_cache() as artifact_cache:
             self.do_test_artifact_cache(artifact_cache)
 
+    def test_local_cache_with_seperate_extraction_root(self):
+        with self.setup_local_cache(seperate_extraction_root=True) as artifact_cache:
+            self.do_test_artifact_cache(artifact_cache)
+
     @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
     def test_restful_cache(self):
         with self.assertRaises(InvalidRESTfulCacheProtoError):
@@ -76,7 +86,7 @@ class TestArtifactCache(TestBase):
         bad_url = "http://badhost:123"
 
         with temporary_dir() as artifact_root:
-            local = TempLocalArtifactCache(artifact_root, 0)
+            local = TempLocalArtifactCache(artifact_root, artifact_root, 0)
 
             # With fail-over, rest call second time will succeed
             with self.setup_server() as good_server:
@@ -108,7 +118,10 @@ class TestArtifactCache(TestBase):
             self.assertTrue(bool(artifact_cache.use_cached_files(key)))
 
             # Check that it was recovered correctly.
-            with open(path, "rb") as infile:
+            extracted_file_path = os.path.join(
+                artifact_cache.artifact_extraction_root, os.path.basename(path)
+            )
+            with open(extracted_file_path, "rb") as infile:
                 content = infile.read()
             self.assertEqual(content, TEST_CONTENT1)
 
@@ -120,7 +133,7 @@ class TestArtifactCache(TestBase):
         """make sure that the combined cache finds what it should and that it backfills."""
         with self.setup_server() as server:
             with self.setup_local_cache() as local:
-                tmp = TempLocalArtifactCache(local.artifact_root, 0)
+                tmp = TempLocalArtifactCache(local.artifact_root, local.artifact_extraction_root, 0)
                 remote = RESTfulArtifactCache(
                     local.artifact_root, BestUrlSelector([server.url]), tmp
                 )
@@ -168,7 +181,9 @@ class TestArtifactCache(TestBase):
         with temporary_dir() as remote_cache_dir:
             with self.setup_server(cache_root=remote_cache_dir) as server:
                 with self.setup_local_cache() as local:
-                    tmp = TempLocalArtifactCache(local.artifact_root, compression=1)
+                    tmp = TempLocalArtifactCache(
+                        local.artifact_root, local.artifact_extraction_root, compression=1
+                    )
                     remote = RESTfulArtifactCache(
                         local.artifact_root, BestUrlSelector([server.url]), tmp
                     )


### PR DESCRIPTION
### Problem

Extracting tarball artifacts into a FUSE context leads to excessive readlink calls on the pants workdir symlink. Readlinks can be slow in FUSE filesystems, which may not cache readlink results. Running pants on a moderate size target can lead to 100's of thousands of readlink calls, which degrades performance perceptibly.

### Solution

If the pants workdir is a symlink, cache the real path to the symlink and pass it to the tarball artifact extractor, to sidestep decompressing into the FUSE context.

### Result
The accumulated syscall profile's look like:
**Before** Wall time: 05:29
```  
...
  fchmod                                                        93680
  futimes                                                       93680
  open                                                         109223
  close_nocancel                                               114798
  poll                                                         127104
  psynch_mutexwait                                             140191
  readlink====================================================>202344
  gettimeofday                                                 254803
  psynch_cvsignal                                              264753
  psynch_cvwait                                                264861
  write                                                        299240
  statfs64                                                     405704
...
```

**After**  Wall time: 03:37
```
...
  link                                                            288
  select_nocancel                                                 306
  proc_info                                                       322
  sendto                                                          357
  necp_client_action                                              408
  kqueue                                                          489
  readlink=======================================================>549
  sigaltstack                                                     559
  rename                                                          567
  rmdir                                                           586
  sysctl                                                          590
  recvfrom_nocancel                                               624
  pwrite                                                          774
  munmap                                                          942
...
```

The speed up happened when building from a clean state, and with all artifacts pulled from a remote cache and decompressed into the workdir. The cold compile time, when artifacts are built and stored locally, was the same for before and after.