### PR TITLE
Change google maven mirror url

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -31,7 +31,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
            maven central due to all RBE traffic appearing to them as coming from a single IP.
            There's no harm in trying this even outside RBE, as it is world-visible. -->
       <ibiblio name="maven-central-mirror" m2compatible="true" descriptor="required"
-               root="https://maven-central.storage-download.googleapis.com/repos/central/data"/>
+               root="https://maven-central.storage-download.googleapis.com/maven2"/>
 
       <ibiblio name="maven-central" m2compatible="true" descriptor="required"/>
 

--- a/pants.toml
+++ b/pants.toml
@@ -462,7 +462,7 @@ repos = [
   # First try RBE's maven central mirror, as we can get throttled by
   # maven central due to all RBE traffic appearing to them as coming from a single IP.
   # There's no harm in trying this even outside RBE, as it is world-visible.
-  'https://maven-central.storage-download.googleapis.com/repos/central/data',
+  'https://maven-central.storage-download.googleapis.com/maven2',
   'https://repo1.maven.org/maven2',
   # Custom repo for Kythe jars, as Google doesn't currently publish them anywhere.
   'https://raw.githubusercontent.com/toolchainlabs/binhost/master/',

--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -40,7 +40,7 @@ class CoursierSubsystem(Script):
             fingerprint=True,
             help="Maven style repos",
             default=[
-                "https://maven-central.storage-download.googleapis.com/repos/central/data",
+                "https://maven-central.storage-download.googleapis.com/maven2",
                 "https://repo1.maven.org/maven2",
             ],
         )

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -20,7 +20,7 @@ class IvySubsystem(Script):
 
     _default_urls = [
         "https://repo1.maven.org/maven2/org/apache/ivy/ivy/{version}/ivy-{version}.jar",
-        "https://maven-central.storage-download.googleapis.com/repos/central/data/org/apache/ivy/ivy/{version}/ivy-{version}.jar",
+        "https://maven-central.storage-download.googleapis.com/maven2/org/apache/ivy/ivy/{version}/ivy-{version}.jar",
     ]
 
     @classmethod

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -77,7 +77,7 @@ class CoursierResolveTest(NailgunTaskTestBase):
                 "a",
                 "b",
                 "c",
-                url="https://maven-central.storage-download.googleapis.com/repos/central/data/junit/junit/4.12/junit-4.12.jar",
+                url="https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.12/junit-4.12.jar",
             )
             dep_with_url_lib = self.make_target("//:a", JarLibrary, jars=[dep_with_url])
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -153,7 +153,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
                     "junit:junit:4.12",
                     "-r",
                     # This is needed to get around the maven blacklisting RBE.
-                    "https://maven-central.storage-download.googleapis.com/repos/central/data",
+                    "https://maven-central.storage-download.googleapis.com/maven2",
                 ],
                 stdout=f,
             )

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -31,7 +31,7 @@ class SyntheticClasspathTest(NailgunTaskTestBase):
             try:
                 # Download a jar that echoes things.
                 fetcher.download(
-                    "https://maven-central.storage-download.googleapis.com/repos/central/data/io/get-coursier/echo/1.0.0/echo-1.0.0.jar",
+                    "https://maven-central.storage-download.googleapis.com/maven2/io/get-coursier/echo/1.0.0/echo-1.0.0.jar",
                     path_or_fd=temp_path.name,
                     timeout_secs=2,
                 )


### PR DESCRIPTION
because 
https://maven-central.storage-download.googleapis.com/maven2/org/pantsbuild/zinc-compiler_2.12/0.0.20/zinc-compiler_2.12-0.0.20.pom
works, whereas
https://maven-central.storage-download.googleapis.com/repos/central/data/org/pantsbuild/zinc-compiler_2.12/0.0.20/zinc-compiler_2.12-0.0.20.pom
does not.