### PR TITLE
Demonstrate use of the Target API with `python_create_binary.py`

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -1,38 +1,79 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+from typing import Optional
+
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
+from pants.backend.python.rules.targets import EntryPoint, PythonBinarySources
+from pants.backend.python.rules.targets import targets as python_targets
 from pants.backend.python.targets.python_binary import PythonBinary
+from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.legacy.structs import PythonBinaryAdaptor
+from pants.engine.parser import HydratedStruct
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
+from pants.engine.target import SourcesRequest, SourcesResult, Target, hydrated_struct_to_target
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
-from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
+
+
+@dataclass(frozen=True)
+class PythonBinaryFields:
+    address: Address
+    sources: PythonBinarySources
+    entry_point: EntryPoint
+
+    # TODO: consume the other PythonBinary fields like `ZipSafe`. Consider making those fields
+    #  optional. We _need_ PythonBinarySources and EntryPoint to work properly. If your target
+    #  type also has ZipSafe, AlwaysWriteCache, etc, then we can do some additional things as an
+    #  extra bonus. Consider adding `Target.maybe_get()` to facilitate this.
+
+    @staticmethod
+    def is_valid_target(tgt: Target) -> bool:
+        return tgt.has_fields([EntryPoint, PythonBinarySources])
+
+    @classmethod
+    def create(cls, tgt: Target) -> "PythonBinaryFields":
+        return cls(
+            tgt.address, sources=tgt.get(PythonBinarySources), entry_point=tgt.get(EntryPoint)
+        )
 
 
 @rule
 async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> CreatedBinary:
-    # TODO(#8420) This way of calculating the entry point works but is a bit hackish.
-    if hasattr(python_binary_adaptor, "entry_point"):
-        entry_point = python_binary_adaptor.entry_point
+    # TODO: instead, get this to work via the engine. Have the rule request `PythonBinaryFields`,
+    #  which means that all we care about in the world is that those 2 Fields are defined on the
+    #  target (so it's extensible to custom target types).
+    hydrated_struct = await Get[HydratedStruct](Address, python_binary_adaptor.address)
+    tgt = hydrated_struct_to_target(hydrated_struct, target_types=python_targets())
+    fields = PythonBinaryFields.create(tgt)
+
+    entry_point: Optional[str]
+    if fields.entry_point.value is not None:
+        entry_point = fields.entry_point.value
     else:
-        sources = await Get[SourceFiles](
-            AllSourceFilesRequest([python_binary_adaptor], strip_source_roots=True)
+        # TODO: rework determine_source_files.py to work with the Target API. It should take the
+        #  Sources AsyncField as input, rather than TargetAdaptor.
+        sources_result = await Get[SourcesResult](SourcesRequest, fields.sources.request)
+        stripped_sources = await Get[SourceRootStrippedSources](
+            StripSnapshotRequest(sources_result.snapshot)
         )
-        # NB: `python_binary` targets may have 0-1 sources. This is enforced by
-        # `PythonBinaryAdaptor`.
-        if len(sources.snapshot.files) == 1:
-            module_name = sources.snapshot.files[0]
+        source_files = stripped_sources.snapshot.files
+        # NB: `PythonBinarySources` enforces that we have 0-1 sources.
+        if len(source_files) == 1:
+            module_name = source_files[0]
             entry_point = PythonBinary.translate_source_path_to_py_module_specifier(module_name)
         else:
             entry_point = None
 
     request = CreatePexFromTargetClosure(
-        addresses=Addresses((python_binary_adaptor.address,)),
+        # TODO: pass Targets, rather than Addresses, to this helper.
+        addresses=Addresses([tgt.address]),
         entry_point=entry_point,
-        output_filename=f"{python_binary_adaptor.address.target_name}.pex",
+        output_filename=f"{tgt.address.target_name}.pex",
     )
 
     pex = await Get[Pex](CreatePexFromTargetClosure, request)

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -42,7 +42,6 @@ class TestPythonSources(TestBase):
         assert sources.sanitized_raw_value == files
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, sources.request)
-        assert "//:lib" in str(exc)
         assert "f.hs" in str(exc)
 
         # Also check that we support valid sources
