### PR TITLE
Change `UnionMembership` to use `dict` instead of `OrderedDict`

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, Dict, Type
@@ -29,7 +29,7 @@ class BuildConfiguration:
     _exposed_context_aware_object_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
     _optionables: OrderedSet = field(default_factory=OrderedSet)
     _rules: OrderedSet = field(default_factory=OrderedSet)
-    _union_rules: "OrderedDict[Type, OrderedSet[Type]]" = field(default_factory=OrderedDict)
+    _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
 
     class ParseState(namedtuple("ParseState", ["parse_context", "parse_globals"])):
         @property
@@ -181,7 +181,7 @@ class BuildConfiguration:
         """
         return list(self._rules)
 
-    def union_rules(self) -> "OrderedDict[Type, OrderedSet[Type]]":
+    def union_rules(self) -> Dict[Type, OrderedSet[Type]]:
         """Returns a mapping of registered union base types -> [OrderedSet of union member
         types]."""
         return self._union_rules

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -7,9 +7,8 @@ import itertools
 import sys
 import typing
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple, Type, get_type_hints
+from typing import Callable, Dict, List, Optional, Tuple, Type, get_type_hints
 
 from pants.engine.goal import Goal
 from pants.engine.objects import union
@@ -312,7 +311,7 @@ class UnionRule:
 
 @dataclass(frozen=True)
 class UnionMembership:
-    union_rules: "OrderedDict[Type, OrderedSet[Type]]"
+    union_rules: Dict[Type, OrderedSet[Type]]
 
     def is_member(self, union_type, putative_member):
         members = self.union_rules.get(union_type)
@@ -450,24 +449,23 @@ class RootRule(Rule):
 @dataclass(frozen=True)
 class NormalizedRules:
     rules: FrozenOrderedSet
-    union_rules: "OrderedDict[Type, OrderedSet[Type]]"
+    union_rules: Dict[Type, OrderedSet[Type]]
 
 
-# TODO: add typechecking here -- use dicts for `union_rules`.
 @dataclass(frozen=True)
 class RuleIndex:
     """Holds a normalized index of Rules used to instantiate Nodes."""
 
-    rules: OrderedDict
-    roots: OrderedSet
-    union_rules: "OrderedDict[Type, OrderedSet[Type]]"
+    rules: Dict
+    roots: FrozenOrderedSet
+    union_rules: Dict[Type, OrderedSet[Type]]
 
     @classmethod
     def create(cls, rule_entries, union_rules=None) -> "RuleIndex":
         """Creates a RuleIndex with tasks indexed by their output type."""
-        serializable_rules: OrderedDict = OrderedDict()
+        serializable_rules: Dict = {}
         serializable_roots: OrderedSet = OrderedSet()
-        union_rules = OrderedDict(union_rules or ())
+        union_rules = dict(union_rules or ())
 
         def add_task(product_type, rule):
             # TODO(#7311): make a defaultdict-like wrapper for OrderedDict if more widely used.
@@ -517,7 +515,7 @@ functions decorated with @rule.""".format(
                     )
                 )
 
-        return cls(serializable_rules, serializable_roots, union_rules)
+        return cls(serializable_rules, FrozenOrderedSet(serializable_roots), union_rules)
 
     def normalized_rules(self) -> NormalizedRules:
         rules = FrozenOrderedSet(

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -31,9 +31,8 @@ from pants.util.dirutil import check_no_overlapping_paths
 from pants.util.strutil import pluralize
 
 if TYPE_CHECKING:
-    from collections import OrderedDict
     from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
-    from pants.util.ordered_set import OrderedSet
+    from pants.util.ordered_set import OrderedSet  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -71,12 +70,12 @@ class Scheduler:
         build_root: str,
         local_store_dir: str,
         rules: Tuple[Rule, ...],
-        union_rules: "OrderedDict[Type, OrderedSet[Type]]",
+        union_rules: Dict[Type, "OrderedSet[Type]"],
         execution_options: ExecutionOptions,
         include_trace_on_error: bool = True,
         visualize_to_dir: Optional[str] = None,
         validate: bool = True,
-    ):
+    ) -> None:
         """
         :param native: An instance of engine.native.Native.
         :param ignore_patterns: A list of gitignore-style file patterns for pants to ignore.
@@ -182,7 +181,7 @@ class Scheduler:
         return tasks
 
     def _register_task(
-        self, tasks, output_type, rule: TaskRule, union_rules: "OrderedDict[Type, OrderedSet[Type]]"
+        self, tasks, output_type, rule: TaskRule, union_rules: Dict[Type, "OrderedSet[Type]"]
     ) -> None:
         """Register the given TaskRule with the native scheduler."""
         func = Function(self._to_key(rule.func))

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import ClassVar, List, Optional, Tuple
@@ -168,7 +167,7 @@ def test_add_custom_fields() -> None:
                 return False
             return self.raw_value
 
-    union_membership = UnionMembership(OrderedDict({HaskellTarget: OrderedSet([CustomField])}))
+    union_membership = UnionMembership({HaskellTarget: OrderedSet([CustomField])})
     tgt_values = {CustomField.alias: True}
     tgt = HaskellTarget(tgt_values, union_membership=union_membership)
     assert tgt.field_types == (HaskellGhcExtensions, HaskellSources, CustomField)

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 from pathlib import Path
 from typing import Iterable, List, Type, cast
 from unittest.mock import Mock
@@ -127,9 +126,7 @@ class FmtTest(TestBase):
         per_target_caching: bool,
     ) -> str:
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership(
-            OrderedDict({LanguageFormatters: OrderedSet(language_formatters)})
-        )
+        union_membership = UnionMembership({LanguageFormatters: OrderedSet(language_formatters)})
         result: Fmt = run_rule(
             fmt,
             rule_args=[

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 from typing import Iterable, List, Tuple, Type
 from unittest.mock import Mock
 
@@ -102,7 +101,7 @@ class LintTest(TestBase):
         per_target_caching: bool,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership(OrderedDict({Linter: OrderedSet(linters)}))
+        union_membership = UnionMembership({Linter: OrderedSet(linters)})
         result: Lint = run_rule(
             lint,
             rule_args=[

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from collections import OrderedDict
 from pathlib import PurePath
 from textwrap import dedent
 from typing import Optional
@@ -265,9 +264,7 @@ class TestTest(TestBase):
         adaptor_cls = PythonTestsAdaptor if test_target_type else PythonBinaryAdaptor
         type_alias = "python_tests" if test_target_type else "python_binary"
         adaptor = adaptor_cls(address=address, type_alias=type_alias, sources=mocked_fileset)
-        union_membership = UnionMembership(
-            union_rules=OrderedDict({TestTarget: OrderedSet([PythonTestsAdaptorWithOrigin])})
-        )
+        union_membership = UnionMembership({TestTarget: OrderedSet([PythonTestsAdaptorWithOrigin])})
         with self.captured_logging(logging.INFO):
             result: AddressAndTestResult = run_rule(
                 coordinator_of_tests,


### PR DESCRIPTION
As of Python 3.6+, dictionaries are ordered by default. (While this is not formalized until Python 3.7, the implementation detail is guaranteed in 3.6 and it was not formalized in 3.6 so that later Python versions maintained flexibility to change the guarantee.)

Dicts are more ergonomic than `OrderedDict`s, such as being easier to create and having a simpler `repr()`.