### PR TITLE
Compute Node start time for heavy-hitters and Workunit start time simultaneously

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -27,7 +27,11 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   type Item: Clone + Debug + Eq + Send + 'static;
   type Error: NodeError;
 
-  fn run(self, context: Self::Context) -> BoxFuture<Self::Item, Self::Error>;
+  fn run(
+    self,
+    context: Self::Context,
+    start_time: std::time::SystemTime,
+  ) -> BoxFuture<Self::Item, Self::Error>;
 
   ///
   /// If the given Node output represents an FS operation, returns its Digest.

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -434,7 +434,7 @@ impl Node for TNode {
   type Item = Vec<T>;
   type Error = TError;
 
-  fn run(self, context: TContext) -> BoxFuture<Vec<T>, TError> {
+  fn run(self, context: TContext, _start_time: std::time::SystemTime) -> BoxFuture<Vec<T>, TError> {
     context.ran(self.clone());
     let token = T(self.0, context.salt());
     if let Some(dep) = context.dependency_of(&self) {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1032,14 +1032,14 @@ impl Node for NodeKey {
   type Item = NodeResult;
   type Error = Failure;
 
-  fn run(self, context: Context) -> NodeFuture<NodeResult> {
+  fn run(self, context: Context, start_time: std::time::SystemTime) -> NodeFuture<NodeResult> {
     let (maybe_started_workunit, maybe_span_id) = if context.session.should_handle_workunits() {
       let user_facing_name = self.user_facing_name();
       let span_id = generate_random_64bit_string();
       let parent_id = workunit_store::get_parent_id();
       let maybe_started_workunit = user_facing_name.as_ref().map(|node_name| StartedWorkUnit {
         name: node_name.to_string(),
-        start_time: std::time::SystemTime::now(),
+        start_time,
         span_id: span_id.clone(),
         parent_id,
       });


### PR DESCRIPTION
### Problem

Previously, the `heavy_hitters` priority queue, which we used to figure out what node executions were useful to display in the v2 UI, was using the `start_time` field on `EntryState::Running`, which is set when we transition the state of a node from `NotStarted`. However, the time that we create an `EntryState::Running` value is (nearly) simultaneous with the time we install a new future to do the work represented by that node - not when the work of that node itself actually starts. This means that the time value displayed in the V2 UI could be much longer than the amount of time a given Node is actually spending doing useful work, since it is also counting time while that Node's future is waiting to be scheduled by the future scheduling system.

### Solution

The Workunits code was already using the implementation of `Node::run` on `NodeKey` as the place to start a real-time timer to track workunit durations. This commit modifies the `run` method on that trait to accept an additional `start_time` argument, which is computed in the closure that creates that future. This commit also modifies the `start_time` param on `EntryState::Running` to take a mutex'd optional start time, which is updated to have a start time calculated at the same time we pass it into the `Node::run` method.

The Workunits code was expecting a value of type `std::time::SystemTime`, and the `EntryState` code expecting one of `std::time::Instant`, so we cannot use literally the same computed start time value on both `Workunit` and `EntryState` unless we change the type of one of them. Changing the signature of `run` makes it clear that these are supposed to be conceptually the same time, even if the types they are reified with are different; and we can make the type change in a follow up commit unless there's a good reason to use `Instant` in one place and `SystemTime` in another.

### Result

The times in seconds displayed in the V2 UI should now be a better reflection of how long execution for a given node actually takes.