### PR TITLE
Allow stripping source roots from a `Sources` field

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -15,9 +15,9 @@ from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
-from pants.engine.target import SourcesRequest, SourcesResult, Target, hydrated_struct_to_target
+from pants.engine.target import Target, hydrated_struct_to_target
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
+from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripSourcesFieldRequest
 
 
 # TODO: consider replacing this with sugar like `SelectFields(EntryPoint, PythonBinarySources)` so
@@ -59,11 +59,8 @@ async def create_python_binary(fields: PythonBinaryFields) -> CreatedBinary:
     if fields.entry_point.value is not None:
         entry_point = fields.entry_point.value
     else:
-        # TODO: rework determine_source_files.py to work with the Target API. It should take the
-        #  Sources AsyncField as input, rather than TargetAdaptor.
-        sources_result = await Get[SourcesResult](SourcesRequest, fields.sources.request)
         stripped_sources = await Get[SourceRootStrippedSources](
-            StripSnapshotRequest(sources_result.snapshot)
+            StripSourcesFieldRequest(fields.sources)
         )
         source_files = stripped_sources.snapshot.files
         # NB: `PythonBinarySources` enforces that we have 0-1 sources.

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -55,7 +55,10 @@ from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.distdir import DistDir
-from pants.rules.core.strip_source_roots import LegacyStripTargetRequest, SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import (
+    LegacySourceRootStrippedSources,
+    LegacyStripTargetRequest,
+)
 from pants.source.source_root import SourceRootConfig
 
 logger = logging.getLogger(__name__)
@@ -448,7 +451,7 @@ async def get_sources(
 ) -> SetupPySources:
     targets = request.hydrated_targets
     stripped_srcs_list = await MultiGet(
-        Get[SourceRootStrippedSources](LegacyStripTargetRequest(target.adaptor))
+        Get[LegacySourceRootStrippedSources](LegacyStripTargetRequest(target.adaptor))
         for target in targets
     )
 

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -55,7 +55,7 @@ from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.distdir import DistDir
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripTargetRequest
+from pants.rules.core.strip_source_roots import LegacyStripTargetRequest, SourceRootStrippedSources
 from pants.source.source_root import SourceRootConfig
 
 logger = logging.getLogger(__name__)
@@ -448,7 +448,8 @@ async def get_sources(
 ) -> SetupPySources:
     targets = request.hydrated_targets
     stripped_srcs_list = await MultiGet(
-        Get[SourceRootStrippedSources](StripTargetRequest(target.adaptor)) for target in targets
+        Get[SourceRootStrippedSources](LegacyStripTargetRequest(target.adaptor))
+        for target in targets
     )
 
     # Create a chroot with all the sources, and any ancestor __init__.py files that might be needed

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -40,8 +40,8 @@ from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.python.python_requirement import PythonRequirement
 from pants.rules.core.strip_source_roots import (
+    legacy_strip_source_roots_from_target,
     strip_source_roots_from_snapshot,
-    strip_source_roots_from_target,
 )
 from pants.source.source_root import SourceRootConfig
 from pants.testutil.subsystem.util import init_subsystem
@@ -69,7 +69,7 @@ class TestGenerateChroot(TestSetupPyBase):
             get_sources,
             get_requirements,
             strip_source_roots_from_snapshot,
-            strip_source_roots_from_target,
+            legacy_strip_source_roots_from_target,
             get_ancestor_init_py,
             get_owned_dependencies,
             get_exporting_owner,
