### PR TITLE
Provide better TypeError in extern_identify hash failure

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -686,7 +686,7 @@ class ExternContext:
         try:
             hash_ = hash(obj)
         except TypeError as e:
-            raise TypeError(f'failed to hash object {obj}: {e}') from e
+            raise TypeError(f"failed to hash object {obj}: {e}") from e
         type_id = self.to_id(type(obj))
         return (hash_, TypeId(type_id))
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -683,7 +683,10 @@ class ExternContext:
 
     def identify(self, obj):
         """Return an Ident-shaped tuple for the given object."""
-        hash_ = hash(obj)
+        try:
+            hash_ = hash(obj)
+        except TypeError as e:
+            raise TypeError(f'failed to hash object {obj}: {e}') from e
         type_id = self.to_id(type(obj))
         return (hash_, TypeId(type_id))
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -288,12 +288,19 @@ class SchedulerWithNestedRaiseTest(TestBase):
                 dedent(
                     """\
                     Traceback (most recent call last):
-                      File LOCATION-INFO, in extern_identify
-                        return c.identify(obj)
                       File LOCATION-INFO, in identify
                         hash_ = hash(obj)
                       File "<string>", line 2, in __hash__
                     TypeError: unhashable type: 'list'
+
+                    The above exception was the direct cause of the following exception:
+
+                    Traceback (most recent call last):
+                      File LOCATION-INFO, in extern_identify
+                        return c.identify(obj)
+                      File LOCATION-INFO, in identify
+                        raise TypeError(f"failed to hash object {obj}: {e}") from e
+                    TypeError: failed to hash object CollectionType(items=[1, 2, 3]): unhashable type: 'list'
                     """
                 ),
                 exc_str,


### PR DESCRIPTION
### Problem

If the engine is passed a dataclass with a field containing a list or other unhashable object, `extern_identify` will present an error message to the user saying an object was unhashable, but doesn't explain what was unhashable or why.

### Solution

- Add the original object being hashed to the error message when a hash fails in `extern_identify` to improve debuggability.