### PR TITLE
Fix incorrect guidance for running fmt.

### DIFF
--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -53,7 +53,8 @@ echo "* Checking shell scripts via our custom linter"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking formatting and Flake8"
-  ./v2 --changed-since="${MERGE_BASE}" lint || die "If there were formatting errors, run \`./v2 --changed-since=master fmt\`"
+  ./v2 --changed-since="${MERGE_BASE}" lint || \
+    die "If there were formatting errors, run \`./v2 --changed-since=$(git rev-parse --symbolic "${MERGE_BASE}") fmt\`"
 
   echo "* Checking types"
   ./build-support/bin/mypy.py || exit 1


### PR DESCRIPTION
We already calculated a merge base, so use that in the message. Do not
assume master.

# Delete this line to force CI to run Clippy and the Rust tests.
[ci skip-rust-tests]  # No Rust changes made.

# Delete this line to force CI to run the JVM tests.
[ci skip-jvm-tests]  # No JVM changes made.