### PR TITLE
Fix use of NailgunError.pid in error handler

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -191,8 +191,6 @@ class RemotePantsRunner:
         or failing that, the `pid` of the pantsd instance.
         """
         sources = [pantsd_pid]
-        if nailgun_error.pid is not None:
-            sources = [abs(nailgun_error.pid)] + sources
 
         exception_text = None
         for source in sources:


### PR DESCRIPTION
In #9389, we removed the `pid` field from `NailgunError`. However, some error-handling code in `remote_pants_runner.py` was still assuming this field existed, and using it to print an additional error message in one case. Now that we don't care about a remote PID in Nailgun code, this error print line should be removed.