### PR TITLE
remove HermeticPex mixin and add python repos to pex creation

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -7,11 +7,11 @@ from pants.backend.awslambda.common.awslambda_common_rules import AWSLambdaTarge
 from pants.backend.awslambda.python.lambdex import Lambdex
 from pants.backend.python.rules import (
     download_pex_bin,
-    hermetic_pex,
     pex,
     pex_from_target_closure,
     prepare_chrooted_python_sources,
 )
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -60,13 +60,15 @@ async def create_python_awslambda(
 
     # NB: Lambdex modifies its input pex in-place, so the input file is also the output file.
     lambdex_args = ("build", "-e", lambda_tgt_adaptor.handler, pex_filename)
-    process_request = lambdex_setup.requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=lambdex_args,
-        input_files=merged_input_files,
-        output_files=(pex_filename,),
-        description=f"Run Lambdex for {lambda_tgt_adaptor.address.reference()}",
-    ))
-    result = await Get[ExecuteProcessResult](hermetic_pex.HermeticPexRequest, process_request)
+    hermetic_pex_request = lambdex_setup.requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=lambdex_args,
+            input_files=merged_input_files,
+            output_files=(pex_filename,),
+            description=f"Run Lambdex for {lambda_tgt_adaptor.address.reference()}",
+        )
+    )
+    result = await Get[ExecuteProcessResult](HermeticPexRequest, hermetic_pex_request)
     return CreatedAWSLambda(digest=result.output_directory_digest, name=pex_filename)
 
 

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -6,7 +6,8 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -107,12 +108,14 @@ async def lint(
         )
     )
 
-    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(specified_source_files=specified_source_files, bandit=bandit),
-        input_files=merged_input_files,
-        description=f"Run Bandit for {address_references}",
-    ))
-    result = await Get[FallibleExecuteProcessResult](hermetic_pex.HermeticPexRequest, request)
+    request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(specified_source_files=specified_source_files, bandit=bandit),
+            input_files=merged_input_files,
+            description=f"Run Bandit for {address_references}",
+        )
+    )
+    result = await Get[FallibleExecuteProcessResult](HermeticPexRequest, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from pants.backend.python.lint.bandit.rules import BanditLinter
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -31,7 +32,7 @@ class BanditIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *bandit_rules(), RootRule(BanditLinter))
+        return (*super().rules(), *bandit_rules(), *hermetic_pex_rules(), RootRule(BanditLinter))
 
     def make_target_with_origin(
         self,

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -8,7 +8,8 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_formatter import PythonFormatter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -133,16 +134,18 @@ async def setup(
         )
     )
 
-    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(
-            specified_source_files=specified_source_files,
-            black=black,
-            check_only=request.check_only,
-        ),
-        input_files=merged_input_files,
-        output_files=all_source_files_snapshot.files,
-        description=f"Run black for {address_references}",
-    ))
+    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(
+                specified_source_files=specified_source_files,
+                black=black,
+                check_only=request.check_only,
+            ),
+            input_files=merged_input_files,
+            output_files=all_source_files_snapshot.files,
+            description=f"Run black for {address_references}",
+        )
+    )
     process_request = await Get[ExecuteProcessRequest](HermeticPexRequest, hermetic_pex_request)
     return Setup(process_request)
 

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.black.rules import BlackFormatter
 from pants.backend.python.lint.black.rules import rules as black_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent, Snapshot
@@ -29,7 +30,7 @@ class BlackIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *black_rules(), RootRule(BlackFormatter))
+        return (*super().rules(), *black_rules(), *hermetic_pex_rules(), RootRule(BlackFormatter))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -6,7 +6,7 @@ from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_formatter import PythonFormatter
-from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -110,11 +110,8 @@ async def setup(
         )
     )
 
-    process_request = requirements_pex.create_execute_request(
-        python_setup=python_setup,
-        subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path="./docformatter.pex",
-        pex_args=generate_args(
+    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
+        argv=generate_args(
             specified_source_files=specified_source_files,
             docformatter=docformatter,
             check_only=request.check_only,
@@ -122,7 +119,8 @@ async def setup(
         input_files=merged_input_files,
         output_files=all_source_files_snapshot.files,
         description=f"Run docformatter for {address_references}",
-    )
+    ))
+    process_request = await Get[ExecuteProcessRequest](HermeticPexRequest, hermetic_pex_request)
     return Setup(process_request)
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -6,7 +6,8 @@ from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_formatter import PythonFormatter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -110,16 +111,18 @@ async def setup(
         )
     )
 
