### PR TITLE
Fix flaky pantsd test.

### DIFF
--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -119,7 +119,9 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 checker.assert_started()
 
                 # Assert pantsd is in a good functional state.
-                self.assert_success(self.run_pants_with_workdir(["help"], workdir, pantsd_config))
+                self.assert_success(
+                    self.run_pants_with_workdir(["--no-v1", "--v2", "help"], workdir, pantsd_config)
+                )
                 checker.assert_running()
 
     @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6114


### PR DESCRIPTION
The part of the test that ran a failing pants command and checked that pantsd doesn't die was working, but the final part, where we run a passing command to check that pantsd is "in a good functional state." did cause the daemon to die. 

For reasons unclear to me, setting `--no-v1 --v2` on the passing command (so it has the same values for those options as the failing command) keeps pantsd alive. 

We'll want to figure out why switching from v2 to v1 causes the daemon to die, but meanwhile this change preserves the core purpose of this test. 