### PR TITLE
Pass all `python_binary` fields to V2 `binary` and `run` 

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -10,7 +10,7 @@ from pants.backend.python.rules.targets import (
     PexAlwaysWriteCache,
     PexEmitWarnings,
     PexIgnoreErrors,
-    PexIndices,
+    PexIndexes,
     PexInheritPath,
     PexRepositories,
     PexShebang,
@@ -37,7 +37,7 @@ class PythonBinaryConfiguration(BinaryConfiguration):
     always_write_cache: PexAlwaysWriteCache
     emit_warnings: PexEmitWarnings
     ignore_errors: PexIgnoreErrors
-    indices: PexIndices
+    indexes: PexIndexes
     inherit_path: PexInheritPath
     repositories: PexRepositories
     shebang: PexShebang
@@ -52,8 +52,11 @@ class PythonBinaryConfiguration(BinaryConfiguration):
             args.append("--no-emit-warnings")
         if self.ignore_errors.value is True:
             args.append("--ignore-errors")
-        if self.indices.value is not None:
-            args.extend([f"--index={index}" for index in self.indices.value])
+        if self.indexes.value is not None:
+            if not self.indexes.value:
+                args.append("--no-index")
+            else:
+                args.extend([f"--index={index}" for index in self.indexes.value])
         if self.inherit_path.value is not None:
             args.append(f"--inherit-path={self.inherit_path.value}")
         if self.repositories.value is not None:

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -8,20 +8,18 @@ from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.rules.targets import EntryPoint, PythonBinarySources
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.build_graph.address import Address
 from pants.engine.addressable import Addresses
 from pants.engine.rules import UnionRule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Target
-from pants.rules.core.binary import BinaryImplementation, CreatedBinary
+from pants.rules.core.binary import BinaryConfiguration, CreatedBinary
 from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
 
 
 @dataclass(frozen=True)
-class PythonBinaryImplementation(BinaryImplementation):
+class PythonBinaryConfiguration(BinaryConfiguration):
     required_fields = (EntryPoint, PythonBinarySources)
 
-    address: Address
     sources: PythonBinarySources
     entry_point: EntryPoint
 
@@ -31,18 +29,20 @@ class PythonBinaryImplementation(BinaryImplementation):
     #  required fields. Use `Target.get()` in the `create()` method.
 
     @classmethod
-    def create(cls, tgt: Target) -> "PythonBinaryImplementation":
-        return cls(tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint])
+    def create(cls, tgt: Target) -> "PythonBinaryConfiguration":
+        return cls(
+            address=tgt.address, sources=tgt[PythonBinarySources], entry_point=tgt[EntryPoint]
+        )
 
 
 @rule
-async def create_python_binary(implementation: PythonBinaryImplementation) -> CreatedBinary:
+async def create_python_binary(config: PythonBinaryConfiguration) -> CreatedBinary:
     entry_point: Optional[str]
-    if implementation.entry_point.value is not None:
-        entry_point = implementation.entry_point.value
+    if config.entry_point.value is not None:
+        entry_point = config.entry_point.value
     else:
         source_files = await Get[SourceFiles](
-            AllSourceFilesRequest([implementation.sources], strip_source_roots=True)
+            AllSourceFilesRequest([config.sources], strip_source_roots=True)
         )
         # NB: `PythonBinarySources` enforces that we have 0-1 sources.
         if len(source_files.files) == 1:
@@ -52,9 +52,9 @@ async def create_python_binary(implementation: PythonBinaryImplementation) -> Cr
             entry_point = None
 
     request = CreatePexFromTargetClosure(
-        addresses=Addresses([implementation.address]),
+        addresses=Addresses([config.address]),
         entry_point=entry_point,
-        output_filename=f"{implementation.address.target_name}.pex",
+        output_filename=f"{config.address.target_name}.pex",
     )
 
     pex = await Get[Pex](CreatePexFromTargetClosure, request)
@@ -62,4 +62,4 @@ async def create_python_binary(implementation: PythonBinaryImplementation) -> Cr
 
 
 def rules():
-    return [create_python_binary, UnionRule(BinaryImplementation, PythonBinaryImplementation)]
+    return [create_python_binary, UnionRule(BinaryConfiguration, PythonBinaryConfiguration)]

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -178,10 +178,8 @@ class PexInheritPath(StringField):
     def compute_value(
         cls, raw_value: Optional[Union[str, bool]], *, address: Address
     ) -> Optional[str]:
-        if raw_value is False:
-            return "false"
-        if raw_value is True:
-            return "prefer"
+        if isinstance(raw_value, bool):
+            return "prefer" if raw_value else "false"
         return super().compute_value(raw_value, address=address)
 
 

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -137,7 +137,7 @@ class Timeout(IntField):
         return result
 
 
