### PR TITLE
Add runtime type checking to Fields

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import Optional
 
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
@@ -19,7 +19,7 @@ from pants.rules.core.determine_source_files import AllSourceFilesRequest, Sourc
 
 @dataclass(frozen=True)
 class PythonBinaryImplementation(BinaryImplementation):
-    required_fields: ClassVar = (EntryPoint, PythonBinarySources)
+    required_fields = (EntryPoint, PythonBinarySources)
 
     address: Address
     sources: PythonBinarySources

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pathlib import PurePath
-from typing import ClassVar, Optional
+from typing import Optional
 
 from pants.build_graph.address import Address
 from pants.engine.fs import Snapshot
@@ -32,11 +32,11 @@ class PythonSources(Sources):
 
 
 class PythonLibrarySources(PythonSources):
-    default_globs: ClassVar = ("*.py", "!test_*.py", "!*_test.py", "!conftest.py")
+    default_globs = ("*.py", "!test_*.py", "!*_test.py", "!conftest.py")
 
 
 class PythonTestsSources(PythonSources):
-    default_globs: ClassVar = ("test_*.py", "*_test.py", "conftest.py")
+    default_globs = ("test_*.py", "*_test.py", "conftest.py")
 
 
 class PythonBinarySources(PythonSources):
@@ -59,17 +59,17 @@ class Compatibility(StringOrStringSequenceField):
     As a shortcut, you can leave off `CPython`, e.g. `>=2.7` will be expanded to `CPython>=2.7`.
     """
 
-    alias: ClassVar = "compatibility"
+    alias = "compatibility"
 
 
 class Provides(UnimplementedField):
-    alias: ClassVar = "provides"
+    alias = "provides"
 
 
 class Coverage(StringOrStringSequenceField):
     """The module(s) whose coverage should be generated, e.g. `['pants.util']`."""
 
-    alias: ClassVar = "coverage"
+    alias = "coverage"
 
 
 class Timeout(IntField):
@@ -78,7 +78,7 @@ class Timeout(IntField):
     This only applies if `--pytest-timeouts` is set to True.
     """
 
-    alias: ClassVar = "timeout"
+    alias = "timeout"
 
     def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[int]:
         hydrated_value = super().hydrate(raw_value, address=address)
@@ -97,59 +97,59 @@ class EntryPoint(StringField):
     `__main__` function.
     """
 
-    alias: ClassVar = "entry_point"
+    alias = "entry_point"
 
 
 class Platforms(StringOrStringSequenceField):
     """Extra platforms to target when building a Python binary."""
 
-    alias: ClassVar = "platforms"
+    alias = "platforms"
 
 
 class PexInheritPath(BoolField):
     """Whether to inherit the `sys.path` of the environment that the binary runs in or not."""
 
-    alias: ClassVar = "inherit_path"
-    default: ClassVar = False
+    alias = "inherit_path"
+    default = False
 
 
 class PexZipSafe(BoolField):
     """Whether or not this binary is safe to run in compacted (zip-file) form."""
 
-    alias: ClassVar = "zip_safe"
-    default: ClassVar = True
+    alias = "zip_safe"
+    default = True
 
 
 class PexAlwaysWriteCache(BoolField):
     """Whether Pex should always write the .deps cache of the Pex file to disk or not."""
 
-    alias: ClassVar = "always_write_cache"
-    default: ClassVar = False
+    alias = "always_write_cache"
+    default = False
 
 
 class PexRepositories(StringOrStringSequenceField):
     """Repositories for Pex to query for dependencies."""
 
-    alias: ClassVar = "repositories"
+    alias = "repositories"
 
 
 class PexIndices(StringOrStringSequenceField):
     """Indices for Pex to use for packages."""
 
-    alias: ClassVar = "indices"
+    alias = "indices"
 
 
 class IgnorePexErrors(BoolField):
     """Should we ignore when Pex cannot resolve dependencies?"""
 
-    alias: ClassVar = "ignore_errors"
-    default: ClassVar = False
+    alias = "ignore_errors"
+    default = False
 
 
 class PexShebang(StringField):
     """For the generated Pex, use this shebang."""
 
-    alias: ClassVar = "shebang"
+    alias = "shebang"
 
 
 # TODO: This option is weird. Its default is determined by `--python-binary-pex-emit-warnings`.
@@ -158,8 +158,8 @@ class PexShebang(StringField):
 class EmitPexWarnings(BoolField):
     """Whether or not to emit Pex warnings at runtime."""
 
-    alias: ClassVar = "emit_warnings"
-    default: ClassVar = True
+    alias = "emit_warnings"
+    default = True
 
 
 COMMON_PYTHON_FIELDS = (*COMMON_TARGET_FIELDS, Compatibility, Provides)
@@ -173,8 +173,8 @@ class PythonBinary(Target):
     http://pantsbuild.github.io/python-readme.html#how-pex-files-work.
     """
 
