### PR TITLE
Skip flaky `RscCompileIntegrationYoutline` test.

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -10,6 +10,7 @@ from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base i
 
 
 class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
+    @pytest.mark.skip(reason="flaky: https://github.com/pantsbuild/pants/issues/9396")
     @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
     def test_basic_binary(self):
         self._testproject_compile("mutual", "bin", "A")


### PR DESCRIPTION
The `test_basic_binary` test intermittently fails.

See #9396

[ci skip-rust-tests]  # No Rust changes made.

[ci skip-jvm-tests]  # No JVM changes made.
