### PR TITLE
Additional refactoring around pants initialization

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -234,10 +234,6 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
             ) as finalizer:
                 yield finalizer
 
-    def _maybe_get_client_start_time_from_env(self, env):
-        client_start_time = env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
-        return None if client_start_time is None else float(client_start_time)
-
     def run(self):
         # Ensure anything referencing sys.argv inherits the Pailgun'd args.
         sys.argv = self._args
@@ -282,7 +278,10 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 )
                 with ExceptionSink.exiter_as_until_exception(lambda _: PantsRunFailCheckerExiter()):
                     runner = LocalPantsRunner.create(env, options_bootstrapper, specs, session)
-                    runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
+
+                    st = self._env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
+                    start_time = float(st) if st else None
+                    runner.set_start_time(start_time)
                     runner.run()
 
             except KeyboardInterrupt:

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -279,8 +279,8 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 with ExceptionSink.exiter_as_until_exception(lambda _: PantsRunFailCheckerExiter()):
                     runner = LocalPantsRunner.create(env, options_bootstrapper, specs, session)
 
-                    st = self._env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
-                    start_time = float(st) if st else None
+                    env_start_time = self._env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
+                    start_time = float(env_start_time) if env_start_time else None
                     runner.set_start_time(start_time)
                     runner.run()
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -20,6 +20,7 @@ from pants.java.nailgun_io import (
     PipedNailgunStreamWriter,
 )
 from pants.java.nailgun_protocol import ChunkType, MaybeShutdownSocket, NailgunProtocol
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket
 
@@ -261,9 +262,10 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 # Clean global state.
                 clean_global_runtime_state(reset_subsystem=True)
 
-                options, _, options_bootstrapper = LocalPantsRunner.parse_options(
-                    self._args, self._env
-                )
+                args = self._args
+                env = self._env
+                options_bootstrapper = OptionsBootstrapper.create(args=args, env=env)
+                options, _ = LocalPantsRunner.parse_options(options_bootstrapper)
 
                 global_options = options.for_global_scope()
                 session = self._scheduler_service.prepare_graph(options)
@@ -279,9 +281,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                     session, specs, options, options_bootstrapper
                 )
                 with ExceptionSink.exiter_as_until_exception(lambda _: PantsRunFailCheckerExiter()):
-                    runner = LocalPantsRunner.create(
-                        self._args, self._env, specs, session, options_bootstrapper,
-                    )
+                    runner = LocalPantsRunner.create(env, options_bootstrapper, specs, session)
                     runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
                     runner.run()
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -204,10 +204,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
         # If we're running with the daemon, we'll be handed a session from the
         # resident graph helper - otherwise initialize a new one here.
-        if daemon_graph_session:
-            graph_session = daemon_graph_session
-        else:
-            graph_session = cls._init_graph_session(options_bootstrapper, build_config, options)
+        graph_session = (
+            daemon_graph_session
+            if daemon_graph_session
+            else cls._init_graph_session(options_bootstrapper, build_config, options)
+        )
 
         if specs is None:
             global_options = options.for_global_scope()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -119,7 +119,6 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     union_membership: UnionMembership
     is_daemon: bool
     profile_path: Optional[str]
-    _run_start_time: Optional[float] = None
     _run_tracker: Optional[RunTracker] = None
     _reporting: Optional[Reporting] = None
     _repro: Optional[Repro] = None
@@ -225,7 +224,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
             profile_path=profile_path,
         )
 
-    def set_start_time(self, start_time: float) -> None:
+    def set_start_time(self, start_time: Optional[float]) -> None:
         # Launch RunTracker as early as possible (before .run() is called).
         self._run_tracker = RunTracker.global_instance()
 
@@ -233,9 +232,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         os.environ["PANTS_PARENT_BUILD_ID"] = self._run_tracker.run_id
 
         self._reporting = Reporting.global_instance()
-
-        self._run_start_time = start_time
-        self._reporting.initialize(self._run_tracker, self.options, start_time=self._run_start_time)
+        self._reporting.initialize(self._run_tracker, self.options, start_time=start_time)
 
         spec_parser = CmdLineSpecParser(get_buildroot())
         specs = [spec_parser.parse_spec(spec).to_spec_string() for spec in self.options.specs]

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -260,13 +260,6 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         if self._repro:
             self._repro.capture(self._run_tracker.run_info.get_as_dict())
 
-    def _maybe_handle_help(self):
-        """Handle requests for `help` information."""
-        if self.options.help_request:
-            help_printer = HelpPrinter(options=self.options, union_membership=self.union_membership)
-            result = help_printer.print_help()
-            return result
-
     def _maybe_run_v1(self, v1: bool) -> int:
         v1_goals, ambiguous_goals, _ = self.options.goals_by_version
         if not v1:
@@ -350,8 +343,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 self.scheduler_session, callbacks=callbacks, report_interval_seconds=report_interval
             )
 
-            help_output = self._maybe_handle_help()
-            if help_output is not None:
+            if self.options.help_request:
+                help_printer = HelpPrinter(
+                    options=self.options, union_membership=self.union_membership
+                )
+                help_output = help_printer.print_help()
                 self._exiter.exit(help_output)
 
             v1 = global_options.v1

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import sys
 import time
 
 from pants.base.exception_sink import ExceptionSink
@@ -25,10 +26,10 @@ def test_env():
 
 
 def main():
-    start_time = time.time()
-
     with maybe_profiled(os.environ.get("PANTSC_PROFILE")):
+        start_time = time.time()
         try:
-            PantsRunner(start_time=start_time).run()
+            runner = PantsRunner(args=sys.argv, env=os.environ,)
+            runner.run(start_time)
         except KeyboardInterrupt as e:
             ExceptionSink.get_global_exiter().exit_and_fail("Interrupted by user:\n{}".format(e))

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -29,7 +29,7 @@ def main():
     with maybe_profiled(os.environ.get("PANTSC_PROFILE")):
         start_time = time.time()
         try:
-            runner = PantsRunner(args=sys.argv, env=os.environ,)
+            runner = PantsRunner(args=sys.argv, env=os.environ)
             runner.run(start_time)
         except KeyboardInterrupt as e:
             ExceptionSink.get_global_exiter().exit_and_fail("Interrupted by user:\n{}".format(e))

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -99,8 +99,6 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # N.B. Inlining this import speeds up the python thin client run by about 100ms.
         from pants.bin.local_pants_runner import LocalPantsRunner
 
-        runner = LocalPantsRunner.create(
-            self.args, self.env, options_bootstrapper=options_bootstrapper
-        )
+        runner = LocalPantsRunner.create(env=self.env, options_bootstrapper=options_bootstrapper)
         runner.set_start_time(start_time)
         runner.run()

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -16,15 +16,13 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     """A higher-level runner that delegates runs to either a LocalPantsRunner or
     RemotePantsRunner."""
 
     args: List[str]
-    env: Mapping[
-        str, str,
-    ]
+    env: Mapping[str, str]
 
     # This could be a bootstrap option, but it's preferable to keep these very limited to make it
     # easier to make the daemon the default use case. Once the daemon lifecycle is stable enough we
@@ -94,7 +92,7 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 RemotePantsRunner(self._exiter, self.args, self.env, options_bootstrapper).run()
                 return
             except RemotePantsRunner.Fallback as e:
-                logger.warning(f"Client exception: {e}, falling back to non-daemon mode")
+                logger.warning("Client exception: {!r}, falling back to non-daemon mode".format(e))
 
         # N.B. Inlining this import speeds up the python thin client run by about 100ms.
         from pants.bin.local_pants_runner import LocalPantsRunner

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -6,18 +6,19 @@ import os
 from pants.fs.fs import safe_filename_from_path
 from pants.goal.goal import Goal
 from pants.init.options_initializer import BuildConfigInitializer
+from pants.option.option_value_container import OptionValueContainer
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_rmtree
 
 
-def init_workdir(global_options):
+def init_workdir(global_options: OptionValueContainer) -> str:
     """Given the bootstrap options (generally immediately after bootstrap), initialize the workdir.
 
     If it is in use, the "physical" workdir is a directory under the `pants_physical_workdir_base`
     that is unique to each working copy (via including the entire path to the working copy in its
     name using `safe_filename_from_path`).
     """
-    workdir_src = global_options.pants_workdir
+    workdir_src: str = global_options.pants_workdir
     if not global_options.pants_physical_workdir_base:
         safe_mkdir(workdir_src)
         return workdir_src

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import cast
 
 from pants.fs.fs import safe_filename_from_path
 from pants.goal.goal import Goal
@@ -18,7 +19,7 @@ def init_workdir(global_options: OptionValueContainer) -> str:
     that is unique to each working copy (via including the entire path to the working copy in its
     name using `safe_filename_from_path`).
     """
-    workdir_src: str = global_options.pants_workdir
+    workdir_src = cast(str, global_options.pants_workdir)
     if not global_options.pants_physical_workdir_base:
         safe_mkdir(workdir_src)
         return workdir_src


### PR DESCRIPTION
This is a continuation of the work started in #9348 to make the code paths around initializing pants easier to understand, removing cruft, ultimately with the goal of making the initialization process more performant and reducing user-visible CLI latency.