@@ -67,7 +66,6 @@ class TestPythonSources(TestBase):
         multiple_sources = PythonBinarySources(["f1.py", "f2.py"], address=address)
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, multiple_sources.request)
-        assert "//:binary" in str(exc)
         assert "has 2 sources" in str(exc)
 
     def test_python_library_sources_default_globs(self) -> None:

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.rules.targets import (
     PythonTestsSources,
     Timeout,
 )
+from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
@@ -19,9 +20,9 @@ from pants.testutil.test_base import TestBase
 
 
 def test_timeout_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(TargetDefinitionException):
         Timeout(-100, address=Address.parse(":tests"))
-    with pytest.raises(ValueError):
+    with pytest.raises(TargetDefinitionException):
         Timeout(0, address=Address.parse(":tests"))
     assert Timeout(5, address=Address.parse(":tests")).value == 5
 
@@ -41,7 +42,6 @@ class TestPythonSources(TestBase):
         assert sources.sanitized_raw_value == files
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, sources.request)
-        assert "non-Python sources" in str(exc)
         assert "f.hs" in str(exc)
 
         # Also check that we support valid sources
@@ -66,7 +66,7 @@ class TestPythonSources(TestBase):
         multiple_sources = PythonBinarySources(["f1.py", "f2.py"], address=address)
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, multiple_sources.request)
-        assert "//:binary had 2 sources" in str(exc)
+        assert "has 2 sources" in str(exc)
 
     def test_python_library_sources_default_globs(self) -> None:
         self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -42,6 +42,7 @@ class TestPythonSources(TestBase):
         assert sources.sanitized_raw_value == files
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, sources.request)
+        assert "//:lib" in str(exc)
         assert "f.hs" in str(exc)
 
         # Also check that we support valid sources
@@ -66,6 +67,7 @@ class TestPythonSources(TestBase):
         multiple_sources = PythonBinarySources(["f1.py", "f2.py"], address=address)
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(SourcesResult, multiple_sources.request)
+        assert "//:binary" in str(exc)
         assert "has 2 sources" in str(exc)
 
     def test_python_library_sources_default_globs(self) -> None:

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -37,6 +37,9 @@ class ErrorWhileTesting(TaskError):
     """
 
 
+# TODO: Create subclasses for the V2 Target API, e.g. one for an invalid field. We don't
+#  want to use the exceptions in build_graph.target.Target to avoid coupling to V1. Likely, these
+#  new exceptions should live in engine.target for fewer import statements for target authors.
 class TargetDefinitionException(Exception):
     """Indicates an invalid target definition.
 
