### PR TITLE
Eliminate PEX_ROOT warning for CreatePex.

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from pants.backend.python.rules.hermetic_pex import HermeticPex
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
@@ -62,7 +62,7 @@ class DownloadedPexBin(HermeticPex):
         pex_args: Iterable[str],
         description: str,
         input_files: Optional[Digest] = None,
-        env: Optional[Dict[str, str]] = None,
+        env: Optional[Mapping[str, str]] = None,
         **kwargs: Any,
     ) -> ExecuteProcessRequest:
         """Creates an ExecuteProcessRequest that will run the pex CLI tool hermetically.
@@ -82,7 +82,7 @@ class DownloadedPexBin(HermeticPex):
         :param kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
         """
 
-        env = env.copy() if env else {}
+        env = dict(env) if env else {}
         env.update(
             # We ask Pex to --disable-cache so we shouldn't also set a PEX_ROOT (asking it to
             # cache).

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from pants.backend.python.rules.hermetic_pex import HermeticPex
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
@@ -62,22 +62,33 @@ class DownloadedPexBin(HermeticPex):
         pex_args: Iterable[str],
         description: str,
         input_files: Optional[Digest] = None,
+        env: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> ExecuteProcessRequest:
         """Creates an ExecuteProcessRequest that will run the pex CLI tool hermetically.
 
-        :param python_setup: The parameters for selecting python interpreters to use when invoking the
-                             pex tool.
-        :param subprocess_encoding_environment: The locale settings to use for the pex tool invocation.
+        :param python_setup: The parameters for selecting python interpreters to use when invoking
+                             the pex tool.
+        :param subprocess_encoding_environment: The locale settings to use for the pex tool
+                                                invocation.
         :param pex_build_environment: The build environment for the pex tool.
         :param pex_args: The arguments to pass to the pex CLI tool.
         :param description: A description of the process execution to be performed.
-        :param input_files: The files that contain the pex CLI tool itself and any input files it needs
-                            to run against. By default just the files that contain the pex CLI tool
-                            itself. To merge in additional files, include the `directory_digest` in
-                            `DirectoriesToMerge` request.
+        :param input_files: The files that contain the pex CLI tool itself and any input files it
+                            needs to run against. By default just the files that contain the pex CLI
+                            tool itself. To merge in additional files, include the
+                            `directory_digest` in `DirectoriesToMerge` request.
+        :param env: The environment to run the PEX in.
         :param kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
         """
+
+        env = env.copy() if env else {}
+        env.update(
+            # We ask Pex to --disable-cache so we shouldn't also set a PEX_ROOT (asking it to
+            # cache).
+            PEX_ROOT="",
+            **pex_build_environment.invocation_environment_dict,
+        )
 
         return super().create_execute_request(
             python_setup=python_setup,
@@ -86,7 +97,7 @@ class DownloadedPexBin(HermeticPex):
             pex_args=["--disable-cache"] + list(pex_args),
             description=description,
             input_files=input_files or self.directory_digest,
-            env=pex_build_environment.invocation_environment_dict,
+            env=env,
             **kwargs,
         )
 

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -27,14 +27,15 @@ class HermeticPex:
     ) -> ExecuteProcessRequest:
         """Creates an ExecuteProcessRequest that will run a PEX hermetically.
 
-        :param python_setup: The parameters for selecting python interpreters to use when invoking the
-                             PEX.
+        :param python_setup: The parameters for selecting python interpreters to use when invoking
+                             the PEX.
         :param subprocess_encoding_environment: The locale settings to use for the PEX invocation.
-        :param pex_path: The path within `input_files` of the PEX file (or directory if a loose pex).
+        :param pex_path: The path within `input_files` of the PEX file (or directory if a loose
+                         pex).
         :param pex_args: The arguments to pass to the PEX executable.
         :param description: A description of the process execution to be performed.
-        :param input_files: The files that contain the pex itself and any input files it needs to run
-                            against.
+        :param input_files: The files that contain the pex itself and any input files it needs to
+                            run against.
         :param env: The environment to run the PEX in.
         :param **kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
         """
@@ -48,14 +49,15 @@ class HermeticPex:
         # platforms, when we introduce platforms in https://github.com/pantsbuild/pants/issues/7735.
         argv = ("python", pex_path, *pex_args)
 
-        hermetic_env = env.copy() if env else {}
-        hermetic_env.update(
+        hermetic_env = dict(
             PATH=create_path_env_var(python_setup.interpreter_search_paths),
             PEX_ROOT="./pex_root",
             PEX_INHERIT_PATH="false",
             PEX_IGNORE_RCFILES="true",
             **subprocess_encoding_environment.invocation_environment_dict
         )
+        if env:
+            hermetic_env.update(env)
 
         return ExecuteProcessRequest(
             argv=argv, input_files=input_files, description=description, env=hermetic_env, **kwargs

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest
@@ -22,7 +22,7 @@ class HermeticPex:
         pex_args: Iterable[str],
         description: str,
         input_files: Digest,
-        env: Optional[Dict[str, str]] = None,
+        env: Optional[Mapping[str, str]] = None,
         **kwargs: Any
     ) -> ExecuteProcessRequest:
         """Creates an ExecuteProcessRequest that will run a PEX hermetically.

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Tuple
+from typing import Dict, Tuple
 
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
@@ -143,7 +143,7 @@ class PexBuildEnvironment:
     ld_flags: Tuple[str, ...]
 
     @property
-    def invocation_environment_dict(self):
+    def invocation_environment_dict(self) -> Dict[str, str]:
         return {
             "CPPFLAGS": safe_shlex_join(self.cpp_flags),
             "LDFLAGS": safe_shlex_join(self.ld_flags),

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -3,7 +3,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 from pants.engine.rules import rule, subsystem_rule
 from pants.subsystem.subsystem import Subsystem
@@ -39,7 +39,7 @@ class SubprocessEncodingEnvironment:
     lc_all: Optional[str]
 
     @property
-    def invocation_environment_dict(self):
+    def invocation_environment_dict(self) -> Dict[str, str]:
         return {
             "LANG": self.lang or "",
             "LC_ALL": self.lc_all or "",


### PR DESCRIPTION
Although this warning would only show up when passing -ldebug, it does
signal a misconfiguration of the Pex CLI when we satisfy CreatePex requests.
Fix HermeticPex to allow overrides of its env var settings and leverage this
in DownloadedPexBin to unset PEX_ROOT and only pass --disable-cache.

# Delete this line to force CI to run Clippy and the Rust tests.
[ci skip-rust-tests]  # No Rust changes made.

# Delete this line to force CI to run the JVM tests.
[ci skip-jvm-tests]  # No JVM changes made.