### PR TITLE
Fix uploading `native_engine.so` to AWS too many times in CI

### DIFF
--- a/build-support/bin/bootstrap_and_deploy_ci_pants_pex.py
+++ b/build-support/bin/bootstrap_and_deploy_ci_pants_pex.py
@@ -37,11 +37,10 @@ def main() -> None:
         f"{args.native_engine_so_key_prefix}/{native_engine_so_hash}/native_engine.so"
     )
     native_engine_so_aws_url = f"s3://{args.aws_bucket}/{native_engine_so_aws_key}"
-    native_engine_so_already_cached = native_engine_so_in_s3_cache(
-        aws_bucket=args.aws_bucket, native_engine_so_aws_key=native_engine_so_aws_key
-    )
 
-    if native_engine_so_already_cached:
+    if native_engine_so_in_s3_cache(
+        aws_bucket=args.aws_bucket, native_engine_so_aws_key=native_engine_so_aws_key
+    ):
         banner(
             f"`native_engine.so` found in the AWS S3 cache at {native_engine_so_aws_url}. "
             f"Downloading to avoid unnecessary Rust compilation."
@@ -58,7 +57,9 @@ def main() -> None:
 
     bootstrap_pants_pex(python_version)
 
-    if native_engine_so_already_cached:
+    if native_engine_so_in_s3_cache(
+        aws_bucket=args.aws_bucket, native_engine_so_aws_key=native_engine_so_aws_key
+    ):
         banner(f"`native_engine.so` already cached at {native_engine_so_aws_url}. Skipping deploy.")
     else:
         banner(f"Deploying `native_engine.so` to {native_engine_so_aws_url}.")

--- a/build-support/bin/native/bootstrap_cffi.sh
+++ b/build-support/bin/native/bootstrap_cffi.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 set -e
 

--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -1,4 +1,8 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
+
 # Defines:
 # + CACHE_ROOT: The pants cache directory, ie: ~/.cache/pants.
 # Exposes:

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -1,3 +1,6 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 
 # Defines:

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -1,5 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 
 # Exposes:

--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 set -e
 

--- a/build-support/bin/native/print_engine_hash.sh
+++ b/build-support/bin/native/print_engine_hash.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
- # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
- # Licensed under the Apache License, Version 2.0 (see LICENSE).
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 
  # shellcheck source=build-support/bin/native/calculate_engine_hash.sh

--- a/build-support/bin/native/rust_toolchain.sh
+++ b/build-support/bin/native/rust_toolchain.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 set -e
 


### PR DESCRIPTION
It was possible for multiple distinct bootstrap shards to have an empty cache at their start, so initiate a compile, and then to all try uploading `native_engine.so` around a similar time without detecting that another shard already uploaded during the time to compile.

This PR reduces the risk of this race condition happening. 

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.

