### PR TITLE
Add `convert_source_to_sources.py` script to help users migrate away from deprecated `source` field

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -25,7 +25,7 @@ python_binary(
 
 python_binary(
   name = 'check_banned_imports',
-  source = 'check_banned_imports.py',
+  sources = ['check_banned_imports.py'],
   dependencies = [
     ':common',
   ],
@@ -34,7 +34,7 @@ python_binary(
 
 python_binary(
   name = 'check_header',
-  source = 'check_header.py',
+  sources = ['check_header.py'],
   dependencies = [
     ':common',
   ],
@@ -43,7 +43,7 @@ python_binary(
 
 python_binary(
   name = 'check_pants_pex_abi',
-  source = 'check_pants_pex_abi.py',
+  sources = ['check_pants_pex_abi.py'],
   dependencies = [
     ':common',
   ],
@@ -52,7 +52,7 @@ python_binary(
 
 python_binary(
   name = 'ci',
-  source = 'ci.py',
+  sources = ['ci.py'],
   dependencies = [
     ':common',
   ],
@@ -61,13 +61,13 @@ python_binary(
 
 python_library(
   name = 'common',
-  source = 'common.py',
+  sources = ['common.py'],
   tags = {'type_checked'},
 )
 
 python_binary(
   name = 'deploy_to_s3',
-  source = 'deploy_to_s3.py',
+  sources = ['deploy_to_s3.py'],
   dependencies = [
     ':common',
   ],
@@ -95,7 +95,7 @@ python_binary(
 
 python_binary(
   name = 'mypy',
-  source = 'mypy.py',
+  sources = ['mypy.py'],
   dependencies = [
     ':common',
   ],
@@ -104,7 +104,7 @@ python_binary(
 
 python_binary(
   name = 'shellcheck',
-  source = 'shellcheck.py',
+  sources = ['shellcheck.py'],
   dependencies = [
     ':common',
   ],

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -53,7 +53,7 @@ echo "* Checking shell scripts via our custom linter"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking formatting and Flake8"
-  ./v2 --changed-since="${MERGE_BASE}" lint || \
+  ./v2 --changed-since="${MERGE_BASE}" --tag='-nolint' lint || \
     die "If there were formatting errors, run \`./v2 --changed-since=$(git rev-parse --symbolic "${MERGE_BASE}") fmt\`"
 
   echo "* Checking types"

--- a/build-support/migration-support/convert_source_to_sources.py
+++ b/build-support/migration-support/convert_source_to_sources.py
@@ -1,0 +1,120 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import argparse
+import tokenize
+from difflib import unified_diff
+from io import BytesIO
+from pathlib import Path
+from token import NAME, OP
+from typing import Dict, List, Optional, Set
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+    build_files: Set[Path] = set(
+        fp
+        for folder in args.folders
+        for fp in [*folder.rglob("BUILD"), *folder.rglob("BUILD.*")]
+        # Check that it really is a BUILD file
+        if fp.is_file() and fp.stem == "BUILD"
+    )
+    updates: Dict[Path, List[str]] = {}
+    for build in build_files:
+        possibly_new_build = maybe_rewrite_build(build)
+        if possibly_new_build is not None:
+            updates[build] = possibly_new_build
+    for build, new_content in updates.items():
+        if args.preview:
+            print(generate_diff(build, new_content))
+        else:
+            build.write_text("\n".join(new_content) + "\n")
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert deprecated `source` fields to `sources`.",
+    )
+    parser.add_argument(
+        "folders", type=Path, nargs="+", help="Folders to recursively search for `BUILD` files",
+    )
+    parser.add_argument(
+        "-p",
+        "--preview",
+        action="store_true",
+        help="Output to stdout rather than overwriting BUILD files.",
+    )
+    return parser
+
+
+def maybe_rewrite_line(line: str) -> Optional[str]:
+    try:
+        tokens = list(tokenize.tokenize(BytesIO(line.encode()).readline))
+    except tokenize.TokenError:
+        return None
+    source_field = next(
+        (token for token in tokens if token.type is NAME and token.string == "source"), None
+    )
+    if not source_field:
+        return None
+    source_field_index = tokens.index(source_field)
+
+    # Ensure that the next token is `=`
+    if (
+        tokens[source_field_index + 1].type is not OP
+        and tokens[source_field_index + 1].string != "="
+    ):
+        return None
+
+    source_value = tokens[source_field_index + 2]
+
+    prefix = line[: source_field.start[1]]
+    interfix = line[source_field.end[1] : source_value.start[1]]
+    suffix = line[source_value.end[1] :]
+    return f"{prefix}sources{interfix}[{source_value.string}]{suffix}"
+
+
+def maybe_rewrite_build(build_file: Path) -> Optional[List[str]]:
+    original_text = build_file.read_text()
+    original_text_lines = original_text.splitlines()
+    updated_text_lines = original_text_lines.copy()
+    # import ipdb;
+    # ipdb.set_trace()
+    for i, line in enumerate(original_text_lines):
+        maybe_new_line = maybe_rewrite_line(line)
+        if maybe_new_line is not None:
+            updated_text_lines[i] = maybe_new_line
+    return updated_text_lines if updated_text_lines != original_text_lines else None
+
+
+def generate_diff(build_file: Path, new_content: List[str]) -> str:
+    def green(s: str) -> str:
+        return f"\x1b[32m{s}\x1b[0m"
+
+    def red(s: str) -> str:
+        return f"\x1b[31m{s}\x1b[0m"
+
+    diff = unified_diff(
+        build_file.read_text().splitlines(),
+        new_content,
+        fromfile=str(build_file),
+        tofile=str(build_file),
+    )
+    msg = ""
+    for line in diff:
+        if line.startswith("+") and not line.startswith("+++"):
+            msg += green(line)
+        elif line.startswith("-") and not line.startswith("---"):
+            msg += red(line)
+        else:
+            msg += line
+        if not (line.startswith("+++") or line.startswith("---") or line.startswith("@@ ")):
+            msg += "\n"
+    return msg
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/build-support/migration-support/convert_source_to_sources.py
+++ b/build-support/migration-support/convert_source_to_sources.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 

--- a/build-support/migration-support/convert_source_to_sources_test.py
+++ b/build-support/migration-support/convert_source_to_sources_test.py
@@ -1,0 +1,93 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from convert_source_to_sources import maybe_rewrite_build, maybe_rewrite_line
+
+from pants.util.contextutil import temporary_dir
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "sources=['foo.py'],",
+        "sources= ('foo.py', ),"
+        "sources = {'foo.py'},"
+        "sources =['*.py'],"
+        'sources =["!ignore.java"],',
+        'sources   =    (    "!ignore.java",   )',
+        '     sources=[""]',
+    ],
+)
+def test_no_op_when_already_valid(line: str) -> None:
+    assert maybe_rewrite_line(line) is None
+
+
+@pytest.mark.parametrize(
+    "line", ["\n", "    123  ", "python_library()", "name='hello'", "name='sources'",],
+)
+def test_safe_with_unrelated_lines(line: str) -> None:
+    assert maybe_rewrite_line(line) is None
+
+
+def test_respects_original_formatting() -> None:
+    # Preserve whitespace around the `=` operator
+    assert maybe_rewrite_line("source ='foo.py'") == "sources =['foo.py']"
+    assert maybe_rewrite_line("source= 'foo.py'") == "sources= ['foo.py']"
+    assert maybe_rewrite_line("source =  'foo.py'") == "sources =  ['foo.py']"
+
+    # Preserve trailing commas
+    assert maybe_rewrite_line("source='foo.py'") == "sources=['foo.py']"
+    assert maybe_rewrite_line("source='foo.py',") == "sources=['foo.py'],"
+
+    # Preserve leading whitespace
+    assert maybe_rewrite_line("\t\tsource='foo.py'") == "\t\tsources=['foo.py']"
+    assert maybe_rewrite_line("  source='foo.py'") == "  sources=['foo.py']"
+
+    # Preserve trailing whitespace
+    assert maybe_rewrite_line("source='foo.py'  ") == "sources=['foo.py']  "
+    assert maybe_rewrite_line("source='foo.py',  ") == "sources=['foo.py'],  "
+
+    # Preserve whether the original used single quotes or double quotes
+    assert maybe_rewrite_line("source='foo.py'") == "sources=['foo.py']"
+    assert maybe_rewrite_line('source="foo.py"') == 'sources=["foo.py"]'
+
+
+def test_can_handle_sharing_a_line() -> None:
+    assert (
+        maybe_rewrite_line("python_library(source='foo.py')")
+        == "python_library(sources=['foo.py'])"
+    )
+    assert maybe_rewrite_line("name='lib', source='foo.py'") == "name='lib', sources=['foo.py']"
+
+
+def test_can_handle_comments() -> None:
+    assert maybe_rewrite_line("source='foo.py'  # test") == "sources=['foo.py']  # test"
+    assert maybe_rewrite_line("source = 'foo.py' ####") == "sources = ['foo.py'] ####"
+
+
+def test_can_handle_variables() -> None:
+    assert maybe_rewrite_line("source=VAR") == "sources=[VAR]"
+    assert maybe_rewrite_line("source = x_y_z") == "sources = [x_y_z]"
+
+
+def test_update_build_file() -> None:
+    template = dedent(
+        """\
+        python_library(
+            sources=['good.py'],
+        )
+        
+        python_tests(
+           {}
+        )
+        """
+    )
+    with temporary_dir() as tmpdir:
+        build = Path(tmpdir, "BUILD")
+        build.write_text(template.format("source='bad.py'"))
+        rewritten = maybe_rewrite_build(build)
+    assert "\n".join(rewritten) + "\n" == template.format("sources=['bad.py']")

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -27,5 +27,5 @@ target(
 
 files(
   name = 'isort_cfg',
-  source = '.isort.cfg',
+  sources = ['.isort.cfg'],
 )

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
@@ -16,7 +16,7 @@ python_library(
 
 python_binary(
   name='hello-bin',
-  source='hello_handler.py',
+  sources=['hello_handler.py'],
   dependencies=[
     ':pycountry',
     ':hello-lib',

--- a/contrib/go/BUILD
+++ b/contrib/go/BUILD
@@ -3,7 +3,7 @@
 
 page(
   name='go_readme',
-  source='README.md',
+  sources=['README.md'],
 )
 
 files(

--- a/contrib/mypy/examples/src/python/mypy_plugin/BUILD
+++ b/contrib/mypy/examples/src/python/mypy_plugin/BUILD
@@ -17,7 +17,7 @@ python_requirement_library(
 
 python_library(
   name='settings',
-  source='settings.py',
+  sources=['settings.py'],
   dependencies=[
     ':django-stubs',
   ],
@@ -26,7 +26,7 @@ python_library(
 
 python_library(
   name='valid',
-  source='valid.py',
+  sources=['valid.py'],
   dependencies=[
     ':django',
     ':settings',
@@ -36,7 +36,7 @@ python_library(
 
 python_library(
   name='invalid',
-  source='invalid.py',
+  sources=['invalid.py'],
   dependencies=[
     ':django',
     ':settings',

--- a/contrib/mypy/examples/src/python/simple/BUILD
+++ b/contrib/mypy/examples/src/python/simple/BUILD
@@ -3,11 +3,11 @@
 
 python_library(
   name = 'valid',
-  source = 'valid.py',
+  sources = ['valid.py'],
   tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'invalid',
-  source = 'invalid.py',
+  sources = ['invalid.py'],
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
@@ -3,7 +3,7 @@
 
 python_tests(
   name='mypy',
-  source = 'test_mypy.py',
+  sources = ['test_mypy.py'],
   dependencies=[
     'src/python/pants/testutil:task_test_base',
     'contrib/mypy/src/python/pants/contrib/mypy/tasks',

--- a/contrib/node/BUILD
+++ b/contrib/node/BUILD
@@ -3,7 +3,7 @@
 
 page(
   name='node_readme',
-  source='README.md',
+  sources=['README.md'],
 )
 
 files(

--- a/contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources/BUILD
+++ b/contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources/BUILD
@@ -1,5 +1,5 @@
 jvm_binary(
-  source = 'JsResourcesMain.java',
+  sources = ['JsResourcesMain.java'],
   main = 'org.pantsbuild.testproject.jsresources.JsResourcesMain',
   dependencies = [
     '3rdparty:guava',
@@ -7,7 +7,7 @@ jvm_binary(
   ]
 )
 jvm_binary(name='jsresources-unprocessed',
-  source = 'JsResourcesMain.java',
+  sources = ['JsResourcesMain.java'],
   main = 'org.pantsbuild.testproject.jsresources.JsResourcesMain',
   dependencies = [
     '3rdparty:guava',
@@ -16,7 +16,7 @@ jvm_binary(name='jsresources-unprocessed',
 )
 
 jvm_binary(name = 'jsresources-with-dependency-artifacts',
-  source = 'JsResourcesMain.java',
+  sources = ['JsResourcesMain.java'],
   main = 'org.pantsbuild.testproject.jsresources.JsResourcesMain',
   dependencies = [
     '3rdparty:guava',

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -8,5 +8,5 @@ files(
 
 files(
   name = 'isort_cfg',
-  source = '.isort.cfg',
+  sources = ['.isort.cfg'],
 )

--- a/examples/src/java/org/pantsbuild/example/BUILD
+++ b/examples/src/java/org/pantsbuild/example/BUILD
@@ -22,7 +22,7 @@ target(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
   links=[
     ':3rdparty_jvm',
     ':from_maven',
@@ -38,7 +38,7 @@ page(
 
 page(
   name='from_maven',
-  source='from_maven.md',
+  sources=['from_maven.md'],
   links=[
     ':3rdparty_jvm',
     ':readme',
@@ -47,7 +47,7 @@ page(
 
 page(
   name='publish',
-  source='publish.md',
+  sources=['publish.md'],
   links=[
     'src/docs:dev_tasks_publish_extras',
     'src/docs:howto_plugin',
@@ -56,7 +56,7 @@ page(
 
 page(
   name='3rdparty_jvm',
-  source='3rdparty_jvm.md',
+  sources=['3rdparty_jvm.md'],
   links=[
     'src/docs:3rdparty',
   ],
@@ -64,7 +64,7 @@ page(
 
 page(
   name='page',
-  source='page.md',
+  sources=['page.md'],
   dependencies=[
     'src/docs:howto_contribute'
   ]

--- a/examples/src/java/org/pantsbuild/example/annotation/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/annotation/main/BUILD
@@ -4,7 +4,7 @@
 #  Example for annotation_processor() target
 
 jvm_binary(
-  source='Main.java',
+  sources=['Main.java'],
   main='org.pantsbuild.example.annotation.main.Main',
   basename = 'annotation-example',
   dependencies=[

--- a/examples/src/java/org/pantsbuild/example/antlr3/BUILD
+++ b/examples/src/java/org/pantsbuild/example/antlr3/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(
-  source='ExampleAntlr3.java',
+  sources=['ExampleAntlr3.java'],
   main='org.pantsbuild.example.antlr3.ExampleAntlr3',
   dependencies=[
     'examples/src/antlr/org/pantsbuild/example/exp:exp_antlr3',

--- a/examples/src/java/org/pantsbuild/example/antlr4/BUILD
+++ b/examples/src/java/org/pantsbuild/example/antlr4/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(
-  source='ExampleAntlr4.java',
+  sources=['ExampleAntlr4.java'],
   main='org.pantsbuild.example.antlr4.ExampleAntlr4',
   dependencies=[
     'examples/src/antlr/org/pantsbuild/example/exp:exp_antlr4',

--- a/examples/src/java/org/pantsbuild/example/hello/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/main/BUILD
@@ -22,7 +22,7 @@ jvm_binary(name = 'main-bin',
     'examples/src/java/org/pantsbuild/example/hello/greet',
     'examples/src/resources/org/pantsbuild/example/hello',
   ],
-  source = 'HelloMain.java',
+  sources = ['HelloMain.java'],
   main = 'org.pantsbuild.example.hello.main.HelloMain',
   basename = 'hello-example',
 )

--- a/examples/src/java/org/pantsbuild/example/hello/simple/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/simple/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(
-  source = 'HelloWorld.java',
+  sources = ['HelloWorld.java'],
   main = 'org.pantsbuild.example.hello.simple.HelloWorld',
 )
 

--- a/examples/src/java/org/pantsbuild/example/javac/plugin/BUILD
+++ b/examples/src/java/org/pantsbuild/example/javac/plugin/BUILD
@@ -61,5 +61,5 @@ java_library(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
 )

--- a/examples/src/java/org/pantsbuild/example/jaxb/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/jaxb/main/BUILD
@@ -7,6 +7,6 @@ jvm_binary(
     'examples/src/java/org/pantsbuild/example/jaxb/reader',
     'examples/src/resources/org/pantsbuild/example/jaxb',
   ],
-  source='ExampleJaxb.java',
+  sources=['ExampleJaxb.java'],
   main='org.pantsbuild.example.jaxb.main.ExampleJaxb',
 )

--- a/examples/src/java/org/pantsbuild/example/protobuf/distance/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/distance/BUILD
@@ -7,6 +7,6 @@ jvm_binary(
     'examples/src/protobuf/org/pantsbuild/example/distance',
     '3rdparty:protobuf-java',
   ],
-  source='ExampleProtobuf.java',
+  sources=['ExampleProtobuf.java'],
   main='org.pantsbuild.example.protobuf.distance.ExampleProtobuf',
 )

--- a/examples/src/java/org/pantsbuild/example/protobuf/imports/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/imports/BUILD
@@ -7,6 +7,6 @@ jvm_binary(
     'examples/src/protobuf/org/pantsbuild/example/imports',
     '3rdparty:protobuf-java',
   ],
-  source='ExampleProtobufImports.java',
+  sources=['ExampleProtobufImports.java'],
   main='org.pantsbuild.example.protobuf.imports.ExampleProtobufImports',
 )

--- a/examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars/BUILD
@@ -3,7 +3,7 @@
 
 jvm_binary(
   basename='protobuf-unpacked-jars-example',
-  source='ExampleProtobufExternalArchive.java',
+  sources=['ExampleProtobufExternalArchive.java'],
   main='org.pantsbuild.example.protobuf.unpacked_jars.ExampleProtobufExternalArchive',
   dependencies=[
     '3rdparty:protobuf-java',

--- a/examples/src/java/org/pantsbuild/example/wire/element/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/element/BUILD
@@ -8,6 +8,6 @@ jvm_binary(
     'examples/src/wire/org/pantsbuild/example/element',
     'examples/src/wire/org/pantsbuild/example/temperature',
   ],
-  source='WireElementExample.java',
+  sources=['WireElementExample.java'],
   main='org.pantsbuild.example.wire.element.WireElementExample',
 )

--- a/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
@@ -6,7 +6,7 @@ jvm_binary(
   dependencies=[
     'examples/src/wire/org/pantsbuild/example/roots',
   ],
-  source='WireRootsExample.java',
+  sources=['WireRootsExample.java'],
   main='org.pantsbuild.example.wire.roots.WireRootsExample',
 )
 

--- a/examples/src/java/org/pantsbuild/example/wire/temperatureservice/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/temperatureservice/BUILD
@@ -7,6 +7,6 @@ jvm_binary(
     '3rdparty:wire-runtime',
     'examples/src/wire/org/pantsbuild/example/temperature',
   ],
-  source='WireTemperatureExample.java',
+  sources=['WireTemperatureExample.java'],
   main='org.pantsbuild.example.pants.temperatureservice.WireTemperatureExample',
 )

--- a/examples/src/python/example/BUILD
+++ b/examples/src/python/example/BUILD
@@ -13,7 +13,7 @@ target(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
   links=[
     ':3rdparty_py',
     'src/docs:first_concepts',
@@ -22,7 +22,7 @@ page(
 
 page(
   name='3rdparty_py',
-  source='3rdparty_py.md',
+  sources=['3rdparty_py.md'],
   links=[
     'src/docs:3rdparty',
   ]

--- a/examples/src/python/example/grpcio/client/BUILD
+++ b/examples/src/python/example/grpcio/client/BUILD
@@ -7,7 +7,7 @@ python_binary(
     'examples/3rdparty/python:grpcio',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
   ],
-  source='service_client.py',
+  sources=['service_client.py'],
 )
 
 python_binary(
@@ -16,5 +16,5 @@ python_binary(
     'examples/3rdparty/python:grpcio',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/imports',
   ],
-  source='imports_client.py',
+  sources=['imports_client.py'],
 )

--- a/examples/src/python/example/grpcio/server/BUILD
+++ b/examples/src/python/example/grpcio/server/BUILD
@@ -9,5 +9,5 @@ python_binary(
     'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/imports',
   ],
-  source='server.py',
+  sources=['server.py'],
 )

--- a/examples/src/python/example/hello/main/BUILD
+++ b/examples/src/python/example/hello/main/BUILD
@@ -7,7 +7,7 @@ python_binary(
   dependencies=[
     'examples/src/python/example/hello/greet:greet',
   ],
-  source='main.py',
+  sources=['main.py'],
 )
 
 # An "app" is a binary plus other loose files bundled together in

--- a/examples/src/python/example/tensorflow_custom_op/BUILD
+++ b/examples/src/python/example/tensorflow_custom_op/BUILD
@@ -41,7 +41,7 @@ ctypes_compatible_cpp_library(
 
 python_binary(
   name='show-tf-version',
-  source='show_tf_version.py',
+  sources=['show_tf_version.py'],
   dependencies=[
     'examples/3rdparty/python:tensorflow',
   ],

--- a/examples/src/scala/org/pantsbuild/example/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/BUILD
@@ -16,7 +16,7 @@ target(
 
 page(
   name = 'readme',
-  source = 'README.md',
+  sources = ['README.md'],
   links = [
     'examples/src/java/org/pantsbuild/example:readme',
   ],

--- a/examples/src/scala/org/pantsbuild/example/hello/exe/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/hello/exe/BUILD
@@ -5,6 +5,6 @@ jvm_binary(
   dependencies=[
     'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
   ],
-  source='Exe.scala',
+  sources=['Exe.scala'],
   main='org.pantsbuild.example.hello.exe.Exe',
 )

--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/BUILD
@@ -76,5 +76,5 @@ scala_library(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
 )

--- a/examples/src/thrift/org/pantsbuild/example/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/BUILD
@@ -11,7 +11,7 @@ target(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
   links=[
     'examples/src/java/org/pantsbuild/example:publish',
   ])

--- a/src/docs/BUILD
+++ b/src/docs/BUILD
@@ -1,11 +1,11 @@
 page(
   name='1.0',
-  source='1.0.md',
+  sources=['1.0.md'],
 )
 
 page(
   name='3rdparty',
-  source='3rdparty.md',
+  sources=['3rdparty.md'],
   links=[
     'examples/src/java/org/pantsbuild/example:3rdparty_jvm',
     'examples/src/python/example:3rdparty_py',
@@ -14,12 +14,12 @@ page(
 
 page(
   name='announce_201409',
-  source='announce_201409.md',
+  sources=['announce_201409.md'],
 )
 
 page(
   name='architecture',
-  source='architecture.md',
+  sources=['architecture.md'],
   links=[
     ':architecture_pantsd',
   ]
@@ -27,7 +27,7 @@ page(
 
 page(
   name='build_files',
-  source='build_files.md',
+  sources=['build_files.md'],
   links=[
     ':first_tutorial',
   ]
@@ -35,27 +35,27 @@ page(
 
 page(
   name='committers',
-  source='committers.md',
+  sources=['committers.md'],
 )
 
 page(
   name='common_tasks',
-  source='common_tasks/index.md',
+  sources=['common_tasks/index.md'],
 )
 
 page(
     name='community',
-    source='community.md',
+    sources=['community.md'],
 )
 
 page(
     name='architecture_pantsd',
-    source='architecture_pantsd.md',
+    sources=['architecture_pantsd.md'],
 )
 
 page(
   name='first_concepts',
-  source='first_concepts.md',
+  sources=['first_concepts.md'],
   links=[
     ':first_tutorial',
   ]
@@ -63,7 +63,7 @@ page(
 
 page(
   name='first_tutorial',
-  source='first_tutorial.md',
+  sources=['first_tutorial.md'],
   links=[
     ':first_concepts',
     ':invoking',
@@ -74,12 +74,12 @@ page(
 
 page(
   name='ide_support',
-  source='ide_support.md',
+  sources=['ide_support.md'],
 )
 
 page(
   name='index',
-  source='index.md',
+  sources=['index.md'],
   links=[
     ':3rdparty',
     ':1.0',
@@ -107,7 +107,7 @@ page(
 
 page(
   name='invoking',
-  source='invoking.md',
+  sources=['invoking.md'],
   links=[
     ':first_tutorial',
     ':options',
@@ -117,7 +117,7 @@ page(
 
 page(
   name='install',
-  source='install.md',
+  sources=['install.md'],
   links=[
     ':setup_repo',
     ':options',
@@ -126,27 +126,27 @@ page(
 
 page(
   name='orgs',
-  source='orgs.md',
+  sources=['orgs.md'],
 )
 
 page(
     name='options',
-    source='options.md',
+    sources=['options.md'],
 )
 
 page(
   name='powered_by',
-  source='powered_by.md',
+  sources=['powered_by.md'],
 )
 
 page(
     name='reporting_server',
-    source='reporting_server.md',
+    sources=['reporting_server.md'],
 )
 
 page(
   name='setup_repo',
-  source='setup_repo.md',
+  sources=['setup_repo.md'],
   links=[
     ':build_files',
     ':first_concepts',
@@ -160,12 +160,12 @@ page(
 
 page(
   name='target_addresses',
-  source='target_addresses.md'
+  sources=['target_addresses.md']
 )
 
 page(
   name='tshoot',
-  source='tshoot.md',
+  sources=['tshoot.md'],
   links=[
     ':community',
     ':reporting_server',
@@ -175,7 +175,7 @@ page(
 
 page(
   name='dev',
-  source='dev.md',
+  sources=['dev.md'],
   links=[
     ':architecture',
     ':committers',
@@ -198,7 +198,7 @@ page(
 
 page(
   name='release_strategy',
-  source='release_strategy.md',
+  sources=['release_strategy.md'],
   links=[
     ':deprecation_policy',
     ':howto_contribute',
@@ -208,7 +208,7 @@ page(
 
 page(
   name='dev_tasks',
-  source='dev_tasks.md',
+  sources=['dev_tasks.md'],
   links=[
     ':howto_plugin',
     'src/docs:invoking',
@@ -217,32 +217,32 @@ page(
 
 page(
   name='dev_tasks_publish_extras',
-  source='dev_tasks_publish_extras.md',
+  sources=['dev_tasks_publish_extras.md'],
 )
 
 page(
   name='deprecation_policy',
-  source='deprecation_policy.md',
+  sources=['deprecation_policy.md'],
 )
 
 page(
   name='docs',
-  source='docs.md',
+  sources=['docs.md'],
 )
 
 page(
   name='export',
-  source='export.md',
+  sources=['export.md'],
 )
 
 page(
   name='howto_ask',
-  source='howto_ask.md',
+  sources=['howto_ask.md'],
 )
 
 page(
   name='howto_contribute',
-  source='howto_contribute.md',
+  sources=['howto_contribute.md'],
   links=[
     ':docs',
     ':howto_ask',
@@ -254,7 +254,7 @@ page(
 
 page(
   name='howto_develop',
-  source='howto_develop.md',
+  sources=['howto_develop.md'],
   links=[
     ':howto_contribute',
     'src/docs:first_tutorial',
@@ -263,7 +263,7 @@ page(
 
 page(
   name='howto_plugin',
-  source='howto_plugin.md',
+  sources=['howto_plugin.md'],
   links=[
     ':docs',
     ':howto_develop',
@@ -272,14 +272,14 @@ page(
 
 page(
   name='intellij',
-  source='intellij.md',
+  sources=['intellij.md'],
   links=[
     'src/docs:ide_support',
   ])
 
 page(
   name='internals',
-  source='internals.md',
+  sources=['internals.md'],
   links=[
     ':dev_tasks',
     'src/docs:first_concepts',
@@ -289,7 +289,7 @@ page(
 
 page(
   name='release',
-  source='release.md',
+  sources=['release.md'],
   links=[
     ':release_jvm',
     ':release_strategy',
@@ -298,7 +298,7 @@ page(
 
 page(
   name='release_jvm',
-  source='release_jvm.md',
+  sources=['release_jvm.md'],
   links=[
     'examples/src/java/org/pantsbuild/example:publish',
   ]
@@ -306,7 +306,7 @@ page(
 
 page(
   name='styleguide',
-  source='styleguide.md',
+  sources=['styleguide.md'],
   links=[
     ':howto_contribute',
   ]
@@ -314,5 +314,5 @@ page(
 
 page(
   name='why_use_pants',
-  source='why_use_pants.md'
+  sources=['why_use_pants.md']
 )

--- a/src/docs/blog/BUILD
+++ b/src/docs/blog/BUILD
@@ -1,4 +1,4 @@
 page(
   name='coursier_migration',
-  source='coursier_migration.md'
+  sources=['coursier_migration.md']
 )

--- a/src/docs/common_tasks/BUILD
+++ b/src/docs/common_tasks/BUILD
@@ -1,145 +1,145 @@
 page(
   name='alias',
-  source='alias.md',
+  sources=['alias.md'],
 )
 
 page(
   name='bundle',
-  source='bundle.md',
+  sources=['bundle.md'],
 )
 
 page(
   name='clean',
-  source='clean.md',
+  sources=['clean.md'],
 )
 
 page(
   name='cli_args',
-  source='cli_args.md',
+  sources=['cli_args.md'],
 )
 
 page(
   name='common_tasks',
-  source='index.md',
+  sources=['index.md'],
 )
 
 page(
   name='compile',
-  source='compile.md',
+  sources=['compile.md'],
 )
 
 page(
   name='dependencies',
-  source='dependencies.md',
+  sources=['dependencies.md'],
 )
 
 page(
   name='file_bundles',
-  source='file_bundles.md',
+  sources=['file_bundles.md'],
 )
 
 page(
   name='globs',
-  source='globs.md',
+  sources=['globs.md'],
 )
 
 page(
   name='jvm_binary',
-  source='jvm_binary.md',
+  sources=['jvm_binary.md'],
 )
 
 page(
   name='jvm_library',
-  source='jvm_library.md',
+  sources=['jvm_library.md'],
 )
 
 page(
   name='jvm_options',
-  source='jvm_options.md',
+  sources=['jvm_options.md'],
 )
 
 page(
   name='jvm_tests',
-  source='jvm_tests.md',
+  sources=['jvm_tests.md'],
 )
 
 page(
   name='list_goals',
-  source='list_goals.md',
+  sources=['list_goals.md'],
 )
 
 page(
   name='list_targets',
-  source='list_targets.md'
+  sources=['list_targets.md']
 )
 
 page(
   name='login',
-  source='login.md'
+  sources=['login.md']
 )
 
 page(
   name='multiple_jvm_versions',
-  source='multiple_jvm_versions.md',
+  sources=['multiple_jvm_versions.md'],
 )
 
 page(
   name='pex',
-  source='pex.md',
+  sources=['pex.md'],
 )
 
 page(
   name='python_library',
-  source='python_library.md',
+  sources=['python_library.md'],
 )
 
 page(
   name='python_tests',
-  source='python_tests.md',
+  sources=['python_tests.md'],
 )
 
 page(
   name='repl',
-  source='repl.md',
+  sources=['repl.md'],
 )
 
 page(
   name='resources',
-  source='resources.md',
+  sources=['resources.md'],
 )
 
 page(
   name='run',
-  source='run.md'
+  sources=['run.md']
 )
 
 page(
   name='server',
-  source='server.md',
+  sources=['server.md'],
 )
 
 page(
   name='target_aggregate',
-  source='target_aggregate.md',
+  sources=['target_aggregate.md'],
 )
 
 page(
   name='test',
-  source='test.md',
+  sources=['test.md'],
 )
 
 page(
   name='test_suite',
-  source='test_suite.md',
+  sources=['test_suite.md'],
 )
 
 page(
   name='thrift_gen',
-  source='thrift_gen.md',
+  sources=['thrift_gen.md'],
 )
 
 
 page(
   name='python_proto_gen',
-  source='python_proto_gen.md',
+  sources=['python_proto_gen.md'],
 )

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -40,7 +40,7 @@ python_library(
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
 )
 
 python_library(
@@ -60,7 +60,7 @@ resources(
 
 page(
   name='changelog',
-  source='CHANGELOG.md',
+  sources=['CHANGELOG.md'],
   links=[
     'src/python/pants/notes:notes-1.0.x',
     'src/python/pants/notes:notes-master',

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -32,7 +32,7 @@ python_library(
 
 page(
   name = 'readme',
-  source = 'README.md',
+  sources = ['README.md'],
   links = [
     'src/python/pants:readme',
   ]

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -3,7 +3,7 @@
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
 )
 
 # TODO: Get rid of all these microtargets. The entire package should be one target,

--- a/src/python/pants/notes/BUILD
+++ b/src/python/pants/notes/BUILD
@@ -1,139 +1,139 @@
 page(
   name='notes-master',
-  source='master.rst'
+  sources=['master.rst']
 )
 
 page(
   name='notes-1.0.x',
-  source='1.0.x.rst'
+  sources=['1.0.x.rst']
 )
 
 page(
   name='notes-1.1.x',
-  source='1.1.x.rst'
+  sources=['1.1.x.rst']
 )
 
 page(
   name='notes-1.2.x',
-  source='1.2.x.rst'
+  sources=['1.2.x.rst']
 )
 
 page(
   name='notes-1.3.x',
-  source='1.3.x.rst'
+  sources=['1.3.x.rst']
 )
 
 page(
   name='notes-1.4.x',
-  source='1.4.x.rst'
+  sources=['1.4.x.rst']
 )
 
 page(
   name='notes-1.5.x',
-  source='1.5.x.rst'
+  sources=['1.5.x.rst']
 )
 
 page(
   name='notes-1.6.x',
-  source='1.6.x.rst'
+  sources=['1.6.x.rst']
 )
 
 page(
   name='notes-1.7.x',
-  source='1.7.x.rst'
+  sources=['1.7.x.rst']
 )
 
 page(
   name='notes-1.8.x',
-  source='1.8.x.rst'
+  sources=['1.8.x.rst']
 )
 
 page(
   name='notes-1.9.x',
-  source='1.9.x.rst'
+  sources=['1.9.x.rst']
 )
 
 page(
   name='notes-1.10.x',
-  source='1.10.x.rst'
+  sources=['1.10.x.rst']
 )
 
 page(
   name='notes-1.11.x',
-  source='1.11.x.rst'
+  sources=['1.11.x.rst']
 )
 
 page(
   name='notes-1.12.x',
-  source='1.12.x.rst'
+  sources=['1.12.x.rst']
 )
 
 page(
   name='notes-1.13.x',
-  source='1.13.x.rst'
+  sources=['1.13.x.rst']
 )
 
 page(
   name='notes-1.14.x',
-  source='1.14.x.rst'
+  sources=['1.14.x.rst']
 )
 
 page(
   name='notes-1.15.x',
-  source='1.15.x.rst'
+  sources=['1.15.x.rst']
 )
 
 page(
   name='notes-1.16.x',
-  source='1.16.x.rst'
+  sources=['1.16.x.rst']
 )
 
 page(
   name='notes-1.17.x',
-  source='1.17.x.rst'
+  sources=['1.17.x.rst']
 )
 
 page(
   name='notes-1.18.x',
-  source='1.18.x.rst'
+  sources=['1.18.x.rst']
 )
 
 page(
   name='notes-1.19.x',
-  source='1.19.x.rst'
+  sources=['1.19.x.rst']
 )
 
 page(
   name='notes-1.20.x',
-  source='1.20.x.rst'
+  sources=['1.20.x.rst']
 )
 
 page(
   name='notes-1.21.x',
-  source='1.21.x.rst'
+  sources=['1.21.x.rst']
 )
 
 page(
   name='notes-1.22.x',
-  source='1.22.x.rst'
+  sources=['1.22.x.rst']
 )
 
 page(
   name='notes-1.23.x',
-  source='1.23.x.rst'
+  sources=['1.23.x.rst']
 )
 
 page(
   name='notes-1.24.x',
-  source='1.24.x.rst'
+  sources=['1.24.x.rst']
 )
 
 page(
   name='notes-1.25.x',
-  source='1.25.x.rst'
+  sources=['1.25.x.rst']
 )
 
 page(
   name='notes-1.26.x',
-  source='1.26.x.rst'
+  sources=['1.26.x.rst']
 )

--- a/src/python/pants/releases/BUILD
+++ b/src/python/pants/releases/BUILD
@@ -3,7 +3,7 @@
 
 python_binary(
   name = 'reversion',
-  source = 'reversion.py',
+  sources = ['reversion.py'],
   dependencies = [
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/testutil/engine/BUILD
+++ b/src/python/pants/testutil/engine/BUILD
@@ -15,7 +15,7 @@ python_library(
 
 python_library(
   name = 'util',
-  source = 'util.py',
+  sources = ['util.py'],
   dependencies = [
     '3rdparty/python:ansicolors',
     '3rdparty/python:dataclasses',

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -154,7 +154,7 @@ python_library(
 
 python_binary(
   name = 's3_log_aggregator',
-  source = 's3_log_aggregator.py',
+  sources = ['s3_log_aggregator.py'],
   entry_point = 'pants.util.s3_log_aggregator',
   dependencies = [
     '3rdparty/python:s3logparse'

--- a/testprojects/maven_layout/provided_patching/leaf/BUILD
+++ b/testprojects/maven_layout/provided_patching/leaf/BUILD
@@ -8,7 +8,7 @@
 # not match up with what the Common class expects.
 
 jvm_binary(name='one',
-  source='src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java',
+  sources=['src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java'],
   main='org.pantsbuild.testproject.provided_patching.UseShadow',
   dependencies=[
     'testprojects/maven_layout/provided_patching/two/src/main/java:common',
@@ -17,7 +17,7 @@ jvm_binary(name='one',
 )
 
 jvm_binary(name='two',
-  source='src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java',
+  sources=['src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java'],
   main='org.pantsbuild.testproject.provided_patching.UseShadow',
   dependencies=[
     'testprojects/maven_layout/provided_patching/three/src/main/java:common',
@@ -26,7 +26,7 @@ jvm_binary(name='two',
 )
 
 jvm_binary(name='three',
-  source='src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java',
+  sources=['src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java'],
   main='org.pantsbuild.testproject.provided_patching.UseShadow',
   dependencies=[
     'testprojects/maven_layout/provided_patching/one/src/main/java:common',
@@ -35,7 +35,7 @@ jvm_binary(name='three',
 )
 
 jvm_binary(name='fail',
-  source='src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java',
+  sources=['src/main/java/org/pantsbuild/testproject/provided_patching/UseShadow.java'],
   main='org.pantsbuild.testproject.provided_patching.UseShadow',
   dependencies=[
     'testprojects/maven_layout/provided_patching/one/src/main/java:common',

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/main/BUILD
@@ -4,7 +4,7 @@
 #  Test project for resource mapping feature
 
 jvm_binary(
-  source='Main.java',
+  sources=['Main.java'],
   main='org.pantsbuild.testproject.annotation.main.Main',
   basename = 'annotation-example',
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
@@ -3,7 +3,7 @@
 
 
 jvm_binary(
-  source = 'Main.java',
+  sources = ['Main.java'],
   main = 'org.pantsbuild.testproject.annotation.processorwithdep.Main',
   basename = 'processorwithdep-main',
   dependencies = [

--- a/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
@@ -64,7 +64,7 @@ jvm_app(
 
 jvm_binary(
   name = 'bundle-bin',
-  source = 'BundleMain.java',
+  sources = ['BundleMain.java'],
   main = 'org.pantsbuild.testproject.bundle.BundleMain',
   basename = 'bundle-example-bin',
   dependencies = [
@@ -76,7 +76,7 @@ jvm_binary(
 # Tests resources ordering via integration test.
 jvm_binary(
   name='bundle-resource-ordering',
-  source='BundleMain.java',
+  sources=['BundleMain.java'],
   main='org.pantsbuild.testproject.bundle.BundleMain',
   dependencies=[
     '3rdparty:guava',

--- a/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
@@ -3,7 +3,7 @@
 
 jvm_binary(
   basename='cwd-example',
-  source='ExampleCwd.java',
+  sources=['ExampleCwd.java'],
   main='org.pantsbuild.testproject.cwdexample.ExampleCwd',
   dependencies=[
     "3rdparty:guava",

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -19,5 +19,5 @@ jvm_app(
 
 python_binary(
     name='python_app',
-    source='main.py',
+    sources=['main.py'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/intransitive/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/intransitive/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(
-  source='A.java',
+  sources=['A.java'],
   main='org.pantsbuild.testproject.intransitive.A',
   dependencies=[
     ':diamond',

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/testscope/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/testscope/BUILD
@@ -11,7 +11,7 @@ junit_tests(name='tests',
 )
 
 jvm_binary(name='bin',
-  source='CheckForLibrary.java',
+  sources=['CheckForLibrary.java'],
   main='org.pantsbuild.testproject.junit.testscope.CheckForLibrary',
   dependencies=[
     ':lib',

--- a/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(
-  source = 'Manifest.java',
+  sources = ['Manifest.java'],
   name = 'manifest-with-source',
   main = 'org.pantsbuild.testproject.manifest.Manifest',
   manifest_entries = {

--- a/testprojects/src/java/org/pantsbuild/testproject/page/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/page/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 page(name="readme",
-     source="README.md",
+     sources=["README.md"],
      links=[
        'examples/src/java/org/pantsbuild/example/hello/main:readme',
        ':circular',
@@ -10,7 +10,7 @@ page(name="readme",
 )
 
 page(name="circular",
-     source="circular.md",
+     sources=["circular.md"],
      links=[
        ':readme',
      ]

--- a/testprojects/src/java/org/pantsbuild/testproject/phrases/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/phrases/BUILD
@@ -3,22 +3,22 @@
 
 jvm_binary(name='lesser-of-two',
   main='org.pantsbuild.testproject.phrases.LesserOfTwo',
-  source='LesserOfTwo.java',
+  sources=['LesserOfTwo.java'],
 )
 
 jvm_binary(name='once-upon-a-time',
   main='org.pantsbuild.testproject.phrases.OnceUponATime',
-  source='OnceUponATime.java',
+  sources=['OnceUponATime.java'],
 )
 
 jvm_binary(name='ten-thousand',
   main='org.pantsbuild.testproject.phrases.TenThousand',
-  source='TenThousand.java',
+  sources=['TenThousand.java'],
 )
 
 jvm_binary(name='there-was-a-duck',
   main='org.pantsbuild.testproject.phrases.ThereWasADuck',
-  source='ThereWasADuck.java',
+  sources=['ThereWasADuck.java'],
   dependencies=[
     ':with-her-trusty-companion',
   ]

--- a/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
@@ -1,5 +1,5 @@
 jvm_binary(
   main='org.pantsbuild.testproject.printversion.PrintVersion',
   basename='printversion',
-  source='PrintVersion.java',
+  sources=['PrintVersion.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/provided/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/provided/BUILD
@@ -35,7 +35,7 @@ jvm_binary(name='c-bin',
 )
 
 jvm_binary(name='c-with-direct-dep',
-  source='subc/C.java',
+  sources=['subc/C.java'],
   main='org.pantsbuild.testproject.provided.subc.C',
   dependencies=[
     ':a',
@@ -50,7 +50,7 @@ target(name='trans-3', dependencies=[':trans-2'])
 target(name='trans-4', dependencies=[':trans-3'])
 
 jvm_binary(name='c-with-transitive-dep',
-  source='subc/C.java',
+  sources=['subc/C.java'],
   main='org.pantsbuild.testproject.provided.subc.C',
   dependencies=[
     ':trans-1',

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/main/BUILD
@@ -16,7 +16,7 @@ jvm_binary(name = 'main-bin',
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet',
   ],
-  source = 'HelloMain.java',
+  sources = ['HelloMain.java'],
   main = 'org.pantsbuild.testproject.publish.hello.main.HelloMain',
   basename = 'hello-example',
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/runtime/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/runtime/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jvm_binary(name='compile-fail',
-  source='CompileReference.java',
+  sources=['CompileReference.java'],
   main='org.pantsbuild.testproject.runtime.CompileReference',
   dependencies=[
     scoped('3rdparty:gson', scope='runtime'),
@@ -10,7 +10,7 @@ jvm_binary(name='compile-fail',
 )
 
 jvm_binary(name='compile-pass',
-  source='CompileReference.java',
+  sources=['CompileReference.java'],
   main='org.pantsbuild.testproject.runtime.CompileReference',
   dependencies=[
     scoped('3rdparty:gson', scope='compile'),
@@ -18,7 +18,7 @@ jvm_binary(name='compile-pass',
 )
 
 jvm_binary(name='runtime-fail',
-  source='RuntimeReference.java',
+  sources=['RuntimeReference.java'],
   main='org.pantsbuild.testproject.runtime.RuntimeReference',
   dependencies=[
     scoped('3rdparty:gson', scope='compile'),
@@ -27,7 +27,7 @@ jvm_binary(name='runtime-fail',
 )
 
 jvm_binary(name='runtime-pass',
-  source='RuntimeReference.java',
+  sources=['RuntimeReference.java'],
   main='org.pantsbuild.testproject.runtime.RuntimeReference',
   dependencies=[
     scoped('3rdparty:gson', scope='runtime'),

--- a/testprojects/src/java/org/pantsbuild/testproject/unicode/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/unicode/main/BUILD
@@ -9,6 +9,6 @@ jvm_binary(
     'testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber',
     'testprojects/src/scala/org/pantsbuild/testproject/unicode/shapeless',
   ],
-  source = 'CucumberMain.java',
+  sources = ['CucumberMain.java'],
   main = 'org.pantsbuild.testproject.unicode.main.CucumberMain',
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/utf8proto/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/utf8proto/BUILD
@@ -7,6 +7,6 @@ jvm_binary(
     'testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto',
     '3rdparty:protobuf-java',
   ],
-  source='ExampleUtf8Proto.java',
+  sources=['ExampleUtf8Proto.java'],
   main='org.pantsbuild.testproject.utf8proto.ExampleUtf8Proto',
 )

--- a/testprojects/src/python/coordinated_runs/BUILD
+++ b/testprojects/src/python/coordinated_runs/BUILD
@@ -1,14 +1,14 @@
 python_binary(
   name='creator',
-  source='creator.py',
+  sources=['creator.py'],
 )
 
 python_binary(
   name='phaser',
-  source='phaser.py',
+  sources=['phaser.py'],
 )
 
 python_binary(
   name='waiter',
-  source='waiter.py',
+  sources=['waiter.py'],
 )

--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -8,7 +8,8 @@ python_library(
   name = 'echo_interpreter_version_lib',
   sources = ['echo_interpreter_version.py'],
   # Play with this to test interpreter selection in the pex machinery.
-  compatibility = ['CPython>=2.7']
+  compatibility = ['CPython>=2.7'],
+  tags={"nolint"},
 )
 
 python_binary(
@@ -17,7 +18,8 @@ python_binary(
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
-  compatibility = ['CPython>=3.3']
+  compatibility = ['CPython>=3.3'],
+  tags={"nolint"},
 )
 
 python_binary(
@@ -26,7 +28,8 @@ python_binary(
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
-  compatibility = ['CPython>=2.7,<3']
+  compatibility = ['CPython>=2.7,<3'],
+  tags={"nolint"},
 )
 
 # Note: Used by tests, but also useful for manual testing.
@@ -36,6 +39,7 @@ python_binary(
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
+  tags={"nolint"},
 )
 
 # Note: Used by tests, but also useful for manual testing.
@@ -45,13 +49,15 @@ python_binary(
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
-  compatibility = ['CPython<2.7']
+  compatibility = ['CPython<2.7'],
+  tags={"nolint"},
 )
 
 python_library(
   name = 'die_lib',
   sources = ['die.py'],
-  compatibility = ['CPython>=2.7,<3']
+  compatibility = ['CPython>=2.7,<3'],
+  tags={"nolint"},
 )
 
 python_binary(
@@ -60,4 +66,5 @@ python_binary(
     ':die_lib',
   ],
   entry_point = 'interpreter_selection.die',
+  tags={"nolint"},
 )

--- a/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
@@ -18,7 +18,7 @@
 
 python_binary(
   name='main_py3',
-  source='main_py3.py',
+  sources=['main_py3.py'],
   compatibility=['CPython>3'],
   dependencies=[
     # We depend on libraries with both narrow and wide ranges in order to confirm that the narrower
@@ -47,7 +47,7 @@ python_tests(
 
 python_binary(
   name='main_py2',
-  source='main_py2.py',
+  sources=['main_py2.py'],
   compatibility=['CPython>2.7.6,<3'],
   dependencies=[
     # We depend on libraries with both narrow and wide ranges in order to confirm that the narrower
@@ -76,7 +76,7 @@ python_tests(
 
 python_binary(
   name='main_py23',
-  source='main_py23.py',
+  sources=['main_py23.py'],
   compatibility=['CPython>2.7'],
   dependencies=[
     ':lib_py23'

--- a/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
@@ -25,13 +25,15 @@ python_binary(
     # range is the one selected.
     ':lib_py3',
     ':lib_py23',
-  ]
+  ],
+  tags={"nolint"},
 )
 
 python_library(
   name='lib_py3',
   sources=['lib_py3.py'],
-  compatibility=['CPython>3']
+  compatibility=['CPython>3'],
+  tags={"nolint"},
 )
 
 python_tests(
@@ -42,7 +44,8 @@ python_tests(
   dependencies=[
     ':main_py3'
   ],
-  compatibility=['CPython>3']
+  compatibility=['CPython>3'],
+  tags={"nolint"},
 )
 
 python_binary(
@@ -54,13 +57,15 @@ python_binary(
     # range is the one selected.
     ':lib_py2',
     ':lib_py23',
-  ]
+  ],
+  tags={"nolint"},
 )
 
 python_library(
   name='lib_py2',
   sources=['lib_py2.py'],
-  compatibility=['CPython>2.7.6,<3']
+  compatibility=['CPython>2.7.6,<3'],
+  tags={"nolint"},
 )
 
 python_tests(
@@ -71,7 +76,8 @@ python_tests(
   dependencies=[
     ':main_py2'
   ],
-  compatibility=['CPython>2.7.6,<3']
+  compatibility=['CPython>2.7.6,<3'],
+  tags={"nolint"},
 )
 
 python_binary(
@@ -80,13 +86,15 @@ python_binary(
   compatibility=['CPython>2.7'],
   dependencies=[
     ':lib_py23'
-  ]
+  ],
+  tags={"nolint"},
 )
 
 python_library(
   name='lib_py23',
   sources=['lib_py23.py'],
-  compatibility=['CPython>2.7']
+  compatibility=['CPython>2.7'],
+  tags={"nolint"},
 )
 
 python_tests(
@@ -97,5 +105,6 @@ python_tests(
   dependencies=[
     ':main_py23'
   ],
-  compatibility=['CPython>2.7']
+  compatibility=['CPython>2.7'],
+  tags={"nolint"},
 )

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
@@ -4,5 +4,6 @@ python_binary(
     'testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project',
   ],
   entry_point='interpreter_selection.test_target_with_no_sources.src.python.test_project',
-  compatibility=['CPython>3']
+  compatibility=['CPython>3'],
+  tags={"nolint"},
 )

--- a/testprojects/src/python/nested_runs/BUILD
+++ b/testprojects/src/python/nested_runs/BUILD
@@ -1,6 +1,6 @@
 python_binary(
   name="nested_runs",
-  source="run_pants_with_pantsd.py",
+  sources=["run_pants_with_pantsd.py"],
   compatibility=['CPython>=3.6']
 )
 

--- a/testprojects/src/python/print_env/BUILD
+++ b/testprojects/src/python/print_env/BUILD
@@ -1,4 +1,4 @@
 python_binary(
   entry_point = 'print_env.main',
-  source = 'main.py',
+  sources = ['main.py'],
 )

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -27,7 +27,7 @@ python_dist(
 
 python_binary(
   name='bin',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':ctypes',
   ],
@@ -36,7 +36,7 @@ python_binary(
 
 python_binary(
   name='with_platforms',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':ctypes',
     'testprojects/3rdparty/python:numpy',

--- a/testprojects/src/python/python_distribution/ctypes_interop/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_interop/BUILD
@@ -15,7 +15,7 @@ python_dist(
 
 python_binary(
   name='bin',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':ctypes_interop',
   ],

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -22,7 +22,7 @@ python_dist(
 
 python_binary(
   name='bin',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':ctypes',
   ],

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/BUILD
@@ -25,7 +25,7 @@ python_dist(
 
 python_binary(
   name='bin_with_third_party',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':python_dist_with_third_party_cpp',
   ],

--- a/testprojects/src/python/python_distribution/hello_with_install_requires/BUILD
+++ b/testprojects/src/python/python_distribution/hello_with_install_requires/BUILD
@@ -11,7 +11,7 @@ python_dist(
 
 python_binary(
   name='main_with_no_conflict',
-  source='main.py',
+  sources=['main.py'],
   dependencies=[
     ':hello_with_install_requires',
   ],

--- a/testprojects/src/python/python_targets/BUILD
+++ b/testprojects/src/python/python_targets/BUILD
@@ -3,7 +3,7 @@
 
 python_binary(
   name='test',
-  source='test_binary.py',
+  sources=['test_binary.py'],
   dependencies=[':test_library']
 )
 

--- a/testprojects/src/python/unicode/compilation_failure/BUILD
+++ b/testprojects/src/python/unicode/compilation_failure/BUILD
@@ -1,3 +1,3 @@
 python_binary(
-  source = 'main.py'
+  sources = ['main.py']
 )

--- a/testprojects/src/python/unicode/compilation_failure/BUILD
+++ b/testprojects/src/python/unicode/compilation_failure/BUILD
@@ -1,3 +1,4 @@
 python_binary(
-  sources = ['main.py']
+  sources = ['main.py'],
+  tags={"nolint"},
 )

--- a/testprojects/src/python/unicode/compilation_failure/main.py
+++ b/testprojects/src/python/unicode/compilation_failure/main.py
@@ -3,4 +3,4 @@
 # are unicode aware.
 
 if __name__ == '__main__':
-  import sys¡
+    import sys¡

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
@@ -7,7 +7,7 @@ java_library(name='util',
 )
 
 jvm_binary(name='run',
-  source='SyntheticJarRun.java',
+  sources=['SyntheticJarRun.java'],
   main='org.pantsbuild.testproject.syntheticjar.run.SyntheticJarRun',
   dependencies=[
     ':util',

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -3,7 +3,7 @@
 
 page(
   name='readme',
-  source='README.md',
+  sources=['README.md'],
 )
 
 python_library(

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -3,14 +3,14 @@
 
 python_library(
     name="projects_test_base",
-    source="projects_test_base.py",
+    sources=["projects_test_base.py"],
     dependencies=["src/python/pants/testutil:int-test",],
     tags={"partially_type_checked"},
 )
 
 python_tests(
     name="antlr_projects_integration",
-    source="test_antlr_projects_integration.py",
+    sources=["test_antlr_projects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/antlr/org/pantsbuild/example:all_directories",
@@ -22,7 +22,7 @@ python_tests(
 
 python_tests(
     name="java_examples_integration",
-    source="test_java_examples_integration.py",
+    sources=["test_java_examples_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/java/org/pantsbuild/example:all_directories",
@@ -34,7 +34,7 @@ python_tests(
 
 python_tests(
     name="java_testprojects_integration",
-    source="test_java_testprojects_integration.py",
+    sources=["test_java_testprojects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "testprojects/src/java/org/pantsbuild/testproject:all_directories",
@@ -46,7 +46,7 @@ python_tests(
 
 python_tests(
     name="maven_layout_integration",
-    source="test_maven_layout_integration.py",
+    sources=["test_maven_layout_integration.py"],
     dependencies=[":projects_test_base", "testprojects/maven_layout:all_directories",],
     tags={"integration", "partially_type_checked"},
     timeout=300,
@@ -54,7 +54,7 @@ python_tests(
 
 python_tests(
     name="protobuf_projects_integration",
-    source="test_protobuf_projects_integration.py",
+    sources=["test_protobuf_projects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/protobuf/org/pantsbuild/example:all_directories",
@@ -66,7 +66,7 @@ python_tests(
 
 python_tests(
     name="python_examples_integration",
-    source="test_python_examples_integration.py",
+    sources=["test_python_examples_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/python/example:all_directories",
@@ -77,7 +77,7 @@ python_tests(
 
 python_tests(
     name="python_testprojects_src_integration",
-    source="test_python_testprojects_src_integration.py",
+    sources=["test_python_testprojects_src_integration.py"],
     dependencies=[":projects_test_base", "testprojects/src/python:all_directories",],
     tags={"integration", "partially_type_checked"},
     timeout=120,
@@ -85,7 +85,7 @@ python_tests(
 
 python_tests(
     name="python_testprojects_tests_integration",
-    source="test_python_testprojects_tests_integration.py",
+    sources=["test_python_testprojects_tests_integration.py"],
     dependencies=[":projects_test_base", "testprojects/tests/python:all_directories",],
     tags={"integration", "partially_type_checked"},
     timeout=120,
@@ -93,7 +93,7 @@ python_tests(
 
 python_tests(
     name="scala_examples_integration",
-    source="test_scala_examples_integration.py",
+    sources=["test_scala_examples_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/scala/org/pantsbuild/example:all_directories",
@@ -105,7 +105,7 @@ python_tests(
 
 python_tests(
     name="scala_testprojects_integration",
-    source="test_scala_testprojects_integration.py",
+    sources=["test_scala_testprojects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "testprojects/src/scala/org/pantsbuild/testproject:all_directories",
@@ -117,7 +117,7 @@ python_tests(
 
 python_tests(
     name="thrift_projects_integration",
-    source="test_thrift_projects_integration.py",
+    sources=["test_thrift_projects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/thrift/org/pantsbuild/example:all_directories",
@@ -129,7 +129,7 @@ python_tests(
 
 python_tests(
     name="wire_projects_integration",
-    source="test_wire_projects_integration.py",
+    sources=["test_wire_projects_integration.py"],
     dependencies=[
         ":projects_test_base",
         "examples/src/wire/org/pantsbuild/example:all_directories",


### PR DESCRIPTION
We will soon be deprecating `source` in favor of `sources`. 

This is a highly tedious and automatable thing to fix, so we will provide a script to fix ~95-100% of usages. (This handles almost every edge case, except for weird patterns like using a `function` in the `source` argument; it even handles variables.)

We also run the script on the internal codebase to prepare for the change.