### PR TITLE
Formalize default values for Fields

### DIFF
--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -36,11 +36,11 @@ class PythonSources(Sources):
 
 
 class PythonLibrarySources(PythonSources):
-    default_globs = ("*.py", "!test_*.py", "!*_test.py", "!conftest.py")
+    default = ("*.py", "!test_*.py", "!*_test.py", "!conftest.py")
 
 
 class PythonTestsSources(PythonSources):
-    default_globs = ("test_*.py", "*_test.py", "conftest.py")
+    default = ("test_*.py", "*_test.py", "conftest.py")
 
 
 class PythonBinarySources(PythonSources):

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -115,14 +115,15 @@ class Timeout(IntField):
 
     alias = "timeout"
 
-    def hydrate(self, raw_value: Optional[int], *, address: Address) -> Optional[int]:
-        hydrated_value = super().hydrate(raw_value, address=address)
-        if hydrated_value is not None and hydrated_value < 1:
+    @classmethod
+    def compute_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
+        value = super().compute_value(raw_value, address=address)
+        if value is not None and value < 1:
             raise InvalidFieldException(
                 f"The value for the `timeout` field in target {address} must be > 0, but was "
-                f"{raw_value}."
+                f"{value}."
             )
-        return raw_value
+        return value
 
     def calculate_from_global_options(self, pytest: PyTest) -> Optional[int]:
         """Determine the timeout (in seconds) after applying global `pytest` options."""

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -118,13 +118,13 @@ class TestPythonSources(TestBase):
             self.request_single_product(HydratedSources, multiple_sources.request)
         assert "has 2 sources" in str(exc.value)
 
-    def test_python_library_sources_default_globs(self) -> None:
+    def test_python_library_sources_default(self) -> None:
         self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
         sources = PythonLibrarySources(None, address=Address.parse(":lib"))
         result = self.request_single_product(HydratedSources, sources.request)
         assert result.snapshot.files == self.PYTHON_SRC_FILES
 
-    def test_python_tests_sources_default_globs(self) -> None:
+    def test_python_tests_sources_default(self) -> None:
         self.create_files(path="", files=[*self.PYTHON_SRC_FILES, *self.PYTHON_TEST_FILES])
         sources = PythonTestsSources(None, address=Address.parse(":tests"))
         result = self.request_single_product(HydratedSources, sources.request)

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -6,7 +6,7 @@ from typing import Type
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import UnionMembership, goal_rule
-from pants.engine.target import BoolField, Field, RegisteredTargetTypes, Target
+from pants.engine.target import Field, RegisteredTargetTypes, Target
 from pants.util.objects import get_first_line_of_docstring
 
 
@@ -55,13 +55,9 @@ def verbose_target_information(
         #  hints, but it might be weird to handle Optional.
         field_alias_text = f"  {field.alias} = ...,"
         field_alias = console.cyan(f"{field_alias_text:<30}")
-        description = get_first_line_of_docstring(field) or "<no description>"
-        # TODO: should we elevate `default` so that every Field has it, whereas now only bool
-        #  fields have it? V1 `targets` renders a default value, which is helpful.
-        default = console.green(
-            f"(default: {field.default})" if issubclass(field, BoolField) else ""
-        )
-        default_prefix = " " if default else ""
+        description = get_first_line_of_docstring(field) or ""
+        default = console.green(f"(default: {field.default})")
+        default_prefix = " " if description else ""
         return f"{field_alias}  {description}{default_prefix}{default}"
 
     output = [target_type_description, "\n"] if target_type_description else []

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -102,7 +102,7 @@ def test_list_single() -> None:
 
         fortran_tests(
           custom_field = ...,           My custom field! (default: True)
-          fortran_version = ...,        <no description>
+          fortran_version = ...,        (default: None)
         )
         """
     )
@@ -111,7 +111,7 @@ def test_list_single() -> None:
     assert binary_target_stdout == dedent(
         """\
         fortran_binary(
-          fortran_version = ...,        <no description>
+          fortran_version = ...,        (default: None)
         )
         """
     )


### PR DESCRIPTION
Currently, we allow subclasses of `BoolField` and `Sources` to specify a default value, meaning a value used when the user did not explicitly specify the field in a BUILD file (i.e. `raw_value=None`). Everything else is hardcoded to default to `None`.

By formalizing that every field, not just those two, has a default field, we get these benefits:

1. Easier extensibility for subclassed fields. For example, a `StringField` subclass may want to keep the string type checking but change the default from `None` to `my_str`. Now that is possible.
2. Better output in `./v2 target-types2`. We can now always give the default value:

![Screen Shot 2020-03-24 at 12 17 17 AM](https://user-images.githubusercontent.com/14852634/77398469-d3746800-6d64-11ea-8519-7a4de2c801ac.png)

Note that the vast majority of fields will still default to `None`, which we want. But, subclasses can modify this as desired.
