### PR TITLE
Fix `PathGlobs` to be deterministic for more cache hits

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -81,7 +81,7 @@ class PathGlobs:
                                       unmatched globs. For example, this might be the text string
                                       "the option `--isort-config`".
         """
-        self.globs = tuple(globs)
+        self.globs = tuple(sorted(globs))
         self.glob_match_error_behavior = glob_match_error_behavior
         self.conjunction = conjunction
         self.description_of_origin = description_of_origin or ""


### PR DESCRIPTION
We weren't sorting the input `globs` to `PathGlobs`, which resulted in two problems:

1. The ordering won’t be stable if the passed `globs` were not deterministic, e.g. if you passed a set to the constructor
2. Even if you passed a deterministic data structure like a tuple, we will still get more cache misses than we’d like. target1 with `['f1.py', 'f2.py']` sources and target2 with `['f2.py', 'f1'.py']` would be treated as distinct for no good reason

Closes https://github.com/pantsbuild/pants/issues/9346.