### PR TITLE
Improve formatting of `./pants goals` and `./pants target-types2`

### DIFF
--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
+import textwrap
 from typing import Dict, Optional, cast
 
 from colors import cyan, green
@@ -98,11 +99,22 @@ class HelpPrinter:
             title = green(title)
 
         max_width = max(len(name) for name in goal_descriptions.keys())
+        chars_before_description = max_width + 2
 
         def format_goal(name: str, description: str) -> str:
-            name = name.ljust(max_width + 2)
+            name = name.ljust(chars_before_description)
             if self._use_color:
                 name = cyan(name)
+            description_lines = textwrap.wrap(description, 80 - chars_before_description)
+            if len(description_lines) > 1:
+                description_lines = [
+                    description_lines[0],
+                    *(
+                        f"{' ' * (chars_before_description + 4)}{line}"
+                        for line in description_lines[1:]
+                    ),
+                ]
+            description = "\n".join(description_lines)
             return f"{name}{description}"
 
         lines = [

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -2,8 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
+import textwrap
 from typing import Dict, Optional, cast
 
+from colors import cyan, green
 from typing_extensions import Literal
 
 from pants.base.build_environment import pants_release, pants_version
@@ -37,6 +39,7 @@ class HelpPrinter:
         self._options = options
         self._help_request = help_request or self._options.help_request
         self._union_membership = union_membership
+        self._use_color = sys.stdout.isatty()
 
     @property
     def bin_name(self) -> str:
@@ -66,7 +69,6 @@ class HelpPrinter:
         return 0
 
     def _print_goals_help(self) -> None:
-        print(f"\nUse `{self.bin_name} help $goal` to get help for a particular goal.\n")
         global_options = self._options.for_global_scope()
         goal_descriptions: Dict[str, str] = {}
         if global_options.v2:
@@ -91,10 +93,26 @@ class HelpPrinter:
                 {goal.name: goal.description_first_line for goal in Goal.all() if goal.description}
             )
 
