### PR TITLE
Tweak how to add plugin fields to V2 targets to be more explicit

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -86,13 +86,7 @@ _F = TypeVar("_F", bound=Field)
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class Target(ABC):
-    """A Target represents a combination of fields that are valid _together_.
-
-    Plugin authors may add additional fields to pre-existing target types by simply registering
-    UnionRules between the `Target` type and the custom field, e.g. `UnionRule(PythonLibrary,
-    TypeChecked)`. The `Target` will then treat `TypeChecked` as a first-class citizen and plugins
-    can use that Field like any other Field.
-    """
+    """A Target represents a combination of fields that are valid _together_."""
 
     # Subclasses must define these
     alias: ClassVar[str]
@@ -113,7 +107,7 @@ class Target(ABC):
             (
                 ()
                 if union_membership is None
-                else tuple(union_membership.union_rules.get(self.__class__, ()))
+                else tuple(union_membership.union_rules.get(self.PluginField, ()))
             ),
         )
 
@@ -133,6 +127,15 @@ class Target(ABC):
     @property
     def field_types(self) -> Tuple[Type[Field], ...]:
         return (*self.core_fields, *self.plugin_fields)
+
+    class PluginField:
+        """A sentinel class to allow plugin authors to add additional fields to this target type.
+
+        Plugin authors may add additional fields by simply registering UnionRules between the
+        `Target.PluginField` and the custom field, e.g. `UnionRule(PythonLibrary.PluginField,
+        TypeChecked)`. The `Target` will then treat `TypeChecked` as a first-class citizen and
+        plugins can use that Field like any other Field.
+        """
 
     def __repr__(self) -> str:
         return (

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -167,7 +167,7 @@ def test_add_custom_fields() -> None:
                 return False
             return self.raw_value
 
-    union_membership = UnionMembership({HaskellTarget: OrderedSet([CustomField])})
+    union_membership = UnionMembership({HaskellTarget.PluginField: OrderedSet([CustomField])})
     tgt_values = {CustomField.alias: True}
     tgt = HaskellTarget(tgt_values, union_membership=union_membership)
     assert tgt.field_types == (HaskellGhcExtensions, HaskellSources, CustomField)


### PR DESCRIPTION
Unions are supposed to be an `is-a` relationship.

Previously, to add a new field to a pre-existing target, you would do `UnionRule(PythonLibrary, TypeChecked)`. This is not an `is-a` relationship, though; `TypeChecked(Field)` is not a `PythonLibrary(Target)`.

Instead, we add a sentinel class automatically to every `Target` called `PluginField`. So, to add a new field, plugin authors simply register `UnionRule(PythonLibrary.PluginField, TypeChecked)`.