### PR TITLE
Allow a `StringField` to require one of several choices (enum)

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/rules/targets.py
+++ b/contrib/go/src/python/pants/contrib/go/rules/targets.py
@@ -10,10 +10,19 @@ from pants.engine.target import (
     Target,
 )
 
+# -----------------------------------------------------------------------------------------------
+# Common fields
+# -----------------------------------------------------------------------------------------------
+
 
 class GoSources(Sources):
     # NB: We glob on `*` due to the way resources and .c companion files are handled.
     default = ("*", "!BUILD", "!BUILD.*")
+
+
+# -----------------------------------------------------------------------------------------------
+# `go_binary` target
+# -----------------------------------------------------------------------------------------------
 
 
 class GoBuildFlags(StringField):
@@ -29,11 +38,21 @@ class GoBinary(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources, GoBuildFlags)
 
 
+# -----------------------------------------------------------------------------------------------
+# `go_library` target
+# -----------------------------------------------------------------------------------------------
+
+
 class GoLibrary(Target):
     """A Go package."""
 
     alias = "go_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `go_protobuf_library` target
+# -----------------------------------------------------------------------------------------------
 
 
 class GoProtobufSources(Sources):
@@ -53,11 +72,21 @@ class GoProtobufLibrary(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoProtobufSources, ProtocPlugins)
 
 
+# -----------------------------------------------------------------------------------------------
+# `go_thrift_library` target
+# -----------------------------------------------------------------------------------------------
+
+
 class GoThriftLibrary(Target):
     """A Go library generated from Thrift IDL files."""
 
     alias = "go_thrift_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `go_remote_library` and `go_remote_libraries` targets
+# -----------------------------------------------------------------------------------------------
 
 
 class GoPackage(StringField):

--- a/contrib/node/src/python/pants/contrib/node/rules/targets.py
+++ b/contrib/node/src/python/pants/contrib/node/rules/targets.py
@@ -9,7 +9,6 @@ from pants.engine.target import (
     BoolField,
     Dependencies,
     IntField,
-    InvalidFieldException,
     InvalidFieldTypeException,
     PrimitiveField,
     Sources,
@@ -18,6 +17,10 @@ from pants.engine.target import (
 )
 from pants.fs.archive import TYPE_NAMES_PRESERVE_SYMLINKS
 from pants.util.frozendict import FrozenDict
+
+# -----------------------------------------------------------------------------------------------
+# Common fields
+# -----------------------------------------------------------------------------------------------
 
 
 class NodePackageName(StringField):
@@ -40,25 +43,18 @@ class NodePackageName(StringField):
 COMMON_NODE_FIELDS = (*COMMON_TARGET_FIELDS, NodePackageName)
 
 
-class NodeBundleArchiveFormat(StringField):
-    """The archive format to use for the generated bundle.
+# -----------------------------------------------------------------------------------------------
+# `node_bundle` target
+# -----------------------------------------------------------------------------------------------
 
-    Choose from `tar`, `tgz`, or `tbz2`.
-    """
+
+class NodeBundleArchiveFormat(StringField):
+    """The archive format to use for the generated bundle."""
 
     alias = "archive"
     value: str
+    valid_choices = tuple(sorted(TYPE_NAMES_PRESERVE_SYMLINKS))
     default = "tgz"
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value_or_default = super().compute_value(raw_value, address=address)
-        if value_or_default not in TYPE_NAMES_PRESERVE_SYMLINKS:
-            raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} must be one of "
-                f"{list(TYPE_NAMES_PRESERVE_SYMLINKS)}, but was {repr(raw_value)}."
-            )
-        return value_or_default
 
 
 class NodeBundleRequestedModule(StringField):
@@ -73,6 +69,11 @@ class NodeBundle(Target):
 
     alias = "node_bundle"
     core_fields = (*COMMON_NODE_FIELDS, NodeBundleArchiveFormat, NodeBundleRequestedModule)
+
+
+# -----------------------------------------------------------------------------------------------
+# `node_module` target
+# -----------------------------------------------------------------------------------------------
 
 
 class NodePackageManager(StringField):
@@ -194,6 +195,11 @@ class NodeModule(Target):
     )
 
 
+# -----------------------------------------------------------------------------------------------
+# `node_preinstalled_module` target
+# -----------------------------------------------------------------------------------------------
+
+
 class NodeDependenciesArchiveUrl(StringField):
     """The location of a tar.gz file containing containing a node_modules directory."""
 