-    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(
-            specified_source_files=specified_source_files,
-            docformatter=docformatter,
-            check_only=request.check_only,
-        ),
-        input_files=merged_input_files,
-        output_files=all_source_files_snapshot.files,
-        description=f"Run docformatter for {address_references}",
-    ))
+    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(
+                specified_source_files=specified_source_files,
+                docformatter=docformatter,
+                check_only=request.check_only,
+            ),
+            input_files=merged_input_files,
+            output_files=all_source_files_snapshot.files,
+            description=f"Run docformatter for {address_references}",
+        )
+    )
     process_request = await Get[ExecuteProcessRequest](HermeticPexRequest, hermetic_pex_request)
     return Setup(process_request)
 

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.docformatter.rules import DocformatterFormatter
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent, Snapshot
@@ -26,7 +27,12 @@ class DocformatterIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *docformatter_rules(), RootRule(DocformatterFormatter))
+        return (
+            *super().rules(),
+            *docformatter_rules(),
+            *hermetic_pex_rules(),
+            RootRule(DocformatterFormatter),
+        )
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -107,15 +107,12 @@ async def lint(
         )
     )
 
-    request = requirements_pex.create_execute_request(
-        python_setup=python_setup,
-        subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path=f"./flake8.pex",
-        pex_args=generate_args(specified_source_files=specified_source_files, flake8=flake8),
+    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
+        argv=generate_args(specified_source_files=specified_source_files, flake8=flake8),
         input_files=merged_input_files,
         description=f"Run Flake8 for {address_references}",
-    )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    ))
+    result = await Get[FallibleExecuteProcessResult](hermetic_pex.HermeticPexRequest, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -6,7 +6,8 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -107,12 +108,14 @@ async def lint(
         )
     )
 
-    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(specified_source_files=specified_source_files, flake8=flake8),
-        input_files=merged_input_files,
-        description=f"Run Flake8 for {address_references}",
-    ))
-    result = await Get[FallibleExecuteProcessResult](hermetic_pex.HermeticPexRequest, request)
+    request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(specified_source_files=specified_source_files, flake8=flake8),
+            input_files=merged_input_files,
+            description=f"Run Flake8 for {address_references}",
+        )
+    )
+    result = await Get[FallibleExecuteProcessResult](HermeticPexRequest, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from pants.backend.python.lint.flake8.rules import Flake8Linter
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -32,7 +33,7 @@ class Flake8IntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *flake8_rules(), RootRule(Flake8Linter))
+        return (*super().rules(), *flake8_rules(), *hermetic_pex_rules(), RootRule(Flake8Linter))
 
     def make_target_with_origin(
         self,

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -6,7 +6,8 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_formatter import PythonFormatter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -126,17 +127,19 @@ async def setup(
         )
     )
 
-    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(
-            specified_source_files=specified_source_files,
-            isort=isort,
-            check_only=request.check_only,
-        ),
-        input_files=merged_input_files,
-        output_files=all_source_files_snapshot.files,
-        description=f"Run isort for {address_references}",
-    ))
-    process_request = await Get[ExecuteProcessRequest](hermetic_pex.HermeticPexRequest, hermetic_pex_request)
+    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(
+                specified_source_files=specified_source_files,
+                isort=isort,
+                check_only=request.check_only,
+            ),
+            input_files=merged_input_files,
+            output_files=all_source_files_snapshot.files,
+            description=f"Run isort for {address_references}",
+        )
+    )
+    process_request = await Get[ExecuteProcessRequest](HermeticPexRequest, hermetic_pex_request)
     return Setup(process_request)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_formatter import PythonFormatter
-from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -126,11 +126,8 @@ async def setup(
         )
     )
 
