### PR TITLE
Bump to most recent versions of JVM dependencies.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -16,7 +16,7 @@ class JarTool(JvmToolMixin, Subsystem):
         cls.register_jvm_tool(
             register,
             "jar-tool",
-            classpath=[JarDependency(org="org.pantsbuild", name="jar-tool", rev="0.0.16")],
+            classpath=[JarDependency(org="org.pantsbuild", name="jar-tool", rev="0.0.17")],
         )
 
     def run(self, context, runjava, args):

--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -17,7 +17,7 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
     RUNNER_MAIN = "org.pantsbuild.tools.junit.ConsoleRunner"
 
     LIBRARY_JAR = JarDependency(org="junit", name="junit", rev=LIBRARY_REV)
-    _RUNNER_JAR = JarDependency(org="org.pantsbuild", name="junit-runner", rev="1.0.28")
+    _RUNNER_JAR = JarDependency(org="org.pantsbuild", name="junit-runner", rev="1.0.29")
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -91,7 +91,7 @@ class Zinc:
             cls.register_jvm_tool(
                 register,
                 Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME,
-                classpath=[JarDependency("org.pantsbuild", "zinc-bootstrapper_2.12", "0.0.12")],
+                classpath=[JarDependency("org.pantsbuild", "zinc-bootstrapper_2.12", "0.0.14")],
                 main=Zinc.ZINC_BOOTSTRAPPER_MAIN,
                 custom_rules=shader_rules,
             )

--- a/src/python/pants/backend/jvm/tasks/ivy_outdated.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_outdated.py
@@ -44,7 +44,7 @@ class IvyOutdated(NailgunTask):
             "dependency-update-checker",
             classpath=[
                 JarDependency(
-                    org="org.pantsbuild", name="ivy-dependency-update-checker", rev="0.0.4"
+                    org="org.pantsbuild", name="ivy-dependency-update-checker", rev="0.0.5"
                 ),
             ],
             main=cls._IVY_DEPENDENCY_UPDATE_MAIN,

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -32,7 +32,7 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
         cls.register_jvm_tool(
             register,
             "pants-runner",
-            classpath=[JarDependency(org="org.pantsbuild", name="pants-runner", rev="0.0.1")],
+            classpath=[JarDependency(org="org.pantsbuild", name="pants-runner", rev="0.0.8")],
             main=ScalaRepl._RUNNER_MAIN,
         )
 

--- a/testprojects/3rdparty/javactool/BUILD
+++ b/testprojects/3rdparty/javactool/BUILD
@@ -4,5 +4,5 @@
 # Used for integration tests of using custom javac jars.
 jar_library(name='custom_javactool_for_testing',
             jars=[
-              jar('org.pantsbuild', 'custom_javactool_for_testing', '0.0.1')
+              jar('org.pantsbuild', 'custom_javactool_for_testing', '0.0.7')
             ])

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -63,7 +63,7 @@ class ExportTest(ConsoleTaskTestBase):
         init_subsystems([JUnit, ScalaPlatform, ScoveragePlatform], scala_options)
 
         self.make_target(
-            ":jar-tool", JarLibrary, jars=[JarDependency("org.pantsbuild", "jar-tool", "0.0.10")]
+            ":jar-tool", JarLibrary, jars=[JarDependency("org.pantsbuild", "jar-tool", "0.0.17")]
         )
 
         # NB: `test_has_python_requirements` will attempt to inject every possible scala compiler target

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -68,7 +68,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         init_subsystems([JUnit, ScalaPlatform, ScoveragePlatform], scala_options)
 
         self.make_target(
-            ":jar-tool", JarLibrary, jars=[JarDependency("org.pantsbuild", "jar-tool", "0.0.10")]
+            ":jar-tool", JarLibrary, jars=[JarDependency("org.pantsbuild", "jar-tool", "0.0.17")]
         )
 
         # NB: `test_has_python_requirements` will attempt to inject every possible scala compiler target


### PR DESCRIPTION
### Problem

A bunch of stuff has been published via https://www.pantsbuild.org/release_jvm.html , but hasn't been consumed yet (in some cases in a few publishes.)

### Solution

Consume it.