### PR TITLE
Remove clean_global_runtime_state

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -13,7 +13,6 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.logging import encapsulated_global_logger
 from pants.init.specs_calculator import SpecsCalculator
-from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import (
     NailgunStreamStdinReader,
     NailgunStreamWriterError,
@@ -247,9 +246,6 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
             exit_code = PANTS_SUCCEEDED_EXIT_CODE
             try:
-                # Clean global state.
-                clean_global_runtime_state(reset_subsystem=True)
-
                 options_bootstrapper = OptionsBootstrapper.create(args=self.args, env=self.env)
                 options, _ = LocalPantsRunner.parse_options(options_bootstrapper)
 

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -5,10 +5,7 @@ import os
 from typing import cast
 
 from pants.fs.fs import safe_filename_from_path
-from pants.goal.goal import Goal
-from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.option_value_container import OptionValueContainer
-from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_rmtree
 
 
@@ -49,19 +46,3 @@ def init_workdir(global_options: OptionValueContainer) -> str:
         safe_rmtree(workdir_src)
         absolute_symlink(workdir_dst, workdir_src)
     return workdir_src
-
-
-def clean_global_runtime_state(reset_subsystem=False):
-    """Resets the global runtime state of a pants runtime for cleaner forking.
-
-    :param bool reset_subsystem: Whether or not to clean Subsystem global state.
-    """
-    if reset_subsystem:
-        # Reset subsystem state.
-        Subsystem.reset()
-
-    # Reset Goals and Tasks.
-    Goal.clear()
-
-    # Reset global plugin state.
-    BuildConfigInitializer.reset()

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -28,7 +28,6 @@ from pants.engine.rules import RootRule
 from pants.engine.scheduler import SchedulerSession
 from pants.engine.selectors import Params
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.util import clean_global_runtime_state
 from pants.option.global_options import BuildFileImportsBehavior
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.source.source_root import SourceRootConfig
@@ -305,8 +304,6 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         :API: public
         """
         super().setUp()
-        # Avoid resetting the Runtracker here, as that is specific to fork'd process cleanup.
-        clean_global_runtime_state(reset_subsystem=True)
 
         self.addCleanup(self._reset_engine)
 


### PR DESCRIPTION
This function has a note saying it applies to forking-pantsd, so maybe it is no longer necessary.

[ci skip-rust-tests]  # No Rust changes made.

[ci skip-jvm-tests]  # No JVM changes made.
