### PR TITLE
Allow subclassing `Field`s for custom `Field` behavior with the Target API

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -76,6 +76,9 @@ class AsyncField(Field, metaclass=ABCMeta):
         sources = await Get[SourcesResult](Sources, my_tgt.get(Sources))
     """
 
+    def __str__(self) -> str:
+        return f"{self.alias}={repr(self.raw_value)}"
+
 
 _F = TypeVar("_F", bound=Field)
 
@@ -97,7 +100,7 @@ class Target(ABC):
 
     # These get calculated in the constructor
     plugin_fields: Tuple[Type[Field], ...]
-    field_values: Dict[Type[Field], Any]
+    field_values: Dict[Type[Field], Field]
 
     def __init__(
         self,
@@ -145,15 +148,45 @@ class Target(ABC):
         fields = ", ".join(str(field) for field in self.field_values.values())
         return f"{self.alias}({fields})"
 
+    def _find_registered_field_subclass(self, parent_field: Type[_F]) -> Optional[Type[_F]]:
+        """Check if a subclass of the requested Field is registered on this Target.
+
+        This is necessary to allow targets to override the functionality of common fields like
+        `Sources`. For example, Python targets may want to have `PythonSources` to add extra
+        validation that every source file ends in `*.py`. At the same time, we still want to be
+        able to call `my_python_tgt.get(Sources)`, in addition to
+        `my_python_tgt.get(PythonSources)`.
+        """
+        subclass = (
+            next(
+                (
+                    registered_field
+                    for registered_field in self.field_types
+                    if issubclass(registered_field, parent_field)
+                ),
+                None,
+            ),
+        )
+        return cast(Optional[Type[_F]], subclass)
+
     def get(self, field: Type[_F]) -> _F:
-        return cast(_F, self.field_values[field])
+        result = self.field_values.get(field, None)
+        if result is not None:
+            return cast(_F, result)
+        field_subclass = self._find_registered_field_subclass(field)
+        if field_subclass is not None:
+            return cast(_F, self.field_values[field_subclass])
+        raise KeyError(
+            f"The target `{self}` does not have a field `{field}`. Before calling "
+            f"`my_tgt.get({field.__name__})`, call `my_tgt.has_fields([{field.__name__}])` to "
+            "filter out any irrelevant Targets."
+        )
 
     def has_fields(self, fields: Iterable[Type[Field]]) -> bool:
-        # TODO: consider if this should support subclasses. For example, if a target has a
-        #  field PythonSources(Sources), then .has_fields(Sources) should still return True. Why?
-        #  This allows overriding how fields behave for custom target types, e.g. a `python3_library`
-        #  subclassing the Field Compatibility with its own custom Python3Compatibility field.
-        #  When adding this, be sure to update `.get()` to allow looking up by subclass, too.
-        #  (Is it possible to do that in a performant way, i.e. w/o having to iterate over every
-        #  self.field_type (O(n) vs the current O(1))?)
-        return all(field in self.field_types for field in fields)
+        unrecognized_fields = [field for field in fields if field not in self.field_types]
+        if not unrecognized_fields:
+            return True
+        for unrecognized_field in unrecognized_fields:
+            if self._find_registered_field_subclass(unrecognized_field) is None:
+                return False
+        return True

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -148,24 +148,21 @@ class Target(ABC):
         fields = ", ".join(str(field) for field in self.field_values.values())
         return f"{self.alias}({fields})"
 
-    def _find_registered_field_subclass(self, parent_field: Type[_F]) -> Optional[Type[_F]]:
-        """Check if a subclass of the requested Field is registered on this Target.
+    def _find_registered_field_subclass(self, requested_field: Type[_F]) -> Optional[Type[_F]]:
+        """Check if the Target has registered a subclass of the requested Field.
 
         This is necessary to allow targets to override the functionality of common fields like
         `Sources`. For example, Python targets may want to have `PythonSources` to add extra
-        validation that every source file ends in `*.py`. At the same time, we still want to be
-        able to call `my_python_tgt.get(Sources)`, in addition to
-        `my_python_tgt.get(PythonSources)`.
+        validation that every source file ends in `*.py`. At the same time, we still want to be able
+        to call `my_python_tgt.get(Sources)`, in addition to `my_python_tgt.get(PythonSources)`.
         """
