### PR TITLE
Revert internally enforcing Flake8's E231 trailing comma lint

### DIFF
--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 extend-ignore:
   E203,  # whitespace before ':' (conflicts with Black)
+  E231,  # Bad trailing comma (conflicts with Black)
   E262,  # inline comment doesn't start with `#` (enable once fixed)
   E266,  # Too many leading # for block comment (maybe enable once fixed)
   E301,  # expected 1 blank line (enable once fixed)


### PR DESCRIPTION
For example, we will once more allow `['foo',]`, rather than requiring `['foo']`.

While these trailing commas are hard to read, Black does not automatically remove them. When deciding to use Black, we ceded control of formatting to the tool, even though that means ~5% of its decisions we won't like. It's a bad user experience to say "Black will handle it all, expect for this one thing that you need to manually fix."