### PR TITLE
Allow using Target API `Field`s with `determine_source_files.py`

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -23,9 +23,9 @@ from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.lint import Linter, LintResult
 
@@ -82,12 +82,12 @@ async def lint(
     )
 
     all_source_files = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
         )
     )
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins)
     )
 
     merged_input_files = await Get[Digest](

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -29,9 +29,9 @@ from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import Linter, LintResult
@@ -104,7 +104,7 @@ async def setup(
 
     if request.formatter.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(
+            LegacyAllSourceFilesRequest(
                 adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
             )
         )
@@ -113,7 +113,7 @@ async def setup(
         all_source_files_snapshot = request.formatter.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins)
     )
 
     merged_input_files = await Get[Digest](

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -26,9 +26,9 @@ from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import Linter, LintResult
@@ -82,7 +82,7 @@ async def setup(
 
     if request.formatter.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(
+            LegacyAllSourceFilesRequest(
                 adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
             )
         )
@@ -91,7 +91,7 @@ async def setup(
         all_source_files_snapshot = request.formatter.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins)
     )
 
     merged_input_files = await Get[Digest](

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -23,9 +23,9 @@ from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.lint import Linter, LintResult
 
@@ -82,12 +82,12 @@ async def lint(
     )
 
     all_source_files = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
         )
     )
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins)
     )
 
     merged_input_files = await Get[Digest](

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -28,9 +28,9 @@ from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import Linter, LintResult
@@ -97,7 +97,7 @@ async def setup(
 
     if request.formatter.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(
+            LegacyAllSourceFilesRequest(
                 adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
             )
         )
@@ -106,7 +106,7 @@ async def setup(
         all_source_files_snapshot = request.formatter.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins)
     )
 
     merged_input_files = await Get[Digest](

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -26,7 +26,7 @@ from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.rules.core import determine_source_files, strip_source_roots
-from pants.rules.core.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
+from pants.rules.core.determine_source_files import LegacySpecifiedSourceFilesRequest, SourceFiles
 from pants.rules.core.lint import Linter, LintResult
 
 
@@ -107,7 +107,7 @@ async def lint(
     )
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(adaptors_with_origins, strip_source_roots=True)
+        LegacySpecifiedSourceFilesRequest(adaptors_with_origins, strip_source_roots=True)
     )
 
     address_references = ", ".join(

--- a/src/python/pants/backend/python/lint/python_formatter.py
+++ b/src/python/pants/backend/python/lint/python_formatter.py
@@ -11,7 +11,7 @@ from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get
-from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.rules.core.determine_source_files import LegacyAllSourceFilesRequest, SourceFiles
 from pants.rules.core.fmt import FmtResult, Formatter, LanguageFmtResults, LanguageFormatters
 
 
@@ -34,7 +34,7 @@ async def format_python_target(
 ) -> LanguageFmtResults:
     adaptors_with_origins = python_formatters.adaptors_with_origins
     original_sources = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins
         )
     )

--- a/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
+++ b/src/python/pants/backend/python/rules/prepare_chrooted_python_sources.py
@@ -10,7 +10,7 @@ from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.rules.core import determine_source_files
-from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.rules.core.determine_source_files import LegacyAllSourceFilesRequest, SourceFiles
 
 
 @dataclass(frozen=True)
