### PR TITLE
Allow `Sources` subclasses to specify the # of expected files

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -942,11 +942,13 @@ class Sources(AsyncField):
                             " or ".join(str(n) for n in self.expected_num_files) + " files"
                         )
                     else:
-                        expected_str = f"a number of files in the range {self.expected_num_files}"
+                        expected_str = (
+                            f"a number of files in the range `{self.expected_num_files}`"
+                        )
                 else:
                     expected_str = pluralize(self.expected_num_files, "file")
                 raise InvalidFieldException(
-                    f"The {repr(self.alias)} field in target {self.address} must only have "
+                    f"The {repr(self.alias)} field in target {self.address} must have "
                     f"{expected_str}, but it had {pluralize(num_files, 'file')}."
                 )
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -942,9 +942,7 @@ class Sources(AsyncField):
                             " or ".join(str(n) for n in self.expected_num_files) + " files"
                         )
                     else:
-                        expected_str = (
-                            f"a number of files in the range `{self.expected_num_files}`"
-                        )
+                        expected_str = f"a number of files in the range `{self.expected_num_files}`"
                 else:
                     expected_str = pluralize(self.expected_num_files, "file")
                 raise InvalidFieldException(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -27,6 +27,7 @@ from pants.util.collections import ensure_str_list
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
+from pants.util.strutil import pluralize
 
 # -----------------------------------------------------------------------------------------------
 # Core Field abstractions
@@ -880,6 +881,7 @@ class Sources(AsyncField):
     sanitized_raw_value: Optional[Tuple[str, ...]]
     default: ClassVar[Optional[Tuple[str, ...]]] = None
     expected_file_extensions: ClassVar[Optional[Tuple[str, ...]]] = None
+    expected_num_files: ClassVar[Optional[Union[int, range]]] = None
 
     @classmethod
     def sanitize_raw_value(
@@ -901,13 +903,16 @@ class Sources(AsyncField):
         return tuple(sorted(value_or_default))
 
     def validate_snapshot(self, snapshot: Snapshot) -> None:
-        """Perform any additional validation on the resulting snapshot, e.g. ensuring that there are
-        only a certain number of resolved files.
+        """Perform any additional validation on the resulting snapshot, e.g. ensuring that certain
+        banned files are not used.
 
         To enforce that the resulting files end in certain extensions, such as `.py` or `.java`, set
         the class property `expected_file_extensions`.
+
+        To enforce that there are only a certain number of resulting files, such as binary targets
+        checking for only 0-1 sources, set the class property `expected_num_files`.
         """
-        if self.expected_file_extensions:
+        if self.expected_file_extensions is not None:
             bad_files = [
                 fp
                 for fp in snapshot.files
@@ -922,6 +927,27 @@ class Sources(AsyncField):
                 raise InvalidFieldException(
                     f"The {repr(self.alias)} field in target {self.address} must only contain "
                     f"files that end in {expected}, but it had these files: {sorted(bad_files)}."
+                )
+        if self.expected_num_files is not None:
+            num_files = len(snapshot.files)
+            is_bad_num_files = (
+                num_files not in self.expected_num_files
+                if isinstance(self.expected_num_files, range)
+                else num_files != self.expected_num_files
+            )
+            if is_bad_num_files:
+                if isinstance(self.expected_num_files, range):
+                    if len(self.expected_num_files) == 2:
+                        expected_str = (
+                            " or ".join(str(n) for n in self.expected_num_files) + " files"
+                        )
+                    else:
+                        expected_str = f"a number of files in the range {self.expected_num_files}"
+                else:
+                    expected_str = pluralize(self.expected_num_files, "file")
+                raise InvalidFieldException(
+                    f"The {repr(self.alias)} field in target {self.address} must only have "
+                    f"{expected_str}, but it had {pluralize(num_files, 'file')}."
                 )
 
     @final

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -608,10 +608,10 @@ class TestSources(TestBase):
 
         with pytest.raises(ExecutionError) as exc:
             hydrate(ExpectedNumber, [])
-        assert "must only have 2 files" in str(exc.value)
+        assert "must have 2 files" in str(exc.value)
         with pytest.raises(ExecutionError) as exc:
             hydrate(ExpectedRange, ["f1.txt", "f2.txt"])
-        assert "must only have 1 or 3 files" in str(exc.value)
+        assert "must have 1 or 3 files" in str(exc.value)
 
         # Also check that we support valid # files.
         assert hydrate(ExpectedNumber, ["f1.txt", "f2.txt"]).snapshot.files == ("f1.txt", "f2.txt")

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type
 
 import pytest
 from typing_extensions import final
@@ -590,3 +590,34 @@ class TestSources(TestBase):
         assert self.request_single_product(
             HydratedSources, valid_sources.request
         ).snapshot.files == ("src/fortran/s.f95",)
+
+    def test_expected_num_files(self) -> None:
+        class ExpectedNumber(Sources):
+            expected_num_files = 2
+
+        class ExpectedRange(Sources):
+            # We allow for 1 or 3 files
+            expected_num_files = range(1, 4, 2)
+
+        self.create_files("", files=["f1.txt", "f2.txt", "f3.txt", "f4.txt"])
+
+        def hydrate(sources_cls: Type[Sources], sources: Iterable[str]) -> HydratedSources:
+            return self.request_single_product(
+                HydratedSources, sources_cls(sources, address=Address.parse(":example")).request
+            )
+
+        with pytest.raises(ExecutionError) as exc:
+            hydrate(ExpectedNumber, [])
+        assert "must only have 2 files" in str(exc.value)
+        with pytest.raises(ExecutionError) as exc:
+            hydrate(ExpectedRange, ["f1.txt", "f2.txt"])
+        assert "must only have 1 or 3 files" in str(exc.value)
+
+        # Also check that we support valid # files.
+        assert hydrate(ExpectedNumber, ["f1.txt", "f2.txt"]).snapshot.files == ("f1.txt", "f2.txt")
+        assert hydrate(ExpectedRange, ["f1.txt"]).snapshot.files == ("f1.txt",)
+        assert hydrate(ExpectedRange, ["f1.txt", "f2.txt", "f3.txt"]).snapshot.files == (
+            "f1.txt",
+            "f2.txt",
+            "f3.txt",
+        )


### PR DESCRIPTION
Twice now, we've had `Sources` fields that require a specific number of files. So, this PR formalizes a mechanism to do this.

Error message #1:

> ERROR: The 'sources' field in target build-support/bin:check_banned_imports must have 3 files, but it had 1 file.

Error message #2: 

> ERROR: The 'sources' field in target build-support/bin:check_banned_imports must have 2 or 3 files, but it had 1 file.

Error message #3: 

> ERROR: The 'sources' field in target build-support/bin:check_banned_imports must have a number of files in the range `range(20, 20000, 10)`, but it had 1 file.


[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.