### PR TITLE
Port `./v2 test` to use the Target API (Old implementation)

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -95,6 +95,16 @@ from pants.source.source_root import SourceRootConfig
 
 
 COVERAGE_PLUGIN_MODULE_NAME = "__coverage_coverage_plugin__"
+COVERAGE_PLUGIN_INPUT = InputFilesContent(
+    FilesContent(
+        (
+            FileContent(
+                path=f"{COVERAGE_PLUGIN_MODULE_NAME}.py",
+                content=pkg_resources.resource_string(__name__, "coverage_plugin/plugin.py"),
+            ),
+        )
+    )
+)
 
 DEFAULT_COVERAGE_CONFIG = dedent(
     """
@@ -108,19 +118,6 @@ DEFAULT_COVERAGE_CONFIG = dedent(
 
 def get_coveragerc_input(coveragerc_content: str) -> InputFilesContent:
     return InputFilesContent([FileContent(path=".coveragerc", content=coveragerc_content.encode())])
-
-
-def get_coverage_plugin_input() -> InputFilesContent:
-    return InputFilesContent(
-        FilesContent(
-            (
-                FileContent(
-                    path=f"{COVERAGE_PLUGIN_MODULE_NAME}.py",
-                    content=pkg_resources.resource_string(__name__, "coverage_plugin/plugin.py"),
-                ),
-            )
-        )
-    )
 
 
 def ensure_section(config_parser: configparser.ConfigParser, section: str) -> None:
@@ -233,7 +230,7 @@ class CoverageSetup:
 
 @rule
 async def setup_coverage(coverage: PytestCoverage) -> CoverageSetup:
-    plugin_file_digest = await Get[Digest](InputFilesContent, get_coverage_plugin_input())
+    plugin_file_digest = await Get[Digest](InputFilesContent, COVERAGE_PLUGIN_INPUT)
     output_pex_filename = "coverage.pex"
     requirements_pex = await Get[Pex](
         CreatePex(

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -14,7 +14,7 @@ from pants.backend.python.rules import (
     pytest_coverage,
     pytest_runner,
 )
-from pants.backend.python.rules.pytest_runner import PytestRunner
+from pants.backend.python.rules.pytest_runner import PytestTarget
 from pants.backend.python.rules.targets import PythonTests
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -121,7 +121,7 @@ class PytestRunnerIntegrationTest(TestBase):
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
             subsystem_rule(TestOptions),
-            RootRule(PytestRunner),
+            RootRule(PytestTarget),
         )
 
     def run_pytest(
@@ -140,7 +140,7 @@ class PytestRunnerIntegrationTest(TestBase):
         if origin is None:
             origin = SingleAddress(directory=address.spec_path, name=address.target_name)
         tgt = PythonTests({}, address=address)
-        params = Params(PytestRunner.create(TargetWithOrigin(tgt, origin)), options_bootstrapper)
+        params = Params(PytestTarget.create(TargetWithOrigin(tgt, origin)), options_bootstrapper)
         test_result = self.request_single_product(TestResult, params)
         debug_request = self.request_single_product(TestDebugRequest, params)
         debug_result = InteractiveRunner(self.scheduler).run_local_interactive_process(

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -14,7 +14,7 @@ from pants.backend.python.rules import (
     pytest_coverage,
     pytest_runner,
 )
-from pants.backend.python.rules.pytest_runner import PytestTarget
+from pants.backend.python.rules.pytest_runner import PythonTestConfiguration
 from pants.backend.python.rules.targets import PythonTests
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -121,7 +121,7 @@ class PytestRunnerIntegrationTest(TestBase):
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
             subsystem_rule(TestOptions),
-            RootRule(PytestTarget),
+            RootRule(PythonTestConfiguration),
         )
 
     def run_pytest(
@@ -140,7 +140,9 @@ class PytestRunnerIntegrationTest(TestBase):
         if origin is None:
             origin = SingleAddress(directory=address.spec_path, name=address.target_name)
         tgt = PythonTests({}, address=address)
-        params = Params(PytestTarget.create(TargetWithOrigin(tgt, origin)), options_bootstrapper)
+        params = Params(
+            PythonTestConfiguration.create(TargetWithOrigin(tgt, origin)), options_bootstrapper
+        )
         test_result = self.request_single_product(TestResult, params)
         debug_request = self.request_single_product(TestDebugRequest, params)
         debug_result = InteractiveRunner(self.scheduler).run_local_interactive_process(

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -12,12 +12,12 @@ from pants.engine.addressable import Addresses
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Target
-from pants.rules.core.binary import BinaryImplementation, CreatedBinary
+from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
 
 
 @dataclass(frozen=True)
-class PythonBinaryImplementation(BinaryImplementation):
+class PexTarget(BinaryTarget):
     required_fields = (EntryPoint, PythonBinarySources)
 
     sources: PythonBinarySources
@@ -29,20 +29,20 @@ class PythonBinaryImplementation(BinaryImplementation):
     #  required fields. Use `Target.get()` in the `create()` method.
 
     @classmethod
-    def create(cls, tgt: Target) -> "PythonBinaryImplementation":
+    def create(cls, tgt: Target) -> "PexTarget":
         return cls(
             address=tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint]
         )
 
 
 @rule
-async def create_python_binary(implementation: PythonBinaryImplementation) -> CreatedBinary:
+async def create_python_binary(target: PexTarget) -> CreatedBinary:
     entry_point: Optional[str]
-    if implementation.entry_point.value is not None:
-        entry_point = implementation.entry_point.value
+    if target.entry_point.value is not None:
+        entry_point = target.entry_point.value
     else:
         source_files = await Get[SourceFiles](
-            AllSourceFilesRequest([implementation.sources], strip_source_roots=True)
+            AllSourceFilesRequest([target.sources], strip_source_roots=True)
         )
         # NB: `PythonBinarySources` enforces that we have 0-1 sources.
         if len(source_files.files) == 1:
@@ -52,9 +52,9 @@ async def create_python_binary(implementation: PythonBinaryImplementation) -> Cr
             entry_point = None
 
     request = CreatePexFromTargetClosure(
-        addresses=Addresses([implementation.address]),
+        addresses=Addresses([target.address]),
         entry_point=entry_point,
-        output_filename=f"{implementation.address.target_name}.pex",
+        output_filename=f"{target.address.target_name}.pex",
     )
 
     pex = await Get[Pex](CreatePexFromTargetClosure, request)
@@ -62,4 +62,4 @@ async def create_python_binary(implementation: PythonBinaryImplementation) -> Cr
 
 
 def rules():
-    return [create_python_binary, UnionRule(BinaryImplementation, PythonBinaryImplementation)]
+    return [create_python_binary, UnionRule(BinaryTarget, PexTarget)]

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -8,7 +8,6 @@ from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.rules.targets import EntryPoint, PythonBinarySources
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
@@ -21,7 +20,6 @@ from pants.rules.core.determine_source_files import AllSourceFilesRequest, Sourc
 class PythonBinaryImplementation(BinaryImplementation):
     required_fields = (EntryPoint, PythonBinarySources)
 
-    address: Address
     sources: PythonBinarySources
     entry_point: EntryPoint
 
@@ -32,7 +30,9 @@ class PythonBinaryImplementation(BinaryImplementation):
 
     @classmethod
     def create(cls, tgt: Target) -> "PythonBinaryImplementation":
-        return cls(tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint])
+        return cls(
+            address=tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint]
+        )
 
 
 @rule

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -660,7 +660,7 @@ async def resolve_target(
     if target_type is None:
         raise TargetDefinitionException(
             address,
-            f"Target type {type_alias} is not recognized. All valid target types: "
+            f"Target type {repr(type_alias)} is not recognized. All valid target types: "
             f"{sorted(registered_target_types.aliases)}.",
         )
     return WrappedTarget(target_type(kwargs, address=address))

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -22,7 +22,7 @@ from pants.rules.core.distdir import DistDir
 @union
 @dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class BinaryTarget(ABC):
-    """An ad-hoc collection of the fields necessary for a binary implementation to work with a
+    """An ad hoc collection of the fields necessary for a binary implementation to work with a
     target."""
 
     required_fields: ClassVar[Tuple[Type[Field], ...]]

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -21,8 +21,11 @@ from pants.rules.core.distdir import DistDir
 # TODO: This might not be the right level of abstraction. Possibly factor out some superclass.
 #  Revisit after porting lint.py, fmt.py, and test.py to use the Target API.
 @union
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class BinaryImplementation(ABC):
     required_fields: ClassVar[Tuple[Type[Field], ...]]
+
+    address: Address
 
     @classmethod
     def is_valid_target(cls, tgt: Target) -> bool:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -13,7 +13,7 @@ from pants.engine.interactive_runner import InteractiveProcessRequest, Interacti
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.option.custom_types import shell_str
-from pants.rules.core.binary import BinaryImplementation, CreatedBinary
+from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
 
@@ -22,8 +22,9 @@ class RunOptions(GoalSubsystem):
 
     name = "run"
 
-    # NB: To be runnable, there must be a BinaryImplementation that works with the target.
-    required_union_implementations = (BinaryImplementation,)
+    # NB: To be runnable, the target must be able to be converted into an ad-hoc subclass of
+    # BinaryTarget.
+    required_union_implementations = (BinaryTarget,)
 
     @classmethod
     def register_options(cls, register) -> None:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -22,7 +22,7 @@ class RunOptions(GoalSubsystem):
 
     name = "run"
 
-    # NB: To be runnable, the target must be able to be converted into an ad-hoc subclass of
+    # NB: To be runnable, the target must be able to be converted into an ad hoc subclass of
     # BinaryTarget.
     required_union_implementations = (BinaryTarget,)
 

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -13,7 +13,7 @@ from pants.engine.interactive_runner import InteractiveProcessRequest, Interacti
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.option.custom_types import shell_str
-from pants.rules.core.binary import BinaryTarget, CreatedBinary
+from pants.rules.core.binary import BinaryConfiguration, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
 
@@ -24,7 +24,7 @@ class RunOptions(GoalSubsystem):
 
     # NB: To be runnable, the target must be able to be converted into an ad hoc subclass of
     # BinaryTarget.
-    required_union_implementations = (BinaryTarget,)
+    required_union_implementations = (BinaryConfiguration,)
 
     @classmethod
     def register_options(cls, register) -> None:

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -73,7 +73,7 @@ class TestDebugRequest:
 @union
 @dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class TestTarget(ABC):
-    """An ad-hoc collection of the fields necessary for a test implementation to run on a target."""
+    """An ad hoc collection of the fields necessary for a test implementation to run on a target."""
 
     required_fields: ClassVar[Tuple[Type[Field], ...]]
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -270,9 +270,7 @@ async def run_tests(
         return Test(debug_result.process_exit_code)
 
     results = await MultiGet(
-        Get[AddressAndTestResult](
-            WrappedTestTarget, WrappedTestTarget(test_target_type.create(target_with_origin))
-        )
+        Get[AddressAndTestResult](WrappedTestTarget(test_target_type.create(target_with_origin)))
         for target_with_origin in targets_with_origins
         for test_target_type in test_target_types
         if test_target_type.is_valid(target_with_origin.target)

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -7,9 +7,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import Iterable, Optional, Type
+from typing import ClassVar, Iterable, Optional, Tuple, Type
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
+from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.engine import desktop
 from pants.engine.console import Console
@@ -17,11 +18,16 @@ from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.isolated_process import FallibleExecuteProcessResult
-from pants.engine.legacy.graph import HydratedTargetsWithOrigins
-from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
+from pants.engine.target import (
+    Field,
+    RegisteredTargetTypes,
+    Target,
+    TargetsWithOrigins,
+    TargetWithOrigin,
+)
 
 # TODO(#6004): use proper Logging singleton, rather than static logger.
 logger = logging.getLogger(__name__)
@@ -67,14 +73,31 @@ class TestDebugRequest:
 @union
 @dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
 class TestRunner(ABC):
-    adaptor_with_origin: TargetAdaptorWithOrigin
+    required_fields: ClassVar[Tuple[Type[Field], ...]]
+
+    address: Address
+    origin: OriginSpec
 
     __test__ = False
 
-    @staticmethod
+    @classmethod
+    def is_valid_target(cls, tgt: Target) -> bool:
+        return tgt.has_fields(cls.required_fields)
+
+    @classmethod
+    def valid_target_types(
+        cls, target_types: Iterable[Type[Target]], *, union_membership: UnionMembership
+    ) -> Tuple[Type[Target], ...]:
+        return tuple(
+            target_type
+            for target_type in target_types
+            if target_type.class_has_fields(cls.required_fields, union_membership=union_membership)
+        )
+
+    @classmethod
     @abstractmethod
-    def is_valid_target(_: TargetAdaptorWithOrigin) -> bool:
-        """Return True if the test runner can meaningfully operate on this target."""
+    def create(cls, target_with_origin: TargetWithOrigin) -> "TestRunner":
+        pass
 
 
 # NB: This is only used for the sake of coordinator_of_tests. Consider inlining that rule so that
@@ -195,50 +218,56 @@ class Test(Goal):
 async def run_tests(
     console: Console,
     options: TestOptions,
-    runner: InteractiveRunner,
-    targets_with_origins: HydratedTargetsWithOrigins,
+    interactive_runner: InteractiveRunner,
+    targets_with_origins: TargetsWithOrigins,
     workspace: Workspace,
     union_membership: UnionMembership,
+    registered_target_types: RegisteredTargetTypes,
 ) -> Test:
     test_runners: Iterable[Type[TestRunner]] = union_membership.union_rules[TestRunner]
 
     if options.values.debug:
         target_with_origin = targets_with_origins.expect_single()
-        adaptor_with_origin = TargetAdaptorWithOrigin.create(
-            target_with_origin.target.adaptor, target_with_origin.origin
-        )
-        address = adaptor_with_origin.adaptor.address
-        valid_test_runners = [
-            test_runner
-            for test_runner in test_runners
-            if test_runner.is_valid_target(adaptor_with_origin)
-        ]
+        target = target_with_origin.target
+        valid_test_runners = [runner for runner in test_runners if runner.is_valid_target(target)]
+
         if not valid_test_runners:
-            raise ValueError(f"No valid test runner for {address}.")
-        if len(valid_test_runners) > 1:
+            all_valid_target_types = itertools.chain.from_iterable(
+                runner.valid_target_types(
+                    registered_target_types.types, union_membership=union_membership
+                )
+                for runner in test_runners
+            )
+            formatted_target_types = sorted(
+                target_type.alias for target_type in all_valid_target_types
+            )
             raise ValueError(
-                f"Multiple possible test runners for {address} "
-                f"({', '.join(test_runner.__name__ for test_runner in valid_test_runners)})."
+                f"The `test` goal only works with the following target types: "
+                f"{formatted_target_types}\n\nYou used {target.address} with target type "
+                f"{repr(target.alias)}."
+            )
+        if len(valid_test_runners) > 1:
+            possible_runners = sorted(
+                implementation.__name__ for implementation in valid_test_runners
+            )
+            raise ValueError(
+                f"Multiple of the registered test runners work for {target.address} "
+                f"(target type {repr(target.alias)}). It is ambiguous which implementation to use. "
+                f"Possible implementations: {possible_runners}."
             )
         test_runner = valid_test_runners[0]
-        logger.info(f"Starting test in debug mode: {address.reference()}")
-        request = await Get[TestDebugRequest](TestRunner, test_runner(adaptor_with_origin))
-        debug_result = runner.run_local_interactive_process(request.ipr)
+        logger.info(f"Starting test in debug mode: {target.address.reference()}")
+        request = await Get[TestDebugRequest](TestRunner, test_runner.create(target_with_origin))
+        debug_result = interactive_runner.run_local_interactive_process(request.ipr)
         return Test(debug_result.process_exit_code)
-
-    adaptors_with_origins = tuple(
-        TargetAdaptorWithOrigin.create(target_with_origin.target.adaptor, target_with_origin.origin)
-        for target_with_origin in targets_with_origins
-        if target_with_origin.target.adaptor.has_sources()
-    )
 
     results = await MultiGet(
         Get[AddressAndTestResult](
-            WrappedTestRunner, WrappedTestRunner(test_runner(adaptor_with_origin))
+            WrappedTestRunner, WrappedTestRunner(runner.create(target_with_origin))
         )
-        for adaptor_with_origin in adaptors_with_origins
-        for test_runner in test_runners
-        if test_runner.is_valid_target(adaptor_with_origin)
+        for target_with_origin in targets_with_origins
+        for runner in test_runners
+        if runner.is_valid_target(target_with_origin.target)
     )
 
     did_any_fail = False
@@ -292,30 +321,28 @@ async def run_tests(
                 coverage_report_files.append(report_file)
 
         if coverage_report_files and options.values.open_coverage:
-            desktop.ui_open(console, runner, coverage_report_files)
+            desktop.ui_open(console, interactive_runner, coverage_report_files)
 
     return Test(exit_code)
 
 
 @rule
-async def coordinator_of_tests(wrapped_test_runner: WrappedTestRunner) -> AddressAndTestResult:
-    test_runner = wrapped_test_runner.runner
-    adaptor_with_origin = test_runner.adaptor_with_origin
-    adaptor = adaptor_with_origin.adaptor
+async def coordinator_of_tests(wrapped_runner: WrappedTestRunner) -> AddressAndTestResult:
+    runner = wrapped_runner.runner
 
     # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
     # live TTY, periodically dump heavy hitters to stderr. See
     # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
-    logger.info(f"Starting tests: {adaptor.address.reference()}")
+    logger.info(f"Starting tests: {runner.address.reference()}")
     # NB: This has the effect of "casting" a TargetAdaptorWithOrigin to a member of the TestTarget
     # union. If the adaptor is not a member of the union, the engine will fail at runtime with a
     # useful error message.
-    result = await Get[TestResult](TestRunner, test_runner)
+    result = await Get[TestResult](TestRunner, runner)
     logger.info(
         f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
-        f"{adaptor.address.reference()}"
+        f"{runner.address.reference()}"
     )
-    return AddressAndTestResult(adaptor.address, result)
+    return AddressAndTestResult(runner.address, result)
 
 
 def rules():


### PR DESCRIPTION
### Result: better error messages for invalid target types with `--debug`

Before:

> ERROR: No valid test runner for src/python/pants/util:strutil.

After:

> ERROR: The `test` goal only works with the following target types: ['python_tests']
>
> You used src/python/pants/util:strutil with target type 'python_library'.

### Result: works with custom target types

So long as the target type has the field `PythonTestsSources` (or a subclass), it will work with `./v2 test`.

## Result: simpler test setup

Tests no longer need to set up mocked `HydratedTargetsWithOrigins`. Now, they can simply import `PythonTests` and call `PythonTests({}, address=address)` and we will use all the default values for a `PythonTests` target.

## Result: less hydration of sources

Previously, `HydratedTarget` would hydrate every target's sources no matter now. Now, we only hydrate sources for targets that we know are valid test targets (and for their transitive closure).

## Implementation: Configurations (ad hoc collections of fields)

A target is defined as _a unique combination of fields that are meaningful together_. Normally, we think of this in the context of a public-facing Target that appears in a BUILD file, like `python_tests`. But, with the Target API, we can also create _ad hoc_ targets, i.e. unique combinations of fields used by a rule that are not exposed externally to the user.

These ad hoc combinations of fields do not need to correspond 1-1 with the public targets. For example, `python_tests` has a `tags` field, which is completely ignored by `pytest_runner.py`.

Previously, for the Target API port of `./v2 binary`, we had called this combination of fields `BinaryImplementation`, e.g. `PythonBinaryImplementation`. We were calling the `test.py` abstraction `TestRunner`, e.g. `PytestRunner`. Likewise, `lint.py` had `Linter`, e.g. `BanditLinter`. These were misnomers (as pointed out by @stuhood) - they were dataclasses that wrapped instances of `Targets`; it's confusing to say `bandit_linter.target_with_origin`.

Instead, we use the name `Configuration` to represent the ad hoc combination of `Field`s used by a rule. Now, we have `TestConfiguration` and `PythonTestConfiguration`, along with `BinaryConfiguration` and `PythonBinaryConfiguration`.

(The PR originally used `TestTarget` and `BinaryTarget` to represent the idea of an ad hoc target, but this was rejected in favor of `Configuration` because it is far too easy to confuse a publically facing `Target` vs. an `AdHocTarget`.)

A followup will provide more structure to this idea of ad hoc collections of fields, including factoring out boilerplate.

## Implementation: filtering out empty `sources`

With Pytest, when a target has no source files, which means we pass no args to Pytest, Pytest will resort to auto-discovery on all the files in the test chroot, i.e. running tests on the 3rd party dependencies. This is incorrect behavior.

Previously, we were able to filter out empty sources proactively in `test.py` because `TargetAdaptor`s always had hydrated sources. 

Now, `Targets` have unhydrated sources, so we must go out of our way to hydrate them in `test.py` and filter out there. We have an optimization that we solely hydrate if we know the target type is valid, e.g. that it's a `python_tests` target.

We could move this filtering down one layer of abstraction into `pytest_runner.py`, but this would not be easy to do because of how we have the `setup_py` rule as an intermediate rule. We don't have a simple way to short-circuit that rule.

Even though the hydration will happen both in `test.py` and again in `pytest_runner.py`, engine caching means this should mitigate the cost. 