### PR TITLE
Implement Cobertura output option for #9275

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -77,7 +77,6 @@ class Scoverage(CoverageEngine):
                 help="Export cobertura formats which would allow users to merge with cobertura coverage for java targets.",
             )
 
-
         def create(self, settings, targets, execute_java_for_targets):
             """
             :param settings: Generic code coverage settings.

--- a/src/python/pants/java/jar/jar_dependency.py
+++ b/src/python/pants/java/jar/jar_dependency.py
@@ -121,6 +121,7 @@ class JarDependency:
     intransitive: bool
     excludes: Tuple[Exclude, ...]
     base_path: str
+    output_as_cobertura: bool
 
     def __init__(
         self,
@@ -136,6 +137,7 @@ class JarDependency:
         intransitive: bool = False,
         excludes: Optional[Sequence[Exclude]] = None,
         base_path: Optional[str] = None,
+        output_as_cobertura: bool = False,
     ) -> None:
         self.org = org
         self.base_name = name
@@ -152,6 +154,7 @@ class JarDependency:
         if os.path.isabs(base_path):
             base_path = os.path.relpath(base_path, get_buildroot())
         self.base_path = base_path
+        self.output_as_cobertura = output_as_cobertura
 
     def __str__(self):
         return "JarDependency({})".format(self.coordinate)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -113,6 +113,11 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     def test_junit_run_with_coverage_succeeds_scoverage(self):
         self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot", "--fast"])
 
+    def test_junit_run_with_coverage_succeeds_cobertura_merged(self):
+        self.do_test_junit_run_with_coverage_succeeds_cobertura(
+            args=["--test-junit-coverage", "--scoverage-enable-scoverage", "--scoverage-report-output-as-cobertura"],
+        )
+
     def do_test_junit_run_with_coverage_succeeds_cobertura(self, tests=(), args=()):
         html_path = (
             "test/junit/coverage/reports/html/"

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -113,11 +113,6 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     def test_junit_run_with_coverage_succeeds_scoverage(self):
         self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot", "--fast"])
 
-    def test_junit_run_with_coverage_succeeds_cobertura_merged(self):
-        self.do_test_junit_run_with_coverage_succeeds_cobertura(
-            args=["--test-junit-coverage", "--scoverage-enable-scoverage", "--scoverage-report-output-as-cobertura"],
-        )
-
     def do_test_junit_run_with_coverage_succeeds_cobertura(self, tests=(), args=()):
         html_path = (
             "test/junit/coverage/reports/html/"


### PR DESCRIPTION
### Problem

Implement Cobertura output option for #9275

### Solution

Add new option (`--scoverage-report-output-as-cobertura`) for triggering `CoberturaXmlWriter(...)` method call in `scoverage-report-generator_2.12-0.0.3.jar` to generate Cobertura output

### Result

Generate Cobertura output (`.pants.d/test/junit/_runs/*/*/all/scoverage/reports/xml/cobertura.xml`) 
when `--scoverage-enable-scoverage --scoverage-report-output-as-cobertura` options are provided in pants command.