### PR TITLE
 Remove custom properties from nailgun

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -238,12 +238,6 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # Ensure anything referencing sys.argv inherits the Pailgun'd args.
         sys.argv = self._args
 
-        # Broadcast our process group ID (in PID form - i.e. negated) to the remote client so
-        # they can send signals (e.g. SIGINT) to all processes in the runners process group.
-        with self._maybe_shutdown_socket.lock:
-            NailgunProtocol.send_pid(self._maybe_shutdown_socket.socket, os.getpid())
-            NailgunProtocol.send_pgrp(self._maybe_shutdown_socket.socket, os.getpgrp() * -1)
-
         # Invoke a Pants run with stdio redirected and a proxied environment.
         with self.nailgunned_stdio(
             self._maybe_shutdown_socket, self._env

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 import sys
 import termios
 import time

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -36,7 +36,6 @@ class PailgunClientSignalHandler(SignalHandler):
             timeout=self._timeout,
             reason=KeyboardInterrupt("Interrupted by user over pailgun client!"),
         )
-        self._pailgun_client.maybe_send_signal(signum)
 
     def handle_sigint(self, signum, _frame):
         if self._pailgun_client._maybe_last_pid():

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -37,6 +37,7 @@ class PailgunClientSignalHandler(SignalHandler):
             timeout=self._timeout,
             reason=KeyboardInterrupt("Interrupted by user over pailgun client!"),
         )
+        self._pailgun_client.maybe_send_signal(signum)
 
     def handle_sigint(self, signum, _frame):
         self._forward_signal_with_timeout(signum, "SIGINT")
@@ -148,6 +149,7 @@ class RemotePantsRunner:
 
     def _connect_and_execute(self, pantsd_handle: PantsDaemon.Handle):
         port = pantsd_handle.port