-class EntryPoint(StringField):
+class PythonEntryPoint(StringField):
     """The default entry point for the binary.
 
     If omitted, Pants will try to infer the entry point by looking at the `source` argument for a
@@ -147,28 +147,49 @@ class EntryPoint(StringField):
     alias = "entry_point"
 
 
-class Platforms(StringOrStringSequenceField):
-    """Extra platforms to target when building a Python binary."""
+class PythonPlatforms(StringOrStringSequenceField):
+    """Extra platforms to target when building a Python binary.
+
+    This defaults to the current platform, but can be overridden to different platforms. You can
+    give a list of multiple platforms to create a multiplatform PEX.
+
+    To use wheels for specific interpreter/platform tags, you can append them to the platform with
+    hyphens like: PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-27-cp27mu",
+    "macosx_10.12_x86_64-cp-36-cp36m"). PLATFORM is the host platform e.g. "linux-x86_64",
+    "macosx-10.12-x86_64", etc". IMPL is the Python implementation abbreviation
+    (e.g. "cp", "pp", "jp"). PYVER is a two-digit string representing the python version
+    (e.g. "27", "36"). ABI is the ABI tag (e.g. "cp36m", "cp27mu", "abi3", "none").
+    """
 
     alias = "platforms"
 
 
-class PexInheritPath(BoolField):
-    """Whether to inherit the `sys.path` of the environment that the binary runs in or not."""
+class PexInheritPath(StringField):
+    """Whether to inherit the `sys.path` of the environment that the binary runs in.
+
+    Use `false` to not inherit `sys.path`; use `fallback` to inherit `sys.path` after packaged
+    dependencies; and use `prefer` to inherit `sys.path` before packaged dependencies.
+    """
 
     alias = "inherit_path"
-    default = False
+    valid_values = ("false", "fallback", "prefer")
 
 
 class PexZipSafe(BoolField):
-    """Whether or not this binary is safe to run in compacted (zip-file) form."""
+    """Whether or not this binary is safe to run in compacted (zip-file) form.
+
+    If they are not zip safe, they will be written to disk prior to execution.
+    """
 
     alias = "zip_safe"
     default = True
 
 
 class PexAlwaysWriteCache(BoolField):
-    """Whether Pex should always write the .deps cache of the Pex file to disk or not."""
+    """Whether Pex should always write the .deps cache of the Pex file to disk or not.
+
+    This can use less memory in RAM constrained environments.
+    """
 
     alias = "always_write_cache"
     default = False
@@ -181,12 +202,12 @@ class PexRepositories(StringOrStringSequenceField):
 
 
 class PexIndices(StringOrStringSequenceField):
-    """Indices for Pex to use for packages."""
+    """Additional indices for Pex to use for packages."""
 
     alias = "indices"
 
 
-class IgnorePexErrors(BoolField):
+class PexIgnoreErrors(BoolField):
     """Should we ignore when Pex cannot resolve dependencies?"""
 
     alias = "ignore_errors"
@@ -202,7 +223,7 @@ class PexShebang(StringField):
 # TODO: This option is weird. Its default is determined by `--python-binary-pex-emit-warnings`.
 #  How would that work with the Target API? Likely, make this an AsyncField and in the rule
 #  request the corresponding subsystem. For now, we ignore the option.
-class EmitPexWarnings(BoolField):
+class PexEmitWarnings(BoolField):
     """Whether or not to emit Pex warnings at runtime."""
 
     alias = "emit_warnings"
@@ -224,16 +245,16 @@ class PythonBinary(Target):
     core_fields = (
         *COMMON_PYTHON_FIELDS,
         PythonBinarySources,
-        EntryPoint,
-        Platforms,
+        PythonEntryPoint,
+        PythonPlatforms,
         PexInheritPath,
         PexZipSafe,
         PexAlwaysWriteCache,
         PexRepositories,
         PexIndices,
-        IgnorePexErrors,
+        PexIgnoreErrors,
         PexShebang,
-        EmitPexWarnings,
+        PexEmitWarnings,
     )
 
 

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -209,8 +209,12 @@ class PexRepositories(StringOrStringSequenceField):
     alias = "repositories"
 
 
-class PexIndices(StringOrStringSequenceField):
-    """Additional indices for Pex to use for packages."""
+class PexIndexes(StringOrStringSequenceField):
+    """Additional indices for Pex to use for packages.
+
+    If set to an empty list, i.e. `indices=[]`, then Pex will use no indices (meaning it will not
+    use PyPI).
+    """
 
     alias = "indices"
 
@@ -259,7 +263,7 @@ class PythonBinary(Target):
         PexZipSafe,
         PexAlwaysWriteCache,
         PexRepositories,
-        PexIndices,
+        PexIndexes,
         PexIgnoreErrors,
         PexShebang,
         PexEmitWarnings,

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -3,7 +3,7 @@
 
 import os.path
 from pathlib import PurePath
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.build_graph.address import Address
@@ -172,6 +172,17 @@ class PexInheritPath(StringField):
     """
 
     alias = "inherit_path"
