### PR TITLE
Store the `Filespec` on the `Sources` field

### DIFF
--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-from pathlib import PurePath
 from typing import Optional, Tuple, Union
 
 from pants.backend.python.subsystems.pytest import PyTest
@@ -27,13 +26,7 @@ from pants.rules.core.determine_source_files import SourceFiles
 
 @union
 class PythonSources(Sources):
-    def validate_snapshot(self, snapshot: Snapshot) -> None:
-        non_python_files = [fp for fp in snapshot.files if not PurePath(fp).suffix == ".py"]
-        if non_python_files:
-            raise InvalidFieldException(
-                f"The {repr(self.alias)} field in target {self.address} must only contain Python "
-                f"files that end in `.py`, but it had these non-Python files: {non_python_files}."
-            )
+    expected_file_extensions = (".py",)
 
 
 class PythonLibrarySources(PythonSources):

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -274,7 +274,7 @@ class FilesetRelPathWrapper(ABC):
         return [ensure_string_wrapped_in_list(exclude) for exclude in raw_exclude]
 
     @classmethod
-    def to_filespec(cls, args: Iterable[str], root: str = "", exclude=None,) -> Filespec:
+    def to_filespec(cls, args: Iterable[str], root: str = "", exclude=None) -> Filespec:
         """Return a dict representation of this glob list, relative to the buildroot."""
         result: Filespec = {"globs": [os.path.join(root, arg) for arg in args]}
         if exclude:


### PR DESCRIPTION
We need this for the `filedeps` goal and for backward-compatibility with V1.

This PR also makes these improvements to `Sources`:

* Fixes `sources` allowing a `str` instead of `Iterable[str]`.
* Fixes glob conjunction working improperly with default values.
* Adds new `expected_file_extensions` class property for cheap validation
* Adds tests