-        subclass = (
-            next(
-                (
-                    registered_field
-                    for registered_field in self.field_types
-                    if issubclass(registered_field, parent_field)
-                ),
-                None,
+        subclass = next(
+            (
+                registered_field
+                for registered_field in self.field_types
+                if issubclass(registered_field, requested_field)
             ),
+            None,
         )
         return cast(Optional[Type[_F]], subclass)
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -214,14 +214,21 @@ def test_override_preexisting_field_via_new_target() -> None:
             {*HaskellTarget.core_fields, CustomHaskellGhcExtensions} - {HaskellGhcExtensions}
         )
 
-    tgt = CustomHaskellTarget({HaskellGhcExtensions.alias: ["GhcNormalExtension"]})
+    custom_tgt = CustomHaskellTarget({HaskellGhcExtensions.alias: ["GhcNormalExtension"]})
 
-    assert tgt.has_fields([HaskellGhcExtensions]) is True
-    assert tgt.has_fields([CustomHaskellGhcExtensions]) is True
-    assert tgt.has_fields([HaskellGhcExtensions, CustomHaskellGhcExtensions]) is True
+    assert custom_tgt.has_fields([HaskellGhcExtensions]) is True
+    assert custom_tgt.has_fields([CustomHaskellGhcExtensions]) is True
+    assert custom_tgt.has_fields([HaskellGhcExtensions, CustomHaskellGhcExtensions]) is True
 
-    assert tgt.get(HaskellGhcExtensions) == tgt.get(CustomHaskellGhcExtensions)
-    assert tgt.get(HaskellGhcExtensions).value == [
+    # Ensure that subclasses not defined on a target are not accepted. This allows us to, for
+    # example, filter every target with `PythonSources` (or a subclass) and to ignore targets with
+    # only `Sources`.
+    normal_tgt = HaskellTarget({})
+    assert normal_tgt.has_fields([HaskellGhcExtensions]) is True
+    assert normal_tgt.has_fields([CustomHaskellGhcExtensions]) is False
+
+    assert custom_tgt.get(HaskellGhcExtensions) == custom_tgt.get(CustomHaskellGhcExtensions)
+    assert custom_tgt.get(HaskellGhcExtensions).value == [
         "GhcNormalExtension",
         *CustomHaskellGhcExtensions.default_extensions,
     ]


### PR DESCRIPTION
### Problem

One of the requirements for the Target API's extensibility goal is that plugin authors can create new target types that behave almost identically to the pre-existing target type, but that somehow override a field. For example, `python3_library` may override the `Compatibility` field to always return `CPython>=3.5`.

(We don't allow plugins to change the behavior of a pre-existing target. You must create a new target type.)

Plugin authors may subclass a particular `Field` currently, but then core Pants code will stop working correctly. For example, Core Pants code may filter out targets by the `Compatibility` field. So, a `Python3Compatibility` field that subclasses `Compatibility` would no longer be recognized when calling `my_tgt.has_fields([Compatibility])` or `my_tgt.get(Compatibility)`, as `Python3Compatibility != Compatibility`, even though it is a subclass.

### Solution

Modify `Target.get()` and `Target.has_fields()` to first check if the exact type is registered on the Target, then fall back to checking if the requested Field is a superclass of any of the registered fields.

### Result

A plugin author can now define `Python3Library`, which is identical to `PythonLibrary`, except for having `Python3Compatibility` in lieu of `Compatibility`. Code that depends on `my_tgt.has_fields([Compatibility])` will continue to work with this custom target type.

If a plugin needs the more precise `Field`, that will work too. `my_tgt.has_fields([Python3Compatibility])` would return `True` for `Python3Library`, but not `PythonLibrary`. This is a useful property—we can, for example, filter to get all targets with `PythonSources`, even if other targets have the field `Sources`.