### PR TITLE
Filter sources passed to the pytest invocation.

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -28,6 +28,7 @@ from pants.engine.interactive_runner import InteractiveProcessRequest
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import (
+    FilesAdaptor,
     PythonTargetAdaptor,
     PythonTestsAdaptorWithOrigin,
     ResourcesAdaptor,
@@ -164,7 +165,9 @@ async def setup_pytest_for_target(
 
     # TODO: Replace this with appropriate target API logic.
     python_targets = [t for t in all_targets if isinstance(t.adaptor, PythonTargetAdaptor)]
-    resource_targets = [t for t in all_targets if isinstance(t.adaptor, ResourcesAdaptor)]
+    resource_targets = [
+        t for t in all_targets if isinstance(t.adaptor, (FilesAdaptor, ResourcesAdaptor))
+    ]
 
     # TODO(John Sirois): Support exploiting concurrency better:
     #   https://github.com/pantsbuild/pants/issues/9294

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -276,6 +276,10 @@ class ResourcesAdaptor(TargetAdaptor):
     pass
 
 
+class FilesAdaptor(TargetAdaptor):
+    pass
+
+
 class RemoteSourcesAdaptor(TargetAdaptor):
     def __init__(self, dest=None, **kwargs):
         """

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -32,6 +32,7 @@ from pants.engine.legacy.graph import LegacyBuildGraph, create_legacy_graph_task
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (
+    FilesAdaptor,
     JvmAppAdaptor,
     JvmBinaryAdaptor,
     PageAdaptor,
@@ -140,6 +141,7 @@ def _legacy_symbol_table(build_file_aliases: BuildFileAliases) -> SymbolTable:
     table["python_requirement_library"] = PythonRequirementLibraryAdaptor
     table["remote_sources"] = RemoteSourcesAdaptor
     table["resources"] = ResourcesAdaptor
+    table["files"] = FilesAdaptor
     table["page"] = PageAdaptor
     table["python_awslambda"] = PythonAWSLambdaAdaptor
 


### PR DESCRIPTION
### Problem

We were passing all sources from the entire dep closure to the pytest EPR. This included, for example, the requirements.txt file. So modifying requirements.txt, even by just adding a comment, would cause pytest to be re-run, even if the change had no effect on the actual set of requirements.

### Solution

Only pass python sources and resources to pytest.
Only pass python sources to the coverage config.

### Result

Whitespace changes to requirements.txt no longer invalidate the pytest EPR.