### PR TITLE
[WIP] Use ivy settings during bootstrap

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -105,7 +105,7 @@ write_to = ["%(local_artifact_cache)s"]
 # A custom ivysettings.xml file to allow for consumption from a local .m2 repository.
 # If you don't need access to a local .m2 repository, remove this setting to use the default.
 ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
-ivy.bootstrap_ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
+bootstrap_ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
 # We need a custom ivy profile to grab the optional pgp libs for
 # signing artifacts we publish to maven central.
 ivy_profile = "%(pants_supportdir)s/ivy/ivy.xml"

--- a/pants.toml
+++ b/pants.toml
@@ -105,6 +105,7 @@ write_to = ["%(local_artifact_cache)s"]
 # A custom ivysettings.xml file to allow for consumption from a local .m2 repository.
 # If you don't need access to a local .m2 repository, remove this setting to use the default.
 ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
+ivy.bootstrap_ivy_settings = "%(pants_supportdir)s/ivy/ivysettings.xml"
 # We need a custom ivy profile to grab the optional pgp libs for
 # signing artifacts we publish to maven central.
 ivy_profile = "%(pants_supportdir)s/ivy/ivy.xml"


### PR DESCRIPTION
### Problem

```
pants_test/contrib/googlejavaformat/test_googlejavaformat.py:88: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pants/testutil/jvm/jvm_tool_task_test_base.py:123: in execute
    task.execute()
pants/backend/jvm/tasks/rewrite_base.py:76: in execute
    self._execute_for([vt.target for vt in invalidation_check.invalid_vts])
pants/backend/jvm/tasks/rewrite_base.py:83: in _execute_for
    result = Xargs(self._invoke_tool).execute(target_sources)
pants/process/xargs.py:45: in execute
    return self._cmd(all_args)
pants/backend/jvm/tasks/rewrite_base.py:105: in _invoke_tool
    result = self.invoke_tool(toolroot, target_sources)
pants/contrib/googlejavaformat/googlejavaformat.py:58: in invoke_tool
    classpath=self.tool_classpath("google-java-format"),
pants/backend/jvm/tasks/jvm_tool_task_mixin.py:56: in tool_classpath
    self.context.products, key, scope=self._scope(scope)
pants/backend/jvm/subsystems/jvm_tool_mixin.py:236: in tool_classpath_from_products
    entry.path for entry in cls.tool_classpath_entries_from_products(products, key, scope)
pants/backend/jvm/subsystems/jvm_tool_mixin.py:254: in tool_classpath_entries_from_products
    return callback()
pants/backend/jvm/tasks/bootstrap_jvm_tools.py:406: in bootstrap_classpath
    cache["classpath"] = self._bootstrap_jvm_tool(dep_spec, jvm_tool)
pants/backend/jvm/tasks/bootstrap_jvm_tools.py:395: in _bootstrap_jvm_tool
    return self._bootstrap_classpath(jvm_tool, targets)
pants/backend/jvm/tasks/bootstrap_jvm_tools.py:279: in _bootstrap_classpath
    self.resolve(executor=None, targets=targets, classpath_products=classpath_holder)
pants/backend/jvm/tasks/ivy_task_mixin.py:151: in resolve
    pinned_artifacts=artifact_set,
pants/backend/jvm/tasks/ivy_task_mixin.py:184: in _resolve_subset
    pinned_artifacts=pinned_artifacts,
pants/backend/jvm/tasks/ivy_task_mixin.py:287: in _ivy_resolve
    workunit_name,
pants/backend/jvm/tasks/ivy_task_mixin.py:337: in _perform_resolution
    executor, extra_args, targets, jvm_options, workunit_name, workunit_factory
pants/backend/jvm/ivy_utils.py:270: in exec_and_load
    executor, extra_args, targets, jvm_options, workunit_name, workunit_factory
pants/backend/jvm/ivy_utils.py:291: in _do_resolve
    executor, extra_args, ivyxml, jvm_options, hash_name, workunit_factory, workunit_name
pants/backend/jvm/ivy_utils.py:147: in _call_ivy
    workunit_name,
pants/backend/jvm/ivy_utils.py:860: in do_resolve
    ivy = Bootstrapper.default_ivy(bootstrap_workunit_factory=workunit_factory)
pants/ivy/bootstrapper.py:50: in default_ivy
    return cls.instance().ivy(bootstrap_workunit_factory=bootstrap_workunit_factory)
pants/ivy/bootstrapper.py:80: in ivy
    self._get_classpath(bootstrap_workunit_factory),
pants/ivy/bootstrapper.py:92: in _get_classpath
    self._classpath = self._bootstrap_ivy_classpath(workunit_factory)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _bootstrap_ivy_classpath(self, workunit_factory, retry=True):
        ivy_bootstrap_dir = os.path.join(
            self._ivy_subsystem.get_options().pants_bootstrapdir, "tools", "jvm", "ivy"
        )
        digest = hashlib.sha1()
        if self._ivyxml and os.path.isfile(self._ivyxml):
            with open(self._ivyxml, "rb") as fp:
                digest.update(fp.read())
        digest.update(self._version.encode())
        classpath = os.path.join(ivy_bootstrap_dir, f"{digest.hexdigest()}")
    
        if not os.path.exists(classpath):
            with safe_concurrent_creation(classpath) as safe_classpath:
                ivy = self._bootstrap_ivy()
                args = ["-confs", "default", "-cachepath", safe_classpath]
                if self._ivyxml and os.path.isfile(self._ivyxml):
                    args.extend(["-ivy", self._ivyxml])
                else:
                    args.extend(["-dependency", "org.apache.ivy", "ivy", self._version])
    
                try:
                    ivy.execute(
                        args=args, workunit_factory=workunit_factory, workunit_name="ivy-bootstrap"
                    )
                except ivy.Error as e:
>                   raise self.Error("Failed to bootstrap an ivy classpath! {}".format(e))
E                   pants.ivy.bootstrapper.Bootstrapper.Error: Failed to bootstrap an ivy classpath! Ivy command failed with exit code 1: -confs default -cachepath /home/nobody/.cache/pants/tools/jvm/ivy/0c6799f2e85eccc7061443f76e45b7b268892b58.tmp.c08c2601b8934833b4c0227894c93147 -dependency org.apache.ivy ivy 2.4.0

pants/ivy/bootstrapper.py:120: Error
----------------------------- Captured stderr call -----------------------------

Starting workunit cache
 
Starting workunit ivy-bootstrap
:: loading settings :: url = jar:file:/home/nobody/.cache/pants/bin/ivy/2.4.0/ivy!/org/apache/ivy/core/settings/ivysettings.xml
:: resolving dependencies :: org.apache.ivy#ivy-caller;working
	confs: [default]
:: resolution report :: resolve 682ms :: artifacts dl 0ms
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   1   |   0   |   0   |   0   ||   0   |   0   |
	---------------------------------------------------------------------

:: problems summary ::
:::: WARNINGS
		module not found: org.apache.ivy#ivy;2.4.0

	==== local: tried

	  /home/nobody/.ivy2/local/org.apache.ivy/ivy/2.4.0/ivys/ivy.xml

	  -- artifact org.apache.ivy#ivy;2.4.0!ivy.jar:

	  /home/nobody/.ivy2/local/org.apache.ivy/ivy/2.4.0/jars/ivy.jar

	==== shared: tried

	  /home/nobody/.ivy2/shared/org.apache.ivy/ivy/2.4.0/ivys/ivy.xml

	  -- artifact org.apache.ivy#ivy;2.4.0!ivy.jar:

	  /home/nobody/.ivy2/shared/org.apache.ivy/ivy/2.4.0/jars/ivy.jar

	==== public: tried

	  https://repo1.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.pom

	  -- artifact org.apache.ivy#ivy;2.4.0!ivy.jar:

	  https://repo1.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar

		::::::::::::::::::::::::::::::::::::::::::::::

		::          UNRESOLVED DEPENDENCIES         ::

		::::::::::::::::::::::::::::::::::::::::::::::

		:: org.apache.ivy#ivy;2.4.0: not found

		::::::::::::::::::::::::::::::::::::::::::::::
```
suggests `build-support/ivy/ivysettings.xml` isn't used during bootstrap, and it's required in order to hit the google maven mirror.

### Solution

define `ivy.bootstrap_ivy_settings`
