### PR TITLE
Simplify `PrimitiveField` to eagerly hydrate values

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -267,9 +267,9 @@ python_library(
   sources=['target.py'],
   dependencies=[
     ':rules',
+    '3rdparty/python:typing-extensions',
     'src/python/pants/util:collections',
     'src/python/pants/util:meta',
-    'src/python/pants/util:memo',
   ],
   tags = {'type_checked'},
 )


### PR DESCRIPTION
### Problem

Laziness can be great, particularly for better performance. We need laziness for certain `Fields` like `Sources` that are very expensive to hydrate and often not even needed.

But, laziness has its downsides (see Haskell). Laziness generally makes code more difficult to work with and reason with. 

For example, by having `PrimitiveField` do its hydration and validation lazily, every `PrimitiveField` must now import and use the decorater `@memoized_property`. 

Further, it becomes harder for us to refer to a `Field`'s owning `Address` when we encounter validation errors; if lazy, we must then store `Address` on the `Field` instance because `Field`s have no way of referring back to their owning `Target` (this is by design).

Finally, lazy validation of `PrimitiveField`s means that it is much harder for users to detect when they have invalid BUILD files.

### Solution

Change `PrimitiveField` to eagerly validate and hydrate in the constructor. 

If the hydration is particularly expensive, then the user should use `AsyncField` to get the engine's caching + the laziness of `AsyncField`.

#### Rejected alternative: `LazyField`

`PrimitiveField` would have two subclasses: `EagerField` and `LazyField`. We would still have `AsyncField`. `LazyField` would be for when you need light-weight validation that you want to do lazily.

This was rejected as a premature abstraction. For example, the performance cost of validating that every `timeout` field is `> 0` is likely very negligible. Perhaps, we find that it is indeed costly so we add `LazyField` down the road, but for now, it's premature.