### PR TITLE
Skip Rust tests and JVM tests in CI when no respective changes were made

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS=AKIAV6A6G7RQWPRUWIXR
   - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   - RUST_BACKTRACE="all"
-matrix:
+jobs:
   include:
   - addons:
       apt:
@@ -478,6 +478,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=clippy
+    if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Clippy (Rust linter)
     os: linux
     python:
@@ -501,6 +502,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=cargo_audit
+    if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Cargo audit
     os: linux
     python:
@@ -2087,6 +2089,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=rust_tests.linux
+    if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Rust tests - Linux
     os: linux
     python:
@@ -2122,6 +2125,7 @@ matrix:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - CACHE_NAME=rust_tests.osx
+    if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Rust tests - OSX
     os: osx
     osx_image: xcode8.3
@@ -2331,6 +2335,7 @@ matrix:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=jvm_tests.py36
+    if: commit_message !~ /\[ci skip-jvm-tests\]/
     language: python
     name: JVM tests (Python 3.6)
     os: linux
@@ -2392,6 +2397,7 @@ matrix:
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
     - CACHE_NAME=jvm_tests.py37
+    if: commit_message !~ /\[ci skip-jvm-tests\]/
     language: python
     name: JVM tests (Python 3.7)
     os: linux

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -547,6 +547,7 @@ def run_rust_tests() -> None:
 
 
 def run_jvm_tests() -> None:
+    # NB: Ensure that this stays in sync with githooks/prepare-commit-msg.
     targets = ["src/java::", "src/scala::", "tests/java::", "tests/scala::", "zinc::"]
     _run_command(
         ["./pants.pex", "doc", "test", *targets],

--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -1,13 +1,19 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
-
 # Defines:
 # + CACHE_ROOT: The pants cache directory, ie: ~/.cache/pants.
 # Exposes:
 # + die: Exit in a failure state and optionally log an error message to the console.
-# + fingerprint_data: Fingerprints the data on stdin.
-
 # shellcheck source=build-support/common.sh
 source "${REPO_ROOT}/build-support/common.sh"
+
+# Defines:
+# + NATIVE_ROOT: The Rust code directory, ie: src/rust/engine.
+# + MODE: Whether to run in debug or release mode.
+# + MODE_FLAG: The string to pass to Cargo to determine if we're in debug or release mode.
+# Exposes:
+# + calculate_current_hash: Generate a stable hash to determine if we need to rebuild the engine.
+# shellcheck source=build-support/bin/native/calculate_engine_hash.sh
+source "${REPO_ROOT}/build-support/bin/native/calculate_engine_hash.sh"
 
 KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
 case "${KERNEL}" in
@@ -22,41 +28,9 @@ case "${KERNEL}" in
     ;;
 esac
 
-readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 readonly NATIVE_ENGINE_BINARY="native_engine.so"
 readonly NATIVE_ENGINE_RESOURCE="${REPO_ROOT}/src/python/pants/engine/${NATIVE_ENGINE_BINARY}"
-
-# N.B. Set $MODE to "debug" for faster builds.
-readonly MODE="${MODE:-release}"
-case "$MODE" in
-  debug) MODE_FLAG="" ;;
-  *) MODE_FLAG="--release" ;;
-esac
-
 readonly NATIVE_ENGINE_CACHE_DIR=${CACHE_ROOT}/bin/native-engine
