### PR TITLE
[junit-runner] allow test specs to work for parameterized tests and t…

### DIFF
--- a/src/java/org/pantsbuild/args4j/StringArgumentsHandler.java
+++ b/src/java/org/pantsbuild/args4j/StringArgumentsHandler.java
@@ -1,0 +1,46 @@
+package org.pantsbuild.args4j;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.Messages;
+import org.kohsuke.args4j.spi.OptionHandler;
+import org.kohsuke.args4j.spi.Parameters;
+import org.kohsuke.args4j.spi.Setter;
+
+/**
+ * Picks up all non-option prefixed arguments. Can only be used with Argument types.
+ */
+public class StringArgumentsHandler extends OptionHandler<String> {
+
+  public StringArgumentsHandler(CmdLineParser parser, OptionDef option, Setter<String> setter) {
+    super(parser, option, setter);
+
+    if (!option.isArgument()) {
+      throw new IllegalArgumentException(
+          StringArgumentsHandler.class.getSimpleName() + " must be used with an argument not an " +
+              "option. Was used for option with usage: " + option.usage());
+    }
+  }
+
+  @Override
+  public int parseArguments(Parameters params) throws CmdLineException {
+    int counter = 0;
+    for (; counter < params.size(); counter++) {
+      String param = params.getParameter(counter);
+
+      if (param.startsWith("-")) {
+        break;
+      }
+
+      setter.addValue(param);
+    }
+
+    return counter;
+  }
+
+  @Override
+  public String getDefaultMetaVariable() {
+    return Messages.DEFAULT_META_REST_OF_ARGUMENTS_HANDLER.format();
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -47,8 +47,8 @@ import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
-import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 import org.pantsbuild.args4j.InvalidCmdLineArgumentException;
+import org.pantsbuild.args4j.StringArgumentsHandler;
 import org.pantsbuild.junit.annotations.TestParallel;
 import org.pantsbuild.junit.annotations.TestSerial;
 import org.pantsbuild.tools.junit.impl.experimental.ConcurrentComputer;
@@ -892,7 +892,7 @@ public class ConsoleRunnerImpl {
                         + "whitespace delimited arguments found inside added to the list",
                 required = true,
                 metaVar = "TESTS",
-                handler = StringArrayOptionHandler.class)
+                handler = StringArgumentsHandler.class)
       private String[] tests = {};
 
       @Option(name="-use-experimental-runner",
@@ -933,7 +933,7 @@ public class ConsoleRunnerImpl {
       if (test.startsWith("@")) {
         try {
           String argFileContents = Files.toString(new File(test.substring(1)), Charsets.UTF_8);
-          tests.addAll(Arrays.asList(argFileContents.split("\\s+")));
+          tests.addAll(Arrays.asList(argFileContents.split("\n")));
         } catch (IOException e) {
           System.err.printf("Failed to load args from arg file %s: %s\n", test, e.getMessage());
           exit(1);

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -47,6 +47,8 @@ import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+import org.kohsuke.args4j.spi.StringOptionHandler;
 import org.pantsbuild.args4j.InvalidCmdLineArgumentException;
 import org.pantsbuild.args4j.StringArgumentsHandler;
 import org.pantsbuild.junit.annotations.TestParallel;
@@ -889,7 +891,7 @@ public class ConsoleRunnerImpl {
 
       @Argument(usage = "Names of junit test classes or test methods to run.  Names prefixed "
                         + "with @ are considered arg file paths and these will be loaded and the "
-                        + "whitespace delimited arguments found inside added to the list",
+                        + "newline delimited arguments found inside added to the list.",
                 required = true,
                 metaVar = "TESTS",
                 handler = StringArgumentsHandler.class)
@@ -928,21 +930,7 @@ public class ConsoleRunnerImpl {
             new PrintStream(new BufferedOutputStream(System.out), true),
             new PrintStream(new BufferedOutputStream(System.err), true));
 
-    List<String> tests = Lists.newArrayList();
-    for (String test : options.tests) {
-      if (test.startsWith("@")) {
-        try {
-          String argFileContents = Files.toString(new File(test.substring(1)), Charsets.UTF_8);
-          tests.addAll(Arrays.asList(argFileContents.split("\n")));
-        } catch (IOException e) {
-          System.err.printf("Failed to load args from arg file %s: %s\n", test, e.getMessage());
-          exit(1);
-        }
-      } else {
-        tests.add(test);
-      }
-    }
-    runner.setTestsToRun(tests);
+    runner.setTestsToRun(Lists.newArrayList(options.tests));
     return runner;
   }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/Spec.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Spec.java
@@ -19,14 +19,20 @@ import org.pantsbuild.junit.annotations.TestSerial;
 class Spec {
   private final Class<?> clazz;
   private final ImmutableSet<String> methods;
+  private final boolean hasCustomRunner;
 
   Spec(Class<?> clazz) {
     this(clazz, ImmutableSet.of());
   }
 
   private Spec(Class<?> clazz, ImmutableSet<String> methods) {
+    this(clazz, methods, false);
+  }
+
+  private Spec(Class<?> clazz, ImmutableSet<String> methods, boolean hasCustomRunner) {
     this.clazz = Objects.requireNonNull(clazz);
     this.methods = Objects.requireNonNull(methods);
+    this.hasCustomRunner = hasCustomRunner;
   }
 
   String getSpecName() {
@@ -44,7 +50,7 @@ class Spec {
    * @return A new spec that includes the added method.
    */
   Spec withMethod(String method) {
-    return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build());
+    return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build(), this.hasCustomRunner);
   }
 
   /**
@@ -66,5 +72,23 @@ class Spec {
 
   public Collection<String> getMethods() {
     return methods;
+  }
+
+  // NB: If a test class has a custom runner, then we can't assume spec's method portion's format.
+  public Spec asCustomRunnerSpec() {
+    return new Spec(this.clazz, this.methods, true);
+  }
+
+  public boolean methodNameAllowedToNotMatch() {
+    return hasCustomRunner;
+  }
+
+  @Override
+  public String toString() {
+    return "Spec{" +
+        "clazz=" + clazz +
+        ", methods=" + methods +
+        ", hasCustomRunner=" + hasCustomRunner +
+        '}';
   }
 }

--- a/src/java/org/pantsbuild/tools/junit/impl/Spec.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Spec.java
@@ -50,7 +50,8 @@ class Spec {
    * @return A new spec that includes the added method.
    */
   Spec withMethod(String method) {
-    return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build(), this.hasCustomRunner);
+    return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build(),
+        this.hasCustomRunner);
   }
 
   /**

--- a/src/java/org/pantsbuild/tools/junit/impl/Util.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Util.java
@@ -157,17 +157,17 @@ final class Util {
       return false;
     }
 
+    // Support classes using junit 4.x custom runners.
+    if (isUsingCustomRunner(clazz)) {
+      return true;
+    }
+
     // The class must have some public constructor to be instantiated by the runner being used
     if (!Iterables.any(Arrays.asList(clazz.getConstructors()), IS_PUBLIC_CONSTRUCTOR)) {
       return false;
     }
 
     if (isJunit3Test(clazz)) {
-      return true;
-    }
-
-    // Support classes using junit 4.x custom runners.
-    if (isUsingCustomRunner(clazz)) {
       return true;
     }
 

--- a/tests/java/org/pantsbuild/args4j/StringArgumentsHandlerTest.java
+++ b/tests/java/org/pantsbuild/args4j/StringArgumentsHandlerTest.java
@@ -1,0 +1,45 @@
+package org.pantsbuild.args4j;
+
+import org.junit.Test;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.NamedOptionDef;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.ConfigElement;
+import org.kohsuke.args4j.spi.OptionImpl;
+import org.kohsuke.args4j.spi.StringOptionHandler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StringArgumentsHandlerTest {
+  public static class Options {
+    @Argument(metaVar = "REST", handler = StringArgumentsHandler.class)
+    String[] rest;
+
+    @Option(name="-m", metaVar = "MESSAGE", handler = StringOptionHandler.class)
+    String message;
+  }
+
+  private Options parse(String... args) throws CmdLineException {
+    Options options = new Options();
+    CmdLineParser cmdLineParser = new CmdLineParser(options);
+    cmdLineParser.parseArgument(args);
+    return options;
+  }
+
+  @Test
+  public void parsingArgumentsAndSkippingOptions() throws CmdLineException {
+    assertThat(parse("a", "b c").rest, is(new String[]{"a", "b c"}));
+    assertThat(parse("a", "-m", "msg", "b c").rest, is(new String[]{"a", "b c"}));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void errorOnOptionOption() throws ClassNotFoundException {
+    ConfigElement ce = new ConfigElement();
+    ce.name = "-a";
+
+    new StringArgumentsHandler(null, new NamedOptionDef(new OptionImpl(ce)),null);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -411,6 +411,15 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   }
 
   @Test
+  public void testMultipleArgfileElements() throws IOException {
+    File file = temporary.newFile();
+    Files.write("org.pantsbuild.tools.junit.lib.MockTest1\norg.pantsbuild.tools.junit.lib.MockTest2", file,
+        Charsets.UTF_8);
+    invokeConsoleRunner("@" + file.getAbsolutePath());
+    assertThat(TestRegistry.getCalledTests(), is("test11 test12 test13 test21 test22"));
+  }
+
+  @Test
   public void testMockJUnit3Test() throws Exception {
     invokeConsoleRunner("MockJUnit3Test");
     assertEquals("mju3t1", TestRegistry.getCalledTests());

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -6,7 +6,10 @@ package org.pantsbuild.tools.junit.impl;
 import com.google.common.base.Charsets;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import com.google.common.io.Files;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -399,6 +402,14 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   }
 
   @Test
+  public void testArgFile() throws IOException {
+    File file = temporary.newFile();
+    Files.write("org.pantsbuild.tools.junit.lib.MockScalaTest#test should pass", file, Charsets.UTF_8);
+    invokeConsoleRunner("@" + file.getAbsolutePath());
+    assertThat(TestRegistry.getCalledTests(), is("MockScalaTest-1"));
+  }
+
+  @Test
   public void testMockJUnit3Test() throws Exception {
     invokeConsoleRunner("MockJUnit3Test");
     assertEquals("mju3t1", TestRegistry.getCalledTests());
@@ -414,6 +425,21 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   public void testMockScalaTest() throws Exception {
     invokeConsoleRunner("MockScalaTest");
     assertEquals("MockScalaTest-1", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testMockScalaTestTestCase() throws Exception {
+    invokeConsoleRunner(Arrays.asList(
+        "org.pantsbuild.tools.junit.lib.MockScalaTest#test should pass",
+        "org.pantsbuild.tools.junit.lib.MockScalaTest1#test should pass"));
+    assertEquals("MockScalaTest-1 MockScalaTest-2", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testParameterizedTestMethod() throws Exception {
+    invokeConsoleRunner("ParameterizedTest#isLessThanFive[1] " +
+        "ParameterizedTest#isLessThanFive[3]");
+    assertEquals("isLessThanFive[1] isLessThanFive[3]", TestRegistry.getCalledTests());
   }
 
   @Test

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -413,7 +413,9 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   @Test
   public void testMultipleArgfileElements() throws IOException {
     File file = temporary.newFile();
-    Files.write("org.pantsbuild.tools.junit.lib.MockTest1\norg.pantsbuild.tools.junit.lib.MockTest2", file,
+    Files.write(
+        "org.pantsbuild.tools.junit.lib.MockTest1\norg.pantsbuild.tools.junit.lib.MockTest2",
+        file,
         Charsets.UTF_8);
     invokeConsoleRunner("@" + file.getAbsolutePath());
     assertThat(TestRegistry.getCalledTests(), is("test11 test12 test13 test21 test22"));

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -404,7 +404,8 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   @Test
   public void testArgFile() throws IOException {
     File file = temporary.newFile();
-    Files.write("org.pantsbuild.tools.junit.lib.MockScalaTest#test should pass", file, Charsets.UTF_8);
+    Files.write("org.pantsbuild.tools.junit.lib.MockScalaTest#test should pass", file,
+        Charsets.UTF_8);
     invokeConsoleRunner("@" + file.getAbsolutePath());
     assertThat(TestRegistry.getCalledTests(), is("MockScalaTest-1"));
   }

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.pantsbuild.tools.junit.lib.MockJUnit3Test;
 import org.pantsbuild.tools.junit.lib.MockRunWithTest;
 import org.pantsbuild.tools.junit.lib.MockScalaTest;
+import org.pantsbuild.tools.junit.lib.ParameterizedTest;
 import org.pantsbuild.tools.junit.lib.UnannotatedTestClass;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -97,6 +98,37 @@ public class SpecParserTest {
       assertThat(expected.getMessage(),
           containsString("Method doesNotExist not found in class"));
     }
+  }
+
+  @Test
+  public void testScalaSpec() {
+    String specString = "org.pantsbuild.tools.junit.lib.MockScalaTest#test should pass";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
+    assertEquals(MockScalaTest.class, spec.getSpecClass());
+    assertEquals("org.pantsbuild.tools.junit.lib.MockScalaTest", spec.getSpecName());
+  }
+
+  @Test
+  public void testParameterizedSpec() {
+    String specString = "org.pantsbuild.tools.junit.lib.ParameterizedTest#isLessThanFive[1]";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
+    assertEquals(ParameterizedTest.class, spec.getSpecClass());
+    assertEquals("org.pantsbuild.tools.junit.lib.ParameterizedTest", spec.getSpecName());
+  }
+
+  @Test
+  public void testMultipleParameterizedSpecs() {
+    SpecParser parser = new SpecParser(ImmutableList.of(
+        "org.pantsbuild.tools.junit.lib.ParameterizedTest#isLessThanFive[1]",
+        "org.pantsbuild.tools.junit.lib.ParameterizedTest#isLessThanFive[2]"));
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
+    assertEquals(ParameterizedTest.class, spec.getSpecClass());
+    assertEquals("org.pantsbuild.tools.junit.lib.ParameterizedTest", spec.getSpecName());
   }
 
   private void assertNoSpecs(String className) {

--- a/tests/java/org/pantsbuild/tools/junit/impl/UtilTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/UtilTest.java
@@ -16,6 +16,7 @@ import org.pantsbuild.tools.junit.lib.NotATestNoPublicConstructor;
 import org.pantsbuild.tools.junit.lib.NotATestNoRunnableMethods;
 import org.pantsbuild.tools.junit.lib.NotATestNonzeroArgConstructor;
 import org.pantsbuild.tools.junit.lib.NotATestPrivateClass;
+import org.pantsbuild.tools.junit.lib.ParameterizedTest;
 import org.pantsbuild.tools.junit.lib.UnannotatedTestClass;
 import org.pantsbuild.tools.junit.lib.XmlReportFirstTestIngoredTest;
 import org.pantsbuild.tools.junit.lib.XmlReportIgnoredTestSuiteTest;
@@ -104,6 +105,7 @@ public class UtilTest {
     assertTrue(Util.isTestClass(MockRunWithTest.class));
     assertTrue(Util.isTestClass(UnannotatedTestClass.class));
     assertTrue(Util.isTestClass(MockScalaTest.class));
+    assertTrue(Util.isTestClass(ParameterizedTest.class));
     assertFalse(Util.isTestClass(NotATestAbstractClass.class));
     assertFalse(Util.isTestClass(NotATestNonzeroArgConstructor.class));
     assertFalse(Util.isTestClass(NotATestNoPublicConstructor.class));

--- a/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
@@ -102,6 +102,10 @@ public abstract class ConsoleRunnerTestBase {
     prepareConsoleRunner(argsString).run();
   }
 
+  protected void invokeConsoleRunner(List<String> argsStrings) {
+    prepareConsoleRunner(argsStrings).run();
+  }
+
   /**
    * As invokeConsoleRunner, but returns a ConsoleRunnerImpl ready for calling run() on.
    */
@@ -114,8 +118,12 @@ public abstract class ConsoleRunnerTestBase {
       }
       testArgs.add(arg);
     }
+    return prepareConsoleRunner(testArgs);
+  }
 
+  protected ConsoleRunnerImpl prepareConsoleRunner(List<String> testArgs) {
     // Tack on extra parameters from the Parameterized runner
+    testArgs = new ArrayList<>(testArgs);
     if (!testArgs.contains(DEFAULT_CONCURRENCY_FLAG) && parameters.defaultConcurrency != null) {
       if (!testArgs.contains(DEFAULT_CONCURRENCY_FLAG)
           && !testArgs.contains(DEFAULT_PARALLEL_FLAG)) {

--- a/tests/java/org/pantsbuild/tools/junit/lib/ParameterizedTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ParameterizedTest.java
@@ -1,0 +1,35 @@
+package org.pantsbuild.tools.junit.lib;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(Parameterized.class)
+public class ParameterizedTest {
+  private int element;
+
+  @Parameters(name = "{0}")
+  public static Object[] data() {
+    return new Integer[]{1, 2, 3, 4};
+  }
+
+  public ParameterizedTest(int element) {
+    this.element = element;
+  }
+
+  @Test
+  public void isLessThanFive() {
+    TestRegistry.registerTestCall("isLessThanFive[" + element + "]");
+    assertTrue(element < 5);
+  }
+
+  @Test
+  public void isLessThanThree() {
+    TestRegistry.registerTestCall("isLessThanThree[" + element + "]");
+    assertTrue(element < 3);
+  }
+}


### PR DESCRIPTION
### Problem

When I want to run one instance of a parameterized test, or any scala test, I can't specify a spec for it on the command line for pants' test runner.

### Solution

When a custom runner or the scala test runner is being used, allow the method name portion of specs to have arbitrary contents. Also, update arg splitting to use the args as they are provided rather than splitting each individual argument.

### Result

Both parameterized tests and scala tests can be referred to directly by `--test-junit-test=`