### PR TITLE
Add Cobertura output option for Scoverage

### DIFF
--- a/src/scala/org/pantsbuild/scoverage/report/ScoverageReport.scala
+++ b/src/scala/org/pantsbuild/scoverage/report/ScoverageReport.scala
@@ -8,7 +8,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import scoverage.{ Coverage, IOUtils, Serializer }
-import scoverage.report.{ ScoverageHtmlWriter, ScoverageXmlWriter }
+import scoverage.report.{ CoberturaXmlWriter, ScoverageHtmlWriter, ScoverageXmlWriter }
 
 object ScoverageReport {
   val Scoverage = "scoverage"
@@ -172,6 +172,12 @@ object ScoverageReport {
         prepareFile(reportDirXml, settings, "xml")
         logger.info(s"Writing XML scoverage reports to [$reportDirXml]")
         new ScoverageXmlWriter(Seq(sourceDir), reportDirXml, false).write(coverage)
+
+        if (settings.outputAsCobertura) {
+          // Cobertura Output
+          logger.info(s"Writing XML scoverage in Cobertura format reports to [$reportDirXml]")
+          new CoberturaXmlWriter(Seq(sourceDir), reportDirXml).write(coverage)
+        }
       }
 
       if (!settings.xmlDebugDirPath.isEmpty) {

--- a/src/scala/org/pantsbuild/scoverage/report/Settings.scala
+++ b/src/scala/org/pantsbuild/scoverage/report/Settings.scala
@@ -12,7 +12,8 @@ case class Settings(
   xmlDirPath: String = "",
   xmlDebugDirPath: String = "",
   cleanOldReports: Boolean = false,
-  targetFilters: Seq[String] = Seq())
+  targetFilters: Seq[String] = Seq(),
+  outputAsCobertura: Boolean = false)
 
 object Settings {
 
@@ -58,5 +59,9 @@ object Settings {
     opt[Seq[String]]("targetFilters")
       .action((f: Seq[String], s: Settings) => s.copy(targetFilters = f))
       .text("Directory names for which report has to be generated.")
+
+    opt[Unit]("outputAsCobertura")
+      .action((_, s: Settings) => s.copy(outputAsCobertura = true))
+      .text("Export Cobertura formats for Scoverage.")
   }
 }


### PR DESCRIPTION
### Problem

Scoverage supports exporting cobertura formats which would allow us to merge with cobertura coverage for java targets. Pants doesn't expose this option at the moment. 

### Solution

Call `CoberturaXmlWriter` method to generate Cobertura output when `--scoverage-enable-scoverage --scoverage-report-output-as-cobertura` options are provided in `pants` command

### Result
Generate  Cobertura output (`.pants.d/test/junit/_runs/*/*/all/scoverage/reports/xml/cobertura.xml`)