### PR TITLE
Revision: ensure that 1 < 1.0.1; reformat test cases to use bare asserts

### DIFF
--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -120,7 +120,7 @@ class Revision:
                 ours, theirs = self._fill_value_if_missing(ours, theirs)
                 ours, theirs = self._stringify_if_different_types(ours, theirs)
                 if ours == theirs:
-                   continue
+                    continue
                 return ours < theirs
         return False
 

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -119,6 +119,8 @@ class Revision:
             if ours != theirs:
                 ours, theirs = self._fill_value_if_missing(ours, theirs)
                 ours, theirs = self._stringify_if_different_types(ours, theirs)
+                if ours == theirs:
+                   continue
                 return ours < theirs
         return False
 

--- a/tests/python/pants_test/base/test_revision.py
+++ b/tests/python/pants_test/base/test_revision.py
@@ -7,8 +7,7 @@ from pants.base.revision import Revision
 
 
 class RevisionTest(unittest.TestCase):
-    def assertComponents(self, revision, *expected):
-        self.assertEqual(list(expected), revision.components)
+    pass
 
 
 class SemverTest(RevisionTest):
@@ -18,92 +17,98 @@ class SemverTest(RevisionTest):
                 Revision.semver(bad_rev)
 
     def test_simple(self):
-        self.assertEqual(Revision.semver("1.2.3"), Revision.semver("1.2.3"))
-        self.assertComponents(Revision.semver("1.2.3"), 1, 2, 3, None, None)
+        assert Revision.semver("1.2.3") == Revision.semver("1.2.3")
+        assert Revision.semver("1.2.3").components == [1, 2, 3, None, None]
 
-        self.assertTrue(Revision.semver("1.2.3") > Revision.semver("1.2.2"))
-        self.assertTrue(Revision.semver("1.3.0") > Revision.semver("1.2.2"))
-        self.assertTrue(Revision.semver("1.3.10") > Revision.semver("1.3.2"))
-        self.assertTrue(Revision.semver("2.0.0") > Revision.semver("1.3.2"))
+        assert Revision.semver("1.2.3") > Revision.semver("1.2.2")
+        assert Revision.semver("1.3.0") > Revision.semver("1.2.2")
+        assert Revision.semver("1.3.10") > Revision.semver("1.3.2")
+        assert Revision.semver("2.0.0") > Revision.semver("1.3.2")
 
     def test_pre_release(self):
-        self.assertEqual(
-            Revision.semver("1.2.3-pre1.release.1"), Revision.semver("1.2.3-pre1.release.1")
-        )
-        self.assertComponents(
-            Revision.semver("1.2.3-pre1.release.1"), 1, 2, 3, "pre1", "release", 1, None
-        )
+        assert Revision.semver("1.2.3-pre1.release.1") == Revision.semver("1.2.3-pre1.release.1")
 
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.1") < Revision.semver("1.2.3-pre2.release.1")
-        )
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.2") < Revision.semver("1.2.3-pre1.release.10")
-        )
+        assert Revision.semver("1.2.3-pre1.release.1").components == [
+            1,
+            2,
+            3,
+            "pre1",
+            "release",
+            1,
+            None,
+        ]
 
-        self.assertTrue(Revision.semver("1.2.3") < Revision.semver("1.2.3-pre2.release.1"))
+        assert Revision.semver("1.2.3-pre1.release.1") < Revision.semver("1.2.3-pre2.release.1")
+
+        assert Revision.semver("1.2.3-pre1.release.2") < Revision.semver("1.2.3-pre1.release.10")
+
+        assert Revision.semver("1.2.3") < Revision.semver("1.2.3-pre2.release.1")
 
     def test_build(self):
-        self.assertEqual(
-            Revision.semver("1.2.3+pre1.release.1"), Revision.semver("1.2.3+pre1.release.1")
-        )
-        self.assertComponents(
-            Revision.semver("1.2.3+pre1.release.1"), 1, 2, 3, None, "pre1", "release", 1
-        )
+        # TODO in semver 2.0.0, build data has no effect on precedence.
+        assert Revision.semver("1.2.3+pre1.release.1") == Revision.semver("1.2.3+pre1.release.1")
+        assert Revision.semver("1.2.3+pre1.release.1").components == [
+            1,
+            2,
+            3,
+            None,
+            "pre1",
+            "release",
+            1,
+        ]
 
-        self.assertTrue(
-            Revision.semver("1.2.3+pre1.release.1") < Revision.semver("1.2.3+pre2.release.1")
-        )
-        self.assertTrue(
-            Revision.semver("1.2.3+pre1.release.2") < Revision.semver("1.2.3+pre1.release.10")
-        )
-
-        self.assertTrue(Revision.semver("1.2.3") < Revision.semver("1.2.3+pre2.release.1"))
-        self.assertTrue(
-            Revision.semver("1.2.3+pre1.release.2") < Revision.semver("1.2.3-pre1.release.2")
-        )
+        assert Revision.semver("1.2.3+pre1.release.1") < Revision.semver("1.2.3+pre2.release.1")
+        assert Revision.semver("1.2.3+pre1.release.2") < Revision.semver("1.2.3+pre1.release.10")
+        assert Revision.semver("1.2.3") < Revision.semver("1.2.3+pre2.release.1")
+        assert Revision.semver("1.2.3+pre1.release.2") < Revision.semver("1.2.3-pre1.release.2")
 
     def test_pre_release_build(self):
