### PR TITLE
Enable E231 lint internally to check for bad trailing commas

### DIFF
--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 extend-ignore:
   E203,  # whitespace before ':' (conflicts with Black)
-  E231,  # Missing whitespace after `,` (enable once fixed)
   E262,  # inline comment doesn't start with `#` (enable once fixed)
   E266,  # Too many leading # for block comment (maybe enable once fixed)
   E301,  # expected 1 blank line (enable once fixed)

--- a/contrib/avro/src/python/pants/contrib/avro/register.py
+++ b/contrib/avro/src/python/pants/contrib/avro/register.py
@@ -9,7 +9,7 @@ from pants.contrib.avro.tasks.avro_gen import AvroJavaGenTask
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={JavaAvroLibrary.alias(): JavaAvroLibrary,})
+    return BuildFileAliases(targets={JavaAvroLibrary.alias(): JavaAvroLibrary})
 
 
 def register_goals():

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/register.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/register.py
@@ -10,7 +10,7 @@ from pants.contrib.awslambda.python.tasks.lambdex_run import LambdexRun
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"python_awslambda": PythonAWSLambda,})
+    return BuildFileAliases(targets={"python_awslambda": PythonAWSLambda})
 
 
 def register_goals():

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
@@ -20,9 +20,7 @@ class PythonAWSLambda(Target):
         :param string handler: Lambda handler entrypoint (module.dotted.name:handler_func).
         """
         payload = Payload()
-        payload.add_fields(
-            {"binary": PrimitiveField(binary), "handler": PrimitiveField(handler),}
-        )
+        payload.add_fields({"binary": PrimitiveField(binary), "handler": PrimitiveField(handler)})
         super().__init__(payload=payload, **kwargs)
 
     @classmethod

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/extract_java.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/extract_java.py
@@ -49,7 +49,7 @@ class ExtractJava(JvmToolTaskMixin):
         cls.register_jvm_tool(
             register,
             "javac9",
-            custom_rules=[Shader.exclude_package("com.sun", recursive=True),],
+            custom_rules=[Shader.exclude_package("com.sun", recursive=True)],
             main="com.sun.tools.javac.main.Main",
         )
 

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/index_java.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/index_java.py
@@ -50,7 +50,7 @@ class IndexJava(NailgunTask):
         cls.register_jvm_tool(
             register,
             "javac9",
-            custom_rules=[Shader.exclude_package("com.sun", recursive=True),],
+            custom_rules=[Shader.exclude_package("com.sun", recursive=True)],
             main="com.sun.tools.javac.main.Main",
         )
 

--- a/contrib/cpp/src/python/pants/contrib/cpp/register.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/register.py
@@ -13,7 +13,7 @@ from pants.contrib.cpp.tasks.cpp_run import CppRun
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"cpp_library": CppLibrary, "cpp_binary": CppBinary,})
+    return BuildFileAliases(targets={"cpp_library": CppLibrary, "cpp_binary": CppBinary})
 
 
 def register_goals():

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
@@ -90,7 +90,7 @@ class FindBugs(NailgunTask):
             "findbugs",
             classpath=[JarDependency(org="com.github.spotbugs", name="spotbugs", rev="3.1.3")],
             main=cls._FINDBUGS_MAIN,
-            custom_rules=[Shader.exclude_package("edu.umd.cs.findbugs", recursive=True),],
+            custom_rules=[Shader.exclude_package("edu.umd.cs.findbugs", recursive=True)],
         )
 
     @classmethod

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
@@ -9,7 +9,7 @@ from pants.contrib.jax_ws.tasks.jax_ws_gen import JaxWsGen
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"jax_ws_library": JaxWsLibrary,})
+    return BuildFileAliases(targets={"jax_ws_library": JaxWsLibrary})
 
 
 def register_goals():

--- a/contrib/node/src/python/pants/contrib/node/targets/node_bundle.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_bundle.py
@@ -31,7 +31,7 @@ class NodeBundle(NodePackage):
 
         payload = payload or Payload()
         payload.add_fields(
-            {"archive": PrimitiveField(archive), "node_module": PrimitiveField(node_module),}
+            {"archive": PrimitiveField(archive), "node_module": PrimitiveField(node_module)}
         )
         super().__init__(address=address, payload=payload, **kwargs)
 

--- a/contrib/node/src/python/pants/contrib/node/targets/node_package.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_package.py
@@ -19,9 +19,7 @@ class NodePackage(Target):
                                     used.
         """
         payload = payload or Payload()
-        payload.add_fields(
-            {"package_name": PrimitiveField(package_name or address.target_name),}
-        )
+        payload.add_fields({"package_name": PrimitiveField(package_name or address.target_name)})
         super().__init__(address=address, payload=payload, **kwargs)
 
     @property

--- a/contrib/node/src/python/pants/contrib/node/targets/node_preinstalled_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_preinstalled_module.py
@@ -25,9 +25,7 @@ class NodePreinstalledModule(NodeModule):
         :param string url: The location of a tar.gz file containing containing a node_modules directory.
         """
         payload = payload or Payload()
-        payload.add_fields(
-            {"dependencies_archive_url": PrimitiveField(dependencies_archive_url),}
-        )
+        payload.add_fields({"dependencies_archive_url": PrimitiveField(dependencies_archive_url)})
         super().__init__(sources=sources, address=address, payload=payload, **kwargs)
 
     @property

--- a/contrib/node/src/python/pants/contrib/node/targets/node_remote_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_remote_module.py
@@ -18,7 +18,7 @@ class NodeRemoteModule(NodePackage):
         """
         payload = payload or Payload()
         payload.add_fields(
-            {"version": PrimitiveField(version or "*"),}  # Guard against/allow `None`.
+            {"version": PrimitiveField(version or "*")}  # Guard against/allow `None`.
         )
         super().__init__(address=address, payload=payload, **kwargs)
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
@@ -24,7 +24,7 @@ class NodeBuild(NodeTask):
     def _snapshotted_classpath(self, results_dir):
         relpath = fast_relpath(results_dir, get_buildroot())
         (classes_dir_snapshot,) = self.context._scheduler.capture_snapshots(
-            [PathGlobsAndRoot(PathGlobs([relpath]), get_buildroot(), Digest.load(relpath),),]
+            [PathGlobsAndRoot(PathGlobs([relpath]), get_buildroot(), Digest.load(relpath))]
         )
         return ClasspathEntry(results_dir, classes_dir_snapshot.directory_digest)
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/variable_names.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/variable_names.py
@@ -85,7 +85,7 @@ class PEP8VariableNames(CheckstylePlugin):
     def name(cls):
         return "variable-names"
 