+
+    # TODO(#9388): deprecate allowing this to be a `bool`.
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Union[str, bool]], *, address: Address
+    ) -> Optional[str]:
+        if raw_value is False:
+            return "false"
+        if raw_value is True:
+            return "prefer"
+        return super().compute_value(raw_value, address=address)
 
 
 class PexZipSafe(BoolField):

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -172,7 +172,6 @@ class PexInheritPath(StringField):
     """
 
     alias = "inherit_path"
-    valid_values = ("false", "fallback", "prefer")
 
 
 class PexZipSafe(BoolField):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -637,29 +637,15 @@ class FloatField(PrimitiveField, metaclass=ABCMeta):
 
 
 class StringField(PrimitiveField, metaclass=ABCMeta):
-    """A field for a string value.
-
-    You can set `valid_values` to emulate an enum, i.e. to ensure that the string is one of the
-    valid options.
-    """
-
     value: Optional[str]
     default: ClassVar[Optional[str]] = None
-    valid_values: ClassVar[Optional[Tuple[str, ...]]] = None
 
     @classmethod
     def compute_value(cls, raw_value: Optional[str], *, address: Address) -> Optional[str]:
         value_or_default = super().compute_value(raw_value, address=address)
-        if value_or_default is None:
-            return None
-        if not isinstance(value_or_default, str):
+        if value_or_default is not None and not isinstance(value_or_default, str):
             raise InvalidFieldTypeException(
                 address, cls.alias, value_or_default, expected_type="a string",
-            )
-        if cls.valid_values is not None and value_or_default not in cls.valid_values:
-            raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} must be one of "
-                f"{sorted(cls.valid_values)}, but was {repr(raw_value)}."
             )
         return value_or_default
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -637,15 +637,29 @@ class FloatField(PrimitiveField, metaclass=ABCMeta):
 
 
 class StringField(PrimitiveField, metaclass=ABCMeta):
+    """A field for a string value.
+
+    You can set `valid_values` to emulate an enum, i.e. to ensure that the string is one of the
+    valid options.
+    """
+
     value: Optional[str]
     default: ClassVar[Optional[str]] = None
+    valid_values: ClassVar[Optional[Tuple[str, ...]]] = None
 
     @classmethod
     def compute_value(cls, raw_value: Optional[str], *, address: Address) -> Optional[str]:
         value_or_default = super().compute_value(raw_value, address=address)
-        if value_or_default is not None and not isinstance(value_or_default, str):
+        if value_or_default is None:
+            return None
+        if not isinstance(value_or_default, str):
             raise InvalidFieldTypeException(
                 address, cls.alias, value_or_default, expected_type="a string",
+            )
+        if cls.valid_values is not None and value_or_default not in cls.valid_values:
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} must be one of "
+                f"{sorted(cls.valid_values)}, but was {repr(raw_value)}."
             )
         return value_or_default
 

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -57,9 +57,9 @@ class BinaryConfiguration(ABC):
         return cls(  # type: ignore[call-arg]
             address=tgt.address,
             **{
-                dataclass_field_name: tgt[field_cls]
-                if field_cls in cls.required_fields
-                else tgt.get(field_cls)
+                dataclass_field_name: (
+                    tgt[field_cls] if field_cls in cls.required_fields else tgt.get(field_cls)
+                )
                 for dataclass_field_name, field_cls in all_expected_fields.items()
             },
         )

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -20,14 +20,18 @@ from pants.engine.target import Field, RegisteredTargetTypes, Target, WrappedTar
 from pants.rules.core.distdir import DistDir
 
 
-# TODO: This might not be the right level of abstraction. Possibly factor out some superclass.
-#  Revisit after porting lint.py, fmt.py, and test.py to use the Target API.
+# TODO: Factor this out once porting fmt.py and lint.py to the Target API.
 @union
-class BinaryImplementation(ABC):
+@dataclass(frozen=True)  # type: ignore[misc]   # https://github.com/python/mypy/issues/5374
+class BinaryConfiguration(ABC):
+    """An ad hoc collection of the fields necessary to create a binary from a target."""
+
     required_fields: ClassVar[Tuple[Type[Field], ...]]
 
+    address: Address
+
     @classmethod
-    def is_valid_target(cls, tgt: Target) -> bool:
+    def is_valid(cls, tgt: Target) -> bool:
         return tgt.has_fields(cls.required_fields)
 
     @classmethod
@@ -42,7 +46,7 @@ class BinaryImplementation(ABC):
 
     @classmethod
     @abstractmethod
-    def create(cls, tgt: Target) -> "BinaryImplementation":
+    def create(cls, tgt: Target) -> "BinaryConfiguration":
         pass
 
 
@@ -58,7 +62,7 @@ class BinaryOptions(LineOriented, GoalSubsystem):
 
     name = "binary"
 
-    required_union_implementations = (BinaryImplementation,)
+    required_union_implementations = (BinaryConfiguration,)
 
 
 class Binary(Goal):
@@ -94,20 +98,18 @@ async def coordinator_of_binaries(
     registered_target_types: RegisteredTargetTypes,
 ) -> CreatedBinary:
     target = wrapped_target.target
-    binary_implementations: Iterable[Type[BinaryImplementation]] = union_membership.union_rules[
-        BinaryImplementation
+    binary_config_types: Iterable[Type[BinaryConfiguration]] = union_membership.union_rules[
+        BinaryConfiguration
     ]
-    valid_binary_implementations = [
-        binary_implementation
-        for binary_implementation in binary_implementations
-        if binary_implementation.is_valid_target(target)
+    valid_binary_config_types = [
+        config_type for config_type in binary_config_types if config_type.is_valid(target)
     ]
-    if not valid_binary_implementations:
+    if not valid_binary_config_types:
         all_valid_target_types = itertools.chain.from_iterable(
-            implementation.valid_target_types(
+            config_type.valid_target_types(
                 registered_target_types.types, union_membership=union_membership
             )
-            for implementation in binary_implementations
+            for config_type in binary_config_types
         )
         formatted_target_types = sorted(target_type.alias for target_type in all_valid_target_types)
         # TODO: this is a leaky abstraction that the error message knows this rule is being used
@@ -122,9 +124,9 @@ async def coordinator_of_binaries(
     #  with one implementation. But, we don't necessarily need to enforce this with `./v2 binary`.
     #  See https://github.com/pantsbuild/pants/pull/9345#discussion_r395221542 for some possible
     #  semantics for `./v2 binary`.
-    if len(valid_binary_implementations) > 1:
-        possible_implementations = sorted(
-            implementation.__name__ for implementation in valid_binary_implementations
+    if len(valid_binary_config_types) > 1:
+        possible_config_types = sorted(
+            config_type.__name__ for config_type in valid_binary_config_types
         )
         # TODO: improve this error message. (It's never actually triggered yet because we only have
         #  Python implemented with V2.) A better error message would explain to users how they can
@@ -132,10 +134,10 @@ async def coordinator_of_binaries(
         raise ValueError(
             f"Multiple of the registered binary implementations work for {target.address} "
             f"(target type {repr(target.alias)}). It is ambiguous which implementation to use. "
-            f"Possible implementations: {possible_implementations}."
+            f"Possible implementations: {possible_config_types}."
         )
-    binary_implementation = valid_binary_implementations[0]
-    return await Get[CreatedBinary](BinaryImplementation, binary_implementation.create(target))
+    config_type = valid_binary_config_types[0]
+    return await Get[CreatedBinary](BinaryConfiguration, config_type.create(target))
 
 
 def rules():

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -14,7 +14,7 @@ from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 from pants.option.custom_types import shell_str
 from pants.option.global_options import GlobalOptions
-from pants.rules.core.binary import BinaryImplementation, CreatedBinary
+from pants.rules.core.binary import BinaryConfiguration, CreatedBinary
 from pants.util.contextutil import temporary_dir
 
 
@@ -23,8 +23,8 @@ class RunOptions(GoalSubsystem):
 
     name = "run"
 
-    # NB: To be runnable, there must be a BinaryImplementation that works with the target.
-    required_union_implementations = (BinaryImplementation,)
+    # NB: To be runnable, there must be a BinaryConfiguration that works with the target.
+    required_union_implementations = (BinaryConfiguration,)
 
     @classmethod
     def register_options(cls, register) -> None:


### PR DESCRIPTION
We were ignoring optional fields like `ZipSafe`.

## Implications for the Target API

### Uses `Configuration` name

This represents the ad hoc collection of Fields needed by a rule to work.

### New sugar for `Configuration`s

We use the `dataclasses` API to factor up the `.create()` class method on `Configuration`s.

This allows us to make `Configuration` declarations truly declarative. They simply register all Fields as dataclass fields/attributes, then indicate which of those Fields are required vs. optional, and `Configuration` will set everything up.

```python
class PythonBinaryConfiguration(BinaryConfiguration):
    required_fields = (PythonEntryPoint, PythonBinarySources)

    sources: PythonBinarySources
    entry_point: PythonEntryPoint

    always_write_cache: PexAlwaysWriteCache
    emit_warnings: PexEmitWarnings
    ignore_errors: PexIgnoreErrors
    ...
```