### PR TITLE
Add `DictStringToStringField` and `DictStringToStringSequenceField` field templates

### DIFF
--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -11,6 +11,8 @@ from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.target import (
     AsyncField,
     BoolField,
+    DictStringToStringField,
+    DictStringToStringSequenceField,
     Field,
     FloatField,
     IntField,
@@ -101,6 +103,8 @@ class FieldInfo:
                     AsyncField,
                     PrimitiveField,
                     BoolField,
+                    DictStringToStringField,
+                    DictStringToStringSequenceField,
                     FloatField,
                     IntField,
                     StringField,

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -166,12 +166,6 @@ class RemoteSourcesTargetType(PrimitiveField):
         return cast(Type[TargetV1], super().compute_value(raw_value, address=address))
 
 
-# TODO: maybe add a DictField? This could be a can of worms. How should we type the values? It
-#  doesn't seem safe to assume `Dict[str, str]`. We would want to use `FrozenDict` to store the
-#  computed value, but how should we handle converting the values into hashable types, e.g.
-#  converting a List[str] to Tuple[str, ...]?
-#
-#  Audit other uses of dict fields before adding something.
 class RemoteSourcesArgs(PrimitiveField):
     """Any additional arguments necessary to construct the synthetic destination target (sources and
     dependencies are supplied automatically)."""


### PR DESCRIPTION
While writing bindings for 5 different backends, several times I encountered fields that are either `Dict[str, str]` or `Dict[str, Iterable[str]]`. It appears frequently enough to warrant a template field, especially because the code is particularly tricky to validate and hydrate.

This also adds testing for several other field templates and fixes some missed edge cases.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
