### PR TITLE
[zinc] Add -fatal-warnings and -non-fatal-warnings-patterns

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -327,6 +327,21 @@ object Main {
             .ConcreteAnalysisContents(result.analysis, result.setup)
         )
       }
+
+      if (settings.fatalWarnings) {
+        val problems: List[Problem] = inputs.setup.reporter.problems.toList
+        val nonFatalWarningPatterns: Seq[String] = settings.nonFatalWarningPatterns
+        val thereWasAFatalWarning = problems.exists(p =>
+          p.severity() == Severity.Warn &&
+          !nonFatalWarningPatterns.exists(pattern => p.message().contains(pattern))
+        )
+        if (thereWasAFatalWarning) {
+          log.error("Compilation failed because there were non-permitted warnings when fatal_warnings were enabled.")
+          exit(1)
+        }
+      }
+
+
       log.info("Compile success " + Util.timing(startTime))
       // if compile is successful, jar the contents of classesDirectory and copy to outputJar
       if (settings.outputJar.isDefined) {

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -44,7 +44,9 @@ case class Settings(
     analysis: AnalysisOptions = AnalysisOptions(),
     creationTime: Long = 0,
     compiledBridgeJar: Option[File] = None,
-    useBarebonesLogger: Boolean = false
+    useBarebonesLogger: Boolean = false,
+    fatalWarnings: Boolean = false,
+    nonFatalWarningPatterns: Seq[String] = Seq.empty
 ) {
   import Settings._
 
@@ -464,6 +466,17 @@ object Settings {
       .action(
         (x, c) => c.copy(analysis = c.analysis.copy(clearInvalid = false)))
       .text("If set, zinc will fail rather than purging illegal analysis.")
+
+    opt[Unit]("fatal-warnings")
+        .abbr("fatal-warnings")
+        .action((x, c) => c.copy(fatalWarnings = true))
+        .text("If set, zinc will treat all warnings as fatal.")
+
+    opt[Seq[String]]("non-fatal-warnings-patterns")
+        .abbr("non-fatal-warnings-patterns")
+        .action((x, c) => c.copy(nonFatalWarningPatterns = x))
+        .text("List of warning patterns that will not be fatal evel if -fatal-warnings is enabled. " +
+              "These are defined as plain strings (not regexes) that will try to match the warning message.")
 
     opt[String]("scalac-option")
       .abbr("S")


### PR DESCRIPTION
 Add the ability for zinc to filter fatal warnings, and define fatal warnings outside of the compiler

[ci skip-rust-tests]  # No Rust changes made.

### Problem

For some targets, we'd like to treat some (but not all) warnings as fatal. More concretely, we'd like to treat all warnings _except_ for `Unused import` as fatal.

The current version of `scalac` doesn't allow this. It will be supported in scala 2.13 ([ref](
https://github.com/scala/scala/commit/39d3b3a93cd3cf01303ba9aba487b742943d8e57)), but we'd like to have it before than that.

Up til then, the Scala community's solution seems to be to implement external filters: https://github.com/scala/bug/issues/8410 

### Solution

Implement those external filters in our zinc wrapper. This comes in the form of two new flags:
- `-fatal-warnings` will make it so that a compliation will fail if there is a warning even if there were no errors. This is meant to be set "by target", similar to the current `compiler_option_sets = { "fatal_warnings" }`.
- `-non-fatal-warnings-patterns` will define a set of strings that, if found in the message of a warning, will prevent that warning from failing the compilation, even if `-fatal-warnings` is enabled. This is meant to live in a repo-wide configuration file, similar to the current `compiler_option_sets_enabled_args`.

This would allow us to express things like "fail on every warning except the ones that contain the substring 'Unused import'". This is not perfect (matching strings never is), but will get us close enough to the precision we need. 

### Result

No noticeable result for now, but there will be a follow-up PR with changes to Pants to consume this.