### PR TITLE
Add core abstractions for the V2 Target API

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -261,6 +261,18 @@ python_library(
   tags = {'partially_type_checked'},
 )
 
+python_library(
+  name='target',
+  sources=['target.py'],
+  dependencies=[
+    ':rules',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:meta',
+    'src/python/pants/util:memo',
+  ],
+  tags = {'type_checked'},
+)
+
 resources(
   name='native_engine_shared_library',
   sources=['native_engine.so']

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -16,6 +16,7 @@ python_tests(
     ':goal',
     ':platform',
     ':rules',
+    ':target',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/engine:util',
   ],

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -147,6 +147,15 @@ class Target(ABC):
     def get(self, field: Type[_F]) -> _F:
         return cast(_F, self.field_values[field])
 
+    def has_fields(self, fields: Iterable[Type[Field]]) -> bool:
+        # TODO: consider if this should support subclasses. For example, if a target has a
+        #  field PythonSources(Sources), then .has_fields(Sources) should still return True. Why?
+        #  This allows overriding how fields behave for custom target types, e.g. a `python3_library`
+        #  subclassing the Field Compatibility with its own custom implementation. When adding
+        #  this, be sure to update `.get()` to allow looking up by subclass, too. (Is it possible
+        #  to do that in a performant way?)
+        return all(field in self.field_types for field in fields)
+
 
 class Sources(AsyncField):
     alias: ClassVar = "sources"

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -60,9 +60,11 @@ class AsyncField(Field, metaclass=ABCMeta):
 
         @rule
         def hydrate_sources(sources: Sources) -> SourcesResult:
-            sources.validate_pre_hydration()
+            # possibly validate `sources.raw_value`
+            ...
             result = await Get[Snapshot](PathGlobs(sources.raw_value))
-            sources.validate_post_hydration(result)
+            # possibly validate `result`
+            ...
             return SourcesResult(result)
 
 
@@ -73,22 +75,6 @@ class AsyncField(Field, metaclass=ABCMeta):
 
         sources = await Get[SourcesResult](Sources, my_tgt.get(Sources))
     """
-
-    def validate_pre_hydration(self) -> None:
-        """Any validation that can be done on the original `raw_value`.
-
-        It is cheaper to do any possible validation here, rather than in `validate_post_hydration`,
-        because we can short-circuit if an invariant is violated before incurring the expense of
-        hydration.
-        """
-
-    def validate_post_hydration(self, result: Any) -> None:
-        """Any validation that must be done after hydration by inspecting the result of that
-        hydration.
-
-        For example, a `PythonSources` field may validate that all hydrated source files end in
-        `.py`.
-        """
 
 
 _F = TypeVar("_F", bound=Field)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -52,6 +52,7 @@ class AsyncField(Field, metaclass=ABCMeta):
             alias: ClassVar = "sources"
             raw_value: Optional[List[str]]
 
+
         @dataclass(frozen=True)
         class SourcesResult:
             snapshot: Snapshot
@@ -61,7 +62,7 @@ class AsyncField(Field, metaclass=ABCMeta):
         def hydrate_sources(sources: Sources) -> SourcesResult:
             sources.validate_pre_hydration()
             result = await Get[Snapshot](PathGlobs(sources.raw_value))
-            sources.validate_post_hydration()
+            sources.validate_post_hydration(result)
             return SourcesResult(result)
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -149,17 +149,17 @@ class Target(ABC):
         )
 
         self.field_values = {}
-        aliases_to_fields = {field.alias: field for field in self.field_types}
+        aliases_to_field_types = {field_type.alias: field_type for field_type in self.field_types}
         for alias, value in unhydrated_values.items():
-            if alias not in aliases_to_fields:
+            if alias not in aliases_to_field_types:
                 raise ValueError(
                     f"Unrecognized field `{alias}={value}` for target type `{self.alias}`."
                 )
-            field = aliases_to_fields[alias]
-            self.field_values[field] = field(value)
+            field_type = aliases_to_field_types[alias]
+            self.field_values[field_type] = field_type(value)
         # For undefined fields, mark the raw value as None.
-        for field in set(self.field_types) - set(self.field_values.keys()):
-            self.field_values[field] = field(raw_value=None)
+        for field_type in set(self.field_types) - set(self.field_values.keys()):
+            self.field_values[field_type] = field_type(raw_value=None)
 
     @property
     def field_types(self) -> Tuple[Type[Field], ...]:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1,0 +1,200 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, ClassVar, Iterable, List, Optional, Type, Union
+
+from pants.engine.rules import UnionRule, union
+from pants.util.collections import ensure_str_list
+from pants.util.memo import memoized_property
+from pants.util.meta import classproperty
+
+
+@dataclass(frozen=True)
+class Field(ABC):
+    unhydrated: Any
+    alias: ClassVar[str]
+
+    @abstractmethod
+    @memoized_property
+    def hydrated(self) -> Any:
+        """Validate and hydrate self.unhydrated into a value usable by downstream rules.
+
+        All validation and hydration should happen here, such as converting a field that might be
+        a single string or a list of strings to always being a list of strings.
+
+        This property is memoized because hydration and validation can often be costly. This
+        hydration will only happen when a downstream rule explicitly requests this field.
+        """
+
+
+class Target(ABC):
+    @classproperty
+    @abstractmethod
+    def field_type(cls) -> Type:
+        """This is used to tell the engine what typed fields the target has.
+
+        For example, if you have a PythonLibraryTarget, you will create a corresponding
+        PythonLibraryField class, which is annotated with `@union`. Then, you would set
+        PythonLibraryTarget.field_type to PythonLibraryTarget. Finally, in the file's rules()
+        function, you'd register a UnionRule(PythonLibraryField, MyField) for every field belonging
+        to that target type.
+
+            @union
+            class PythonLibraryField:
+                pass
+
+
+            class PythonLibraryTarget:
+                field_type = PythonLibraryTarget
+
+
+            def rules():
+                return [
+                    UnionRule(PythonLibraryField, Sources),
+                    UnionRules(PythonLibraryField, Compatibility),
+                    ...
+                ]
+        """
+
+    def get(self, field: Type[Field]) -> Field:
+        pass
+
+
+@dataclass(frozen=True)
+class Sources(Field):
+    unhydrated: Optional[Iterable[str]] = None
+    alias: ClassVar[str] = "sources"
+
+    # TODO: this needs to call the engine. How could we do that?
+    #  Async property and `await my_target.sources`?
+    @memoized_property
+    def hydrated(self):
+        return self.unhydrated
+
+
+@dataclass(frozen=True)
+class BinarySources(Sources):
+
+    @memoized_property
+    def hydrated(self):
+        if self.unhydrated is not None and len(list(self.unhydrated)) not in [0, 1]:
+            raise ValueError("TODO")
+        return super().hydrated
+
+
+@dataclass(frozen=True)
+class Compatibility(Field):
+    unhydrated: Optional[Union[str, Iterable[str]]] = None
+    alias: ClassVar[str] = "compatibility"
+
+    @memoized_property
+    def hydrated(self) -> Optional[List[str]]:
+        if self.unhydrated is None:
+            return None
+        return ensure_str_list(self.unhydrated)
+
+
+@dataclass(frozen=True)
+class Coverage(Field):
+    unhydrated: Optional[Union[str, Iterable[str]]] = None
+    alias: ClassVar[str] = "coverage"
+
+    @memoized_property
+    def hydrated(self) -> Optional[List[str]]:
+        if self.unhydrated is None:
+            return None
+        return ensure_str_list(self.unhydrated)
+
+
+@dataclass(frozen=True)
+class Timeout(Field):
+    unhydrated: Optional[int] = None
+    alias: ClassVar[str] = "timeout"
+
+    @memoized_property
+    def hydrated(self) -> Optional[int]:
+        if self.unhydrated is None:
+            return None
+        if not isinstance(self.unhydrated, int):
+            raise ValueError("")
+        if self.unhydrated < 0:
+            raise ValueError("")
+        return self.unhydrated
+
+
+@dataclass(frozen=True)
+class EntryPoint(Field):
+    unhydrated: Optional[str] = None
+    alias: ClassVar[str] = "entry_point"
+
+    @memoized_property
+    def hydrated(self) -> Optional[str]:
+        return self.unhydrated
+
+
+@dataclass(frozen=True)
+class ZipSafe(Field):
+    unhydrated: bool = True
+    alias: ClassVar[str] = "zip_safe"
+
+    @memoized_property
+    def hydrated(self) -> bool:
+        return self.unhydrated
+
+
+@dataclass(frozen=True)
+class AlwaysWriteCache(Field):
+    unhydrated: bool = False
+    alias: ClassVar[str] = "always_write_cache"
+
+    @memoized_property
+    def hydrated(self) -> bool:
+        return self.unhydrated
+
+
+@union
+class PythonBinaryField(Field):
+    pass
+
+
+@union
+class PythonLibraryField(Field):
+    pass
+
+
+@union
+class PythonTestsField(Field):
+    pass
+
+
+class PythonBinary(Target):
+    alias = "python_binary"
+    field_type = PythonBinaryField
+
+
+class PythonLibrary(Target):
+    alias = "python_library"
+    field_type = PythonLibraryField
+
+
+class PythonTests(Target):
+    alias = "python_tests"
+    field_type = PythonTestsField
+
+
+def rules():
+    common_fields = [Compatibility]
+    binary_fields = [EntryPoint, ZipSafe, AlwaysWriteCache]
+    library_fields = []
+    test_fields = [Coverage, Timeout]
+
+    union_rules = []
+    for tgt_cls in [PythonBinary, PythonLibrary, PythonTests]:
+        for field in common_fields:
+            union_rules.append(UnionRule(tgt_cls.field_type, field))
+    union_rules.extend(UnionRule(PythonBinary.field_type, field) for field in binary_fields)
+    union_rules.extend(UnionRule(PythonLibrary.field_type, field) for field in library_fields)
+    union_rules.extend(UnionRule(PythonTests.field_type, field) for field in test_fields)
+    return union_rules

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -3,28 +3,30 @@
 
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar, Iterable, List, Optional, Type, Union
+from typing import Any, ClassVar, Iterable, List, Optional, Tuple, Type, Union, cast
 
-from pants.engine.rules import UnionRule, union
+from pants.engine.objects import union
+from pants.engine.rules import UnionMembership
 from pants.util.collections import ensure_str_list
 from pants.util.memo import memoized_property
-from pants.util.meta import classproperty
+from pants.util.meta import frozen_after_init
 
 
 @dataclass(frozen=True)
 class Field(ABC):
-    unhydrated: Any
     alias: ClassVar[str]
+    unhydrated: Any
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class PrimitiveField(Field, metaclass=ABCMeta):
     """A Field that does not need the engine in order to be hydrated.
 
     This applies to the majority of fields.
     """
-    @abstractmethod
+
     @memoized_property
+    @abstractmethod
     def hydrated(self) -> Any:
         """Validate and hydrate self.unhydrated into a value usable by downstream rules.
 
@@ -36,54 +38,74 @@ class PrimitiveField(Field, metaclass=ABCMeta):
         """
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class AsyncField(Field, metaclass=ABCMeta):
     """A field that needs the engine in order to be hydrated."""
 
     # TODO: what should this be?
-    @abstractmethod
     @memoized_property
+    @abstractmethod
     def hydration_request(self) -> Any:
         pass
 
 
+class PluginField:
+    """Allows plugin authors to add new fields to pre-existing target types via UnionRules.
+
+    When defining a Target, authors should create a corresponding PluginField class marked with
+    `@union`. Then, plugin authors simply need to create whatever new `Field` they want and in a
+    `register.py`'s `rules()` function call. For example, to add a
+    `TypeChecked` field to `python_library`, register `UnionRule(PythonLibraryField, TypeChecked)`.
+
+        @union
+        class PythonLibraryField(PluginField):
+            pass
+
+
+        class PythonLibrary(Target):
+            core_fields = (Compatibility, PythonSources, ...)
+            plugin_field_type = PythonLibraryField
+
+
+        class TypeChecked(PrimitiveField):
+            ...
+
+
+        def rules():
+            return [
+                UnionRule(PythonLibraryField, TypeChecked),
+            ]
+    """
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class Target(ABC):
-    @classproperty
-    @abstractmethod
-    def field_type(cls) -> Type:
-        """This is used to tell the engine what typed fields the target has.
+    # Subclasses must define these
+    alias: ClassVar[str]
+    core_fields: ClassVar[Tuple[Type[Field], ...]]
+    plugin_field_type: ClassVar[Type[PluginField]]
 
-        For example, if you have a PythonLibraryTarget, you will create a corresponding
-        PythonLibraryField class, which is annotated with `@union`. Then, you would set
-        PythonLibraryTarget.field_type to PythonLibraryTarget. Finally, in the file's rules()
-        function, you'd register a UnionRule(PythonLibraryField, MyField) for every field belonging
-        to that target type.
+    # These get calculated in the constructor
+    plugin_fields: Tuple[Type[Field], ...]
+    field_types: Tuple[Type[Field], ...]
 
-            @union
-            class PythonLibraryField:
-                pass
-
-
-            class PythonLibraryTarget:
-                field_type = PythonLibraryTarget
-
-
-            def rules():
-                return [
-                    UnionRule(PythonLibraryField, Sources),
-                    UnionRules(PythonLibraryField, Compatibility),
-                    ...
-                ]
-        """
-
-    def get(self, field: Type[Field]) -> Field:
-        pass
+    def __init__(self, *, union_membership: Optional[UnionMembership] = None) -> None:
+        self.plugin_fields = cast(
+            Tuple[Type[Field], ...],
+            (
+                ()
+                if union_membership is None
+                else tuple(union_membership.union_rules.get(self.plugin_field_type, ()))
+            ),
+        )
+        self.field_types = (*self.core_fields, *self.plugin_fields)
 
 
 @dataclass(frozen=True)
 class Sources(AsyncField):
+    alias: ClassVar = "sources"
     unhydrated: Optional[Iterable[str]] = None
-    alias: ClassVar[str] = "sources"
 
     @memoized_property
     def hydration_request(self) -> Any:
@@ -96,7 +118,6 @@ class Sources(AsyncField):
 
 @dataclass(frozen=True)
 class BinarySources(Sources):
-
     @memoized_property
     def hydration_request(self):
         if self.unhydrated is not None and len(list(self.unhydrated)) not in [0, 1]:
@@ -106,8 +127,8 @@ class BinarySources(Sources):
 
 @dataclass(frozen=True)
 class Compatibility(PrimitiveField):
+    alias: ClassVar = "compatibility"
     unhydrated: Optional[Union[str, Iterable[str]]] = None
-    alias: ClassVar[str] = "compatibility"
 
     @memoized_property
     def hydrated(self) -> Optional[List[str]]:
@@ -118,8 +139,8 @@ class Compatibility(PrimitiveField):
 
 @dataclass(frozen=True)
 class Coverage(PrimitiveField):
+    alias: ClassVar = "coverage"
     unhydrated: Optional[Union[str, Iterable[str]]] = None
-    alias: ClassVar[str] = "coverage"
 
     @memoized_property
     def hydrated(self) -> Optional[List[str]]:
@@ -130,8 +151,8 @@ class Coverage(PrimitiveField):
 
 @dataclass(frozen=True)
 class Timeout(PrimitiveField):
+    alias: ClassVar = "timeout"
     unhydrated: Optional[int] = None
-    alias: ClassVar[str] = "timeout"
 
     @memoized_property
     def hydrated(self) -> Optional[int]:
@@ -149,8 +170,8 @@ class Timeout(PrimitiveField):
 
 @dataclass(frozen=True)
 class EntryPoint(PrimitiveField):
+    alias: ClassVar = "entry_point"
     unhydrated: Optional[str] = None
-    alias: ClassVar[str] = "entry_point"
 
     @memoized_property
     def hydrated(self) -> Optional[str]:
@@ -159,8 +180,8 @@ class EntryPoint(PrimitiveField):
 
 @dataclass(frozen=True)
 class ZipSafe(PrimitiveField):
+    alias: ClassVar = "zip_safe"
     unhydrated: bool = True
-    alias: ClassVar[str] = "zip_safe"
 
     @memoized_property
     def hydrated(self) -> bool:
@@ -169,8 +190,8 @@ class ZipSafe(PrimitiveField):
 
 @dataclass(frozen=True)
 class AlwaysWriteCache(PrimitiveField):
+    alias: ClassVar = "always_write_cache"
     unhydrated: bool = False
-    alias: ClassVar[str] = "always_write_cache"
 
     @memoized_property
     def hydrated(self) -> bool:
@@ -178,46 +199,36 @@ class AlwaysWriteCache(PrimitiveField):
 
 
 @union
-class PythonBinaryField(Field):
+class PythonBinaryField(PluginField):
     pass
 
 
 @union
-class PythonLibraryField(Field):
+class PythonLibraryField(PluginField):
     pass
 
 
 @union
-class PythonTestsField(Field):
+class PythonTestsField(PluginField):
     pass
+
+
+PYTHON_TARGET_FIELDS = (Compatibility,)
 
 
 class PythonBinary(Target):
-    alias = "python_binary"
-    field_type = PythonBinaryField
+    alias: ClassVar = "python_binary"
+    core_fields: ClassVar = (*PYTHON_TARGET_FIELDS, EntryPoint, ZipSafe, AlwaysWriteCache)
+    plugin_field_type = PythonBinaryField
 
 
 class PythonLibrary(Target):
-    alias = "python_library"
-    field_type = PythonLibraryField
+    alias: ClassVar = "python_library"
+    core_fields: ClassVar = PYTHON_TARGET_FIELDS
+    plugin_field_type = PythonLibraryField
 
 
 class PythonTests(Target):
-    alias = "python_tests"
-    field_type = PythonTestsField
-
-
-def rules():
-    common_fields = [Compatibility]
-    binary_fields = [EntryPoint, ZipSafe, AlwaysWriteCache]
-    library_fields = []
-    test_fields = [Coverage, Timeout]
-
-    union_rules = []
-    for tgt_cls in [PythonBinary, PythonLibrary, PythonTests]:
-        for field in common_fields:
-            union_rules.append(UnionRule(tgt_cls.field_type, field))
-    union_rules.extend(UnionRule(PythonBinary.field_type, field) for field in binary_fields)
-    union_rules.extend(UnionRule(PythonLibrary.field_type, field) for field in library_fields)
-    union_rules.extend(UnionRule(PythonTests.field_type, field) for field in test_fields)
-    return union_rules
+    alias: ClassVar = "python_tests"
+    core_fields: ClassVar = (*PYTHON_TARGET_FIELDS, Coverage, Timeout)
+    plugin_field_type = PythonTestsField

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -2,12 +2,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from collections import OrderedDict
-from typing import ClassVar, List, Optional
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import ClassVar, List, Optional, Tuple
 
 import pytest
 
-from pants.engine.rules import UnionMembership
-from pants.engine.target import PluginField, PrimitiveField, Target
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, PathGlobs, Snapshot
+from pants.engine.rules import UnionMembership, rule
+from pants.engine.selectors import Get
+from pants.engine.target import AsyncField, PluginField, PrimitiveField, Target
+from pants.testutil.engine.util import MockGet, run_rule
+from pants.util.collections import ensure_str_list
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import OrderedSet
 
@@ -18,16 +24,46 @@ class HaskellGhcExtensions(PrimitiveField):
 
     @memoized_property
     def value(self) -> List[str]:
-        # Add some arbitrary validation to test that hydration works properly.
         if self.raw_value is None:
             return []
-        for extension in self.raw_value:
-            if not extension.startswith("Ghc"):
-                raise ValueError(
-                    f"All elements of `ghc_extensions` must be prefixed by `Ghc`. Received "
-                    f"{extension}"
-                )
+        # Add some arbitrary validation to test that hydration works properly.
+        bad_extensions = [
+            extension for extension in self.raw_value if not extension.startswith("Ghc")
+        ]
+        if bad_extensions:
+            raise ValueError(
+                f"All elements of `{self.alias}` must be prefixed by `Ghc`. Received "
+                f"{bad_extensions}."
+            )
         return self.raw_value
+
+
+class HaskellSources(AsyncField):
+    alias: ClassVar = "sources"
+    raw_value: Optional[List[str]]
+
+    def validate_pre_hydration(self) -> None:
+        ensure_str_list(self.raw_value)
+
+    def validate_post_hydration(self, result: Snapshot) -> None:
+        non_haskell_sources = [fp for fp in result.files if PurePath(fp).suffix != ".hs"]
+        if non_haskell_sources:
+            raise ValueError(
+                f"Received non-Haskell sources in {self.alias}: {non_haskell_sources}."
+            )
+
+
+@dataclass(frozen=True)
+class HaskellSourcesResult:
+    snapshot: Snapshot
+
+
+@rule
+async def hydrate_haskell_sources(sources: HaskellSources) -> HaskellSourcesResult:
+    sources.validate_pre_hydration()
+    result = await Get[Snapshot](PathGlobs("*.hs"))
+    sources.validate_post_hydration(result)
+    return HaskellSourcesResult(result)
 
 
 class HaskellField(PluginField):
@@ -36,7 +72,7 @@ class HaskellField(PluginField):
 
 class HaskellTarget(Target):
     alias: ClassVar = "haskell"
-    core_fields: ClassVar = (HaskellGhcExtensions,)
+    core_fields: ClassVar = (HaskellGhcExtensions, HaskellSources)
     plugin_field_type: ClassVar = HaskellField
 
 
@@ -46,7 +82,7 @@ def test_invalid_fields_rejected() -> None:
     assert "Unrecognized field `invalid_field=True` for target type `haskell`." in str(exc)
 
 
-def test_get_field() -> None:
+def test_get_primitive_field() -> None:
     extensions = ["GhcExistentialQuantification"]
     extensions_field = HaskellTarget({HaskellGhcExtensions.alias: extensions}).get(
         HaskellGhcExtensions
@@ -57,6 +93,49 @@ def test_get_field() -> None:
     default_extensions_field = HaskellTarget({}).get(HaskellGhcExtensions)
     assert default_extensions_field.raw_value is None
     assert default_extensions_field.value == []
+
+
+def test_get_async_field() -> None:
+    def hydrate_field(
+        *, raw_source_files: List[str], hydrated_source_files: Tuple[str, ...]
+    ) -> HaskellSourcesResult:
+        sources_field = HaskellTarget({HaskellSources.alias: raw_source_files}).get(HaskellSources)
+        assert sources_field.raw_value == raw_source_files
+        result: HaskellSourcesResult = run_rule(
+            hydrate_haskell_sources,
+            rule_args=[sources_field],
+            mock_gets=[
+                MockGet(
+                    product_type=Snapshot,
+                    subject_type=PathGlobs,
+                    mock=lambda _: Snapshot(
+                        directory_digest=EMPTY_DIRECTORY_DIGEST,
+                        files=hydrated_source_files,
+                        dirs=(),
+                    ),
+                )
+            ],
+        )
+        return result
+
+    # Normal field
+    expected_files = ("monad.hs", "abstract_art.hs", "abstract_algebra.hs")
+    assert (
+        hydrate_field(
+            raw_source_files=["monad.hs", "abstract_*.hs"], hydrated_source_files=expected_files
+        ).snapshot.files
+        == expected_files
+    )
+
+    # Test pre-hydration validation
+    with pytest.raises(ValueError) as exc:
+        hydrate_field(raw_source_files=[0, 1, 2], hydrated_source_files=())  # type: ignore[call-arg]
+    assert "Not all elements of the iterable have type" in str(exc)
+
+    # Test post-hydration validation
+    with pytest.raises(ValueError) as exc:
+        hydrate_field(raw_source_files=["*.js"], hydrated_source_files=("not_haskell.js",))
+    assert "Received non-Haskell sources" in str(exc)
 
 
 def test_has_fields() -> None:
@@ -103,8 +182,8 @@ def test_add_custom_fields() -> None:
 
     union_membership = UnionMembership(OrderedDict({HaskellField: OrderedSet([CustomField])}))
     tgt = HaskellTarget({CustomField.alias: True}, union_membership=union_membership)
-    assert tgt.field_types == (HaskellGhcExtensions, CustomField)
-    assert tgt.core_fields == (HaskellGhcExtensions,)
+    assert tgt.field_types == (HaskellGhcExtensions, HaskellSources, CustomField)
+    assert tgt.core_fields == (HaskellGhcExtensions, HaskellSources)
     assert tgt.plugin_fields == (CustomField,)
     assert tgt.get(CustomField).value is True
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -3,7 +3,9 @@
 
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
+
+import pytest
 
 from pants.engine.rules import UnionMembership
 from pants.engine.target import PluginField, PrimitiveField, Target
@@ -14,10 +16,17 @@ from pants.util.ordered_set import OrderedSet
 @dataclass(frozen=True)
 class HaskellGhcExtensions(PrimitiveField):
     alias: ClassVar = "ghc_extensions"
-    unhydrated: List[str]
+    unhydrated: Optional[List[str]] = None
 
     @memoized_property
     def hydrated(self) -> List[str]:
+        # Add some arbitrary validation to test that hydration works properly.
+        for extension in self.unhydrated:
+            if not extension.startswith("Ghc"):
+                raise ValueError(
+                    f"All elements of `ghc_extensions` must be prefixed by `Ghc`. Received "
+                    f"{extension}"
+                )
         return self.unhydrated
 
 
@@ -31,19 +40,41 @@ class HaskellTarget(Target):
     plugin_field_type: ClassVar = HaskellField
 
 
+def test_invalid_fields_rejected() -> None:
+    with pytest.raises(ValueError) as exc:
+        HaskellTarget({"invalid_field": True})
+    assert "Unrecognized field `invalid_field=True` for target type `haskell`." in str(exc)
+
+
+def test_field_hydration_is_lazy() -> None:
+    bad_extension = "DoesNotStartWithGhc"
+    # No error upon creating the Target because validation does not happen until a call site
+    # hydrates the specific field.
+    tgt = HaskellTarget(
+        {HaskellGhcExtensions.alias: ["GhcExistentialQuantification", bad_extension]}
+    )
+    # When hydrating, we expect a failure.
+    with pytest.raises(ValueError) as exc:
+        tgt.get(HaskellGhcExtensions).hydrated
+    assert "must be prefixed by `Ghc`" in str(exc)
+
+
 def test_add_custom_fields() -> None:
     @dataclass(frozen=True)
     class CustomField(PrimitiveField):
         alias: ClassVar = "custom_field"
-        unhydrated: bool
+        unhydrated: bool = False
 
         @memoized_property
         def hydrated(self) -> bool:
             return self.unhydrated
 
-    tgt = HaskellTarget(
-        union_membership=UnionMembership(OrderedDict({HaskellField: OrderedSet([CustomField])}))
-    )
+    union_membership = UnionMembership(OrderedDict({HaskellField: OrderedSet([CustomField])}))
+    tgt = HaskellTarget({CustomField.alias: True}, union_membership=union_membership)
     assert tgt.field_types == (HaskellGhcExtensions, CustomField)
     assert tgt.core_fields == (HaskellGhcExtensions,)
     assert tgt.plugin_fields == (CustomField,)
+    assert tgt.get(CustomField).hydrated is True
+
+    default_tgt = HaskellTarget({}, union_membership=union_membership)
+    assert default_tgt.get(CustomField).hydrated is False

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -14,7 +14,7 @@ from pants.util.ordered_set import OrderedSet
 
 class HaskellGhcExtensions(PrimitiveField):
     alias: ClassVar = "ghc_extensions"
-    raw_value: Optional[List[str]] = None
+    raw_value: Optional[List[str]]
 
     @memoized_property
     def value(self) -> List[str]:
@@ -62,7 +62,7 @@ def test_get_field() -> None:
 def test_has_fields() -> None:
     class UnrelatedField(PrimitiveField):
         alias: ClassVar = "unrelated"
-        raw_value: Optional[bool] = None
+        raw_value: Optional[bool]
 
         @memoized_property
         def value(self) -> bool:
@@ -93,7 +93,7 @@ def test_field_hydration_is_lazy() -> None:
 def test_add_custom_fields() -> None:
     class CustomField(PrimitiveField):
         alias: ClassVar = "custom_field"
-        raw_value: Optional[bool] = None
+        raw_value: Optional[bool]
 
         @memoized_property
         def value(self) -> bool:

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import ClassVar, List
+
+from pants.engine.rules import UnionMembership
+from pants.engine.target import PluginField, PrimitiveField, Target
+from pants.util.memo import memoized_property
+from pants.util.ordered_set import OrderedSet
+
+
+@dataclass(frozen=True)
+class HaskellGhcExtensions(PrimitiveField):
+    alias: ClassVar = "ghc_extensions"
+    unhydrated: List[str]
+
+    @memoized_property
+    def hydrated(self) -> List[str]:
+        return self.unhydrated
+
+
+class HaskellField(PluginField):
+    pass
+
+
+class HaskellTarget(Target):
+    alias: ClassVar = "haskell"
+    core_fields: ClassVar = (HaskellGhcExtensions,)
+    plugin_field_type: ClassVar = HaskellField
+
+
+def test_add_custom_fields() -> None:
+    @dataclass(frozen=True)
+    class CustomField(PrimitiveField):
+        alias: ClassVar = "custom_field"
+        unhydrated: bool
+
+        @memoized_property
+        def hydrated(self) -> bool:
+            return self.unhydrated
+
+    tgt = HaskellTarget(
+        union_membership=UnionMembership(OrderedDict({HaskellField: OrderedSet([CustomField])}))
+    )
+    assert tgt.field_types == (HaskellGhcExtensions, CustomField)
+    assert tgt.core_fields == (HaskellGhcExtensions,)
+    assert tgt.plugin_fields == (CustomField,)

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -19,7 +19,7 @@ class HaskellGhcExtensions(PrimitiveField):
     unhydrated: Optional[List[str]] = None
 
     @memoized_property
-    def hydrated(self) -> List[str]:
+    def value(self) -> List[str]:
         # Add some arbitrary validation to test that hydration works properly.
         for extension in self.unhydrated:
             if not extension.startswith("Ghc"):
@@ -55,7 +55,7 @@ def test_field_hydration_is_lazy() -> None:
     )
     # When hydrating, we expect a failure.
     with pytest.raises(ValueError) as exc:
-        tgt.get(HaskellGhcExtensions).hydrated
+        tgt.get(HaskellGhcExtensions).value
     assert "must be prefixed by `Ghc`" in str(exc)
 
 
@@ -66,7 +66,7 @@ def test_add_custom_fields() -> None:
         unhydrated: bool = False
 
         @memoized_property
-        def hydrated(self) -> bool:
+        def value(self) -> bool:
             return self.unhydrated
 
     union_membership = UnionMembership(OrderedDict({HaskellField: OrderedSet([CustomField])}))
@@ -74,7 +74,7 @@ def test_add_custom_fields() -> None:
     assert tgt.field_types == (HaskellGhcExtensions, CustomField)
     assert tgt.core_fields == (HaskellGhcExtensions,)
     assert tgt.plugin_fields == (CustomField,)
-    assert tgt.get(CustomField).hydrated is True
+    assert tgt.get(CustomField).value is True
 
     default_tgt = HaskellTarget({}, union_membership=union_membership)
-    assert default_tgt.get(CustomField).hydrated is False
+    assert default_tgt.get(CustomField).value is False


### PR DESCRIPTION
## Problem

See https://github.com/pantsbuild/pants/issues/4535 and the [recent design doc](https://docs.google.com/document/d/1nxPdvuzgCPKhTabhfYBN2tbcr85enSR83OpcvdfWXfY/edit).

This design implements the main goals of the Target API:

1. Extensibility - add new target types.
2. Extensibility - add new fields to pre-existing target types.
3. Typed fields.
    * See [Typed Fields](https://docs.google.com/document/d/1nxPdvuzgCPKhTabhfYBN2tbcr85enSR83OpcvdfWXfY/edit#heading=h.ctjckb8e5t03) for a justification of this.
4. All fields are lazily hydrated/validated.
5. Has a utility for filtering based on required fields (see `test_has_fields()`)
     * This is important to how rules will consume the Target API. `python_test_runner.py` might say something like `if my_tgt.has_fields([PythonSources, Timeout])`.
     * See [Proposed Design](https://docs.google.com/document/d/1nxPdvuzgCPKhTabhfYBN2tbcr85enSR83OpcvdfWXfY/edit#heading=h.z97og7gj9rvs) for the importance of using Pure Python for this filtering, rather than engine code. 
6. Works 100% with MyPy.
7. Nice `repr` and `dir` functions to allow for easy debugging.

## Solution

Add `Target` and `Field` types. A `Target` type is a combination of several `Field`s that are valid _together_.

Given a target, the two main expected API calls will be:

```python
my_tgt.has_fields([PythonSources, Compatibility])
compatibility: Compatibility = my_tgt.get(Compatibility)
```

MyPy understands both of these calls, including `Target.get` thanks to generics.

### Lazy hydration - primitive vs. async fields

About 5% of fields require the engine for hydration, e.g. `sources` and `bundles`. The other 95% of fields, though, are nothing more than a `str`, `List[str]`, `bool`, etc.

We do not want to complicate accessing the majority of fields. While some field values will need to be accessed via `await Get`, the majority should not be this complex.

So, we introduce `PrimitiveField` and `AsyncField` to distinguish between the two. 

Thanks to MyPy and autocomplete, rule authors will quickly know when working with an `AsyncField` that they cannot call `my_field.value` like they normally could.

### Extensibility - add new fields on pre-existing targets

This is a new feature that we want as a better version of `tags`. To add a new field, plugin authors simply need to create the new field then register, for example, `UnionRule(PythonLibrary, TypeChecked)`.

The Target constructor will recognize this new field and treat it as first-class. Core Pants code can safely ignore the field, while plugins can now use the new field.

## Followups

1. Add a way to go from `HydratedStruct -> Target`, so that we can actually use this with production code.
2. Add syntactic sugar for declaring new fields, e.g. add `BoolField` and `StringField`.
3. Add a mechanism to actually register new target types and their aliases, e.g. a new backend registration hook

```python
def targets() -> Sequence[Type[Target]]:
   return (PythonLibrary, PythonTests)
```

4. Add implementations for Python targets as a real-world use case.
5. Use the new Python target types in some rules like Black and Isort.
6. Allow going from a V2 `Target` to a V1 `Target`.
7. Improve error messages for invalid fields and targets, e.g. point to the actual target upon failure.
8. Remove `TargetAdaptor`.