### PR TITLE
Move verification of configs out of OptionsBootstrapper

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -203,7 +203,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
         # Verify configs.
         if global_options.verify_config:
-            options_bootstrapper.verify_configs_against_options(options)
+            options.verify_configs_against_self(options_bootstrapper.config)
 
         union_membership = UnionMembership(build_config.union_rules())
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -203,7 +203,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
         # Verify configs.
         if global_options.verify_config:
-            options.verify_configs_against_self(options_bootstrapper.config)
+            options.verify_configs(options_bootstrapper.config)
 
         union_membership = UnionMembership(build_config.union_rules())
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -264,7 +264,7 @@ class Options:
         """Freezes this Options instance."""
         self._frozen = True
 
-    def verify_configs_against_self(self, global_config: Config) -> None:
+    def verify_configs(self, global_config: Config) -> None:
         """Verify all loaded configs have correct scopes and options."""
 
         error_log = []


### PR DESCRIPTION
In the interest of trying to pare down the size and complexity of `OptionsBootstrapper` code, move the `verify_configs_against_options` method from `OptionsBootstrapper` to `Options`.