+        pid = pantsd_handle.pid
         # Merge the nailgun TTY capability environment variables with the passed environment dict.
         ng_env = NailgunProtocol.isatty_to_env(self._stdin, self._stdout, self._stderr)
         modified_env = {
@@ -166,6 +168,7 @@ class RemotePantsRunner:
         # Instantiate a NailgunClient.
         client = NailgunClient(
             port=port,
+            remote_pid=pid,
             ins=self._stdin,
             out=self._stdout,
             err=self._stderr,

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -19,17 +19,18 @@ logger = logging.getLogger(__name__)
 
 
 class PailgunClientSignalHandler(SignalHandler):
-    def __init__(self, pailgun_client, timeout=1, *args, **kwargs):
+    def __init__(self, pailgun_client, pid, timeout=1, *args, **kwargs):
         assert isinstance(pailgun_client, NailgunClient)
         self._pailgun_client = pailgun_client
         self._timeout = timeout
+        self.pid = pid
         super().__init__(*args, **kwargs)
 
     def _forward_signal_with_timeout(self, signum, signame):
         # TODO Consider not accessing the private function _maybe_last_pid here, or making it public.
         logger.info(
             "Sending {} to pantsd with pid {}, waiting up to {} seconds before sending SIGKILL...".format(
-                signame, self._pailgun_client._maybe_last_pid(), self._timeout
+                signame, self.pid, self._timeout
             )
         )
         self._pailgun_client.set_exit_timeout(
@@ -38,12 +39,7 @@ class PailgunClientSignalHandler(SignalHandler):
         )
 
     def handle_sigint(self, signum, _frame):
-        if self._pailgun_client._maybe_last_pid():
-            self._forward_signal_with_timeout(signum, "SIGINT")
-        else:
-            # NB: We consider not having received a PID yet as "not having started substantial work".
-            # So in this case, we let the client die gracefully, and the server handle the closed socket.
-            super(PailgunClientSignalHandler, self).handle_sigint(signum, _frame)
+        self._forward_signal_with_timeout(signum, "SIGINT")
 
     def handle_sigquit(self, signum, _frame):
         self._forward_signal_with_timeout(signum, "SIGQUIT")
@@ -97,10 +93,12 @@ class RemotePantsRunner:
         self._stderr = stderr or sys.stderr.buffer
 
     @contextmanager
-    def _trapped_signals(self, client):
+    def _trapped_signals(self, client, pid: int):
         """A contextmanager that handles SIGINT (control-c) and SIGQUIT (control-\\) remotely."""
         signal_handler = PailgunClientSignalHandler(
-            client, timeout=self._bootstrap_options.for_global_scope().pantsd_pailgun_quit_timeout
+            client,
+            pid=pid,
+            timeout=self._bootstrap_options.for_global_scope().pantsd_pailgun_quit_timeout,
         )
         with ExceptionSink.trapped_signals(signal_handler):
             yield
@@ -175,7 +173,7 @@ class RemotePantsRunner:
             metadata_base_dir=pantsd_handle.metadata_base_dir,
         )
 
-        with self._trapped_signals(client), STTYSettings.preserved():
+        with self._trapped_signals(client, pantsd_handle.pid), STTYSettings.preserved():
             # Execute the command on the pailgun.
             result = client.execute(self.PANTS_COMMAND, *self._args, **modified_env)
 

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -11,8 +11,6 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
 
-from pants.util.osutil import Pid
-
 STDIO_DESCRIPTORS = (0, 1, 2)
 
 

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -31,15 +31,6 @@ class ChunkType:
     ENVIRONMENT = b"E"
     WORKING_DIR = b"D"
     COMMAND = b"C"
-    # PGRP and PID are custom extensions to the Nailgun protocol spec for transmitting pid info.
-    # PGRP is used to allow the client process to try killing the nailgun server and everything in its
-    # process group when the thin client receives a signal. PID is used to retrieve logs for fatal
-    # errors from the remote process at that PID.
-    # TODO(#6579): we should probably move our custom extensions to a ChunkType subclass in
-    # nailgun_client.py and differentiate clearly whether the client accepts the pailgun extensions
-    # (e.g. by calling it PailgunClient).
-    PGRP = b"G"
-    PID = b"P"
     STDIN = b"0"
     STDOUT = b"1"
     STDERR = b"2"
@@ -47,7 +38,7 @@ class ChunkType:
     STDIN_EOF = b"."
     EXIT = b"X"
     REQUEST_TYPES = (ARGUMENT, ENVIRONMENT, WORKING_DIR, COMMAND)
-    EXECUTION_TYPES = (PGRP, PID, STDIN, STDOUT, STDERR, START_READING_INPUT, STDIN_EOF, EXIT)
+    EXECUTION_TYPES = (STDIN, STDOUT, STDERR, START_READING_INPUT, STDIN_EOF, EXIT)
     VALID_TYPES = REQUEST_TYPES + EXECUTION_TYPES
 
 
@@ -333,20 +324,6 @@ class NailgunProtocol:
         """Send an Exit chunk over the specified socket, containing the specified return code."""
         encoded_exit_status = cls.encode_int(code)
         cls.send_exit(sock, payload=encoded_exit_status)
-
-    @classmethod
-    def send_pid(cls, sock, pid):
-        """Send the PID chunk over the specified socket."""
-        assert isinstance(pid, Pid) and pid > 0
-        encoded_int = cls.encode_int(pid)
-        cls.write_chunk(sock, ChunkType.PID, encoded_int)
-
-    @classmethod
-    def send_pgrp(cls, sock, pgrp):
-        """Send the PGRP chunk over the specified socket."""
-        assert isinstance(pgrp, Pid) and pgrp < 0
-        encoded_int = cls.encode_int(pgrp)
-        cls.write_chunk(sock, ChunkType.PGRP, encoded_int)
 
     @classmethod
     def encode_int(cls, obj):

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -170,34 +170,3 @@ class TestNailgunClient(unittest.TestCase):
 
     def test_repr(self):
         self.assertIsNotNone(repr(self.nailgun_client))
-
-    @unittest.mock.patch("os.kill", **PATCH_OPTS)
-    def test_send_control_c(self, mock_kill):
-        self.nailgun_client._maybe_last_pid = lambda: 31337
-        self.nailgun_client._maybe_last_pgrp = lambda: -31336
-        self.nailgun_client.maybe_send_signal(signal.SIGINT)
-        mock_kill.assert_has_calls(
-            [
-                # The pid is killed first, then the pgrp, if include_pgrp=True.
-                unittest.mock.call(31337, signal.SIGINT),
-                unittest.mock.call(-31336, signal.SIGINT),
-            ]
-        )
-
-    @unittest.mock.patch("os.kill", **PATCH_OPTS)
-    def test_send_signal_no_pgrp(self, mock_kill):
-        self.nailgun_client._maybe_last_pid = lambda: 111111
-        self.nailgun_client.maybe_send_signal(signal.SIGINT, include_pgrp=False)
-        mock_kill.assert_called_once_with(111111, signal.SIGINT)
-
-    @unittest.mock.patch("os.kill", **PATCH_OPTS)
-    def test_send_control_c_noop_none(self, mock_kill):
-        self.nailgun_client._session = None
-        self.nailgun_client.maybe_send_signal(signal.SIGINT)
-        mock_kill.assert_not_called()
-
-    @unittest.mock.patch("os.kill", **PATCH_OPTS)
-    def test_send_control_c_noop_nopid(self, mock_kill):
-        self.nailgun_client._session = unittest.mock.Mock(remote_pid=None, remote_pgrp=None)
-        self.nailgun_client.maybe_send_signal(signal.SIGINT)
-        mock_kill.assert_not_called()

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import signal
 import socket
 import unittest
 import unittest.mock
@@ -166,3 +167,9 @@ class TestNailgunClient(unittest.TestCase):
 
     def test_repr(self):
         self.assertIsNotNone(repr(self.nailgun_client))
+
+    @unittest.mock.patch("os.kill", **PATCH_OPTS)
+    def test_send_control_c(self, mock_kill):
+        self.nailgun_client.remote_pid = 31337
+        self.nailgun_client.maybe_send_signal(signal.SIGINT)
+        mock_kill.assert_has_calls([unittest.mock.call(31337, signal.SIGINT)])

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import signal
 import socket
 import unittest
 import unittest.mock
@@ -71,7 +70,6 @@ class TestNailgunClientSession(unittest.TestCase):
     @unittest.mock.patch("psutil.Process", **PATCH_OPTS)
     def test_process_session(self, mock_psutil_process):
         mock_psutil_process.cmdline.return_value = ["mock", "process"]
-        NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b"31337")
         NailgunProtocol.write_chunk(self.server_sock, ChunkType.START_READING_INPUT)
         NailgunProtocol.write_chunk(self.server_sock, ChunkType.STDOUT, self.TEST_PAYLOAD)
         NailgunProtocol.write_chunk(self.server_sock, ChunkType.STDERR, self.TEST_PAYLOAD)
