### PR TITLE
Use V2 Flake8 internally instead of `pants.contrib.python.checks`

### DIFF
--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -1,0 +1,22 @@
+[flake8]
+extend-ignore:
+  E203,  # whitespace before ':' (conflicts with Black)
+  E231,  # Missing whitespace after `,` (enable once fixed)
+  E262,  # inline comment doesn't start with `#` (enable once fixed)
+  E266,  # Too many leading # for block comment (maybe enable once fixed)
+  E301,  # expected 1 blank line (enable once fixed)
+  E306,  # expected 1 blank line (enable once fixed)
+  E501,  # line too long (> 79 characters)
+  E711,  # Comparison to `None` is not idiomatic (enable once fixed)
+  E712,  # Comparison to `False` is not idiomatic (enable once fixed)
+  E713,  # Test for membership should be `not in`  (enable once fixed)
+  E731,  # Do not assign a lambda expression
+  E741,  # Ambiguous variable name (enable once fixed)
+  F723,  # Unrecognized syntax in type comment (remove on next Flake8 release)
+  F821,  # undefined name (remove on next Flake8 release)
+  W291,  # Trailing whitespace (enable once fixed)
+  W293,  # Blank line contains whitespace (enable once fixed)
+  W503,  # line break before binary operator  (conflicts with Black)
+  W605,  # invalid escape sequence (enable once fixed)
+  PB10,  # Bad class attribute (enable once fixed)
+  PB13,  # `open()` not within a context manager (possibly enable once fixed)

--- a/build-support/flake8/BUILD
+++ b/build-support/flake8/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  sources = ['*'],
+)

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -52,15 +52,8 @@ echo "* Checking shell scripts via our custom linter"
 # When travis builds a tag, it does so in a shallow clone without master fetched, which
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
-  echo "* Checking formatting of Python files"
-  ./v2 --changed-parent="${MERGE_BASE}" lint || die "To fix formatting, run \`./v2 --changed-since=master fmt\`"
-
-  # TODO(CMLivingston) Make lint use `-q` option again after addressing proper workunit labeling:
-  # https://github.com/pantsbuild/pants/issues/6633
-  # TODO: add a test case for this while including a pexrc file, as python checkstyle currently fails
-  # quite often with a pexrc available.
-  echo "* Checking lint"
-  ./pants --exclude-target-regexp='testprojects/.*' --changed-parent="${MERGE_BASE}" lint || exit 1
+  echo "* Checking formatting and Flake8"
+  ./v2 --changed-parent="${MERGE_BASE}" lint || die "If there were formatting errors, run \`./v2 --changed-since=master fmt\`"
 
   echo "* Checking types"
   ./build-support/bin/mypy.py || exit 1

--- a/pants.toml
+++ b/pants.toml
@@ -36,7 +36,6 @@ pythonpath = [
   "%(buildroot)s/contrib/jax_ws/src/python",
   "%(buildroot)s/contrib/mypy/src/python",
   "%(buildroot)s/contrib/node/src/python",
-  "%(buildroot)s/contrib/python/src/python",
   "%(buildroot)s/contrib/scalajs/src/python",
   "%(buildroot)s/contrib/scrooge/src/python",
   "%(buildroot)s/contrib/thrifty/src/python",
@@ -57,7 +56,6 @@ backend_packages.add = [
   "pants.contrib.jax_ws",
   "pants.contrib.scalajs",
   "pants.contrib.node",
-  "pants.contrib.python.checks",
   "pants.contrib.scrooge",
   "pants.contrib.thrifty",
   "internal_backend.repositories",
@@ -73,6 +71,7 @@ backend_packages2 = [
   "pants.backend.python",
   "pants.backend.python.lint.black",
   "pants.backend.python.lint.docformatter",
+  "pants.backend.python.lint.flake8",
   "pants.backend.python.lint.isort",
   "pants.backend.native",
   "internal_backend.rules_for_testing",
@@ -250,14 +249,15 @@ setupdir = "%(pants_supportdir)s/eslint"
 config = "%(pants_supportdir)s/eslint/.eslintrc"
 ignore = "%(pants_supportdir)s/eslint/.eslintignore"
 
+[flake8]
+config = "build-support/flake8/.flake8"
+extra_requirements.add = ["flake8-pantsbuild>=2.0"]
+
 [google-java-format]
 skip = true
 
 [isort]
 config = [".isort.cfg", "contrib/.isort.cfg", "examples/.isort.cfg"]
-
-[python-eval]
-skip = true
 
 [scalafmt]
 skip = true
@@ -273,33 +273,6 @@ excludes = "%(buildroot)s/build-support/scalastyle/excludes.txt"
 
 [protoc.gen.go-protobuf]
 version = "3.4.1"
-
-[pycheck-class-factoring]
-skip = true
-
-[pycheck-context-manager]
-skip = true
-
-[pycheck-import-order]
-skip = true
-
-[pycheck-indentation]
-skip = true
-
-[pycheck-newlines]
-skip = true
-
-[pycheck-newstyle-classes]
-skip = true
-
-[pycheck-pycodestyle]
-skip = true
-
-[pycheck-trailing-whitespace]
-skip = true
-
-[pycheck-variable-names]
-skip = true
 
 [scala]
 version = 2.12

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -81,6 +81,7 @@ python_binary(
     '//:pyproject',
     'build-support/checkstyle',
     'build-support/eslint',
+    'build-support/flake8',
     'build-support/ivy',
     'build-support/mypy',
     'build-support/pylint',

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -106,7 +106,12 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 # Run target that throws an exception in pants.
                 self.assert_failure(
                     self.run_pants_with_workdir(
-                        ["lint", "testprojects/src/python/unicode/compilation_failure"],
+                        [
+                            "--no-v1",
+                            "--v2",
+                            "lint",
+                            "testprojects/src/python/unicode/compilation_failure",
+                        ],
                         workdir,
                         pantsd_config,
                     )


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/issues/8897, we will very soon be deprecating `pants.contrib.python.checks` in favor of the much more powerful and simpler V2 `Flake8` implementation. 

Here, we blindly ignore any lint failures for a smaller diff. In followup PRs, we can un-ignore codes and even add new Flake8 plugins for extra linting.