### PR TITLE
Skip flaky `TestPantsDaemonIntegration` test.

### DIFF
--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -143,6 +143,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 pantsd_run(cmd[1:], {"GLOBAL": {"level": cmd[0]}})
                 checker.assert_running()
 
+    @pytest.mark.skip(reason="flaky: https://github.com/pantsbuild/pants/issues/9420")
     def test_pantsd_lifecycle_non_invalidation(self):
         with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):
             variants = (["-q", "help"], ["--no-colors", "help"], ["help"])


### PR DESCRIPTION
In particular `test_pantsd_lifecycle_non_invalidation` flakes as
detailed in #9420.

[ci skip-rust-tests]
[ci skip-jvm-tests]