-    process_request = requirements_pex.create_execute_request(
-        python_setup=python_setup,
-        subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path="./isort.pex",
-        pex_args=generate_args(
+    hermetic_pex_request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
+        argv=generate_args(
             specified_source_files=specified_source_files,
             isort=isort,
             check_only=request.check_only,
@@ -138,7 +135,8 @@ async def setup(
         input_files=merged_input_files,
         output_files=all_source_files_snapshot.files,
         description=f"Run isort for {address_references}",
-    )
+    ))
+    process_request = await Get[ExecuteProcessRequest](hermetic_pex.HermeticPexRequest, hermetic_pex_request)
     return Setup(process_request)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.rules import IsortFormatter
 from pants.backend.python.lint.isort.rules import rules as isort_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, FileContent, InputFilesContent, Snapshot
@@ -36,7 +37,7 @@ class IsortIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *isort_rules(), RootRule(IsortFormatter))
+        return (*super().rules(), *isort_rules(), *hermetic_pex_rules(), RootRule(IsortFormatter))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -7,7 +7,8 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex, prepare_chrooted_python_sources
+from pants.backend.python.rules import download_pex_bin, pex, prepare_chrooted_python_sources
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -117,11 +118,13 @@ async def lint(
         )
     )
 
-    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=generate_args(specified_source_files=specified_source_files, pylint=pylint),
-        input_files=merged_input_files,
-        description=f"Run Pylint for {address_references}",
-    ))
+    request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=generate_args(specified_source_files=specified_source_files, pylint=pylint),
+            input_files=merged_input_files,
+            description=f"Run Pylint for {address_references}",
+        )
+    )
     result = await Get[FallibleExecuteProcessResult](HermeticPexRequest, request)
     return LintResult.from_fallible_execute_process_result(result)
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, pex, prepare_chrooted_python_sources
+from pants.backend.python.rules import download_pex_bin, hermetic_pex, pex, prepare_chrooted_python_sources
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -117,15 +117,12 @@ async def lint(
         )
     )
 
-    request = requirements_pex.create_execute_request(
-        python_setup=python_setup,
-        subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path=f"./pylint.pex",
-        pex_args=generate_args(specified_source_files=specified_source_files, pylint=pylint),
+    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
+        argv=generate_args(specified_source_files=specified_source_files, pylint=pylint),
         input_files=merged_input_files,
         description=f"Run Pylint for {address_references}",
-    )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    ))
+    result = await Get[FallibleExecuteProcessResult](HermeticPexRequest, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 from pants.backend.python.lint.pylint.rules import PylintLinter
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.address import Address
@@ -41,7 +42,7 @@ class PylintIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *pylint_rules(), RootRule(PylintLinter))
+        return (*super().rules(), *pylint_rules(), *hermetic_pex_rules(), RootRule(PylintLinter))
 
     def write_file(self, file_content: FileContent) -> None:
         self.create_file(relpath=file_content.path, contents=file_content.content.decode())

--- a/src/python/pants/backend/python/lint/python_formatter_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_formatter_integration_test.py
@@ -8,6 +8,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.isort.rules import IsortFormatter
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_formatter import PythonFormatters, format_python_target
+from pants.backend.python.rules.hermetic_pex import rules as hermetic_pex_rules
 from pants.base.specs import SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Snapshot
@@ -27,6 +28,7 @@ class PythonFormatterIntegrationTest(TestBase):
             *super().rules(),
             format_python_target,
             *black_rules(),
+            *hermetic_pex_rules(),
             *isort_rules(),
             RootRule(PythonFormatters),
             RootRule(BlackFormatter),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,6 +6,7 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
     download_pex_bin,
+    hermetic_pex,
     inject_init,
     pex,
     pex_from_target_closure,
@@ -109,6 +110,7 @@ def register_goals():
 def rules():
     return (
         *download_pex_bin.rules(),
+        *hermetic_pex.rules(),
         *inject_init.rules(),
         *prepare_chrooted_python_sources.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -56,6 +56,7 @@ def global_subsystems():
         python_native_code.PythonNativeCode,
         subprocess_environment.SubprocessEnvironment,
         PexBuilderWrapper.Factory,
+        hermetic_pex.HermeticPex,
     }
 
 

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -2,10 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional
 
-from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
-from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.binaries.binary_tool import BinaryToolFetchRequest, Script, ToolForPlatform, ToolVersion
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.fs import Digest, SingleFileExecutable, Snapshot
@@ -13,7 +10,6 @@ from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.engine.platform import PlatformConstraint
 from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
