### PR TITLE
Visualize the rule graph for @goal_rules

### DIFF
--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -798,7 +798,6 @@ class RuleGraphTest(TestBase):
                 {fmt_non_param_edge(b_from_suba, C, return_func=RuleFormatRequest(suba_from_c))}
                 {fmt_param_edge(C, C, RuleFormatRequest(suba_from_c))}
                 {fmt_param_edge(SubA, SubA, via_func=RuleFormatRequest(a, gets=[("B", "C")]), return_func=RuleFormatRequest(b_from_suba, C))}
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(b_from_suba))}
                 }}
                 """
             ).strip(),
@@ -1165,6 +1164,6 @@ class RuleGraphTest(TestBase):
 
     def create_subgraph(self, requested_product, rules, subject, validate=True):
         scheduler = create_scheduler(rules + _suba_root_rules, validate=validate)
-        return "\n".join(scheduler.rule_subgraph_visualization(type(subject), requested_product))
+        return "\n".join(scheduler.rule_subgraph_visualization([type(subject)], requested_product))
 
     assert_equal_with_printing = assert_equal_with_printing


### PR DESCRIPTION
### Problem

The rule graph is most helpful in the context of a particular root that you are trying to debug, but we don't currently expose a way to render a subgraph of rules from the command line.

### Solution

Although dedicated "native" goals (like `help`, which is not implemented using `@rules`) for explaining the rule graph are probably an eventuality, this change punts on designing those, and exposes visualization for `@goal_rules` when `--native-engine-visualize-to` is passed.

### Result

```
./pants --native-engine-visualize-to=example list
```
...creates a dot file that renders as:
![rule_graph list dot](https://user-images.githubusercontent.com/46740/77379187-482fae00-6d35-11ea-82fb-f95e0a244642.png)
