### PR TITLE
Add `Target.maybe_get()`

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -30,10 +30,10 @@ class PythonBinaryFields:
     sources: PythonBinarySources
     entry_point: EntryPoint
 
-    # TODO: consume the other PythonBinary fields like `ZipSafe`. Consider making those fields
-    #  optional. We _need_ PythonBinarySources and EntryPoint to work properly. If your target
-    #  type also has ZipSafe, AlwaysWriteCache, etc, then we can do some additional things as an
-    #  extra bonus. Consider adding `Target.maybe_get()` to facilitate this.
+    # TODO: consume the other PythonBinary fields like `ZipSafe` and `AlwaysWriteCache`. These are
+    #  optional fields. If your target type has them registered, we can do extra meaningful things;
+    #  if you don't have them on your target type, we can still operate so long as you have the
+    #  required fields. Use `Target.maybe_get()` in the `create()` method.
 
     @staticmethod
     def is_valid_target(tgt: Target) -> bool:

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -37,6 +37,11 @@ class HaskellGhcExtensions(PrimitiveField):
         return tuple(raw_value)
 
 
+class UnrelatedField(BoolField):
+    alias: ClassVar = "unrelated"
+    default: ClassVar = False
+
+
 class HaskellSources(AsyncField):
     alias: ClassVar = "sources"
     sanitized_raw_value: Optional[Tuple[str, ...]]
@@ -149,13 +154,15 @@ def test_get_async_field() -> None:
     assert "//:lib" in str(exc)
 
 
+def test_maybe_get_field() -> None:
+    tgt = HaskellTarget({}, address=Address.parse(":lib"))
+    assert tgt.get(HaskellGhcExtensions) == tgt.maybe_get(HaskellGhcExtensions)
+    assert tgt.get(HaskellSources) == tgt.maybe_get(HaskellSources)
+    assert tgt.maybe_get(UnrelatedField) is None
+
+
 def test_has_fields() -> None:
-    class UnrelatedField(BoolField):
-        alias: ClassVar = "unrelated"
-        default: ClassVar = False
-
     empty_union_membership = UnionMembership({})
-
     tgt = HaskellTarget({}, address=Address.parse(":lib"))
     assert tgt.has_fields([]) is True
     assert HaskellTarget.class_has_fields([], union_membership=empty_union_membership) is True


### PR DESCRIPTION
### Problem

Soon, we will port `./v2 test` to use the Target API. For Pytest, the only field that we absolutely must have is `PythonTestsSources`. 

It's an added bonus if the target type has `Timeout` and `Coverage`. Even if they don't have those fields registered, we can still meaningfully return a `TestResult`. We simply can't use the added features of `--run-coverage` and `--pytest-timeouts`.

This pattern appears frequently beyond `./v2 test`. For example, `./v2 binary` can do extra information if the target type has the field `ZipSafe` registered, but we don't strictly need that field to operate.

### Solution

Add `Target.maybe_get()` to complement `Target.get()`.

Why not always use `Target.maybe_get()`? It's often clunky to have to unpack an `Optional[X]`. If the user already called `Target.has_field()`, then it's redundant to have to unwrap the `Optional`.

### Result

We more accurately reflect in rules what fields we actually must have vs. would like to have.

A crucial side effect of this change is that it makes it much easier for core Pants devs to add new `Fields` to pre-existing target types and to consume those fields in core Pants without forcing all plugin authors to implement that field.

For example, we may want to add the field `RequirementsConstraints` to `PythonBinary` one day and use that in `python_create_binary.py` if we have that field registered, but still be able to operate on target types without it. This PR provides a mechanism for us to not only add that new field, but express in `python_create_binary.py` that we would like to use that field if it's available, without breaking any plugin authors.