### PR TITLE
Support build file aliases in v2.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -75,6 +75,16 @@ def build_file_aliases():
     )
 
 
+def build_file_aliases2():
+    return BuildFileAliases(
+        objects={
+            "python_requirement": PythonRequirement,
+            "setup_py": PythonArtifact,
+        },
+        context_aware_object_factories={"python_requirements": PythonRequirements,},
+    )
+
+
 def register_goals():
     task(name="interpreter", action=SelectInterpreter).install("pyprep")
     task(name="build-local-dists", action=BuildLocalPythonDistributions).install("pyprep")

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -77,10 +77,7 @@ def build_file_aliases():
 
 def build_file_aliases2():
     return BuildFileAliases(
-        objects={
-            "python_requirement": PythonRequirement,
-            "setup_py": PythonArtifact,
-        },
+        objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact,},
         context_aware_object_factories={"python_requirements": PythonRequirements,},
     )
 

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -139,6 +139,9 @@ def load_plugins(
             if "rules" in entries:
                 rules = entries["rules"].load()()
                 build_configuration.register_rules(rules)
+            if "build_file_aliases2" in entries:
+                build_file_aliases2 = entries["build_file_aliases2"].load()()
+                build_configuration.register_aliases(build_file_aliases2)
         loaded[dist.as_requirement().key] = dist
 
 
@@ -210,3 +213,6 @@ def load_backend(
         rules = invoke_entrypoint("rules")
         if rules:
             build_configuration.register_rules(rules)
+        build_file_aliases2 = invoke_entrypoint("build_file_aliases2")
+        if build_file_aliases2:
+            build_configuration.register_aliases(build_file_aliases2)

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -1,8 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Union
-
 from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -47,7 +45,6 @@ async def list_targets(console: Console, list_options: ListOptions, addresses: A
     provides = list_options.values.provides
     provides_columns = list_options.values.provides_columns
     documented = list_options.values.documented
-    collection: Union[HydratedTargets, Addresses]
     if provides or documented:
         # To get provides clauses or documentation, we need hydrated targets.
         collection = await Get[HydratedTargets](Addresses, addresses)
@@ -60,9 +57,9 @@ async def list_targets(console: Console, list_options: ListOptions, addresses: A
                 push_db_basedir=lambda adaptor: adaptor.provides.repo.push_db_basedir,
             )
 
-            def print_provides(column_extractors, target):
+            def print_provides(col_extractors, target):
                 if getattr(target.adaptor, "provides", None):
-                    return " ".join(extractor(target.adaptor) for extractor in column_extractors)
+                    return " ".join(extractor(target.adaptor) for extractor in col_extractors)
 
             try:
                 column_extractors = [extractors[col] for col in (provides_columns.split(","))]

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Union
+
 from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
@@ -45,6 +47,7 @@ async def list_targets(console: Console, list_options: ListOptions, addresses: A
     provides = list_options.values.provides
     provides_columns = list_options.values.provides_columns
     documented = list_options.values.documented
+    collection: Union[HydratedTargets, Addresses]
     if provides or documented:
         # To get provides clauses or documentation, we need hydrated targets.
         collection = await Get[HydratedTargets](Addresses, addresses)


### PR DESCRIPTION
This is currently necessary in order to support the
python_requirements() macro.  However this may be
superseded by the v2 target API, so this is more of
a stopgap.

Note that we introduce a new hook, build_file_aliases2,
instead of using the existing build_file_aliases.  This is
so we can minimally introduce just what we need to get
things working in v2-exclusive mode, until the full v2
target API is implemented.

Also fixes some nits in list_targets.py that weren't worth
their own PR.
