### PR TITLE
Add Target API bindings for `contrib/go`

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/BUILD
@@ -4,6 +4,7 @@
 contrib_plugin(
   name='plugin',
   dependencies=[
+    'contrib/go/src/python/pants/contrib/go/rules',
     'contrib/go/src/python/pants/contrib/go/targets',
     'contrib/go/src/python/pants/contrib/go/tasks',
     'src/python/pants/build_graph',

--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -4,11 +4,19 @@
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.goal.task_registrar import TaskRegistrar as task
 
-from pants.contrib.go.targets.go_binary import GoBinary
-from pants.contrib.go.targets.go_library import GoLibrary
-from pants.contrib.go.targets.go_protobuf_library import GoProtobufLibrary
-from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
-from pants.contrib.go.targets.go_thrift_library import GoThriftLibrary
+from pants.contrib.go.rules.targets import (
+    GoBinary,
+    GoLibrary,
+    GoProtobufLibrary,
+    GoRemoteLibraries,
+    GoRemoteLibrary,
+    GoThriftLibrary,
+)
+from pants.contrib.go.targets.go_binary import GoBinary as GoBinaryV1
+from pants.contrib.go.targets.go_library import GoLibrary as GoLibraryV1
+from pants.contrib.go.targets.go_protobuf_library import GoProtobufLibrary as GoProtobufLibraryV1
+from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary as GoRemoteLibraryV1
+from pants.contrib.go.targets.go_thrift_library import GoThriftLibrary as GoThriftLibraryV1
 from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
 from pants.contrib.go.tasks.go_buildgen import GoBuildgen
 from pants.contrib.go.tasks.go_checkstyle import GoCheckstyle
@@ -25,15 +33,15 @@ from pants.contrib.go.tasks.go_thrift_gen import GoThriftGen
 def build_file_aliases():
     return BuildFileAliases(
         targets={
-            GoBinary.alias(): TargetMacro.Factory.wrap(GoBinary.create, GoBinary),
-            GoLibrary.alias(): TargetMacro.Factory.wrap(GoLibrary.create, GoLibrary),
-            GoProtobufLibrary.alias(): GoProtobufLibrary,
-            GoThriftLibrary.alias(): GoThriftLibrary,
+            GoBinaryV1.alias(): TargetMacro.Factory.wrap(GoBinaryV1.create, GoBinaryV1),
+            GoLibraryV1.alias(): TargetMacro.Factory.wrap(GoLibraryV1.create, GoLibraryV1),
+            GoProtobufLibraryV1.alias(): GoProtobufLibraryV1,
+            GoThriftLibraryV1.alias(): GoThriftLibraryV1,
             "go_remote_libraries": TargetMacro.Factory.wrap(
-                GoRemoteLibrary.from_packages, GoRemoteLibrary
+                GoRemoteLibraryV1.from_packages, GoRemoteLibraryV1
             ),
             "go_remote_library": TargetMacro.Factory.wrap(
-                GoRemoteLibrary.from_package, GoRemoteLibrary
+                GoRemoteLibraryV1.from_package, GoRemoteLibraryV1
             ),
         }
     )
@@ -52,3 +60,14 @@ def register_goals():
     task(name="go", action=GoCheckstyle).install("lint")
     task(name="go", action=GoTest).install("test")
     task(name="go", action=GoFmt).install("fmt")
+
+
+def targets2():
+    return [
+        GoBinary,
+        GoLibrary,
+        GoProtobufLibrary,
+        GoRemoteLibrary,
+        GoRemoteLibraries,
+        GoThriftLibrary,
+    ]

--- a/contrib/go/src/python/pants/contrib/go/rules/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/rules/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    'src/python/pants/engine:target',
+  ],
+  tags = {"type_checked"},
+)

--- a/contrib/go/src/python/pants/contrib/go/rules/targets.py
+++ b/contrib/go/src/python/pants/contrib/go/rules/targets.py
@@ -16,7 +16,7 @@ class GoSources(Sources):
     default = ("*", "!BUILD", "!BUILD.*")
 
 
-class BuildFlags(StringField):
+class GoBuildFlags(StringField):
     """Build flags to pass to the Go compiler."""
 
     alias = "build_flags"
@@ -26,7 +26,7 @@ class GoBinary(Target):
     """A Go main package."""
 
     alias = "go_binary"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources, BuildFlags)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources, GoBuildFlags)
 
 
 class GoLibrary(Target):