@@ -84,12 +82,10 @@ class TestNailgunClientSession(unittest.TestCase):
         self.assertEqual(self.fake_stderr.content, self.TEST_PAYLOAD * 3)
         self.mock_stdin_reader.start.assert_called_once_with()
         self.mock_stdin_reader.stop.assert_called_once_with()
-        self.assertEqual(self.nailgun_client_session.remote_pid, 31337)
 
     @unittest.mock.patch("psutil.Process", **PATCH_OPTS)
     def test_process_session_bad_chunk(self, mock_psutil_process):
         mock_psutil_process.cmdline.return_value = ["mock", "process"]
-        NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b"31337")
         NailgunProtocol.write_chunk(self.server_sock, ChunkType.START_READING_INPUT)
         NailgunProtocol.write_chunk(self.server_sock, self.BAD_CHUNK_TYPE, "")
 
@@ -145,7 +141,7 @@ class TestNailgunClient(unittest.TestCase):
     @unittest.mock.patch("pants.java.nailgun_client.NailgunClientSession", **PATCH_OPTS)
     def test_execute_propagates_connection_error_on_connect(self, mock_session, mock_try_connect):
         mock_try_connect.side_effect = NailgunClient.NailgunConnectionError(
-            "127.0.0.1:31337", 31337, -31336, Exception("oops"),
+            "127.0.0.1:31337", Exception("oops"),
         )
 
         with self.assertRaises(NailgunClient.NailgunConnectionError):

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -158,22 +158,6 @@ class TestNailgunProtocol(unittest.TestCase):
         chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock)
         self.assertEqual((chunk_type, payload), (ChunkType.EXIT, self.TEST_OUTPUT))
 
-    def test_send_pgrp(self):
-        test_pgrp = -1
-        NailgunProtocol.send_pgrp(self.server_sock, test_pgrp)
-        chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock, return_bytes=True)
-        self.assertEqual(
-            (chunk_type, payload), (ChunkType.PGRP, NailgunProtocol.encode_int(test_pgrp))
-        )
-
-    def test_send_pid(self):
-        test_pid = 1
-        NailgunProtocol.send_pid(self.server_sock, test_pid)
-        chunk_type, payload = NailgunProtocol.read_chunk(self.client_sock, return_bytes=True)
-        self.assertEqual(
-            (chunk_type, payload), (ChunkType.PID, NailgunProtocol.encode_int(test_pid))
-        )
-
     def test_send_exit_with_code(self):
         return_code = 1
         NailgunProtocol.send_exit_with_code(self.server_sock, return_code)


### PR DESCRIPTION
### Problem

We had previously extended the Nailgun protocol as used in pants for communication with pantsd, by adding two new properties PID and PGRP. These were added to facilitate the previous design of pantsd, where it would fork repeatedly. However, since pantsd no longer works this way, these properties are superfluous and can be removed.

### Solution

Remove these custom Nailgun protocol extensions and the tests that use them. This also entails removing the entire notion of a remote PID from the `NailgunClient` data structure.
