### PR TITLE
Add support for hydrating `sources` with the Target API

### DIFF
--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -5,6 +5,7 @@ from pathlib import PurePath
 from typing import Any, ClassVar, Optional
 
 from pants.build_graph.address import Address
+from pants.engine.fs import Snapshot
 from pants.engine.objects import union
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -12,7 +13,6 @@ from pants.engine.target import (
     ImmutableValue,
     PrimitiveField,
     Sources,
-    SourcesResult,
     StringField,
     StringOrStringSequenceField,
     Target,
@@ -21,12 +21,11 @@ from pants.engine.target import (
 
 @union
 class PythonSources(Sources):
-    @classmethod
-    def validate_result(cls, result: SourcesResult) -> None:
-        non_python_files = [fp for fp in result.snapshot.files if not PurePath(fp).suffix == ".py"]
+    def validate_snapshot(self, snapshot: Snapshot) -> None:
+        non_python_files = [fp for fp in snapshot.files if not PurePath(fp).suffix == ".py"]
         if non_python_files:
             raise ValueError(
-                f"Target {result.address} has non-Python sources in its `sources` field: "
+                f"Target {self.address} has non-Python sources in its `sources` field: "
                 f"{non_python_files}"
             )
 
@@ -40,13 +39,13 @@ class PythonTestsSources(PythonSources):
 
 
 class PythonBinarySources(PythonSources):
-    @classmethod
-    def validate_result(cls, result: SourcesResult) -> None:
-        super().validate_result(result)
-        if len(result.snapshot.files) not in [0, 1]:
+    def validate_snapshot(self, snapshot: Snapshot) -> None:
+        super().validate_snapshot(snapshot)
+        if len(snapshot.files) not in [0, 1]:
             raise ValueError(
                 "Binary targets must have only 0 or 1 source files. Any additional files should "
-                "be put in a `python_library` which is added to `dependencies`"
+                f"be put in a `python_library` which is added to `dependencies`. The target "
+                f"{self.address} had {len(snapshot.files)} sources: {snapshot.files}."
             )
 
 

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -9,6 +9,7 @@ from pants.engine.objects import union
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
+    ImmutableValue,
     PrimitiveField,
     Sources,
     SourcesResult,
@@ -65,7 +66,7 @@ class Compatibility(StringOrStringSequenceField):
 class Provides(PrimitiveField):
     alias: ClassVar = "provides"
 
-    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> Any:
+    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> ImmutableValue:
         return raw_value
 
 

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -3,8 +3,19 @@
 
 import pytest
 
-from pants.backend.python.rules.targets import Timeout
+from pants.backend.python.rules.targets import (
+    PythonBinarySources,
+    PythonLibrarySources,
+    PythonSources,
+    PythonTestsSources,
+    Timeout,
+)
 from pants.build_graph.address import Address
+from pants.engine.rules import RootRule
+from pants.engine.scheduler import ExecutionError
+from pants.engine.target import SourcesRequest, SourcesResult
+from pants.engine.target import rules as target_rules
+from pants.testutil.test_base import TestBase
 
 
 def test_timeout_validation() -> None:
@@ -13,3 +24,58 @@ def test_timeout_validation() -> None:
     with pytest.raises(ValueError):
         Timeout(0, address=Address.parse(":tests"))
     assert Timeout(5, address=Address.parse(":tests")).value == 5
+
+
+class TestPythonSources(TestBase):
+    PYTHON_SRC_FILES = ("f1.py", "f2.py")
+    PYTHON_TEST_FILES = ("conftest.py", "test_f1.py", "f1_test.py")
+
+    @classmethod
+    def rules(cls):
+        return [*target_rules(), RootRule(SourcesRequest)]
+
+    def test_python_sources_validation(self) -> None:
+        files = ("f.js", "f.hs", "f.txt", "f.py")
+        self.create_files(path="", files=files)
+        sources = PythonSources(files, address=Address.parse(":lib"))
+        assert sources.sanitized_raw_value == files
+        with pytest.raises(ExecutionError) as exc:
+            self.request_single_product(SourcesResult, sources.request)
+        assert "non-Python sources" in str(exc)
+        assert "f.hs" in str(exc)
+
+        # Also check that we support valid sources
+        valid_sources = PythonSources(["f.py"], address=Address.parse(":lib"))
+        assert valid_sources.sanitized_raw_value == ("f.py",)
+        assert self.request_single_product(SourcesResult, valid_sources.request).snapshot.files == (
+            "f.py",
+        )
+
+    def test_python_binary_sources_validation(self) -> None:
+        self.create_files(path="", files=["f1.py", "f2.py"])
+        address = Address.parse(":binary")
+
+        zero_sources = PythonBinarySources(None, address=address)
+        assert self.request_single_product(SourcesResult, zero_sources.request).snapshot.files == ()
+
+        one_source = PythonBinarySources(["f1.py"], address=address)
+        assert self.request_single_product(SourcesResult, one_source.request).snapshot.files == (
+            "f1.py",
+        )
+
+        multiple_sources = PythonBinarySources(["f1.py", "f2.py"], address=address)
+        with pytest.raises(ExecutionError) as exc:
+            self.request_single_product(SourcesResult, multiple_sources.request)
+        assert "//:binary had 2 sources" in str(exc)
+
+    def test_python_library_sources_default_globs(self) -> None:
+        self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
+        sources = PythonLibrarySources(None, address=Address.parse(":lib"))
+        result = self.request_single_product(SourcesResult, sources.request)
+        assert result.snapshot.files == self.PYTHON_SRC_FILES
+
+    def test_python_tests_sources_default_globs(self) -> None:
+        self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
+        sources = PythonTestsSources(None, address=Address.parse(":tests"))
+        result = self.request_single_product(SourcesResult, sources.request)
+        assert set(result.snapshot.files) == set(self.PYTHON_TEST_FILES)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -3,13 +3,21 @@
 
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 from typing_extensions import final
 
 from pants.build_graph.address import Address
-from pants.engine.fs import Snapshot
-from pants.engine.rules import UnionMembership
+from pants.engine.fs import (
+    EMPTY_SNAPSHOT,
+    GlobExpansionConjunction,
+    GlobMatchErrorBehavior,
+    PathGlobs,
+    Snapshot,
+)
+from pants.engine.rules import RootRule, UnionMembership, rule
+from pants.engine.selectors import Get
 from pants.util.collections import ensure_str_list
 from pants.util.meta import frozen_after_init
 
@@ -18,8 +26,11 @@ from pants.util.meta import frozen_after_init
 ImmutableValue = Any
 
 
+# NB: We don't generate `__eq__` because dataclass would only look at the `alias` classvar, which
+# is always the same between every Field instance. Instead, subclasses like `PrimitiveField` should
+# define `__eq__`.
 @frozen_after_init
-@dataclass(unsafe_hash=True)  # type: ignore[misc]  # MyPy doesn't like the abstract __init__()
+@dataclass(eq=False)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class Field(ABC):
     alias: ClassVar[str]
 
@@ -35,6 +46,8 @@ class Field(ABC):
         pass
 
 
+@frozen_after_init
+@dataclass(unsafe_hash=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class PrimitiveField(Field, metaclass=ABCMeta):
     """A Field that does not need the engine in order to be hydrated.
 
@@ -93,6 +106,13 @@ class PrimitiveField(Field, metaclass=ABCMeta):
         return f"{self.alias}={self.value}"
 
 
+# Type alias to express the intent that the type should be a new Request class created to
+# correspond with its AsyncField.
+AsyncFieldRequest = Any
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class AsyncField(Field, metaclass=ABCMeta):
     """A field that needs the engine in order to be hydrated.
 
@@ -100,8 +120,11 @@ class AsyncField(Field, metaclass=ABCMeta):
     immutable and hashable so that this Field may be used by the V2 engine. This means, for example,
     using tuples rather than lists and using `FrozenOrderedSet` rather than `set`.
 
-    You should also create a corresponding Result class and define a rule to go from this
-    AsyncField to the Result.
+    You should also create corresponding Request and Result classes and define a rule to go from
+    this Request to Result. The Request type must be registered as a RootRule. Then, implement
+    the property `AsyncField.request` to instantiate the Request type. If you use MyPy, you should
+    mark `AsyncField.request` as `@final` (from `typing_extensions)` to ensure that subclasses
+    don't change this property.
 
     For example:
 
@@ -114,6 +137,22 @@ class AsyncField(Field, metaclass=ABCMeta):
             ) -> Optional[Tuple[str, ...]]:
                 ...
 
+            @final
+            @property
+            def request(self) -> SourcesRequest:
+                return SourcesRequest(self)
+
+            # Example extension point provided by this field. Subclasses can override this to do
+            # whatever validation they'd like. Each AsyncField must define its own entry points
+            # like this to allow subclasses to change behavior.
+            def validate_snapshot(self, snapshot: Snapshot) -> None:
+                pass
+
+
+        @dataclass(frozen=True)
+        class SourcesRequest:
+            field: Sources
+
 
         @dataclass(frozen=True)
         class SourcesResult:
@@ -121,21 +160,21 @@ class AsyncField(Field, metaclass=ABCMeta):
 
 
         @rule
-        def hydrate_sources(sources: Sources) -> SourcesResult:
-            # possibly validate `sources.raw_value`
-            ...
-            result = await Get[Snapshot](PathGlobs(sources.raw_value))
-            # possibly validate `result`
+        def hydrate_sources(request: SourcesRequest) -> SourcesResult:
+            result = await Get[Snapshot](PathGlobs(request.field.sanitized_raw_value))
+            request.field.validate_snapshot(result)
             ...
             return SourcesResult(result)
 
 
         def rules():
-            return [hydrate_sources]
+            return [hydrate_sources, RootRule(SourcesRequest)]
 
-    Then, call sites can `await Get` if they need to hydrate the field:
+    Then, call sites can `await Get` if they need to hydrate the field, even if they subclassed
+    the original `AsyncField` to have custom behavior:
 
-        sources = await Get[SourcesResult](Sources, my_tgt.get(Sources))
+        sources1 = await Get[SourcesResult](SourcesRequest, my_tgt.get(Sources).request)
+        sources2 = await Get[SourcesResult[(SourcesRequest, custom_tgt.get(CustomSources).request)
     """
 
     address: Address
@@ -157,12 +196,26 @@ class AsyncField(Field, metaclass=ABCMeta):
         """
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__}(alias={self.alias}, sanitized_raw_value={self.sanitized_raw_value})"
-        )
+        return f"{self.__class__}(alias={repr(self.alias)}, sanitized_raw_value={self.sanitized_raw_value})"
 
     def __str__(self) -> str:
         return f"{self.alias}={self.sanitized_raw_value}"
+
+    @property
+    @abstractmethod
+    def request(self) -> AsyncFieldRequest:
+        """Wrap the field in its corresponding Request type.
+
+        This is necessary to avoid ambiguity in the V2 rule graph when dealing with possible
+        subclasses of this AsyncField.
+
+        For example:
+
+            @final
+            @property
+            def request() -> SourcesRequest:
+                return SourcesRequest(self)
+        """
 
 
 # NB: This TypeVar is what allows `Target.get()` to properly work with MyPy so that MyPy knows
@@ -366,13 +419,13 @@ class Dependencies(AsyncField):
             return None
         return tuple(raw_value)
 
+    def request(self) -> Any:
+        raise NotImplementedError("Hydration of the Dependencies field is not yet implemented.")
+
 
 COMMON_TARGET_FIELDS = (Dependencies, Tags)
 
 
-# TODO: implement the hydration for this so that you can
-#  `await Get[SourcesResult](Sources, my_tgt.get(Sources)`. Tricky part of this...this _must_
-#  support subclassing the field to give custom behavior.
 class Sources(AsyncField):
     alias: ClassVar = "sources"
     default_globs: ClassVar[Optional[Tuple[str, ...]]] = None
@@ -383,12 +436,70 @@ class Sources(AsyncField):
             return None
         return tuple(raw_value)
 
-    @classmethod
-    def validate_result(cls, _: "SourcesResult") -> None:
-        pass
+    def validate_snapshot(self, _: Snapshot) -> None:
+        """Perform any validation on the resulting snapshot, e.g. ensuring that all files end in
+        `.py`."""
+
+    @final
+    @property
+    def request(self) -> "SourcesRequest":
+        return SourcesRequest(self)
+
+    @final
+    def prefix_glob_with_address(self, glob: str) -> str:
+        if glob.startswith("!"):
+            return f"!{PurePath(self.address.spec_path, glob[1:])}"
+        return str(PurePath(self.address.spec_path, glob))
+
+
+@dataclass(frozen=True)
+class SourcesRequest:
+    field: Sources
 
 
 @dataclass(frozen=True)
 class SourcesResult:
-    address: Address
     snapshot: Snapshot
+
+    # TODO: do we want to support the `extension` parameter from Target.has_sources()? In V1,
+    # it's used to distinguish between Java vs. Scala files. For now, we should leave it off to
+    # keep things as simple as possible, but we may want to add it in the future.
+    def has_sources(self) -> bool:
+        return bool(self.snapshot.files)
+
+
+@rule
+async def hydrate_sources(
+    request: SourcesRequest, glob_match_error_behavior: GlobMatchErrorBehavior
+) -> SourcesResult:
+    sources_field = request.field
+    globs: Iterable[str]
+    if sources_field.sanitized_raw_value is not None:
+        globs = ensure_str_list(sources_field.sanitized_raw_value)
+        conjunction = GlobExpansionConjunction.all_match
+    else:
+        if sources_field.default_globs is None:
+            return SourcesResult(EMPTY_SNAPSHOT)
+        globs = sources_field.default_globs
+        conjunction = GlobExpansionConjunction.any_match
+
+    snapshot = await Get[Snapshot](
+        PathGlobs(
+            (sources_field.prefix_glob_with_address(glob) for glob in globs),
+            conjunction=conjunction,
+            glob_match_error_behavior=glob_match_error_behavior,
+            # TODO(#9012): add line number referring to the sources field. When doing this, we'll
+            # likely need to `await Get[BuildFileAddress](Address)`.
+            description_of_origin=(
+                f"{sources_field.address}'s `{sources_field.alias}` field"
+                if glob_match_error_behavior != GlobMatchErrorBehavior.ignore
+                else None
+            ),
+        )
+    )
+    sources_field.validate_snapshot(snapshot)
+    return SourcesResult(snapshot)
+
+
+def rules():
+    return [hydrate_sources, RootRule(SourcesRequest)]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -13,6 +13,10 @@ from pants.engine.rules import UnionMembership
 from pants.util.collections import ensure_str_list
 from pants.util.meta import frozen_after_init
 
+# Type alias to express the intent that the type should be immutable and hashable. There's nothing
+# to actually enforce this, outside of convention. Maybe we could develop a MyPy plugin?
+ImmutableValue = Any
+
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)  # type: ignore[misc]  # MyPy doesn't like the abstract __init__()
@@ -58,7 +62,7 @@ class PrimitiveField(Field, metaclass=ABCMeta):
                 return raw_value
     """
 
-    value: Any
+    value: ImmutableValue
 
     @final
     def __init__(self, raw_value: Optional[Any], *, address: Address) -> None:
@@ -70,7 +74,7 @@ class PrimitiveField(Field, metaclass=ABCMeta):
         self.value = self.hydrate(raw_value, address=address)
 
     @abstractmethod
-    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> Any:
+    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> ImmutableValue:
         """Convert the `raw_value` into `self.value`.
 
         You should perform any validation and/or hydration here. For example, you may want to check
@@ -135,7 +139,7 @@ class AsyncField(Field, metaclass=ABCMeta):
     """
 
     address: Address
-    sanitized_raw_value: Any
+    sanitized_raw_value: ImmutableValue
 
     @final
     def __init__(self, raw_value: Optional[Any], *, address: Address) -> None:
@@ -143,7 +147,7 @@ class AsyncField(Field, metaclass=ABCMeta):
         self.sanitized_raw_value = self.sanitize_raw_value(raw_value)
 
     @abstractmethod
-    def sanitize_raw_value(self, raw_value: Optional[Any]) -> Any:
+    def sanitize_raw_value(self, raw_value: Optional[Any]) -> ImmutableValue:
         """Sanitize the `raw_value` into a type that is safe for the V2 engine to use.
 
         The resulting type should be immutable and hashable.

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.engine.target import rules as target_rules
 from pants.rules.core import (
     binary,
     cloc,
@@ -33,4 +34,5 @@ def rules():
         *strip_source_roots.rules(),
         *distdir.rules(),
         *test.rules(),
+        *target_rules(),
     ]


### PR DESCRIPTION
This fleshes out how we use `AsyncField`s, which are much more complex than `PrimitiveField`s.

## Result

```python
sources = await Get[SourcesResult](SourcesRequest, tgt.get(Sources).request)
print(sources.snapshot.files)
```

This also works:

```python
if tgt.has_fields([PythonLibrarySources]):
  sources1 = await Get[Sources](SourcesRequest, tgt.get(PythonLibrarySources).request)
  sources2 = await Get[Sources](SourcesRequest, tgt.get(Sources).request)
  assert sources1 == sources2
```

`PythonSources` and its subclasses will validate that all resulting files end in `*.py` (new behavior). `PythonLibrarySources` and `PythonTestsSources` will use the previous default globs. `PythonBinarySources` will enforce that `sources` is 0 or 1 files (previous behavior).

## Solution

### Ensuring support for subclassed `AsyncField`s

With the Target API, we allow new targets to subclass `Field`s for custom behavior. For example, `PythonLibrarySources` might use the default globs of `*.py` whereas `PythonTestSources` might use the default globs of `test_*.py`.

To allow these custom subclasses of `Field`s, we added support in https://github.com/pantsbuild/pants/pull/9286 for substituting in the subclass with the original parent class. For example, `my_python_library.get(Sources) == my_python_library.get(PythonSources) == my_python_library.get(PythonLibrarySources)`.

This works great with `PrimitiveField` but is tricky to implement with `AsyncField` due to the engine not supporting subclasses.

Originally, I tried achieving this extensibility through a union, which would allow the engine to have multiple ways to get a common result type like `SourcesResult`. But, this created a problem that there became multiple paths in the rule graph to compute the same product, e.g. `Sources->SourcesResult`, `PythonSources->SourcesResult`, etc.

Instead, each `AsyncField` should define a simple `Request` dataclass that simply wraps the underlying `AsyncField`. This allows us to have only one path from `SourcesRequest -> SourcesResult`, but still give custom behavior in the underlying `SourcesRequest`. Within the hydration rule, the rule will call standardized extension points provided by the underlying field.

**This means that the onus is on the `AsyncField` author to expose certain entry points for customizing the field's behavior.** For example, `Sources` defines the entry points of `default_globs` and `validate_snapshot()`. `Dependencies` might provide entry points like `inject_dependencies()` and `validate_dependencies()` (not necessarily, only possibilities).

While this approach has lots of boilerplate and less extensibility than `PrimitiveField`s, it solves the graph ambiguity and still allows for subclassing an `AsyncField`.

### Fixing `__eq__` for `Field`s

The previous naive implementation resulted in `Field`s only comparing their classvar `alias`, rather than their actual underlying values. This meant that the engine would cache values when it should not have.

This tweaks how we use dataclasses to ensure that the engine works correctly with `AsyncField`s.