### PR TITLE
Prepare 1.25.1rc0

### DIFF
--- a/src/python/pants/notes/1.25.x.rst
+++ b/src/python/pants/notes/1.25.x.rst
@@ -10,6 +10,45 @@ The ``1.25.x`` series brings two major changes to Pants:
 
 Please see https://groups.google.com/forum/#!topic/pants-devel/3nmdSeyvwU0 for more information.
 
+1.25.1rc0 (03/20/2020)
+----------------------
+
+API Changes
+~~~~~~~~~~~
+
+* Zinc: Use an Array[PublishDiagnosticsParam] for LSP compliance (#9292)
+  `PR #9292 <https://github.com/pantsbuild/pants/pull/9292>`_
+
+* Enable zinc to log diagnostics for jvm languages (#9228)
+  `PR #9228 <https://github.com/pantsbuild/pants/pull/9228>`_
+
+New Features
+~~~~~~~~~~~~
+
+* Report warnings and errors to reporting server for JVM targets (#9293)
+  `PR #9293 <https://github.com/pantsbuild/pants/pull/9293>`_
+
+Bugfixes
+~~~~~~~~
+
+* Fix relative path in Zinc compiler (#9261)
+  `PR #9261 <https://github.com/pantsbuild/pants/pull/9261>`_
+
+* Revert "Load the bootstrapped zinc compiler from the zinc server's classpath. (#8753)" (#9226)
+  `PR #9226 <https://github.com/pantsbuild/pants/pull/9226>`_
+
+* fixing scoverage sourcePath to be relative in OSS (#8132)
+  `PR #8132 <https://github.com/pantsbuild/pants/pull/8132>`_
+
+Refactoring, Improvements, and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix `PathGlobs` to be deterministic for more cache hits (#9347)
+  `PR #9347 <https://github.com/pantsbuild/pants/pull/9347>`_
+
+* Format zinc compiler with scalafmt (#9227)
+  `PR #9227 <https://github.com/pantsbuild/pants/pull/9227>`_
+
 1.25.0 (03/12/2020)
 -------------------
 


### PR DESCRIPTION
### Problem

Twitter is still using version 1.25.x or pants and we are interested in recent changes that allow zinc to report the number of diagnostics per target to our reporting server.

### Solution

Prepare a release candidate for 1.25.1

### Result

We will be able to cherry-pick this commit to the 1.25.x branch and release 1.25.1rc0