### PR TITLE
[junit-runner] simplify fail fast

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleListener.java
@@ -32,7 +32,7 @@ class ConsoleListener extends TextListener {
     if (testsFinished) {
       // If this method is called after the testRunFinished callback then it means another listener
       // threw an exception in its testRunFinished callback. This is our chance to display the error
-      failure.getException().printStackTrace(out);
+      printFailure(failure, "Reported after run");
     } else {
       out.append(Util.isAssertionFailure(failure) ? 'F' : 'E');
     }

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -41,6 +41,7 @@ import org.junit.runner.manipulation.Filter;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
 import org.kohsuke.args4j.Argument;
@@ -329,17 +330,13 @@ public class ConsoleRunnerImpl {
    */
   public static class FailFastListener extends RunListener {
     private final RunNotifier runNotifier;
-    private final Result result = new Result();
 
     public FailFastListener(RunNotifier runNotifier) {
       this.runNotifier = runNotifier;
-      this.runNotifier.addListener(result.createListener());
     }
 
     @Override
-    public void testFailure(Failure failure) throws Exception {
-      runNotifier.fireTestFinished(failure.getDescription());
-      runNotifier.fireTestRunFinished(result);
+    public void testFailure(Failure failure) {
       runNotifier.pleaseStop();
     }
   }
@@ -361,7 +358,12 @@ public class ConsoleRunnerImpl {
 
     @Override public void run(RunNotifier notifier) {
       notifier.addListener(new FailFastListener(notifier));
-      wrappedRunner.run(notifier);
+      try {
+        wrappedRunner.run(notifier);
+      } catch (StoppedByUserException ignore) {
+        // NB: By swallowing StoppedByUserException here, we ensure that the RunFinished callback is
+        // fired once, by JUnitCore.
+      }
     }
   }
 
@@ -606,25 +608,16 @@ public class ConsoleRunnerImpl {
       requests = setFilterForTestShard(requests);
     }
 
+    Runner requestRunner;
     if (this.parallelThreads > 1) {
-      ConcurrentCompositeRequestRunner concurrentRunner = new ConcurrentCompositeRequestRunner(
+      requestRunner = new ConcurrentCompositeRequestRunner(
           requests, this.defaultConcurrency, this.parallelThreads);
-      Runner runner = maybeWithFailFastRunner(concurrentRunner);
-      return core.run(runner).getFailureCount();
+    } else {
+      requestRunner = new CompositeRequestRunner(requests);
     }
+    requestRunner = maybeWithFailFastRunner(requestRunner);
 
-    int failures = 0;
-    Result result;
-    for (Request request : requests) {
-      result = core.run(runnerFor(request));
-      failures += result.getFailureCount();
-    }
-    return failures;
-  }
-
-  private Runner runnerFor(Request request) {
-    Runner reqRunner = request.getRunner();
-    return maybeWithFailFastRunner(reqRunner);
+    return core.run(requestRunner).getFailureCount();
   }
 
   private Runner maybeWithFailFastRunner(Runner runner) {

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
@@ -3,8 +3,6 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import com.google.common.base.Charsets;
-import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -12,15 +10,18 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Result;
@@ -158,8 +159,8 @@ public class ConsoleRunnerImplTest {
         useExperimentalRunner,
         outputStream,
         System.err  // TODO, if there's an error reported on system err, it doesn't show up in
-                    // the test failures.
-        );
+        // the test failures.
+    );
 
     try {
       runner.run(tests);
@@ -420,7 +421,8 @@ public class ConsoleRunnerImplTest {
     }
 
     @Override
-    protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+    protected boolean matchesSafely(Iterable<? super T> collection,
+                                    Description mismatchDescription) {
       boolean foundOne = false;
       String s;
       for (Object t : collection) {


### PR DESCRIPTION
[ci skip-rust-tests]  # No Rust changes made.

### Problem

There's certain circumstances where fail fast would print results twice.

### Solution

This simplifies the interaction between that fail fast listener and the notifier and fixes the double print issue.

### Result

Now now fail fast does not make additional notifier calls that aren't necessary.

This change also updates the console listener behavior so that it will print out a full failure result when it encounters failures after the results have been printed instead of an unformatted stack trace.