-        max_width = max(len(name) for name in goal_descriptions.keys()) if goal_descriptions else 0
-        for name, description in sorted(goal_descriptions.items()):
-            print(f"  {name.rjust(max_width)}: {description}")
-        print()
+        title_text = "Goals"
+        title = f"{title_text}\n{'-' * len(title_text)}"
+        if self._use_color:
+            title = green(title)
+
+        def format_goal(name: str, description: str) -> str:
+            if self._use_color:
+                name = cyan(name)
+            return "\n".join([name, textwrap.fill(description, 80), ""])
+
+        lines = [
+            f"\n{title}\n",
+            f"Use `{self.bin_name} help $goal` to get help for a particular goal.",
+            "\n",
+            *(
+                format_goal(name, description)
+                for name, description in sorted(goal_descriptions.items())
+            ),
+        ]
+        print("\n".join(lines))
 
     def _print_options_help(self) -> None:
         """Print a help screen.
@@ -176,7 +194,7 @@ class HelpPrinter:
             scope=scope,
             show_advanced=show_advanced_and_deprecated,
             show_deprecated=show_advanced_and_deprecated,
-            color=sys.stdout.isatty(),
+            color=self._use_color,
         )
         formatted_lines = help_formatter.format_options(
             scope, description, self._options.get_parser(scope).option_registrations_iter()

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -109,13 +109,10 @@ class HelpPrinter:
             if len(description_lines) > 1:
                 description_lines = [
                     description_lines[0],
-                    *(
-                        f"{' ' * (chars_before_description + 4)}{line}"
-                        for line in description_lines[1:]
-                    ),
+                    *(f"{' ' * chars_before_description}{line}" for line in description_lines[1:]),
                 ]
             description = "\n".join(description_lines)
-            return f"{name}{description}"
+            return f"{name}{description}\n"
 
         lines = [
             f"\n{title}\n",

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
-import textwrap
 from typing import Dict, Optional, cast
 
 from colors import cyan, green
@@ -98,10 +97,13 @@ class HelpPrinter:
         if self._use_color:
             title = green(title)
 
+        max_width = max(len(name) for name in goal_descriptions.keys())
+
         def format_goal(name: str, description: str) -> str:
+            name = name.ljust(max_width + 2)
             if self._use_color:
                 name = cyan(name)
-            return "\n".join([name, textwrap.fill(description, 80), ""])
+            return f"{name}{description}"
 
         lines = [
             f"\n{title}\n",

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -44,8 +44,8 @@ class AbbreviatedTargetInfo:
         return cls(alias=target_type.alias, description=get_docstring_summary(target_type))
 
     def format_for_cli(self, console: Console, *, longest_target_alias: int) -> str:
-        chars_before_description = longest_target_alias + 4
-        alias = console.cyan(f"{self.alias}()".ljust(chars_before_description))
+        chars_before_description = longest_target_alias + 2
+        alias = console.cyan(f"{self.alias}".ljust(chars_before_description))
         if not self.description:
             description = "<no description>"
         else:
@@ -53,13 +53,10 @@ class AbbreviatedTargetInfo:
             if len(description_lines) > 1:
                 description_lines = [
                     description_lines[0],
-                    *(
-                        f"{' ' * (chars_before_description + 4)}{line}"
-                        for line in description_lines[1:]
-                    ),
+                    *(f"{' ' * chars_before_description}{line}" for line in description_lines[1:]),
                 ]
             description = "\n".join(description_lines)
-        return f"{alias}{description}"
+        return f"{alias}{description}\n"
 
 
 @dataclass(frozen=True)
@@ -125,7 +122,7 @@ class VerboseTargetInfo:
         )
 
     def format_for_cli(self, console: Console) -> str:
-        output = [console.green(f"{self.alias}()\n{'-' * (len(self.alias) + 2)}\n")]
+        output = [console.green(f"{self.alias}\n{'-' * len(self.alias)}\n")]
         if self.description:
             output.append(f"{self.description}\n")
         output.extend(

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -43,10 +43,12 @@ class AbbreviatedTargetInfo:
     def create(cls, target_type: Type[Target]) -> "AbbreviatedTargetInfo":
         return cls(alias=target_type.alias, description=get_docstring_summary(target_type))
 
-    def format_for_cli(self, *, console: Console, longest_target_alias: int) -> str:
-        formatted_alias = console.cyan(f"{self.alias:>{longest_target_alias + 1}}:")
-        description = self.description or "<no description>"
-        return f"{formatted_alias} {description}"
+    def format_for_cli(self, console: Console) -> str:
+        alias = console.cyan(f"{self.alias}()")
+        description = (
+            textwrap.fill(self.description, 80) if self.description else "<no description>"
+        )
+        return f"{alias}\n{description}\n"
 
 
 @dataclass(frozen=True)
@@ -73,7 +75,7 @@ class FieldInfo:
             default=str(field.default),
         )
 
-    def format_for_cli(self, *, console: Console) -> str:
+    def format_for_cli(self, console: Console) -> str:
         field_alias = console.magenta(f"{self.alias}")
         indent = "    "
         type_info = console.cyan(f"{indent}type: {self.type_hint}, default: {self.default}")
@@ -102,14 +104,14 @@ class VerboseTargetInfo:
             ],
         )
 
-    def format_for_cli(self, *, console: Console) -> str:
+    def format_for_cli(self, console: Console) -> str:
         output = [console.green(f"{self.alias}()\n{'-' * (len(self.alias) + 2)}\n")]
         if self.description:
             output.append(f"{self.description}\n")
         output.extend(
             [
                 "Valid fields:\n",
-                *sorted(f"{field.format_for_cli(console=console)}\n" for field in self.fields),
+                *sorted(f"{field.format_for_cli(console)}\n" for field in self.fields),
             ]
         )
         return "\n".join(output).rstrip()
@@ -135,22 +137,25 @@ def list_target_types(
                 target_type, union_membership=union_membership
             )
             print_stdout("")
-            print_stdout(verbose_target_info.format_for_cli(console=console))
+            print_stdout(verbose_target_info.format_for_cli(console))
         else:
-            print_stdout(
-                "Use `./pants target-types2 --details=$target_type` to get detailed information "
-                "for a particular target type.\n"
-            )
-            longest_target_alias = max(
-                len(target_type.alias) for target_type in registered_target_types.types
-            )
-            for target_type in registered_target_types.types:
-                target_info = AbbreviatedTargetInfo.create(target_type)
-                print_stdout(
-                    target_info.format_for_cli(
-                        console=console, longest_target_alias=longest_target_alias
-                    )
-                )
+            title_text = "Target types"
+            title = console.green(f"{title_text}\n{'-' * len(title_text)}")
+            target_infos = [
+                AbbreviatedTargetInfo.create(target_type)
+                for target_type in registered_target_types.types
+            ]
+            lines = [
+                f"\n{title}\n",
+                textwrap.fill(
+                    "Use `./pants target-types2 --details=$target_type` to get detailed "
+                    "information for a particular target type.",
+                    80,
+                ),
+                "\n",
+                *(target_info.format_for_cli(console) for target_info in target_infos),
+            ]
+            print_stdout("\n".join(lines).rstrip())
     return TargetTypes(exit_code=0)
 
 

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -146,7 +146,7 @@ def list_target_types(
                 for target_type in registered_target_types.types
             ]
             lines = [
-                f"\n{title}\n",
+                f"{title}\n",
                 textwrap.fill(
                     "Use `./pants target-types2 --details=$target_type` to get detailed "
                     "information for a particular target type.",

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -44,8 +44,21 @@ class AbbreviatedTargetInfo:
         return cls(alias=target_type.alias, description=get_docstring_summary(target_type))
 
     def format_for_cli(self, console: Console, *, longest_target_alias: int) -> str:
-        alias = console.cyan(f"{self.alias}()".ljust(longest_target_alias + 4))
-        description = self.description or "<no description>"
+        chars_before_description = longest_target_alias + 4
+        alias = console.cyan(f"{self.alias}()".ljust(chars_before_description))
+        if not self.description:
+            description = "<no description>"
+        else:
+            description_lines = textwrap.wrap(self.description, 80 - chars_before_description)
+            if len(description_lines) > 1:
+                description_lines = [
+                    description_lines[0],
+                    *(
+                        f"{' ' * (chars_before_description + 4)}{line}"
+                        for line in description_lines[1:]
+                    ),
+                ]
+            description = "\n".join(description_lines)
         return f"{alias}{description}"
 
 

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -72,7 +72,6 @@ def test_list_all() -> None:
     stdout = run_goal()
     assert stdout == dedent(
         """\
