### PR TITLE
Skip flaky `TestArtifactCache` test.

### DIFF
--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -155,6 +155,7 @@ class TestArtifactCache(TestBase):
             artifact_cache.delete(key)
             self.assertFalse(artifact_cache.has(key))
 
+    @pytest.mark.skip(reason="flaky: https://github.com/pantsbuild/pants/issues/9426")
     def test_local_backed_remote_cache(self):
         """make sure that the combined cache finds what it should and that it backfills."""
         with self.setup_server() as server:


### PR DESCRIPTION
The `test_local_backed_remote_cache` test is flaky as described in
 #9426.

[ci skip-rust-tests]
[ci skip-jvm-tests]