-from pants.python.python_setup import PythonSetup
 
 
 class PexBinUrlGenerator(BinaryToolUrlGenerator):

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -1,64 +1,121 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Iterable, Mapping, Optional
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, cast
 
+from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest
 from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.python.python_setup import PythonSetup
+from pants.subsystem.subsystem import Subsystem
 from pants.util.strutil import create_path_env_var
 
 
-class HermeticPex:
-    """A mixin for types that provide an executable Pex that should be executed hermetically."""
+@dataclass(frozen=True)
+class HermeticPexRequest:
+    exe_req: ExecuteProcessRequest
 
-    def create_execute_request(
-        self,
-        python_setup: PythonSetup,
-        subprocess_encoding_environment: SubprocessEncodingEnvironment,
-        *,
-        pex_path: str,
-        pex_args: Iterable[str],
-        description: str,
-        input_files: Digest,
-        env: Optional[Mapping[str, str]] = None,
-        **kwargs: Any
-    ) -> ExecuteProcessRequest:
-        """Creates an ExecuteProcessRequest that will run a PEX hermetically.
 
-        :param python_setup: The parameters for selecting python interpreters to use when invoking
-                             the PEX.
-        :param subprocess_encoding_environment: The locale settings to use for the PEX invocation.
-        :param pex_path: The path within `input_files` of the PEX file (or directory if a loose
-                         pex).
-        :param pex_args: The arguments to pass to the PEX executable.
-        :param description: A description of the process execution to be performed.
-        :param input_files: The files that contain the pex itself and any input files it needs to
-                            run against.
-        :param env: The environment to run the PEX in.
-        :param **kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
-        """
+@dataclass(frozen=True)
+class HermeticPexResult:
+    exe_req: ExecuteProcessRequest
 
-        # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
-        # `sys.executable`, to ensure that the interpreter may be discovered both locally and in remote
-        # execution (so long as `env` is populated with a `PATH` env var and `python` is discoverable
-        # somewhere on that PATH). This is only used to run the downloaded PEX tool; it is not
-        # necessarily the interpreter that PEX will use to execute the generated .pex file.
-        # TODO(#7735): Set --python-setup-interpreter-search-paths differently for the host and target
-        # platforms, when we introduce platforms in https://github.com/pantsbuild/pants/issues/7735.
-        argv = ("python", pex_path, *pex_args)
 
-        hermetic_env = dict(
-            PATH=create_path_env_var(python_setup.interpreter_search_paths),
-            PEX_ROOT="./pex_root",
-            PEX_INHERIT_PATH="false",
-            PEX_IGNORE_RCFILES="true",
-            **subprocess_encoding_environment.invocation_environment_dict
-        )
-        if env:
-            hermetic_env.update(env)
+class HermeticPex(Subsystem):
+    options_scope = 'hermetic-pex-creation'
 