@@ -48,7 +51,7 @@ class TargetDefinitionException(Exception):
     :param target: the target in question
     :param string msg: a description of the target misconfiguration
     """
-        super().__init__("Invalid target {}: {}".format(target, msg))
+        super().__init__(f"Invalid target {target}: {msg}")
 
 
 class BuildConfigurationError(Exception):

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -38,8 +38,6 @@ class TargetAdaptor(StructWithDeps):
 
     @property
     def address(self) -> Address:
-        # TODO: this isn't actually safe to override as not being Optional. There are
-        # some cases where this property is not defined. But, then we get a ton of MyPy issues.
         return cast(Address, super().address)
 
     def get_sources(self) -> Optional["GlobsWithConjunction"]:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -516,10 +516,8 @@ def hydrated_struct_to_target(
     # We special case `address` and the field `name`. The `Target` constructor requires an
     # `Address`, so we use the value pre-calculated via `build_files.py`'s `hydrate_struct` rule.
     # We throw away the field `name` because it can be accessed via `tgt.address.target_name`, so
-    # there is no (known) reason to preserve the field.
-    # TODO: is this safe to do..? We annotate HydratedStruct.value.address as Optional. Are we
-    #  certain that every HydratedStruct indeed has an address? What would we do if it didn't...?
-    #  The Target API requires Addresses to work.
+    # there is no (known) reason to preserve the field and it's slightly tricky to get the default
+    # value correct for the field.
     address = cast(Address, kwargs.pop("address"))
     kwargs.pop("name", None)
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -504,7 +504,7 @@ async def hydrate_sources(
     return SourcesResult(snapshot)
 
 
-# TODO: move this conversion into the engine. Create a singleton to access all the registered
+# TODO: move this conversion into a rule. Create a singleton to access all the registered
 #  targets (or maybe just use unions). Consider having that singleton be a dict from alias ->
 #  Target for efficient lookups (we're guaranteed only one alias per target type).
 def hydrated_struct_to_target(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -261,7 +261,11 @@ class Target(ABC):
         aliases_to_field_types = {field_type.alias: field_type for field_type in self.field_types}
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
-                raise TargetDefinitionException(address, f"Unrecognized field `{alias}={value}`.")
+                raise TargetDefinitionException(
+                    address,
+                    f"Unrecognized field `{alias}={value}`. Valid fields for the target type "
+                    f"`{self.alias}`: {sorted(aliases_to_field_types.keys())}."
+                )
             field_type = aliases_to_field_types[alias]
             self.field_values[field_type] = field_type(value, address=address)
         # For undefined fields, mark the raw value as None.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -264,7 +264,7 @@ class Target(ABC):
                 raise TargetDefinitionException(
                     address,
                     f"Unrecognized field `{alias}={value}`. Valid fields for the target type "
-                    f"`{self.alias}`: {sorted(aliases_to_field_types.keys())}."
+                    f"`{self.alias}`: {sorted(aliases_to_field_types.keys())}.",
                 )
             field_type = aliases_to_field_types[alias]
             self.field_values[field_type] = field_type(value, address=address)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type, T
 
 from typing_extensions import final
 
+from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
 from pants.engine.fs import (
     EMPTY_SNAPSHOT,
@@ -16,6 +17,7 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
+from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.selectors import Get
 from pants.util.collections import ensure_str_list
@@ -259,10 +261,7 @@ class Target(ABC):
         aliases_to_field_types = {field_type.alias: field_type for field_type in self.field_types}
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
-                raise ValueError(
-                    f"Unrecognized field `{alias}={value}` for target {address} with target "
-                    f"type `{self.alias}`."
-                )
+                raise TargetDefinitionException(address, f"Unrecognized field `{alias}={value}`.")
             field_type = aliases_to_field_types[alias]
             self.field_values[field_type] = field_type(value, address=address)
         # For undefined fields, mark the raw value as None.
@@ -499,6 +498,52 @@ async def hydrate_sources(
     )
     sources_field.validate_snapshot(snapshot)
     return SourcesResult(snapshot)
+
+
+# TODO: move this conversion into the engine. Create a singleton to access all the registered
+#  targets (or maybe just use unions). Consider having that singleton be a dict from alias ->
+#  Target for efficient lookups (we're guaranteed only one alias per target type).
+def hydrated_struct_to_target(
+    hydrated_struct: HydratedStruct, *, target_types: Iterable[Type[Target]]
+) -> Target:
+    kwargs = hydrated_struct.value.kwargs().copy()
+    type_alias = kwargs.pop("type_alias")
+
+    # We special case `address` and the field `name`. The `Target` constructor requires an
+    # `Address`, so we use the value pre-calculated via `build_files.py`'s `hydrate_struct` rule.
+    # We throw away the field `name` because it can be accessed via `tgt.address.target_name`, so
+    # there is no (known) reason to preserve the field.
+    # TODO: is this safe to do..? We annotate HydratedStruct.value.address as Optional. Are we
+    #  certain that every HydratedStruct indeed has an address? What would we do if it didn't...?
+    #  The Target API requires Addresses to work.
+    address = cast(Address, kwargs.pop("address"))
+    kwargs.pop("name", None)
+
+    # We convert `source` into `sources` because the Target API has no `Source` field, only
+    # `Sources`.
+    if "source" in kwargs and "sources" in kwargs:
+        raise TargetDefinitionException(
+            address, "Cannot specify both `source` and `sources` fields."
+        )
+    if "source" in kwargs:
+        source = kwargs.pop("source")
+        if not isinstance(source, str):
+            raise TargetDefinitionException(
+                address,
+                f"The `source` field must be a string containing a path relative to the target, "
+                f"but got {source} of type {type(source)}.",
+            )
+        kwargs["sources"] = [source]
+
+    aliases_to_target_types = {target_type.alias: target_type for target_type in target_types}
+    target_type = aliases_to_target_types.get(type_alias, None)
+    if target_type is None:
+        raise TargetDefinitionException(
+            address,
+            f"Target type {type_alias} is not recognized. All valid target types: "
+            f"{sorted(aliases_to_target_types.keys())}.",
+        )
+    return target_type(kwargs, address=address)
 
 
 def rules():


### PR DESCRIPTION
This adds our very first usage of the Target API in production by using it for `./v2 run` and `./v2 binary`:

```bash
▶ ./v2 run build-support/bin:check_banned_imports


Running target: build-support/bin:check_banned_imports
build-support/bin:check_banned_imports ran successfully.
```

The end functionality is the same, except we now give a good error message for invalid fields on `python_binary`, which we used to silently accept.

```
▶ ./v2 --no-print-exception-stacktrace run build-support/bin:check_banned_imports


ERROR: Invalid target build-support/bin:check_banned_imports: Unrecognized field `fake=1`. Valid fields for the target type `python_binary`: ['always_write_cache', 'compatibility', 'dependencies', 'emit_warnings', 'entry_point', 'ignore_errors', 'indices', 'inherit_path', 'platforms', 'provides', 'repositories', 'shebang', 'sources', 'tags', 'zip_safe'].
```

### Converting `HydratedStruct` -> `Target`

For now, we hydrate BUILD files into Targets by going from `eval() -> HydratedStruct -> Target`. `HydratedStruct` will do the bare minimum of hydration we need for a `Target`, e.g. resolving the `Address` and mapping the field `dependencies` to other `Address`es. (We might remove `HydratedStruct` in some future.)

We can't go from `TargetAdaptor -> Target` because `TargetAdaptor` will have already hydrated the `sources`.

This adds a pure function to convert `HydratedStruct -> Target`. A followup will convert this to a rule.

### New pattern (tentative design): rules expressing the minimum fields they need to operate

A key goal of the Target API is for rules to stop saying that they only work with certain target types, but to instead express which precise typed `Field`s they need to operate. For example, Black only needs `PythonSources` and doesn't care about any other fields.

To get this working with the engine, (for now), downstream rules should declare a new dataclass called `MyRuleFields`, e.g. `PythonBinaryFields`, which has an entry for each typed `Field`. This should expose the methods `.is_valid_target()` and `.create()`. 

The downstream rule will then request `PythonBinaryFields` as its input, and its upstream rule will filter out its collection of `Targets` (plural) via `PythonBinaryFields.is_valid_target()` to pass down instances of `PythonBinaryFields` where relevant. This is the same pattern we use for `lint.py` with `Linter.is_valid_target()`. As with `lint.py`, we can use unions to allow multiple downstream rules, e.g. `PythonBinaryFields` vs. `JavaBinaryFields`.

(The specific mechanism might change, e.g. using `SelectFields(EntryPoint, PythonBinarySources)` as the rule param instead of `PythonBinaryFields`. The important part is the need for a mechanism for rules to request the precise fields they need in their rule definition - less important is how we do that at the moment.)

### Also improves error messages

We use `TargetDefinitionError` to have more useful and structured error messages. In a followup, we'll want to make these more helpful. This is only a first pass.