### PR TITLE
Port `filedeps2` to use the Target API and add the missing `--transitive` option

### DIFF
--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -1,24 +1,29 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pathlib import Path
-from typing import Set
+import itertools
+from pathlib import PurePath
+from typing import Iterable
 
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.addressable import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.legacy.graph import TransitiveHydratedTargets
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    Sources,
+    Target,
+    Targets,
+    TransitiveTargets,
+)
 
 
 class FiledepsOptions(LineOriented, GoalSubsystem):
-    """List all source and BUILD files a target transitively depends on.
-
-    Files may be listed with absolute or relative paths and any BUILD files implied in the
-    transitive closure of targets are also included.
-    """
+    """List all source and BUILD files a target depends on."""
 
     name = "filedeps2"
 
@@ -29,12 +34,25 @@ class FiledepsOptions(LineOriented, GoalSubsystem):
             "--absolute",
             type=bool,
             default=True,
-            help="If True, output with absolute path; else, output with path relative to the build root",
+            help=(
+                "If True, output with absolute path; else, output with path relative to the "
+                "build root."
+            ),
         )
         register(
             "--globs",
             type=bool,
-            help="Instead of outputting filenames, output globs (ignoring excludes)",
+            default=False,
+            help=(
+                "Instead of outputting filenames, output the original globs used in the BUILD "
+                "file. This will not include exclude globs (i.e. globs that start with `!`)."
+            ),
+        )
+        register(
+            "--transitive",
+            type=bool,
+            default=False,
+            help="If True, include the files used by dependencies in the output.",
         )
 
 
@@ -44,33 +62,40 @@ class Filedeps(Goal):
 
 @goal_rule
 async def file_deps(
-    console: Console,
-    options: FiledepsOptions,
-    build_root: BuildRoot,
-    transitive_hydrated_targets: TransitiveHydratedTargets,
+    console: Console, options: FiledepsOptions, build_root: BuildRoot, addresses: Addresses,
 ) -> Filedeps:
-    unique_rel_paths: Set[str] = set()
+    targets: Iterable[Target]
+    if options.values.transitive:
+        transitive_targets = await Get[TransitiveTargets](Addresses, addresses)
+        targets = transitive_targets.closure
+    else:
+        targets = await Get[Targets](Addresses, addresses)
+
     build_file_addresses = await MultiGet(
-        Get[BuildFileAddress](Address, hydrated_target.adaptor.address)
-        for hydrated_target in transitive_hydrated_targets.closure
+        Get[BuildFileAddress](Address, tgt.address) for tgt in targets
     )