-        self.assertEqual(
-            Revision.semver("1.2.3-pre1.release.1+1"), Revision.semver("1.2.3-pre1.release.1+1")
+        assert Revision.semver("1.2.3-pre1.release.1+1") == Revision.semver(
+            "1.2.3-pre1.release.1+1"
         )
-        self.assertComponents(
-            Revision.semver("1.2.3-pre1.release.1+1"), 1, 2, 3, "pre1", "release", 1, 1
+        assert Revision.semver("1.2.3-pre1.release.1+1").components == [
+            1,
+            2,
+            3,
+            "pre1",
+            "release",
+            1,
+            1,
+        ]
+
+        assert Revision.semver("1.2.3-pre1.release.1") < Revision.semver("1.2.3-pre2.release.1+1")
+
+        assert Revision.semver("1.2.3-pre1.release.2") > Revision.semver("1.2.3-pre1.release.1+1")
+
+        assert Revision.semver("1.2.3") < Revision.semver("1.2.3-pre2.release.2+1.foo")
+
+        assert Revision.semver("1.2.3-pre1.release.2+1") < Revision.semver(
+            "1.2.3-pre1.release.2+1.foo"
         )
 
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.1") < Revision.semver("1.2.3-pre2.release.1+1")
-        )
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.2") > Revision.semver("1.2.3-pre1.release.1+1")
-        )
-
-        self.assertTrue(Revision.semver("1.2.3") < Revision.semver("1.2.3-pre2.release.2+1.foo"))
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.2+1")
-            < Revision.semver("1.2.3-pre1.release.2+1.foo")
-        )
-        self.assertTrue(
-            Revision.semver("1.2.3-pre1.release.2+1") < Revision.semver("1.2.3-pre1.release.2+2")
-        )
+        assert Revision.semver("1.2.3-pre1.release.2+1") < Revision.semver("1.2.3-pre1.release.2+2")
 
 
 class LenientTest(RevisionTest):
     def test(self):
-        self.assertComponents(Revision.lenient("1.2.3"), 1, 2, 3)
-        self.assertComponents(Revision.lenient("1.2.3-SNAPSHOT-eabc"), 1, 2, 3, "SNAPSHOT", "eabc")
-        self.assertComponents(Revision.lenient("1.2.3-SNAPSHOT4"), 1, 2, 3, "SNAPSHOT", 4)
+        # TODO we may want to change these particular cases
+        assert Revision.lenient("1") > Revision.lenient("1.0.0")
+        assert Revision.lenient("1.0") > Revision.lenient("1.0.0")
 
-        self.assertTrue(Revision.lenient("a") < Revision.lenient("b"))
-        self.assertTrue(Revision.lenient("1") < Revision.lenient("2"))
-        self.assertTrue(Revision.lenient("1") < Revision.lenient("a"))
+        assert Revision.lenient("1") < Revision.lenient("1.0.1")
+        assert Revision.lenient("1.0") < Revision.lenient("1.0.1")
+        assert Revision.lenient("1.0.1") < Revision.lenient("1.0.2")
 
-        self.assertEqual(Revision.lenient("1.2.3"), Revision.lenient("1.2.3"))
-        self.assertTrue(Revision.lenient("1.2.3") < Revision.lenient("1.2.3-SNAPSHOT"))
-        self.assertTrue(Revision.lenient("1.2.3-SNAPSHOT") < Revision.lenient("1.2.3-SNAPSHOT-abc"))
-        self.assertTrue(
-            Revision.lenient("1.2.3-SNAPSHOT-abc") < Revision.lenient("1.2.3-SNAPSHOT-bcd")
-        )
-        self.assertTrue(
-            Revision.lenient("1.2.3-SNAPSHOT-abc6") < Revision.lenient("1.2.3-SNAPSHOT-abc10")
-        )
+        assert Revision.lenient("1.2.3").components == [1, 2, 3]
+        assert Revision.lenient("1.2.3-SNAPSHOT-eabc").components == [1, 2, 3, "SNAPSHOT", "eabc"]
+        assert Revision.lenient("1.2.3-SNAPSHOT4").components == [1, 2, 3, "SNAPSHOT", 4]
+
+        assert Revision.lenient("a") < Revision.lenient("b")
+        assert Revision.lenient("1") < Revision.lenient("2")
+        assert Revision.lenient("1") < Revision.lenient("a")
+
+        assert Revision.lenient("1.2.3") == Revision.lenient("1.2.3")
+        assert Revision.lenient("1.2.3") < Revision.lenient("1.2.3-SNAPSHOT")
+        assert Revision.lenient("1.2.3-SNAPSHOT") < Revision.lenient("1.2.3-SNAPSHOT-abc")
+        assert Revision.lenient("1.2.3-SNAPSHOT-abc") < Revision.lenient("1.2.3-SNAPSHOT-bcd")
+        assert Revision.lenient("1.2.3-SNAPSHOT-abc6") < Revision.lenient("1.2.3-SNAPSHOT-abc10")


### PR DESCRIPTION
### Problem

Currently `Revision.lenient("1") > Revision.lenient("1.0.1")`

See also #9289

### Solution

Update `__lt__` to fix error.

### Result

Fixes above as `Revision.lenient("1") < Revision.lenient("1.0.1")`