-        
         Target types
         ------------
 

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -72,6 +72,7 @@ def test_list_all() -> None:
     stdout = run_goal()
     assert stdout == dedent(
         """\
+
         Target types
         ------------
 
@@ -79,14 +80,9 @@ def test_list_all() -> None:
         for a particular target type.
 
 
-        fortran_binary()
-        <no description>
-
-        fortran_library()
-        A library of Fortran code.
-
-        fortran_tests()
-        Tests for Fortran code.
+        fortran_binary()  <no description>
+        fortran_library() A library of Fortran code.
+        fortran_tests()   Tests for Fortran code.
         """
     )
 

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -72,11 +72,22 @@ def test_list_all() -> None:
     stdout = run_goal()
     assert stdout == dedent(
         """\
-        Use `./pants target-types2 --details=$target_type` to get detailed information for a particular target type.
         
-          fortran_binary: <no description>
-         fortran_library: A library of Fortran code.
-           fortran_tests: Tests for Fortran code.
+        Target types
+        ------------
+
+        Use `./pants target-types2 --details=$target_type` to get detailed information
+        for a particular target type.
+
+
+        fortran_binary()
+        <no description>
+
+        fortran_library()
+        A library of Fortran code.
+
+        fortran_tests()
+        Tests for Fortran code.
         """
     )
 

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -80,9 +80,11 @@ def test_list_all() -> None:
         for a particular target type.
 
 
-        fortran_binary()  <no description>
-        fortran_library() A library of Fortran code.
-        fortran_tests()   Tests for Fortran code.
+        fortran_binary   <no description>
+
+        fortran_library  A library of Fortran code.
+
+        fortran_tests    Tests for Fortran code.
         """
     )
 
@@ -104,8 +106,8 @@ def test_list_single() -> None:
     assert tests_target_stdout == dedent(
         """\
 
-        fortran_tests()
-        ---------------
+        fortran_tests
+        -------------
 
         Tests for Fortran code.
         
@@ -126,8 +128,8 @@ def test_list_single() -> None:
     assert binary_target_stdout == dedent(
         """\
 
-        fortran_binary()
-        ----------------
+        fortran_binary
+        --------------
 
         Valid fields:
 


### PR DESCRIPTION
Before:

<img width="788" alt="Screen Shot 2020-03-28 at 11 32 08 AM" src="https://user-images.githubusercontent.com/14852634/77830730-c39faf80-70e7-11ea-89d3-ac25cc6670ec.png">

<img width="823" alt="Screen Shot 2020-03-28 at 11 31 34 AM" src="https://user-images.githubusercontent.com/14852634/77830718-aff44900-70e7-11ea-8f73-127b1d740f5b.png">

After:

![Screen Shot 2020-03-30 at 9 47 05 AM](https://user-images.githubusercontent.com/14852634/77939050-6b91b600-726b-11ea-8889-fcc92d956c45.png)

![Screen Shot 2020-03-30 at 9 47 42 AM](https://user-images.githubusercontent.com/14852634/77939107-819f7680-726b-11ea-8b2b-5f89332c24f2.png)


