### PR TITLE
Add `FrozenDict` as an immutable wrapper around native dictionaries

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -4,6 +4,8 @@
 python_tests(
   name='tests',
   dependencies=[
+    '3rdparty/python:dataclasses',
+    ':frozendict',
     ':ordered_set',
   ],
   tags = {'type_checked'},
@@ -76,6 +78,12 @@ python_library(
   name = 'filtering',
   sources = ['filtering.py'],
   tags = {'partially_type_checked'},
+)
+
+python_library(
+  name = 'frozendict',
+  sources = ['frozendict.py'],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Any, Dict, Hashable, Iterable, Iterator, Mapping, Optional, Tuple, TypeVar, Union
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V", bound=Hashable)
+
+
+class FrozenDict(Mapping[K, V]):
+    """A wrapper around a normal `dict` that removes all methods to mutate the instance and that
+    implements __hash__.
+
+    This should be used instead of normal dicts when working with the engine because normal dicts
+    are not safe to use.
+    """
+
+    def __init__(self, item: Optional[Union[Mapping[K, V], Iterable[Tuple[K, V]]]] = None) -> None:
+        """Creates a `FrozenDict` from a mapping object or a sequence of tuples representing
+        entries.
+
+        These value should be immutable and hashable, but this collection does not do any validation
+        that that is true.
+        """
+        self._data: Dict[K, V] = dict(item)  # type: ignore[arg-type]
+
+    def __getitem__(self, k: K) -> V:
+        return self._data[k]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[K]:
+        return iter(self._data)
+
+    def __reversed__(self) -> Iterator[K]:
+        return reversed(tuple(self._data))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, FrozenDict):
+            return NotImplemented
+        return tuple(self.items()) == tuple(other.items())
+
+    def __hash__(self) -> int:
+        try:
+            return hash(tuple(self.items()))
+        except TypeError as e:
+            raise TypeError(
+                "Even though you are using a `FrozenDict`, the underlying values are not hashable. "
+                "Please use hashable and immutable types for the underlying values, e.g. use "
+                f"tuples instead of lists and use FrozenOrderedSet instead of set().\n\n"
+                f"Original error message: {repr(e)}"
+            )
+
+    def __repr__(self) -> str:
+        return f"FrozenDict({repr(self._data)})"

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -19,7 +19,7 @@ class FrozenDict(Mapping[K, V]):
         """Creates a `FrozenDict` from a mapping object or a sequence of tuples representing
         entries.
 
-        These values must be immutable and hashable, which we proactively validate.
+        These values must be hashable, which we proactively validate.
         """
         self._data: Dict[K, V] = dict(item)  # type: ignore[arg-type]
         # NB: We eagerly compute the hash to validate that the values are hashable and to avoid
@@ -50,8 +50,8 @@ class FrozenDict(Mapping[K, V]):
         except TypeError as e:
             raise TypeError(
                 "Even though you are using a `FrozenDict`, the underlying values are not hashable. "
-                "Please use hashable and immutable types for the underlying values, e.g. use "
-                f"tuples instead of lists and use FrozenOrderedSet instead of set().\n\n"
+                "Please use hashable (and preferably immutable) types for the underlying values, "
+                "e.g. use tuples instead of lists and use FrozenOrderedSet instead of set().\n\n"
                 f"Original error message: {e}\n\nValue: {self}"
             )
 

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -1,10 +1,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Dict, Hashable, Iterable, Iterator, Mapping, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple, TypeVar, Union
 
-K = TypeVar("K", bound=Hashable)
-V = TypeVar("V", bound=Hashable)
+K = TypeVar("K")
+V = TypeVar("V")
 
 
 class FrozenDict(Mapping[K, V]):

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -1,0 +1,121 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from collections import OrderedDict
+from dataclasses import dataclass
+
+import pytest
+
+from pants.util.frozendict import FrozenDict
+
+
+def test_flexible_constructor() -> None:
+    expected = FrozenDict({"a": 0, "b": 1})
+    assert FrozenDict(OrderedDict({"a": 0, "b": 1})) == expected
+    assert FrozenDict([("a", 0), ("b", 1)]) == expected
+    assert FrozenDict((("a", 0), ("b", 1))) == expected
+
+
+def test_items_can_be_mutable() -> None:
+    # We avoid runtime type checking for now to avoid the slight performance hit and to keep this
+    # API simple and aligned with how other immutable Python types like `tuple` behave. Possibly,
+    # we will want to enforce this in the future.
+    #
+    # MyPy will also check that the types implement the Hashable protocol.
+    #
+    # NB: the collection will not be hashable when the underlying values are not hashable (see
+    # `test_hash()`). This means that the engine will provide runtime type checking for us if the
+    # FrozenDict is passed to the engine.
+    fd1 = FrozenDict({0: ["a"]})  # type: ignore[type-var]
+    fd1[0].append("x")
+    fd1[0].append("y")
+    assert fd1[0] == ["a", "x", "y"]
+
+
+def test_len() -> None:
+    assert len(FrozenDict({})) == 0
+    assert len(FrozenDict({"a": 0, "b": 1})) == 2
+
+
+def test_contains() -> None:
+    fd1 = FrozenDict({"a": 0})
+    assert "a" in fd1
+    assert "z" not in fd1
+    assert object() not in fd1
+
+
+def test_get() -> None:
+    fd1 = FrozenDict({"a": 0})
+    assert fd1["a"] == 0
+    assert fd1.get("a") == 0
+
+    with pytest.raises(KeyError):
+        fd1["z"]
+    assert fd1.get("z") == None
+    assert fd1.get("z", 26) == 26
+
+
+def test_iter() -> None:
+    fd1 = FrozenDict({"a": 0, "b": 1})
+    assert list(iter(fd1)) == ["a", "b"]
+    assert [k for k in fd1] == ["a", "b"]
+
+
+def test_keys() -> None:
+    d1 = {"a": 0, "b": 1}
+    assert FrozenDict(d1).keys() == d1.keys()
+
+
+def test_values() -> None:
+    d1 = {"a": 0, "b": 1}
+    # __eq__ seems to be busted for dict.values()...d1.values() != d1.values().
+    assert list(FrozenDict(d1).values()) == list(d1.values())
+
+
+def test_items() -> None:
+    d1 = {"a": 0, "b": 1}
+    assert FrozenDict(d1).items() == d1.items()
+
+
+def test_eq() -> None:
+    d1 = {"a": 0, "b": 1}
+    fd1 = FrozenDict(d1)
+    assert fd1 == fd1
+    assert fd1 == FrozenDict(d1)
+    # Order matters
+    assert fd1 != FrozenDict({"b": 1, "a": 0})
+    # Must be an instance of FrozenDict
+    assert fd1 != d1
+
+
+def test_hash() -> None:
+    d1 = {"a": 0, "b": 1}
+    assert hash(FrozenDict(d1)) == hash(FrozenDict(d1))
+    # Order matters.
+    assert hash(FrozenDict(d1)) != hash(FrozenDict({"b": 1, "a": 0}))
+    # If the underlying type is not hashable, then the FrozenDict will not be.
+    with pytest.raises(TypeError):
+        hash(FrozenDict({"a": []}))  # type: ignore[type-var]
+
+
+def test_works_with_dataclasses() -> None:
+    @dataclass(frozen=True)
+    class Frozen:
+        x: int
+
+    @dataclass
+    class Mutable:
+        x: int
+
+    fd1 = FrozenDict({"a": Frozen(0)})
+    fd2 = FrozenDict({Frozen(0): "a"})
+    fd3 = FrozenDict({"a": Mutable(0)})
+    with pytest.raises(TypeError):
+        FrozenDict({Mutable(0): "a"})
+
+    assert hash(fd1) == hash(fd1)
+    assert hash(fd2) == hash(fd2)
+    assert hash(fd1) != hash(fd2)
+
+    with pytest.raises(TypeError):
+        hash(fd3)

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -21,12 +21,10 @@ def test_items_can_be_mutable() -> None:
     # API simple and aligned with how other immutable Python types like `tuple` behave. Possibly,
     # we will want to enforce this in the future.
     #
-    # MyPy will also check that the types implement the Hashable protocol.
-    #
     # NB: the collection will not be hashable when the underlying values are not hashable (see
     # `test_hash()`). This means that the engine will provide runtime type checking for us if the
     # FrozenDict is passed to the engine.
-    fd1 = FrozenDict({0: ["a"]})  # type: ignore[type-var]
+    fd1 = FrozenDict({0: ["a"]})
     fd1[0].append("x")
     fd1[0].append("y")
     assert fd1[0] == ["a", "x", "y"]
@@ -95,7 +93,7 @@ def test_hash() -> None:
     assert hash(FrozenDict(d1)) != hash(FrozenDict({"b": 1, "a": 0}))
     # If the underlying type is not hashable, then the FrozenDict will not be.
     with pytest.raises(TypeError):
-        hash(FrozenDict({"a": []}))  # type: ignore[type-var]
+        hash(FrozenDict({"a": []}))
 
 
 def test_works_with_dataclasses() -> None:

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -81,6 +81,14 @@ def test_frozen_is_hashable() -> None:
 
 
 @pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_rejects_unhashable_elements(cls: OrderedSetCls) -> None:
+    # This is a useful by-product of using a dict internally to store the data, as all keys for a
+    # dict must be hashable.
+    with pytest.raises(TypeError):
+        cls([["a", "b"], ["c"]])
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
 def test_binary_operations(cls: OrderedSetCls) -> None:
     set1 = cls("abracadabra")
     set2 = cls("simsalabim")


### PR DESCRIPTION
## Problem

We have no ergonomic way to work with dictionaries with the engine, as `dict` is mutable and not hashable. We've resorted to using custom constructors in dataclasses that allow the user to pass a `Dict`, and then, in the constructor, converting it to a `Tuple[Tuple[K, V], ...]`, which is still clunky to use.

https://github.com/pantsbuild/pants/blob/eeb9d7488a39bb428bf19e273584675d1041745b/src/python/pants/engine/isolated_process.py#L24-L62

## Solution

Add `FrozenDict` as a very lightweight wrapper around native `dict`, with the only differences that it removes all entry points for mutation (e.g. `d.update()`) and it implements `__hash__()`.

### Rejected alternative: proactive casting of unhashable elements

Toolchain has a `FrozenDict` implementation that proactively attempts to convert hashable elements to hashable, and has additional guarantees to ensure the dict truly is frozen. For example, it will convert `{'a': [1]}` to `{'a': (1,)}`.

Instead, we take a much simpler approach to validate and give a nice error message when using unhashable elements, so that the rule author may fix their code. This is simpler, more performant, and more transparent.

### Does not use `typing.Hashable`

This is a way in MyPy to express that something must must be hashable. However, it does not work as well as expected, e.g. complaining about `typing.Type`, such as `str`, not being hashable, even though `hash(str)` works.

## Result

In a followup, we will audit the current engine code to see where we can clean things up by using `FrozenDict`.