### PR TITLE
completely specify platform names like linux-x86_64 to conform to pex 2 platform parsing

### DIFF
--- a/src/python/pants/python/BUILD
+++ b/src/python/pants/python/BUILD
@@ -23,6 +23,7 @@ python_library(
 
 python_tests(
   name='tests',
+  sources=['*_test.py', '!*_integration.py'],
   dependencies=[
     '3rdparty/python:pex',
     ':python',
@@ -34,4 +35,15 @@ python_tests(
     'src/python/pants/testutil:test_base',
   ],
   tags = {'partially_type_checked'},
+)
+
+python_tests(
+  name='integration',
+  sources=['*_integration.py'],
+  dependencies=[
+    'src/python/pants/util:contextutil',
+    'src/python/pants/testutil:int-test',
+    'testprojects/src/python/python_targets:test-multiplatform-binary-files',
+  ],
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/src/python/pants/python/pex_build_util_test_integration.py
+++ b/src/python/pants/python/pex_build_util_test_integration.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+
+from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+from pants.util.contextutil import temporary_dir
+
+
+class PexBuildUtilIntegrationTest(PantsRunIntegrationTest):
+
+    tests_target_address = "testprojects/src/python/python_targets:test-multiplatform-binary"
+
+    def test_multiplatform_python_binary(self):
+        with temporary_dir() as tmp_dir:
+            self.do_command(
+                "binary", self.tests_target_address, config={"GLOBAL": {"pants_distdir": tmp_dir}}
+            )
+
+            pex_path = os.path.join(tmp_dir, "test-multiplatform-binary.pex")
+            assert os.path.isfile(pex_path)
+            pex_execution_result = subprocess.run([pex_path], stdout=subprocess.PIPE, check=True)
+            assert pex_execution_result.stdout.decode() == "hey!"

--- a/testprojects/src/python/python_targets/BUILD
+++ b/testprojects/src/python/python_targets/BUILD
@@ -41,3 +41,18 @@ python_library(
   sources=[],
   dependencies=[':test_library_transitive_dependee_3']
 )
+
+python_binary(
+  name='test-multiplatform-binary',
+  source='main.py',
+  compatibility=['CPython>=3'],
+  platforms=[
+    'linux-x86_64',
+    "macosx-10.13-x86_64",
+  ]
+)
+
+files(
+  name='test-multiplatform-binary-files',
+  sources=['*'],
+)

--- a/testprojects/src/python/python_targets/main.py
+++ b/testprojects/src/python/python_targets/main.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+print("hey!")


### PR DESCRIPTION
### Problem

Platform strings such as `linux-x86_64` are no longer acceptable to pex, and when they are used in the `platforms` argument of a `python_binary()`, the following error message occurs:
```
Exception message: Not a valid platform specifier: linux-x86_64

Platform strings must be in one of two forms:
1. Canonical: <platform>-<python impl abbr>-<python version>-<abi>
2. Abbreviated: <platform>-<python impl abbr>-<python version>-<abbr abi>

Given a canonical platform string for CPython 3.7.5 running on 64 bit linux of:
  linux-x86_64-cp-37-cp37m

Where the fields above are:
+ <platform>: linux-x86_64
+ <python impl abbr>: cp
+ <python version>: 37
+ <abi>: cp37m

The abbreviated platform string is:
  linux-x86_64-cp-37-m

These fields stem from wheel name conventions as outlined in
https://www.python.org/dev/peps/pep-0427#file-name-convention and influenced by
https://www.python.org/dev/peps/pep-0425.
```

Pex now appears to require interpreter-specific information in the `Platform` object, and `pex.platform.parse_platform()` will not add that information for you, instead producing the above error when it is given the string `linux-x86_64`. This is a regression, so we'd like to fix this.

### Solution

- Use `pex.platform.Platform.of_interpreter()` to get a `Platform` object for each interpreter used in the pex builder.
  - Then, modify the `Platform`'s `.platform` field to contain the `linux-x86_64` string (or whatever is provided).
- Add a test for creating a multiplatform `python_binary()`!!!
  - It was surprising that this didn't exist before!

### Result

`python_binary(..., platforms=['linux-x86_64'])` will now work again!