### PR TITLE
Upgrade to Pex 2.1.7.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==2.1.6
+pex==2.1.7
 psutil==5.6.3
 Pygments==2.3.1
 pyopenssl==17.3.0

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -624,6 +624,7 @@ function build_pex() {
   execute_pex \
     -o "${dest}" \
     --no-emit-warnings \
+    --no-strip-pex-env \
     --script=pants \
     --interpreter-constraint="${interpreter_constraint}" \
     "${platform_flags[@]}" \

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -37,16 +37,16 @@ class DownloadedPexBin(HermeticPex):
     class Factory(Script):
         options_scope = "download-pex-bin"
         name = "pex"
-        default_version = "v2.1.6"
+        default_version = "v2.1.7"
 
         # Note: You can compute the digest and size using:
         # curl -L https://github.com/pantsbuild/pex/releases/download/vX.Y.Z/pex | tee >(wc -c) >(shasum -a 256) >/dev/null
         default_versions_and_digests = {
             PlatformConstraint.none: ToolForPlatform(
                 digest=Digest(
-                    "73e692f9a67a8d8b3f8b246076a3fd99f29fd5cbe18126c69657ac8c99c277fc", 2614280
+                    "375ab4a405a6db57f3afd8d60eca666e61931b44f156dc78ac7d8e47bddc96d6", 2620451
                 ),
-                version=ToolVersion("v2.1.6"),
+                version=ToolVersion("v2.1.7"),
             ),
         }
 


### PR DESCRIPTION
This brings in fixes that support our use of `--disable-cache` with the
Pex PEX binary that had regressed in the Pex 2.x series.

Also leverage the new `--no-strip-pex-env` option when building the
pants PEX we deploy.

Further improvements including better error messages in some cases are
detailed in the release notes:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.7

Fixes #9361

[ci skip-jvm-tests]  # No JVM changes made.