-    CLASS_GLOBAL_BUILTINS = frozenset({"__slots__", "__metaclass__",})
+    CLASS_GLOBAL_BUILTINS = frozenset({"__slots__", "__metaclass__"})
 
     def iter_class_methods(self, class_node):
         for node in class_node.body:

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/register.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/register.py
@@ -14,7 +14,7 @@ from pants.contrib.scalajs.tasks.scala_js_zinc_compile import ScalaJSZincCompile
 
 def build_file_aliases():
     return BuildFileAliases(
-        targets={"scala_js_binary": ScalaJSBinary, "scala_js_library": ScalaJSLibrary,},
+        targets={"scala_js_binary": ScalaJSBinary, "scala_js_library": ScalaJSLibrary}
     )
 
 

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
@@ -35,7 +35,7 @@ class ScroogeGenTest(PantsRunIntegrationTest):
                     ],
                 },
                 "service_exports": {
-                    "java": ["3rdparty:thrift",],
+                    "java": ["3rdparty:thrift"],
                     "scala": [
                         "3rdparty:thrift",
                         "3rdparty/jvm/com/twitter:finagle-thrift",
@@ -43,12 +43,12 @@ class ScroogeGenTest(PantsRunIntegrationTest):
                     ],
                 },
                 "structs_deps": {
-                    "java": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core",],
-                    "scala": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core",],
+                    "java": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core"],
+                    "scala": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core"],
                 },
                 "structs_exports": {
-                    "java": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core",],
-                    "scala": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core",],
+                    "java": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core"],
+                    "scala": ["3rdparty:thrift", "3rdparty/jvm/com/twitter:scrooge-core"],
                 },
             },
         }

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -19,7 +19,7 @@ class ThriftLinterTest(TaskTestBase):
 
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"java_thrift_library": JavaThriftLibrary,},)
+        return BuildFileAliases(targets={"java_thrift_library": JavaThriftLibrary})
 
     @classmethod
     def task_type(cls):

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/register.py
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/register.py
@@ -9,7 +9,7 @@ from pants.contrib.thrifty.java_thrifty_library import JavaThriftyLibrary
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_thrifty_library": JavaThriftyLibrary,})
+    return BuildFileAliases(targets={"java_thrifty_library": JavaThriftyLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/antlr/java/register.py
+++ b/src/python/pants/backend/codegen/antlr/java/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_antlr_library": JavaAntlrLibrary,})
+    return BuildFileAliases(targets={"java_antlr_library": JavaAntlrLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/antlr/python/register.py
+++ b/src/python/pants/backend/codegen/antlr/python/register.py
@@ -7,7 +7,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"python_antlr_library": PythonAntlrLibrary,})
+    return BuildFileAliases(targets={"python_antlr_library": PythonAntlrLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/grpcio/python/register.py
+++ b/src/python/pants/backend/codegen/grpcio/python/register.py
@@ -9,7 +9,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"python_grpcio_library": PythonGrpcioLibrary,})
+    return BuildFileAliases(targets={"python_grpcio_library": PythonGrpcioLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/jaxb/jaxb_library.py
+++ b/src/python/pants/backend/codegen/jaxb/jaxb_library.py
@@ -21,7 +21,7 @@ class JaxbLibrary(JvmTarget):
 
         payload = payload or Payload()
         payload.add_fields(
-            {"package": PrimitiveField(package), "jaxb_language": PrimitiveField(language),}
+            {"package": PrimitiveField(package), "jaxb_language": PrimitiveField(language)}
         )
         super().__init__(payload=payload, **kwargs)
 

--- a/src/python/pants/backend/codegen/jaxb/register.py
+++ b/src/python/pants/backend/codegen/jaxb/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"jaxb_library": JaxbLibrary,})
+    return BuildFileAliases(targets={"jaxb_library": JaxbLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/protobuf/java/register.py
+++ b/src/python/pants/backend/codegen/protobuf/java/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_protobuf_library": JavaProtobufLibrary,})
+    return BuildFileAliases(targets={"java_protobuf_library": JavaProtobufLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/ragel/java/register.py
+++ b/src/python/pants/backend/codegen/ragel/java/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_ragel_library": JavaRagelLibrary,})
+    return BuildFileAliases(targets={"java_ragel_library": JavaRagelLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/thrift/java/register.py
+++ b/src/python/pants/backend/codegen/thrift/java/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_thrift_library": JavaThriftLibrary,})
+    return BuildFileAliases(targets={"java_thrift_library": JavaThriftLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -11,7 +11,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"python_thrift_library": PythonThriftLibrary,})
+    return BuildFileAliases(targets={"python_thrift_library": PythonThriftLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/codegen/wire/java/register.py
+++ b/src/python/pants/backend/codegen/wire/java/register.py
@@ -8,7 +8,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"java_wire_library": JavaWireLibrary,})
+    return BuildFileAliases(targets={"java_wire_library": JavaWireLibrary})
 
 
 def register_goals():

--- a/src/python/pants/backend/docgen/register.py
+++ b/src/python/pants/backend/docgen/register.py
@@ -10,7 +10,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 def build_file_aliases():
     return BuildFileAliases(
-        targets={"page": Page,},
+        targets={"page": Page},
         objects={
             "wiki_artifact": WikiArtifact,
             # TODO: Why is this capitalized?

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -16,7 +16,7 @@ class JarTool(JvmToolMixin, Subsystem):
         cls.register_jvm_tool(
             register,
             "jar-tool",
-            classpath=[JarDependency(org="org.pantsbuild", name="jar-tool", rev="0.0.16"),],
+            classpath=[JarDependency(org="org.pantsbuild", name="jar-tool", rev="0.0.16")],
         )
 
     def run(self, context, runjava, args):

--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -22,12 +22,12 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
-        cls.register_jvm_tool(register, "junit_library", classpath=[cls.LIBRARY_JAR,])
+        cls.register_jvm_tool(register, "junit_library", classpath=[cls.LIBRARY_JAR])
 
         cls.register_jvm_tool(
             register,
             "junit",
-            classpath=[cls._RUNNER_JAR,],
+            classpath=[cls._RUNNER_JAR],
             main=cls.RUNNER_MAIN,
             # TODO(John Sirois): Investigate how much less we can get away with.
             # Clearly both tests and the runner need access to the same @Test,

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -91,7 +91,7 @@ class Zinc:
             cls.register_jvm_tool(
                 register,
                 Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME,
-                classpath=[JarDependency("org.pantsbuild", "zinc-bootstrapper_2.12", "0.0.12"),],
+                classpath=[JarDependency("org.pantsbuild", "zinc-bootstrapper_2.12", "0.0.12")],
                 main=Zinc.ZINC_BOOTSTRAPER_MAIN,
                 custom_rules=shader_rules,
             )

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -31,9 +31,7 @@ class JarRule(FingerprintedMixin, metaclass=ABCMeta):
                 "The supplied apply_pattern: {pattern} "
                 "is not a valid regular expression: {msg}".format(pattern=apply_pattern, msg=e)
             )
-        self.payload.add_fields(
-            {"apply_pattern": PrimitiveField(apply_pattern),}
-        )
+        self.payload.add_fields({"apply_pattern": PrimitiveField(apply_pattern)})
 
     def fingerprint(self):
         return self.payload.fingerprint()
@@ -118,9 +116,7 @@ class Duplicate(JarRule):
           or ``Duplicate.FAIL``.
         """
         payload = Payload()
-        payload.add_fields(
-            {"action": PrimitiveField(self.validate_action(action)),}
-        )
+        payload.add_fields({"action": PrimitiveField(self.validate_action(action))})
         super().__init__(apply_pattern, payload=payload)
 
     @property
@@ -274,9 +270,7 @@ class ManifestEntries(FingerprintedMixin):
                             key, type(key).__name__
                         )
                     )
-        self.payload.add_fields(
-            {"entries": PrimitiveField(entries or {}),}
-        )
+        self.payload.add_fields({"entries": PrimitiveField(entries or {})})
 
     def fingerprint(self):
         return self.payload.fingerprint()

--- a/src/python/pants/backend/jvm/targets/runtime_platform_mixin.py
+++ b/src/python/pants/backend/jvm/targets/runtime_platform_mixin.py
@@ -30,9 +30,7 @@ class RuntimePlatformMixin(ABC):
 
     def __init__(self, payload, runtime_platform=None, **kwargs):
         payload = payload or Payload()
-        payload.add_fields(
-            {"runtime_platform": PrimitiveField(runtime_platform),}
-        )
+        payload.add_fields({"runtime_platform": PrimitiveField(runtime_platform)})
         super(RuntimePlatformMixin, self).__init__(payload=payload, **kwargs)
 
     @property

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -55,7 +55,7 @@ class Checkstyle(LintTaskMixin, NailgunTask):
             register,
             "checkstyle",
             # Note that checkstyle 7.0 does not run on Java 7 runtimes or below.
-            classpath=[JarDependency(org="com.puppycrawl.tools", name="checkstyle", rev="6.19"),],
+            classpath=[JarDependency(org="com.puppycrawl.tools", name="checkstyle", rev="6.19")],
             main=cls._CHECKSTYLE_MAIN,
             custom_rules=[
                 # Checkstyle uses reflection to load checks and has an affordance that

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -151,9 +151,7 @@ class JavacCompile(JvmCompile):
                 ]
             )
         else:
-            javac_args.extend(
-                ["-d", ctx.classes_dir.path,]
-            )
+            javac_args.extend(["-d", ctx.classes_dir.path])
 
         javac_args.extend(self._javac_plugin_args(javac_plugin_map))
 
@@ -164,9 +162,7 @@ class JavacCompile(JvmCompile):
         )
         javac_args.extend(compiler_option_sets_args)
 
-        javac_args.extend(
-            ["-classpath", ":".join(classpath),]
-        )
+        javac_args.extend(["-classpath", ":".join(classpath)])
         javac_args.extend(ctx.sources)
 
         # From https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#BHCJEIBB

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -232,7 +232,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath=[
                 JarDependency(org="com.twitter", name="rsc_2.12", rev="0.0.0-768-7357aa0a",),
             ],
-            custom_rules=[Shader.exclude_package("rsc", recursive=True),],
+            custom_rules=[Shader.exclude_package("rsc", recursive=True)],
         )
 
         scalac_outliner_version = "2.12.10"
@@ -763,7 +763,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
                         # NB: We want to ensure the 'runtime_classpath' product *only* contains the outputs of
                         # zinc compiles, and that the 'rsc_mixed_compile_classpath' entries for rsc-compatible targets
                         # *only* contain the output of an rsc compile for that target.
-                        output_products=[runtime_classpath_product,],
+                        output_products=[runtime_classpath_product],
                         dep_keys=list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)),
                     )
                 ),
@@ -772,7 +772,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
                     make_zinc_job(
                         compile_target,
                         input_product_key="rsc_mixed_compile_classpath",
-                        output_products=[runtime_classpath_product,],
+                        output_products=[runtime_classpath_product],
                         dep_keys=list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)),
                     )
                 ),
@@ -869,9 +869,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         else:
             additional_snapshots = []
             initial_args = (
-                [distribution.java,]
+                [distribution.java]
                 + rsc_jvm_options
-                + ["-cp", os.pathsep.join(tool_classpath), main,]
+                + ["-cp", os.pathsep.join(tool_classpath), main]
             )
 
         (argfile_snapshot,) = self.context._scheduler.capture_snapshots(
@@ -981,7 +981,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         zinc_args = []
         zinc_args.extend(self.create_zinc_log_level_args())
         zinc_args.extend(
-            ["-analysis-cache", analysis_cache, "-classpath", os.pathsep.join(relative_classpath),]
+            ["-analysis-cache", analysis_cache, "-classpath", os.pathsep.join(relative_classpath)]
         )
 
         compiler_bridge_classpath_entry = self._zinc.compile_compiler_bridge(self.context)
@@ -1074,7 +1074,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath_entry = self._classpath_for_context(zinc_compile_context)
             relpath = fast_relpath(classpath_entry.path, get_buildroot())
             (classes_dir_snapshot,) = self.context._scheduler.capture_snapshots(
-                [PathGlobsAndRoot(PathGlobs([relpath]), get_buildroot(), Digest.load(relpath),),]
+                [PathGlobsAndRoot(PathGlobs([relpath]), get_buildroot(), Digest.load(relpath))]
             )
             classpath_entry.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
             # Re-validate the vts!

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -158,7 +158,7 @@ class BaseZincCompile(JvmCompile):
             "--whitelisted-args",
             advanced=True,
             type=dict,
-            default={"-S.*": False, "-C.*": False, "-file-filter": True, "-msg-filter": True,},
+            default={"-S.*": False, "-C.*": False, "-file-filter": True, "-msg-filter": True},
             help="A dict of option regexes that make up pants' supported API for zinc. "
             "Options not listed here are subject to change/removal. The value of the dict "
             "indicates that an option accepts an argument.",
@@ -787,7 +787,7 @@ class BaseZincCompile(JvmCompile):
 
         def _get_analysis_snapshot():
             (_analysis_snapshot,) = self.context._scheduler.capture_snapshots(
-                [PathGlobsAndRoot(PathGlobs([relpath_to_analysis]), get_buildroot(),),]
+                [PathGlobsAndRoot(PathGlobs([relpath_to_analysis]), get_buildroot())]
             )
             return _analysis_snapshot
 
@@ -797,7 +797,7 @@ class BaseZincCompile(JvmCompile):
                     zip_ref.extractall(classes_dir)
 
             (_classes_dir_snapshot,) = self.context._scheduler.capture_snapshots(
-                [PathGlobsAndRoot(PathGlobs([classes_dir + "/**"]), get_buildroot(),),]
+                [PathGlobsAndRoot(PathGlobs([classes_dir + "/**"]), get_buildroot())]
             )
             return _classes_dir_snapshot
 

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -32,7 +32,7 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
         cls.register_jvm_tool(
             register,
             "pants-runner",
-            classpath=[JarDependency(org="org.pantsbuild", name="pants-runner", rev="0.0.1"),],
+            classpath=[JarDependency(org="org.pantsbuild", name="pants-runner", rev="0.0.1")],
             main=ScalaRepl._RUNNER_MAIN,
         )
 

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -181,7 +181,7 @@ class _Executable(_ExtensibleAlgebraic):
         """
         lib_path_env_var: str = match(
             Platform.current,
-            {Platform.darwin: "DYLD_LIBRARY_PATH", Platform.linux: "LD_LIBRARY_PATH",},
+            {Platform.darwin: "DYLD_LIBRARY_PATH", Platform.linux: "LD_LIBRARY_PATH"},
         )
 
         return {

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -57,7 +57,7 @@ class GCC(NativeTool):
 
     @memoized_property
     def _common_include_dirs(self):
-        return self._filemap([("include",), ("lib/gcc/*", self.version(), "include"),])
+        return self._filemap([("include",), ("lib/gcc/*", self.version(), "include")])
 
     def c_compiler(self, platform: Platform) -> CCompiler:
         return CCompiler(
@@ -70,7 +70,7 @@ class GCC(NativeTool):
 
     @memoized_property
     def _cpp_include_dirs(self):
-        most_cpp_include_dirs = self._filemap([("include/c++", self.version()),])
+        most_cpp_include_dirs = self._filemap([("include/c++", self.version())])
 
         # TODO(#6143): determine whether there is any manual explaining when any of these file paths are
         # necessary.

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -83,7 +83,7 @@ class LLVM(NativeTool):
     def linker(self, platform: Platform) -> Linker:
         return Linker(
             path_entries=self.path_entries,
-            exe_filename=match(platform, {Platform.darwin: "ld64.lld", Platform.linux: "lld",}),
+            exe_filename=match(platform, {Platform.darwin: "ld64.lld", Platform.linux: "lld"}),
             runtime_library_dirs=(),
             linking_library_dirs=(),
             extra_args=(),

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -48,7 +48,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
             advanced=True,
             default=match(
                 Platform.current,
-                {Platform.darwin: ToolchainVariant.llvm, Platform.linux: ToolchainVariant.gnu,},
+                {Platform.darwin: ToolchainVariant.llvm, Platform.linux: ToolchainVariant.gnu},
             ),
             type=ToolchainVariant,
             fingerprint=True,

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -218,7 +218,7 @@ async def select_llvm_c_toolchain(
             .prepend_field("runtime_library_dirs", provided_gcc.runtime_library_dirs)
         )
 
-    working_c_compiler = joined_c_compiler.prepend_field("extra_args", ["-x", "c", "-std=c11",])
+    working_c_compiler = joined_c_compiler.prepend_field("extra_args", ["-x", "c", "-std=c11"])
 
     llvm_linker_wrapper = await Get[LLVMLinker](NativeToolchain, native_toolchain)
     working_linker = llvm_linker_wrapper.for_compiler(working_c_compiler)
@@ -300,7 +300,7 @@ async def select_gcc_c_toolchain(
     # GCC needs an assembler, so we provide that (platform-specific) tool here.
     assembler = await Get[Assembler](NativeToolchain, native_toolchain)
     working_c_compiler = joined_c_compiler.sequence(assembler).prepend_field(
-        "extra_args", ["-x", "c", "-std=c11",]
+        "extra_args", ["-x", "c", "-std=c11"]
     )
 
     gcc_linker_wrapper = await Get[GCCLinker](NativeToolchain, native_toolchain)

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -25,7 +25,7 @@ class XCodeCLITools(Subsystem):
     options_scope = "xcode-cli-tools"
 
     _REQUIRED_FILES = {
-        "bin": ["as", "cc", "c++", "clang", "clang++", "ld", "lipo",],
+        "bin": ["as", "cc", "c++", "clang", "clang++", "ld", "lipo"],
         # Any of the entries that would be here are not directly below the 'include' or 'lib' dirs, and
         # we haven't yet encountered an invalid XCode/CLI tools installation which has the include dirs,
         # but incorrect files. These would need to be updated if such an issue arises.

--- a/src/python/pants/backend/native/targets/external_native_library.py
+++ b/src/python/pants/backend/native/targets/external_native_library.py
@@ -108,9 +108,7 @@ class ExternalNativeLibrary(Target):
             raise_type=self._DeprecatedStringPackage,
         )
 
-        payload.add_fields(
-            {"packages": ConanRequirementSetField(packages),}
-        )
+        payload.add_fields({"packages": ConanRequirementSetField(packages)})
         super().__init__(payload=payload, **kwargs)
 
     @property

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -135,7 +135,7 @@ class ConanFetch(SimpleCodegenTask):
 
     @memoized_property
     def _conan_os_name(self):
-        return match(Platform.current, {Platform.darwin: "Macos", Platform.linux: "Linux",})
+        return match(Platform.current, {Platform.darwin: "Macos", Platform.linux: "Linux"})
 
     @property
     def _copy_target_attributes(self):

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -21,7 +21,7 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
                 "python_library": PythonLibrary,
                 "python_requirement_library": PythonRequirementLibrary,
             },
-            objects={"python_requirement": PythonRequirement,},
+            objects={"python_requirement": PythonRequirement},
         )
 
     @classmethod

--- a/src/python/pants/backend/project_info/rules/source_file_validator_test.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator_test.py
@@ -85,8 +85,8 @@ class MultiMatcherTest(unittest.TestCase):
             self.assertEqual(expected_encoding, encoding)
 
         check({"python_header", "no_six"}, "utf8", "foo/bar/baz.py")
-        check({"jvm_header",}, "utf8", "foo/bar/baz.java")
-        check({"jvm_header",}, "utf8", "foo/bar/baz.scala")
+        check({"jvm_header"}, "utf8", "foo/bar/baz.java")
+        check({"jvm_header"}, "utf8", "foo/bar/baz.scala")
         check(set(), None, "foo/bar/baz.c")
         check(set(), None, "foo/bar/bazpy")
 
@@ -130,7 +130,7 @@ class MultiMatcherTest(unittest.TestCase):
 
     def test_pattern_name_checks(self):
         bad_config1 = {
-            "required_matches": {"unknown_path_pattern1": (), "unknown_path_pattern2": (),}
+            "required_matches": {"unknown_path_pattern1": (), "unknown_path_pattern2": ()}
         }
         with self.assertRaisesRegex(
             ValueError,

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -14,7 +14,7 @@ class PythonArtifact(PayloadField):
     class UnsupportedArgument(Exception):
         pass
 
-    UNSUPPORTED_ARGS = frozenset({"data_files", "package_dir", "package_data", "packages",})
+    UNSUPPORTED_ARGS = frozenset({"data_files", "package_dir", "package_data", "packages"})
 
     def __init__(self, **kwargs):
         """

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -85,8 +85,8 @@ def build_file_aliases():
 
 def build_file_aliases2():
     return BuildFileAliases(
-        objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact,},
-        context_aware_object_factories={"python_requirements": PythonRequirements,},
+        objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact},
+        context_aware_object_factories={"python_requirements": PythonRequirements},
     )
 
 

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -99,7 +99,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
                 "python_tests": PythonTests,
                 "python_requirement_library": PythonRequirementLibrary,
             },
-            objects={"python_requirement": PythonRequirement,},
+            objects={"python_requirement": PythonRequirement},
         )
 
     @classmethod

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -54,7 +54,7 @@ class TestSetupPyBase(TestBase):
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
         return BuildFileAliases(
-            objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact,}
+            objects={"python_requirement": PythonRequirement, "setup_py": PythonArtifact}
         )
 
     def tgt(self, addr: str) -> HydratedTarget:

--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -22,9 +22,7 @@ class PythonRequirementLibrary(Target):
         payload = payload or Payload()
 
         assert_list(requirements, expected_type=PythonRequirement, key_arg="requirements")
-        payload.add_fields(
-            {"requirements": PythonRequirementsField(requirements or []),}
-        )
+        payload.add_fields({"requirements": PythonRequirementsField(requirements or [])})
         super().__init__(payload=payload, **kwargs)
 
     @property

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -42,7 +42,7 @@ def build_file_aliases():
             "remote_sources": RemoteSources,
             "target": Target,
         },
-        objects={"get_buildroot": get_buildroot, "netrc": Netrc, "pants_version": pants_version,},
+        objects={"get_buildroot": get_buildroot, "netrc": Netrc, "pants_version": pants_version},
         context_aware_object_factories={
             "buildfile_path": BuildFilePath,
             "intransitive": IntransitiveDependencyFactory,

--- a/src/python/pants/help/build_dictionary_info_extracter_test.py
+++ b/src/python/pants/help/build_dictionary_info_extracter_test.py
@@ -203,7 +203,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
         macro_factory = TargetMacro.Factory.wrap(lambda ctx: None, Target2)
 
         bfa = BuildFileAliases(
-            targets={"target1": Target1, "target2": macro_factory, "target3": Target3,},
+            targets={"target1": Target1, "target2": macro_factory, "target3": Target3},
             objects={},
             context_aware_object_factories={},
         )

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -40,12 +40,12 @@ class HelpInfoExtracterTest(unittest.TestCase):
         do_test(["--foo"], {"metavar": "xx"}, ["--foo=xx"], ["--foo"])
         do_test(["--foo"], {"type": int}, ["--foo=<int>"], ["--foo"])
         do_test(
-            ["--foo"], {"type": list}, ["--foo=\"['<str>', '<str>', ...]\"",], ["--foo"],
+            ["--foo"], {"type": list}, ["--foo=\"['<str>', '<str>', ...]\""], ["--foo"],
         )
         do_test(
             ["--foo"],
             {"type": list, "member_type": int},
-            ['--foo="[<int>, <int>, ...]"',],
+            ['--foo="[<int>, <int>, ...]"'],
             ["--foo"],
         )
         do_test(

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -99,14 +99,14 @@ class IvySubsystem(Script):
         if http_proxy:
             host, port = self._parse_proxy_string(http_proxy)
             extra_options.extend(
-                ["-Dhttp.proxyHost={}".format(host), "-Dhttp.proxyPort={}".format(port),]
+                ["-Dhttp.proxyHost={}".format(host), "-Dhttp.proxyPort={}".format(port)]
             )
 
         https_proxy = self.https_proxy()
         if https_proxy:
             host, port = self._parse_proxy_string(https_proxy)
             extra_options.extend(
-                ["-Dhttps.proxyHost={}".format(host), "-Dhttps.proxyPort={}".format(port),]
+                ["-Dhttps.proxyHost={}".format(host), "-Dhttps.proxyPort={}".format(port)]
             )
         return extra_options
 

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -152,10 +152,10 @@ class File1(ConfigFile):
     @property
     def expected_options(self) -> Dict:
         ini_values = {
-            "a": {"list": "[1, 2, 3, 42]", "list2": "+[7, 8, 9]", "list3": '-["x", "y", "z"]',},
-            "b": {"preempt": "True",},
+            "a": {"list": "[1, 2, 3, 42]", "list2": "+[7, 8, 9]", "list3": '-["x", "y", "z"]'},
+            "b": {"preempt": "True"},
             "b.nested": {"dict": "{\n'a': 1,\n'b': 42,\n'c': ['42', '42'],\n}"},
-            "b.nested.nested-again": {"movie": "inception",},
+            "b.nested.nested-again": {"movie": "inception"},
             "c": {
                 "name": "overridden_from_default",
                 "interpolated_from_section": "overridden_from_default is interpolated",
@@ -168,7 +168,7 @@ class File1(ConfigFile):
                 ConfigFormat.ini: ini_values,
                 ConfigFormat.toml: {
                     **ini_values,
-                    "a": {**ini_values["a"], "list": '["1", "2", "3", "42"]',},
+                    "a": {**ini_values["a"], "list": '["1", "2", "3", "42"]'},
                     "b.nested": {"dict": '{\n  "a": 1,\n  "b": "42",\n  "c": ["42", "42"],\n}'},
                 },
             },
@@ -264,7 +264,7 @@ class ConfigBaseTest(TestBase):
         self.expected_combined_values = {
             **self.file1.expected_options,
             **self.file2.expected_options,
-            "a": {**self.file2.expected_options["a"], **self.file1.expected_options["a"],},
+            "a": {**self.file2.expected_options["a"], **self.file1.expected_options["a"]},
         }
 
     def test_sections(self) -> None:
@@ -422,11 +422,11 @@ def test_toml_serializer() -> None:
             "listy": ["a", "b", "c"],
             "map": {"a": 0, "b": 1},
         },
-        "cache.java": {"o": "",},
-        "inception.nested.nested-again.one-more": {"o": "",},
+        "cache.java": {"o": ""},
+        "inception.nested.nested-again.one-more": {"o": ""},
     }
     assert TomlSerializer(original_values).normalize() == {
-        "GLOBAL": {**original_values["GLOBAL"], "map": "{'a': 0, 'b': 1}",},
+        "GLOBAL": {**original_values["GLOBAL"], "map": "{'a': 0, 'b': 1}"},
         "cache": {"java": {"o": ""}},
         "inception": {"nested": {"nested-again": {"one-more": {"o": ""}}}},
     }

--- a/src/python/pants/option/enclosing_scopes_test.py
+++ b/src/python/pants/option/enclosing_scopes_test.py
@@ -54,7 +54,7 @@ class TestEnclosingScopeTraversal(unittest.TestCase):
         self.assertEqual(enclosing_scope(compound_scope), base_dashed_scope)
         self.assertEqual(
             list(all_enclosing_scopes(compound_scope)),
-            [compound_scope, base_dashed_scope, GLOBAL_SCOPE,],
+            [compound_scope, base_dashed_scope, GLOBAL_SCOPE],
         )
 
         invalid_scope = "a.b..c.d"

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -82,7 +82,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
                 "pants_supportdir": "/from_config/build-support",
                 "pants_distdir": "/from_config/dist",
             },
-            env={"PANTS_SUPPORTDIR": "/from_env/build-support", "PANTS_DISTDIR": "/from_env/dist",},
+            env={"PANTS_SUPPORTDIR": "/from_env/build-support", "PANTS_DISTDIR": "/from_env/dist"},
             args=["--pants-distdir=/from_args/dist"],
             workdir="/from_config/.pants.d",
             supportdir="/from_env/build-support",
@@ -154,7 +154,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
     def test_bootstrapped_options_ignore_irrelevant_env(self) -> None:
         included = "PANTS_SUPPORTDIR"
         excluded = "NON_PANTS_ENV"
-        bootstrapper = OptionsBootstrapper.create(env={excluded: "pear", included: "banana",})
+        bootstrapper = OptionsBootstrapper.create(env={excluded: "pear", included: "banana"})
         self.assertIn(included, bootstrapper.env)
         self.assertNotIn(excluded, bootstrapper.env)
 

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -883,13 +883,13 @@ class OptionsTest(TestBase):
             self.assertEqual(expected_val, val)
 
         check_pants_foo(
-            "AAA", {"PANTS_GLOBAL_PANTS_FOO": "AAA", "PANTS_PANTS_FOO": "BBB", "PANTS_FOO": "CCC",}
+            "AAA", {"PANTS_GLOBAL_PANTS_FOO": "AAA", "PANTS_PANTS_FOO": "BBB", "PANTS_FOO": "CCC"}
         )
-        check_pants_foo("BBB", {"PANTS_PANTS_FOO": "BBB", "PANTS_FOO": "CCC",})
-        check_pants_foo("CCC", {"PANTS_FOO": "CCC",})
+        check_pants_foo("BBB", {"PANTS_PANTS_FOO": "BBB", "PANTS_FOO": "CCC"})
+        check_pants_foo("CCC", {"PANTS_FOO": "CCC"})
         check_pants_foo(None, {})
         # Check that an empty string is distinct from no value being specified.
-        check_pants_foo("", {"PANTS_PANTS_FOO": "", "PANTS_FOO": "CCC",})
+        check_pants_foo("", {"PANTS_PANTS_FOO": "", "PANTS_FOO": "CCC"})
 
         # A global option that doesn't begin with 'pants-': Setting BAR_BAZ should have no effect.
 
@@ -898,10 +898,10 @@ class OptionsTest(TestBase):
             self.assertEqual(expected_val, val)
 
         check_bar_baz(
-            "AAA", {"PANTS_GLOBAL_BAR_BAZ": "AAA", "PANTS_BAR_BAZ": "BBB", "BAR_BAZ": "CCC",}
+            "AAA", {"PANTS_GLOBAL_BAR_BAZ": "AAA", "PANTS_BAR_BAZ": "BBB", "BAR_BAZ": "CCC"}
         )
-        check_bar_baz("BBB", {"PANTS_BAR_BAZ": "BBB", "BAR_BAZ": "CCC",})
-        check_bar_baz(None, {"BAR_BAZ": "CCC",})
+        check_bar_baz("BBB", {"PANTS_BAR_BAZ": "BBB", "BAR_BAZ": "CCC"})
+        check_bar_baz(None, {"BAR_BAZ": "CCC"})
         check_bar_baz(None, {})
 
     def test_scoped_env_vars(self) -> None:
@@ -1633,9 +1633,9 @@ class OptionsTest(TestBase):
         options = Options.create(
             env={},
             config=self._create_config(
-                {"DEFAULT": {"foo": "aa"}, DummyOptionable1.options_scope: {"foo": "xx"},}
+                {"DEFAULT": {"foo": "aa"}, DummyOptionable1.options_scope: {"foo": "xx"}}
             ),
-            known_scope_infos=[global_scope(), DummyOptionable1.get_scope_info(),],
+            known_scope_infos=[global_scope(), DummyOptionable1.get_scope_info()],
             args=shlex.split("./pants"),
         )
 

--- a/src/python/pants/python/pex_build_util.py
+++ b/src/python/pants/python/pex_build_util.py
@@ -531,7 +531,7 @@ class PexBuilderWrapper:
         # produced when the .ipex is first executed will read and resolve all those requirements from
         # the BOOTSTRAP-PEX-INFO.
         self.add_resolved_requirements(
-            [self._pex_requirement, self._setuptools_requirement,],
+            [self._pex_requirement, self._setuptools_requirement],
             override_ipex_build_do_actually_add_distribution=True,
         )
 

--- a/src/python/pants/python/pex_build_util_test_integration.py
+++ b/src/python/pants/python/pex_build_util_test_integration.py
@@ -35,7 +35,7 @@ class PexBuildUtilIntegrationTest(PantsRunIntegrationTest):
                 self.binary_target_address,
                 config={
                     "GLOBAL": {"pants_distdir": tmp_dir},
-                    "python-setup": {"interpreter_constraints": [cur_interpreter_constraint],},
+                    "python-setup": {"interpreter_constraints": [cur_interpreter_constraint]},
                 },
             )
 

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -165,7 +165,7 @@ def main():
     parser.add_argument(
         "--glob",
         action="append",
-        default=["*.dist-info/*", "*-nspkg.pth",],
+        default=["*.dist-info/*", "*-nspkg.pth"],
         help="Globs (fnmatch) to rewrite within the whl: may be specified multiple times.",
     )
     args = parser.parse_args()

--- a/src/python/pants/rules/core/list_roots_test.py
+++ b/src/python/pants/rules/core/list_roots_test.py
@@ -59,7 +59,7 @@ class AllRootsTest(TestBase):
         output = run_rule(
             list_roots.all_roots,
             rule_args=[source_root_config],
-            mock_gets=[MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=provider_rule),],
+            mock_gets=[MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=provider_rule)],
         )
 
         self.assertEqual(

--- a/src/python/pants/rules/core/repl_integration_test.py
+++ b/src/python/pants/rules/core/repl_integration_test.py
@@ -41,7 +41,7 @@ class ReplTest(GoalRuleTestBase):
 
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(targets={"python_library": PythonLibrary,})
+        return BuildFileAliases(targets={"python_library": PythonLibrary})
 
     def setup_python_library(self) -> None:
         library_source = FileContent(path="some_lib.py", content=b"class SomeClass:\n  pass\n")

--- a/src/python/pants/source/test_source_root.py
+++ b/src/python/pants/source/test_source_root.py
@@ -144,7 +144,7 @@ class SourceRootTest(TestBase):
         trie.add_pattern("src/main/*")
         trie.add_pattern("src/main/*/foo")
         self.assertEqual(
-            {"*", "src/*/code", "src/main/*/code", "src/main/*", "src/main/*", "src/main/*/foo",},
+            {"*", "src/*/code", "src/main/*/code", "src/main/*", "src/main/*", "src/main/*/foo"},
             trie.traverse(),
         )
 
@@ -153,7 +153,7 @@ class SourceRootTest(TestBase):
         trie.add_pattern("src/*/code")
         trie.add_pattern("src/main/*/code")
         self.assertEqual(
-            {"src/*/code", "^/src/scala-source-code", "src/main/*/code",}, trie.traverse()
+            {"src/*/code", "^/src/scala-source-code", "src/main/*/code"}, trie.traverse()
         )
 
     def test_fixed_source_root_at_buildroot(self):

--- a/src/python/pants/source/test_wrapped_globs.py
+++ b/src/python/pants/source/test_wrapped_globs.py
@@ -18,7 +18,7 @@ class DummyTarget(Target):
     def __init__(self, address=None, payload=None, sources=None, **kwargs):
         payload = payload or Payload()
         payload.add_fields(
-            {"sources": self.create_sources_field(sources, address.spec_path, key_arg="sources"),}
+            {"sources": self.create_sources_field(sources, address.spec_path, key_arg="sources")}
         )
         super().__init__(address=address, payload=payload, **kwargs)
 

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -56,7 +56,7 @@ class GoalRuleTestBase(TestBase):
         )
         BuildConfigInitializer.get(options_bootstrapper)
         full_options = options_bootstrapper.get_full_options(
-            [*GlobalOptions.known_scope_infos(), *self.goal_cls.subsystem_cls.known_scope_infos(),]
+            [*GlobalOptions.known_scope_infos(), *self.goal_cls.subsystem_cls.known_scope_infos()]
         )
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr)

--- a/src/python/pants/testutil/task_test_base.py
+++ b/src/python/pants/testutil/task_test_base.py
@@ -387,7 +387,7 @@ class DeclarativeTaskTestMixin:
         )
         all_synthesized_task_types = (
             run_before_synthesized_task_types
-            + [self._testing_task_type,]
+            + [self._testing_task_type]
             + run_after_synthesized_task_types
         )
 

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -37,7 +37,7 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
         return (
             super()
             .alias_groups()
-            .merge(BuildFileAliases(targets={"java_antlr_library": JavaAntlrLibrary,},))
+            .merge(BuildFileAliases(targets={"java_antlr_library": JavaAntlrLibrary}))
         )
 
     PARTS = {

--- a/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen.py
@@ -20,7 +20,7 @@ class AntlrPyGenTest(NailgunTaskTestBase):
         return (
             super()
             .alias_groups()
-            .merge(BuildFileAliases(targets={"python_antlr_library": PythonAntlrLibrary,},))
+            .merge(BuildFileAliases(targets={"python_antlr_library": PythonAntlrLibrary}))
         )
 
     def test_antlr_py_gen(self):

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
@@ -140,7 +140,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
             split_points = [
                 index for index, line in enumerate(lines) if split_pattern.search(line) or not line
             ]
-            return [lines[start:end] for start, end in pairs(split_points + [-1,]) if lines[start]]
+            return [lines[start:end] for start, end in pairs(split_points + [-1]) if lines[start]]
 
         # Scraping debug statements for protoc compilation.
         all_blocks = list(

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -163,7 +163,7 @@ org.pantsbuild.namespace: [(src/py-thrift-clashing:clashingA, src/py-thrift-clas
             [
                 (
                     "org.pantsbuild.py_whatever",
-                    [(commented_thrift_source_target, "src/py-thrift/with-header.thrift"),],
+                    [(commented_thrift_source_target, "src/py-thrift/with-header.thrift")],
                 )
             ],
             list(namespaces_by_files.items()),

--- a/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
@@ -29,7 +29,7 @@ class WireGenTest(NailgunTaskTestBase):
         self.make_target(
             ":wire-compiler",
             JarLibrary,
-            jars=[JarDependency(org="com.squareup.wire", name="wire-compiler", rev=version),],
+            jars=[JarDependency(org="com.squareup.wire", name="wire-compiler", rev=version)],
         )
 
     def test_compiler_args(self):

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -15,7 +15,7 @@ class WikiPageTest(TestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(
-            targets={"page": Page,},
+            targets={"page": Page},
             objects={
                 "Wiki": Wiki,
                 "wiki_artifact": WikiArtifact,

--- a/tests/python/pants_test/backend/graph_info/tasks/test_cloc_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_cloc_integration.py
@@ -8,7 +8,7 @@ from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 class ClocIntegrationTest(PantsRunIntegrationTest):
     def test_cloc(self):
-        pants_run = self.run_pants(["cloc", "testprojects/src/python/python_targets:test_library",])
+        pants_run = self.run_pants(["cloc", "testprojects/src/python/python_targets:test_library"])
         self.assert_success(pants_run)
         # Strip out the header which is non-deterministic because it has speed information in it.
         stdout = "\n".join(pants_run.stdout_data.split("\n")[1:])

--- a/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
@@ -34,7 +34,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
                 "python_tests": PythonTests,
                 "resources": Resources,
             },
-            objects={"jar": JarDependency, "scala_jar": ScalaJarDependency,},
+            objects={"jar": JarDependency, "scala_jar": ScalaJarDependency},
         )
 
     def setUp(self):
@@ -291,7 +291,7 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
         self.assert_console_output(
             "src/thrift/dependent:my-example",
             "src/thrift/example:compiled_scala",
-            targets=[self.target("src/thrift/example:mybird"),],
+            targets=[self.target("src/thrift/example:mybird")],
         )
 
     def test_external_dependency(self):

--- a/tests/python/pants_test/backend/graph_info/tasks/test_filemap.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_filemap.py
@@ -13,7 +13,7 @@ from pants.testutil.task_test_base import ConsoleTaskTestBase
 class FilemapTest(ConsoleTaskTestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"python_library": PythonLibrary,},)
+        return BuildFileAliases(targets={"python_library": PythonLibrary})
 
     @classmethod
     def task_type(cls):

--- a/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
@@ -137,7 +137,7 @@ class ListTargetsTest(GoalRuleTestBase):
             "a/b/d:d",
             "a/b/e:e1",
             "f:alias",
-            args=["--sep=, ", "::",],
+            args=["--sep=, ", "::"],
         )
 
         self.assert_console_output(

--- a/tests/python/pants_test/backend/graph_info/tasks/test_minimal_cover.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_minimal_cover.py
@@ -66,13 +66,13 @@ class MinimalCoverTest(BaseMinimalCovertTest):
             "common/a:a",
             "common/b:b",
             "common/c:c",
-            targets=[self.target("common/a"), self.target("common/b"), self.target("common/c"),],
+            targets=[self.target("common/a"), self.target("common/b"), self.target("common/c")],
         )
 
     def test_identical(self):
         self.assert_console_output(
             "common/a:a",
-            targets=[self.target("common/a"), self.target("common/a"), self.target("common/a"),],
+            targets=[self.target("common/a"), self.target("common/a"), self.target("common/a")],
         )
 
     def test_intersection(self):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
@@ -70,7 +70,7 @@ class CustomScalaTest(NailgunTaskTestBase):
         )
 
     def scala_platform_setup(self):
-        options = {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.10",}}
+        options = {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.10"}}
         init_subsystem(ScalaPlatform, options)
 
         self.make_target(

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
@@ -49,13 +49,13 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
 
     def test_unmanaged_no_default(self):
         self._assert_run_classpath(
-            {self.set_default: True, self.set_managed: False, self.set_managed2: False,},
+            {self.set_default: True, self.set_managed: False, self.set_managed2: False},
             "unmanaged",
         )
 
     def test_unmanaged_default2(self):
         self._assert_run_classpath(
-            {self.set_default: False, self.set_managed: False, self.set_managed2: True,},
+            {self.set_default: False, self.set_managed: False, self.set_managed2: True},
             "unmanaged",
             default_target=self.manager2_target,
             conflict_strategy="USE_MANAGED",
@@ -75,7 +75,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
 
     def test_managed_ignore_default(self):
         self._assert_run_classpath(
-            {self.set_default: False, self.set_managed: True, self.set_managed2: False,},
+            {self.set_default: False, self.set_managed: True, self.set_managed2: False},
             "managed",
             default_target=self.manager2_target,
             conflict_strategy="USE_MANAGED",
@@ -83,7 +83,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
 
     def test_managed_auto(self):
         self._assert_run_classpath(
-            {self.set_default: False, self.set_managed: True, self.set_managed2: False,},
+            {self.set_default: False, self.set_managed: True, self.set_managed2: False},
             "managed-auto",
         )
 
@@ -123,7 +123,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
 
     def test_managed_redundant(self):
         self._assert_run_classpath(
-            {self.set_default: False, self.set_managed: True, self.set_managed2: False,},
+            {self.set_default: False, self.set_managed: True, self.set_managed2: False},
             "redundant",
         )
 
@@ -133,7 +133,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
 
     def test_managed_forceful_use_managed(self):
         self._assert_run_classpath(
-            {self.set_default: False, self.set_managed: True, self.set_managed2: False,},
+            {self.set_default: False, self.set_managed: True, self.set_managed2: False},
             "forceful",
             conflict_strategy="USE_MANAGED",
         )
@@ -147,13 +147,13 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
             "testprojects/3rdparty/managed:managed",
             "testprojects/3rdparty/managed:org.eclipse.jetty.jetty-jsp",
         ]
-        run = self.run_pants(["filter", "testprojects/3rdparty/managed::",])
+        run = self.run_pants(["filter", "testprojects/3rdparty/managed::"])
         self.assert_success(run)
         for spec in expected_specs:
             self.assertIn(spec, run.stdout_data)
 
     def test_managed_jar_libraries_resolve(self):
-        run = self.run_pants(["resolve", "testprojects/3rdparty/managed::",])
+        run = self.run_pants(["resolve", "testprojects/3rdparty/managed::"])
         self.assert_success(run)
 
     def test_two_managers_build(self):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_scoverage_platform.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_scoverage_platform.py
@@ -17,7 +17,7 @@ class ScoveragePlatformTest(TestBase):
     blacklist_file_path = "my/file/new_blacklist_scoverage_test"
 
     def setup_scoverage_platform(self):
-        options = {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.10",}}
+        options = {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.10"}}
 
         options2 = {ScoveragePlatform.options_scope: {"enable_scoverage": "False"}}
 

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency_integration.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency_integration.py
@@ -6,7 +6,5 @@ from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 class JarDependencyIntegrationTest(PantsRunIntegrationTest):
     def test_resolve_relative(self):
-        pants_run = self.run_pants(
-            ["resolve", "testprojects/3rdparty/org/pantsbuild/testprojects",]
-        )
+        pants_run = self.run_pants(["resolve", "testprojects/3rdparty/org/pantsbuild/testprojects"])
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -52,7 +52,7 @@ class JarRulesTest(unittest.TestCase):
 class JvmBinaryTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return build_file_aliases().merge(BuildFileAliases(objects={"duplicate": Duplicate,},))
+        return build_file_aliases().merge(BuildFileAliases(objects={"duplicate": Duplicate}))
 
     def test_simple(self):
         self.add_to_build_file(

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -15,7 +15,7 @@ class UnpackedJarsTest(TestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(
-            targets={"jar_library": JarLibrary, "unpacked_jars": UnpackedJars,},
+            targets={"jar_library": JarLibrary, "unpacked_jars": UnpackedJars},
             objects={"jar": JarDependency},
         )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
@@ -75,7 +75,7 @@ class BaseCompileIT(PantsRunIntegrationTest):
         :API: public
         """
         config = {
-            "cache": {"write": True, "write_to": [cacheurl],},
+            "cache": {"write": True, "write_to": [cacheurl]},
         }
         task = "test" if test else "compile"
         args = self._EXTRA_TASK_ARGS + [task] + (extra_args if extra_args else []) + [target]

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -34,7 +34,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
 
             self.assert_success(
                 self.run_pants(
-                    ["compile", "testprojects/src/java/org/pantsbuild/testproject/nocache::",],
+                    ["compile", "testprojects/src/java/org/pantsbuild/testproject/nocache::"],
                     config=config,
                 )
             )
@@ -191,13 +191,13 @@ class JavaCompileIntegrationTest(BaseCompileIT):
             dotted_path = path_prefix.replace(os.path.sep, ".")
 
             config = {
-                "cache.compile.rsc": {"write_to": [cache_dir], "read_from": [cache_dir],},
-                "compile.rsc": {"incremental_caching": True,},
+                "cache.compile.rsc": {"write_to": [cache_dir], "read_from": [cache_dir]},
+                "compile.rsc": {"incremental_caching": True},
             }
 
             self.assert_success(
                 self.run_pants_with_workdir(
-                    ["compile", f"{path_prefix}:only-15-directly",], workdir, config
+                    ["compile", f"{path_prefix}:only-15-directly"], workdir, config
                 )
             )
             guava_15_base_dir = self.get_cache_subdir(cache_dir)
@@ -211,7 +211,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
             # Rerun for guava 16
             self.assert_success(
                 self.run_pants_with_workdir(
-                    ["compile", (f"{path_prefix}:alongside-16"),], workdir, config
+                    ["compile", (f"{path_prefix}:alongside-16")], workdir, config
                 )
             )
 
@@ -234,7 +234,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
             with cache_server(cache_root=cachedir) as server:
                 target = "testprojects/tests/java/org/pantsbuild/testproject/matcher"
                 config = {
-                    "cache.compile.rsc": {"write_to": [server.url], "read_from": [server.url],},
+                    "cache.compile.rsc": {"write_to": [server.url], "read_from": [server.url]},
                 }
 
                 # Compile to populate the cache, and actually run the tests to help verify runtime.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -163,7 +163,7 @@ class JavaCompileSettingsPartitioningTest(NailgunTaskTestBase):
             default_platform="11",
         )
         self.assert_partitions_equal(
-            {self._version("11"): {java, java11}, self._version("12"): {java12},}, partition
+            {self._version("11"): {java, java11}, self._version("12"): {java12}}, partition
         )
 
     def test_invalid_source_target_combination_by_jvm_platform(self):
@@ -199,7 +199,7 @@ class JavaCompileSettingsPartitioningTest(NailgunTaskTestBase):
                 JvmPlatformSettings(
                     source_level="1.8",
                     target_level="1.8",
-                    args=["foo", "bar", "foo:$JAVA_HOME/bar:$JAVA_HOME/foobar", "$JAVA_HOME",],
+                    args=["foo", "bar", "foo:$JAVA_HOME/bar:$JAVA_HOME/foobar", "$JAVA_HOME"],
                     jvm_options=[],
                 )
             )
@@ -254,7 +254,7 @@ class JavaCompileSettingsPartitioningTest(NailgunTaskTestBase):
             of paths to the java homes for each distribution.
             """
             with fake_distributions(versions) as paths:
-                path_options = {DistributionLocator.options_scope: {"paths": {os_name: paths,}}}
+                path_options = {DistributionLocator.options_scope: {"paths": {os_name: paths}}}
                 Subsystem.reset()
                 init_subsystem(DistributionLocator, options=path_options)
                 yield paths

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_javac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_javac_plugin_integration.py
@@ -52,7 +52,7 @@ class JavacPluginIntegrationTest(BaseCompileIT):
     def test_global_with_local_args(self):
         self._do_test(
             ["args", "from", "target", "global_with_local_args"],
-            {"java": {"javac_plugins": ["simple_javac_plugin"],},},
+            {"java": {"javac_plugins": ["simple_javac_plugin"]}},
             "global_with_local_args",
         )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -327,7 +327,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
             with self.temporary_workdir() as workdir:
                 pants_run = self.run_pants_with_workdir(
-                    ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe",],
+                    ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe"],
                     workdir,
                     config,
                 )
@@ -363,7 +363,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
             with self.temporary_workdir() as workdir:
                 pants_run = self.run_pants_with_workdir(
-                    ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe",],
+                    ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe"],
                     workdir,
                     config,
                 )
@@ -420,7 +420,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
                         f.write(new_temp_test)
 
                     pants_run = self.run_pants_with_workdir(
-                        ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe",],
+                        ["-q", "run", "examples/src/scala/org/pantsbuild/example/hello/exe"],
                         workdir,
                         config,
                     )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -73,7 +73,7 @@ class RscCompileIntegrationBase(BaseCompileIT):
             config={
                 "cache.compile.rsc": {"ignore": True},
                 "jvm-platform": {"compiler": "rsc"},
-                "compile.rsc": {"workflow": workflow.value, "execution_strategy": "hermetic",},
+                "compile.rsc": {"workflow": workflow.value, "execution_strategy": "hermetic"},
                 "rsc": {"jvm_options": ["-Djava.security.manager=java.util.Optional"]},
             },
         )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -415,7 +415,7 @@ class RscCompileTest(NailgunTaskTestBase):
     def init_dependencies_for_scala_libraries(self):
         init_subsystem(
             ScalaPlatform,
-            {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.12",}},
+            {ScalaPlatform.options_scope: {"version": "custom", "suffix_version": "2.12"}},
         )
         init_subsystem(JUnit,)
         init_subsystem(ScoveragePlatform)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -319,7 +319,7 @@ class BaseZincCompileIntegrationTest:
         # Compile a target that we expect will raise an "Unused import" warning.
         with self.temporary_workdir() as workdir:
             with self.temporary_cachedir() as cachedir:
-                args = ['--compile-rsc-args=+["-S-Ywarn-unused:_"]', "-ldebug",] + (
+                args = ['--compile-rsc-args=+["-S-Ywarn-unused:_"]', "-ldebug"] + (
                     ["--compile-rsc-use-barebones-logger"] if use_barebones_logger else []
                 )
                 pants_run = self.run_test_compile(

--- a/tests/python/pants_test/backend/jvm/tasks/test_check_published_deps.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_check_published_deps.py
@@ -23,7 +23,7 @@ class CheckPublishedDepsTest(ConsoleTaskTestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(
-            targets={"target": Target, "jar_library": JarLibrary, "java_library": JavaLibrary,},
+            targets={"target": Target, "jar_library": JarLibrary, "java_library": JavaLibrary},
             objects={
                 "artifact": Artifact,
                 "jar": JarDependency,

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -61,7 +61,7 @@ class CheckstyleTest(NailgunTaskTestBase):
                     "bootstrap_tools": ["//:checkstyle"],
                     "properties": properties or {},
                 },
-                CheckstyleSubsystem.options_scope: {"config": self._create_config_file(rules_xml),},
+                CheckstyleSubsystem.options_scope: {"config": self._create_config_file(rules_xml)},
             },
             target_roots=target_roots,
         )
@@ -150,7 +150,7 @@ class CheckstyleTest(NailgunTaskTestBase):
         with_tab_2 = self._create_target("with_tab_2", self._TEST_JAVA_SOURCE_WITH_TAB)
         context = self._create_context(
             rules_xml=[self._RULE_XML_SUPPRESSION_FILTER, self._RULE_XML_FILE_TAB_CHECKER],
-            properties={"checkstyle.suppression.file": suppression_file,},
+            properties={"checkstyle.suppression.file": suppression_file},
             target_roots=[no_tab, with_tab_1, with_tab_2],
         )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -523,7 +523,7 @@ class ClasspathProductsTest(TestBase):
                 classpath_products,
                 [a],
                 base_dir,
-                ["a.b.b-0.jar", "a.b.b-1", "a.b.b-2.jar",],
+                ["a.b.b-0.jar", "a.b.b-1", "a.b.b-2.jar"],
                 {
                     "a.b.b-classpath.txt": "{}/a.jar:{}/resources:{}/{}\n".format(
                         self.pants_workdir, self.pants_workdir, self.pants_workdir, jar_path
@@ -539,7 +539,7 @@ class ClasspathProductsTest(TestBase):
             classpath_products,
             [a],
             base_dir,
-            ["a.b.b-0.jar",],
+            ["a.b.b-0.jar"],
             {"a.b.b-classpath.txt": f"{self.pants_workdir}/a.jar\n"},
         )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
@@ -40,12 +40,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         default_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         context = self.context(target_roots=[default_target, jar_library])
         manager = self._init_manager(default_target="//foo:management")
@@ -59,7 +59,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         context = self.context(target_roots=[jar_library])
         self._init_manager(default_target="//foo:nonexistant")
@@ -72,12 +72,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         context = self.context(target_roots=[management_target, jar_library])
         manager = self._init_manager()
@@ -90,12 +90,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
             managed_dependencies="//foo:management",
         )
         context = self.context(target_roots=[management_target, jar_library])
@@ -110,17 +110,17 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         default_target = self.make_target(
             spec="//foo:foobar",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="3"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="3")],
         )
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
             managed_dependencies="//foo:management",
         )
         context = self.context(target_roots=[default_target, management_target, jar_library])
@@ -135,17 +135,17 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         pin_jar_library = self.make_target(
             spec="//foo:pinned-library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            jars=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=["//foo:pinned-library",],
+            artifacts=["//foo:pinned-library"],
         )
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
             managed_dependencies="//foo:management",
         )
         context = self.context(target_roots=[management_target, jar_library, pin_jar_library])
@@ -175,7 +175,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar"),],
+            artifacts=[JarDependency(org="foobar", name="foobar")],
         )
         context = self.context(target_roots=[management_target])
         self._init_manager()
@@ -187,12 +187,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar", rev="3"),],
+            jars=[JarDependency(org="foobar", name="foobar", rev="3")],
         )
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"), "//foo:library",],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"), "//foo:library"],
         )
         context = self.context(target_roots=[jar_library, management_target])
         self._init_manager()
@@ -204,12 +204,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         jar_library = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar", rev=None),],
+            jars=[JarDependency(org="foobar", name="foobar", rev=None)],
         )
         management_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"), "//foo:library",],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"), "//foo:library"],
         )
         context = self.context(target_roots=[jar_library, management_target])
         self._init_manager()
@@ -221,20 +221,20 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         default_target = self.make_target(
             spec="//foo:management",
             target_type=ManagedJarDependencies,
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         jar_library1 = self.make_target(
             spec="//foo:library",
             target_type=JarLibrary,
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         jar_library2 = self.make_target(
             spec="//foo:library2",
             target_type=JarLibrary,
-            jars=[JarDependency(org="vegetables", name="potato", rev="3"),],
+            jars=[JarDependency(org="vegetables", name="potato", rev="3")],
         )
         unpacked_target = self.make_target(
-            spec="//foo:unpacked", target_type=UnpackedJars, libraries=[":library2",]
+            spec="//foo:unpacked", target_type=UnpackedJars, libraries=[":library2"]
         )
         context = self.context(
             target_roots=[default_target, jar_library1, jar_library2, unpacked_target]
@@ -252,15 +252,15 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         management_target = self.make_target(
             target_type=ManagedJarDependencies,
             spec="//foo:management_indirect",
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         default_target = self.make_target(
-            target_type=Target, spec="//foo:management", dependencies=[management_target,],
+            target_type=Target, spec="//foo:management", dependencies=[management_target],
         )
         jar_library1 = self.make_target(
             target_type=JarLibrary,
             spec="//foo:library",
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         context = self.context(target_roots=[default_target, jar_library1, management_target])
         manager = self._init_manager(default_target="//foo:management")
@@ -308,12 +308,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                 JarDependency(org="foobar", name="foobar", rev="3"),
                 JarDependency(org="fruit", name="apple", rev="4"),
             ],
-            dependencies=[management_target,],
+            dependencies=[management_target],
         )
         jar_library1 = self.make_target(
             target_type=JarLibrary,
             spec="//foo:library",
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
 
         def check_task_execution(manager):
@@ -344,10 +344,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         management_target2 = self.make_target(
             target_type=ManagedJarDependencies,
             spec="//foo:management_indirect2",
-            artifacts=[JarDependency(org="foobar", name="foobar", rev="7", ext="tar"),],
+            artifacts=[JarDependency(org="foobar", name="foobar", rev="7", ext="tar")],
         )
         indirection_2 = self.make_target(
-            target_type=Target, spec="//foo:indirection_2", dependencies=[management_target2,],
+            target_type=Target, spec="//foo:indirection_2", dependencies=[management_target2],
         )
         default_target = self.make_target(
             target_type=ManagedJarDependencies,
@@ -356,12 +356,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                 JarDependency(org="foobar", name="foobar", rev="3"),
                 JarDependency(org="fruit", name="apple", rev="4"),
             ],
-            dependencies=[management_target, indirection_2,],
+            dependencies=[management_target, indirection_2],
         )
         jar_library1 = self.make_target(
             target_type=JarLibrary,
             spec="//foo:library",
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
 
         def check_task_execution(manager):
@@ -391,20 +391,20 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         jar_library_unversioned = self.make_target(
             target_type=JarLibrary,
             spec="//foo:library-unversioned",
-            jars=[JarDependency(org="foobar", name="foobar"),],
+            jars=[JarDependency(org="foobar", name="foobar")],
         )
         jar_library_versioned = self.make_target(
             target_type=JarLibrary,
             spec="//foo:library-versioned",
-            jars=[JarDependency(org="foobar", name="foobar", rev="2"),],
+            jars=[JarDependency(org="foobar", name="foobar", rev="2")],
         )
         indirect_target = self.make_target(
-            target_type=Target, spec="//foo:indirect-deps", dependencies=[jar_library_versioned,]
+            target_type=Target, spec="//foo:indirect-deps", dependencies=[jar_library_versioned]
         )
         management_target = self.make_target(
             target_type=ManagedJarDependencies,
             spec="//foo:management",
-            artifacts=["//foo:indirect-deps",],
+            artifacts=["//foo:indirect-deps"],
         )
         context = self.context(
             target_roots=[
@@ -425,16 +425,16 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
         class DummyTarget(Target):
             pass
 
-        dummy_target = self.make_target(target_type=DummyTarget, spec="//foo:dummy",)
+        dummy_target = self.make_target(target_type=DummyTarget, spec="//foo:dummy")
         indirect_target = self.make_target(
-            target_type=Target, spec="//foo:indirect", dependencies=[dummy_target,]
+            target_type=Target, spec="//foo:indirect", dependencies=[dummy_target]
         )
         management_target = self.make_target(
             target_type=ManagedJarDependencies,
             spec="//foo:management",
-            artifacts=["//foo:indirect",],
+            artifacts=["//foo:indirect"],
         )
-        context = self.context(target_roots=[management_target, indirect_target, dummy_target,])
+        context = self.context(target_roots=[management_target, indirect_target, dummy_target])
         self._init_manager()
         task = self.create_task(context)
         with self.assertRaises(TargetDefinitionException):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -34,8 +34,8 @@ class JarPublishTest(NailgunTaskTestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(
-            targets={"jar_library": JarLibrary, "java_library": JavaLibrary, "target": Target,},
-            objects={"artifact": Artifact, "scala_artifact": ScalaArtifact,},
+            targets={"jar_library": JarLibrary, "java_library": JavaLibrary, "target": Target},
+            objects={"artifact": Artifact, "scala_artifact": ScalaArtifact},
             context_aware_object_factories={
                 "internal": lambda _: Repository(
                     name="internal", url="http://example.com", push_db_basedir=cls.push_db_basedir
@@ -110,7 +110,7 @@ class JarPublishTest(NailgunTaskTestBase):
         return targets
 
     def _get_repos(self):
-        return {"internal": {"resolver": "example.com",}}
+        return {"internal": {"resolver": "example.com"}}
 
     def _prepare_mocks(self, task):
         task.scm = Mock()
@@ -125,7 +125,7 @@ class JarPublishTest(NailgunTaskTestBase):
 
     def test_publish_unlisted_repo(self):
         # Note that we set a different config here, so repos:internal has no config
-        repos = {"another-repo": {"resolver": "example.org",}}
+        repos = {"another-repo": {"resolver": "example.org"}}
 
         targets = self._prepare_for_publishing()
         with temporary_dir():

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
@@ -29,7 +29,7 @@ def publish_extra_config(unique_config):
             # Turn off --verify-config as some scopes in pants.toml will not be
             # recognized due to the select few backend packages.
             "verify_config": False,
-            "pythonpath": ["examples/src/python", "pants-plugins/src/python",],
+            "pythonpath": ["examples/src/python", "pants-plugins/src/python"],
             "backend_packages": [
                 "example.pants_publish_plugin",
                 "internal_backend.repositories",
@@ -37,7 +37,7 @@ def publish_extra_config(unique_config):
                 "pants.backend.jvm",
             ],
         },
-        "publish.jar": {"publish_extras": {"extra_test_jar_example": unique_config,},},
+        "publish.jar": {"publish_extras": {"extra_test_jar_example": unique_config}},
     }
 
 
@@ -152,7 +152,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
     def test_publish_extras_name_classifier(self):
         self.publish_extras_runner(
             extra_config=publish_extra_config(
-                {"override_name": "{target_provides_name}-extra_example", "classifier": "classy",}
+                {"override_name": "{target_provides_name}-extra_example", "classifier": "classy"}
             ),
             artifact_name="hello-greet-extra_example-0.0.1-SNAPSHOT-classy.jar",
         )
@@ -160,7 +160,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
     def test_publish_extras_name(self):
         self.publish_extras_runner(
             extra_config=publish_extra_config(
-                {"override_name": "{target_provides_name}-extra_example",}
+                {"override_name": "{target_provides_name}-extra_example"}
             ),
             artifact_name="hello-greet-extra_example-0.0.1-SNAPSHOT.jar",
         )
@@ -187,7 +187,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
 
     def test_publish_extras_classifier(self):
         self.publish_extras_runner(
-            extra_config=publish_extra_config({"classifier": "classy",}),
+            extra_config=publish_extra_config({"classifier": "classy"}),
             artifact_name="hello-greet-0.0.1-SNAPSHOT-classy.jar",
         )
 
@@ -195,7 +195,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
     # should fail with an error from pants.
     def test_publish_extras_invalid_args(self):
         self.publish_extras_runner(
-            extra_config=publish_extra_config({"extension": "jar",}),
+            extra_config=publish_extra_config({"extension": "jar"}),
             artifact_name="hello-greet-0.0.1-SNAPSHOT.jar",
             success_expected=False,
         )

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -22,7 +22,7 @@ class BaseJarTaskTest(JarTaskTestBase):
         return (
             super()
             .alias_groups()
-            .merge(BuildFileAliases(targets={"java_agent": JavaAgent, "jvm_binary": JvmBinary,},))
+            .merge(BuildFileAliases(targets={"java_agent": JavaAgent, "jvm_binary": JvmBinary}))
         )
 
     def setUp(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -301,7 +301,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
             JvmPlatform.options_scope,
             default_platform="java8",
             platforms={
-                "java8": {"source": "8", "target": "8",},
+                "java8": {"source": "8", "target": "8"},
                 "java8-extra": {
                     "source": "8",
                     "target": "8",
@@ -374,14 +374,14 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
             spec="tests/java/org/pantsbuild/foo:foo_test",
             target_type=JUnitTests,
             sources=["FooTest.java"],
-            extra_env_vars={"HELLO": 27, "THERE": 32,},
+            extra_env_vars={"HELLO": 27, "THERE": 32},
         )
 
         self.make_target(
             spec="tests/java/org/pantsbuild/foo:bar_test",
             target_type=JUnitTests,
             sources=["FooTest.java"],
-            extra_env_vars={"THE_ANSWER": 42, "HELLO": 12,},
+            extra_env_vars={"THE_ANSWER": 42, "HELLO": 12},
         )
 
         self._execute_junit_runner(

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
@@ -32,6 +32,6 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
                 target,
                 bundle_name,
                 bundle_jar_name=bundle_name,
-                bundle_options=["--bundle-jvm-use-basename-prefix",],
+                bundle_options=["--bundle-jvm-use-basename-prefix"],
             )
             self.assertEqual(stdout, f"Hello world!: resource from example {name}\n")

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -49,7 +49,7 @@ class TestJvmDependencyUsage(TaskTestBase):
         t3 = self.make_java_target(spec=":t3", sources=["d.java", "e.java"], dependencies=[t1])
         self.set_options(size_estimator="filecount")
         dep_usage, product_deps_by_target = self._setup(
-            {t1: ["a.class", "b.class"], t2: ["c.class"], t3: ["d.class", "e.class"],}
+            {t1: ["a.class", "b.class"], t2: ["c.class"], t3: ["d.class", "e.class"]}
         )
         product_deps_by_target[t1] = []
         product_deps_by_target[t2] = ["a.class"]
@@ -111,7 +111,7 @@ class TestJvmDependencyUsage(TaskTestBase):
         )
         self.set_options(strict_deps=False)
         dep_usage, product_deps_by_target = self._setup(
-            {a: ["a.class"], b: ["b.class"], c: ["c.class"],}
+            {a: ["a.class"], b: ["b.class"], c: ["c.class"]}
         )
 
         product_deps_by_target[c] = ["a.class"]
@@ -135,7 +135,7 @@ class TestJvmDependencyUsage(TaskTestBase):
         t4 = self.make_java_target(spec=":t4", sources=["d.java"], dependencies=[t3])
         self.set_options(strict_deps=False)
         dep_usage, product_deps_by_target = self._setup(
-            {t1: ["a.class"], t2: ["a.class", "b.class"], t3: ["c.class"], t4: ["d.class"],}
+            {t1: ["a.class"], t2: ["a.class", "b.class"], t3: ["c.class"], t4: ["d.class"]}
         )
         product_deps_by_target[t3] = ["a.class"]
         product_deps_by_target[t4] = ["a.class"]
@@ -169,7 +169,7 @@ class TestJvmDependencyUsage(TaskTestBase):
         t2 = self.make_java_target(spec=":t2", sources=["b.java"], dependencies=[t1])
         self.create_file("b.java")
         self.set_options(size_estimator="filecount")
-        dep_usage, product_deps_by_target = self._setup({t1: ["a.class"], t2: ["b.class"],})
+        dep_usage, product_deps_by_target = self._setup({t1: ["a.class"], t2: ["b.class"]})
         product_deps_by_target[t1] = []
         product_deps_by_target[t2] = ["a.class"]
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis.py
@@ -25,14 +25,14 @@ class JvmPlatformAnalysisTestMixin:
 
     def _plain(self, name, deps=None):
         """Make a non-jvm target, useful for testing non-jvm intermediate dependencies."""
-        return self.make_target(spec=f"java:{name}", target_type=Target, dependencies=deps or [],)
+        return self.make_target(spec=f"java:{name}", target_type=Target, dependencies=deps or [])
 
     def simple_task(self, targets, **options):
         self.set_options(**options)
         platforms = {
-            "6": {"source": 6, "target": 6, "args": [],},
-            "7": {"source": 7, "target": 7, "args": [],},
-            "8": {"source": 8, "target": 8, "args": [],},
+            "6": {"source": 6, "target": 6, "args": []},
+            "7": {"source": 7, "target": 7, "args": []},
+            "8": {"source": 8, "target": 8, "args": []},
         }
         self.set_options_for_scope("jvm-platform", platforms=platforms, default_platform="6")
         context = self.context(target_roots=targets)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
@@ -19,27 +19,27 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
 
     def test_run_runtime_pass(self):
         self.assert_success(
-            self.run_pants(["--no-java-strict-deps", "run", self._spec("runtime-pass"),])
+            self.run_pants(["--no-java-strict-deps", "run", self._spec("runtime-pass")])
         )
 
     def test_run_runtime_fail(self):
         self.assert_failure(
-            self.run_pants(["--no-java-strict-deps", "run", self._spec("runtime-fail"),])
+            self.run_pants(["--no-java-strict-deps", "run", self._spec("runtime-fail")])
         )
 
     def test_compile_compile_pass(self):
         self.assert_success(
-            self.run_pants(["--no-java-strict-deps", "compile", self._spec("compile-pass"),])
+            self.run_pants(["--no-java-strict-deps", "compile", self._spec("compile-pass")])
         )
 
     def test_compile_compile_fail(self):
         self.assert_failure(
-            self.run_pants(["--no-java-strict-deps", "compile", self._spec("compile-fail"),])
+            self.run_pants(["--no-java-strict-deps", "compile", self._spec("compile-fail")])
         )
 
     def test_run_compile_fail(self):
         self.assert_failure(
-            self.run_pants(["--no-java-strict-deps", "run", self._spec("compile-pass"),])
+            self.run_pants(["--no-java-strict-deps", "run", self._spec("compile-pass")])
         )
 
     def test_runtime_binary_has_correct_contents_and_runs(self):
@@ -84,7 +84,7 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
         spec = self._spec("runtime-pass")
         with temporary_dir() as distdir:
             with self.pants_results(
-                [f"--pants-distdir={distdir}", "--no-java-strict-deps", "bundle", spec,]
+                [f"--pants-distdir={distdir}", "--no-java-strict-deps", "bundle", spec]
             ) as run:
                 self.assert_success(run)
                 bundle_dir = os.path.join(distdir, f"{re.sub('[:/]', '.', spec)}-bundle")
@@ -101,7 +101,7 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
         spec = self._spec("compile-pass")
         with temporary_dir() as distdir:
             with self.pants_results(
-                [f"--pants-distdir={distdir}", "--no-java-strict-deps", "bundle", spec,]
+                [f"--pants-distdir={distdir}", "--no-java-strict-deps", "bundle", spec]
             ) as run:
                 self.assert_success(run)
                 bundle_dir = os.path.join(distdir, f"{re.sub('[:/]', '.', spec)}-bundle")
@@ -156,7 +156,7 @@ class ScopeChangesCacheInvalidationIntegrationTest(PantsRunIntegrationTest):
                 write_build("")
                 self.assert_success(
                     self.run_pants_with_workdir(
-                        ["--no-java-strict-deps", "compile", spec("bar"),], workdir=workdir
+                        ["--no-java-strict-deps", "compile", spec("bar")], workdir=workdir
                     ),
                     msg="Normal build from a clean cache failed. Something may be wrong "
                     "with the test setup.",
@@ -165,7 +165,7 @@ class ScopeChangesCacheInvalidationIntegrationTest(PantsRunIntegrationTest):
                 write_build("runtime")
                 self.assert_failure(
                     self.run_pants_with_workdir(
-                        ["--no-java-strict-deps", "compile", spec("bar"),], workdir=workdir
+                        ["--no-java-strict-deps", "compile", spec("bar")], workdir=workdir
                     ),
                     msg="Build from a dirty cache with the dependency on :foo scoped to "
                     "runtime passed, when it should have had a compile failure. The "
@@ -175,7 +175,7 @@ class ScopeChangesCacheInvalidationIntegrationTest(PantsRunIntegrationTest):
                 write_build("compile")
                 self.assert_success(
                     self.run_pants_with_workdir(
-                        ["--no-java-strict-deps", "compile", spec("bar"),], workdir=workdir
+                        ["--no-java-strict-deps", "compile", spec("bar")], workdir=workdir
                     ),
                     msg="Build from a dirty cache with the scope changed to compile "
                     "failed. The cache may not have been invalidated.",
@@ -184,7 +184,7 @@ class ScopeChangesCacheInvalidationIntegrationTest(PantsRunIntegrationTest):
                 write_build("compile")
                 self.assert_failure(
                     self.run_pants_with_workdir(
-                        ["--no-java-strict-deps", "run", spec("bin"),], workdir=workdir
+                        ["--no-java-strict-deps", "run", spec("bin")], workdir=workdir
                     ),
                     msg="Attempt to run binary with the dependency on :foo scoped to "
                     "compile passed. This should have caused a runtime failure.",

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_test_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_test_integration.py
@@ -27,7 +27,7 @@ class ScopeTestIntegrationTest(PantsRunIntegrationTest):
 
         It should be included because it has the 'test' scope.
         """
-        self.assert_success(self.run_pants(["--no-java-strict-deps", "test", self._spec("tests"),]))
+        self.assert_success(self.run_pants(["--no-java-strict-deps", "test", self._spec("tests")]))
 
     def test_binary_compiles(self):
         """This should compile just fine, because the reference to the 'test' class is dynamic.
@@ -36,10 +36,8 @@ class ScopeTestIntegrationTest(PantsRunIntegrationTest):
         'test' class. We want to make sure that the test-case below this one isn't failing just
         because of an unrelated syntax error.
         """
-        self.assert_success(
-            self.run_pants(["--no-java-strict-deps", "compile", self._spec("bin"),])
-        )
+        self.assert_success(self.run_pants(["--no-java-strict-deps", "compile", self._spec("bin")]))
 
     def test_binary_fails_to_run(self):
         """Ensure the binary does not have access to 'test'-scoped dependencies at runtime."""
-        self.assert_failure(self.run_pants(["--no-java-strict-deps", "run", self._spec("bin"),]))
+        self.assert_failure(self.run_pants(["--no-java-strict-deps", "run", self._spec("bin")]))

--- a/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
@@ -13,7 +13,7 @@ class TestLibcDirectorySearchFailure(TestBase):
     def setUp(self):
         init_subsystems(
             [LibcDev],
-            options={"libc": {"enable_libc_search": True, "libc_dir": "/does/not/exist",},},
+            options={"libc": {"enable_libc_search": True, "libc_dir": "/does/not/exist"}},
         )
 
         self.libc = global_subsystem_instance(LibcDev)
@@ -30,7 +30,7 @@ class TestLibcSearchDisabled(TestBase):
     def setUp(self):
         init_subsystems(
             [LibcDev],
-            options={"libc": {"enable_libc_search": False, "libc_dir": "/does/not/exist",},},
+            options={"libc": {"enable_libc_search": False, "libc_dir": "/does/not/exist"}},
         )
 
         self.libc = global_subsystem_instance(LibcDev)

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -30,9 +30,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     def setUp(self):
         super().setUp()
 
-        init_subsystems(
-            [LibcDev, NativeToolchain], options={"libc": {"enable_libc_search": True,},}
-        )
+        init_subsystems([LibcDev, NativeToolchain], options={"libc": {"enable_libc_search": True}})
 
         self.platform = Platform.current
         self.toolchain = global_subsystem_instance(NativeToolchain)

--- a/tests/python/pants_test/backend/native/tasks/test_c_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_c_compile.py
@@ -71,7 +71,7 @@ class CCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
         c = self.create_header_only_alternate_c_library(alternate_extension)
         context = self.prepare_context_for_compile(
             target_roots=[c],
-            options={"c-compile-settings": {"header_file_extensions": [alternate_extension],},},
+            options={"c-compile-settings": {"header_file_extensions": [alternate_extension]}},
         )
 
         # Test that the task runs without error if provided a header-only library.

--- a/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
+++ b/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
@@ -38,7 +38,7 @@ class ConanFetchTest(TaskTestBase):
         user_home = conan_fetch._conan_user_home(conan_pex, in_workdir=True)
 
         (stdout, stderr, exit_code, _) = conan_pex.output(
-            ["remote", "list"], env={"CONAN_USER_HOME": user_home,}
+            ["remote", "list"], env={"CONAN_USER_HOME": user_home}
         )
         self.assertEqual(0, exit_code)
         self.assertEqual(stdout, "pants-conan: https://conan.bintray.com [Verify SSL: True]\n")

--- a/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
+++ b/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
@@ -18,13 +18,13 @@ class LinkSharedLibrariesTest(NativeTaskTestBase, NativeCompileTestMixin):
         return LinkSharedLibraries
 
     def test_caching(self):
-        cpp = self.create_simple_cpp_library(ctypes_native_library=NativeArtifact(lib_name="test"),)
+        cpp = self.create_simple_cpp_library(ctypes_native_library=NativeArtifact(lib_name="test"))
 
         cpp_compile_task_type = self.synthesize_task_subtype(CppCompile, "cpp_compile_scope")
         context = self.prepare_context_for_compile(
             target_roots=[cpp],
             for_task_types=[cpp_compile_task_type],
-            options={"libc": {"enable_libc_search": True,},},
+            options={"libc": {"enable_libc_search": True}},
         )
 
         cpp_compile = cpp_compile_task_type(

--- a/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
@@ -33,7 +33,7 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
         third = self.make_target("dependencies:third", target_type=JavaLibrary, sources=[],)
 
         first = self.make_target(
-            "dependencies:first", target_type=JavaLibrary, sources=[], dependencies=[third,],
+            "dependencies:first", target_type=JavaLibrary, sources=[], dependencies=[third],
         )
 
         second = self.make_target(
@@ -43,7 +43,7 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
         )
 
         project = self.make_target(
-            "project:project", target_type=JavaLibrary, sources=[], dependencies=[first, second,],
+            "project:project", target_type=JavaLibrary, sources=[], dependencies=[first, second],
         )
 
         self.make_target("project:dep-bag", target_type=Target, dependencies=[second, project])
@@ -125,7 +125,7 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
             "dependencies:python_inner",
             target_type=PythonLibrary,
             sources=[],
-            dependencies=[python_leaf,],
+            dependencies=[python_leaf],
         )
 
         python_inner_with_external = self.make_target(
@@ -138,7 +138,7 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
             "dependencies:python_root",
             target_type=PythonLibrary,
             sources=[],
-            dependencies=[python_inner, python_inner_with_external,],
+            dependencies=[python_inner, python_inner_with_external],
         )
 
     def test_normal(self):

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -140,7 +140,7 @@ class ExportTest(ConsoleTaskTestBase):
         self.make_target(
             ":nailgun-server",
             JarLibrary,
-            jars=[JarDependency(org="com.martiansoftware", name="nailgun-server", rev="0.9.1"),],
+            jars=[JarDependency(org="com.martiansoftware", name="nailgun-server", rev="0.9.1")],
         )
 
         self.make_target(
@@ -358,7 +358,7 @@ class ExportTest(ConsoleTaskTestBase):
         result = self.execute_export_json("project_info:third")
 
         self.assertEqual(
-            ["project_info/com/foo/Bar.scala", "project_info/com/foo/Baz.scala",],
+            ["project_info/com/foo/Bar.scala", "project_info/com/foo/Baz.scala"],
             sorted(result["targets"]["project_info:third"]["sources"]),
         )
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -145,7 +145,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         self.make_target(
             ":nailgun-server",
             JarLibrary,
-            jars=[JarDependency(org="com.martiansoftware", name="nailgun-server", rev="0.9.1"),],
+            jars=[JarDependency(org="com.martiansoftware", name="nailgun-server", rev="0.9.1")],
         )
 
     def execute_export(self, *specs, **options_overrides):
@@ -737,7 +737,7 @@ class ExportDepAsJarTestWithCodegenTargets(ExportDepAsJarTest):
             set(result["targets"].keys()),
         )
         self.assertEqual(
-            {"project_info:b", "project_info:f",},
+            {"project_info:b", "project_info:f"},
             set(result["targets"]["project_info:a"]["targets"]),
         )
 
@@ -754,7 +754,7 @@ class ExportDepAsJarTestWithCodegenTargets(ExportDepAsJarTest):
             set(result["targets"].keys()),
         )
         self.assertEqual(
-            {"project_info:b", "project_info:f",},
+            {"project_info:b", "project_info:f"},
             set(result["targets"]["project_info:a"]["targets"]),
         )
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -118,7 +118,7 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
     def test_javac_options(self):
         target_to_test = f"{self.javac_test_targets_dir}/plugin:local"
         config = {}
-        expected_options = {"javac_args": ["-Xplugin:simple_javac_plugin args from target local",]}
+        expected_options = {"javac_args": ["-Xplugin:simple_javac_plugin args from target local"]}
         self._check_compiler_options_for_target_are(target_to_test, expected_options, config)
 
     def test_extra_jvm_options(self):

--- a/tests/python/pants_test/backend/python/targets/test_python_binary.py
+++ b/tests/python/pants_test/backend/python/targets/test_python_binary.py
@@ -9,7 +9,7 @@ from pants.testutil.test_base import TestBase
 class PythonBinaryTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"python_binary": PythonBinary,},)
+        return BuildFileAliases(targets={"python_binary": PythonBinary})
 
     subsystems = PythonBinary.subsystems()
 

--- a/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
+++ b/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
@@ -29,7 +29,7 @@ class UnpackedWheelsTest(TestBase):
 
     def test_simple(self):
         self.make_target(
-            ":import_whls", PythonRequirementLibrary, requirements=[PythonRequirement("foo==123"),]
+            ":import_whls", PythonRequirementLibrary, requirements=[PythonRequirement("foo==123")]
         )
         target = self.make_target(
             ":foo", UnpackedWheels, libraries=[":import_whls"], module_name="foo"
@@ -45,7 +45,7 @@ class UnpackedWheelsTest(TestBase):
 
     def test_bad_libraries_ref(self):
         self.make_target(
-            ":right-type", PythonRequirementLibrary, requirements=[PythonRequirement("foo==123"),]
+            ":right-type", PythonRequirementLibrary, requirements=[PythonRequirement("foo==123")]
         )
         # Making a target which is not a requirement library, which causes an error.
         self.make_target(

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
@@ -19,7 +19,7 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import (
 class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):
     @classproperty
     def run_before_task_types(cls):
-        return [CCompile, CppCompile, LinkSharedLibraries,] + super().run_before_task_types
+        return [CCompile, CppCompile, LinkSharedLibraries] + super().run_before_task_types
 
     dist_specs = OrderedDict(
         [

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -62,8 +62,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
             pants_run = self.run_pants(
                 command=["binary", self._binary_target],
                 config={
-                    GLOBAL_SCOPE_CONFIG_SECTION: {"pants_distdir": tmp_dir,},
-                    "native-build-step": {"toolchain_variant": toolchain_variant.value,},
+                    GLOBAL_SCOPE_CONFIG_SECTION: {"pants_distdir": tmp_dir},
+                    "native-build-step": {"toolchain_variant": toolchain_variant.value},
                 },
             )
 
@@ -89,7 +89,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
             # so there is only one name to check.
             linker_names_to_check = match(
                 toolchain_variant,
-                {ToolchainVariant.gnu: ["g++"], ToolchainVariant.llvm: ["clang++"],},
+                {ToolchainVariant.gnu: ["g++"], ToolchainVariant.llvm: ["clang++"]},
             )
             for linker_name in linker_names_to_check:
                 self.assertIn(f"selected linker exe name: '{linker_name}'", pants_run.stdout_data)
@@ -148,9 +148,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
                 command=["binary", self._binary_target_with_interop],
                 # Explicitly set to True (although this is the default).
                 config={
-                    "native-build-step": {"toolchain_variant": toolchain_variant.value,},
+                    "native-build-step": {"toolchain_variant": toolchain_variant.value},
                     # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
-                    "native-build-settings": {"strict_deps": True,},
+                    "native-build-settings": {"strict_deps": True},
                 },
                 workdir=os.path.join(buildroot.new_buildroot, ".pants.d"),
             )
@@ -170,14 +170,14 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # DYLD_LIBRARY_PATH during the 'run' goal somehow.
         attempt_pants_run = match(
             Platform.current,
-            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True,},
+            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True},
         )
         if attempt_pants_run:
             pants_run_interop = self.run_pants(
                 ["-q", "run", self._binary_target_with_interop],
                 config={
-                    "native-build-step": {"toolchain_variant": toolchain_variant.value,},
-                    "native-build-settings": {"strict_deps": True,},
+                    "native-build-step": {"toolchain_variant": toolchain_variant.value},
+                    "native-build-settings": {"strict_deps": True},
                 },
             )
             self.assert_success(pants_run_interop)
@@ -190,7 +190,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     def test_ctypes_third_party_integration(self, toolchain_variant):
         pants_binary = self.run_pants(
             ["binary", self._binary_target_with_third_party],
-            config={"native-build-step": {"toolchain_variant": toolchain_variant.value,},},
+            config={"native-build-step": {"toolchain_variant": toolchain_variant.value}},
         )
         self.assert_success(pants_binary)
 
@@ -198,12 +198,12 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # be available on the runtime library path.
         attempt_pants_run = match(
             Platform.current,
-            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True,},
+            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True},
         )
         if attempt_pants_run:
             pants_run = self.run_pants(
                 ["-q", "run", self._binary_target_with_third_party],
-                config={"native-build-step": {"toolchain_variant": toolchain_variant.value,},},
+                config={"native-build-step": {"toolchain_variant": toolchain_variant.value}},
             )
             self.assert_success(pants_run)
             self.assertIn("Test worked!\n", pants_run.stdout_data)
@@ -226,7 +226,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(
             command=command,
             config={
-                "native-build-step": {"toolchain_variant": "llvm",},
+                "native-build-step": {"toolchain_variant": "llvm"},
                 "python-setup": {"platforms": ["current", foreign_platform]},
             },
         )
@@ -244,7 +244,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # be available on the runtime library path.
         attempt_pants_run = match(
             Platform.current,
-            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True,},
+            {Platform.darwin: toolchain_variant == ToolchainVariant.llvm, Platform.linux: True},
         )
         if not attempt_pants_run:
             return
@@ -253,10 +253,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(
             command=command,
             config={
-                "native-build-step": {"toolchain_variant": toolchain_variant.value,},
+                "native-build-step": {"toolchain_variant": toolchain_variant.value},
                 "native-build-step.cpp-compile-settings": {
-                    "compiler_option_sets_enabled_args": {"asdf": ["-D_ASDF=1"],},
-                    "compiler_option_sets_disabled_args": {"asdf": ["-D_ASDF=0"],},
+                    "compiler_option_sets_enabled_args": {"asdf": ["-D_ASDF=1"]},
+                    "compiler_option_sets_disabled_args": {"asdf": ["-D_ASDF=0"]},
                 },
             },
         )

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -39,7 +39,7 @@ setup(
                 {
                     "key": "pycountry",
                     "target_type": PythonRequirementLibrary,
-                    "requirements": [PythonRequirement("pycountry==18.5.20"),],
+                    "requirements": [PythonRequirement("pycountry==18.5.20")],
                 },
             ),
             (
@@ -47,7 +47,7 @@ setup(
                 {
                     "key": "setup_requires",
                     "target_type": PythonDistribution,
-                    "setup_requires": ["3rdparty/python:pycountry",],
+                    "setup_requires": ["3rdparty/python:pycountry"],
                     "sources": ["__init__.py", "setup.py"],
                     "filemap": {
                         "__init__.py": "",

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -77,7 +77,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     def test_conflict_via_config(self):
         # Tests that targets with compatibility conflict with targets with default compatibility.
         # NB: Passes empty `args` to avoid having the default CLI args override the config.
-        config = {"python-setup": {"interpreter_constraints": ["CPython<2.7"],}}
+        config = {"python-setup": {"interpreter_constraints": ["CPython<2.7"]}}
         binary_target = f"{self.testproject}:echo_interpreter_version"
         pants_run = self._build_pex(binary_target, config=config, args=[])
         self.assert_failure(pants_run, f"Unexpected successful build of {binary_target}.")
@@ -128,7 +128,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
     def test_stale_interpreter_purge_integration(self):
         target = f"{self.testproject}:{'echo_interpreter_version'}"
-        config = {"python-setup": {"interpreter_constraints": ["CPython>=2.7,<4"],}}
+        config = {"python-setup": {"interpreter_constraints": ["CPython>=2.7,<4"]}}
         with self.temporary_workdir() as workdir:
             pants_run = self.run_pants_with_workdir(["run", target], workdir=workdir, config=config)
             self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -172,7 +172,7 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
             },
         )
         binary = self.create_python_binary(
-            "src/ipex", "bin", "main", dependencies=["3rdparty/ipex:ansicolors", ":lib",]
+            "src/ipex", "bin", "main", dependencies=["3rdparty/ipex:ansicolors", ":lib"]
         )
 
         self.set_options(generate_ipex=True)

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -65,8 +65,8 @@ class PythonToolPrepTest(PythonTaskTestBase):
                 for_task_types=[tool_prep_type],
                 for_subsystems=[Tool],
                 options={
-                    "": {"pants_bootstrapdir": tmp_dir,},
-                    "test-tool": {"interpreter_constraints": [constraint_string],},
+                    "": {"pants_bootstrapdir": tmp_dir},
+                    "test-tool": {"interpreter_constraints": [constraint_string]},
                 },
             )
             tool_prep_task = tool_prep_type(
@@ -96,7 +96,7 @@ class PythonToolPrepTest(PythonTaskTestBase):
         context = self.context(
             for_task_types=[tool_prep_type],
             for_subsystems=[Tool],
-            options={"test-tool": {"needs_to_be_invoked_for_some_reason": False,},},
+            options={"test-tool": {"needs_to_be_invoked_for_some_reason": False}},
         )
         tool_prep_task = tool_prep_type(context, os.path.join(self.pants_workdir, "tool_prep_dir"))
         tool_prep_task.execute()

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -154,7 +154,7 @@ class TestSetupPy(SetupPyTestBase):
         foo_bin_dep = self.create_python_library(relpath="foo/dep", name="dep")
 
         foo_bin = self.create_python_binary(
-            relpath="foo/bin", name="bin", entry_point="foo.bin:foo", dependencies=["foo/dep",]
+            relpath="foo/bin", name="bin", entry_point="foo.bin:foo", dependencies=["foo/dep"]
         )
 
         foo = self.create_python_library(
@@ -241,7 +241,7 @@ class TestSetupPy(SetupPyTestBase):
         req3 = create_requirement_lib("req3")
 
         self.create_python_library(
-            relpath="src/python/pants/base", name="base", dependencies=["req1", "req2",]
+            relpath="src/python/pants/base", name="base", dependencies=["req1", "req2"]
         )
         self.create_python_binary(
             relpath="src/python/pants/bin",
@@ -641,7 +641,7 @@ class TestSetupPyFindPackages(SetupPyTestBase):
         assert_single_chroot(["foo"], [], {"foo": ["blork.dat"]})
 
         resources = {
-            "foo": ["f0", os.path.join("bar", "baz", "f1"), os.path.join("bar", "baz", "f2"),]
+            "foo": ["f0", os.path.join("bar", "baz", "f1"), os.path.join("bar", "baz", "f2")]
         }
         assert_single_chroot(["foo"], [], resources)
 

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -31,7 +31,7 @@ class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):
 
         expected_entries = [
             f"{key}-0.0.1/{relpath}"
-            for relpath in ["", "MANIFEST.in", "PKG-INFO", "setup.cfg", "setup.py", "src/",]
+            for relpath in ["", "MANIFEST.in", "PKG-INFO", "setup.cfg", "setup.py", "src/"]
             + src_entries
             + egg_info_entries
         ]

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -84,7 +84,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
             target_roots=[python_dist_target] + extra_targets,
             for_subsystems=[PythonRepos, LibcDev],
             # TODO(#6848): we should be testing all of these with both of our toolchains.
-            options={"native-build-step": {"toolchain_variant": ToolchainVariant.llvm,},},
+            options={"native-build-step": {"toolchain_variant": ToolchainVariant.llvm}},
         )
         context = result.context
         python_create_distributions_task_instance = result.this_task

--- a/tests/python/pants_test/backend/python/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/python/test_backend_independence_integration.py
@@ -14,6 +14,6 @@ class BackendIndependenceTest(PantsRunIntegrationTest):
     def test_independent_test_run(self):
         pants_run = self.run_pants(
             command=["test", "examples/tests/python/example_test/hello/greet"],
-            config={"GLOBAL": {"pythonpath": [], "backend_packages": ["pants.backend.python"],}},
+            config={"GLOBAL": {"pythonpath": [], "backend_packages": ["pants.backend.python"]}},
         )
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -36,7 +36,7 @@ class TestInterpreterCache(TestBase):
     def _create_interpreter_cache(self, setup_options=None):
         Subsystem.reset(reset_options=True)
         self.context(
-            for_subsystems=[PythonInterpreterCache], options={"python-setup": setup_options,}
+            for_subsystems=[PythonInterpreterCache], options={"python-setup": setup_options}
         )
         return PythonInterpreterCache.global_instance()
 

--- a/tests/python/pants_test/backend/python/test_python_requirement_list.py
+++ b/tests/python/pants_test/backend/python/test_python_requirement_list.py
@@ -14,8 +14,8 @@ class PythonRequirementListTest(TestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(
-            targets={"python_requirement_library": PythonRequirementLibrary,},
-            objects={"python_requirement": PythonRequirement,},
+            targets={"python_requirement_library": PythonRequirementLibrary},
+            objects={"python_requirement": PythonRequirement},
         )
 
     def test_bad_list(self):

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -284,7 +284,7 @@ Current thread [^\n]+ \\(most recent call first\\):
 
         # The exiter that gets added when this option is changed prints that option to stderr.
         changed_exiter_run = self.run_pants(
-            ["--lifecycle-stubs-add-exiter-message='NEW MESSAGE'",] + lifecycle_stub_cmdline
+            ["--lifecycle-stubs-add-exiter-message='NEW MESSAGE'"] + lifecycle_stub_cmdline
         )
         self.assert_failure(changed_exiter_run)
         self.assertIn("erroneous!", changed_exiter_run.stderr_data)
@@ -302,7 +302,7 @@ Current thread [^\n]+ \\(most recent call first\\):
             some_file = os.path.join(tmpdir, "some_file")
             safe_file_dump(some_file, "")
             redirected_pants_run = self.run_pants(
-                [f"--lifecycle-stubs-new-interactive-stream-output-file={some_file}",]
+                [f"--lifecycle-stubs-new-interactive-stream-output-file={some_file}"]
                 + lifecycle_stub_cmdline
             )
             self.assert_failure(redirected_pants_run)

--- a/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
+++ b/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
@@ -121,7 +121,7 @@ class ExcludeTargetRegexpIntegrationTest(PantsRunIntegrationTest):
 
     def test_exclude_thoe(self):
         self._test_bundle_existences(
-            [Bundles.phrase_path + "::", r"--exclude-target-regexp=\bth[oe]",],
+            [Bundles.phrase_path + "::", r"--exclude-target-regexp=\bth[oe]"],
             set(Bundles.all_bundles) - {Bundles.there_was_a_duck, Bundles.ten_thousand},
         )
 

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -111,7 +111,7 @@ class FilesystemBuildFileTest(unittest.TestCase):
 
     def test_build_files_family_lookup_with_ignore(self):
         self.assertEqual(
-            OrderedSet([self.create_buildfile("grandparent/parent/BUILD"),]),
+            OrderedSet([self.create_buildfile("grandparent/parent/BUILD")]),
             self.get_build_files_family("grandparent/parent", build_ignore_patterns=["*.twitter"]),
         )
 

--- a/tests/python/pants_test/binaries/test_binary_tool.py
+++ b/tests/python/pants_test/binaries/test_binary_tool.py
@@ -87,10 +87,10 @@ class BinaryToolBaseTest(TestBase):
                     "binaries_baseurls": ["https://binaries.example.org"],
                     "pants_bootstrapdir": str(temporary_dir()),
                 },
-                "another-tool": {"version": "0.0.2",},
-                "default-version-test.another-tool": {"version": "YYY",},
-                "custom-urls": {"version": "v2.3",},
-                "old_tool_scope": {"old_tool_version": "3",},
+                "another-tool": {"version": "0.0.2"},
+                "default-version-test.another-tool": {"version": "YYY"},
+                "custom-urls": {"version": "v2.3"},
+                "old_tool_scope": {"old_tool_version": "3"},
             },
         )
 
@@ -155,7 +155,7 @@ class BinaryToolBaseTest(TestBase):
             )
             context = self.context(
                 for_subsystems=[DefaultVersion],
-                options={GLOBAL_SCOPE: {"binaries_baseurls": [f"file:///{temp_dir}"],},},
+                options={GLOBAL_SCOPE: {"binaries_baseurls": [f"file:///{temp_dir}"]}},
             )
             self.maxDiff = None
             default_version_tool = DefaultVersion.global_instance()

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -113,7 +113,7 @@ class ParseSpecTest(unittest.TestCase):
             return parse_spec(
                 spec,
                 relative_to=relative_to,
-                subproject_roots=["subprojectA", "path/to/subprojectB",],
+                subproject_roots=["subprojectA", "path/to/subprojectB"],
             )
 
         # Ensure that a spec in subprojectA is determined correctly.

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -338,7 +338,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(TestWithBuildFileParse
                 "create_java_libraries": cls.create_java_libraries,
                 "path_util": cls.path_relative_util,
             },
-            objects={"artifact": cls.Artifact, "jar": cls.Jar,},
+            objects={"artifact": cls.Artifact, "jar": cls.Jar},
         )
 
     def test_context_aware_object_factories(self):

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -52,7 +52,7 @@ class BuildGraphTest(TestBase):
 
     def test_transitive_closure_address(self):
         root_address = self.inject_graph(
-            "//:foo", {"//:foo": ["a"], "a": ["a/b:bat"], "a/b:bat": [],}
+            "//:foo", {"//:foo": ["a"], "a": ["a/b:bat"], "a/b:bat": []}
         )
 
         self.assertEqual(len(self.build_graph.transitive_subgraph_of_addresses([root_address])), 3)
@@ -273,9 +273,7 @@ class BuildGraphTest(TestBase):
         )
 
     def test_transitive_subgraph_of_addresses_bfs_predicate(self):
-        root = self.inject_graph(
-            "a", {"a": ["b", "c"], "b": ["d", "e"], "c": [], "d": [], "e": [],}
-        )
+        root = self.inject_graph("a", {"a": ["b", "c"], "b": ["d", "e"], "c": [], "d": [], "e": []})
 
         predicate = lambda t: t.address.target_name != "b"
         filtered = self.build_graph.transitive_subgraph_of_addresses_bfs(

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -33,7 +33,7 @@ class BuildGraphIntegrationTest(PantsRunIntegrationTest):
     def banned_import(self, dir):
         with self.file_renamed(dir, "TEST_BUILD", "BUILD"):
             pants_run = self.run_pants(
-                ["--build-file-imports=error", "run", f"{dir}:hello",],
+                ["--build-file-imports=error", "run", f"{dir}:hello"],
                 print_exception_stacktrace=False,
             )
             self.assert_failure(pants_run)
@@ -47,7 +47,7 @@ class BuildGraphIntegrationTest(PantsRunIntegrationTest):
 
     def warn_import(self, dir):
         with self.file_renamed(dir, "TEST_BUILD", "BUILD"):
-            pants_run = self.run_pants(["--build-file-imports=warn", "run", f"{dir}:hello",])
+            pants_run = self.run_pants(["--build-file-imports=warn", "run", f"{dir}:hello"])
             self.assert_success(pants_run)
             assert "Hello\n" in pants_run.stdout_data
             assert f"Import used in {dir}/BUILD at line" in pants_run.stderr_data

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -13,7 +13,7 @@ from pants.testutil.test_base import TestBase
 class SourceMapperTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"java_library": JavaLibrary,},)
+        return BuildFileAliases(targets={"java_library": JavaLibrary})
 
     def owner(self, owner, f):
         request = OwnersRequest(sources=(f,))

--- a/tests/python/pants_test/core_tasks/test_run_prep_command.py
+++ b/tests/python/pants_test/core_tasks/test_run_prep_command.py
@@ -37,7 +37,7 @@ class RunPrepCommandTest(TaskTestBase):
 
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"prep_command": PrepCommand,},)
+        return BuildFileAliases(targets={"prep_command": PrepCommand})
 
     def test_prep_order(self):
         with temporary_dir() as workdir:

--- a/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+++ b/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
@@ -9,12 +9,12 @@ class AliasTargetIntegrationTest(PantsRunIntegrationTest):
     test_module = "testprojects/src/java/org/pantsbuild/testproject/aliases"
 
     def test_jvm_binary_alias(self):
-        test_run = self.run_pants(["run", f"{self.test_module}:convenient",])
+        test_run = self.run_pants(["run", f"{self.test_module}:convenient"])
         self.assert_success(test_run)
         self.assertIn("AliasedBinaryMain is up and running.", test_run.stdout_data)
 
     def test_intransitive_target_alias(self):
-        test_run = self.run_pants(["run", f"{self.test_module}:run-use-intransitive",])
+        test_run = self.run_pants(["run", f"{self.test_module}:run-use-intransitive"])
         self.assert_success(test_run)
 
     def test_alias_missing_target(self):

--- a/tests/python/pants_test/engine/legacy/test_goal_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_goal_rule_integration.py
@@ -59,7 +59,7 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
 
             # Launch the loop as a background process.
             handle = self.run_pants_with_workdir_without_waiting(
-                ["--no-v1", "--v2", "--loop", "--loop-max=3", "list", f"{tmpdir}:",],
+                ["--no-v1", "--v2", "--loop", "--loop-max=3", "list", f"{tmpdir}:"],
                 workdir,
                 config,
             )

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -164,7 +164,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         address_specs = AddressSpecs(
             [SingleAddress("root", "not_me")], exclude_patterns=tuple(["root.*"])
         )