@@ -191,7 +191,7 @@ class TestGetSources(TestSetupPyBase):
         return super().rules() + [
             get_sources,
             strip_source_roots_from_snapshot,
-            strip_source_roots_from_target,
+            legacy_strip_source_roots_from_target,
             get_ancestor_init_py,
             RootRule(SetupPySourcesRequest),
             RootRule(SourceRootConfig),

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -14,7 +14,7 @@ from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
 from pants.engine.rules import RootRule
 from pants.engine.scheduler import ExecutionError
-from pants.engine.target import SourcesRequest, SourcesResult
+from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import rules as target_rules
 from pants.testutil.test_base import TestBase
 
@@ -33,7 +33,7 @@ class TestPythonSources(TestBase):
 
     @classmethod
     def rules(cls):
-        return [*target_rules(), RootRule(SourcesRequest)]
+        return [*target_rules(), RootRule(HydrateSourcesRequest)]
 
     def test_python_sources_validation(self) -> None:
         files = ("f.js", "f.hs", "f.txt", "f.py")
@@ -41,41 +41,43 @@ class TestPythonSources(TestBase):
         sources = PythonSources(files, address=Address.parse(":lib"))
         assert sources.sanitized_raw_value == files
         with pytest.raises(ExecutionError) as exc:
-            self.request_single_product(SourcesResult, sources.request)
+            self.request_single_product(HydratedSources, sources.request)
         assert "f.hs" in str(exc)
 
         # Also check that we support valid sources
         valid_sources = PythonSources(["f.py"], address=Address.parse(":lib"))
         assert valid_sources.sanitized_raw_value == ("f.py",)
-        assert self.request_single_product(SourcesResult, valid_sources.request).snapshot.files == (
-            "f.py",
-        )
+        assert self.request_single_product(
+            HydratedSources, valid_sources.request
+        ).snapshot.files == ("f.py",)
 
     def test_python_binary_sources_validation(self) -> None:
         self.create_files(path="", files=["f1.py", "f2.py"])
         address = Address.parse(":binary")
 
         zero_sources = PythonBinarySources(None, address=address)
-        assert self.request_single_product(SourcesResult, zero_sources.request).snapshot.files == ()
+        assert (
+            self.request_single_product(HydratedSources, zero_sources.request).snapshot.files == ()
+        )
 
         one_source = PythonBinarySources(["f1.py"], address=address)
-        assert self.request_single_product(SourcesResult, one_source.request).snapshot.files == (
+        assert self.request_single_product(HydratedSources, one_source.request).snapshot.files == (
             "f1.py",
         )
 
         multiple_sources = PythonBinarySources(["f1.py", "f2.py"], address=address)
         with pytest.raises(ExecutionError) as exc:
-            self.request_single_product(SourcesResult, multiple_sources.request)
+            self.request_single_product(HydratedSources, multiple_sources.request)
         assert "has 2 sources" in str(exc)
 
     def test_python_library_sources_default_globs(self) -> None:
         self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
         sources = PythonLibrarySources(None, address=Address.parse(":lib"))
-        result = self.request_single_product(SourcesResult, sources.request)
+        result = self.request_single_product(HydratedSources, sources.request)
         assert result.snapshot.files == self.PYTHON_SRC_FILES
 
     def test_python_tests_sources_default_globs(self) -> None:
         self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
         sources = PythonTestsSources(None, address=Address.parse(":tests"))
-        result = self.request_single_product(SourcesResult, sources.request)
+        result = self.request_single_product(HydratedSources, sources.request)
         assert set(result.snapshot.files) == set(self.PYTHON_TEST_FILES)

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -10,7 +10,7 @@ from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core import strip_source_roots
-from pants.rules.core.strip_source_roots import SourceRootStrippedSources, StripTargetRequest
+from pants.rules.core.strip_source_roots import LegacyStripTargetRequest, SourceRootStrippedSources
 from pants.util.meta import frozen_after_init
 
 
@@ -57,7 +57,7 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
     """Merge all the `sources` for targets into one snapshot."""
     if request.strip_source_roots:
         stripped_snapshots = await MultiGet(
-            Get[SourceRootStrippedSources](StripTargetRequest(adaptor))
+            Get[SourceRootStrippedSources](LegacyStripTargetRequest(adaptor))
             for adaptor in request.adaptors
         )
         input_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
@@ -117,7 +117,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
         all_adaptors = (*full_snapshots.keys(), *snapshot_subset_requests.keys())
         stripped_snapshots = await MultiGet(
             Get[SourceRootStrippedSources](
-                StripTargetRequest(adaptor, specified_files_snapshot=snapshot)
+                LegacyStripTargetRequest(adaptor, specified_files_snapshot=snapshot)
             )
             for adaptor, snapshot in zip(all_adaptors, all_snapshots)
         )

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -10,7 +10,10 @@ from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core import strip_source_roots
-from pants.rules.core.strip_source_roots import LegacyStripTargetRequest, SourceRootStrippedSources
+from pants.rules.core.strip_source_roots import (
+    LegacySourceRootStrippedSources,
+    LegacyStripTargetRequest,
+)
 from pants.util.meta import frozen_after_init
 
 
@@ -57,7 +60,7 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
     """Merge all the `sources` for targets into one snapshot."""
     if request.strip_source_roots:
         stripped_snapshots = await MultiGet(
-            Get[SourceRootStrippedSources](LegacyStripTargetRequest(adaptor))
+            Get[LegacySourceRootStrippedSources](LegacyStripTargetRequest(adaptor))
             for adaptor in request.adaptors
         )
         input_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
@@ -116,7 +119,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
     if request.strip_source_roots:
         all_adaptors = (*full_snapshots.keys(), *snapshot_subset_requests.keys())
         stripped_snapshots = await MultiGet(
-            Get[SourceRootStrippedSources](
+            Get[LegacySourceRootStrippedSources](
                 LegacyStripTargetRequest(adaptor, specified_files_snapshot=snapshot)
             )
             for adaptor, snapshot in zip(all_adaptors, all_snapshots)

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -17,6 +17,7 @@ from pants.rules.core import (
     strip_source_roots,
     test,
 )
+from pants.rules.core.targets import Files
 
 
 def rules():
@@ -36,3 +37,7 @@ def rules():
         *test.rules(),
         *target_rules(),
     ]
+
+
+def targets():
+    return [Files]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -22,6 +22,7 @@ from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
+from pants.engine.target import rules as target_rules
 from pants.rules.core.targets import FilesSources
 from pants.source.source_root import NoSourceRootError, SourceRootConfig
 
@@ -208,6 +209,7 @@ def rules():
         subsystem_rule(SourceRootConfig),
         RootRule(StripSnapshotRequest),
         RootRule(StripSourcesFieldRequest),
+        *target_rules(),
         legacy_strip_source_roots_from_target,
         RootRule(LegacyStripTargetRequest),
     ]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -44,7 +44,7 @@ class StripSnapshotRequest:
 
 
 @dataclass(frozen=True)
-class StripTargetRequest:
+class LegacyStripTargetRequest:
     """A request to strip source roots for every file in a target's `sources` field.
 
     The call site may optionally give a snapshot to `specified_files_snapshot` to only strip a
@@ -112,7 +112,9 @@ async def strip_source_roots_from_snapshot(
 
 
 @rule
-async def strip_source_roots_from_target(request: StripTargetRequest,) -> SourceRootStrippedSources:
+async def legacy_strip_source_roots_from_target(
+    request: LegacyStripTargetRequest,
+) -> SourceRootStrippedSources:
     """Remove source roots from a target, e.g. `src/python/pants/util/strutil.py` ->
     `pants/util/strutil.py`."""
     target_adaptor = request.adaptor
@@ -140,8 +142,8 @@ async def strip_source_roots_from_target(request: StripTargetRequest,) -> Source
 def rules():
     return [
         strip_source_roots_from_snapshot,
-        strip_source_roots_from_target,
+        legacy_strip_source_roots_from_target,
         subsystem_rule(SourceRootConfig),
-        RootRule(StripTargetRequest),
+        RootRule(LegacyStripTargetRequest),
         RootRule(StripSnapshotRequest),
     ]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -20,8 +20,8 @@ from pants.engine.fs import (
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
+from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
-from pants.engine.target import SourcesRequest, SourcesResult
 from pants.rules.core.targets import FilesSources
 from pants.source.source_root import NoSourceRootError, SourceRootConfig
 
@@ -130,8 +130,10 @@ async def strip_source_roots_from_sources_field(
     if request.specified_files_snapshot is not None:
         sources_snapshot = request.specified_files_snapshot
     else:
-        sources_result = await Get[SourcesResult](SourcesRequest, request.sources_field.request)
-        sources_snapshot = sources_result.snapshot
+        hydrated_sources = await Get[HydratedSources](
+            HydrateSourcesRequest, request.sources_field.request
+        )
+        sources_snapshot = hydrated_sources.snapshot
 
     if not sources_snapshot.files:
         return SourceRootStrippedSources(EMPTY_SNAPSHOT)

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pathlib import PurePath
-from typing import List, Optional, Union
+from typing import List, Optional, Type, Union
 from unittest.mock import Mock
 
 import pytest
@@ -12,13 +12,17 @@ from pants.build_graph.files import Files
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
+from pants.engine.target import Sources as SourcesField
+from pants.engine.target import rules as target_rules
 from pants.rules.core.strip_source_roots import (
     LegacySourceRootStrippedSources,
     LegacyStripTargetRequest,
     SourceRootStrippedSources,
     StripSnapshotRequest,
+    StripSourcesFieldRequest,
 )
 from pants.rules.core.strip_source_roots import rules as strip_source_root_rules
+from pants.rules.core.targets import FilesSources
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
@@ -29,17 +33,18 @@ class StripSourceRootsTest(TestBase):
         return (
             *super().rules(),
             *strip_source_root_rules(),
+            *target_rules(),
         )
 
     def get_stripped_files(
         self,
-        request: Union[StripSnapshotRequest, LegacyStripTargetRequest],
+        request: Union[StripSnapshotRequest, StripSourcesFieldRequest, LegacyStripTargetRequest],
         *,
         args: Optional[List[str]] = None,
     ) -> List[str]:
         product = (
             SourceRootStrippedSources
-            if isinstance(request, StripSnapshotRequest)
+            if not isinstance(request, LegacyStripTargetRequest)
             else LegacySourceRootStrippedSources
         )
         result = self.request_single_product(
@@ -92,7 +97,54 @@ class StripSourceRootsTest(TestBase):
             get_stripped_files_for_snapshot(file_names, use_representative_path=False)
         ) == sorted(["project/example.py", "com/project/example.java"])
 
-    def test_strip_target(self) -> None:
+    def test_strip_sources_field(self) -> None:
+        source_root = "src/python/project"
+
+        def get_stripped_files_for_sources_field(
+            *,
+            source_files: Optional[List[str]],
+            sources_field_cls: Type[SourcesField] = SourcesField,
+            specified_source_files: Optional[List[str]] = None,
+        ) -> List[str]:
+            if source_files:
+                self.create_files(path=source_root, files=source_files)
+            sources_field = sources_field_cls(
+                source_files, address=Address.parse(f"{source_root}:lib")
+            )
+            specified_sources_snapshot = (
+                None
+                if not specified_source_files
+                else self.make_snapshot_of_empty_files(
+                    f"{source_root}/{f}" for f in specified_source_files
+                )
+            )
+            return self.get_stripped_files(
+                StripSourcesFieldRequest(
+                    sources_field, specified_files_snapshot=specified_sources_snapshot,
+                )
+            )
+
+        # normal sources
+        assert get_stripped_files_for_sources_field(source_files=["f1.py", "f2.py"]) == sorted(
+            ["project/f1.py", "project/f2.py"]
+        )
+
+        # empty sources
+        assert get_stripped_files_for_sources_field(source_files=None) == []
+
+        # FilesSources is not stripped
+        assert get_stripped_files_for_sources_field(
+            source_files=["f1.py"], sources_field_cls=FilesSources,
+        ) == [f"{source_root}/f1.py"]
+
+        # When given `specified_files_snapshot`, only strip what is specified, even if that snapshot
+        # has files not belonging to the corresponding Sources field! (Validation of ownership
+        # would have a performance cost.)
+        assert get_stripped_files_for_sources_field(
+            source_files=["f1.py"], specified_source_files=["f1.py", "different_owner.py"],
+        ) == sorted(["project/f1.py", "project/different_owner.py"])
+
+    def test_legacy_strip_target(self) -> None:
         def get_stripped_files_for_target(
             *,
             source_paths: Optional[List[str]],

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -13,9 +13,9 @@ from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.rules.core.strip_source_roots import (
+    LegacyStripTargetRequest,
     SourceRootStrippedSources,
     StripSnapshotRequest,
-    StripTargetRequest,
 )
 from pants.rules.core.strip_source_roots import rules as strip_source_root_rules
 from pants.testutil.option.util import create_options_bootstrapper
@@ -32,7 +32,7 @@ class StripSourceRootsTest(TestBase):
 
     def get_stripped_files(
         self,
-        request: Union[StripSnapshotRequest, StripTargetRequest],
+        request: Union[StripSnapshotRequest, LegacyStripTargetRequest],
         *,
         args: Optional[List[str]] = None,
     ) -> List[str]:
@@ -106,7 +106,7 @@ class StripSourceRootsTest(TestBase):
                 else self.make_snapshot_of_empty_files(specified_sources)
             )
             return self.get_stripped_files(
-                StripTargetRequest(
+                LegacyStripTargetRequest(
                     TargetAdaptor(address=address, type_alias=type_alias, sources=sources),
                     specified_files_snapshot=specified_sources_snapshot,
                 )

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -13,7 +13,6 @@ from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.engine.target import Sources as SourcesField
-from pants.engine.target import rules as target_rules
 from pants.rules.core.strip_source_roots import (
     LegacySourceRootStrippedSources,
     LegacyStripTargetRequest,
@@ -30,11 +29,7 @@ from pants.testutil.test_base import TestBase
 class StripSourceRootsTest(TestBase):
     @classmethod
     def rules(cls):
-        return (
-            *super().rules(),
-            *strip_source_root_rules(),
-            *target_rules(),
-        )
+        return (*super().rules(), *strip_source_root_rules())
 
     def get_stripped_files(
         self,

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -13,6 +13,7 @@ from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.rules.core.strip_source_roots import (
+    LegacySourceRootStrippedSources,
     LegacyStripTargetRequest,
     SourceRootStrippedSources,
     StripSnapshotRequest,
@@ -36,8 +37,13 @@ class StripSourceRootsTest(TestBase):
         *,
         args: Optional[List[str]] = None,
     ) -> List[str]:
+        product = (
+            SourceRootStrippedSources
+            if isinstance(request, StripSnapshotRequest)
+            else LegacySourceRootStrippedSources
+        )
         result = self.request_single_product(
-            SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args))
+            product, Params(request, create_options_bootstrapper(args=args)),
         )
         return sorted(result.snapshot.files)
 

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import ClassVar
+
+from pants.engine.target import COMMON_TARGET_FIELDS, Sources, Target
+
+
+class FilesSources(Sources):
+    """Sources for loose files.
+
+    These will not have their source roots stripped, unlike every other Sources subclass.
+    """
+
+
+class Files(Target):
+    """A collection of loose files."""
+
+    core_fields: ClassVar = (*COMMON_TARGET_FIELDS, FilesSources)


### PR DESCRIPTION
### Problem

Currently, we can do either of these calls:

```
await Get[StrippedSourceRootFiles](StripTargetRequest(adaptor))
await Get[StrippedSourceRootFiles](StripSnapshotRequest(snapshot))
```

We will always want `StripSnapshotRequest`, and we must keep support for `StripTargetRequest` for now until `TargetAdaptor` is removed. But, we also need to be able to strip a `Sources` field.

### Solution

Rename `StripTargetRequest` to `LegacyStripTargetRequest`.

Add `StripSourcesFieldRequest`.

### Also changes the naming convention for `AsyncField`s

Previously, we recommended creating types called `SourcesRequest` and `SourcesResult`. See https://github.com/pantsbuild/pants/pull/9306.

However, when using these types in the wild, they ended up being unnatural names. I kept reaching for a name like `HydratedSources`. So, this uses `HydratedSources` and `HydrateSourcesRequest` as names, and changes the general recommended naming scheme.

Beyond the name being more natural and more descriptive, this fits well with Pants' conventions of using the term `hydrated`, e.g. `HydratedTarget`, `HydrateableField`, and `HydratedField`.