### PR TITLE
Change `Target` to have a similar interface to `dict[t]` and `dict.get(t)`

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -30,10 +30,10 @@ class PythonBinaryFields:
     sources: PythonBinarySources
     entry_point: EntryPoint
 
-    # TODO: consume the other PythonBinary fields like `ZipSafe`. Consider making those fields
-    #  optional. We _need_ PythonBinarySources and EntryPoint to work properly. If your target
-    #  type also has ZipSafe, AlwaysWriteCache, etc, then we can do some additional things as an
-    #  extra bonus. Consider adding `Target.maybe_get()` to facilitate this.
+    # TODO: consume the other PythonBinary fields like `ZipSafe` and `AlwaysWriteCache`. These are
+    #  optional fields. If your target type has them registered, we can do extra meaningful things;
+    #  if you don't have them on your target type, we can still operate so long as you have the
+    #  required fields. Use `Target.get()` in the `create()` method.
 
     @staticmethod
     def is_valid_target(tgt: Target) -> bool:
@@ -41,9 +41,7 @@ class PythonBinaryFields:
 
     @classmethod
     def create(cls, tgt: Target) -> "PythonBinaryFields":
-        return cls(
-            tgt.address, sources=tgt.get(PythonBinarySources), entry_point=tgt.get(EntryPoint)
-        )
+        return cls(tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint])
 
 
 @rule


### PR DESCRIPTION
### Problem

As described in https://github.com/pantsbuild/pants/pull/9337, we need a mechanism to express that some rules optionally may use Fields when registered on the target type, but don't actually need them to operate.

For example, with `./v2 test`, the only Field we absolutely need for Pytest is `PythonTestsSources`. It's an added bonus if the target type has `Timeout` and `Coverage`. Even if they don't have those fields registered, we can still meaningfully return a `TestResult`. We simply can't use the added features of `--run-coverage` and `--pytest-timeouts`.

When these rules are using targets without those optional fields, we typically will want to use a default value for the `Field` when not registered. Typically, we will want that default to be the same as `Field(raw_value=None)`. Sometimes, we will want to be able to override that default value.

### Solution

Align `Target` with how you access a dictionary:

1. `tgt[Timeout]` will get the field instance if registered on the target type, else raise `KeyError`.
2. `tgt.get(Timeout)` will get the field instance if registered on the target type, else return `Timeout(raw_value=None)`.
3. `tgt.get(Timeout, default_raw_value=100)` will get the field instance if registered on the target type, else return `Timeout(raw_value=100)`.

Conceptually, it makes sense to think of `Target` similarly to a dictionary. We define a `Target` as *a unique combination of fields that are valid together*.  Tangibly, the dictionary maps `Type[Field] -> Field`.

### Result

Accessing fields on `Target` aligns more with Python conventions.

--

We can now more accurately reflect in rules what fields we actually must have vs. would like to have.

A crucial benefit of this is that it makes it much easier for core Pants devs to add new `Fields` to pre-existing target types and to consume those fields in core Pants without forcing all plugin authors to implement that field.

For example, we may want to add the field `RequirementsConstraints` to `PythonBinary` one day and use that in `python_create_binary.py` if we have that field registered, but still be able to operate on target types without it. This PR provides a mechanism for us to not only add that new field, but express in `python_create_binary.py` that we would like to use that field if it's available, without breaking any plugin authors.