### PR TITLE
Allow registering new target types with the Target API

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -16,14 +16,15 @@ from pants.backend.python.rules import (
     repl,
     run_setup_py,
 )
+from pants.backend.python.rules.targets import PythonBinary, PythonLibrary, PythonTests
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_app import PythonApp
-from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_binary import PythonBinary as PythonBinaryV1
 from pants.backend.python.targets.python_distribution import PythonDistribution
-from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_requirements_file import PythonRequirementsFile
-from pants.backend.python.targets.python_tests import PythonTests
+from pants.backend.python.targets.python_tests import PythonTests as PythonTestsV1
 from pants.backend.python.targets.unpacked_whls import UnpackedWheels
 from pants.backend.python.tasks.build_local_python_distributions import (
     BuildLocalPythonDistributions,
@@ -61,9 +62,9 @@ def build_file_aliases():
     return BuildFileAliases(
         targets={
             PythonApp.alias(): PythonApp,
-            PythonBinary.alias(): PythonBinary,
-            PythonLibrary.alias(): PythonLibrary,
-            PythonTests.alias(): PythonTests,
+            PythonBinaryV1.alias(): PythonBinaryV1,
+            PythonLibraryV1.alias(): PythonLibraryV1,
+            PythonTestsV1.alias(): PythonTestsV1,
             PythonDistribution.alias(): PythonDistribution,
             "python_requirement_library": PythonRequirementLibrary,
             PythonRequirementsFile.alias(): PythonRequirementsFile,
@@ -120,3 +121,7 @@ def rules():
         *run_setup_py.rules(),
         *subprocess_environment.rules(),
     )
+
+
+def targets():
+    return [PythonBinary, PythonLibrary, PythonTests]

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -123,5 +123,5 @@ def rules():
     )
 
 
-def targets():
+def targets2():
     return [PythonBinary, PythonLibrary, PythonTests]

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -7,15 +7,13 @@ from typing import Optional
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.rules.targets import EntryPoint, PythonBinarySources
-from pants.backend.python.rules.targets import targets as python_targets
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.legacy.structs import PythonBinaryAdaptor
-from pants.engine.parser import HydratedStruct
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
-from pants.engine.target import SourcesRequest, SourcesResult, Target, hydrated_struct_to_target
+from pants.engine.target import SourcesRequest, SourcesResult, Target, WrappedTarget
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
 
@@ -48,9 +46,8 @@ class PythonBinaryFields:
 
 @rule
 async def convert_python_binary_target(adaptor: PythonBinaryAdaptor) -> PythonBinaryFields:
-    hydrated_struct = await Get[HydratedStruct](Address, adaptor.address)
-    tgt = hydrated_struct_to_target(hydrated_struct, target_types=python_targets())
-    return PythonBinaryFields.create(tgt)
+    wrapped_tgt = await Get[WrappedTarget](Address, adaptor.address)
+    return PythonBinaryFields.create(wrapped_tgt.target)
 
 
 @rule

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -202,7 +202,3 @@ class PythonLibrary(Target):
 class PythonTests(Target):
     alias: ClassVar = "python_tests"
     core_fields: ClassVar = (*COMMON_PYTHON_FIELDS, PythonTestsSources, Coverage, Timeout)
-
-
-def targets():
-    return [PythonBinary, PythonLibrary, PythonTests]

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/base:specs',
     'src/python/pants/base:validation',
+    'src/python/pants/engine:target',
     'src/python/pants/fs',
     'src/python/pants/option',
     'src/python/pants/source',

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -189,6 +189,10 @@ class BuildConfiguration:
         types]."""
         return self._union_rules
 
+    # NB: We expect the parameter to be Iterable[Type[Target]], but we can't be confident in this
+    # because we pass whatever people put in their `register.py`s to this function; i.e., this is
+    # an impure function that reads from the outside world. So, we use the type hint `Any` and
+    # perform runtime type checking.
     def register_targets(self, targets: Union[typing.Iterable[Type[Target]], Any]) -> None:
         """Registers the given target types."""
         if not isinstance(targets, Iterable):

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -16,7 +16,7 @@ from pants.engine.rules import RuleIndex
 from pants.engine.target import Target
 from pants.option.optionable import Optionable
 from pants.util.memo import memoized_method
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.ordered_set import OrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class BuildConfiguration:
     _optionables: OrderedSet = field(default_factory=OrderedSet)
     _rules: OrderedSet = field(default_factory=OrderedSet)
     _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
-    _targets: FrozenOrderedSet[Type[Target]] = field(default_factory=FrozenOrderedSet)
+    _targets: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
 
     class ParseState(namedtuple("ParseState", ["parse_context", "parse_globals"])):
         @property
@@ -209,9 +209,9 @@ class BuildConfiguration:
                 "Every element of the entrypoint `targets` must be a subclass of "
                 f"{Target.__name__}. Bad elements: {bad_elements}."
             )
-        self._targets = FrozenOrderedSet(sorted(targets, key=lambda target_type: target_type.alias))
+        self._targets.update(targets)
 
-    def targets(self) -> FrozenOrderedSet[Type[Target]]:
+    def targets(self) -> OrderedSet[Type[Target]]:
         return self._targets
 
     @memoized_method

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -2,19 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+import typing
 from collections import namedtuple
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Dict, Type
+from typing import Any, Dict, Type, Union
 
 from pants.base.parse_context import ParseContext
 from pants.build_graph.addressable import AddressableCallProxy
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target_addressable import TargetAddressable
 from pants.engine.rules import RuleIndex
+from pants.engine.target import Target
 from pants.option.optionable import Optionable
 from pants.util.memo import memoized_method
-from pants.util.ordered_set import OrderedSet
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,7 @@ class BuildConfiguration:
     _optionables: OrderedSet = field(default_factory=OrderedSet)
     _rules: OrderedSet = field(default_factory=OrderedSet)
     _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
+    _targets: FrozenOrderedSet[Type[Target]] = field(default_factory=FrozenOrderedSet)
 
     class ParseState(namedtuple("ParseState", ["parse_context", "parse_globals"])):
         @property
@@ -185,6 +188,27 @@ class BuildConfiguration:
         """Returns a mapping of registered union base types -> [OrderedSet of union member
         types]."""
         return self._union_rules
+
+    def register_targets(self, targets: Union[typing.Iterable[Type[Target]], Any]) -> None:
+        """Registers the given target types."""
+        if not isinstance(targets, Iterable):
+            raise TypeError(
+                f"The entrypoint `targets` must return an iterable. Given {repr(targets)}"
+            )
+        bad_elements = [
+            tgt_type
+            for tgt_type in targets
+            if not isinstance(tgt_type, type) or not issubclass(tgt_type, Target)
+        ]
+        if bad_elements:
+            raise TypeError(
+                "Every element of the entrypoint `targets` must be a subclass of "
+                f"{Target.__name__}. Bad elements: {bad_elements}."
+            )
+        self._targets = FrozenOrderedSet(sorted(targets, key=lambda target_type: target_type.alias))
+
+    def targets(self) -> FrozenOrderedSet[Type[Target]]:
+        return self._targets
 
     @memoized_method
     def _get_addressable_factory(self, target_type, alias):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -17,7 +17,6 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.selectors import Get
 from pants.util.collections import ensure_str_list
@@ -378,6 +377,36 @@ class Target(ABC):
         return True
 
 
+@dataclass(frozen=True)
+class WrappedTarget:
+    """A light wrapper to encapsulate all the distinct `Target` subclasses into a single type.
+
+    This is necessary when using a single target in a rule because the engine expects exact types
+    and does not work with subtypes.
+    """
+
+    target: Target
+
+
+@dataclass(frozen=True)
+class RegisteredTargetTypes:
+    # TODO: add `FrozenDict` as a light-weight wrapper around `dict` that de-registers the
+    #  mutation entry points.
+    aliases_to_types: Dict[str, Type[Target]]
+
+    @classmethod
+    def create(cls, target_types: Iterable[Type[Target]]) -> "RegisteredTargetTypes":
+        return cls({target_type.alias: target_type for target_type in target_types})
+
+    @property
+    def aliases(self) -> Tuple[str, ...]:
+        return tuple(self.aliases_to_types.keys())
+
+    @property
+    def types(self) -> Tuple[Type[Target], ...]:
+        return tuple(self.aliases_to_types.values())
+
+
 # TODO: add light-weight runtime type checking to these helper fields, such as ensuring that
 # the raw_value of `BoolField` is in fact a `bool` and not an int or str. Use `instanceof`. All
 # the types are primitive objects like `str` and `int`, so this should be performant and easy to
@@ -533,50 +562,6 @@ async def hydrate_sources(
     )
     sources_field.validate_snapshot(snapshot)
     return SourcesResult(snapshot)
-
-
-# TODO: move this conversion into a rule. Create a singleton to access all the registered
-#  targets (or maybe just use unions). Consider having that singleton be a dict from alias ->
-#  Target for efficient lookups (we're guaranteed only one alias per target type).
-def hydrated_struct_to_target(
-    hydrated_struct: HydratedStruct, *, target_types: Iterable[Type[Target]]
-) -> Target:
-    kwargs = hydrated_struct.value.kwargs().copy()
-    type_alias = kwargs.pop("type_alias")
-
-    # We special case `address` and the field `name`. The `Target` constructor requires an
-    # `Address`, so we use the value pre-calculated via `build_files.py`'s `hydrate_struct` rule.
-    # We throw away the field `name` because it can be accessed via `tgt.address.target_name`, so
-    # there is no (known) reason to preserve the field and it's slightly tricky to get the default
-    # value correct for the field.
-    address = cast(Address, kwargs.pop("address"))
-    kwargs.pop("name", None)
-
-    # We convert `source` into `sources` because the Target API has no `Source` field, only
-    # `Sources`.
-    if "source" in kwargs and "sources" in kwargs:
-        raise TargetDefinitionException(
-            address, "Cannot specify both `source` and `sources` fields."
-        )
-    if "source" in kwargs:
-        source = kwargs.pop("source")
-        if not isinstance(source, str):
-            raise TargetDefinitionException(
-                address,
-                f"The `source` field must be a string containing a path relative to the target, "
-                f"but got {source} of type {type(source)}.",
-            )
-        kwargs["sources"] = [source]
-
-    aliases_to_target_types = {target_type.alias: target_type for target_type in target_types}
-    target_type = aliases_to_target_types.get(type_alias, None)
-    if target_type is None:
-        raise TargetDefinitionException(
-            address,
-            f"Target type {type_alias} is not recognized. All valid target types: "
-            f"{sorted(aliases_to_target_types.keys())}.",
-        )
-    return target_type(kwargs, address=address)
 
 
 def rules():

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -434,7 +434,12 @@ class RegisteredTargetTypes:
 
     @classmethod
     def create(cls, target_types: Iterable[Type[Target]]) -> "RegisteredTargetTypes":
-        return cls({target_type.alias: target_type for target_type in target_types})
+        return cls(
+            {
+                target_type.alias: target_type
+                for target_type in sorted(target_types, key=lambda target_type: target_type.alias)
+            }
+        )
 
     @property
     def aliases(self) -> Tuple[str, ...]:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -56,6 +56,7 @@ from pants.engine.platform import create_platform_rules
 from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.scheduler import Scheduler, SchedulerSession
 from pants.engine.selectors import Params
+from pants.engine.target import RegisteredTargetTypes
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import (
     DEFAULT_EXECUTION_OPTIONS,
@@ -369,6 +370,10 @@ class EngineInitializer:
 
         symbol_table = _legacy_symbol_table(build_file_aliases)
 
+        # TODO: register this with the SymbolTable/LegacyPythonCallbacksParser so that the aliases
+        #  exposed by the Target API are interpreted correctly.
+        registered_target_types = RegisteredTargetTypes.create(build_configuration.targets())
+
         execution_options = execution_options or DEFAULT_EXECUTION_OPTIONS
 
         # Register "literal" subjects required for these rules.
@@ -395,6 +400,10 @@ class EngineInitializer:
             return symbol_table
 
         @rule
+        def registered_target_types_singleton() -> RegisteredTargetTypes:
+            return registered_target_types
+
+        @rule
         def union_membership_singleton() -> UnionMembership:
             return UnionMembership(build_configuration.union_rules())
 
@@ -409,6 +418,7 @@ class EngineInitializer:
             glob_match_error_behavior_singleton,
             build_configuration_singleton,
             symbol_table_singleton,
+            registered_target_types_singleton,
             union_membership_singleton,
             build_root_singleton,
             *create_legacy_graph_tasks(),

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -138,8 +138,8 @@ def load_plugins(
             if "build_file_aliases2" in entries:
                 build_file_aliases2 = entries["build_file_aliases2"].load()()
                 build_configuration.register_aliases(build_file_aliases2)
-            if "targets" in entries:
-                targets = entries["targets"].load()()
+            if "targets2" in entries:
+                targets = entries["targets2"].load()()
                 build_configuration.register_targets(targets)
         loaded[dist.as_requirement().key] = dist
 
@@ -208,7 +208,7 @@ def load_backend(
         rules = invoke_entrypoint("rules")
         if rules:
             build_configuration.register_rules(rules)
-        targets = invoke_entrypoint("targets")
+        targets = invoke_entrypoint("targets2")
         if targets:
             build_configuration.register_targets(targets)
         build_file_aliases2 = invoke_entrypoint("build_file_aliases2")

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -123,15 +123,11 @@ def load_plugins(
         if is_v1_plugin:
             if "register_goals" in entries:
                 entries["register_goals"].load()()
-
-            # TODO: Might v2 plugins need to register global subsystems? Hopefully not.
             if "global_subsystems" in entries:
                 subsystems = entries["global_subsystems"].load()()
                 build_configuration.register_optionables(subsystems)
-
-            # The v2 target API is still TBD, so we keep build_file_aliases as a v1-only thing.
-            # Having thus no overlap between v1 and v2 backend entrypoints makes things much simpler.
-            # TODO: Revisit, ideally with a v2-only entry point, once the v2 target API is a thing.
+            # For now, `build_file_aliases` is still V1-only. TBD what entry-point we use for
+            # `objects` and `context_aware_object_factories`.
             if "build_file_aliases" in entries:
                 aliases = entries["build_file_aliases"].load()()
                 build_configuration.register_aliases(aliases)
@@ -142,6 +138,9 @@ def load_plugins(
             if "build_file_aliases2" in entries:
                 build_file_aliases2 = entries["build_file_aliases2"].load()()
                 build_configuration.register_aliases(build_file_aliases2)
+            if "targets" in entries:
+                targets = entries["targets"].load()()
+                build_configuration.register_targets(targets)
         loaded[dist.as_requirement().key] = dist
 
 
@@ -197,15 +196,11 @@ def load_backend(
 
     if is_v1_backend:
         invoke_entrypoint("register_goals")
-
-        # TODO: Might v2 plugins need to register global subsystems? Hopefully not.
         subsystems = invoke_entrypoint("global_subsystems")
         if subsystems:
             build_configuration.register_optionables(subsystems)
-
-        # The v2 target API is still TBD, so we keep build_file_aliases as a v1-only thing.
-        # Having thus no overlap between v1 and v2 backend entrypoints makes things much simpler.
-        # TODO: Revisit, ideally with a v2-only entry point, once the v2 target API is a thing.
+        # For now, `build_file_aliases` is still V1-only. TBD what entry-point we use for
+        # `objects` and `context_aware_object_factories`.
         build_file_aliases = invoke_entrypoint("build_file_aliases")
         if build_file_aliases:
             build_configuration.register_aliases(build_file_aliases)
@@ -213,6 +208,9 @@ def load_backend(
         rules = invoke_entrypoint("rules")
         if rules:
             build_configuration.register_rules(rules)
+        targets = invoke_entrypoint("targets")
+        if targets:
+            build_configuration.register_targets(targets)
         build_file_aliases2 = invoke_entrypoint("build_file_aliases2")
         if build_file_aliases2:
             build_configuration.register_aliases(build_file_aliases2)

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -265,6 +265,7 @@ class TestArtifactCache(TestBase):
                 call_insert((cache, key, [path], False))
                 self.assertFalse(call_use_cached_files((cache, key, None)))
 
+    @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
     def test_noops_after_max_retries_exceeded(self):
         key = CacheKey("muppet_key", "fake_hash")
 


### PR DESCRIPTION
## Problem 1: registering new target types

We need a light-weight mechanism for plugin authors to register new target types in their `register.py`.

In V1, you do this:

```python
def build_file_aliases():
    return BuildFileAliases(
        targets={
            PythonBinary.alias(): PythonBinary,
            PythonLibrary.alias(): PythonLibrary,
            PythonTests.alias(): PythonTests,
        },
```

Instead, the Target API registration is much lighter weight:

```python
def targets2():
    return [PythonBinary, PythonLibrary, PythonTests]
```

We use `targets2()` to retain flexibility in the case that we want to change this endpoint.

It's not yet clear how `objects` and `context_aware_object_factories` should be registered. That is punted on for now. Those are much less common than registering a `Target`, so the registration of a `Target` should not be made more difficult/clunky to accommodate `objects`.

### Deferred problem: registering the alias with the Parser

In a followup, we will replace the explicit registration of symbols like `python_library` in `engine_initializer.py` with instead dynamic registration of symbols based on all the registered Target types.

## Problem 2: Allow rules to request all registered target types

We need a singleton for rules to get all the registered target types. For example, we need this to  convert a `HydratedStruct -> Target` so that we know which `Target` subclass to use.

A simple singleton would return `FrozenOrderedSet[Type[Target]]`. But, a very common pattern is to want to be able to quickly map from `alias -> target type`; for example, we need this mapping to efficiently know how to convert `HydratedStruct` into a `Target` subclass.

So, we add a new `RegisteredFieldTypes` dataclass which is a light wrapper around a dictionary of `alias -> target type`. We use properties to allow call sites to very easily (and performantly) get all aliases and/or get all target types.

## Result

We have a new rule to go from `HydratedStruct -> Target`. `python_create_binary.py` now exclusively uses the engine to go from `Address -> PythonBinary -> PythonBinaryFields`.