-
-function calculate_current_hash() {
-  # Cached and unstaged files, with ignored files excluded.
-  # NB: We fork a subshell because one or both of `ls-files`/`hash-object` are
-  # sensitive to the CWD, and the `--work-tree` option doesn't seem to resolve that.
-  #
-  # Assumes we're in the venv that will be used to build the native engine.
-  (
-   cd "${REPO_ROOT}" || exit 1
-   (echo "${MODE_FLAG}"
-    echo "${RUST_TOOLCHAIN}"
-    uname
-    python --version 2>&1
-    git ls-files --cached --others --exclude-standard \
-     "${NATIVE_ROOT}" \
-     "${REPO_ROOT}/rust-toolchain" \
-     "${REPO_ROOT}/src/python/pants/engine/native.py" \
-     "${REPO_ROOT}/build-support/bin/native" \
-     "${REPO_ROOT}/3rdparty/python/requirements.txt" \
-   | grep -v -E -e "/BUILD$" -e "/[^/]*\.md$" \
-   | git hash-object --stdin-paths) | fingerprint_data
-  )
-}
 
 function _build_native_code() {
   # Builds the native code, and echos the path of the built binary.

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -1,0 +1,42 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
+
+# Exposes:
+# + fingerprint_data: Fingerprints the data on stdin.
+# shellcheck source=build-support/common.sh
+source "${REPO_ROOT}/build-support/common.sh"
+
+readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
+
+# N.B. Set $MODE to "debug" for faster builds.
+readonly MODE="${MODE:-release}"
+case "$MODE" in
+  debug) MODE_FLAG="" ;;
+  *) MODE_FLAG="--release" ;;
+esac
+
+RUST_TOOLCHAIN="$(cat "${REPO_ROOT}/rust-toolchain")"
+
+function calculate_current_hash() {
+  # Cached and unstaged files, with ignored files excluded.
+  # NB: We fork a subshell because one or both of `ls-files`/`hash-object` are
+  # sensitive to the CWD, and the `--work-tree` option doesn't seem to resolve that.
+  #
+  # Assumes we're in the venv that will be used to build the native engine.
+  (
+   cd "${REPO_ROOT}" || exit 1
+   (echo "${MODE_FLAG}"
+    echo "${RUST_TOOLCHAIN}"
+    uname
+    python --version 2>&1
+    git ls-files --cached --others --exclude-standard \
+     "${NATIVE_ROOT}" \
+     "${REPO_ROOT}/rust-toolchain" \
+     "${REPO_ROOT}/src/python/pants/engine/native.py" \
+     "${REPO_ROOT}/build-support/bin/native" \
+     "${REPO_ROOT}/3rdparty/python/requirements.txt" \
+   | grep -v -E -e "/BUILD$" -e "/[^/]*\.md$" \
+   | git hash-object --stdin-paths) | fingerprint_data
+  )
+}

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -24,6 +24,8 @@ function calculate_current_hash() {
   # sensitive to the CWD, and the `--work-tree` option doesn't seem to resolve that.
   #
   # Assumes we're in the venv that will be used to build the native engine.
+  #
+  # NB: Ensure that this stays in sync wtih `githooks/prepare-commit-msg`.
   (
    cd "${REPO_ROOT}" || exit 1
    (echo "${MODE_FLAG}"

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -67,5 +67,4 @@ function fingerprint_data() {
 function git_merge_base() {
   # This prints the tracking branch if set and otherwise falls back to local "master".
   git rev-parse --symbolic-full-name --abbrev-ref HEAD@\{upstream\} 2>/dev/null || echo 'master'
-
 }

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -1,15 +1,66 @@
 #!/usr/bin/env bash
-
 COMMIT_MSG_FILEPATH=$1
 COMMIT_MSG_SRC=$2
 
-NUM_NON_MD_FILES=$(git status -s --porcelain | grep -cv ".\md$")
+# NB: prepare-commit-msg runs in the context of GIT_WORK_TREE, ie: pwd == REPO_ROOT
+source build-support/common.sh
+MERGE_BASE="$(git_merge_base)"
 
-# The msg source will be "commit" if we were called with --amend.
-if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
+# NB: We consider all changed files since the merge base, rather than only inspecting the latest
+# commit. With a feature branch, this usually means all the local commits since the last push to
+# the PR.
+#
+# That means that we do not calculate skips based off what is in the overall PR, but rather what is
+# in the changeset being pushed. For example, if a PR's first commit changes Rust and that gets
+# pushed, then we will run the Rust tests for that build; but, if in a followup push, we don't
+# make any further changes to Rust, then we will _not_ rerun those Rust tests by default in the
+# new build.
+CHANGED_FILES="$(git diff --name-only "${MERGE_BASE}")"
+
+NUM_NON_MD_FILES=$(echo "${CHANGED_FILES})" | grep -c -v ".\md$")
+
+# Ensure that this stays in sync with `build-support/bin/native/calculate_engine_hash.sh`.
+NUM_RUST_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
+  -e "^src/rust/engine" \
+  -e "^rust-toolchain" \
+  -e "^src/python/pants/engine/native.py" \
+  -e "^build-support/bin/native" \
+  -e "^3rdparty/python/requirements.txt")
+
+# Ensure that this stays in sync with `build-support/bin/ci.py`.
+NUM_JVM_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
+  -e "^src/java" \
+  -e "^src/scala" \
+  -e "^tests/java" \
+  -e "^tests/scala" \
+  -e "^zinc")
+
+# Check if we were called with `--amend` to avoid putting skip labels multiple times.
+IS_AMEND=false
+if [ "${COMMIT_MSG_SRC}" = "commit" ]; then
+  IS_AMEND=true
+fi
+
+if [ "${IS_AMEND}" = "false" ] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
 # Delete this line to force a full CI run for documentation-only changes.
 [ci skip]  # Documentation-only change.
+EOF
+fi
+
+if [ "${IS_AMEND}" = "false" ] && [ "${NUM_RUST_FILES}" -eq 0 ]; then
+cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
+
+# Delete this line to force CI to run Clippy and the Rust tests.
+[ci skip-rust-tests]  # No Rust changes made.
+EOF
+fi
+
+if [ "${IS_AMEND}" = "false" ] && [ "${NUM_JVM_FILES}" -eq 0 ]; then
+cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
+
+# Delete this line to force CI to run the JVM tests.
+[ci skip-jvm-tests]  # No JVM changes made.
 EOF
 fi


### PR DESCRIPTION
## Problem

Our CI is painfully slow and flaky. 

One easy win we can make is to stop running irrelevant jobs when there is no need to. We already do this for docs-only changes, where we skip all of CI.

One other low hanging fruit is to skip any Rust tests and JVM tests when no changes were made to their relevant files.

## Solution

Use Travis's built-in skip mechanism https://docs.travis-ci.com/user/conditional-builds-stages-jobs#conditional-jobs to skip Rust and JVM when possible. Per its [Conditions docs](https://docs.travis-ci.com/user/conditions-v1), we can't use complex logic to calculate the skip, e.g. we can't run some script. So, we instead inspect the commit message to see if it has the special lines `[ci skip-rust-tests]` and/or `[ci skip-jvm-tests]`. 

Specifically, we teach the githook `prepare-commit-msg` to not only look for docs-only changes, but to also look if Rust-related files are changed and JVM-related files are changed.

### Checking the entire changeset rather than the last commit

Our previous implementation was buggy in that it would only check for the most recent commit. For example, even if you had a commit with 20 Python files changed, if the next commit only updated a doc, then we would skip CI for the whole PR.

Instead, we check against the merge base for the files changed, which typically corresponds to the changes since the most recent push to the remote / PR.

### Also extract `calculate_engine_hash.sh`

This refactor makes it easier to keep the githook in sync with the `native_engine.so` fingerprint code. This also is prework for a followup change to start caching `native_engine.so` in CI.

## Result

The majority of builds will have 4 fewer shards and save about 40 minutes of overall CI time.

If users want to override this automatic skipping, they can easily modify the commit message to remove the `[ci skip-{rust,jvm}-tests]` label.