### PR TITLE
Change `ensure_list` to not accept a single element by default

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -148,7 +148,7 @@ class Jar:
 
         :param iterable classpath: a list of paths
         """
-        self._classpath = self._classpath + ensure_str_list(classpath)
+        self._classpath = self._classpath + ensure_str_list(classpath, allow_single_str=True)
 
     def write(self, src, dest=None):
         """Schedules a write of the file at ``src`` to the ``dest`` path in this jar.

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -109,10 +109,14 @@ class PythonBinary(PythonTarget):
                 "inherit_path": PrimitiveField(inherit_path),
                 "zip_safe": PrimitiveField(bool(zip_safe)),
                 "always_write_cache": PrimitiveField(bool(always_write_cache)),
-                "repositories": PrimitiveField(ensure_str_list(repositories or [])),
-                "indices": PrimitiveField(ensure_str_list(indices or [])),
+                "repositories": PrimitiveField(
+                    ensure_str_list(repositories or [], allow_single_str=True)
+                ),
+                "indices": PrimitiveField(ensure_str_list(indices or [], allow_single_str=True)),
                 "ignore_errors": PrimitiveField(bool(ignore_errors)),
-                "platforms": PrimitiveField(tuple(ensure_str_list(platforms or []))),
+                "platforms": PrimitiveField(
+                    tuple(ensure_str_list(platforms or [], allow_single_str=True))
+                ),
                 "shebang": PrimitiveField(shebang),
                 "emit_warnings": PrimitiveField(self.Defaults.should_emit_warnings(emit_warnings)),
             }

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -40,7 +40,11 @@ class PythonDistribution(PythonTarget):
 
         payload = payload or Payload()
         payload.add_fields(
-            {"setup_requires": PrimitiveField(ensure_str_list(setup_requires or ()))}
+            {
+                "setup_requires": PrimitiveField(
+                    ensure_str_list(setup_requires or (), allow_single_str=True)
+                )
+            }
         )
         super().__init__(address=address, payload=payload, sources=sources, **kwargs)
 

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -49,7 +49,9 @@ class PythonTarget(Target):
             {
                 "sources": self.create_sources_field(sources, address.spec_path, key_arg="sources"),
                 "provides": provides,
-                "compatibility": PrimitiveField(ensure_str_list(compatibility or ())),
+                "compatibility": PrimitiveField(
+                    ensure_str_list(compatibility or (), allow_single_str=True)
+                ),
             }
         )
         super().__init__(address=address, payload=payload, **kwargs)

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -25,7 +25,9 @@ class PythonTests(PythonTarget):
         :param int timeout: A timeout (in seconds) which covers the total runtime of all tests in this
           target. Only applied if `--test-pytest-timeouts` is set to True.
         """
-        self._coverage = ensure_str_list(coverage) if coverage is not None else []
+        self._coverage = (
+            ensure_str_list(coverage, allow_single_str=True) if coverage is not None else []
+        )
         self._timeout = timeout
         super().__init__(**kwargs)
 

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -79,7 +79,9 @@ class UnpackedWheels(ImportWheelsMixin, Target):
                 "module_name": PrimitiveField(module_name),
                 "include_patterns": PrimitiveField(include_patterns or ()),
                 "exclude_patterns": PrimitiveField(exclude_patterns or ()),
-                "compatibility": PrimitiveField(ensure_str_list(compatibility or ())),
+                "compatibility": PrimitiveField(
+                    ensure_str_list(compatibility or (), allow_single_str=True)
+                ),
                 "within_data_subdir": PrimitiveField(within_data_subdir),
                 # TODO: consider supporting transitive deps like UnpackedJars!
                 # TODO: consider supporting `platforms` as in PythonBinary!

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -139,7 +139,7 @@ class Bundle:
 
         # A fileset is either a string or a list of file paths. All globs are expected to already
         # have been expanded.
-        fileset = ensure_str_list(fileset)
+        fileset = ensure_str_list(fileset, allow_single_str=True)
         assert all("*" not in fp for fp in fileset), (
             "All globs should have already been hydrated for the `bundle(fileset=)` field. "
             f"Given the fileset: {fileset}"

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -318,7 +318,7 @@ class PythonTargetAdaptor(TargetAdaptor):
     def compatibility(self) -> Optional[List[str]]:
         if "compatibility" not in self._kwargs:
             return None
-        return ensure_str_list(self._kwargs["compatibility"])
+        return ensure_str_list(self._kwargs["compatibility"], allow_single_str=True)
 
 
 class PythonBinaryAdaptor(PythonTargetAdaptor):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -38,7 +38,7 @@ ImmutableValue = Any
 
 class Field(ABC):
     alias: ClassVar[str]
-    default: ClassVar[Any]
+    default: ClassVar[ImmutableValue]
     required: ClassVar[bool] = False
 
     # This is a little weird to have an abstract __init__(). We do this to ensure that all
@@ -680,18 +680,15 @@ class StringSequenceField(PrimitiveField, metaclass=ABCMeta):
         value_or_default = super().compute_value(raw_value, address=address)
         if value_or_default is None:
             return None
-        invalid_type_exception = InvalidFieldTypeException(
-            address,
-            cls.alias,
-            raw_value,
-            expected_type="an iterable of strings (e.g. a list of strings)",
-        )
-        if isinstance(value_or_default, str):
-            raise invalid_type_exception
         try:
             ensure_str_list(value_or_default)
         except ValueError:
-            raise invalid_type_exception
+            raise InvalidFieldTypeException(
+                address,
+                cls.alias,
+                raw_value,
+                expected_type="an iterable of strings (e.g. a list of strings)",
+            )
         return tuple(value_or_default)
 
 
@@ -715,7 +712,7 @@ class StringOrStringSequenceField(PrimitiveField, metaclass=ABCMeta):
         if value_or_default is None:
             return None
         try:
-            str_list = ensure_str_list(value_or_default)
+            str_list = ensure_str_list(value_or_default, allow_single_str=True)
         except ValueError:
             raise InvalidFieldTypeException(
                 address,
@@ -770,7 +767,7 @@ class DictStringToStringSequenceField(PrimitiveField, metaclass=ABCMeta):
             raise invalid_type_exception
         result = {}
         for k, v in value_or_default.items():
-            if not isinstance(k, str) or isinstance(v, str):
+            if not isinstance(k, str):
                 raise invalid_type_exception
             try:
                 result[k] = tuple(ensure_str_list(v))
@@ -862,8 +859,6 @@ class Sources(AsyncField):
             value_or_default,
             expected_type="an iterable of strings (e.g. a list of strings)",
         )
-        if isinstance(value_or_default, str):
-            raise invalid_field_type
         try:
             ensure_str_list(value_or_default)
         except ValueError:

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -31,7 +31,7 @@ class Ivy:
         :param ivy_resolution_cache_dir: path to store downloaded ivy artifacts
         :param extra_jvm_options: list of strings to add to command line when invoking Ivy
         """