-        return ExecuteProcessRequest(
-            argv=argv, input_files=input_files, description=description, env=hermetic_env, **kwargs
-        )
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register('--python-executable-name', type=str, default='python',
+                 help='The python executable to search for in --python-setup-interpreter-search-paths '
+                      'when creating a pex with the v2 python backend.')
+        register('--use-pex-cache', type=bool, default=False,
+                 help='Whether to enable the pex local cache when executing hermetically.')
+
+    @property
+    def python_executable_name(self) -> str:
+        return cast(str, self.get_options().python_executable_name)
+
+    @property
+    def use_pex_cache(self) -> bool:
+        return cast(bool, self.get_options().use_pex_cache)
+
+
+@rule
+def make_hermetic_pex_exe_request(
+    python_setup: PythonSetup,
+    subprocess_encoding_environment: SubprocessEncodingEnvironment,
+    downloaded_pex_bin: DownloadedPexBin,
+    hermetic_pex_factory: HermeticPex,
+    req: HermeticPexRequest
+) -> HermeticPexResult:
+    """Creates an ExecuteProcessRequest that will run a PEX hermetically.
+
+    :param python_setup: The parameters for selecting python interpreters to use when invoking the
+                         PEX.
+    :param subprocess_encoding_environment: The locale settings to use for the PEX invocation.
+    :param pex_path: The path within `input_files` of the PEX file (or directory if a loose pex).
+    :param pex_args: The arguments to pass to the PEX executable.
+    :param description: A description of the process execution to be performed.
+    :param input_files: The files that contain the pex itself and any input files it needs to run
+                        against.
+    :param env: The environment to run the PEX in.
+    :param **kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
+    """
+    orig_exe_req = req.exe_req
+
+    pex_path = downloaded_pex_bin.executable
+
+    hermetic_env = orig_exe_req.env_dict.copy()
+    hermetic_env.update(
+        PATH=create_path_env_var(python_setup.interpreter_search_paths_ensure_directories),
+        # We ask Pex to --disable-cache so we shouldn't also set a PEX_ROOT (asking it to
+        # cache).
+        PEX_ROOT="",
+        PEX_INHERIT_PATH="false",
+        PEX_IGNORE_RCFILES="true",
+        **subprocess_encoding_environment.invocation_environment_dict
+    )
+
+    input_files = orig_exe_req.input_files
+    if not input_files:
+        input_files = downloaded_pex_bin.directory_digest
+
+    cache_args = []
+    if not hermetic_pex_factory.use_pex_cache:
+        cache_args.append('--disable-cache')
+
+    # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
+    # `sys.executable`, to ensure that the interpreter may be discovered both locally and in remote
+    # execution (so long as `env` is populated with a `PATH` env var and `python` is discoverable
+    # somewhere on that PATH). This is only used to run the downloaded PEX tool; it is not
+    # necessarily the interpreter that PEX will use to execute the generated .pex file.
+    # TODO(#7735): Set --python-setup-interpreter-search-paths differently for the host and target
+    # platforms, when we introduce platforms in https://github.com/pantsbuild/pants/issues/7735.
+    python_exe_name = hermetic_pex_factory.python_executable_name
+    argv = (
+        python_exe_name, downloaded_pex_bin.executable,
+        *cache_args,
+        *orig_exe_req.argv,
+    )
+
+    modified_exe_req = dataclasses.replace(
+        orig_exe_req,
+        argv=argv,
+        env=hermetic_env,
+        input_files=input_files,
+    )
+    return HermeticPexResult(modified_exe_req)
+
+
+def rules():
+    return [
+        subsystem_rule(HermeticPex),
+        RootRule(HermeticPexRequest),
+        make_hermetic_pex_exe_request,
+    ]

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -81,7 +81,7 @@ def make_hermetic_pex_exe_request(
 
     hermetic_env = orig_exe_req.env_dict.copy()
     hermetic_env.update(
-        PATH=create_path_env_var(python_setup.interpreter_search_paths_ensure_directories),
+        PATH=create_path_env_var(python_setup.interpreter_search_paths_ensure_directories()),
         # We ask Pex to --disable-cache so we shouldn't also set a PEX_ROOT (asking it to
         # cache).
         PEX_ROOT="",

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -17,11 +17,7 @@ from pants.util.strutil import create_path_env_var
 
 @dataclass(frozen=True)
 class HermeticPexRequest:
-    exe_req: ExecuteProcessRequest
-
-
-@dataclass(frozen=True)
-class HermeticPexResult:
+    pex_path: str
     exe_req: ExecuteProcessRequest
 
 
@@ -53,7 +49,7 @@ def make_hermetic_pex_exe_request(
     downloaded_pex_bin: DownloadedPexBin,
     hermetic_pex_factory: HermeticPex,
     req: HermeticPexRequest
-) -> HermeticPexResult:
+) -> ExecuteProcessRequest:
     """Creates an ExecuteProcessRequest that will run a PEX hermetically.
 
     :param python_setup: The parameters for selecting python interpreters to use when invoking the
@@ -69,7 +65,7 @@ def make_hermetic_pex_exe_request(
     """
     orig_exe_req = req.exe_req
 
-    pex_path = downloaded_pex_bin.executable
+    pex_path = req.pex_path
 
     hermetic_env = orig_exe_req.env_dict.copy()
     hermetic_env.update(
@@ -104,13 +100,12 @@ def make_hermetic_pex_exe_request(
         *orig_exe_req.argv,
     )
 
-    modified_exe_req = dataclasses.replace(
+    return dataclasses.replace(
         orig_exe_req,
         argv=argv,
         env=hermetic_env,
         input_files=input_files,
     )
-    return HermeticPexResult(modified_exe_req)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -9,7 +9,7 @@ from typing import FrozenSet, Iterable, Iterator, List, NamedTuple, Optional, Se
 from pkg_resources import Requirement
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
-from pants.backend.python.rules.hermetic_pex import HermeticPex
+from pants.backend.python.rules.hermetic_pex import HermeticPexRequest, HermeticPexResult
 from pants.backend.python.rules.targets import Compatibility
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -24,12 +24,13 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult, MultiPlatformExecuteProcessRequest
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
+from pants.python.python_repos import PythonRepos
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
@@ -181,7 +182,7 @@ class CreatePex:
 
 
 @dataclass(frozen=True)
-class Pex(HermeticPex):
+class Pex:
     """Wrapper for a digest containing a pex file created with some filename."""
 
     directory_digest: Digest
@@ -222,6 +223,7 @@ async def create_pex(
     request: CreatePex,
     pex_bin: DownloadedPexBin,
     python_setup: PythonSetup,
+    python_repos: PythonRepos,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
     pex_build_environment: PexBuildEnvironment,
     platform: Platform,
@@ -248,11 +250,19 @@ async def create_pex(
     else:
         argv.append("--no-manylinux")
 
+    argv.append('--no-compile')
+
     if request.entry_point is not None:
         argv.extend(["--entry-point", request.entry_point])
 
     if python_setup.requirement_constraints is not None:
         argv.extend(["--constraints", python_setup.requirement_constraints])
+
+    argv.extend([
+      '--no-pypi',
+      *(f'--index={url}' for url in python_repos.indexes),
+      *(f'--find-links={url}' for url in python_repos.repos),
+    ])
 
     source_dir_name = "source_files"
     argv.append(f"--sources-directory={source_dir_name}")
@@ -296,20 +306,19 @@ async def create_pex(
     # (execution_platform_constraint, target_platform_constraint) of this dictionary is "The output of
     # this command is intended for `target_platform_constraint` iff it is run on `execution_platform
     # constraint`".
+    hermetic_pex_exe_request = await Get[HermeticPexResult](HermeticPexRequest(
+        ExecuteProcessRequest(
+            argv=tuple(argv),
+            input_files=merged_digest,
+            description=f"Resolving {', '.join(request.requirements.requirements)}",
+            output_files=(request.output_filename,),
+        )))
     execute_process_request = MultiPlatformExecuteProcessRequest(
         {
             (
                 PlatformConstraint(platform.value),
                 PlatformConstraint(platform.value),
-            ): pex_bin.create_execute_request(
-                python_setup=python_setup,
-                subprocess_encoding_environment=subprocess_encoding_environment,
-                pex_build_environment=pex_build_environment,
-                pex_args=argv,
-                input_files=merged_digest,
-                description=f"Resolving {', '.join(request.requirements.requirements)}",
-                output_files=(request.output_filename,),
-            )
+            ): hermetic_pex_exe_request.exe_req
         }
     )
 
@@ -332,5 +341,6 @@ async def create_pex(
 def rules():
     return [
         create_pex,
+        subsystem_rule(PythonRepos),
         subsystem_rule(PythonSetup),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -4,16 +4,10 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from pants.backend.python.rules.pex import (
-    CreatePex,
-    Pex,
-    PexInterpreterConstraints,
-    PexRequirements,
-)
+from pants.backend.python.rules.pex import CreatePex, PexInterpreterConstraints, PexRequirements
 from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import FilesAdaptor, PythonTargetAdaptor, ResourcesAdaptor
 from pants.engine.rules import rule

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -13,6 +13,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import FilesAdaptor, PythonTargetAdaptor, ResourcesAdaptor
 from pants.engine.rules import rule
@@ -36,7 +37,7 @@ class CreatePexFromTargetClosure:
 @rule(name="Create PEX from targets")
 async def create_pex_from_target_closure(
     request: CreatePexFromTargetClosure, python_setup: PythonSetup
-) -> Pex:
+) -> CreatePex:
     transitive_hydrated_targets = await Get[TransitiveHydratedTargets](Addresses, request.addresses)
     all_targets = transitive_hydrated_targets.closure
 
@@ -65,7 +66,7 @@ async def create_pex_from_target_closure(
         adaptors=all_target_adaptors, additional_requirements=request.additional_requirements
     )
 
-    create_pex_request = CreatePex(
+    return CreatePex(
         output_filename=request.output_filename,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
@@ -73,9 +74,6 @@ async def create_pex_from_target_closure(
         input_files_digest=merged_input_digest,
         additional_args=request.additional_args,
     )
-
-    pex = await Get[Pex](CreatePex, create_pex_request)
-    return pex
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -309,12 +309,14 @@ async def merge_coverage_data(
         for result in data_batch.addresses_and_test_results
     ]
     coverage_args = ["combine", *prefixes]
-    request = coverage_setup.requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=coverage_args,
-        input_files=merged_input_files,
-        output_files=(".coverage",),
-        description=f"Merge coverage reports.",
-    ))
+    request = coverage_setup.requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=tuple(coverage_args),
+            input_files=merged_input_files,
+            output_files=(".coverage",),
+            description=f"Merge coverage reports.",
+        )
+    )
 
     result = await Get[ExecuteProcessResult](HermeticPexRequest, request)
     return MergedCoverageData(coverage_data=result.output_directory_digest)
@@ -369,13 +371,15 @@ async def generate_coverage_report(
     )
     report_type = coverage_toolbase.options.report
     coverage_args = [report_type.report_name]
-    request = requirements_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=coverage_args,
-        input_files=merged_input_files,
-        output_directories=("htmlcov",),
-        output_files=("coverage.xml",),
-        description=f"Generate coverage report.",
-    ))
+    request = requirements_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=tuple(coverage_args),
+            input_files=merged_input_files,
+            output_directories=("htmlcov",),
+            output_files=("coverage.xml",),
+            description=f"Generate coverage report.",
+        )
+    )
 
     result = await Get[ExecuteProcessResult](HermeticPexRequest, request)
     if report_type == ReportType.CONSOLE:

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -229,16 +229,18 @@ async def run_python_test(
     """Runs pytest for one target."""
     env = {"PYTEST_ADDOPTS": f"--color={'yes' if global_options.options.colors else 'no'}"}
     run_coverage = test_options.values.run_coverage
-    request = test_setup.test_runner_pex.create_hermetic_pex_request(ExecuteProcessRequest(
-        argv=test_setup.args,
-        input_files=test_setup.input_files_digest,
-        output_directories=(".coverage",) if run_coverage else None,
-        description=f"Run Pytest for {pytest_runner.adaptor_with_origin.adaptor.address.reference()}",
-        timeout_seconds=(
-            test_setup.timeout_seconds if test_setup.timeout_seconds is not None else 9999
-        ),
-        env=env,
-    ))
+    request = test_setup.test_runner_pex.create_hermetic_pex_request(
+        ExecuteProcessRequest(
+            argv=test_setup.args,
+            input_files=test_setup.input_files_digest,
+            output_directories=(".coverage",) if run_coverage else None,
+            description=f"Run Pytest for {pytest_runner.adaptor_with_origin.adaptor.address.reference()}",
+            timeout_seconds=(
+                test_setup.timeout_seconds if test_setup.timeout_seconds is not None else 9999
+            ),
+            env=env,
+        )
+    )
     result = await Get[FallibleExecuteProcessResult](HermeticPexRequest, request)
     coverage_data = PytestCoverageData(result.output_directory_digest) if run_coverage else None
     return TestResult.from_fallible_execute_process_result(result, coverage_data=coverage_data)

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 from pants.backend.python.rules import (
     download_pex_bin,
+    hermetic_pex,
     pex,
     pex_from_target_closure,
     prepare_chrooted_python_sources,
@@ -110,6 +111,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
             *pytest_runner.rules(),
             *download_pex_bin.rules(),
             *determine_source_files.rules(),
+            *hermetic_pex.rules(),
             *pex.rules(),
             *pex_from_target_closure.rules(),
             *prepare_chrooted_python_sources.rules(),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -374,7 +374,8 @@ async def run_setup_py(
             # TODO: Could there be other useful files to capture?
             output_directories=(dist_dir,),
             description=f"Run setuptools for {req.exported_target.hydrated_target.adaptor.address.reference()}",
-        ))
+        )
+    )
     result = await Get[ExecuteProcessResult](HermeticPexRequest, hermetic_pex_request)
     output_digest = await Get[Digest](
         DirectoryWithPrefixToStrip(result.output_directory_digest, dist_dir)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -72,10 +72,7 @@ class ExecuteProcessRequest:
 
     @memoized_property
     def env_dict(self) -> Dict[str, str]:
-        return {
-            self.env[i]: self.env[i + 1]
-            for i in range(0, len(self.env), 2)
-        }
+        return {self.env[i]: self.env[i + 1] for i in range(0, len(self.env), 2)}
 
 
 @frozen_after_init

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Tuple, Union
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, rule
+from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,13 @@ class ExecuteProcessRequest:
         )
         self.jdk_home = jdk_home
         self.is_nailgunnable = is_nailgunnable
