### PR TITLE
Use `GlobMatchErrorBehavior.error` in `TestBase`

### DIFF
--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -5,7 +5,6 @@ tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integrat
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration_with_zjars
-tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/jvm/tasks:junit_run_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_concurrency_integration

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/buildozer_util.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/buildozer_util.py
@@ -3,10 +3,10 @@
 
 
 def prepare_dependencies(self):
-    self.add_to_build_file("a", 'java_library(name="a")')
-    self.add_to_build_file("b", 'java_library(name="b", dependencies=["a:a"])')
-    self.add_to_build_file("c", 'java_library(name="c", dependencies=["a:a"])')
-    self.add_to_build_file("d", 'java_library(name="d", dependencies=["a:a", "b"])')
+    self.add_to_build_file("a", 'java_library(name="a", sources=[])')
+    self.add_to_build_file("b", 'java_library(name="b", sources=[], dependencies=["a:a"])')
+    self.add_to_build_file("c", 'java_library(name="c", sources=[], dependencies=["a:a"])')
+    self.add_to_build_file("d", 'java_library(name="d", sources=[], dependencies=["a:a", "b"])')
 
     targets = {"a": self.make_target("a")}
     targets["b"] = self.make_target("b", dependencies=[targets["a"]])

--- a/pants.toml
+++ b/pants.toml
@@ -89,6 +89,7 @@ pants_ignore.add = [
   # We shouldn't walk or watch the rust compiler artifacts because it is slow.
   "/src/rust/engine/target",
 ]
+files_not_found_behavior = "error"
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.

--- a/pants.toml
+++ b/pants.toml
@@ -89,7 +89,6 @@ pants_ignore.add = [
   # We shouldn't walk or watch the rust compiler artifacts because it is slow.
   "/src/rust/engine/target",
 ]
-files_not_found_behavior = "error"
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.

--- a/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
+++ b/src/python/pants/backend/project_info/rules/dependencies_integration_test.py
@@ -30,7 +30,11 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
 
     def create_python_library(self, path: str, *, dependencies: Optional[List[str]] = None) -> None:
         self.create_library(
-            path=path, target_type="python_library", name="target", dependencies=dependencies or []
+            path=path,
+            target_type="python_library",
+            name="target",
+            dependencies=dependencies or [],
+            sources=[],
         )
 
     def create_python_requirement_library(self, name: str) -> None:

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -165,17 +165,21 @@ class TestGenerateChroot(TestSetupPyBase):
             "src/python/invalid_binary/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='not_a_binary')
+                python_library(name='not_a_binary', sources=[])
                 python_binary(name='no_entrypoint')
                 python_library(
-                  name='invalid_bin1',
-                  provides=setup_py(name='invalid_bin1', version='1.1.1').with_binaries(
-                  foo=':not_a_binary')
+                    name='invalid_bin1',
+                    sources=[],
+                    provides=setup_py(
+                        name='invalid_bin1', version='1.1.1'
+                    ).with_binaries(foo=':not_a_binary')
                 )
                 python_library(
-                  name='invalid_bin2',
-                  provides=setup_py(name='invalid_bin2', version='1.1.1').with_binaries(
-                  foo=':no_entrypoint')
+                    name='invalid_bin2',
+                    sources=[],
+                    provides=setup_py(
+                        name='invalid_bin2', version='1.1.1'
+                    ).with_binaries(foo=':no_entrypoint')
                 )
                 """
             ),
@@ -334,19 +338,21 @@ class TestGetRequirements(TestSetupPyBase):
             ),
         )
         self.create_file(
-            "src/python/foo/bar/baz/BUILD", "python_library(dependencies=['3rdparty:ext1'])"
+            "src/python/foo/bar/baz/BUILD",
+            "python_library(dependencies=['3rdparty:ext1'], sources=[])",
         )
         self.create_file(
             "src/python/foo/bar/qux/BUILD",
-            "python_library(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'])",
+            "python_library(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'], sources=[])",
         )
         self.create_file(
             "src/python/foo/bar/BUILD",
             textwrap.dedent(
                 """
                 python_library(
-                  dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
-                  provides=setup_py(name='bar', version='9.8.7')
+                    sources=[],
+                    dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
+                    provides=setup_py(name='bar', version='9.8.7'),
                 )
               """
             ),
@@ -356,8 +362,9 @@ class TestGetRequirements(TestSetupPyBase):
             textwrap.dedent(
                 """
                 python_library(
-                  dependencies=['3rdparty:ext3', 'src/python/foo/bar'],
-                  provides=setup_py(name='corge', version='2.2.2')
+                    sources=[],
+                    dependencies=['3rdparty:ext3', 'src/python/foo/bar'],
+                    provides=setup_py(name='corge', version='2.2.2'),
                 )
                 """
             ),
@@ -458,8 +465,8 @@ class TestGetOwnedDependencies(TestSetupPyBase):
             "src/python/foo/bar/baz/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='baz1')
-                python_library(name='baz2')
+                python_library(name='baz1', sources=[])
+                python_library(name='baz2', sources=[])
                 """
             ),
         )
