### PR TITLE
Skip all tests failing from Ivy blocklist (#9330)

### DIFF
--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen_integration.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen_integration.py
@@ -3,9 +3,11 @@
 
 import os
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class AvroJavaGenTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
@@ -1,9 +1,11 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ErrorProneTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
@@ -3,11 +3,13 @@
 
 from textwrap import dedent
 
+import pytest
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_file
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class FindBugsTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
@@ -3,6 +3,7 @@
 
 from textwrap import dedent
 
+import pytest
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.exceptions import TaskError
@@ -45,6 +46,7 @@ class TestBase(NailgunTaskTestBase):
         return super().alias_groups().merge(register_core().merge(register_jvm()))
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class GoogleJavaFormatTests(TestBase):
     @classmethod
     def task_type(cls):
@@ -68,6 +70,7 @@ class GoogleJavaFormatTests(TestBase):
         self.assertEqual(actual, self._GOODFORMAT)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class GoogleJavaFormatCheckFormatTests(TestBase):
     @classmethod
     def task_type(cls):

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
@@ -1,9 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ScroogeGenTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -4,12 +4,14 @@
 from functools import wraps
 from typing import Any, Callable, TypeVar
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 FuncType = Callable[..., Any]
 F = TypeVar("F", bound=FuncType)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ThriftLinterTest(PantsRunIntegrationTest):
 
     lint_warn_token = "LINT-WARN"

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
+import pytest
+
 from pants.backend.codegen.antlr.java.antlr_java_gen import AntlrJavaGen
 from pants.backend.codegen.antlr.java.java_antlr_library import JavaAntlrLibrary
 from pants.base.exceptions import TaskError
@@ -27,6 +29,7 @@ class DummyVersionedTarget:
         return self.results_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class AntlrJavaGenTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen.py
@@ -4,12 +4,15 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.codegen.antlr.python.antlr_py_gen import AntlrPyGen
 from pants.backend.codegen.antlr.python.python_antlr_library import PythonAntlrLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class AntlrPyGenTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
+++ b/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
@@ -3,6 +3,8 @@
 
 import os
 
+import pytest
+
 from pants.backend.codegen.jaxb.jaxb_gen import JaxbGen
 from pants.backend.codegen.jaxb.jaxb_library import JaxbLibrary
 from pants.backend.codegen.jaxb.register import build_file_aliases as register_codegen
@@ -10,6 +12,7 @@ from pants.build_graph.register import build_file_aliases as register_core
 from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JaxbGenJavaTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
@@ -3,6 +3,8 @@
 
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.scalastyle import Scalastyle
 from pants.backend.jvm.targets.jar_library import JarLibrary
@@ -13,6 +15,7 @@ from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants.testutil.subsystem.util import init_subsystem
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class CustomScalaTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -7,12 +7,15 @@ import re
 import shutil
 from textwrap import dedent
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     @contextlib.contextmanager
     def tmp_custom_scala(self, path_suffix):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -5,10 +5,13 @@ import os
 import re
 import shutil
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class DepExportsIntegrationTest(PantsRunIntegrationTest):
 
     SRC_PREFIX = "testprojects/tests"

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
@@ -3,11 +3,14 @@
 
 import os
 
+import pytest
+
 from pants.backend.jvm.tasks.binary_create import BinaryCreate
 from pants.util.contextutil import open_zip
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class TestBinaryCreate(JvmBinaryTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from contextlib import contextmanager
 
+import pytest
+
 from pants.backend.jvm.subsystems.shader import Shading
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
@@ -32,6 +34,7 @@ class BootstrapJvmToolsTestBase(JvmToolTaskTestBase):
         yield out.decode()
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class BootstrapJvmToolsShadingTest(BootstrapJvmToolsTestBase):
     class JvmToolTask(JvmToolTaskMixin, Task):
         @classmethod
@@ -105,6 +108,7 @@ class BootstrapJvmToolsShadingTest(BootstrapJvmToolsTestBase):
         )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class BootstrapJvmToolsOptionalTest(BootstrapJvmToolsTestBase):
     class JvmToolTask(JvmToolTaskMixin, Task):
         @classmethod
@@ -132,6 +136,7 @@ class BootstrapJvmToolsOptionalTest(BootstrapJvmToolsTestBase):
             self.assertIn("OK (0 tests)", out)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class BootstrapJvmToolsNonOptionalNoDefaultTest(BootstrapJvmToolsTestBase):
     class JvmToolTask(JvmToolTaskMixin, Task):
         @classmethod

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -3,6 +3,8 @@
 
 import os
 
+import pytest
+
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -16,6 +18,7 @@ from pants.util.dirutil import safe_file_dump, safe_mkdir, safe_mkdtemp
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class TestBundleCreate(JvmBinaryTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -4,6 +4,8 @@
 import os
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.subsystems.checkstyle import Checkstyle as CheckstyleSubsystem
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.checkstyle import Checkstyle
@@ -13,6 +15,7 @@ from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants.testutil.task_test_base import ensure_cached
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class CheckstyleTest(NailgunTaskTestBase):
     """Tests for the class Checkstyle."""
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ClassmapTaskIntegrationTest(PantsRunIntegrationTest):
     # A test target with both transitive internal dependency as well as external dependency
     TEST_JVM_TARGET = "testprojects/tests/java/org/pantsbuild/testproject/testjvms:eight"

--- a/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
@@ -5,6 +5,8 @@ import os
 import re
 from typing import List
 
+import pytest
+
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -16,6 +18,7 @@ from pants.util.dirutil import safe_file_dump
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class TestConsolidateClasspath(JvmBinaryTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -6,6 +6,8 @@ import re
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+import pytest
+
 from pants.backend.jvm.subsystems.jar_dependency_management import (
     JarDependencyManagement,
     PinnedJarArtifactSet,
@@ -31,6 +33,7 @@ from pants.util.contextutil import temporary_dir, temporary_file_path
 from pants.util.dirutil import safe_delete, safe_rmtree
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class CoursierResolveTest(NailgunTaskTestBase):
     """Tests for the class CoursierResolve."""
 
@@ -320,6 +323,7 @@ class CoursierResolveTest(NailgunTaskTestBase):
         self.set_options_for_scope("", pants_workdir=old_workdir)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class CoursierResolveFingerprintStrategyTest(TaskTestBase):
     class EmptyTask(Task):
         @classmethod

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
@@ -5,6 +5,8 @@ import os
 import zipfile
 from contextlib import contextmanager
 
+import pytest
+
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.ivy_imports import IvyImports
@@ -15,6 +17,7 @@ from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants.util.contextutil import open_zip, temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class IvyImportsTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -5,6 +5,8 @@ import glob
 import os
 from contextlib import contextmanager
 
+import pytest
+
 from pants.backend.jvm.ivy_utils import IvyInfo, IvyModule, IvyModuleRef, IvyResolveResult
 from pants.backend.jvm.subsystems.jar_dependency_management import (
     JarDependencyManagement,
@@ -31,6 +33,7 @@ def strip_workdir(dir, classpath):
     return [(conf, path[len(dir) :]) for conf, path in classpath]
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class IvyResolveTest(NailgunTaskTestBase):
     """Tests for the class IvyResolve."""
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_create.py
@@ -5,6 +5,8 @@ import os
 from contextlib import closing
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
@@ -50,6 +52,7 @@ class JarCreateTestBase(JarTaskTestBase):
         init_subsystem(Target.Arguments)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JarCreateMiscTest(JarCreateTestBase):
     def test_jar_create_init(self):
         self.create_task(self.context(), "/tmp/workdir")
@@ -62,6 +65,7 @@ class JarCreateMiscTest(JarCreateTestBase):
             self.assertFalse(is_jvm_library(target))
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JarCreateExecuteTest(JarCreateTestBase):
     def java_library(self, path, name, sources, dependencies=None):
         return self.create_library(

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -6,6 +6,8 @@ import re
 from contextlib import contextmanager
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jar_task import JarBuilderTask, JarTask
@@ -49,6 +51,7 @@ class BaseJarTaskTest(JarTaskTestBase):
         )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JarTaskTest(BaseJarTaskTest):
     MAX_SUBPROC_ARGS = 50
 
@@ -233,6 +236,7 @@ class JarTaskTest(BaseJarTaskTest):
                     self.assert_listing(jar, "e/", "e/f")
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JarBuilderTest(BaseJarTaskTest):
     class TestJarBuilderTask(JarBuilderTask):
         def execute(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -6,6 +6,8 @@ import subprocess
 from contextlib import contextmanager
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.subsystems.junit import JUnit
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -31,6 +33,7 @@ from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import touch
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class JUnitRunnerTest(JvmToolTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_nailgun_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_nailgun_task.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -14,6 +16,7 @@ from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class NailgunTaskTest(JvmToolTaskTestBase):
     class DetermineJavaCwd(NailgunTask):
         def execute(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -3,12 +3,15 @@
 
 import re
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.dirutil import read_file
 
 TEST_DIR = "testprojects/src/scala/org/pantsbuild/testproject"
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -4,6 +4,8 @@
 import os
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.scalafmt import Scalafmt
 from pants.backend.jvm.subsystems.scoverage_platform import ScoveragePlatform
@@ -96,6 +98,7 @@ class ScalaFmtTestBase(NailgunTaskTestBase):
         )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
     @classmethod
     def task_type(cls):
@@ -122,6 +125,7 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
         self.execute(context)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ScalaFmtFormatTest(ScalaFmtTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -4,6 +4,8 @@
 import logging
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.scalastyle import Scalastyle
 from pants.backend.jvm.subsystems.scoverage_platform import ScoveragePlatform
@@ -20,6 +22,7 @@ from pants.testutil.task_test_base import ensure_cached
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ScalastyleTest(NailgunTaskTestBase):
     """Tests for the class Scalastyle."""
 

--- a/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class BackendIndependenceTest(PantsRunIntegrationTest):
     """Verifies that this backend works with no other backends present."""
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -7,6 +7,8 @@ import textwrap
 from contextlib import contextmanager
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.junit import JUnit
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -38,6 +40,7 @@ from pants.util.dirutil import chmod_plus_x, safe_open
 from pants.util.osutil import get_os_name, normalize_os_name
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ExportTest(ConsoleTaskTestBase):
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -8,6 +8,8 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock
 from zipfile import ZipFile
 
+import pytest
+
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.junit import JUnit
@@ -193,6 +195,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         return runtime_classpath
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ExportDepAsJarTestSuiteOne(ExportDepAsJarTest):
 
     # Version of the scala compiler and libraries used for this test.
@@ -651,6 +654,7 @@ class ExportDepAsJarTestSuiteOne(ExportDepAsJarTest):
         assert dependency_spec in disabled_result["source_dependencies_in_classpath"]
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class ExportDepAsJarTestWithCodegenTargets(ExportDepAsJarTest):
 
     # Version of the scala compiler and libraries used for this test.

--- a/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
+++ b/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
@@ -4,10 +4,13 @@
 import os
 import shutil
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class StrictDepsInvalidationIntegrationTest(PantsRunIntegrationTest):
 
     TEST_SRC = "testprojects/tests/java/org/pantsbuild/testproject/strictdeps"

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -3,11 +3,14 @@
 
 import unittest
 
+import pytest
+
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.testutil.subsystem.util import init_subsystem
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class BootstrapperTest(unittest.TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -3,6 +3,8 @@
 
 import os
 
+import pytest
+
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.java import util
@@ -17,6 +19,7 @@ class DummyRunJavaTask(NailgunTask):
         pass
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9330")
 class SyntheticClasspathTest(NailgunTaskTestBase):
     @classmethod
     def task_type(cls):


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/9330. Until we can fix the underlying issue, which is non-trivial, this allows us to stabilize CI.

We should be careful to avoid landing code that likely impacts any of these tests.