### PR TITLE
Zinc: Use an Array[PublishDiagnosticsParam] for LSP compliance

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -226,7 +226,7 @@ object Main {
     file.getAbsoluteFile().toPath().toUri()
   }
   def toLsp(problems: List[Problem],
-            workingDirectory: File): Iterable[PublishDiagnosticsParams] = {
+            workingDirectory: File): Array[PublishDiagnosticsParams] = {
     import scala.tools.nsc.io.Path._
     problems
       .groupBy(problem => problem.position.sourcePath)
@@ -263,7 +263,7 @@ object Main {
               })
           new PublishDiagnosticsParams(uri, diagnostics.asJava)
         }
-      }
+      }.toArray
   }
 
   def dumpDiagnostics(diagnosticsFile: File,


### PR DESCRIPTION
### Problem

When publishing diagnostics to a json file with an aim for being compliant with the Language Server Protocol (LSP), we used an Iterable which serializes to a json output with this shape:
```
{"head":{"uri":"buildroot://src/java/com/sun/tools/javac/api/JavacTool.java","diagnostics":[{"range":{"start":{"line":92,"character":-1},"end":{"line":92,"character":-1}},"severity":"Warning","code":"","source":"zinc","message":"unchecked conversion\n  required: java.util.Set\u003cjava.lang.String\u003e\n  found:    java.util.HashSet"}]},"tl":{}}
```

Notice the "head" and "tl" keys.

### Solution

Use an array to serialize into the correct LSP compliant json representation.

### Result

The json now looks like this:
```
[{"uri":"buildroot://src/java/com/sun/tools/javac/api/JavacTool.java","diagnostics":[{"range":{"start":{"line":92,"character":-1},"end":{"line":92,"character":-1}},"severity":"Warning","code":"","source":"zinc","message":"unchecked conversion\n  required: java.util.Set\u003cjava.lang.String\u003e\n  found:    java.util.HashSet"}]}]
```
which complies to the LSP and is easier to consume from the python side of things.