@@ -467,11 +474,17 @@ class TestGetOwnedDependencies(TestSetupPyBase):
             "src/python/foo/bar/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='bar1',
-                               dependencies=['src/python/foo/bar/baz:baz1'],
-                               provides=setup_py(name='bar1', version='1.1.1'))
-                python_library(name='bar2',
-                               dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'])
+                python_library(
+                    name='bar1',
+                    sources=[],
+                    dependencies=['src/python/foo/bar/baz:baz1'],
+                    provides=setup_py(name='bar1', version='1.1.1'),
+                )
+                python_library(
+                    name='bar2',
+                    sources=[],
+                    dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
+                )
                 resources(name='bar-resources')
                 """
             ),
@@ -480,9 +493,12 @@ class TestGetOwnedDependencies(TestSetupPyBase):
             "src/python/foo/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='foo',
-                               dependencies=['src/python/foo/bar:bar1', 'src/python/foo/bar:bar2'],
-                               provides=setup_py(name='foo', version='3.4.5'))
+                python_library(
+                    name='foo',
+                    sources=[],
+                    dependencies=['src/python/foo/bar:bar1', 'src/python/foo/bar:bar2'],
+                    provides=setup_py(name='foo', version='3.4.5'),
+                )
                 """
             ),
         )
@@ -535,8 +551,8 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/foo/bar/baz/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='baz1')
-                python_library(name='baz2')
+                python_library(name='baz1', sources=[])
+                python_library(name='baz2', sources=[])
                 """
             ),
         )
@@ -544,11 +560,17 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/foo/bar/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='bar1',
-                               dependencies=['src/python/foo/bar/baz:baz1'],
-                               provides=setup_py(name='bar1', version='1.1.1'))
-                python_library(name='bar2',
-                               dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'])
+                python_library(
+                    name='bar1',
+                    sources=[],
+                    dependencies=['src/python/foo/bar/baz:baz1'],
+                    provides=setup_py(name='bar1', version='1.1.1'),
+                )
+                python_library(
+                    name='bar2',
+                    sources=[],
+                    dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
+                )
                 resources(name='bar-resources')
                 """
             ),
@@ -557,13 +579,19 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/foo/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='foo1',
-                               dependencies=['src/python/foo/bar/baz:baz2'],
-                               provides=setup_py(name='foo1', version='0.1.2'))
-                python_library(name='foo2')
-                python_library(name='foo3',
-                               dependencies=['src/python/foo/bar:bar2'],
-                               provides=setup_py(name='foo3', version='3.4.5'))
+                python_library(
+                    name='foo1',
+                    sources=[],
+                    dependencies=['src/python/foo/bar/baz:baz2'],
+                    provides=setup_py(name='foo1', version='0.1.2'),
+                )
+                python_library(name='foo2', sources=[])
+                python_library(
+                    name='foo3',
+                    sources=[],
+                    dependencies=['src/python/foo/bar:bar2'],
+                    provides=setup_py(name='foo3', version='3.4.5'),
+                )
                 """
             ),
         )
@@ -585,10 +613,13 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/siblings/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='sibling1')
-                python_library(name='sibling2',
-                               dependencies=['src/python/siblings:sibling1'],
-                               provides=setup_py(name='siblings', version='2.2.2'))
+                python_library(name='sibling1', sources=[])
+                python_library(
+                    name='sibling2',
+                    sources=[],
+                    dependencies=['src/python/siblings:sibling1'],
+                    provides=setup_py(name='siblings', version='2.2.2'),
+                )
                 """
             ),
         )
