### PR TITLE
Remove custom antlr repo

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -9,11 +9,7 @@ python_requirements()
 python_requirement_library(
   name='antlr-3.1.3',
   requirements=[
-    # TODO: this library is not currently linked from pypi, so we override the repository
-    # to fetch it from antlr.org instead. If at any point it reappears on pypi, the
-    # repository arg can be removed.
-    python_requirement('antlr_python_runtime==3.1.3',
-                       repository='http://www.antlr3.org/download/Python/')
+    python_requirement('antlr_python_runtime==3.1.3')
   ]
 )
 


### PR DESCRIPTION
It's on pypi now: https://pypi.org/project/antlr_python_runtime/#history