-        address_family = AddressFamily("root", {"not_me": ("root/BUILD", TargetAdaptor()),})
+        address_family = AddressFamily("root", {"not_me": ("root/BUILD", TargetAdaptor())})
 
         targets = self._resolve_addresses(
             address_specs, address_family, self._snapshot(), self._address_mapper()

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -169,13 +169,13 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         # Ignore '*.ln' suffixed items at the root.
         self.assert_walk_files(
             ["**"],
-            ["4.txt", "a/3.txt", "a/4.txt.ln", "a/b/1.txt", "a/b/2",],
+            ["4.txt", "a/3.txt", "a/4.txt.ln", "a/b/1.txt", "a/b/2"],
             ignore_patterns=["/*.ln"],
         )
         # Whitelist one entry.
         self.assert_walk_files(
             ["**"],
-            ["4.txt", "a/3.txt", "a/4.txt.ln", "a/b/1.txt", "a/b/2", "c.ln/1.txt", "c.ln/2",],
+            ["4.txt", "a/3.txt", "a/4.txt.ln", "a/b/1.txt", "a/b/2", "c.ln/1.txt", "c.ln/2"],
             ignore_patterns=["/*.ln", "!c.ln"],
         )
 

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -307,7 +307,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
     def rules(cls):
         return (
             super().rules()
-            + [RootRule(JavacVersionExecutionRequest), get_javac_version_output,]
+            + [RootRule(JavacVersionExecutionRequest), get_javac_version_output]
             + create_cat_stdout_rules()
             + create_javac_compile_rules()
         )

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -39,13 +39,13 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
             run = self.run_pants(
                 ["run", target_spec],
                 config={
-                    "jvm-distributions": {"paths": {os_name: [one.home],}},
+                    "jvm-distributions": {"paths": {os_name: [one.home]}},
                     "jvm-platform": {
                         "default_platform": f"java{one.version.components[1]}",
                         "compiler": "javac",
                     },
                 },
-                extra_env={"JDK_HOME": two.home,},
+                extra_env={"JDK_HOME": two.home},
             )
             self.assert_success(run)
             self.assertIn(f"java.home:{os.path.realpath(one.home)}", run.stdout_data)

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -76,7 +76,7 @@ class TestTestRegistry(unittest.TestCase):
 
         test_specs = [JUnitTest(classname="a.b.c1", methodname=None)]
         matched_specs, unknown_tests = registry.match_test_spec(test_specs)
-        self.assertEqual({JUnitTest("a.b.c1"): "target_a",}, matched_specs)
+        self.assertEqual({JUnitTest("a.b.c1"): "target_a"}, matched_specs)
         self.assertEqual([], unknown_tests)
 
     def test_match_test_specs_fqcn_with_methodname(self):
@@ -91,7 +91,7 @@ class TestTestRegistry(unittest.TestCase):
         registry = self._get_sample_test_registry()
 
         spec, unknown_tests = registry.match_test_spec([JUnitTest(classname="c1", methodname=None)])
-        self.assertEqual({JUnitTest("a.b.c1"): "target_a", JUnitTest("x.y.c1"): "target_b",}, spec)
+        self.assertEqual({JUnitTest("a.b.c1"): "target_a", JUnitTest("x.y.c1"): "target_b"}, spec)
         self.assertEqual([], unknown_tests)
 
     def test_match_test_specs_non_fqcn_no_match(self):

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -238,7 +238,7 @@ class TestNailgunProtocol(unittest.TestCase):
 
         self.assertEqual(
             NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
-            {"NAILGUN_TTY_0": b"0", "NAILGUN_TTY_1": b"0", "NAILGUN_TTY_2": b"0",},
+            {"NAILGUN_TTY_0": b"0", "NAILGUN_TTY_1": b"0", "NAILGUN_TTY_2": b"0"},
         )
 
     def test_construct_chunk(self):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -793,7 +793,7 @@ Interrupted by user over pailgun client!
 
         NB: testprojects/src/python/nested_runs assumes that the pants.toml file is in ${workdir}/pants.toml
         """
-        config = {"GLOBAL": {"pantsd_timeout_when_multiple_invocations": 1,}}
+        config = {"GLOBAL": {"pantsd_timeout_when_multiple_invocations": 1}}
         with self.pantsd_successful_run_context(extra_config=config) as (
             pantsd_run,
             checker,

--- a/tests/python/pants_test/releases/test_reversion.py
+++ b/tests/python/pants_test/releases/test_reversion.py
@@ -47,7 +47,5 @@ class ReversionTest(PantsRunIntegrationTest):
 
             # Confirm that it can be consumed.
             output_pex_file = os.path.join(dest_dir, "out.pex")
-            pex_main.main(
-                ["--disable-cache", "-o", output_pex_file, output_whl_file,]
-            )
+            pex_main.main(["--disable-cache", "-o", output_pex_file, output_whl_file])
             self.assertTrue(os.path.isfile(output_pex_file))

--- a/tests/python/pants_test/targets/test_java_agent.py
+++ b/tests/python/pants_test/targets/test_java_agent.py
@@ -10,7 +10,7 @@ from pants.testutil.test_base import TestBase
 class JavaAgentTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"java_agent": JavaAgent,},)
+        return BuildFileAliases(targets={"java_agent": JavaAgent})
 
     def create_agent(self, name, **kwargs):
         args = {"name": name, "sources": []}

--- a/tests/python/pants_test/targets/test_scala_library.py
+++ b/tests/python/pants_test/targets/test_scala_library.py
@@ -21,7 +21,7 @@ class ScalaLibraryTest(TestBase):
                 "java_library": JavaLibrary,
                 "jar_library": JarLibrary,
             },
-            objects={"jar": JarDependency, "scala_jar": ScalaJarDependency,},
+            objects={"jar": JarDependency, "scala_jar": ScalaJarDependency},
         )
 
     def setUp(self):

--- a/tests/python/pants_test/task/test_simple_codegen_task.py
+++ b/tests/python/pants_test/task/test_simple_codegen_task.py
@@ -21,7 +21,7 @@ class DummyTargetBase(Target):
         self.copied = copied
         payload = Payload()
         payload.add_fields(
-            {"sources": self.create_sources_field(sources, address.spec_path, key_arg="sources"),}
+            {"sources": self.create_sources_field(sources, address.spec_path, key_arg="sources")}
         )
         super().__init__(address=address, payload=payload, **kwargs)
 

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -584,7 +584,7 @@ class TaskTest(TaskTestBase):
 
         registered_option_fp = self._synth_fp(
             cls=AnotherFakeTask,
-            options_fingerprintable={AnotherFakeTask.options_scope: {"fake-option": bool},},
+            options_fingerprintable={AnotherFakeTask.options_scope: {"fake-option": bool}},
         )
         self.assertNotEqual(registered_option_fp, default_fp)
 

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -116,7 +116,7 @@ class ExecutionGraphTest(unittest.TestCase):
 
     def test_simple_unconnected(self):
         exec_graph = ExecutionGraph(
-            [self.job("A", passing_fn, []), self.job("B", passing_fn, []),], False
+            [self.job("A", passing_fn, []), self.job("B", passing_fn, [])], False
         )
 
         self.execute(exec_graph)

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -15,7 +15,7 @@ from pants.testutil.test_base import TestBase
 class MavenLayoutTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"java_library": JavaLibrary, "junit_tests": JUnitTests,},)
+        return BuildFileAliases(targets={"java_library": JavaLibrary, "junit_tests": JUnitTests})
 
     def setUp(self):
         super().setUp()

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -44,7 +44,7 @@ class TestCollections(unittest.TestCase):
         self.assertEqual([64, 8], cubes[4])
 
     def test_recursively_update(self) -> None:
-        d1 = {"a": 1, "b": {"c": 2, "o": "z",}, "z": {"y": 0,}}
+        d1 = {"a": 1, "b": {"c": 2, "o": "z"}, "z": {"y": 0}}
         d2 = {"e": 3, "b": {"f": 4, "o": 9}, "g": {"h": 5}, "z": 7}
         recursively_update(d1, d2)
         self.assertEqual(d1, {"a": 1, "b": {"c": 2, "f": 4, "o": 9}, "e": 3, "g": {"h": 5}, "z": 7})

--- a/tests/python/pants_test/util/test_enums.py
+++ b/tests/python/pants_test/util/test_enums.py
@@ -25,7 +25,7 @@ class EnumMatchTest(unittest.TestCase):
 
     def test_inexhaustive_match(self) -> None:
         with self.assertRaises(InexhaustiveMatchError):
-            match(EnumMatchTest.Test.pig, {EnumMatchTest.Test.pig: "oink",})
+            match(EnumMatchTest.Test.pig, {EnumMatchTest.Test.pig: "oink"})
 
     def test_unrecognized_match(self) -> None:
         with self.assertRaises(UnrecognizedMatchError):


### PR DESCRIPTION
Black preserves trailing commas when converting multiple lines into one line because it assumes the trailing comma was intentional. However, this is confusing to readers because the comma suggests it does something when really it is just noise.

Flake8's E231 lint will enforce that we remove any bad trailing commas leftover from Black.