### PR TITLE
Fix CI running for Jar publish commits

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -373,12 +373,10 @@ branch_notes = """
 
 [publish.jar]
 ivy_settings = "%(pants_supportdir)s/ivy/publish.ivysettings.xml"
-# Prevent Travis-CI from running for this automated jar publish commit:
-#   http://docs.travis-ci.com/user/how-to-skip-a-build/
 push_postscript = """
-# Prevent Travis CI from running for this automated jar publish commit:
-#  http://docs.travis-ci.com/user/how-to-skip-a-build/
-["ci skip"]
+# Prevent Travis CI from running for this automated JAR publish commit:
+#  https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
+[ci skip]
 """
 repos = """
 {

--- a/pants.toml
+++ b/pants.toml
@@ -375,7 +375,11 @@ branch_notes = """
 ivy_settings = "%(pants_supportdir)s/ivy/publish.ivysettings.xml"
 # Prevent Travis-CI from running for this automated jar publish commit:
 #   http://docs.travis-ci.com/user/how-to-skip-a-build/
-push_postscript = '["ci skip"]'
+push_postscript = """
+# Prevent Travis CI from running for this automated jar publish commit:
+#  http://docs.travis-ci.com/user/how-to-skip-a-build/
+["ci skip"]
+"""
 repos = """
 {
   'public': {  # must match the name of the `Repository` object that you defined in your plugin.


### PR DESCRIPTION
This was a bad conversion from `pants.ini` -> `pants.toml`. `[ci-skip]` must be on a distinct new line to work properly.