@@ -60,7 +60,7 @@ class GoThriftLibrary(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
 
 
-class Package(StringField):
+class GoPackage(StringField):
     """The package import path within the remote library.
 
     By default, just the root package will be available.
@@ -70,7 +70,7 @@ class Package(StringField):
     default = "."
 
 
-class Revision(StringField):
+class GoRevision(StringField):
     """Identifies which version of the remote library to download.
 
     This could be a commit SHA (git), node id (hg), etc. If left unspecified the version will
@@ -85,10 +85,10 @@ class GoRemoteLibrary(Target):
     """A remote Go package."""
 
     alias = "go_remote_library"
-    core_fields = (*COMMON_TARGET_FIELDS, Package, Revision)
+    core_fields = (*COMMON_TARGET_FIELDS, GoPackage, GoRevision)
 
 
-class Packages(StringSequenceField):
+class GoPackages(StringSequenceField):
     """The package import paths within the remote library.
 
     By default, just the root package will be available.
@@ -102,4 +102,4 @@ class GoRemoteLibraries(Target):
     """Multiple remote Go packages."""
 
     alias = "go_remote_libraries"
-    core_fields = (*COMMON_TARGET_FIELDS, Packages, Revision)
+    core_fields = (*COMMON_TARGET_FIELDS, GoPackages, GoRevision)

--- a/contrib/go/src/python/pants/contrib/go/rules/targets.py
+++ b/contrib/go/src/python/pants/contrib/go/rules/targets.py
@@ -1,0 +1,105 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    Sources,
+    StringField,
+    StringSequenceField,
+    Target,
+)
+
+
+class GoSources(Sources):
+    # NB: We glob on `*` due to the way resources and .c companion files are handled.
+    default = ("*", "!BUILD", "!BUILD.*")
+
+
+class BuildFlags(StringField):
+    """Build flags to pass to the Go compiler."""
+
+    alias = "build_flags"
+
+
+class GoBinary(Target):
+    """A Go main package."""
+
+    alias = "go_binary"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources, BuildFlags)
+
+
+class GoLibrary(Target):
+    """A Go package."""
+
+    alias = "go_library"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources)
+
+
+class GoProtobufSources(Sources):
+    default = ("*.proto",)
+
+
+class ProtocPlugins(StringSequenceField):
+    """Protoc plugins to use when generating code from this target."""
+
+    alias = "protoc_plugins"
+
+
+class GoProtobufLibrary(Target):
+    """A Go library generated from Protobuf IDL files."""
+
+    alias = "go_protobuf_library"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoProtobufSources, ProtocPlugins)
+
+
+class GoThriftLibrary(Target):
+    """A Go library generated from Thrift IDL files."""
+
+    alias = "go_thrift_library"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+
+
+class Package(StringField):
+    """The package import path within the remote library.
+
+    By default, just the root package will be available.
+    """
+
+    alias = "pkg"
+    default = "."
+
+
+class Revision(StringField):
+    """Identifies which version of the remote library to download.
+
+    This could be a commit SHA (git), node id (hg), etc. If left unspecified the version will
+    default to the latest available. It's highly recommended to not accept the default and to
+    instead  pin the rev explicitly for reproducible builds.
+    """
+
+    alias = "rev"
+
+
+class GoRemoteLibrary(Target):
+    """A remote Go package."""
+
+    alias = "go_remote_library"
+    core_fields = (*COMMON_TARGET_FIELDS, Package, Revision)
+
+
+class Packages(StringSequenceField):
+    """The package import paths within the remote library.
+
+    By default, just the root package will be available.
+    """
+
+    alias = "pkg"
+    default = (".",)
+
+
+class GoRemoteLibraries(Target):
+    """Multiple remote Go packages."""
+
+    alias = "go_remote_libraries"
+    core_fields = (*COMMON_TARGET_FIELDS, Packages, Revision)

--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -1,3 +1,6 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 python_library(
   dependencies=[
     'src/python/pants/base:build_environment',

--- a/contrib/go/src/python/pants/contrib/go/targets/go_thrift_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_thrift_library.py
@@ -16,7 +16,6 @@ class GoThriftLibrary(Target):
         :param sources: thrift source files
         :type sources: :class:`pants.source.wrapped_globs.FilesetWithSpec` or list of strings. Paths
                        are relative to the BUILD file's directory.
-        :param import_path: Deprecated: unused.
         """
         payload = payload or Payload()
         payload.add_field(


### PR DESCRIPTION
The focus is exclusively on accurately reflecting on the state of V1 targets, rather than making any changes.

All new targets:

<img width="557" alt="all go targets" src="https://user-images.githubusercontent.com/14852634/78102178-8add3000-739e-11ea-9b66-d4f88d9197f8.png">

<img width="725" alt="go_binary" src="https://user-images.githubusercontent.com/14852634/78102225-aba58580-739e-11ea-93c9-ba1f484e6e37.png">

<img width="719" alt="go_library" src="https://user-images.githubusercontent.com/14852634/78102242-b9f3a180-739e-11ea-8bb5-c52ab06ccddd.png">

<img width="724" alt="go_protobuf_library" src="https://user-images.githubusercontent.com/14852634/78102268-cbd54480-739e-11ea-84d2-115eb857e423.png">

<img width="711" alt="go_thrift_library" src="https://user-images.githubusercontent.com/14852634/78102294-dee81480-739e-11ea-9dc1-083b859d5ca3.png">

<img width="709" alt="go_remote_library" src="https://user-images.githubusercontent.com/14852634/78102334-f1fae480-739e-11ea-9108-faf8c9a665b4.png">

<img width="715" alt="go_remote_libraries" src="https://user-images.githubusercontent.com/14852634/78102370-0212c400-739f-11ea-9cad-dde55e96a207.png">

