### PR TITLE
Hotfix lint failure due to PR merge order conflict

### DIFF
--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -410,7 +410,7 @@ def osx_shard(
     setup = {
         "os": "osx",
         "language": "generic",
-        "before_script": ["ulimit -c unlimited", "ulimit -n 8192",],
+        "before_script": ["ulimit -c unlimited", "ulimit -n 8192"],
         "before_install": [
             "curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq",
             "chmod 755 /usr/local/bin/jq",

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -49,7 +49,7 @@ def test_get() -> None:
 
     with pytest.raises(KeyError):
         fd1["z"]
-    assert fd1.get("z") == None
+    assert fd1.get("z") is None
     assert fd1.get("z", 26) == 26
 
 


### PR DESCRIPTION
I merged `FrozenDict` and then shortly after enabled some new Flake8 lints. The `FrozenDict` PR had a violation of the new lints, and the Flake8 lint PR's CI did not include `FrozenDict`, so CI is now broken on master.