### PR TITLE
Remove custom properties from nailgun

### DIFF
--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -11,8 +11,6 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
 
-from pants.util.osutil import Pid
-
 STDIO_DESCRIPTORS = (0, 1, 2)
 
 
@@ -31,15 +29,6 @@ class ChunkType:
     ENVIRONMENT = b"E"
     WORKING_DIR = b"D"
     COMMAND = b"C"
-    # PGRP and PID are custom extensions to the Nailgun protocol spec for transmitting pid info.
-    # PGRP is used to allow the client process to try killing the nailgun server and everything in its
-    # process group when the thin client receives a signal. PID is used to retrieve logs for fatal
-    # errors from the remote process at that PID.
-    # TODO(#6579): we should probably move our custom extensions to a ChunkType subclass in
-    # nailgun_client.py and differentiate clearly whether the client accepts the pailgun extensions
-    # (e.g. by calling it PailgunClient).
-    PGRP = b"G"
-    PID = b"P"
     STDIN = b"0"
     STDOUT = b"1"
     STDERR = b"2"
@@ -47,7 +36,7 @@ class ChunkType:
     STDIN_EOF = b"."
     EXIT = b"X"
     REQUEST_TYPES = (ARGUMENT, ENVIRONMENT, WORKING_DIR, COMMAND)
-    EXECUTION_TYPES = (PGRP, PID, STDIN, STDOUT, STDERR, START_READING_INPUT, STDIN_EOF, EXIT)
+    EXECUTION_TYPES = (STDIN, STDOUT, STDERR, START_READING_INPUT, STDIN_EOF, EXIT)
     VALID_TYPES = REQUEST_TYPES + EXECUTION_TYPES
 
 
@@ -333,20 +322,6 @@ class NailgunProtocol:
         """Send an Exit chunk over the specified socket, containing the specified return code."""
         encoded_exit_status = cls.encode_int(code)
         cls.send_exit(sock, payload=encoded_exit_status)
-
-    @classmethod
-    def send_pid(cls, sock, pid):
-        """Send the PID chunk over the specified socket."""
-        assert isinstance(pid, Pid) and pid > 0
-        encoded_int = cls.encode_int(pid)
-        cls.write_chunk(sock, ChunkType.PID, encoded_int)
-
-    @classmethod
-    def send_pgrp(cls, sock, pgrp):
-        """Send the PGRP chunk over the specified socket."""
-        assert isinstance(pgrp, Pid) and pgrp < 0
-        encoded_int = cls.encode_int(pgrp)
-        cls.write_chunk(sock, ChunkType.PGRP, encoded_int)
 
     @classmethod
     def encode_int(cls, obj):

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -198,6 +198,5 @@ class TestNailgunClient(unittest.TestCase):
 
     @unittest.mock.patch("os.kill", **PATCH_OPTS)
     def test_send_control_c_noop_nopid(self, mock_kill):
-        self.nailgun_client._session = unittest.mock.Mock(remote_pid=None, remote_pgrp=None)
         self.nailgun_client.maybe_send_signal(signal.SIGINT)
         mock_kill.assert_not_called()

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -158,22 +158,6 @@ class TestNailgunProtocol(unittest.TestCase):
         chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock)
         self.assertEqual((chunk_type, payload), (ChunkType.EXIT, self.TEST_OUTPUT))
 
-    def test_send_pgrp(self):
-        test_pgrp = -1
-        NailgunProtocol.send_pgrp(self.server_sock, test_pgrp)
-        chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock, return_bytes=True)
-        self.assertEqual(
-            (chunk_type, payload), (ChunkType.PGRP, NailgunProtocol.encode_int(test_pgrp))
-        )
-
-    def test_send_pid(self):
-        test_pid = 1
-        NailgunProtocol.send_pid(self.server_sock, test_pid)
-        chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock, return_bytes=True)
-        self.assertEqual(
-            (chunk_type, payload), (ChunkType.PID, NailgunProtocol.encode_int(test_pid))
-        )
-
     def test_send_exit_with_code(self):
         return_code = 1
         NailgunProtocol.send_exit_with_code(self.server_sock, return_code)


### PR DESCRIPTION
### Problem

We had previously extended the Nailgun protocol as used in pants for communication with pantsd, by adding two new properties PID and PGRP. These were added to facilitate the previous design of pantsd, where it would fork repeatedly. However, since pantsd no longer works this way, these properties are superfluous and can be removed.

### Solution

Remove these custom Nailgun protocol extensions and the tests for them.
