### PR TITLE
try to add a declarative @option() decorator to work with mypy!!!

### DIFF
--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo
+from pants.util.collections import assert_single_element
 from pants.util.memo import memoized_classproperty
 from pants.util.meta import classproperty
 from pants.util.objects import get_docstring_summary
@@ -22,7 +23,7 @@ async def _construct_optionable(optionable_factory):
     return optionable_factory.optionable_cls(scope, scoped_options.options)
 
 
-def option(name, **register_kwargs):
+def option(name: str, **register_kwargs):
     """A decorator for a `def` instance method which registers it as an option.
 
     The type for the option is inferred from the return type of the `def`.
@@ -53,6 +54,9 @@ def option(name, **register_kwargs):
         if hasattr(option_type, "__extra__"):
             option_type = option_type.__extra__
         register_kwargs["type"] = option_type
+
+        if hasattr(option_type, '__args__'):
+            register_kwargs['member_type'] = assert_single_element(option_type.__args__)
 
         func._option_name = name
         func._option_metadata = register_kwargs

--- a/src/python/pants/python/python_repos.py
+++ b/src/python/pants/python/python_repos.py
@@ -1,6 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import List, cast
+
+from pants.option.optionable import option
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -13,30 +16,20 @@ class PythonRepos(Subsystem):
 
     options_scope = "python-repos"
 
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--repos",
-            advanced=True,
-            type=list,
-            default=[],
-            fingerprint=True,
-            help="URLs of code repositories.",
-        )
-        register(
-            "--indexes",
-            advanced=True,
-            type=list,
-            fingerprint=True,
-            default=["https://pypi.org/simple/"],
-            help="URLs of code repository indexes.",
-        )
+    @property                   # type: ignore[misc]
+    @option(
+        "--repos", advanced=True, default=[], fingerprint=True, help="URLs of code repositories.",
+    )
+    def repos(self) -> List[str]:
+        return cast(List[str], self.get_options().repos)
 
-    @property
-    def repos(self):
-        return self.get_options().repos
-
-    @property
-    def indexes(self):
-        return self.get_options().indexes
+    @property                   # type: ignore[misc]
+    @option(
+        "--indexes",
+        advanced=True,
+        fingerprint=True,
+        default=["https://pypi.org/simple/"],
+        help="URLs of code repository indexes.",
+    )
+    def indexes(self) -> List[str]:
+        return cast(List[str], self.get_options().indexes)

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -56,15 +56,13 @@ def assert_single_element(iterable: Iterable[_T]) -> _T:
     :raise: :class:`StopIteration` if there is no element.
     :raise: :class:`ValueError` if there is more than one element.
     """
-    it = iter(iterable)
-    first_item = next(it)
+    items = list(iterable)
 
-    try:
-        next(it)
-    except StopIteration:
-        return first_item
-
-    raise ValueError(f"iterable {iterable!r} has more than one element.")
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 0:
+        raise StopIteration(f'iterable {iterable} had zero elements')
+    raise ValueError(f"iterable {iterable} has more than one element (elements were: {items}).")
 
 
 def ensure_list(val: Union[Any, Iterable[Any]], *, expected_type: Type[_T]) -> List[_T]:


### PR DESCRIPTION
### Problem

As @wisechengyi noted in https://github.com/pantsbuild/pants/pull/8793#discussion_r390043766, it would be really nice to have the pants options system automatically declare typed accessors for options. What we've currently been doing to help make options more type-safe is to just make sure to put proper types on accessors for each option, e.g. in #8793:
```python
    @property
    def _generate_ipex(self) -> bool:
        return cast(bool, self.get_options().generate_ipex)
```

However, we repeat the `type` argument in registering the `--generate-ipex` option in that PR. It would be nice to DRY this and declare an option in the same place as its well-typed accessor.

### Solution

- Create the `@option()` decorator, which takes the arguments of `register()`, and uses the return type of the accessor method to derive the `type` argument to `register()`.
- Register all `@option()` declarations for each class in `Optionable.register_options()`.

The above example would now look like:
```python
    @property                   # type: ignore[misc]
    @option(
        "--generate-ipex",
        advanced=True,
        fingerprint=True,
        ...
    )
    def _generate_ipex(self) -> bool:
        return cast(bool, self.get_options().generate_ipex)

```

### Result

- Options can now be added to an `Optionable` class somewhat more declaratively, without requiring an explicit `register_options()` override (although that still works!!!).
- Option registrations are now co-located with their well-typed accessor methods, which means much less manual work adding types and `cast()`s when dereferencing registered option values!

**I would love to hear input on how this could be improved!!! This PR is merely a first attempt at merging pants options with mypy!!**