-    for hydrated_target, build_file_address in zip(
-        transitive_hydrated_targets.closure, build_file_addresses
-    ):
-        unique_rel_paths.add(build_file_address.rel_path)
-        adaptor = hydrated_target.adaptor
-        if adaptor.has_sources():
-            sources_paths = (
-                adaptor.sources.snapshot.files
-                if not options.values.globs
-                else adaptor.sources.filespec["globs"]
+    unique_rel_paths = {bfa.rel_path for bfa in build_file_addresses}
+
+    if options.values.globs:
+        unique_rel_paths.update(
+            itertools.chain.from_iterable(tgt.get(Sources).filespec["globs"] for tgt in targets)
+        )
+    else:
+        all_hydrated_sources = await MultiGet(
+            Get[HydratedSources](HydrateSourcesRequest, tgt.get(Sources).request) for tgt in targets
+        )
+        unique_rel_paths.update(
+            itertools.chain.from_iterable(
+                hydrated_sources.snapshot.files for hydrated_sources in all_hydrated_sources
             )
-            unique_rel_paths.update(sources_paths)
+        )
 
     with options.line_oriented(console) as print_stdout:
         for rel_path in sorted(unique_rel_paths):
             final_path = (
-                str(Path(build_root.path, rel_path)) if options.values.absolute else rel_path
+                PurePath(build_root.path, rel_path).as_posix()
+                if options.values.absolute
+                else rel_path
             )
             print_stdout(final_path)
 
@@ -78,6 +103,4 @@ async def file_deps(
 
 
 def rules():
-    return [
-        file_deps,
-    ]
+    return [file_deps]

--- a/src/python/pants/rules/core/filedeps_integration_test.py
+++ b/src/python/pants/rules/core/filedeps_integration_test.py
@@ -3,21 +3,23 @@
 
 from typing import List, Optional
 
+import pytest
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
+@pytest.mark.skip(reason="Unskip once we have bindings for JVM targets")
 class FiledepsIntegrationTest(PantsRunIntegrationTest):
     def assert_filedeps(
         self, *, filedeps_options: Optional[List[str]] = None, expected_entries: List[str]
     ) -> None:
-        args = (
-            ["filedeps2", "--no-absolute"]
-            + (filedeps_options or [])
-            + [
-                "examples/src/scala/org/pantsbuild/example/hello/exe:exe",
-                "examples/src/scala/org/pantsbuild/example/hello/welcome:welcome",
-            ]
-        )
+        args = [
+            "filedeps2",
+            "--no-absolute",
+            *(filedeps_options or []),
+            "examples/src/scala/org/pantsbuild/example/hello/exe:exe",
+            "examples/src/scala/org/pantsbuild/example/hello/welcome:welcome",
+        ]
         pants_run = self.run_pants(args)
         self.assert_success(pants_run)
         self.assertEqual(pants_run.stdout_data.strip(), "\n".join(expected_entries))

--- a/src/python/pants/rules/core/filedeps_test.py
+++ b/src/python/pants/rules/core/filedeps_test.py
@@ -4,16 +4,21 @@
 from typing import List, Optional, Set
 from unittest import skip
 
-from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
-from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.backend.jvm.targets.jvm_app import JvmApp
-from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
-from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.codegen.thrift.java.java_thrift_library import (
+    JavaThriftLibrary as JavaThriftLibraryV1,
+)
+from pants.backend.jvm.targets.java_library import JavaLibrary as JavaLibraryV1
+from pants.backend.jvm.targets.jvm_app import JvmApp as JvmAppV1
+from pants.backend.jvm.targets.jvm_binary import JvmBinary as JvmBinaryV1
+from pants.backend.jvm.targets.scala_library import ScalaLibrary as ScalaLibraryV1
+from pants.backend.python.rules.targets import PythonLibrary
+from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.build_graph.resources import Resources
-from pants.build_graph.target import Target
+from pants.build_graph.resources import Resources as ResourcesV1
+from pants.build_graph.target import Target as TargetV1
+from pants.engine.target import rules as target_rules
 from pants.rules.core import filedeps
+from pants.rules.core.targets import GenericTarget, Resources
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
@@ -23,20 +28,24 @@ class FileDepsTest(GoalRuleTestBase):
 
     @classmethod
     def rules(cls):
-        return super().rules() + filedeps.rules()
+        return (*super().rules(), *filedeps.rules(), *target_rules())
+
+    @classmethod
+    def target_types(cls):
+        return [GenericTarget, Resources, PythonLibrary]
 
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
         return BuildFileAliases(
             targets={
-                "target": Target,
-                "resources": Resources,
-                "java_library": JavaLibrary,
-                "java_thrift_library": JavaThriftLibrary,
-                "jvm_app": JvmApp,
-                "jvm_binary": JvmBinary,
-                "scala_library": ScalaLibrary,
-                "python_library": PythonLibrary,
+                "target": TargetV1,
+                "resources": ResourcesV1,
+                "java_library": JavaLibraryV1,
+                "java_thrift_library": JavaThriftLibraryV1,
+                "jvm_app": JvmAppV1,
+                "jvm_binary": JvmBinaryV1,
+                "scala_library": ScalaLibraryV1,
+                "python_library": PythonLibraryV1,
             },
         )
 
@@ -56,12 +65,19 @@ class FileDepsTest(GoalRuleTestBase):
         )
 
     def assert_filedeps(
-        self, *, targets: List[str], expected: Set[str], globs: bool = False
+        self,
+        *,
+        targets: List[str],
+        expected: Set[str],
+        transitive: bool = False,
+        globs: bool = False
     ) -> None:
         args = ["--no-filedeps2-absolute"]
         if globs:
             args.append("--filedeps2-globs")
-        self.assert_console_output(*expected, args=args + targets)
+        if transitive:
+            args.append("--filedeps2-transitive")
+        self.assert_console_output(*expected, args=(*args, *targets))
 
     def test_no_target(self) -> None:
         self.assert_filedeps(targets=[], expected=set())
@@ -86,22 +102,24 @@ class FileDepsTest(GoalRuleTestBase):
     def test_one_target_no_source_one_dep(self) -> None:
         self.create_python_library("dep/target", sources=["file.py"])
         self.create_python_library("some/target", dependencies=["dep/target"])
+        self.assert_filedeps(targets=["some/target"], expected={"some/target/BUILD"})
         self.assert_filedeps(
             targets=["some/target"],
+            transitive=True,
             expected={"some/target/BUILD", "dep/target/BUILD", "dep/target/file.py"},
         )
 
     def test_one_target_one_source_with_dep(self) -> None:
         self.create_python_library("dep/target", sources=["file.py"])
         self.create_python_library("some/target", sources=["file.py"], dependencies=["dep/target"])
+        direct_files = {"some/target/BUILD", "some/target/file.py"}
+        self.assert_filedeps(
+            targets=["some/target"], expected=direct_files,
+        )
         self.assert_filedeps(
             targets=["some/target"],
-            expected={
-                "some/target/BUILD",
-                "some/target/file.py",
-                "dep/target/BUILD",
-                "dep/target/file.py",
-            },
+            transitive=True,
+            expected={*direct_files, "dep/target/BUILD", "dep/target/file.py",},
         )
 
     def test_multiple_targets_one_source(self) -> None:
@@ -124,13 +142,20 @@ class FileDepsTest(GoalRuleTestBase):
         self.create_python_library(
             "other/target", sources=["file.py"], dependencies=["dep2/target"]
         )
+        direct_files = {
+            "some/target/BUILD",
+            "some/target/file.py",
+            "other/target/BUILD",
+            "other/target/file.py",
+        }
+        self.assert_filedeps(
+            targets=["some/target", "other/target"], expected=direct_files,
+        )
         self.assert_filedeps(
             targets=["some/target", "other/target"],
+            transitive=True,
             expected={
-                "some/target/BUILD",
-                "some/target/file.py",
-                "other/target/BUILD",
-                "other/target/file.py",
+                *direct_files,
                 "dep1/target/BUILD",
                 "dep1/target/file.py",
                 "dep2/target/BUILD",
@@ -142,16 +167,17 @@ class FileDepsTest(GoalRuleTestBase):
         self.create_python_library("dep/target", sources=["file.py"])
         self.create_python_library("some/target", sources=["file.py"], dependencies=["dep/target"])
         self.create_python_library("other/target", sources=["file.py"], dependencies=["dep/target"])
+        direct_files = {
+            "some/target/BUILD",
+            "some/target/file.py",
+            "other/target/BUILD",
+            "other/target/file.py",
+        }
+        self.assert_filedeps(targets=["some/target", "other/target"], expected=direct_files)
         self.assert_filedeps(
             targets=["some/target", "other/target"],
-            expected={
-                "some/target/BUILD",
-                "some/target/file.py",
-                "other/target/BUILD",
-                "other/target/file.py",
-                "dep/target/BUILD",
-                "dep/target/file.py",
-            },
+            transitive=True,
+            expected={*direct_files, "dep/target/BUILD", "dep/target/file.py"},
         )
 
     def test_globs(self) -> None:
@@ -191,6 +217,7 @@ class FileDepsTest(GoalRuleTestBase):
         self.assert_filedeps(targets=["src/java"], expected=expected)
         self.assert_filedeps(targets=["src/scala"], expected=expected)
 
+    @skip("Unskip once we have JVM bindings.")
     def test_filter_out_synthetic_targets(self) -> None:
         self.create_library(
             path="src/thrift/storage",
@@ -208,7 +235,7 @@ class FileDepsTest(GoalRuleTestBase):
         self.create_file(".pants.d/gen/thrift/java/storage/Angle.java")
         synthetic_java_lib = self.make_target(
             spec=".pants.d/gen/thrift/java/storage",
-            target_type=JavaLibrary,
+            target_type=JavaLibraryV1,
             derived_from=self.target("src/thrift/storage"),
             sources=["Angle.java"],
         )

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -59,7 +59,7 @@ class GenericTarget(Target):
     """
 
     alias = "target"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
 
 
 class AliasTargetRequestedAddress(StringField):

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -295,7 +295,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         return [RootRule(SourcesField)]
 
     @classmethod
-    def target_types(cls) -> Sequence[Target]:
+    def target_types(cls) -> Sequence[Type[Target]]:
         return ()
 
     @classmethod


### PR DESCRIPTION
A new benefit—thanks to the Target API—is that we don't hydrate sources when `--filedeps-globs` is configured because there is no need to hydrate - this should improve performance.

Once we have JVM Target API bindings, we can also add the missing JVM special-case code to get this V2 rule to completely replace the V1 task.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
