### PR TITLE
Make the list of JS lintable extensions configurable

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -26,8 +26,7 @@ class JavascriptStyleBase(NodeTask):
     :API: public
     """
 
-    _JS_SOURCE_EXTENSION = ".js"
-    _JSX_SOURCE_EXTENSION = ".jsx"
+    _DEFAULT_JS_EXTENSIONS = (".js", ".jsx")
     INSTALL_JAVASCRIPTSTYLE_TARGET_NAME = "synthetic-install-javascriptstyle-module"
 
     def _resolve_conflicting_skip(self, *, old_scope: str):
@@ -44,6 +43,13 @@ class JavascriptStyleBase(NodeTask):
             "--fail-slow", type=bool, help="Check all targets and present the full list of errors."
         )
         register("--color", type=bool, default=True, help="Enable or disable color.")
+        register(
+            "--file-extensions",
+            advanced=True,
+            type=list,
+            default=cls._DEFAULT_JS_EXTENSIONS,
+            help="File extensions that should be linted as JS",
+        )
 
     @classmethod
     def subsystem_dependencies(cls):
@@ -59,10 +65,7 @@ class JavascriptStyleBase(NodeTask):
             target
             for target in targets
             if isinstance(target, NodeModule)
-            and (
-                target.has_sources(self._JS_SOURCE_EXTENSION)
-                or target.has_sources(self._JSX_SOURCE_EXTENSION)
-            )
+            and target.has_sources(tuple(self.get_options().file_extensions))
             and (not target.is_synthetic)
         ]
 
@@ -71,10 +74,7 @@ class JavascriptStyleBase(NodeTask):
         sources.update(
             os.path.join(get_buildroot(), source)
             for source in target.sources_relative_to_buildroot()
-            if (
-                source.endswith(self._JS_SOURCE_EXTENSION)
-                or source.endswith(self._JSX_SOURCE_EXTENSION)
-            )
+            if source.endswith(tuple(self.get_options().file_extensions))
         )
         return sources
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -48,7 +48,7 @@ class JavascriptStyleBase(NodeTask):
             advanced=True,
             type=list,
             default=cls._DEFAULT_JS_EXTENSIONS,
-            help="File extensions that should be linted as JS",
+            help="File extensions that should be linted as JS.",
         )
 
     @classmethod
@@ -65,7 +65,7 @@ class JavascriptStyleBase(NodeTask):
             target
             for target in targets
             if isinstance(target, NodeModule)
-            and target.has_sources(tuple(self.get_options().file_extensions))
+            and any(target.has_sources(ext) for ext in self.get_options().file_extensions)
             and (not target.is_synthetic)
         ]
 
@@ -74,7 +74,7 @@ class JavascriptStyleBase(NodeTask):
         sources.update(
             os.path.join(get_buildroot(), source)
             for source in target.sources_relative_to_buildroot()
-            if source.endswith(tuple(self.get_options().file_extensions))
+            if any(source.endswith(ext) for ext in self.get_options().file_extensions)
         )
         return sources
 


### PR DESCRIPTION
[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.

### Problem

Node plugin only lints .js/.jsx files. These extensions are hardcoded. However, there are more potentially eslintable extensions, such as .ts or .vue.

### Solution

The list of extensions (or rather suffixes, to not mandate the dot) is now configurable as `--lint-javascriptstyle-file-extensions` (`lint_javascriptstyle` scope). The default value has the same two extensions as before, so the default behaviour is unchanged.