### PR TITLE
Use pants_workdir global option in run goal

### DIFF
--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -13,6 +13,7 @@ from pants.engine.interactive_runner import InteractiveProcessRequest, Interacti
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.option.custom_types import shell_str
+from pants.option.global_options import GlobalOptions
 from pants.rules.core.binary import BinaryImplementation, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
@@ -50,13 +51,14 @@ async def run(
     build_root: BuildRoot,
     addresses: Addresses,
     options: RunOptions,
+    global_options: GlobalOptions,
 ) -> Run:
     address = addresses.expect_single()
     binary = await Get[CreatedBinary](Address, address)
 
-    with temporary_dir(
-        root_dir=PurePath(build_root.path, ".pants.d").as_posix(), cleanup=True
-    ) as tmpdir:
+    workdir = global_options.options.pants_workdir
+
+    with temporary_dir(root_dir=workdir, cleanup=True) as tmpdir:
         path_relative_to_build_root = PurePath(tmpdir).relative_to(build_root.path).as_posix()
         workspace.materialize_directory(
             DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -9,6 +9,7 @@ from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
+from pants.option.global_options import GlobalOptions
 from pants.rules.core.binary import CreatedBinary
 from pants.rules.core.run import Run, run
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
@@ -44,6 +45,7 @@ class RunTest(TestBase):
                 BuildRoot(),
                 Addresses([Address.parse(address_spec)]),
                 MockOptions(args=[]),
+                GlobalOptions.global_instance(),
             ],
             mock_gets=[
                 MockGet(


### PR DESCRIPTION
### Problem

In the `run` goal we currently hardcore the pants workdir `.pants.d` as the directory to run a pants-controlled executable in, instead of using the global option like the `repl` goal does.

### Solution

Use the value from the option instead of hardcoding `.pants.d`