@@ -601,7 +632,7 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/notanancestor/aaa/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='aaa')
+                python_library(name='aaa', sources=[])
                 """
             ),
         )
@@ -609,9 +640,12 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/notanancestor/bbb/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='bbb',
-                               dependencies=['src/python/notanancestor/aaa'],
-                               provides=setup_py(name='bbb', version='11.22.33'))
+                python_library(
+                    name='bbb',
+                    sources=[],
+                    dependencies=['src/python/notanancestor/aaa'],
+                    provides=setup_py(name='bbb', version='11.22.33'),
+                )
                 """
             ),
         )
@@ -624,7 +658,7 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/aaa/bbb/ccc/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='ccc')
+                python_library(name='ccc', sources=[])
                 """
             ),
         )
@@ -632,9 +666,12 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/aaa/bbb/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='bbb',
-                               dependencies=['src/python/aaa/bbb/ccc'],
-                               provides=setup_py(name='bbb', version='1.1.1'))
+                python_library(
+                    name='bbb',
+                    sources=[],
+                    dependencies=['src/python/aaa/bbb/ccc'],
+                    provides=setup_py(name='bbb', version='1.1.1'),
+                )
                 """
             ),
         )
@@ -642,9 +679,12 @@ class TestGetExportingOwner(TestSetupPyBase):
             "src/python/aaa/BUILD",
             textwrap.dedent(
                 """
-                python_library(name='aaa',
-                               dependencies=['src/python/aaa/bbb/ccc'],
-                               provides=setup_py(name='aaa', version='2.2.2'))
+                python_library(
+                    name='aaa',
+                    sources=[],
+                    dependencies=['src/python/aaa/bbb/ccc'],
+                    provides=setup_py(name='aaa', version='2.2.2'),
+                )
                 """
             ),
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -46,7 +46,7 @@ class FileNotFoundBehavior(Enum):
         deprecated_conditional(
             lambda: self == type(self).ignore,
             removal_version="1.29.0.dev2",
-            entity_description="--files-not-found-behavior-option=ignore",
+            entity_description="--files-not-found-behavior=ignore",
             hint_message=(
                 "If you currently set `--files-not-found-behavior=ignore`, you will "
                 "need to instead either set `--files-not-found-behavior=warn` (the "

--- a/src/python/pants/rules/core/cloc_test.py
+++ b/src/python/pants/rules/core/cloc_test.py
@@ -89,6 +89,6 @@ class ClocTest(GoalRuleTestBase):
 
     def test_no_sources_exits_gracefully(self) -> None:
         py_dir = "src/py/foo"
-        self.add_to_build_file(py_dir, "python_library()")
+        self.add_to_build_file(py_dir, "python_library(sources=[])")
         output = self.execute_rule(args=[py_dir])
         assert output.strip() == ""

--- a/src/python/pants/rules/core/determine_source_files_test.py
+++ b/src/python/pants/rules/core/determine_source_files_test.py
@@ -67,11 +67,10 @@ class DetermineSourceFilesTest(TestBase):
         sources_field_cls: Type[SourcesField] = SourcesField,
     ) -> Tuple[SourcesField, OriginSpec]:
         sources_field = sources_field_cls(
-            sources.source_files, address=Address.parse(f"{sources.source_root}:lib")
+            sources.source_files if include_sources else [],
+            address=Address.parse(f"{sources.source_root}:lib"),
         )
-        self.create_files(
-            path=sources.source_root, files=(sources.source_files if include_sources else [])
-        )
+        self.create_files(path=sources.source_root, files=sources.source_files)
         if origin is None:
             origin = SiblingAddresses(sources.source_root)
         return sources_field, origin

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources = ['*.py', '!payload_fields.py'],
+  sources = ['*.py', '!payload_fields.py', '!test_*.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:dataclasses',

--- a/src/python/pants/source/test_wrapped_globs.py
+++ b/src/python/pants/source/test_wrapped_globs.py
@@ -36,10 +36,12 @@ class FilesetRelPathWrapperTest(TestBase):
         self.create_link("y", "z/w/y")
 
     def test_no_dir_glob(self) -> None:
+        self.create_file("y/f.txt")
         self.add_to_build_file("y/BUILD", 'dummy_target(name="y", sources=["*"])')
         self.context().scan()
 
     def test_no_dir_glob_question(self) -> None:
+        self.create_file("y/?")
         self.add_to_build_file("y/BUILD", 'dummy_target(name="y", sources=["?"])')
         self.context().scan()
 
@@ -59,6 +61,7 @@ class FilesetRelPathWrapperTest(TestBase):
         )
 
     def test_glob_mid_single(self) -> None:
+        self.create_file("y/a/dir/Fleem.java")
         self._spec_test('["a/*/Fleem.java"]', {"globs": ["y/a/*/Fleem.java"]})
 
     def test_glob_to_spec_list(self) -> None:
@@ -112,25 +115,17 @@ class FilesetRelPathWrapperTest(TestBase):
         )
 
     def test_subdir_glob(self) -> None:
+        self.create_file("y/dir/f.scala")
         self.add_to_build_file("y/BUILD", 'dummy_target(name="y", sources=["dir/*.scala"])')
         self.context().scan()
 
     def test_subdir_glob_question(self) -> None:
+        self.create_file("y/dir/?.scala")
         self.add_to_build_file("y/BUILD", 'dummy_target(name="y", sources=["dir/?.scala"])')
         self.context().scan()
 
-    def test_subdir_bracket_glob(self) -> None:
-        self.add_to_build_file(
-            "y/BUILD",
-            dedent(
-                """
-                dummy_target(name="y", sources=["dir/[dir1, dir2]/*.scala"])
-                """
-            ),
-        )
-        self.context().scan()
-
     def test_subdir_with_dir_glob(self) -> None:
+        self.create_file("y/dir/test/f.scala")
         self.add_to_build_file("y/BUILD", 'dummy_target(name="y", sources=["dir/**/*.scala"])')
         self.context().scan()
 

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -643,7 +643,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         if sources:
             self.create_files(path, sources)
 
-        sources_str = f"sources={repr(sources)}," if sources else ""
+        sources_str = f"sources={repr(sources)}," if sources is not None else ""
         if java_sources is not None:
             formatted_java_sources = ",".join(f'"{str_target}"' for str_target in java_sources)
             java_sources_str = f"java_sources=[{formatted_java_sources}],"

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -21,7 +21,7 @@ from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target as TargetV1
-from pants.engine.fs import PathGlobs, PathGlobsAndRoot, Snapshot
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, PathGlobsAndRoot, Snapshot
 from pants.engine.legacy.graph import HydratedField
 from pants.engine.legacy.structs import SourceGlobs, SourcesField
 from pants.engine.rules import RootRule
@@ -415,6 +415,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             pants_ignore_patterns=[],
             local_store_dir=local_store_dir,
             build_file_imports_behavior=BuildFileImportsBehavior.error,
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
             native=init_native(),
             options_bootstrapper=options_bootstrapper,
             build_root=self.build_root,

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
@@ -50,7 +50,7 @@ class JavaAntlrLibraryTest(TestBase):
                 dedent(
                     """
                     java_antlr_library(name='foo',
-                      sources=['foo'],
+                      sources=[],
                       compiler='antlr9'
                     )"""
                 ),

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -135,7 +135,7 @@ class WikiPageTest(TestBase):
         self.assertNotEqual(fingerprint_before, create_page_target("space2").payload.fingerprint())
 
     def test_no_sources(self):
-        self.add_to_build_file("", "page(name='page', sources=['does-not-exist.md'])")
+        self.add_to_build_file("", "page(name='page', sources=[])")
         with self.assertRaisesRegex(AddressLookupError, r"//:page.*exactly 1 source, but found 0"):
             self.target(":page")
 

--- a/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
@@ -69,6 +69,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
         add_to_build_file("overlaps", "four", alias=True, deps=["common/b"])
         add_to_build_file("overlaps", "five", deps=["overlaps:four"])
 
