### PR TITLE
Add a coverage test for pantsd garbage collection, and fix type error

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -365,6 +365,10 @@ class SchedulerSession:
         self._session = session
         self._run_count = 0
 
+    @property
+    def scheduler(self):
+        return self._scheduler
+
     def poll_workunits(self) -> Tuple[Dict[str, Any], ...]:
         result: Tuple[Dict[str, Any], ...] = self._scheduler.poll_workunits(self._session)
         return result

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -170,7 +170,7 @@ def _make_target_adaptor(base_class, target_type):
 class LegacyGraphScheduler:
     """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
 
-    scheduler: Any
+    scheduler: Scheduler
     build_file_aliases: Any
     goal_map: Any
 

--- a/src/python/pants/pantsd/service/BUILD
+++ b/src/python/pants/pantsd/service/BUILD
@@ -49,3 +49,12 @@ python_library(
   ],
   tags = {"partially_type_checked"},
 )
+
+python_tests(
+  name = 'tests',
+  dependencies = [
+    ':store_gc_service',
+    'src/python/pants/testutil:test_base',
+  ],
+  tags = {"partially_type_checked"},
+)

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -59,7 +59,7 @@ class SchedulerService(PantsService):
         # This session is only used for checking whether any invalidation globs have been invalidated.
         # It is not involved with a build itself; just with deciding when we should restart pantsd.
         self._scheduler_session = self._scheduler.new_session(
-            zipkin_trace_v2=False, build_id="background_pantsd_session",
+            zipkin_trace_v2=False, build_id="scheduler_service_session",
         )
         self._logger = logging.getLogger(__name__)
         self._event_queue: queue.Queue = queue.Queue(maxsize=self.QUEUE_SIZE)

--- a/src/python/pants/pantsd/service/store_gc_service_test.py
+++ b/src/python/pants/pantsd/service/store_gc_service_test.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import threading
+import time
+
+from pants.pantsd.service.store_gc_service import StoreGCService
+from pants.testutil.test_base import TestBase
+
+
+class StoreGCServiceTest(TestBase):
+    def test_run(self):
+        interval_secs = 0.1
+        # Start the service in another thread (`setup` is a required part of the service lifecycle, but
+        # is unused in this case.)
+        sgcs = StoreGCService(
+            self.scheduler.scheduler,
+            period_secs=(interval_secs / 4),
+            lease_extension_interval_secs=interval_secs,
+            gc_interval_secs=interval_secs,
+        )
+        sgcs.setup(services=None)
+        t = threading.Thread(target=sgcs.run, name="sgcs")
+        t.daemon = True
+        t.start()
+
+        # Ensure that the thread runs successfully for long enough to have run each step at least once.
+        # TODO: This is a coverage test: although it could examine the internal details of the service
+        # to validate correctness, we don't do that yet.
+        time.sleep(interval_secs * 10)
+        assert t.is_alive()
+
+        # Exit the thread, and then join it.
+        sgcs.terminate()
+        t.join(timeout=interval_secs * 10)
+        assert not t.is_alive()


### PR DESCRIPTION
### Problem

`StoreGCService` was expecting a `SchedulerSession`, but getting a `Scheduler`. This meant that if `pantsd` ran long enough (the default value for "long enough" was too long to ever be caught in tests), it would crash with a failure to call `lease_files_in_graph` due to the method signature change in #9015.

### Solution

Although just adding enough type hints here would hypothetically be enough for mypy to catch this (?), additionally added a coverage test for `StoreGCService`.

### Result

`pantsd` stays up as long as it should.