### PR TITLE
[WIP] Enhance type mismatch error message

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -807,9 +807,9 @@ impl Task {
                   }
                 }
                 _ => throw(&format!(
-                  "Expected {:?} but got {:?} instead. See {:?}",
-                  get.product,
+                  "Unable to transfrom from {:?} to {:?}. See {:?}",
                   get.subject,
+                  get.product,
                   func.name()
                 )),
               })

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -257,12 +257,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
     def test_get_type_match_failure(self):
         """Test that Get(...)s are now type-checked during rule execution, to allow for union
         types."""
-        expected_msg = (
-            "Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { "
-            "product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, "
-            f"subject: B }}], func: {fmt_rust_function(a_typecheck_fail_test)}(), cacheable: true, display_info: "
-            "None }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })"
-        )
+        expected_msg = 'Exception: Expected A but got A() instead. See "pants_test.engine.test_scheduler:132:a_typecheck_fail_test"'
         with assert_execution_error(self, expected_msg):
             # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
             self.request_single_product(A, Params(TypeCheckFailWrapper(A())))

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -257,7 +257,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
     def test_get_type_match_failure(self):
         """Test that Get(...)s are now type-checked during rule execution, to allow for union
         types."""
-        expected_msg = 'Exception: Expected A but got A() instead. See "pants_test.engine.test_scheduler:132:a_typecheck_fail_test"'
+        expected_msg = 'Exception: Unable to transfrom from A() to A. See "pants_test.engine.test_scheduler:132:a_typecheck_fail_test"'
         with assert_execution_error(self, expected_msg):
             # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
             self.request_single_product(A, Params(TypeCheckFailWrapper(A())))


### PR DESCRIPTION
### Problem
Type mismatches between declared parameter types in `yield Get`s provide an unclear and overly verbose error message. EG) `snapshot = yield Get(Snapshot, PathGlobs, "foo")` returns  the following:
```
Exception: WithDeps(Inner(InnerEntry { params: {Console, OptionsBootstrapper, Specs}, rule: Task(Task { product: List, clause: [Select { product: Console }, Select { product: _Options }, Select { product: Specs }], gets: [Get { product: Snapshot, subject: PathGlobs }, Get { product: HydratedTargets, subject: Specs }, Get { product: BuildFileAddresses, subject: Specs }], func: list_targets(), cacheable: false }) })) did not declare a dependency on JustGet(Get { product: Snapshot, subject: str })
```
Relevant issue: #8349 

### Solution

The verbose entry and dependencies were replaced with subject instance type, product type, and a path to the offending method:

`Exception: Unable to transform from str to Snapshot. See "pants_test.engine.rules:84:pathglobs_to_snapshot()"`
