### PR TITLE
Update cbindgen to latest version

### DIFF
--- a/src/rust/engine/engine_cffi/Cargo.toml
+++ b/src/rust/engine/engine_cffi/Cargo.toml
@@ -22,6 +22,6 @@ workunit_store = { path = "../workunit_store" }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
-cbindgen = "0.8.6"
+cbindgen = "0.13.2"
 cc = "1.0"
 walkdir = "2"


### PR DESCRIPTION
We're currently on a version of cbindgen a few months shy of a year old, so upgrade to the latest.