@@ -209,6 +215,11 @@ class NodePreinstalledModule(Target):
 
     alias = "node_preinstalled_module"
     core_fields = (*NodeModule.core_fields, NodeDependenciesArchiveUrl)
+
+
+# -----------------------------------------------------------------------------------------------
+# `node_remote_module` target
+# -----------------------------------------------------------------------------------------------
 
 
 class NodeRemoteVersion(StringField):
@@ -228,6 +239,11 @@ class NodeRemoteModule(Target):
 
     alias = "node_remote_module"
     core_fields = (*COMMON_NODE_FIELDS, NodeRemoteVersion)
+
+
+# -----------------------------------------------------------------------------------------------
+# `node_test` target
+# -----------------------------------------------------------------------------------------------
 
 
 class NodeTestScriptName(StringField):

--- a/src/python/pants/backend/jvm/rules/targets.py
+++ b/src/python/pants/backend/jvm/rules/targets.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 from pants.backend.jvm.subsystems import shader
 from pants.backend.jvm.targets.jvm_binary import JarRules
@@ -23,8 +23,7 @@ from pants.engine.target import (
 )
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
-from pants.util.collections import ensure_list, ensure_str_list
-from pants.util.frozendict import FrozenDict
+from pants.util.collections import ensure_list
 
 # -----------------------------------------------------------------------------------------------
 # Common JVM Fields
@@ -58,7 +57,7 @@ class JvmExcludes(PrimitiveField):
         return tuple(sorted(value_or_default))
 
 
-class JvmServices(PrimitiveField):
+class JvmServices(DictStringToStringSequenceField):
     """A dictionary mapping service interface names to the classes owned by this target that
     implement them.
 
@@ -69,30 +68,6 @@ class JvmServices(PrimitiveField):
     """
 
     alias = "services"
-    value: Optional[FrozenDict[str, Tuple[str, ...]]] = None
-    default = None
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], *, address: Address
-    ) -> Optional[FrozenDict[str, Tuple[str, ...]]]:
-        value_or_default = super().compute_value(raw_value, address=address)
-        if value_or_default is None:
-            return None
-        invalid_type_exception = InvalidFieldTypeException(
-            address,
-            cls.alias,
-            value_or_default,
-            expected_type=(
-                "a dictionary of service interface name (string) to an iterable of class names"
-            ),
-        )
-        if not isinstance(value_or_default, dict):
-            raise invalid_type_exception
-        try:
-            return FrozenDict({k: ensure_str_list(v) for k, v in value_or_default.items()})
-        except ValueError:
-            raise invalid_type_exception
 
 
 class JvmPlatform(StringField):
@@ -452,15 +427,19 @@ class JunitExtraEnvVars(DictStringToStringField):
     alias = "extra_env_vars"
 
 
-# TODO: add an enum-like validation feature to StringField. Hook it up to `target-types2`. Allow
-#  either defining as a class property a list of valid strings _or_ passing an Enum type.
 class JunitConcurrency(StringField):
