### PR TITLE
Don't rerun uncachable nodes if they are dirtied while running.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -151,7 +151,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     process_execution_local_enable_nailgun=False,
-    experimental_fs_watcher=False,
+    experimental_fs_watcher=True,
 )
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -866,7 +866,7 @@ class GlobalOptions(Subsystem):
         register(
             "--experimental-fs-watcher",
             type=bool,
-            default=False,
+            default=True,
             advanced=True,
             help="Whether to use the engine filesystem watcher which registers the workspace"
             " for kernel file change events",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1103,8 +1103,10 @@ name = "graph"
 version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 boxfuture = { path = "../boxfuture" }
 fnv = "1.0.5"
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../hashing" }
 indexmap = "1.0.2"
 log = "0.4"
@@ -17,3 +18,4 @@ petgraph = "0.4.5"
 
 [dev-dependencies]
 rand = "0.6"
+env_logger = "0.5.4"

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -451,7 +451,7 @@ impl<N: Node> Entry<N> {
             generation,
             previous_result,
           }
-        } else if dirty && self.node.cacheable() {
+        } else if dirty {
           // The node was dirtied while it was running. The dep_generations and new result cannot
           // be trusted and were never published. We continue to use the previous result.
           trace!(

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -370,7 +370,7 @@ impl<N: Node> Entry<N> {
             entry_id,
             run_token,
             generation,
-            if self.node.cacheable(context) {
+            if self.node.cacheable() {
               Some(dep_generations)
             } else {
               None
@@ -451,7 +451,7 @@ impl<N: Node> Entry<N> {
             generation,
             previous_result,
           }
-        } else if dirty {
+        } else if dirty && self.node.cacheable() {
           // The node was dirtied while it was running. The dep_generations and new result cannot
           // be trusted and were never published. We continue to use the previous result.
           trace!(
@@ -473,7 +473,7 @@ impl<N: Node> Entry<N> {
         } else {
           // If the new result does not match the previous result, the generation increments.
           let (generation, next_result) = if let Some(result) = result {
-            let next_result = if !self.node.cacheable(context) {
+            let next_result = if !self.node.cacheable() {
               EntryResult::Uncacheable(result, context.session_id().clone())
             } else if has_dirty_dependencies {
               EntryResult::Dirty(result)

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -169,7 +169,7 @@ impl<N: Node> InnerGraph<N> {
     let mut roots = VecDeque::new();
     roots.push_back(root);
     self
-      .walk(roots, direction, |_| false)
+      .walk(roots, direction, |_, _| false)
       .any(|eid| eid == needle)
   }
 
@@ -291,7 +291,7 @@ impl<N: Node> InnerGraph<N> {
   /// The Walk will iterate over all nodes that descend from the roots in the direction of
   /// traversal but won't necessarily be in topological order.
   ///
-  fn walk<F: Fn(&N) -> bool>(
+  fn walk<F: Fn(&EntryId, &Self) -> bool>(
     &self,
     roots: VecDeque<EntryId>,
     direction: Direction,
@@ -338,7 +338,7 @@ impl<N: Node> InnerGraph<N> {
       .walk(
         root_ids.iter().cloned().collect(),
         Direction::Incoming,
-        |n| !n.cacheable(),
+        |id, graph| !graph.entry_for_id(*id).unwrap().node().cacheable(),
       )
       .filter(|eid| !root_ids.contains(eid))
       .collect();
@@ -400,7 +400,7 @@ impl<N: Node> InnerGraph<N> {
       .cloned()
       .collect();
 
-    for eid in self.walk(root_entries, Direction::Outgoing, |_| false) {
+    for eid in self.walk(root_entries, Direction::Outgoing, |_, _| false) {
       let entry = self.unsafe_entry_for_id(eid);
       let node_str = entry.format(context);
 
@@ -617,7 +617,7 @@ impl<N: Node> InnerGraph<N> {
     self
       .digests_internal(
         self
-          .walk(root_ids, Direction::Outgoing, |_| false)
+          .walk(root_ids, Direction::Outgoing, |_, _| false)
           .collect(),
         context.clone(),
       )
@@ -1098,7 +1098,7 @@ pub mod test_support {
 ///
 struct Walk<'a, N: Node, F>
 where
-  F: Fn(&N) -> bool,
+  F: Fn(&EntryId, &'a InnerGraph<N>) -> bool,
 {
   graph: &'a InnerGraph<N>,
   direction: Direction,
@@ -1107,7 +1107,7 @@ where
   stop_walking_predicate: F,
 }
 
-impl<'a, N: Node + 'a, F: Fn(&N) -> bool> Iterator for Walk<'a, N, F> {
+impl<'a, N: Node + 'a, F: Fn(&EntryId, &InnerGraph<N>) -> bool> Iterator for Walk<'a, N, F> {
   type Item = EntryId;
 
   fn next(&mut self) -> Option<Self::Item> {
@@ -1116,9 +1116,7 @@ impl<'a, N: Node + 'a, F: Fn(&N) -> bool> Iterator for Walk<'a, N, F> {
       // stopping our walk at this node, based on if it satifies the stop_walking_predicate.
       // This mechanism gives us a way to selectively dirty parts of the graph respecting node boundaries
       // like uncacheable nodes, which sholdn't be dirtied.
-      if !self.walked.insert(id)
-        || (self.stop_walking_predicate)(self.graph.entry_for_id(id).unwrap().node())
-      {
+      if !self.walked.insert(id) || (self.stop_walking_predicate)(&id, self.graph) {
         continue;
       }
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -37,7 +37,7 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   ///
   /// If the node result is cacheable, return true.
   ///
-  fn cacheable(&self, context: &Self::Context) -> bool;
+  fn cacheable(&self) -> bool;
 
   /// Nodes optionally have a user-facing name (distinct from their Debug and Display
   /// implementations). This user-facing name is intended to provide high-level information
@@ -55,6 +55,12 @@ pub trait NodeError: Clone + Debug + Eq + Send {
   /// Graph (generally while running).
   ///
   fn invalidated() -> Self;
+  ///
+  /// Creates an instance that represents an uncacheable node failing from
+  /// retrying its dependencies too many times, but never able to resolve them,
+  /// usually because they were invalidated too many times while running.
+  ///
+  fn exhausted() -> Self;
 
   ///
   /// Creates an instance that represents that a Node dependency was cyclic along the given path.
@@ -100,7 +106,7 @@ pub trait NodeTracer<N: Node> {
 ///
 /// A context passed between Nodes that also stores an EntryId to uniquely identify them.
 ///
-pub trait NodeContext: Clone + Send + 'static {
+pub trait NodeContext: Clone + Send + Sync + 'static {
   ///
   /// The type generated when this Context is cloned for another Node.
   ///
@@ -111,7 +117,7 @@ pub trait NodeContext: Clone + Send + 'static {
   /// have Session-specific semantics. More than one context object might be associated with a
   /// single caller "session".
   ///
-  type SessionId: Clone + Debug + Eq;
+  type SessionId: Clone + Debug + Eq + Send;
 
   ///
   /// Creates a clone of this NodeContext to be used for a different Node.

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -524,7 +524,7 @@ struct T(usize, usize);
 /// to the result.
 ///
 #[derive(Clone, Debug)]
-struct TNode(usize, bool /*cacheablility*/);
+struct TNode(usize, bool /*cacheability*/);
 impl TNode {
   fn new(id: usize) -> Self {
     TNode(id, true)

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -307,7 +307,7 @@ fn exhaust_uncacheable_retries() {
     graph2.invalidate_from_roots(|&TNode(n, _)| n == 0);
   });
   let (assertion, subject) = match graph.create(TNode::new(2), &context).wait() {
-    Err(TError::Exhausted) => (true, None),
+    Err(TError::Throw) => (true, None),
     Err(e) => (false, Some(Err(e))),
     other => (false, Some(other)),
   };
@@ -315,7 +315,7 @@ fn exhaust_uncacheable_retries() {
   assert!(
     assertion,
     "expected {:?} found {:?}",
-    Err::<(), TError>(TError::Exhausted),
+    Err::<(), TError>(TError::Throw),
     subject
   );
 }
@@ -771,7 +771,7 @@ impl TContext {
 enum TError {
   Cyclic,
   Invalidated,
-  Exhausted,
+  Throw,
 }
 impl NodeError for TError {
   fn invalidated() -> Self {
@@ -779,7 +779,7 @@ impl NodeError for TError {
   }
 
   fn exhausted() -> Self {
-    TError::Exhausted
+    TError::Throw
   }
 
   fn cyclic(_path: Vec<String>) -> Self {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -296,7 +296,7 @@ fn exhaust_uncacheable_retries() {
       .with_delays(delays)
   };
 
-  let sleep_per_invalidation = Duration::from_millis(50);
+  let sleep_per_invalidation = Duration::from_millis(10);
   let graph2 = graph.clone();
   let (send, recv) = mpsc::channel();
   let _join = thread::spawn(move || loop {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -3,6 +3,7 @@ use rand;
 
 use std::cmp;
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
@@ -21,7 +22,7 @@ fn create() {
   let graph = Arc::new(Graph::new());
   let context = TContext::new(graph.clone());
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
 }
@@ -33,14 +34,17 @@ fn invalidate_and_clean() {
 
   // Create three nodes.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0)]);
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(2), TNode::new(1), TNode::new(0)]
+  );
 
   // Clear the middle Node, which dirties the upper node.
   assert_eq!(
-    graph.invalidate_from_roots(|&TNode(n)| n == 1),
+    graph.invalidate_from_roots(|&TNode(n, _)| n == 1),
     InvalidationResult {
       cleared: 1,
       dirtied: 1
@@ -49,10 +53,13 @@ fn invalidate_and_clean() {
 
   // Confirm that the cleared Node re-runs, and the upper node is cleaned without re-running.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0), TNode(1)]);
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(2), TNode::new(1), TNode::new(0), TNode::new(1)]
+  );
 }
 
 #[test]
@@ -62,14 +69,17 @@ fn invalidate_and_rerun() {
 
   // Create three nodes.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0)]);
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(2), TNode::new(1), TNode::new(0)]
+  );
 
   // Clear the middle Node, which dirties the upper node.
   assert_eq!(
-    graph.invalidate_from_roots(|&TNode(n)| n == 1),
+    graph.invalidate_from_roots(|&TNode(n, _)| n == 1),
     InvalidationResult {
       cleared: 1,
       dirtied: 1
@@ -80,10 +90,10 @@ fn invalidate_and_rerun() {
   // their input values have changed.
   let context = context.new_session(1).with_salt(1);
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 1), T(2, 1)])
   );
-  assert_eq!(context.runs(), vec![TNode(1), TNode(2)]);
+  assert_eq!(context.runs(), vec![TNode::new(1), TNode::new(2)]);
 }
 
 #[test]
@@ -93,13 +103,13 @@ fn invalidate_with_changed_dependencies() {
 
   // Create three nodes.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
 
   // Clear the middle Node, which dirties the upper node.
   assert_eq!(
-    graph.invalidate_from_roots(|&TNode(n)| n == 1),
+    graph.invalidate_from_roots(|&TNode(n, _)| n == 1),
     InvalidationResult {
       cleared: 1,
       dirtied: 1
@@ -107,17 +117,17 @@ fn invalidate_with_changed_dependencies() {
   );
 
   // Request with a new context that truncates execution at the middle Node.
-  let context =
-    TContext::new(graph.clone()).with_dependencies(vec![(TNode(1), None)].into_iter().collect());
+  let context = TContext::new(graph.clone())
+    .with_dependencies(vec![(TNode::new(1), None)].into_iter().collect());
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(1, 0), T(2, 0)])
   );
 
   // Confirm that dirtying the bottom Node does not affect the middle/upper Nodes, which no
   // longer depend on it.
   assert_eq!(
-    graph.invalidate_from_roots(|&TNode(n)| n == 0),
+    graph.invalidate_from_roots(|&TNode(n, _)| n == 0),
     InvalidationResult {
       cleared: 1,
       dirtied: 0,
@@ -145,7 +155,7 @@ fn invalidate_randomly() {
 
       // Invalidate a random node in the graph.
       let candidate = rng.gen_range(0, range);
-      graph2.invalidate_from_roots(|&TNode(n)| n == candidate);
+      graph2.invalidate_from_roots(|&TNode(n, _)| n == candidate);
 
       thread::sleep(sleep_per_invalidation);
     }
@@ -160,7 +170,7 @@ fn invalidate_randomly() {
     let context = TContext::new(graph.clone()).with_salt(iterations);
 
     // Compute the root, and validate its output.
-    let node_output = match graph.create(TNode(range), &context).wait() {
+    let node_output = match graph.create(TNode::new(range), &context).wait() {
       Ok(output) => output,
       Err(TError::Invalidated) => {
         // Some amnount of concurrent invalidation is expected: retry.
@@ -198,33 +208,116 @@ fn dirty_dependents_of_uncacheable_node() {
   // Create a context for which the bottommost Node is not cacheable.
   let context = {
     let mut uncacheable = HashSet::new();
-    uncacheable.insert(TNode(0));
+    uncacheable.insert(TNode::new(0));
     TContext::new(graph.clone()).with_uncacheable(uncacheable)
   };
 
   // Create three nodes.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context.runs(), vec![TNode(2), TNode(1), TNode(0)]);
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(2), TNode::new(1), TNode::new(0)]
+  );
 
   // Re-request the root in a new session and confirm that only the bottom node re-runs.
   let context = context.new_session(1);
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
-  assert_eq!(context.runs(), vec![TNode(0)]);
+  assert_eq!(context.runs(), vec![TNode::new(0)]);
 
   // Re-request with a new session and different salt, and confirm that everything re-runs bottom
   // up (the order of node cleaning).
   let context = context.new_session(2).with_salt(1);
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 1), T(1, 1), T(2, 1)])
   );
-  assert_eq!(context.runs(), vec![TNode(0), TNode(1), TNode(2)]);
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(0), TNode::new(1), TNode::new(2)]
+  );
+}
+
+#[test]
+fn uncachable_node_only_runs_once() {
+  let _logger = env_logger::try_init();
+  let graph = Arc::new(Graph::new());
+
+  let context = {
+    let mut uncacheable = HashSet::new();
+    uncacheable.insert(TNode::new(1));
+    let delay_for_root = Duration::from_millis(1000);
+    let mut delays = HashMap::new();
+    delays.insert(TNode::new(0), delay_for_root);
+    TContext::new(graph.clone())
+      .with_uncacheable(uncacheable)
+      .with_delays(delays)
+  };
+
+  let graph2 = graph.clone();
+  let (send, recv) = mpsc::channel::<()>();
+  let _join = thread::spawn(move || {
+    recv.recv_timeout(Duration::from_millis(100)).unwrap();
+    thread::sleep(Duration::from_millis(50));
+    graph2.invalidate_from_roots(|&TNode(n, _)| n == 0);
+  });
+
+  send.send(()).unwrap();
+  assert_eq!(
+    graph.create(TNode::new(2), &context).wait(),
+    Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
+  );
+  // TNode(0) was cleared by the invalidation while all nodes were running,
+  // but the uncacheable node TNode(1) reties it directly, so it runs twice.
+  assert_eq!(
+    context.runs(),
+    vec![TNode::new(2), TNode::new(1), TNode::new(0), TNode::new(0)]
+  );
+}
+
+#[test]
+fn exhaust_uncacheable_retries() {
+  let _logger = env_logger::try_init();
+  let graph = Arc::new(Graph::new());
+
+  let context = {
+    let mut uncacheable = HashSet::new();
+    uncacheable.insert(TNode::new(1));
+    let delay_for_root = Duration::from_millis(100);
+    let mut delays = HashMap::new();
+    delays.insert(TNode::new(0), delay_for_root);
+    TContext::new(graph.clone())
+      .with_uncacheable(uncacheable)
+      .with_delays(delays)
+  };
+
+  let sleep_per_invalidation = Duration::from_millis(50);
+  let graph2 = graph.clone();
+  let (send, recv) = mpsc::channel();
+  let _join = thread::spawn(move || loop {
+    if let Ok(_) = recv.try_recv() {
+      break;
+    };
+    thread::sleep(sleep_per_invalidation);
+    graph2.invalidate_from_roots(|&TNode(n, _)| n == 0);
+  });
+  let (assertion, subject) = match graph.create(TNode::new(2), &context).wait() {
+    Err(TError::Exhausted) => (true, None),
+    Err(e) => (false, Some(Err(e))),
+    other => (false, Some(other)),
+  };
+  send.send(()).unwrap();
+  assert!(
+    assertion,
+    "expected {:?} found {:?}",
+    Err::<(), TError>(TError::Exhausted),
+    subject
+  );
 }
 
 #[test]
@@ -240,7 +333,7 @@ fn drain_and_resume() {
   // requesting TNode(0).
   let context = {
     let mut delays = HashMap::new();
-    delays.insert(TNode(1), delay_in_task);
+    delays.insert(TNode::new(1), delay_in_task);
     TContext::new(graph.clone()).with_delays(delays)
   };
 
@@ -256,7 +349,7 @@ fn drain_and_resume() {
   // Request a TNode(1) in the "delayed" context, and expect it to be interrupted by the
   // drain.
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Err(TError::Invalidated),
   );
 
@@ -266,7 +359,7 @@ fn drain_and_resume() {
     .mark_draining(false)
     .expect("Should already be draining.");
   assert_eq!(
-    graph.create(TNode(2), &context).wait(),
+    graph.create(TNode::new(2), &context).wait(),
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
 }
@@ -275,13 +368,16 @@ fn drain_and_resume() {
 fn cyclic_failure() {
   // Confirms that an attempt to create a cycle fails.
   let graph = Arc::new(Graph::new());
-  let top = TNode(2);
+  let top = TNode::new(2);
   let context = TContext::new(graph.clone()).with_dependencies(
     // Request creation of a cycle by sending the bottom most node to the top.
-    vec![(TNode(0), Some(top))].into_iter().collect(),
+    vec![(TNode::new(0), Some(top))].into_iter().collect(),
   );
 
-  assert_eq!(graph.create(TNode(2), &context).wait(), Err(TError::Cyclic));
+  assert_eq!(
+    graph.create(TNode::new(2), &context).wait(),
+    Err(TError::Cyclic)
+  );
 }
 
 #[test]
@@ -289,8 +385,8 @@ fn cyclic_dirtying() {
   // Confirms that a dirtied path between two nodes is able to reverse direction while being
   // cleaned.
   let graph = Arc::new(Graph::new());
-  let initial_top = TNode(2);
-  let initial_bot = TNode(0);
+  let initial_top = TNode::new(2);
+  let initial_bot = TNode::new(0);
 
   // Request with a context that creates a path downward.
   let context_down = TContext::new(graph.clone());
@@ -303,7 +399,7 @@ fn cyclic_dirtying() {
   graph.invalidate_from_roots(|n| n == &initial_bot);
   let context_up = context_down.with_salt(1).with_dependencies(
     // Reverse the path from bottom to top.
-    vec![(TNode(1), None), (TNode(0), Some(TNode(1)))]
+    vec![(TNode::new(1), None), (TNode::new(0), Some(TNode::new(1)))]
       .into_iter()
       .collect(),
   );
@@ -348,7 +444,7 @@ fn critical_path() {
   // Describe a few transformations to navigate between our readable data and the actual types
   // needed for the graph.
   let tnode = |node: &str| {
-    TNode(
+    TNode::new(
       nodes
         .iter()
         .map(|(k, _)| k)
@@ -427,8 +523,24 @@ struct T(usize, usize);
 /// A node that builds a Vec of tokens by recursively requesting itself and appending its value
 /// to the result.
 ///
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct TNode(usize);
+#[derive(Clone, Debug)]
+struct TNode(usize, bool /*cacheablility*/);
+impl TNode {
+  fn new(id: usize) -> Self {
+    TNode(id, true)
+  }
+}
+impl PartialEq for TNode {
+  fn eq(&self, other: &Self) -> bool {
+    self.0 == other.0
+  }
+}
+impl Eq for TNode {}
+impl Hash for TNode {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.0.hash(state);
+  }
+}
 impl Node for TNode {
   type Context = TContext;
   type Item = Vec<T>;
@@ -437,8 +549,8 @@ impl Node for TNode {
   fn run(self, context: TContext) -> BoxFuture<Vec<T>, TError> {
     context.ran(self.clone());
     let token = T(self.0, context.salt());
+    context.maybe_delay(&self);
     if let Some(dep) = context.dependency_of(&self) {
-      context.maybe_delay(&self);
       context
         .get(dep)
         .map(move |mut v| {
@@ -455,8 +567,8 @@ impl Node for TNode {
     None
   }
 
-  fn cacheable(&self, context: &Self::Context) -> bool {
-    !context.uncacheable.contains(self)
+  fn cacheable(&self) -> bool {
+    self.1
   }
 }
 
@@ -639,7 +751,13 @@ impl TContext {
     match self.edges.get(node) {
       Some(Some(ref dep)) => Some(dep.clone()),
       Some(None) => None,
-      None if node.0 > 0 => Some(TNode(node.0 - 1)),
+      None if node.0 > 0 => {
+        let new_node_id = node.0 - 1;
+        Some(TNode(
+          new_node_id,
+          !self.uncacheable.contains(&TNode::new(new_node_id)),
+        ))
+      }
       None => None,
     }
   }
@@ -653,10 +771,15 @@ impl TContext {
 enum TError {
   Cyclic,
   Invalidated,
+  Exhausted,
 }
 impl NodeError for TError {
   fn invalidated() -> Self {
     TError::Invalidated
+  }
+
+  fn exhausted() -> Self {
+    TError::Exhausted
   }
 
   fn cyclic(_path: Vec<String>) -> Self {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -287,27 +287,15 @@ pub enum Failure {
   /// A Node failed because a filesystem change invalidated it or its inputs.
   /// A root requestor should usually immediately retry their request.
   Invalidated,
-  /// A uncacheable node exhausted retry attempts for its dependencies because
-  /// they were invalidated too many times while running. This enum variant is distinguished
-  /// from Invalidated because we DONT want the scheduler to retry the request. Uncacheable
-  /// nodes are allowed to have side-effects and they shouldn't be run multiple times in one
-  /// session.
-  Exhausted,
   /// A rule raised an exception.
   Throw(Value, String),
-  FileWatch(String),
 }
 
 impl fmt::Display for Failure {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       Failure::Invalidated => write!(f, "Giving up on retrying due to changed files."),
-      Failure::Exhausted => write!(
-        f,
-        "Giving up on uncacheable node retries due to changing files."
-      ),
       Failure::Throw(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
-      Failure::FileWatch(failure) => write!(f, "{}", failure),
     }
   }
 }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -287,6 +287,12 @@ pub enum Failure {
   /// A Node failed because a filesystem change invalidated it or its inputs.
   /// A root requestor should usually immediately retry their request.
   Invalidated,
+  /// A uncacheable node exhausted retry attempts for its dependencies because
+  /// they were invalidated too many times while running. This enum variant is distinguished
+  /// from Invalidated because we DONT want the scheduler to retry the request. Uncacheable
+  /// nodes are allowed to have side-effects and they shouldn't be run multiple times in one
+  /// session.
+  Exhausted,
   /// A rule raised an exception.
   Throw(Value, String),
   FileWatch(String),
@@ -295,7 +301,11 @@ pub enum Failure {
 impl fmt::Display for Failure {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      Failure::Invalidated => write!(f, "Exhausted retries due to changed files."),
+      Failure::Invalidated => write!(f, "Giving up on retrying due to changed files."),
+      Failure::Exhausted => write!(
+        f,
+        "Giving up on uncacheable node retries due to changing files."
+      ),
       Failure::Throw(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
       Failure::FileWatch(failure) => write!(f, "{}", failure),
     }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -461,9 +461,7 @@ impl From<Result<Value, Failure>> for PyResult {
       Err(f) => {
         let val = match f {
           f @ Failure::Invalidated => create_exception(&format!("{}", f)),
-          f @ Failure::Exhausted => create_exception(&format!("{}", f)),
           Failure::Throw(exc, _) => exc,
-          Failure::FileWatch(failure) => create_exception(&failure),
         };
         PyResult {
           is_throw: true,

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -461,6 +461,7 @@ impl From<Result<Value, Failure>> for PyResult {
       Err(f) => {
         let val = match f {
           f @ Failure::Invalidated => create_exception(&format!("{}", f)),
+          f @ Failure::Exhausted => create_exception(&format!("{}", f)),
           Failure::Throw(exc, _) => exc,
           Failure::FileWatch(failure) => create_exception(&failure),
         };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1161,7 +1161,7 @@ impl NodeError for Failure {
 
   fn exhausted() -> Failure {
     Context::mk_error(
-      "Exhausted retries for uncacheable node. The filesystem was changing to much.",
+      "Exhausted retries for uncacheable node. The filesystem was changing too much.",
     )
   }
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -722,10 +722,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         on those files."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(
-                rules=create_fs_rules(),
-                project_tree=project_tree,
-            )
+            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
             fname = "4.txt"
             new_data = "rouf"
             # read the original file so we have a cached value.
@@ -751,10 +748,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         """Test that FileContent is invalidated after deleting parent directory."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(
-                rules=create_fs_rules(),
-                project_tree=project_tree,
-            )
+            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
             fname = "a/b/1.txt"
             # read the original file so we have nodes to invalidate.
             original_content = self.read_file_content(scheduler, [fname])
@@ -777,10 +771,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         self, mutation_function: Callable[[FileSystemProjectTree, str], Exception]
     ):
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(
-                rules=create_fs_rules(),
-                project_tree=project_tree,
-            )
+            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
             dir_path = "a/"
             dir_glob = dir_path + "*"
             initial_snapshot = self.execute_expecting_one_result(

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -725,7 +725,6 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             scheduler = self.mk_scheduler(
                 rules=create_fs_rules(),
                 project_tree=project_tree,
-                execution_options={"experimental_fs_watcher": True},
             )
             fname = "4.txt"
             new_data = "rouf"
@@ -755,7 +754,6 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             scheduler = self.mk_scheduler(
                 rules=create_fs_rules(),
                 project_tree=project_tree,
-                execution_options={"experimental_fs_watcher": True},
             )
             fname = "a/b/1.txt"
             # read the original file so we have nodes to invalidate.
@@ -782,7 +780,6 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             scheduler = self.mk_scheduler(
                 rules=create_fs_rules(),
                 project_tree=project_tree,
-                execution_options={"experimental_fs_watcher": True},
             )
             dir_path = "a/"
             dir_glob = dir_path + "*"


### PR DESCRIPTION
### Problem

After landing #9318 it was observed that, with invalidation present, goals which modify the workspace like `fmt` were causing goal rules, which have side effects and shouldn't run more than once per session to run up to 8 times (8 is the number of allowed retries in the scheduler). This was codified in #9415 and a work around was merged. This PR fixes the underlying issue which is that goal_rules, which are represented by uncacheable nodes, should not be re-run ever in the same session.

### Solution
If a goal rules dependencies are invalidated while it is running, we now try to rerun them a number of times before giving up, and bubbling an Error up to the scheduler / user. A different error is used to distinguish from the scheduler retries around invalidated deps. We also don't dirty the dependents of uncacheable nodes when walking the inverted graph to invalidate nodes from fs events. This is because if we dirty them while they are running they will re-run, the scheduler will think they failed and will try to re-run them, which would cause their deps (which are uncacheable) to also re-run.

### Result

Running `./v2 --experimental-fs-watcher fmt some/target/::` only runs the fmt once, and doesn't sporadically error. Additionally, changing files in the workspace manually, say while tests are running, won't cause them to print console output multiple times.