### PR TITLE
Additional refactoring around pants initialization

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -260,7 +260,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 # Clean global state.
                 clean_global_runtime_state(reset_subsystem=True)
 
-                options, _, options_bootstrapper = LocalPantsRunner.parse_options(
+                options, build_root, options_bootstrapper = LocalPantsRunner.parse_options(
                     self._args, self._env
                 )
                 graph_helper, specs, exit_code = self._scheduler_service.prepare_v1_graph_run_v2(

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -261,7 +261,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 # Clean global state.
                 clean_global_runtime_state(reset_subsystem=True)
 
-                options, build_root, options_bootstrapper = LocalPantsRunner.parse_options(
+                options, _, options_bootstrapper = LocalPantsRunner.parse_options(
                     self._args, self._env
                 )
 
@@ -272,7 +272,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                     options=options,
                     session=session.scheduler_session,
                     exclude_patterns=tuple(global_options.exclude_target_regexp),
-                    tags=tuple(global_options.tag) if global_options.tag else tuple(),
+                    tags=tuple(global_options.tag) if global_options.tag else (),
                 )
 
                 exit_code = self._scheduler_service.graph_run_v2(

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -204,10 +204,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
         # If we're running with the daemon, we'll be handed a session from the
         # resident graph helper - otherwise initialize a new one here.
-        if daemon_graph_session:
-            graph_session = daemon_graph_session
-        else:
-            graph_session = cls._init_graph_session(options_bootstrapper, build_config, options)
+        graph_session = (
+            daemon_graph_session
+            if daemon_graph_session
+            else cls._init_graph_session(options_bootstrapper, build_config, options)
+        )
 
         if specs is None:
             global_options = options.for_global_scope()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -260,13 +260,6 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         if self._repro:
             self._repro.capture(self._run_tracker.run_info.get_as_dict())
 
-    def _maybe_handle_help(self):
-        """Handle requests for `help` information."""
-        if self.options.help_request:
-            help_printer = HelpPrinter(options=self.options, union_membership=self.union_membership)
-            result = help_printer.print_help()
-            return result
-
     def _maybe_run_v1(self, v1: bool) -> int:
         v1_goals, ambiguous_goals, _ = self.options.goals_by_version
         if not v1:
@@ -350,8 +343,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 self.scheduler_session, callbacks=callbacks, report_interval_seconds=report_interval
             )
 
-            help_output = self._maybe_handle_help()
-            if help_output is not None:
+            if self.options.help_request:
+                help_printer = HelpPrinter(
+                    options=self.options, union_membership=self.union_membership
+                )
+                help_output = help_printer.print_help()
                 self._exiter.exit(help_output)
 
             v1 = global_options.v1

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import sys
 import time
 
 from pants.base.exception_sink import ExceptionSink
@@ -25,10 +26,10 @@ def test_env():
 
 
 def main():
-    start_time = time.time()
-
     with maybe_profiled(os.environ.get("PANTSC_PROFILE")):
+        start_time = time.time()
         try:
-            PantsRunner(start_time=start_time).run()
+            runner = PantsRunner(args=sys.argv, env=os.environ,)
+            runner.run(start_time)
         except KeyboardInterrupt as e:
             ExceptionSink.get_global_exiter().exit_and_fail("Interrupted by user:\n{}".format(e))

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -191,13 +191,6 @@ class SchedulerService(PantsService):
 
         self._event_queue.task_done()
 
-    def product_graph_len(self):
-        """Provides the size of the captive product graph.
-
-        :returns: The node count for the captive product graph.
-        """
-        return self._scheduler.graph_len()
-
     def prepare_v1_graph_run_v2(
         self, options: Options, options_bootstrapper: OptionsBootstrapper,
     ) -> Tuple[LegacyGraphSession, Specs, int]:

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -220,11 +220,9 @@ class SchedulerService(PantsService):
         session = self._graph_helper.new_session(zipkin_trace_v2, build_id, v2_ui)
 
         if options.for_global_scope().get("loop", False):
-            fn = self._loop
+            specs, exit_code = self._loop(session, options, options_bootstrapper)
         else:
-            fn = self._body
-
-        specs, exit_code = fn(session, options, options_bootstrapper)
+            specs, exit_code = self._body(session, options, options_bootstrapper)
         return session, specs, exit_code
 
     def _loop(

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -219,24 +219,24 @@ class SchedulerService(PantsService):
         perform_loop = global_options.get("loop", False)
         v2 = global_options.v2
 
-        if perform_loop:
-            # TODO: See https://github.com/pantsbuild/pants/issues/6288 regarding Ctrl+C handling.
-            iterations = global_options.loop_max
-            exit_code = PANTS_SUCCEEDED_EXIT_CODE
-
-            while iterations and not self._state.is_terminating:
-                try:
-                    exit_code = self._body(session, options, options_bootstrapper, specs, v2)
-                except session.scheduler_session.execution_error_type as e:
-                    self._logger.warning(e)
-
-                iterations -= 1
-                if self._state.is_terminating or self._loop_condition.wait(timeout=1):
-                    break
-
-            return exit_code
-        else:
+        if not perform_loop:
             return self._body(session, options, options_bootstrapper, specs, v2)
+
+        # TODO: See https://github.com/pantsbuild/pants/issues/6288 regarding Ctrl+C handling.
+        iterations = global_options.loop_max
+        exit_code = PANTS_SUCCEEDED_EXIT_CODE
+
+        while iterations and not self._state.is_terminating:
+            try:
+                exit_code = self._body(session, options, options_bootstrapper, specs, v2)
+            except session.scheduler_session.execution_error_type as e:
+                self._logger.warning(e)
+
+            iterations -= 1
+            if self._state.is_terminating or self._loop_condition.wait(timeout=1):
+                break
+
+        return exit_code
 
     def _body(
         self,


### PR DESCRIPTION
This is a continuation of the work started in #9348 to make the code paths around initializing pants easier to understand, removing cruft, ultimately with the goal of making the initialization process more performant and reducing user-visible CLI latency.