-    """One of 'SERIAL', 'PARALLEL_CLASSES', 'PARALLEL_METHODS', or 'PARALLEL_CLASSES_AND_METHODS'.
+    """The concurrency approach to use with tests.
 
     Overrides the setting of --test-junit-default-concurrency.
     """
 
     alias = "concurrency"
+    valid_choices = (
+        "SERIAL",
+        "PARALLEL_CLASSES",
+        "PARALLEL_METHODS",
+        "PARALLEL_CLASSES_AND_METHODS",
+    )
 
 
 class JunitNumThreads(IntField):

--- a/src/python/pants/backend/native/rules/targets.py
+++ b/src/python/pants/backend/native/rules/targets.py
@@ -11,7 +11,6 @@ from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
     Dependencies,
-    InvalidFieldException,
     InvalidFieldTypeException,
     PrimitiveField,
     Sources,
@@ -79,17 +78,7 @@ class ToolchainVariantField(StringField):
     """
 
     alias = "toolchain_variant"
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> Optional[str]:
-        value = super().compute_value(raw_value, address=address)
-        valid_options = list(ToolchainVariant.__members__.keys())
-        if value not in valid_options:
-            raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} must be one of {valid_options}, "
-                f"but was {repr(raw_value)}."
-            )
-        return value
+    valid_choices = ToolchainVariant
 
 
 class NativeCompilerOptionSets(StringSequenceField):

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -165,6 +165,7 @@ class PexInheritPath(StringField):
     """
 
     alias = "inherit_path"
+    valid_choices = ("false", "fallback", "prefer")
 
     # TODO(#9388): deprecate allowing this to be a `bool`.
     @classmethod

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from contextlib import contextmanager
+from enum import Enum
 from textwrap import dedent
 from typing import Optional, cast
 from unittest.mock import Mock
@@ -57,10 +58,27 @@ class FortranTests(Target):
     core_fields = (FortranVersion, FortranTimeout)
 
 
+class ArchiveFormat(Enum):
+    TGZ = ".tgz"
+    TAR = ".tar"
+
+
+class ArchiveFormatField(StringField):
+    alias = "archive_format"
+    valid_choices = ArchiveFormat
+    default = ArchiveFormat.TGZ.value
+
+
+class ErrorBehavior(StringField):
+    alias = "error_behavior"
+    valid_choices = ("ignore", "warn", "error")
+    required = True
+
+
 # Note no docstring.
 class FortranBinary(Target):
     alias = "fortran_binary"
-    core_fields = (FortranVersion,)
+    core_fields = (FortranVersion, ArchiveFormatField, ErrorBehavior)
 
 
 def run_goal(
@@ -147,6 +165,12 @@ def test_list_single() -> None:
         --------------
 
         Valid fields:
+
+            archive_format
+                type: '.tar' | '.tgz' | None, default: '.tgz'
+
+            error_behavior
+                type: 'error' | 'ignore' | 'warn', required
 
             fortran_version
                 type: str | None, default: None

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -17,6 +17,10 @@ from pants.engine.target import (
     Target,
 )
 
+# -----------------------------------------------------------------------------------------------
+# `files` target
+# -----------------------------------------------------------------------------------------------
+
 
 class FilesSources(Sources):
     required = True
@@ -33,6 +37,11 @@ class Files(Target):
 
     alias = "files"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FilesSources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `resources` target
+# -----------------------------------------------------------------------------------------------
 
 
 class ResourcesSources(Sources):
@@ -52,6 +61,11 @@ class Resources(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ResourcesSources)
 
 
+# -----------------------------------------------------------------------------------------------
+# `target` generic target
+# -----------------------------------------------------------------------------------------------
+
+
 class GenericTarget(Target):
     """A generic target with no specific target type.
 
@@ -60,6 +74,11 @@ class GenericTarget(Target):
 
     alias = "target"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
+
+
+# -----------------------------------------------------------------------------------------------
+# `alias` target
+# -----------------------------------------------------------------------------------------------
 
 
 class AliasTargetRequestedAddress(StringField):
@@ -79,6 +98,11 @@ class AliasTarget(Target):
 
     alias = "alias"
     core_fields = (*COMMON_TARGET_FIELDS, AliasTargetRequestedAddress)
+
+
+# -----------------------------------------------------------------------------------------------
+# `prep_command` target
+# -----------------------------------------------------------------------------------------------
 
 
 class PrepCommandExecutable(StringField):
@@ -135,6 +159,11 @@ class PrepCommand(Target):
         PrepCommandEnviron,
         PrepCommandGoals,
     )
+
+
+# -----------------------------------------------------------------------------------------------
+# `remote_sources` targets
+# -----------------------------------------------------------------------------------------------
 
 
 class RemoteSourcesTargetRequestedAddress(StringField):


### PR DESCRIPTION
### Problem

Several times, Fields have wanted to express that they only allow for a fixed number of string values. That is, to act like an Enum.

This pattern has only happened with strings - I've not yet encountered an `IntEnum`-like field, for example.

### Solution

Add a `valid_choices` class property to `StringField`. 

Hook this up to `target-types2`:

![example](https://user-images.githubusercontent.com/14852634/78388448-e291bc00-7595-11ea-89ff-e69569a76c0d.png)

We allow either passing a tuple of strings _or_ an `Enum` instance, which makes for much more flexible call sites.

We always still return back a `str`, rather than a specific `Enum` instance. This makes backward-compatibility much simpler when converting back into a V1 target + makes type hints much simpler.

### Result

Using an invalid value:

> ▶ ./v2 --no-print-exception-stacktrace run build-support/bin:check_banned_imports
>
> ERROR: The 'inherit_path' field in target build-support/bin:check_banned_imports must be one of ['fallback', 'false', 'prefer'], but was 'bad'.