### PR TITLE
Temporarily skip JVM integration tests due to Coursier issue (#9350)

### DIFF
--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
@@ -4,9 +4,11 @@
 import glob
 import os
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestIndexJavaIntegration(PantsRunIntegrationTest):
     def test_index_simple_java_code(self):
         # Very simple test that we can run the extractor and indexer on some

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
@@ -1,9 +1,11 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ErrorProneTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
@@ -3,11 +3,13 @@
 
 from textwrap import dedent
 
+import pytest
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_file
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class FindBugsTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
@@ -4,12 +4,14 @@
 import os
 from contextlib import contextmanager
 
+import pytest
 from pants.fs.archive import archiver_for_path, create_archiver
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class NodeBundleIntegrationTest(PantsRunIntegrationTest):
 
     DIST_DIR = "dist"

--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/test_scalajs_repl_integration.py
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/test_scalajs_repl_integration.py
@@ -3,9 +3,11 @@
 
 from textwrap import dedent
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScalaJSReplIntegrationTest(PantsRunIntegrationTest):
     def setUp(self):
         self.maxDiff = None

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
@@ -1,9 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScroogeGenTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class AntlrJavaGenIntegrationTest(PantsRunIntegrationTest):
     def test_run_antlr3(self):
         stdout_data = self.bundle_and_run(

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
@@ -5,11 +5,14 @@ import os
 import re
 import subprocess
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ProtobufIntegrationTest(PantsRunIntegrationTest):
     def test_import_from_buildroot(self):
         pants_run = self.run_pants(

--- a/tests/python/pants_test/backend/codegen/wire/java/test_wire_integration.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_wire_integration.py
@@ -5,12 +5,15 @@ import os
 import re
 import subprocess
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.file_test_util import exact_files
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import open_zip
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class WireIntegrationTest(PantsRunIntegrationTest):
     def test_good(self):
         # wire example should compile without warnings with correct wire files.

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -7,12 +7,15 @@ import re
 import shutil
 from textwrap import dedent
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     @contextlib.contextmanager
     def tmp_custom_scala(self, path_suffix):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
@@ -5,6 +5,8 @@ import json
 import os
 from textwrap import dedent
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.fs.archive import ZIP
 from pants.java.distribution.distribution import DistributionLocator
@@ -13,6 +15,7 @@ from pants.testutil.subsystem.util import init_subsystem
 from pants.util.contextutil import temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ShaderIntegrationTest(PantsRunIntegrationTest):
     def test_shader_project(self):
         """Test that the binary target at the ``shading_project`` can be built and run.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_javac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_javac_plugin_integration.py
@@ -1,13 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from unittest import skipIf
+import pytest
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 
 
-@skipIf(is_missing_jvm("1.8"), "no java 1.8 installation on testing machine")
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class JavacPluginIntegrationTest(BaseCompileIT):
     example_dir = "examples/src/java/org/pantsbuild/example/javac/plugin"
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -9,6 +9,7 @@ from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base i
 )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
     @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
     def test_basic_binary(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
@@ -1,12 +1,14 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
 
 from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import (
     ScalacPluginIntegrationTestBase,
 )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScalacPluginIntegrationTest(ScalacPluginIntegrationTestBase):
     example_dir = "examples/src/scala/org/pantsbuild/example/scalac/plugin"
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_declared_deps_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_declared_deps_integration.py
@@ -1,12 +1,15 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 
 DIR_DEPS_WHITELISTED = "testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist"
 JAR_DEPS_WHITELISTED = "testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist"
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class DeclaredDepsIntegrationTest(BaseCompileIT):
     def test_direct_source_dep(self):
         # Should fail with strict deps.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -5,10 +5,13 @@ import os
 import re
 import shutil
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class DepExportsIntegrationTest(PantsRunIntegrationTest):
 
     SRC_PREFIX = "testprojects/tests"

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -65,6 +65,7 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
         )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class DepExportsThriftTargets(PantsRunIntegrationTest):
     def test_exports_for_thrift_targets(self):
         pants_run = self.run_pants(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -3,9 +3,12 @@
 
 import re
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
     def test_missing_deps_found(self):
         target = "testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist"

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class BenchmarkRunIntegrationTest(PantsRunIntegrationTest):
     def test_running_an_empty_benchmark_target(self):
         pants_run = self.run_pants(

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
@@ -4,11 +4,14 @@
 import os
 import subprocess
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import open_zip, temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class BinaryCreateIntegrationTest(PantsRunIntegrationTest):
     def test_autovalue_classfiles(self):
         self.build_and_run(

--- a/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ClassmapTaskIntegrationTest(PantsRunIntegrationTest):
     # A test target with both transitive internal dependency as well as external dependency
     TEST_JVM_TARGET = "testprojects/tests/java/org/pantsbuild/testproject/testjvms:eight"

--- a/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
@@ -4,11 +4,14 @@
 import os
 import time
 
+import pytest
+
 from pants.java.jar.manifest import Manifest
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import open_zip
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ExportClasspathIntegrationTest(PantsRunIntegrationTest):
     def test_export_manifest_jar(self):
         ctimes = []

--- a/tests/python/pants_test/backend/jvm/tasks/test_intransitive_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_intransitive_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class IntransitiveIntegrationTest(PantsRunIntegrationTest):
 
     test_spec = "testprojects/src/java/org/pantsbuild/testproject/intransitive"

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class BundleIntegrationTest(PantsRunIntegrationTest):
     def test_bundle_of_nonascii_classes(self):
         """JVM classes can have non-ASCII names.

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
@@ -4,10 +4,13 @@
 import json
 import os
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
     def _run_dep_usage(self, workdir, target, clean_all=False, extra_args=None, cachedir=None):
         if cachedir:

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
@@ -3,11 +3,14 @@
 
 import os
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_delete
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class JvmPrepCommandIntegration(PantsRunIntegrationTest):
     def setUp(self):
         safe_delete("/tmp/running-in-goal-test")

--- a/tests/python/pants_test/backend/jvm/tasks/test_scala_repl_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scala_repl_integration.py
@@ -3,9 +3,12 @@
 
 from textwrap import dedent
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScalaReplIntegrationTest(PantsRunIntegrationTest):
     def run_repl(self, target, program, repl_args=None):
         """Run a repl for the given target with the given input, and return stdout_data."""

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -3,12 +3,15 @@
 
 import re
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.dirutil import read_file
 
 TEST_DIR = "testprojects/src/scala/org/pantsbuild/testproject"
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_provided_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_provided_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScopeProvidedIntegrationTest(PantsRunIntegrationTest):
     """Tests "provided" emulation (having scope='compile test' and transitive=False)."""
 
@@ -38,6 +41,7 @@ class ScopeProvidedIntegrationTest(PantsRunIntegrationTest):
         )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScopeProvidedShadowingIntegrationTest(PantsRunIntegrationTest):
     @classmethod
     def _spec(cls, name):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
@@ -7,11 +7,14 @@ from subprocess import PIPE, Popen
 from textwrap import dedent
 from zipfile import ZipFile
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
     @classmethod
     def _spec(cls, name):
@@ -115,6 +118,7 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
                 )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScopeChangesCacheInvalidationIntegrationTest(PantsRunIntegrationTest):
     def test_invalidate_compiles_when_scopes_change(self):
         with temporary_dir(root_dir=get_buildroot()) as workdir_parent:

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_test_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_test_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ScopeTestIntegrationTest(PantsRunIntegrationTest):
     """Tests for the behavior of the 'test' scope.
 

--- a/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class BackendIndependenceTest(PantsRunIntegrationTest):
     """Verifies that this backend works with no other backends present."""
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -5,11 +5,14 @@ import json
 import os
 import re
 
+import pytest
+
 from pants_test.backend.jvm.tasks.jvm_compile.scala.base_scalac_plugin_integration_test import (
     ScalacPluginIntegrationTestBase,
 )
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
 
     scalac_test_targets_dir = "examples/src/scala/org/pantsbuild/example/scalac"

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -5,6 +5,8 @@ import json
 import os
 import re
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.intermediate_target_factory import hash_target
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
@@ -12,6 +14,7 @@ from pants.util.collections import ensure_str_list
 from pants_test.backend.project_info.tasks.resolve_jars_test_mixin import ResolveJarsTestMixin
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
     _confs_args = [
         "--export-libraries-sources",

--- a/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
+++ b/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from contextlib import contextmanager
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -44,6 +46,7 @@ class Bundles:
     all_bundles = [lesser_of_two, once_upon_a_time, ten_thousand, there_was_a_duck]
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ExcludeTargetRegexpIntegrationTest(PantsRunIntegrationTest):
     """Tests the functionality of the --exclude-target-regexp flag."""
 

--- a/tests/python/pants_test/cache/test_cache_cleanup_integration.py
+++ b/tests/python/pants_test/cache/test_cache_cleanup_integration.py
@@ -5,11 +5,14 @@ import glob
 import os
 import time
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_delete, safe_mkdir, touch
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
     def _create_platform_args(self, version):
         return [

--- a/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+++ b/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class AliasTargetIntegrationTest(PantsRunIntegrationTest):
 
     test_module = "testprojects/src/java/org/pantsbuild/testproject/aliases"

--- a/tests/python/pants_test/engine/legacy/test_bundle_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_bundle_integration.py
@@ -4,10 +4,13 @@
 import os
 from contextlib import contextmanager
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class BundleIntegrationTest(PantsRunIntegrationTest):
 
     TARGET_PATH = "testprojects/src/java/org/pantsbuild/testproject/bundle"

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -4,10 +4,13 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_file_path
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class RunTrackerIntegrationTest(PantsRunIntegrationTest):
 
     load_plugin_cmdline = [

--- a/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
+++ b/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
@@ -4,10 +4,13 @@
 import os
 import shutil
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class StrictDepsInvalidationIntegrationTest(PantsRunIntegrationTest):
 
     TEST_SRC = "testprojects/tests/java/org/pantsbuild/testproject/strictdeps"

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -5,6 +5,8 @@ import os
 from contextlib import contextmanager
 from unittest import skipIf
 
+import pytest
+
 from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.testutil.subsystem.util import global_subsystem_instance
@@ -27,6 +29,7 @@ def _get_two_distributions():
             return None
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class DistributionIntegrationTest(PantsRunIntegrationTest):
     def _test_two_distributions(self, os_name=None):
         java8, java9 = _get_two_distributions()

--- a/tests/python/pants_test/java/test_nailgun_integration.py
+++ b/tests/python/pants_test/java/test_nailgun_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestNailgunIntegration(PantsRunIntegrationTest):
     target = "examples/src/scala/org/pantsbuild/example/hello/welcome"
 

--- a/tests/python/pants_test/projects/test_antlr_projects_integration.py
+++ b/tests/python/pants_test/projects/test_antlr_projects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestAntlrProjectsIntegration(ProjectsTestBase):
     def test_antlr_projects(self) -> None:
         self.assert_valid_projects("examples/src/antlr::", "testprojects/src/antlr::")

--- a/tests/python/pants_test/projects/test_java_examples_integration.py
+++ b/tests/python/pants_test/projects/test_java_examples_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestJavaExamplesIntegration(ProjectsTestBase):
     def test_java_examples(self) -> None:
         self.assert_valid_projects("examples/src/java::", "examples/tests/java::")

--- a/tests/python/pants_test/projects/test_java_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_java_testprojects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestJavaTestprojectsIntegration(ProjectsTestBase):
     def test_java_testprojects(self) -> None:
         self.assert_valid_projects("testprojects/src/java::", "testprojects/tests/java::")

--- a/tests/python/pants_test/projects/test_maven_layout_integration.py
+++ b/tests/python/pants_test/projects/test_maven_layout_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestMavenLayoutIntegration(ProjectsTestBase):
     def test_maven_layout(self) -> None:
         self.assert_valid_projects("testprojects/maven_layout::")

--- a/tests/python/pants_test/projects/test_protobuf_projects_integration.py
+++ b/tests/python/pants_test/projects/test_protobuf_projects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestProtobufProjectsIntegration(ProjectsTestBase):
     def test_protobuf_projects(self) -> None:
         self.assert_valid_projects("examples/src/protobuf::", "testprojects/src/protobuf::")

--- a/tests/python/pants_test/projects/test_scala_examples_integration.py
+++ b/tests/python/pants_test/projects/test_scala_examples_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestScalaExamplesIntegration(ProjectsTestBase):
     def test_scala_examples(self) -> None:
         self.assert_valid_projects("examples/src/scala::", "examples/tests/scala::")

--- a/tests/python/pants_test/projects/test_scala_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_scala_testprojects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestScalaTestprojectsIntegration(ProjectsTestBase):
     def test_scala_testprojects(self) -> None:
         self.assert_valid_projects("testprojects/src/scala::", "testprojects/tests/scala::")

--- a/tests/python/pants_test/projects/test_thrift_projects_integration.py
+++ b/tests/python/pants_test/projects/test_thrift_projects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestThriftProjectsIntegration(ProjectsTestBase):
     def test_thrift_projects(self) -> None:
         self.assert_valid_projects("examples/src/thrift::", "testprojects/src/thrift::")

--- a/tests/python/pants_test/projects/test_wire_projects_integration.py
+++ b/tests/python/pants_test/projects/test_wire_projects_integration.py
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.projects.projects_test_base import ProjectsTestBase
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestWireProjectsIntegration(ProjectsTestBase):
     def test_wire_projects(self) -> None:
         self.assert_valid_projects("examples/src/wire::")

--- a/tests/python/pants_test/targets/test_jvm_app_integration.py
+++ b/tests/python/pants_test/targets/test_jvm_app_integration.py
@@ -4,9 +4,12 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class TestJvmAppIntegrationTest(PantsRunIntegrationTest):
 
     BUNDLE_DIRECTORY = "testprojects/src/java/org/pantsbuild/testproject/bundle"

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -5,6 +5,8 @@ import os
 from contextlib import contextmanager
 from textwrap import dedent
 
+import pytest
+
 from pants.base.build_environment import get_buildroot
 from pants.testutil.git_util import initialize_repo
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
@@ -12,6 +14,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
 
 
+@pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/9350")
 class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
     @contextmanager
     def known_commits(self):


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/9350.

Until we can revert this PR, we should not merge any JVM related PRs.