### PR TITLE
Fix equality and hashing of `engine.Collection` for more cache hits

### DIFF
--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -1,15 +1,79 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
-
 from pants.engine.objects import Collection
 
 
-class CollectionTest(unittest.TestCase):
-    def test_collection_iteration(self) -> None:
-        self.assertEqual([1, 2], [x for x in Collection([1, 2])])
+class Examples(Collection[int]):
+    """A new type to ensure that subclassing works properly."""
 
-    def test_collection_bool(self) -> None:
-        self.assertTrue(bool(Collection([0])))
-        self.assertFalse(bool(Collection([])))
+
+class Examples2(Collection[int]):
+    pass
+
+
+def test_collection_contains() -> None:
+    c1 = Collection([1, 2])
+    assert 1 in c1
+    assert 2 in c1
+    assert 200 not in c1
+    assert "bad" not in c1  # type: ignore[comparison-overlap]
+
+
+def test_collection_iteration() -> None:
+    c1 = Collection([1, 2])
+    assert list(iter(c1)) == [1, 2]
+    assert [x for x in c1] == [1, 2]
+
+
+def test_collection_length() -> None:
+    assert len(Collection([])) == 0
+    assert len(Collection([1, 2])) == 2
+
+
+def test_collection_index() -> None:
+    c1 = Collection([0, 1, 2])
+    assert c1[0] == 0
+    assert c1[-1] == 2
+
+    assert c1[:] == c1
+    assert c1[1:] == Collection([1, 2])
+    assert c1[:1] == Collection([0])
+
+
+def test_collection_reversed() -> None:
+    assert list(reversed(Collection([1, 2, 3]))) == [3, 2, 1]
+
+
+def test_collection_equality() -> None:
+    assert Collection([]) == Collection([])
+    c1 = Collection([1, 2, 3])
+    assert c1 == Collection([1, 2, 3])
+
+    assert c1 != Collection([3, 2, 1])
+    assert c1 != Collection([])
+    assert c1 != Collection([1, 2])
+
+    e1 = Examples([1, 2, 3])
+    assert e1 == Examples([1, 2, 3])
+    assert e1 != Examples2([1, 2, 3])
+
+
+def test_collection_hash() -> None:
+    assert hash(Collection([])) == hash(Collection([]))
+
+    c1 = Collection([1, 2, 3])
+    assert hash(c1) == hash(Collection([1, 2, 3]))
+    assert hash(c1) == hash(Examples([1, 2, 3]))
+
+
+def test_collection_bool() -> None:
+    assert bool(Collection([0])) is True
+    assert bool(Collection([])) is False
+
+
+def test_collection_repr() -> None:
+    assert repr(Collection([])) == "Collection([])"
+    assert repr(Examples([])) == "Examples([])"
+    assert repr(Collection([1, 2, 3])) == "Collection([1, 2, 3])"
+    assert repr(Examples([1, 2, 3])) == "Examples([1, 2, 3])"


### PR DESCRIPTION
Before (identity-based equality):

```python
c1 = Collection([1, 2, 3])
c2 = Collection([1, 2, 3])

assert (c1 == c2) is False
assert (c1.dependencies == c2.dependencies) is True
```

After (value-based equality):

```python
c1 = Collection([1, 2, 3])
c2 = Collection([1, 2, 3])

assert (c1 == c2) is True
assert (c1.dependencies == c2.dependencies) is True
```

This fix is expected to substantially improve cache hits because now duplicate values for `Addresses`, `Targets`, etc will properly leverage the cache.

--

We also tweak `Collection` to be a `Sequence` rather than `Iterable`, which means we have many more useful methods defined like `__len__` and `__contains__`. 

This allows call-sites to directly treat the `Collection` like a tuple newtype, rather than having to access the underlying `.dependencies`.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.