@@ -30,7 +30,9 @@ async def prepare_chrooted_python_sources(
     stripping source roots.
     """
     stripped_sources = await Get[SourceFiles](
-        AllSourceFilesRequest((ht.adaptor for ht in hydrated_targets), strip_source_roots=True)
+        LegacyAllSourceFilesRequest(
+            (ht.adaptor for ht in hydrated_targets), strip_source_roots=True
+        )
     )
     init_injected = await Get[InitInjectedSnapshot](InjectInitRequest(stripped_sources.snapshot))
     return ChrootedPythonSources(init_injected.snapshot)

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -36,7 +36,7 @@ from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import RootRule, UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.python.python_setup import PythonSetup
-from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.rules.core.determine_source_files import LegacyAllSourceFilesRequest, SourceFiles
 from pants.rules.core.distdir import DistDir
 from pants.rules.core.test import (
     AddressAndTestResult,
@@ -174,7 +174,7 @@ async def construct_coverage_config(
     source_root_config: SourceRootConfig, coverage_config_request: CoveragercRequest
 ) -> Coveragerc:
     sources = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             (ht.adaptor for ht in coverage_config_request.hydrated_targets),
             strip_source_roots=False,
         )
@@ -310,7 +310,7 @@ async def merge_coverage_data(
         if result.test_result.coverage_data is not None
     )
     sources = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             (ht.adaptor for ht in transitive_targets.closure), strip_source_roots=False
         )
     )
@@ -380,7 +380,7 @@ async def generate_coverage_report(
 
     coveragerc = await Get[Coveragerc](CoveragercRequest(HydratedTargets(python_targets)))
     sources = await Get[SourceFiles](
-        AllSourceFilesRequest(
+        LegacyAllSourceFilesRequest(
             (ht.adaptor for ht in transitive_targets.closure), strip_source_roots=False
         )
     )

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -38,7 +38,7 @@ from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
-from pants.rules.core.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
+from pants.rules.core.determine_source_files import LegacySpecifiedSourceFilesRequest, SourceFiles
 from pants.rules.core.test import TestDebugRequest, TestOptions, TestResult, TestRunner
 
 
@@ -159,7 +159,7 @@ async def setup_pytest_for_target(
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
     # to test, rather than using auto-discovery.
-    specified_source_files_request = SpecifiedSourceFilesRequest(
+    specified_source_files_request = LegacySpecifiedSourceFilesRequest(
         [adaptor_with_origin], strip_source_roots=True
     )
 
@@ -178,7 +178,7 @@ async def setup_pytest_for_target(
         Get[Pex](CreatePexFromTargetClosure, create_requirements_pex_request),
         Get[Pex](CreatePex, create_test_runner_pex),
         Get[ChrootedPythonSources](HydratedTargets(python_targets + resource_targets)),
-        Get[SourceFiles](SpecifiedSourceFilesRequest, specified_source_files_request),
+        Get[SourceFiles](LegacySpecifiedSourceFilesRequest, specified_source_files_request),
     ]
     if run_coverage:
         requests.append(

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -2,17 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Iterable, Tuple, Union, cast
+from typing import Iterable, NamedTuple, Tuple, Union, cast
 
-from pants.base.specs import AddressSpec
+from pants.base.specs import AddressSpec, OriginSpec
 from pants.engine.fs import DirectoriesToMerge, PathGlobs, Snapshot, SnapshotSubset
 from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
+from pants.engine.target import HydratedSources, HydrateSourcesRequest
+from pants.engine.target import Sources as SourcesField
 from pants.rules.core import strip_source_roots
 from pants.rules.core.strip_source_roots import (
     LegacySourceRootStrippedSources,
     LegacyStripTargetRequest,
+    SourceRootStrippedSources,
+    StripSourcesFieldRequest,
 )
 from pants.util.meta import frozen_after_init
 
@@ -24,6 +28,129 @@ class SourceFiles:
     `LegacyAllSourceFilesRequest`)."""
 
     snapshot: Snapshot
+
+    @property
+    def files(self) -> Tuple[str, ...]:
+        return self.snapshot.files
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class AllSourceFilesRequest:
+    sources_fields: Tuple[SourcesField, ...]
+    strip_source_roots: bool = False
+
+    def __init__(
+        self, sources_fields: Iterable[SourcesField], *, strip_source_roots: bool = False
+    ) -> None:
+        self.sources_fields = tuple(sources_fields)
+        self.strip_source_roots = strip_source_roots
+
+
+class SourcesFieldWithOrigin(NamedTuple):
+    sources_field: SourcesField
+    origin: OriginSpec
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class SpecifiedSourceFilesRequest:
+    sources_fields_with_origins: Tuple[SourcesFieldWithOrigin, ...]
+    strip_source_roots: bool = False
+
+    def __init__(
+        self,
+        sources_fields_with_origins: Iterable[SourcesFieldWithOrigin],
+        *,
+        strip_source_roots: bool = False
+    ) -> None:
+        self.sources_fields_with_origins = tuple(sources_fields_with_origins)
+        self.strip_source_roots = strip_source_roots
+
+
+def calculate_specified_sources(
+    sources_snapshot: Snapshot, origin: OriginSpec
+) -> Union[Snapshot, SnapshotSubset]:
+    # AddressSpecs simply use the entire `sources` field.
+    if isinstance(origin, AddressSpec):
+        return sources_snapshot
+    # NB: we ensure that `precise_files_specified` is a subset of the original `sources` field.
+    # It's possible when given a glob filesystem spec that the spec will have
+    # resolved files not belonging to this target - those must be filtered out.
+    precise_files_specified = set(sources_snapshot.files).intersection(origin.resolved_files)
+    return SnapshotSubset(
+        directory_digest=sources_snapshot.directory_digest,
+        globs=PathGlobs(sorted(precise_files_specified)),
+    )
+
+
+@rule
+async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFiles:
+    """Merge all `Sources` fields into one Snapshot."""
+    if request.strip_source_roots:
+        stripped_snapshots = await MultiGet(
+            Get[SourceRootStrippedSources](StripSourcesFieldRequest(sources_field))
+            for sources_field in request.sources_fields
+        )
+        digests_to_merge = tuple(
+            stripped_snapshot.snapshot.directory_digest for stripped_snapshot in stripped_snapshots
+        )
+    else:
+        all_hydrated_sources = await MultiGet(
+            Get[HydratedSources](HydrateSourcesRequest, sources_field.request)
+            for sources_field in request.sources_fields
+        )
+        digests_to_merge = tuple(
+            hydrated_sources.snapshot.directory_digest for hydrated_sources in all_hydrated_sources
+        )
+    result = await Get[Snapshot](DirectoriesToMerge(digests_to_merge))
+    return SourceFiles(result)
+
+
+@rule
+async def determine_specified_source_files(request: SpecifiedSourceFilesRequest) -> SourceFiles:
+    """Determine the specified `sources` for targets, possibly finding a subset of the original
+    `sources` fields if the user supplied file arguments."""
+    all_hydrated_sources = await MultiGet(
+        Get[HydratedSources](HydrateSourcesRequest, sources_field_with_origin.sources_field.request)
+        for sources_field_with_origin in request.sources_fields_with_origins
+    )
+
+    full_snapshots = {}
+    snapshot_subset_requests = {}
+    for hydrated_sources, sources_field_with_origin in zip(
+        all_hydrated_sources, request.sources_fields_with_origins
+    ):
+        if not hydrated_sources.snapshot.files:
+            continue
+        result = calculate_specified_sources(
+            hydrated_sources.snapshot, sources_field_with_origin.origin
+        )
+        if isinstance(result, Snapshot):
+            full_snapshots[sources_field_with_origin.sources_field] = result
+        else:
+            snapshot_subset_requests[sources_field_with_origin.sources_field] = result
+
+    snapshot_subsets: Tuple[Snapshot, ...] = ()
+    if snapshot_subset_requests:
+        snapshot_subsets = await MultiGet(
+            Get[Snapshot](SnapshotSubset, request) for request in snapshot_subset_requests.values()
+        )
+
+    all_snapshots: Iterable[Snapshot] = (*full_snapshots.values(), *snapshot_subsets)
+    if request.strip_source_roots:
+        all_sources_fields = (*full_snapshots.keys(), *snapshot_subset_requests.keys())
+        stripped_snapshots = await MultiGet(
+            Get[SourceRootStrippedSources](
+                StripSourcesFieldRequest(sources_field, specified_files_snapshot=snapshot)
+            )
+            for sources_field, snapshot in zip(all_sources_fields, all_snapshots)
+        )
+        all_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
+    result = await Get[Snapshot](
+        DirectoriesToMerge(tuple(snapshot.directory_digest for snapshot in all_snapshots))
+    )
+    return SourceFiles(result)
 
 
 @frozen_after_init
@@ -105,7 +232,9 @@ async def legacy_determine_specified_source_files(
         adaptor = adaptor_with_origin.adaptor
         if not adaptor.has_sources():
             continue
-        result = legacy_determine_specified_sources_for_target(adaptor_with_origin)
+        result = calculate_specified_sources(
+            adaptor_with_origin.adaptor.sources.snapshot, adaptor_with_origin.origin
+        )
         if isinstance(result, Snapshot):
             full_snapshots[adaptor] = result
         else:
@@ -135,9 +264,13 @@ async def legacy_determine_specified_source_files(
 
 def rules():
     return [
+        determine_all_source_files,
+        determine_specified_source_files,
+        RootRule(AllSourceFilesRequest),
+        RootRule(SpecifiedSourceFilesRequest),
+        *strip_source_roots.rules(),
         legacy_determine_all_source_files,
         legacy_determine_specified_source_files,
-        *strip_source_roots.rules(),
         RootRule(LegacyAllSourceFilesRequest),
         RootRule(LegacySpecifiedSourceFilesRequest),
     ]

--- a/src/python/pants/rules/core/determine_source_files_test.py
+++ b/src/python/pants/rules/core/determine_source_files_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pathlib import PurePath
-from typing import Iterable, List, NamedTuple, Optional
+from typing import Iterable, List, NamedTuple, Optional, Type
 from unittest.mock import Mock
 
 from pants.base.specs import (
@@ -17,15 +17,20 @@ from pants.base.specs import (
 from pants.build_graph.address import Address
 from pants.build_graph.files import Files
 from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
-from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
+from pants.engine.target import Sources as SourcesField
+from pants.engine.target import rules as target_rules
 from pants.rules.core.determine_source_files import (
+    AllSourceFilesRequest,
     LegacyAllSourceFilesRequest,
     LegacySpecifiedSourceFilesRequest,
     SourceFiles,
+    SourcesFieldWithOrigin,
+    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.determine_source_files import rules as determine_source_files_rules
 from pants.rules.core.strip_source_roots import rules as strip_source_roots_rules
+from pants.rules.core.targets import FilesSources
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
@@ -39,19 +44,243 @@ class TargetSources(NamedTuple):
         return [PurePath(self.source_root, name).as_posix() for name in self.source_files]
 
 
-class LegacyDetermineSourceFilesTest(TestBase):
+SOURCES1 = TargetSources("src/python", ["s1.py", "s2.py", "s3.py"])
+SOURCES2 = TargetSources("tests/python", ["t1.py", "t2.java"])
+SOURCES3 = TargetSources("src/java", ["j1.java", "j2.java"])
 
-    SOURCES1 = TargetSources("src/python", ["s1.py", "s2.py", "s3.py"])
-    SOURCES2 = TargetSources("tests/python", ["t1.py", "t2.java"])
-    SOURCES3 = TargetSources("src/java", ["j1.java", "j2.java"])
 
+class DetermineSourceFilesTest(TestBase):
     @classmethod
     def rules(cls):
         return (
             *super().rules(),
             *determine_source_files_rules(),
             *strip_source_roots_rules(),
-            RootRule(LegacySpecifiedSourceFilesRequest),
+            *target_rules(),
+        )
+
+    def mock_sources_field_with_origin(
+        self,
+        sources: TargetSources,
+        *,
+        origin: Optional[OriginSpec] = None,
+        include_sources: bool = True,
+        sources_field_cls: Type[SourcesField] = SourcesField,
+    ) -> SourcesFieldWithOrigin:
+        sources_field = sources_field_cls(
+            sources.source_files, address=Address.parse(f"{sources.source_root}:lib")
+        )
+        self.create_files(
+            path=sources.source_root, files=(sources.source_files if include_sources else [])
+        )
+        if origin is None:
+            origin = SiblingAddresses(sources.source_root)
+        return SourcesFieldWithOrigin(sources_field, origin)
+
+    def get_all_source_files(
+        self,
+        sources_fields_with_origins: Iterable[SourcesFieldWithOrigin],
+        *,
+        strip_source_roots: bool = False,
+    ) -> List[str]:
+        request = AllSourceFilesRequest(
+            (
+                sources_field_with_origin.sources_field
+                for sources_field_with_origin in sources_fields_with_origins
+            ),
+            strip_source_roots=strip_source_roots,
+        )
+        result = self.request_single_product(
+            SourceFiles, Params(request, create_options_bootstrapper())
+        )
+        return sorted(result.snapshot.files)
+
+    def get_specified_source_files(
+        self,
+        sources_fields_with_origins: Iterable[SourcesFieldWithOrigin],
+        *,
+        strip_source_roots: bool = False,
+    ) -> List[str]:
+        request = SpecifiedSourceFilesRequest(
+            sources_fields_with_origins, strip_source_roots=strip_source_roots,
+        )
+        result = self.request_single_product(
+            SourceFiles, Params(request, create_options_bootstrapper())
+        )
+        return sorted(result.snapshot.files)
+
+    def test_address_specs(self) -> None:
+        sources_field1 = self.mock_sources_field_with_origin(
+            SOURCES1, origin=SingleAddress(directory=SOURCES1.source_root, name="lib")
+        )
+        sources_field2 = self.mock_sources_field_with_origin(
+            SOURCES2, origin=SiblingAddresses(SOURCES2.source_root)
+        )
+        sources_field3 = self.mock_sources_field_with_origin(
+            SOURCES3, origin=DescendantAddresses(SOURCES3.source_root)
+        )
+        sources_field4 = self.mock_sources_field_with_origin(
+            SOURCES1, origin=AscendantAddresses(SOURCES1.source_root)
+        )
+
+        def assert_all_source_files_resolved(
+            sources_field_with_origin: SourcesFieldWithOrigin, sources: TargetSources
+        ) -> None:
+            expected = sources.source_file_absolute_paths
+            assert self.get_all_source_files([sources_field_with_origin]) == expected
+            assert self.get_specified_source_files([sources_field_with_origin]) == expected
+
+        assert_all_source_files_resolved(sources_field1, SOURCES1)
+        assert_all_source_files_resolved(sources_field2, SOURCES2)
+        assert_all_source_files_resolved(sources_field3, SOURCES3)
+        assert_all_source_files_resolved(sources_field4, SOURCES1)
+        # NB: sources_field1 and sources_field3 refer to the same files. We should be able to
+        # handle this gracefully.
+        combined_sources_fields = [sources_field1, sources_field2, sources_field3, sources_field4]
+        combined_expected = sorted(
+            [
+                *SOURCES1.source_file_absolute_paths,
+                *SOURCES2.source_file_absolute_paths,
+                *SOURCES3.source_file_absolute_paths,
+            ]
+        )
+        assert self.get_all_source_files(combined_sources_fields) == combined_expected
+        assert self.get_specified_source_files(combined_sources_fields) == combined_expected
+
+    def test_filesystem_specs(self) -> None:
+        # Literal file arg.
+        sources_field1_all_sources = SOURCES1.source_file_absolute_paths
+        sources_field1_slice = slice(0, 1)
+        sources_field1 = self.mock_sources_field_with_origin(
+            SOURCES1, origin=FilesystemLiteralSpec(sources_field1_all_sources[0])
+        )
+
+        # Glob file arg that matches the entire `sources`.
+        sources_field2_all_sources = SOURCES2.source_file_absolute_paths
+        sources_field2_slice = slice(0, len(sources_field2_all_sources))
+        sources_field2_origin = FilesystemResolvedGlobSpec(
+            f"{SOURCES2.source_root}/*.py", files=tuple(sources_field2_all_sources)
+        )
+        sources_field2 = self.mock_sources_field_with_origin(SOURCES2, origin=sources_field2_origin)
+
+        # Glob file arg that only matches a subset of the `sources` _and_ includes resolved
+        # files not owned by the target.
+        sources_field3_all_sources = SOURCES3.source_file_absolute_paths
+        sources_field3_slice = slice(0, 1)
+        sources_field3_origin = FilesystemResolvedGlobSpec(
+            f"{SOURCES3.source_root}/*.java",
+            files=tuple(
+                PurePath(SOURCES3.source_root, name).as_posix()
+                for name in [SOURCES3.source_files[0], "other_target.java", "j.tmp.java"]
+            ),
+        )
+        sources_field3 = self.mock_sources_field_with_origin(SOURCES3, origin=sources_field3_origin)
+
+        def assert_file_args_resolved(
+            sources_field_with_origin: SourcesFieldWithOrigin,
+            all_sources: List[str],
+            expected_slice: slice,
+        ) -> None:
+            assert self.get_all_source_files([sources_field_with_origin]) == all_sources
+            assert (
+                self.get_specified_source_files([sources_field_with_origin])
+                == all_sources[expected_slice]
+            )
+
+        assert_file_args_resolved(sources_field1, sources_field1_all_sources, sources_field1_slice)
+        assert_file_args_resolved(sources_field2, sources_field2_all_sources, sources_field2_slice)
+        assert_file_args_resolved(sources_field3, sources_field3_all_sources, sources_field3_slice)
+
+        combined_sources_fields = [sources_field1, sources_field2, sources_field3]
+        assert self.get_all_source_files(combined_sources_fields) == sorted(
+            [*sources_field1_all_sources, *sources_field2_all_sources, *sources_field3_all_sources]
+        )
+        assert self.get_specified_source_files(combined_sources_fields) == sorted(
+            [
+                *sources_field1_all_sources[sources_field1_slice],
+                *sources_field2_all_sources[sources_field2_slice],
+                *sources_field3_all_sources[sources_field3_slice],
+            ]
+        )
+
+    def test_strip_source_roots(self) -> None:
+        sources_field1 = self.mock_sources_field_with_origin(SOURCES1)
+        sources_field2 = self.mock_sources_field_with_origin(SOURCES2)
+        sources_field3 = self.mock_sources_field_with_origin(SOURCES3)
+
+        def assert_source_roots_stripped(
+            sources_field_with_origin: SourcesFieldWithOrigin, sources: TargetSources
+        ) -> None:
+            expected = sources.source_files
+            assert (
+                self.get_all_source_files([sources_field_with_origin], strip_source_roots=True)
+                == expected
+            )
+            assert (
+                self.get_specified_source_files(
+                    [sources_field_with_origin], strip_source_roots=True
+                )
+                == expected
+            )
+
+        assert_source_roots_stripped(sources_field1, SOURCES1)
+        assert_source_roots_stripped(sources_field2, SOURCES2)
+        assert_source_roots_stripped(sources_field3, SOURCES3)
+
+        # We must be careful to not strip source roots for `FilesSources`.
+        files_sources_field = self.mock_sources_field_with_origin(
+            SOURCES1, sources_field_cls=FilesSources
+        )
+        files_expected = SOURCES1.source_file_absolute_paths
+
+        assert (
+            self.get_all_source_files([files_sources_field], strip_source_roots=True)
+            == files_expected
+        )
+        assert (
+            self.get_specified_source_files([files_sources_field], strip_source_roots=True)
+            == files_expected
+        )
+
+        combined_sources_fields = [
+            sources_field1,
+            sources_field2,
+            sources_field3,
+            files_sources_field,
+        ]
+        combined_expected = sorted(
+            [
+                *SOURCES1.source_files,
+                *SOURCES2.source_files,
+                *SOURCES3.source_files,
+                *files_expected,
+            ],
+        )
+        assert (
+            self.get_all_source_files(combined_sources_fields, strip_source_roots=True)
+            == combined_expected
+        )
+        assert (
+            self.get_specified_source_files(combined_sources_fields, strip_source_roots=True)
+            == combined_expected
+        )
+
+    def test_gracefully_handle_no_sources(self) -> None:
+        sources_field = self.mock_sources_field_with_origin(SOURCES1, include_sources=False)
+        assert self.get_all_source_files([sources_field]) == []
+        assert self.get_specified_source_files([sources_field]) == []
+        assert self.get_all_source_files([sources_field], strip_source_roots=True) == []
+        assert self.get_specified_source_files([sources_field], strip_source_roots=True) == []
+
+
+class LegacyDetermineSourceFilesTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            *determine_source_files_rules(),
+            *strip_source_roots_rules(),
+            *target_rules(),
         )
 
     def mock_target(
@@ -63,8 +292,8 @@ class LegacyDetermineSourceFilesTest(TestBase):
         type_alias: Optional[str] = None,
     ) -> TargetAdaptorWithOrigin:
         sources_field = Mock()
-        sources_field.snapshot = self.make_snapshot(
-            {fp: "" for fp in (sources.source_file_absolute_paths if include_sources else [])}
+        sources_field.snapshot = self.make_snapshot_of_empty_files(
+            sources.source_file_absolute_paths if include_sources else []
         )
         adaptor = TargetAdaptor(
             address=Address.parse(f"{sources.source_root}:lib"),
@@ -106,17 +335,11 @@ class LegacyDetermineSourceFilesTest(TestBase):
 
     def test_address_specs(self) -> None:
         target1 = self.mock_target(
-            self.SOURCES1, origin=SingleAddress(directory=self.SOURCES1.source_root, name="lib")
+            SOURCES1, origin=SingleAddress(directory=SOURCES1.source_root, name="lib")
         )
-        target2 = self.mock_target(
-            self.SOURCES2, origin=SiblingAddresses(self.SOURCES2.source_root)
-        )
-        target3 = self.mock_target(
-            self.SOURCES3, origin=DescendantAddresses(self.SOURCES3.source_root)
-        )
-        target4 = self.mock_target(
-            self.SOURCES1, origin=AscendantAddresses(self.SOURCES1.source_root)
-        )
+        target2 = self.mock_target(SOURCES2, origin=SiblingAddresses(SOURCES2.source_root))
+        target3 = self.mock_target(SOURCES3, origin=DescendantAddresses(SOURCES3.source_root))
+        target4 = self.mock_target(SOURCES1, origin=AscendantAddresses(SOURCES1.source_root))
 
         def assert_all_source_files_resolved(
             target: TargetAdaptorWithOrigin, sources: TargetSources
@@ -125,18 +348,18 @@ class LegacyDetermineSourceFilesTest(TestBase):
             assert self.get_all_source_files([target]) == expected
             assert self.get_specified_source_files([target]) == expected
 
-        assert_all_source_files_resolved(target1, self.SOURCES1)
-        assert_all_source_files_resolved(target2, self.SOURCES2)
-        assert_all_source_files_resolved(target3, self.SOURCES3)
-        assert_all_source_files_resolved(target4, self.SOURCES1)
+        assert_all_source_files_resolved(target1, SOURCES1)
+        assert_all_source_files_resolved(target2, SOURCES2)
+        assert_all_source_files_resolved(target3, SOURCES3)
+        assert_all_source_files_resolved(target4, SOURCES1)
         # NB: target1 and target4 refer to the same files. We should be able to handle this
         # gracefully.
         combined_targets = [target1, target2, target3, target4]
         combined_expected = sorted(
             [
-                *self.SOURCES1.source_file_absolute_paths,
-                *self.SOURCES2.source_file_absolute_paths,
-                *self.SOURCES3.source_file_absolute_paths,
+                *SOURCES1.source_file_absolute_paths,
+                *SOURCES2.source_file_absolute_paths,
+                *SOURCES3.source_file_absolute_paths,
             ]
         )
         assert self.get_all_source_files(combined_targets) == combined_expected
@@ -144,32 +367,30 @@ class LegacyDetermineSourceFilesTest(TestBase):
 
     def test_filesystem_specs(self) -> None:
         # Literal file arg.
-        target1_all_sources = self.SOURCES1.source_file_absolute_paths
+        target1_all_sources = SOURCES1.source_file_absolute_paths
         target1_slice = slice(0, 1)
-        target1 = self.mock_target(
-            self.SOURCES1, origin=FilesystemLiteralSpec(target1_all_sources[0])
-        )
+        target1 = self.mock_target(SOURCES1, origin=FilesystemLiteralSpec(target1_all_sources[0]))
 
         # Glob file arg that matches the entire target's `sources`.
-        target2_all_sources = self.SOURCES2.source_file_absolute_paths
+        target2_all_sources = SOURCES2.source_file_absolute_paths
         target2_slice = slice(0, len(target2_all_sources))
         target2_origin = FilesystemResolvedGlobSpec(
-            f"{self.SOURCES2.source_root}/*.py", files=tuple(target2_all_sources)
+            f"{SOURCES2.source_root}/*.py", files=tuple(target2_all_sources)
         )
-        target2 = self.mock_target(self.SOURCES2, origin=target2_origin)
+        target2 = self.mock_target(SOURCES2, origin=target2_origin)
 
         # Glob file arg that only matches a subset of the target's `sources` _and_ includes resolved
         # files not owned by the target.
-        target3_all_sources = self.SOURCES3.source_file_absolute_paths
+        target3_all_sources = SOURCES3.source_file_absolute_paths
         target3_slice = slice(0, 1)
         target3_origin = FilesystemResolvedGlobSpec(
-            f"{self.SOURCES3.source_root}/*.java",
+            f"{SOURCES3.source_root}/*.java",
             files=tuple(
-                PurePath(self.SOURCES3.source_root, name).as_posix()
-                for name in [self.SOURCES3.source_files[0], "other_target.java", "j.tmp.java"]
+                PurePath(SOURCES3.source_root, name).as_posix()
+                for name in [SOURCES3.source_files[0], "other_target.java", "j.tmp.java"]
             ),
         )
-        target3 = self.mock_target(self.SOURCES3, origin=target3_origin)
+        target3 = self.mock_target(SOURCES3, origin=target3_origin)
 
         def assert_file_args_resolved(
             target: TargetAdaptorWithOrigin, all_sources: List[str], expected_slice: slice
@@ -194,13 +415,13 @@ class LegacyDetermineSourceFilesTest(TestBase):
         )
 
     def test_strip_source_roots(self) -> None:
-        target1 = self.mock_target(self.SOURCES1)
-        target2 = self.mock_target(self.SOURCES2)
-        target3 = self.mock_target(self.SOURCES3)
+        target1 = self.mock_target(SOURCES1)
+        target2 = self.mock_target(SOURCES2)
+        target3 = self.mock_target(SOURCES3)
 
         # We must be careful to not strip source roots for `files` targets.
-        files_target = self.mock_target(self.SOURCES1, type_alias=Files.alias())
-        files_expected = self.SOURCES1.source_file_absolute_paths
+        files_target = self.mock_target(SOURCES1, type_alias=Files.alias())
+        files_expected = SOURCES1.source_file_absolute_paths
 
         def assert_source_roots_stripped(
             target: TargetAdaptorWithOrigin, sources: TargetSources
@@ -209,9 +430,9 @@ class LegacyDetermineSourceFilesTest(TestBase):
             assert self.get_all_source_files([target], strip_source_roots=True) == expected
             assert self.get_specified_source_files([target], strip_source_roots=True) == expected
 
-        assert_source_roots_stripped(target1, self.SOURCES1)
-        assert_source_roots_stripped(target2, self.SOURCES2)
-        assert_source_roots_stripped(target3, self.SOURCES3)
+        assert_source_roots_stripped(target1, SOURCES1)
+        assert_source_roots_stripped(target2, SOURCES2)
+        assert_source_roots_stripped(target3, SOURCES3)
 
         assert self.get_all_source_files([files_target], strip_source_roots=True) == files_expected
         assert (
@@ -222,9 +443,9 @@ class LegacyDetermineSourceFilesTest(TestBase):
         combined_targets = [target1, target2, target3, files_target]
         combined_expected = sorted(
             [
-                *self.SOURCES1.source_files,
-                *self.SOURCES2.source_files,
-                *self.SOURCES3.source_files,
+                *SOURCES1.source_files,
+                *SOURCES2.source_files,
+                *SOURCES3.source_files,
                 *files_expected,
             ],
         )
@@ -238,7 +459,7 @@ class LegacyDetermineSourceFilesTest(TestBase):
         )
 
     def test_gracefully_handle_no_sources(self) -> None:
-        target = self.mock_target(self.SOURCES1, include_sources=False)
+        target = self.mock_target(SOURCES1, include_sources=False)
         assert self.get_all_source_files([target]) == []
         assert self.get_specified_source_files([target]) == []
         assert self.get_all_source_files([target], strip_source_roots=True) == []

--- a/src/python/pants/rules/core/determine_source_files_test.py
+++ b/src/python/pants/rules/core/determine_source_files_test.py
@@ -20,9 +20,9 @@ from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
+    LegacyAllSourceFilesRequest,
+    LegacySpecifiedSourceFilesRequest,
     SourceFiles,
-    SpecifiedSourceFilesRequest,
 )
 from pants.rules.core.determine_source_files import rules as determine_source_files_rules
 from pants.rules.core.strip_source_roots import rules as strip_source_roots_rules
@@ -39,7 +39,7 @@ class TargetSources(NamedTuple):
         return [PurePath(self.source_root, name).as_posix() for name in self.source_files]
 
 
-class DetermineSourceFilesTest(TestBase):
+class LegacyDetermineSourceFilesTest(TestBase):
 
     SOURCES1 = TargetSources("src/python", ["s1.py", "s2.py", "s3.py"])
     SOURCES2 = TargetSources("tests/python", ["t1.py", "t2.java"])
@@ -51,7 +51,7 @@ class DetermineSourceFilesTest(TestBase):
             *super().rules(),
             *determine_source_files_rules(),
             *strip_source_roots_rules(),
-            RootRule(SpecifiedSourceFilesRequest),
+            RootRule(LegacySpecifiedSourceFilesRequest),
         )
 
     def mock_target(
@@ -81,7 +81,7 @@ class DetermineSourceFilesTest(TestBase):
         *,
         strip_source_roots: bool = False,
     ) -> List[str]:
-        request = AllSourceFilesRequest(
+        request = LegacyAllSourceFilesRequest(
             (adaptor_with_origin.adaptor for adaptor_with_origin in adaptors_with_origins),
             strip_source_roots=strip_source_roots,
         )
@@ -96,7 +96,7 @@ class DetermineSourceFilesTest(TestBase):
         *,
         strip_source_roots: bool = False,
     ) -> List[str]:
-        request = SpecifiedSourceFilesRequest(
+        request = LegacySpecifiedSourceFilesRequest(
             adaptors_with_origins, strip_source_roots=strip_source_roots,
         )
         result = self.request_single_product(


### PR DESCRIPTION
We keep the `TargetAdaptor` request types but rename them to be `Legacy`.