+        self.create_file("resources/a/a.resource")
         self.add_to_build_file(
             "resources/a",
             dedent(
@@ -95,6 +96,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
         )
 
         # Compile idl tests
+        self.create_file("src/thrift/example/1.thrift")
         self.add_to_build_file(
             "src/thrift/example",
             dedent(
@@ -123,6 +125,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
             ),
         )
 
+        self.create_file("src/thrift/example/1.java")
         self.add_to_build_file(
             "src/thrift/example",
             dedent(
@@ -155,6 +158,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
         )
 
         # External Dependency tests
+        self.create_file("src/java/example/1.java")
         self.add_to_build_file(
             "src/java/example",
             dedent(
@@ -168,6 +172,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
             ),
         )
 
+        self.create_file("src/java/example/2.java")
         self.add_to_build_file(
             "src/java/example",
             dedent(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -305,20 +305,6 @@ python_tests(
 )
 
 python_tests(
-  name = 'ivy_resolve_integration',
-  sources = ['test_ivy_resolve_integration.py'],
-  dependencies = [
-    'examples/src/scala/org/pantsbuild/example:hello_directory',
-    'src/java/org/pantsbuild:junit_directory',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/testutil:int-test',
-    'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
-  ],
-  timeout = 240,
-  tags = {'integration', 'partially_type_checked'},
-)
-
-python_tests(
   name = 'ivy_utils',
   sources = ['test_ivy_utils.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
@@ -14,7 +14,8 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
         return BinaryCreate
 
     def test_jvm_binaries_products(self):
-        self.add_to_build_file("bar", 'jvm_binary(name = "bar-binary", source = "Bar.java")')
+        self.create_file("bar/Bar.java")
+        self.add_to_build_file("bar", 'jvm_binary(name = "bar-binary", sources = ["Bar.java"])')
         binary_target = self.target("//bar:bar-binary")
         context = self.context(target_roots=[binary_target])
         classpath_products = self.ensure_classpath_products(context)
@@ -58,11 +59,12 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
         )
         foo_jar_lib = self.target("3rdparty/jvm/org/example:foo")
 
+        self.create_file("bar/Bar.java")
         self.add_to_build_file(
             "bar",
             """jvm_binary(
               name = "bar-binary",
-              source = "Bar.java",
+              sources = ["Bar.java"],
               dependencies = ["3rdparty/jvm/org/example:foo"],
               deploy_excludes = [exclude(org = "org.pantsbuild")],
             )""",

--- a/tests/python/pants_test/backend/jvm/tasks/test_classmap.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classmap.py
@@ -20,6 +20,7 @@ class ClassmapTaskTest(ConsoleTaskTestBase, JvmBinaryTaskTestBase):
         super().setUp()
         init_subsystem(Target.Arguments)
 
+        self.create_files("a", files=["a1.java", "a2.java"])
         self.add_to_build_file(
             "a", 'java_library(sources=["a1.java", "a2.java"])',
         )
@@ -33,7 +34,7 @@ class ClassmapTaskTest(ConsoleTaskTestBase, JvmBinaryTaskTestBase):
         )
 
         self.add_to_build_file(
-            "c", 'java_library(dependencies=["a", "b"])',
+            "c", 'java_library(dependencies=["a", "b"], sources=[])',
         )
 
         self.target_a = self.target("a")

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -73,6 +73,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
         self.b_org = "com.example"
         self.b_name = "b"
+        self.create_file("src/java/targets/z.java")
         self.add_to_build_file(
             "src/java/targets",
             dedent(
@@ -109,6 +110,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
             ),
         )
 
+        self.create_file("src/java/targets/w.java")
         self.add_to_build_file(
             "src/java/targets",
             dedent(

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -253,6 +253,7 @@ class JarBuilderTest(BaseJarTaskTest):
                 """
                 java_agent(
                   name='fake_agent',
+                  sources=[],
                   premain='bob',
                   agent_class='fred',
                   can_redefine=True,

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -213,7 +213,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
                 """
                 python_tests(
                   name='hello',
-                  sources=['some_file.py'],
+                  sources=[],
                 )
                 """
             ),

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
@@ -111,6 +111,7 @@ class PrepareServicesTest(TaskTestBase):
             """
 java_library(
   name = "target",
+  sources=[],
   services = {
     "ServiceInterfaceA": ["ServiceImplA1, ServiceImplA2"],
     "ServiceInterfaceB": [],

--- a/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
@@ -116,6 +116,7 @@ class DepmapTest(BaseDepmapTest):
                 """
             ),
         )
+        self.create_file("resources/a/a.resource")
         self.add_to_build_file(
             "resources/a",
             dedent(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -222,6 +222,7 @@ class ExportTest(ConsoleTaskTestBase):
             "project_info:unrecognized_target_type", target_type=JvmTarget,
         )
 
+        self.create_file("src/python/x/f.py")
         self.add_to_build_file(
             "src/python/x/BUILD",
             """
@@ -229,6 +230,7 @@ class ExportTest(ConsoleTaskTestBase):
             """.strip(),
         )
 
+        self.create_files("src/python/y", files=["subdir/f.py", "Test.py"])
         self.add_to_build_file(
             "src/python/y/BUILD",
             dedent(
@@ -240,6 +242,7 @@ class ExportTest(ConsoleTaskTestBase):
             ),
         )
 
+        self.create_file("src/python/exclude/f.py")
         self.add_to_build_file(
             "src/python/exclude/BUILD",
             """
@@ -254,6 +257,7 @@ class ExportTest(ConsoleTaskTestBase):
             """.strip(),
         )
 
+        self.create_file("src/python/has_reqs/f.py")
         self.add_to_build_file(
             "src/python/has_reqs/BUILD",
             textwrap.dedent(

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -34,11 +34,11 @@ class PythonTaskTestBase(TaskTestBase):
         :API: public
         """
         sources = (
-            None
+            []
             if source_contents_map is None
             else ["__init__.py"] + list(source_contents_map.keys())
         )
-        sources_strs = [f"'{s}'" for s in sources] if sources else None
+        sources_strs = [f"'{s}'" for s in sources]
         self.add_to_build_file(
             relpath=relpath,
             target=dedent(
@@ -54,7 +54,7 @@ class PythonTaskTestBase(TaskTestBase):
                 """
             ).format(
                 name=name,
-                sources_clause=f"sources=[{','.join(sources_strs)}]," if sources_strs else "",
+                sources_clause=f"sources=[{','.join(sources_strs)}],",
                 dependencies=",".join(map(repr, dependencies)),
                 provides_clause=f"provides={provides}," if provides else "",
             ),

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -330,6 +330,7 @@ class TestSetupPy(SetupPyTestBase):
                 """
                 python_library(
                   name='foo1',
+                  sources=[],
                   dependencies=[
                     'foo/bar'
                   ],
@@ -340,6 +341,7 @@ class TestSetupPy(SetupPyTestBase):
                 )
                 python_library(
                   name='foo2',
+                  sources=[],
                   dependencies=[
                     'foo/bar'
                   ],

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -68,6 +68,7 @@ class PayloadTest(TestBase):
         self.context().scan()
 
     def test_single_source(self):
+        self.create_file("y/Source.scala")
         self.add_to_build_file("y/BUILD", 'java_library(name="y", sources=["Source.scala"])')
         self.context().scan()
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -427,7 +427,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         test_build_file = os.path.join(test_path, "BUILD")
         test_src_file = os.path.join(test_path, "some_file.py")
         has_source_root_regex = r'"source_root": ".*/{}"'.format(test_path)
-        export_cmd = ["export", test_path]
+        export_cmd = ["--files-not-found-behavior=warn", "export", test_path]
 
         try:
             with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, _):

--- a/tests/python/pants_test/targets/test_python_binary.py
+++ b/tests/python/pants_test/targets/test_python_binary.py
@@ -45,24 +45,26 @@ python_binary(
         assert self.target(":binary2").entry_point == "bin.blork"
 
     def test_python_binary_with_entry_point_and_source(self):
+        self.create_file("blork.py")
+        self.create_file("bin/blork.py")
         self.add_to_build_file(
             "",
             """python_binary(
   name = "binary1",
   entry_point = "blork",
-  source = "blork.py",
+  sources = ["blork.py"],
 )
 
 python_binary(
   name = "binary2",
   entry_point = "blork:main",
-  source = "blork.py",
+  sources = ["blork.py"],
 )
 
 python_binary(
   name = "binary3",
   entry_point = "bin.blork:main",
-  source = "bin/blork.py",
+  sources = ["bin/blork.py"],
 )""",
         )
 

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -20,6 +20,7 @@ class MavenLayoutTest(TestBase):
     def setUp(self):
         super().setUp()
         init_subsystems([SourceRootConfig, JUnit])
+        self.create_file("projectB/src/test/scala/a/source")
         self.add_to_build_file(
             "projectB/src/test/scala", 'junit_tests(name="test", sources=["a/source"])'
         )


### PR DESCRIPTION
`warn` is a bad default in tests because it is difficult to capture warnings in most tests. Consequently, many tests were doing bad things without us knowing.

Almost always, the fix is to call `self.create_file()` before creating a target.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
