### PR TITLE
fix --tag filtering when a TargetAdaptor has None for the 'tags' kwarg

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -233,6 +233,7 @@ python_library(
 python_tests(
   name='tests',
   dependencies=[
+    'src/python/pants/engine/legacy:structs',
     ':specs'
   ],
   tags = {'partially_type_checked'},

--- a/src/python/pants/base/specs_test.py
+++ b/src/python/pants/base/specs_test.py
@@ -1,13 +1,18 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest
+
 from pants.base.specs import (
+    AddressSpecsMatcher,
     AscendantAddresses,
     DescendantAddresses,
     SiblingAddresses,
     SingleAddress,
     more_specific,
 )
+from pants.build_graph.address import Address
+from pants.engine.legacy.structs import TargetAdaptor
 
 
 def test_more_specific():
@@ -39,3 +44,28 @@ def test_more_specific():
 
     assert descendant_addresses == more_specific(descendant_addresses, None)
     assert descendant_addresses == more_specific(None, descendant_addresses)
+
+
+class AddressSpecsMatcherTest(unittest.TestCase):
+    def _make_target(self, address: str, **kwargs) -> TargetAdaptor:
+        return TargetAdaptor(address=Address.parse(address), **kwargs)
+
+    def _matches(self, matcher: AddressSpecsMatcher, target: TargetAdaptor) -> bool:
+        return matcher.matches_target_address_pair(target.address, target)
+
+    def test_match_target(self):
+        matcher = AddressSpecsMatcher(tags=["-a", "+b"])
+
+        untagged_target = self._make_target(address="//:untagged")
+        b_tagged_target = self._make_target(address="//:b-tagged", tags=["b"])
+        a_and_b_tagged_target = self._make_target(address="//:a-and-b-tagged", tags=["a", "b"])
+        none_tagged_target = self._make_target(address="//:none-tagged-target", tags=None)
+
+        def matches(tgt):
+            return self._matches(matcher, tgt)
+
+        assert not matches(untagged_target)
+        assert matches(b_tagged_target)
+        assert not matches(a_and_b_tagged_target)
+        # This is mostly a test to verify an exception isn't thrown.
+        assert not matches(none_tagged_target)


### PR DESCRIPTION
### Problem

`TargetAdaptor` instances with `tags=None` exist in our monorepo (not yet sure why, this may have happened recently) and this causes an exception when attempting to filter with `--tag`.

### Solution

- Don't assume that a `TargetAdaptor` kwarg is non-`None`.
- Add testing and some type-checking for `AddressSpecsMatcher`.