### PR TITLE
Ignore notify events for pants_ignore patterns.

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -662,7 +662,13 @@ fn expand_files_helper(
 }
 
 fn make_posix_fs<P: AsRef<Path>>(executor: task_executor::Executor, root: P) -> fs::PosixFS {
-  fs::PosixFS::new(&root, &[], executor).unwrap()
+  // Unwrapping the output of creating the git ignorer with no patterns is infallible.
+  fs::PosixFS::new(
+    &root,
+    fs::GitignoreStyleExcludes::create(&[]).unwrap(),
+    executor,
+  )
+  .unwrap()
 }
 
 fn ensure_uploaded_to_remote(

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -131,7 +131,7 @@ pub struct GitignoreStyleExcludes {
 }
 
 impl GitignoreStyleExcludes {
-  fn create(patterns: &[String]) -> Result<Arc<Self>, String> {
+  pub fn create(patterns: &[String]) -> Result<Arc<Self>, String> {
     if patterns.is_empty() {
       return Ok(EMPTY_IGNORE.clone());
     }
@@ -587,15 +587,15 @@ pub struct PosixFS {
 impl PosixFS {
   pub fn new<P: AsRef<Path>>(
     root: P,
-    ignore_patterns: &[String],
+    ignorer: Arc<GitignoreStyleExcludes>,
     executor: task_executor::Executor,
   ) -> Result<PosixFS, String> {
-    Self::new_with_symlink_behavior(root, ignore_patterns, executor, SymlinkBehavior::Aware)
+    Self::new_with_symlink_behavior(root, ignorer, executor, SymlinkBehavior::Aware)
   }
 
   pub fn new_with_symlink_behavior<P: AsRef<Path>>(
     root: P,
-    ignore_patterns: &[String],
+    ignorer: Arc<GitignoreStyleExcludes>,
     executor: task_executor::Executor,
     symlink_behavior: SymlinkBehavior,
   ) -> Result<PosixFS, String> {
@@ -616,15 +616,9 @@ impl PosixFS {
       })
       .map_err(|e| format!("Could not canonicalize root {:?}: {:?}", root, e))?;
 
-    let ignore = GitignoreStyleExcludes::create(&ignore_patterns).map_err(|e| {
-      format!(
-        "Could not parse build ignore inputs {:?}: {:?}",
-        ignore_patterns, e
-      )
-    })?;
     Ok(PosixFS {
       root: canonical_root,
-      ignore: ignore,
+      ignore: ignorer,
       executor: executor,
       symlink_behavior: symlink_behavior,
     })

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -171,6 +171,13 @@ impl GitignoreStyleExcludes {
       ::ignore::Match::Ignore(_) => true,
     }
   }
+
+  pub fn is_ignored_or_child_of_ignored_path(&self, path: &Path, is_dir: bool) -> bool {
+    match self.gitignore.matched_path_or_any_parents(path, is_dir) {
+      ::ignore::Match::None | ::ignore::Match::Whitelist(_) => false,
+      ::ignore::Match::Ignore(_) => true,
+    }
+  }
 }
 
 lazy_static! {

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -2,8 +2,9 @@ use tempfile;
 use testutil;
 
 use crate::{
-  Dir, DirectoryListing, File, GlobExpansionConjunction, GlobMatching, Link, PathGlobs, PathStat,
-  PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior, VFS,
+  Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching,
+  Link, PathGlobs, PathStat, PathStatGetter, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior,
+  VFS,
 };
 
 use async_trait::async_trait;
@@ -384,7 +385,7 @@ async fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
 fn new_posixfs<P: AsRef<Path>>(dir: P) -> PosixFS {
   PosixFS::new(
     dir.as_ref(),
-    &[],
+    GitignoreStyleExcludes::create(&[]).unwrap(),
     task_executor::Executor::new(Handle::current()),
   )
   .unwrap()
@@ -393,7 +394,7 @@ fn new_posixfs<P: AsRef<Path>>(dir: P) -> PosixFS {
 fn new_posixfs_symlink_oblivious<P: AsRef<Path>>(dir: P) -> PosixFS {
   PosixFS::new_with_symlink_behavior(
     dir.as_ref(),
-    &[],
+    GitignoreStyleExcludes::create(&[]).unwrap(),
     task_executor::Executor::new(Handle::current()),
     SymlinkBehavior::Oblivious,
   )

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -4,7 +4,9 @@
 use crate::Store;
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
-use fs::{Dir, File, GlobMatching, PathGlobs, PathStat, PosixFS, SymlinkBehavior};
+use fs::{
+  Dir, File, GitignoreStyleExcludes, GlobMatching, PathGlobs, PathStat, PosixFS, SymlinkBehavior,
+};
 use futures::future::TryFutureExt;
 use futures01::future::{self, join_all, Future};
 use hashing::{Digest, EMPTY_DIGEST};
@@ -540,7 +542,7 @@ impl Snapshot {
       .or_else(|_| {
         let posix_fs = Arc::new(try_future!(PosixFS::new_with_symlink_behavior(
           root_path,
-          &[],
+          try_future!(GitignoreStyleExcludes::create(&[])),
           executor,
           SymlinkBehavior::Oblivious
         )));

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -8,8 +8,8 @@ use tokio::runtime::Handle;
 
 use crate::{OneOffStoreFileByDigest, Snapshot, Store};
 use fs::{
-  Dir, File, GlobExpansionConjunction, GlobMatching, PathGlobs, PathStat, PosixFS,
-  StrictGlobMatching,
+  Dir, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching, PathGlobs, PathStat,
+  PosixFS, StrictGlobMatching,
 };
 
 use std;
@@ -36,7 +36,8 @@ fn setup() -> (
   )
   .unwrap();
   let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();
-  let posix_fs = Arc::new(PosixFS::new(dir.path(), &[], executor).unwrap());
+  let ignorer = GitignoreStyleExcludes::create(&[]).unwrap();
+  let posix_fs = Arc::new(PosixFS::new(dir.path(), ignorer, executor).unwrap());
   let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone());
   (store, dir, posix_fs, file_saver)
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -388,7 +388,8 @@ pub trait CapturedWorkdir {
           future::ok(store::Snapshot::empty()).to_boxed()
         } else {
           // Use no ignore patterns, because we are looking for explicitly listed paths.
-          future::done(fs::PosixFS::new(workdir_path2, &[], executor))
+          future::done(fs::GitignoreStyleExcludes::create(&[]))
+            .and_then(|ignorer| future::done(fs::PosixFS::new(workdir_path2, ignorer, executor)))
             .map_err(|err| {
               format!(
                 "Error making posix_fs to fetch local process execution output files: {}",

--- a/src/rust/engine/src/watch.rs
+++ b/src/rust/engine/src/watch.rs
@@ -93,6 +93,8 @@ impl InvalidationWatcher {
             let paths: HashSet<_> = ev
               .paths
               .into_iter()
+              // TODO ignore gitignored patterns using ignorer on the context.core.
+              // ignored patterns will need to be relative to the build root before being passed to the git ignorer.
               .map(|path| {
                 // relativize paths to build root.
                 let mut paths_to_invalidate: Vec<PathBuf> = vec![];


### PR DESCRIPTION
NB this fixes a performance hit which was merged with #9318 I will land as a close follow up after #9318 lands.

### Problem
#9318 implements a recursive file watch on the build root for macos, but doesn't ignore pants workdir or other pants_ignore locations. File writes to those locations could create hundreds of thousands of events, so they need to be ignored, or else they create huge amounts of work for nothing.

### Solution
Use a GitignoreStyleExcludes to ignore file events which match or are children of files / directories which are passed via `--pants-ignore` in its many forms.  Move the creation of the ignorer to the context creation, and pass in an ignorer to PosixFS.

### Result

File events which happen to pants ignored files / directories are ignored and cannot effect invalidation.