+
+    @memoized_property
+    def env_dict(self) -> Dict[str, str]:
+        return {
+            self.env[i]: self.env[i + 1]
+            for i in range(0, len(self.env), 2)
+        }
 
 
 @frozen_after_init

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -175,6 +175,9 @@ class Collection(Generic[_C], Iterable):
     def __bool__(self) -> bool:
         return bool(self.dependencies)
 
+    def __repr__(self) -> str:
+        return repr(self.dependencies)
+
 
 @decorated_type_checkable
 def union(cls):

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -169,7 +169,8 @@ class PythonSetup(Subsystem):
 
     @property
     def interpreter_search_paths_ensure_directories(self) -> List[str]:
-        """pex will accept direct paths to python executables, but we need directories to create a hermetic PATH."""
+        """pex will accept direct paths to python executables, but we need directories to create a
+        hermetic PATH."""
         return [
             path if os.path.isdir(path) else os.path.dirname(path)
             for path in self.interpreter_search_paths

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import subprocess
-from typing import Iterable, Optional, Tuple, cast
+from typing import Iterable, List, Optional, Tuple, cast
 
 from pex.variables import Variables
 
@@ -166,6 +166,14 @@ class PythonSetup(Subsystem):
     @memoized_property
     def interpreter_search_paths(self):
         return self.expand_interpreter_search_paths(self.get_options().interpreter_search_paths)
+
+    @property
+    def interpreter_search_paths_ensure_directories(self) -> List[str]:
+        """pex will accept direct paths to python executables, but we need directories to create a hermetic PATH."""
+        return [
+            path if os.path.isdir(path) else os.path.dirname(path)
+            for path in self.interpreter_search_paths
+        ]
 
     @property
     def platforms(self):

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -167,7 +167,6 @@ class PythonSetup(Subsystem):
     def interpreter_search_paths(self):
         return self.expand_interpreter_search_paths(self.get_options().interpreter_search_paths)
 
-    @property
     def interpreter_search_paths_ensure_directories(self) -> List[str]:
         """pex will accept direct paths to python executables, but we need directories to create a
         hermetic PATH."""


### PR DESCRIPTION
### Problem
It's not currently possible to use the v2 python backend within twitter, for multiple reasons:
1. The `HermeticPex` mixin assumes that an executable named `python` will be located on `--python-setup-interpreter-search-paths`, which is not the case for us.
2. `--python-setup-interpreter-search-paths` are currently assumed to be directories when we add them to the PATH, but pexrc files can legitimately contain direct paths to python executables, which is the case at Twitter, so attempting to naively put those on the hermetic pex PATH causes an error.
3. `PythonRepos` isn't piped into hermetic pex creation, so attempting to resolve against anything but PyPI (e.g. our internal `--find-links` indices) will fail.

### Solution

- Remove the `HermeticPex` mixin and make it into a subsystem.
  - Also remove the `create_execute_request()` method from `DownloadedPexBin` in favor of adding rules to `hermetic_pex.py`.
- Add `PythonRepos` to hermetic pex creation.

### Result
We can set the python executable name, and we can consume `--python-setup-interpreter-search-paths`, even if those are file instead of directory paths! We can also successfully resolve from internal python repos.