### PR TITLE
Make LocalPantsRunner a dataclass

### DIFF
--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -15,12 +15,12 @@ class TaskError(Exception):
         :param int exit_code: an optional exit code (defaults to nonzero)
         :param list failed_targets: an optional list of failed targets (default=[])
         """
-        self._exit_code = kwargs.pop("exit_code", PANTS_FAILED_EXIT_CODE)
+        self._exit_code: int = kwargs.pop("exit_code", PANTS_FAILED_EXIT_CODE)
         self._failed_targets = kwargs.pop("failed_targets", [])
         super().__init__(*args, **kwargs)
 
     @property
-    def exit_code(self):
+    def exit_code(self) -> int:
         return self._exit_code
 
     @property

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -140,7 +140,7 @@ class GoalRunnerFactory:
 
             return goals, context
 
-    def create(self):
+    def create(self) -> "GoalRunner":
         goals, context = self._setup_context()
         return GoalRunner(
             context=context,
@@ -182,7 +182,7 @@ class GoalRunner:
         )
         return False
 
-    def _execute_engine(self):
+    def _execute_engine(self) -> int:
         engine = RoundEngine()
         sorted_goal_infos = engine.sort_goals(self._context, self._goals)
         RunTracker.global_instance().set_sorted_goal_infos(sorted_goal_infos)
@@ -193,7 +193,7 @@ class GoalRunner:
 
         return result
 
-    def _run_goals(self):
+    def _run_goals(self) -> int:
         should_kill_nailguns = self._kill_nailguns
 
         try:
@@ -221,7 +221,7 @@ class GoalRunner:
 
         return result
 
-    def run(self):
+    def run(self) -> int:
         global_options = self._context.options.for_global_scope()
 
         if not self._is_valid_workdir(global_options.pants_workdir):

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -142,25 +142,6 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
             )
         return graph_session, graph_session.scheduler_session
 
-    @staticmethod
-    def _maybe_init_specs(
-        specs: Optional[Specs],
-        graph_session: LegacyGraphSession,
-        options: Options,
-        build_root: str,
-    ) -> Specs:
-        if specs:
-            return specs
-
-        global_options = options.for_global_scope()
-        return SpecsCalculator.create(
-            options=options,
-            build_root=build_root,
-            session=graph_session.scheduler_session,
-            exclude_patterns=tuple(global_options.exclude_target_regexp),
-            tags=tuple(global_options.tag),
-        )
-
     @classmethod
     def create(
         cls,
@@ -205,7 +186,15 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
             daemon_graph_session, options_bootstrapper, build_config, options
         )
 
-        specs = cls._maybe_init_specs(specs, graph_session, options, build_root)
+        if specs is None:
+            global_options = options.for_global_scope()
+            specs = SpecsCalculator.create(
+                    options=options,
+                    build_root=build_root,
+                    session=graph_session.scheduler_session,
+                    exclude_patterns=tuple(global_options.exclude_target_regexp),
+                    tags=tuple(global_options.tag),
+                    )
 
         profile_path = env.get("PANTS_PROFILE")
 

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -149,7 +149,7 @@ class RemotePantsRunner:
                 traceback = sys.exc_info()[2]
                 raise self._extract_remote_exception(pantsd_handle.pid, e).with_traceback(traceback)
 
-    def _connect_and_execute(self, pantsd_handle):
+    def _connect_and_execute(self, pantsd_handle: PantsDaemon.Handle):
         port = pantsd_handle.port
         # Merge the nailgun TTY capability environment variables with the passed environment dict.
         ng_env = NailgunProtocol.isatty_to_env(self._stdin, self._stdout, self._stderr)

--- a/src/python/pants/engine/legacy_engine.py
+++ b/src/python/pants/engine/legacy_engine.py
@@ -9,13 +9,13 @@ from pants.base.exceptions import TaskError
 class Engine(ABC):
     """An engine for running a pants command line."""
 
-    def execute(self, context, goals):
+    def execute(self, context, goals) -> int:
         """Executes the supplied goals and their dependencies against the given context.
 
         :param context: The pants run context.
         :param list goals: A list of ``Goal`` objects representing the command line goals explicitly
                            requested.
-        :returns int: An exit code of 0 upon success and non-zero otherwise.
+        :returns an exit code of 0 upon success and non-zero otherwise.
         """
         try:
             self.attempt(context, goals)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -9,7 +9,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
@@ -493,7 +493,7 @@ class SchedulerSession:
                 unique_exceptions,
             )
 
-    def run_goal_rule(self, product, subject):
+    def run_goal_rule(self, product, subject) -> int:
         """
         :param product: A Goal subtype.
         :param subject: subject for the request.
@@ -508,7 +508,7 @@ class SchedulerSession:
             self._trace_on_error([exc], request)
             return PANTS_FAILED_EXIT_CODE
         _, state = returns[0]
-        return state.value.exit_code
+        return cast(int, state.value.exit_code)
 
     def product_request(self, product, subjects):
         """Executes a request for a single product for some subjects, and returns the products.

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -214,7 +214,7 @@ class LegacyGraphSession:
         options: Options,
         goals: Iterable[str],
         specs: Specs,
-    ):
+    ) -> int:
         """Runs @goal_rules sequentially and interactively by requesting their implicit Goal
         products.
 


### PR DESCRIPTION
This commit attempts to make the code in LocalPantsRunner cleaner by turning it into a dataclass,
which allows us to get rid of the `__init__` method. Some single-use methods and properties on `LocalPantsRunner` have also been made more concise, and a number of type annotations were added to it and in several other places. `local_pants_runner.py` is now about 30 lines shorter