### PR TITLE
Make Target API safe to use with the engine

### DIFF
--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -13,7 +13,7 @@ from pants.engine.target import (
     Sources,
     SourcesResult,
     StringField,
-    StringOrStringListField,
+    StringOrStringSequenceField,
     Target,
 )
 
@@ -49,7 +49,7 @@ class PythonBinarySources(PythonSources):
             )
 
 
-class Compatibility(StringOrStringListField):
+class Compatibility(StringOrStringSequenceField):
     """A string for Python interpreter constraints on this target.
 
     This should be written in Requirement-style format, e.g. `CPython==2.7.*` or `CPython>=3.6,<4`.
@@ -60,16 +60,16 @@ class Compatibility(StringOrStringListField):
     alias: ClassVar = "compatibility"
 
 
-# TODO: Deal with the `provides` field. This will at least allow us to correctly parse the valid,
+# TODO: Deal with the `provides` field. This will at least allow us to correctly parse the field,
 #  rather than throwing an error when encountering it.
 class Provides(PrimitiveField):
     alias: ClassVar = "provides"
 
-    def hydrate(self, *, address: Address) -> Any:
-        return self.raw_value
+    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> Any:
+        return raw_value
 
 
-class Coverage(StringOrStringListField):
+class Coverage(StringOrStringSequenceField):
     """The module(s) whose coverage should be generated, e.g. `['pants.util']`."""
 
     alias: ClassVar = "coverage"
@@ -82,15 +82,13 @@ class Timeout(PrimitiveField):
     """
 
     alias: ClassVar = "timeout"
-    raw_value: Optional[int]
 
-    def hydrate(self, *, address: Address) -> Optional[int]:
-        if self.raw_value is not None and self.raw_value <= 0:
+    def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[int]:
+        if raw_value is not None and raw_value <= 0:
             raise ValueError(
-                f"The `{self.alias}` field for the target {address} must be > 1. Was "
-                f"{self.raw_value}."
+                f"The `{self.alias}` field for the target {address} must be > 1. Was {raw_value}."
             )
-        return self.raw_value
+        return raw_value
 
 
 class EntryPoint(StringField):
@@ -103,7 +101,7 @@ class EntryPoint(StringField):
     alias: ClassVar = "entry_point"
 
 
-class Platforms(StringOrStringListField):
+class Platforms(StringOrStringSequenceField):
     """Extra platforms to target when building a Python binary."""
 
     alias: ClassVar = "platforms"
@@ -130,13 +128,13 @@ class PexAlwaysWriteCache(BoolField):
     default: ClassVar = False
 
 
-class PexRepositories(StringOrStringListField):
+class PexRepositories(StringOrStringSequenceField):
     """Repositories for Pex to query for dependencies."""
 
     alias: ClassVar = "repositories"
 
 
-class PexIndices(StringOrStringListField):
+class PexIndices(StringOrStringSequenceField):
     """Indices for Pex to use for packages."""
 
     alias: ClassVar = "indices"


### PR DESCRIPTION
### Problem

The engine requires that every value is immutable and hashable. (Technically, it only enforces hashability, but mutable things are fundamentally not safe to hash).

However, many of the `raw_value`s we stored on `Field` are not hashable, such as `List`. The idea of `raw_value` was to preserve exactly what the user typed in a `BUILD` file, but that's fundamentally not safe to do because `BUILD` files can use mutable data types.

### Solution

For `PrimitiveField`, discard the `raw_value` after initialization. We were only keeping it for the sake of debugging. It would be neat to continue storing, but it's not safe to do so with the engine so the best option is to simply discard the value. This also improves the space usage of `PrimitiveField`.

For `AsyncField`, due to lazy hydration, we must preserve the raw value. But, we need to use these fields with the engine, so we introduce the attribute `sanitized_raw_value` and the abstractmethod `sanitize_raw_value()`. This allows us to do things like convert lists into tuples. `sanitize_raw_values()` also means that we can now get some light-weight validation to be eager, which is likely a good thing as it allows us to catch invalid BUILD files eagerly. For example, we can eagerly fail if a user tries doing `sources=[0, 1, 2]`.

### Result

`Target` and `Field` are now safe to use with the engine.*

*`Field` authors can still mess things up. They must use immutable and hashable types for `PrimitiveField.value` and `AsyncField.sanitized_raw_value`. There is nothing enforcing a `Field` author to use a safe type like a tuple over a list, other than convention.** 

** Maybe we could make a MyPy plugin to check that the return type of a function is immutable? This would need to work ergonomically, such as working with native tuples and not forcing us to subclass `Tuple`.