-        self._classpath = ensure_str_list(classpath)
+        self._classpath = ensure_str_list(classpath, allow_single_str=True)
         self._ivy_settings = ivy_settings
         if self._ivy_settings and not isinstance(self._ivy_settings, str):
             raise ValueError(

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -22,11 +22,11 @@ class Executor(ABC):
 
     @staticmethod
     def _scrub_args(classpath, main, jvm_options, args):
-        classpath = ensure_str_list(classpath)
+        classpath = ensure_str_list(classpath, allow_single_str=True)
         if not isinstance(main, str) or not main:
             raise ValueError("A non-empty main classname is required, given: {}".format(main))
-        jvm_options = ensure_str_list(jvm_options or ())
-        args = ensure_str_list(args or ())
+        jvm_options = ensure_str_list(jvm_options or (), allow_single_str=True)
+        args = ensure_str_list(args or (), allow_single_str=True)
         return classpath, main, jvm_options, args
 
     class Error(Exception):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -106,7 +106,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
         self._workdir = workdir
         self._ng_stdout = os.path.join(workdir, "stdout")
         self._ng_stderr = os.path.join(workdir, "stderr")
-        self._nailgun_classpath = ensure_str_list(nailgun_classpath)
+        self._nailgun_classpath = ensure_str_list(nailgun_classpath, allow_single_str=True)
         self._startup_timeout = startup_timeout
         self._connect_timeout = connect_timeout
         self._connect_attempts = connect_attempts

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -133,7 +133,11 @@ def create_context_from_options(
     Other params are as for ``Context``.
     """
     run_tracker = TestContext.DummyRunTracker()
-    target_roots = ensure_list(target_roots, expected_type=Target) if target_roots else []
+    target_roots = (
+        ensure_list(target_roots, expected_type=Target, allow_single_scalar=True)
+        if target_roots
+        else []
+    )
     return TestContext(
         options=options,
         run_tracker=run_tracker,

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -67,18 +67,21 @@ def assert_single_element(iterable: Iterable[_T]) -> _T:
     raise ValueError(f"iterable {iterable!r} has more than one element.")
 
 
-def ensure_list(val: Union[Any, Iterable[Any]], *, expected_type: Type[_T]) -> List[_T]:
-    """Given either a single value or an iterable of values, always return a list.
+def ensure_list(
+    val: Union[Any, Iterable[Any]], *, expected_type: Type[_T], allow_single_scalar: bool = False
+) -> List[_T]:
+    """Ensure that every element of an iterable is the expected type and convert the result to a
+    list.
 
-    This performs runtime type checking to ensure that every element of the list is the expected
-    type.
+    If `allow_single_scalar` is True, a single value T will be wrapped into a `List[T]`.
     """
     if isinstance(val, expected_type):
+        if not allow_single_scalar:
+            raise ValueError(f"The value {val} must be wrapped in an iterable (e.g. a list).")
         return [val]
     if not isinstance(val, collections.abc.Iterable):
         raise ValueError(
-            f"The value {val} (type {type(val)}) did not have the expected type {expected_type} "
-            "nor was it an iterable."
+            f"The value {val} (type {type(val)}) was not an iterable of {expected_type}."
         )
     result: List[_T] = []
     for i, x in enumerate(val):
@@ -91,6 +94,9 @@ def ensure_list(val: Union[Any, Iterable[Any]], *, expected_type: Type[_T]) -> L
     return result
 
 
-def ensure_str_list(val: Union[str, Iterable[str]]) -> List[str]:
-    """Given either a single string or an iterable of strings, always return a list."""
-    return ensure_list(val, expected_type=str)
+def ensure_str_list(val: Union[str, Iterable[str]], *, allow_single_str: bool = False) -> List[str]:
+    """Ensure that every element of an iterable is a string and convert the result to a list.
+
+    If `allow_single_str` is True, a single `str` will be wrapped into a `List[str]`.
+    """
+    return ensure_list(val, expected_type=str, allow_single_scalar=allow_single_str)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -172,7 +172,7 @@ class JarTaskTest(BaseJarTaskTest):
                     + "Class-Path: {}\r\n"
                     + "Created-By: org.pantsbuild.tools.jar.JarBuilder\r\n\r\n"
                 )
-                .format(" ".join(ensure_str_list(classpath)))
+                .format(" ".join(ensure_str_list(classpath, allow_single_str=True)))
                 .encode()
             )
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -33,7 +33,11 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         :rtype: dict
         """
         export_out_file = os.path.join(workdir, "export_out.txt")
-        args = ["export", f"--output-file={export_out_file}", *ensure_str_list(test_target)]
+        args = [
+            "export",
+            f"--output-file={export_out_file}",
+            *ensure_str_list(test_target, allow_single_str=True),
+        ]
         libs_args = ["--no-export-libraries"] if not load_libs else self._confs_args
         if load_libs and only_default:
             libs_args = []

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -52,13 +52,15 @@ class EXE:
 @contextmanager
 def distribution(files=None, executables=None, java_home=None, dist_dir=None):
     # NB attempt to include the java version in the tmp dir name for better test failure messages.
-    executables_as_list = ensure_list(executables or (), expected_type=EXE)
+    executables_as_list = ensure_list(
+        executables or (), expected_type=EXE, allow_single_scalar=True
+    )
     if executables_as_list:
         dist_prefix = "jvm_{}_".format(executables_as_list[0]._version)
     else:
         dist_prefix = "jvm_na_"
     with temporary_dir(root_dir=dist_dir, prefix=dist_prefix) as dist_root:
-        for f in ensure_str_list(files or ()):
+        for f in ensure_str_list(files or (), allow_single_str=True):
             touch(os.path.join(dist_root, f))
         for executable in executables_as_list:
             path = os.path.join(dist_root, executable.relpath)

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -64,11 +64,19 @@ class TestCollections(unittest.TestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_ensure_list(self) -> None:
-        # Single elements should be converted to a one-element list
-        assert ensure_list(0, expected_type=int) == [0]
-        assert ensure_list(True, expected_type=bool) == [True]
+        # Reject single values by default, even if they're the expected type.
+        with pytest.raises(ValueError):
+            ensure_list(0, expected_type=int)
+        with pytest.raises(ValueError):
+            ensure_list(False, expected_type=bool)
+
+        # Allow wrapping single values into a list.
+        assert ensure_list(0, expected_type=int, allow_single_scalar=True) == [0]
+        assert ensure_list(True, expected_type=bool, allow_single_scalar=True) == [True]
         arbitrary_object = object()
-        assert ensure_list(arbitrary_object, expected_type=object) == [arbitrary_object]
+        assert ensure_list(arbitrary_object, expected_type=object, allow_single_scalar=True) == [
+            arbitrary_object
+        ]
 
         ensure_int_list = partial(ensure_list, expected_type=int)
 
@@ -84,15 +92,19 @@ class TestCollections(unittest.TestCase):
 
         # Perform runtime type checks
         with pytest.raises(ValueError):
-            ensure_int_list("bad")
+            ensure_int_list(["bad"])
         with pytest.raises(ValueError):
-            ensure_int_list(0.0)
+            ensure_int_list([0.0])
         with pytest.raises(ValueError):
             ensure_int_list([0, 1, "sneaky", 2, 3])
 
     def test_ensure_str_list(self) -> None:
-        assert ensure_str_list("hello") == ["hello"]
-        assert ensure_str_list(["hello", "there"]) == ["hello", "there"]
+        assert ensure_str_list(("hello", "there")) == ["hello", "there"]
+
+        assert ensure_str_list("hello", allow_single_str=True) == ["hello"]
+        with pytest.raises(ValueError):
+            ensure_str_list("hello")
+
         with pytest.raises(ValueError):
             ensure_str_list(0)  # type: ignore[arg-type]
         with pytest.raises(ValueError):


### PR DESCRIPTION
We are now using `ensure_list` and `ensure_str_list` in several places for the Target API. 

It's surprising that this util allows passing a single element by default. Naively, this results in Fields allowing things like `sources="f.py"`, when we only want to allow `sources=["f.py"]`.

Still, we do have a use case for allowing this `maybe_list` functionality, so we add it as a parameter that's off by default.