### PR TITLE
[IDE] Precompute flattened dependencies for modulizable targets

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -318,7 +318,7 @@ class ExportDepAsJar(ConsoleTask):
             if isinstance(current_target, RuntimePlatformMixin):
                 # We ignore typing here because mypy doesn't behave well with multiple inheritance:
                 # ref: https://github.com/python/mypy/issues/3603
-                info["runtime_platform"] = current_target.runtime_platform.name  # type: [misc]
+                info["runtime_platform"] = current_target.runtime_platform.name  # type: ignore[misc]
 
         info["source_dependencies_in_classpath"] = self._compute_transitive_source_dependencies(
             current_target, info["targets"], modulizable_target_set

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -318,7 +318,7 @@ class ExportDepAsJar(ConsoleTask):
             if isinstance(current_target, RuntimePlatformMixin):
                 # We ignore typing here because mypy doesn't behave well with multiple inheritance:
                 # ref: https://github.com/python/mypy/issues/3603
-                info["runtime_platform"] = current_target.runtime_platform.name # type: [misc]
+                info["runtime_platform"] = current_target.runtime_platform.name  # type: [misc]
 
         info["source_dependencies_in_classpath"] = self._compute_transitive_source_dependencies(
             current_target, info["targets"], modulizable_target_set

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -457,9 +457,11 @@ class ExportDepAsJar(ConsoleTask):
 
         def create_entry_for_target(target: Target) -> None:
             target_key = target
-            non_modulizable_deps = [
-                dep for dep in target.dependencies if dep not in modulizable_targets
-            ]
+            if self._is_strict_deps(target):
+                dependencies = target.strict_dependencies(DependencyContext.global_instance())
+            else:
+                dependencies = target.dependencies
+            non_modulizable_deps = [dep for dep in dependencies if dep not in modulizable_targets]
             entry = OrderedSet()
             for dep in non_modulizable_deps:
                 entry.update(flat_deps.get(dep, set()).union({dep}))

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -316,7 +316,9 @@ class ExportDepAsJar(ConsoleTask):
             info["excludes"] = [self._exclude_id(exclude) for exclude in current_target.excludes]
             info["platform"] = current_target.platform.name
             if isinstance(current_target, RuntimePlatformMixin):
-                info["runtime_platform"] = current_target.runtime_platform.name
+                # We ignore typing here because mypy doesn't behave well with multiple inheritance:
+                # ref: https://github.com/python/mypy/issues/3603
+                info["runtime_platform"] = current_target.runtime_platform.name # type: [misc]
 
         info["source_dependencies_in_classpath"] = self._compute_transitive_source_dependencies(
             current_target, info["targets"], modulizable_target_set

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -5,6 +5,7 @@ import json
 import os
 import zipfile
 from collections import defaultdict
+from typing import Set, Dict, List
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -19,6 +20,7 @@ from pants.backend.project_info.tasks.export_version import DEFAULT_EXPORT_VERSI
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.build_graph.resources import Resources
+from pants.build_graph.target import Target
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.task.console_task import ConsoleTask
@@ -193,25 +195,21 @@ class ExportDepAsJar(ConsoleTask):
                     )
         return f
 
-    def _dependencies_to_include_in_libraries(
-        self, t, modulizable_target_set, dependencies_needed_in_classpath
-    ):
-        """NB: We need to pass dependencies_needed_in_classpath here to make sure we're being strict_deps-aware
-        when computing the dependencies."""
-
-        dependencies_to_include = []
-        self.context.build_graph.walk_transitive_dependency_graph(
-            [direct_dep.address for direct_dep in t.dependencies],
-            # NB: Dependency graph between modulizable targets is represented with modules,
-            #     so we don't need to expand those branches of the dep graph.
-            predicate=lambda dep: (dep not in modulizable_target_set)
-            and (dep in dependencies_needed_in_classpath),
-            work=lambda dep: dependencies_to_include.append(dep),
-        )
-        return list(sorted(dependencies_to_include))
-
     def _extract_arguments_with_prefix_from_zinc_args(self, args, prefix):
         return [option[len(prefix) :] for option in args if option.startswith(prefix)]
+
+
+    def _compute_transitive_source_dependencies(self, target: Target, info_entry: List[str], modulizable_target_set: Set[Target]) -> List[str]:
+        if self._is_strict_deps(target):
+            return info_entry
+        else:
+            transitive_targets = set(info_entry)
+            self.context.build_graph.walk_transitive_dependency_graph(
+                addresses=[target.address],
+                predicate=lambda d: d in modulizable_target_set,
+                work=lambda d: transitive_targets.add(d.address.spec),
+            )
+            return list(transitive_targets)
 
     def _process_target(
         self,
@@ -220,6 +218,7 @@ class ExportDepAsJar(ConsoleTask):
         resource_target_map,
         runtime_classpath,
         zinc_args_for_target,
+        flat_non_modulizable_deps_for_modulizable_targets,
     ):
         """
         :type current_target:pants.build_graph.target.Target
@@ -282,25 +281,10 @@ class ExportDepAsJar(ConsoleTask):
         if not current_target.is_synthetic:
             info["globs"] = current_target.globs_relative_to_buildroot()
 
-        def _dependencies_needed_in_classpath(target):
-            if isinstance(target, JvmTarget):
-                return [
-                    dep
-                    for dep in DependencyContext.global_instance().dependencies_respecting_strict_deps(
-                        target
-                    )
-                ]
-            else:
-                return [dep for dep in target.closure()]
-
-        dependencies_needed_in_classpath = _dependencies_needed_in_classpath(current_target)
-
         libraries_for_target = set(
             [self._jar_id(jar) for jar in iter_transitive_jars(current_target)]
         )
-        for dep in self._dependencies_to_include_in_libraries(
-            current_target, modulizable_target_set, dependencies_needed_in_classpath
-        ):
+        for dep in list(sorted(flat_non_modulizable_deps_for_modulizable_targets[current_target])):
             libraries_for_target.update(_full_library_set_for_target(dep))
         info["libraries"].extend(libraries_for_target)
 
@@ -326,15 +310,7 @@ class ExportDepAsJar(ConsoleTask):
             if hasattr(current_target, "runtime_platform"):
                 info["runtime_platform"] = current_target.runtime_platform.name
 
-        transitive_targets = OrderedSet(
-            [
-                dep.address.spec
-                for dep in dependencies_needed_in_classpath
-                if dep in modulizable_target_set
-            ]
-        )
-        transitive_targets.update(info["targets"])
-        info["source_dependencies_in_classpath"] = [dep for dep in transitive_targets]
+        info["source_dependencies_in_classpath"] = self._compute_transitive_source_dependencies(current_target, info["targets"], modulizable_target_set)
 
         return info
 
@@ -440,6 +416,65 @@ class ExportDepAsJar(ConsoleTask):
                 library_entry["sources"] = jarred_sources.name
         return library_entry
 
+    @staticmethod
+    def _is_strict_deps(target):
+        return isinstance(target, JvmTarget) and DependencyContext.global_instance().defaulted_property(target, "strict_deps")
+
+    def _flat_non_modulizable_deps_for_modulizable_targets(self, modulizable_targets: Set[Target]) -> Dict[Target, Set[Target]]:
+        """
+        Collect flat dependencies for targets that will end up in libraries.
+        When visiting a target, we don't expand the dependencies that are modulizable targets,
+        since we need to reflect those relationships in a separate way later on.
+
+        E.g. if A -> B -> C -> D and A -> E and B -> F, if modulizable_targets = {A, B}, the resulting map will be:
+         {
+            A -> {E},
+            B -> {C, F, D},
+
+            // Some other entries for intermediate dependencies
+            C -> {D},
+            E -> {},
+            F -> {},
+         }
+        Therefore, when computing the library entries for A, we need to walk the (transitive) modulizable dependency graph,
+        and accumulate the entries in the map.
+
+        This function takes strict_deps into account when generating the graph.
+        """
+        flat_deps = {}
+
+        def create_entry_for_target(target: Target):
+            target_key = target
+            deps = [
+                dep for dep in target.dependencies
+                if dep not in modulizable_targets
+            ]
+            entry = set([])
+            for dep in deps:
+                entry.update(flat_deps.get(dep, set([])).union({dep}))
+            flat_deps[target_key] = entry
+
+        targets_with_strict_deps = [t for t in modulizable_targets if self._is_strict_deps(t)]
+        for t in targets_with_strict_deps:
+            flat_deps[t] = t.strict_dependencies(DependencyContext.global_instance())
+
+        self.context.build_graph.walk_transitive_dependency_graph(
+            addresses=[t.address for t in modulizable_targets if not self._is_strict_deps(t)],
+            # Work is to populate the entry of the map by merging the entries of all of the deps.
+            work=create_entry_for_target,
+
+            # We pre-populate the dict according to several principles (e.g. strict_deps),
+            # so a target being there means that there is no need to expand.
+            predicate=lambda target: target not in flat_deps.keys(),
+
+            # We want children to populate their entries in the map before the parents,
+            # so that we are guarranteed to have entries for all dependencies before
+            # computing a target's entry.
+            postorder=True,
+        )
+        return flat_deps
+
+
     def generate_targets_map(self, targets, runtime_classpath, zinc_args_for_all_targets):
         """Generates a dictionary containing all pertinent information about the target graph.
 
@@ -470,6 +505,9 @@ class ExportDepAsJar(ConsoleTask):
                 t, resource_target_map, runtime_classpath
             )
 
+        flat_non_modulizable_deps_for_modulizable_targets: Dict[Target, Set[Target]] = \
+            self._flat_non_modulizable_deps_for_modulizable_targets(modulizable_targets)
+
         for target in modulizable_targets:
             zinc_args_for_target = zinc_args_for_all_targets.get(target)
             if zinc_args_for_target is None:
@@ -486,6 +524,7 @@ class ExportDepAsJar(ConsoleTask):
                 resource_target_map,
                 runtime_classpath,
                 zinc_args_for_target,
+                flat_non_modulizable_deps_for_modulizable_targets,
             )
             targets_map[target.address.spec] = info
 