-    alias: ClassVar = "python_binary"
-    core_fields: ClassVar = (
+    alias = "python_binary"
+    core_fields = (
         *COMMON_PYTHON_FIELDS,
         PythonBinarySources,
         EntryPoint,
@@ -191,10 +191,10 @@ class PythonBinary(Target):
 
 
 class PythonLibrary(Target):
-    alias: ClassVar = "python_library"
-    core_fields: ClassVar = (*COMMON_PYTHON_FIELDS, PythonLibrarySources)
+    alias = "python_library"
+    core_fields = (*COMMON_PYTHON_FIELDS, PythonLibrarySources)
 
 
 class PythonTests(Target):
-    alias: ClassVar = "python_tests"
-    core_fields: ClassVar = (*COMMON_PYTHON_FIELDS, PythonTestsSources, Coverage, Timeout)
+    alias = "python_tests"
+    core_fields = (*COMMON_PYTHON_FIELDS, PythonTestsSources, Coverage, Timeout)

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -45,7 +45,7 @@ class PythonBinarySources(PythonSources):
         if len(snapshot.files) not in [0, 1]:
             raise InvalidFieldException(
                 f"The {repr(self.alias)} field in target {self.address} must only have 0 or 1 "
-                f"files because it is a binary target, but has {len(snapshot.files)} sources: "
+                f"files because it is a binary target, but it has {len(snapshot.files)} sources: "
                 f"{sorted(snapshot.files)}.\n\nTo use any additional files, put them in a "
                 "`python_library` and then add that `python_library` as a `dependency`."
             )

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -37,9 +37,6 @@ class ErrorWhileTesting(TaskError):
     """
 
 
-# TODO: Create subclasses for the V2 Target API, e.g. one for an invalid field. We don't
-#  want to use the exceptions in build_graph.target.Target to avoid coupling to V1. Likely, these
-#  new exceptions should live in engine.target for fewer import statements for target authors.
 class TargetDefinitionException(Exception):
     """Indicates an invalid target definition.
 
@@ -48,9 +45,9 @@ class TargetDefinitionException(Exception):
 
     def __init__(self, target, msg):
         """
-    :param target: the target in question
-    :param string msg: a description of the target misconfiguration
-    """
+        :param target: the target in question
+        :param string msg: a description of the target misconfiguration
+        """
         super().__init__(f"Invalid target {target}: {msg}")
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -537,7 +537,7 @@ class InvalidFieldTypeException(InvalidFieldException):
         )
 
 
-class UnimplementedField(PrimitiveField):
+class UnimplementedField(PrimitiveField, metaclass=ABCMeta):
     """Simply use whatever value the user passed in the BUILD file.
 
     Warning: This is not safe to use with the engine. If the user uses an unhashable type like a
@@ -557,7 +557,7 @@ class UnimplementedField(PrimitiveField):
         return raw_value
 
 
-class BoolField(PrimitiveField):
+class BoolField(PrimitiveField, metaclass=ABCMeta):
     value: bool
     default: ClassVar[bool]
 
@@ -571,7 +571,7 @@ class BoolField(PrimitiveField):
         return raw_value
 
 
-class IntField(PrimitiveField):
+class IntField(PrimitiveField, metaclass=ABCMeta):
     value: Optional[int]
 
     def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[int]:
@@ -582,7 +582,7 @@ class IntField(PrimitiveField):
         return raw_value
 
 
-class FloatField(PrimitiveField):
+class FloatField(PrimitiveField, metaclass=ABCMeta):
     value: Optional[float]
 
     def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[float]:
@@ -597,7 +597,7 @@ class FloatField(PrimitiveField):
         return raw_value
 
 
-class StringField(PrimitiveField):
+class StringField(PrimitiveField, metaclass=ABCMeta):
     value: Optional[str]
 
     def hydrate(self, raw_value: Optional[str], *, address: Address) -> Optional[str]:
@@ -608,7 +608,7 @@ class StringField(PrimitiveField):
         return raw_value
 
 
-class StringSequenceField(PrimitiveField):
+class StringSequenceField(PrimitiveField, metaclass=ABCMeta):
     value: Optional[Tuple[str, ...]]
 
     def hydrate(
@@ -628,7 +628,7 @@ class StringSequenceField(PrimitiveField):
         return tuple(sorted(raw_value))
 
 
-class StringOrStringSequenceField(PrimitiveField):
+class StringOrStringSequenceField(PrimitiveField, metaclass=ABCMeta):
     """The raw_value may either be a string or be an iterable of strings.
 
     This is syntactic sugar that we use for certain fields to make BUILD files simpler when the user

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -659,7 +659,7 @@ class StringOrStringSequenceField(PrimitiveField):
 
 
 class Tags(StringSequenceField):
-    alias: ClassVar = "tags"
+    alias = "tags"
 
 
 # TODO: figure out what support looks like for this. This already gets hydrated into a
@@ -667,7 +667,7 @@ class Tags(StringSequenceField):
 #  back to being a List[str] and we only hydrate into Addresses when necessary? Alternatively, does
 #  hydration mean getting back `Targets`?
 class Dependencies(AsyncField):
-    alias: ClassVar = "dependencies"
+    alias = "dependencies"
     sanitized_raw_value: Optional[Tuple[Address, ...]]
 
     def sanitize_raw_value(
@@ -685,7 +685,7 @@ COMMON_TARGET_FIELDS = (Dependencies, Tags)
 
 
 class Sources(AsyncField):
-    alias: ClassVar = "sources"
+    alias = "sources"
     default_globs: ClassVar[Optional[Tuple[str, ...]]] = None
     sanitized_raw_value: Optional[Tuple[str, ...]]
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type, T
 
 from typing_extensions import final
 
-from pants.base.exceptions import TargetDefinitionException
 from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.engine.addressable import assert_single_address
@@ -55,11 +54,14 @@ class Field(ABC):
 class PrimitiveField(Field, metaclass=ABCMeta):
     """A Field that does not need the engine in order to be hydrated.
 
-    This should be used by the majority of fields.
+    The majority of fields should use subclasses of `PrimitiveField`, e.g. use `BoolField`,
+    `StringField`, or `StringSequenceField`. These subclasses will provide sane type hints and
+    hydration/validation automatically.
 
-    Subclasses must implement `hydrate()` to convert the `raw_value` into `self.value`. This
-    hydration and/or validation happens eagerly in the constructor. If the hydration is
-    particularly expensive, use `AsyncField` instead to get the benefits of the engine's caching.
+    Subclasses of PrimitiveField must implement `hydrate()` to convert the `raw_value` into
+    `self.value`. This hydration and/or validation happens eagerly in the constructor. If the
+    hydration is particularly expensive, use `AsyncField` instead to get the benefits of the
+    engine's caching.
 
     The hydrated `value` must be immutable and hashable so that this Field may be used by the
     V2 engine. This means, for example, using tuples rather than lists and using
@@ -99,8 +101,6 @@ class PrimitiveField(Field, metaclass=ABCMeta):
         Iterable[str] to List[str].
 
         The resulting value should be immutable and hashable.
-
-        If you have no validation/hydration, simply set this function to `return raw_value`.
         """
 
     def __repr__(self) -> str:
@@ -261,10 +261,10 @@ class Target(ABC):
         aliases_to_field_types = {field_type.alias: field_type for field_type in self.field_types}
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
-                raise TargetDefinitionException(
+                raise InvalidFieldException(
                     address,
-                    f"Unrecognized field `{alias}={value}`. Valid fields for the target type "
-                    f"`{self.alias}`: {sorted(aliases_to_field_types.keys())}.",
+                    f"Unrecognized field `{alias}={value}` in target {address}. Valid fields for "
+                    f"the target type `{self.alias}`: {sorted(aliases_to_field_types.keys())}.",
                 )
             field_type = aliases_to_field_types[alias]
             self.field_values[field_type] = field_type(value, address=address)
@@ -520,13 +520,41 @@ class RegisteredTargetTypes:
         return tuple(self.aliases_to_types.values())
 
 
-# TODO: add light-weight runtime type checking to these helper fields, such as ensuring that
-# the raw_value of `BoolField` is in fact a `bool` and not an int or str. Use `instanceof`. All
-# the types are primitive objects like `str` and `int`, so this should be performant and easy to
-# implement.
-#
-# We should also sort where relevant, e.g. in `StringSequenceField`. This is important for cacahe
-# hits.
+class InvalidFieldException(Exception):
+    pass
+
+
+class InvalidFieldTypeException(InvalidFieldException):
+    """This is used to ensure that the field's value conforms with the expected type for the field,
+    e.g. `a boolean` or `a string` or `an iterable of strings and integers`."""
+
+    def __init__(
+        self, address: Address, field_alias: str, raw_value: Optional[Any], *, expected_type: str
+    ) -> None:
+        super().__init__(
+            f"The {repr(field_alias)} field in target {address} must be {expected_type}, but was "
+            f"`{repr(raw_value)}` with type `{type(raw_value).__name__}`."
+        )
+
+
+class UnimplementedField(PrimitiveField):
+    """Simply use whatever value the user passed in the BUILD file.
+
+    Warning: This is not safe to use with the engine. If the user uses an unhashable type like a
+    list, the engine will fail.
+    """
+
+    value: Optional[Any]
+
+    # TODO: maybe implement __hash__ on this so that this can always be used with the engine? For
+    # example, `return hash(repr(raw_value))`?
+    #
+    # Whether we keep this Field or not really depends on how we approach backward-compatibility
+    # with V1. Are we indeed going to remove TargetAdaptor and use this API, which requires an
+    # explicit definition for each Field? How would this interact with custom target types? If we
+    # keep TargetAdaptor around for the sake of V1, then we should remove this Field.
+    def hydrate(self, raw_value: Optional[Any], *, address: Address) -> ImmutableValue:
+        return raw_value
 
 
 class BoolField(PrimitiveField):
@@ -536,6 +564,36 @@ class BoolField(PrimitiveField):
     def hydrate(self, raw_value: Optional[bool], *, address: Address) -> bool:
         if raw_value is None:
             return self.default
+        if not isinstance(raw_value, bool):
+            raise InvalidFieldTypeException(
+                address, self.alias, raw_value, expected_type="a boolean",
+            )
+        return raw_value
+
+
+class IntField(PrimitiveField):
+    value: Optional[int]
+
+    def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[int]:
+        if raw_value and not isinstance(raw_value, int):
+            raise InvalidFieldTypeException(
+                address, self.alias, raw_value, expected_type="an integer",
+            )
+        return raw_value
+
+
+class FloatField(PrimitiveField):
+    value: Optional[float]
+
+    def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[float]:
+        # TODO: consider if we want to also accept `int` and proactively convert it to `float`.
+        #  This is probably more user-friendly, but there are also benefits to forcing a user to
+        #  use `0.0` instead of `0` because it makes them realize that this field does care about
+        #  the extra precision.
+        if raw_value and not isinstance(raw_value, float):
+            raise InvalidFieldTypeException(
+                address, self.alias, raw_value, expected_type="a float",
+            )
         return raw_value
 
 
@@ -543,6 +601,10 @@ class StringField(PrimitiveField):
     value: Optional[str]
 
     def hydrate(self, raw_value: Optional[str], *, address: Address) -> Optional[str]:
+        if raw_value and not isinstance(raw_value, str):
+            raise InvalidFieldTypeException(
+                address, self.alias, raw_value, expected_type="a string",
+            )
         return raw_value
 
 
@@ -554,7 +616,16 @@ class StringSequenceField(PrimitiveField):
     ) -> Optional[Tuple[str, ...]]:
         if raw_value is None:
             return None
-        return tuple(raw_value)
+        try:
+            ensure_str_list(raw_value)
+        except ValueError:
+            raise InvalidFieldTypeException(
+                address,
+                self.alias,
+                raw_value,
+                expected_type="an iterable of strings (e.g. a list of strings)",
+            )
+        return tuple(sorted(raw_value))
 
 
 class StringOrStringSequenceField(PrimitiveField):
@@ -573,7 +644,18 @@ class StringOrStringSequenceField(PrimitiveField):
     ) -> Optional[Tuple[str, ...]]:
         if raw_value is None:
             return None
-        return tuple(ensure_str_list(raw_value))
+        try:
+            str_list = ensure_str_list(raw_value)
+        except ValueError:
+            raise InvalidFieldTypeException(
+                address,
+                self.alias,
+                raw_value,
+                expected_type=(
+                    "either a single string or an iterable of strings (e.g. a list of strings)"
+                ),
+            )
+        return tuple(sorted(str_list))
 
 
 class Tags(StringSequenceField):
@@ -610,7 +692,16 @@ class Sources(AsyncField):
     def sanitize_raw_value(self, raw_value: Optional[Iterable[str]]) -> Optional[Tuple[str, ...]]:
         if raw_value is None:
             return None
-        return tuple(raw_value)
+        try:
+            ensure_str_list(raw_value)
+        except ValueError:
+            raise InvalidFieldTypeException(
+                self.address,
+                self.alias,
+                raw_value,
+                expected_type="an iterable of strings (e.g. a list of strings)",
+            )
+        return tuple(sorted(raw_value))
 
     def validate_snapshot(self, _: Snapshot) -> None:
         """Perform any validation on the resulting snapshot, e.g. ensuring that all files end in

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -39,5 +39,5 @@ def rules():
     ]
 
 
-def targets():
+def targets2():
     return [Files]

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -1,8 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import ClassVar
-
 from pants.engine.target import COMMON_TARGET_FIELDS, Sources, Target
 
 
@@ -16,4 +14,4 @@ class FilesSources(Sources):
 class Files(Target):
     """A collection of loose files."""
 
-    core_fields: ClassVar = (*COMMON_TARGET_FIELDS, FilesSources)
+    core_fields = (*COMMON_TARGET_FIELDS, FilesSources)

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -14,4 +14,5 @@ class FilesSources(Sources):
 class Files(Target):
     """A collection of loose files."""
 
+    alias = "files"
     core_fields = (*COMMON_TARGET_FIELDS, FilesSources)


### PR DESCRIPTION
## Problem

Even when we put type hints on `Field`s for what we expect their `raw_value` to be, we have no way of actually enforcing this beyond runtime type checks. For example, we expect the value for `ZipSafe` to be `Optional[bool]`, but there is nothing stopping users from doing this:

```python
python_binary(
  zip_safe=123,
)
```

Without runtime type checks, this means that our type hints would now be lies and we risk getting weird `TypeError`s that are hard to debug when the value is different than what we expected.

## Solution

Add runtime type checking to each of the `PrimitiveField` helpers, e.g. `BoolField` and `StringField`. This means that almost none of the actual concrete target types had to change - they get the validation automatically thanks to inheritance.

### Stop using `ClassVar` when unnecessary

This also stops annotating all `Field` and `Target` subclasses with `ClassVar`, which John pointed out is redundant. Turns out, it indeed is redundant. See https://docs.python.org/3/library/dataclasses.html#class-variables for how class properties work with dataclasses. This greatly reduces boilerplate.

### Mark `PrimitiveField` subclasses with `ABCMeta`

This ensures that no one ever tries to instantiate `StringField`, `BoolField`, etc. These are only superclasses for boilerplate reduction.

### Fix `Files` target registration

It was missing an `alias` and its `register.py` still used `targets()`, rather than `targets2()` (see https://github.com/pantsbuild/pants/pull/9334).

## Result

Invalid boolean field:

> ERROR: The 'zip_safe' field in target build-support/bin:check_banned_imports must be a boolean, but was `123` with type `int`.

Invalid string sequence field:

> ERROR: The 'tags' field in target build-support/bin:check_banned_imports must be an iterable of strings (e.g. a list of strings), but was `{1, 2}` with type `set`.

Non-python `sources`:

> ERROR: The 'sources' field in target build-support/bin:check_banned_imports must only contain Python files that end in `.py`, but it had these non-Python files: ['build-support/bin/check_clippy.sh'].

Binary target with > 1 source file:

> ERROR: The 'sources' field in target build-support/bin:check_banned_imports must only have 0 or 1 files because it is a binary target, but it has 2 sources: ['build-support/bin/check_banned_imports.py', 'build-support/bin/check_header.py'].
>
> To use any additional files, put them in a `python_library` and then add that `python_library` as a `dependency`.