### PR DESCRIPTION
### Problem

Currently, we walk the transitive closure of every (non-strict-deps) target twice: Once to figure out what dependencies it should have in the classpath, and another one to figure out which of those should be made into libraries. We do that for every modulizable target, which makes `export-dep-as-jar` perform non-linearly with respect to the number of modulizable targets.

**NOTE:** I think this is a pretty convoluted graph thing, so I would love some input on whether this is readable and understandable, and how to improve that if not.

### Solution

We essentially need to be able to do three things with the transitive dep graph of a target:
- Calculate the `libraries` entry: This the flat sorted list of transitive dependencies that are not modulizable targets, respecting strict deps.
- Calculate which modulizable targets are direct dependencies of mine, for the `targets` field.
- Calculate flat closure of my transitive dependencies, modulizable and not modulizable, for `source_dependencies_in_classpath`, respecting strict deps.

So, we implement it this way:
- Traverse the whole dependency graph once to create a `Map[Target, Set[NonModulizableTarget]]`, which will contain the flat list of non-modulizable dependencies. The `libraries` field for a target will correspond exactly with an entry in this map.
- Pass that map to the processing of every target. The entry in `source_dependencies_in_classpath` will be the union of all the entries of all the transitive modulizable dependencies of a target. This operation should be cheap, or at least scale linearly with the size of `modulizable_target_set`.

E.g. if `A -(depends on)-> B -> C -> D` and `A -> E` and `B -> F`, if `modulizable_targets = {A, B}`, the resulting map will be:
 ```       
    flat_deps =  {
            A -> {E},
            B -> {C, F, D},
            // Some other entries for intermediate dependencies
            C -> {D},
            E -> {},
            F -> {},
         }
```
From here:
- `targets` of A: Computed trivially from `A.dependencies`.
- `libraries` of A: Computed from the map (`libraries = flat_deps[A]`)
- `source_dependencies_in_classpath` of A: Computed by traversing the dep closure and unioning the entries for modulizable deps ( `source_deps_in_classpath = flat_deps[A] U flat_deps[B]`, but not `flat_deps[C]`, because `C` is not modulizable).

### Result

No observable funcitonality impact, but a performance improvement.
