### PR TITLE
Use `__slots__` on core engine abstractions for reduced memory consumption

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -186,6 +186,8 @@ class Address:
                 ),
             )
 
+    __slots__ = ("_spec_path", "_target_name", "_hash")
+
     def __init__(self, spec_path: str, target_name: str) -> None:
         """
         :param spec_path: The path from the root of the repo to this Target.
@@ -273,6 +275,8 @@ class BuildFileAddress(Address):
 
     :API: public
     """
+
+    __slots__ = ("rel_path",)
 
     def __init__(
         self,

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -41,6 +41,8 @@ class Console:
 
     side_effecting = True
 
+    __slots__ = ("_stdout", "_stderr", "_use_colors")
+
     def __init__(
         self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None
     ):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -194,7 +194,7 @@ class PathGlobsAndRoot:
     digest_hint: Optional[Digest]
 
     def __init__(
-        self, path_globs: PathGlobs, root: str, *, digest_hint: Optional[Digest] = None
+        self, path_globs: PathGlobs, root: str, digest_hint: Optional[Digest] = None
     ) -> None:
         self.path_globs = path_globs
         self.root = root

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -33,7 +33,7 @@ class FileContent:
     content: bytes
     is_executable: bool
 
-    def __init__(self, path: str, content: bytes, is_executable: bool = False):
+    def __init__(self, path: str, content: bytes, is_executable: bool = False) -> None:
         self.path = path
         self.content = content
         self.is_executable = is_executable

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -121,6 +121,8 @@ class Goal:
     value to indicate whether the rule exited cleanly.
     """
 
+    __slots__ = ("exit_code", "subsystem_cls")
+
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]
 

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -121,7 +121,7 @@ class Goal:
     value to indicate whether the rule exited cleanly.
     """
 
-    __slots__ = ("exit_code", "subsystem_cls")
+    __slots__ = ("exit_code",)
 
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -37,7 +37,7 @@ class InteractiveProcessRequest:
         env: Iterable[str] = (),
         input_files: Digest = EMPTY_DIRECTORY_DIGEST,
         run_in_workspace: bool = False
-    ):
+    ) -> None:
         self.argv = tuple(argv)
         self.env = tuple(env)
         self.input_files = input_files

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Iterable, Tuple
 
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
 from pants.engine.rules import RootRule, side_effecting
+from pants.util.meta import frozen_after_init
 
 if TYPE_CHECKING:
     from pants.engine.scheduler import SchedulerSession
@@ -14,26 +15,48 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class InteractiveProcessResult:
+    __slots__ = ("process_exit_code",)
+
     process_exit_code: int
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class InteractiveProcessRequest:
+    __slots__ = ("_is_frozen", "argv", "env", "input_files", "run_in_workspace")
+
     argv: Tuple[str, ...]
-    env: Tuple[str, ...] = ()
-    input_files: Digest = EMPTY_DIRECTORY_DIGEST
-    run_in_workspace: bool = False
+    env: Tuple[str, ...]
+    input_files: Digest
+    run_in_workspace: bool
+
+    def __init__(
+        self,
+        argv: Iterable[str],
+        *,
+        env: Iterable[str] = (),
+        input_files: Digest = EMPTY_DIRECTORY_DIGEST,
+        run_in_workspace: bool = False
+    ):
+        self.argv = tuple(argv)
+        self.env = tuple(env)
+        self.input_files = input_files
+        self.run_in_workspace = run_in_workspace
+        self.__post_init__()
 
     def __post_init__(self):
         if self.input_files != EMPTY_DIRECTORY_DIGEST and self.run_in_workspace:
             raise ValueError(
-                "InteractiveProessRequest should use the Workspace API to materialize any needed files when it runs in the workspace"
+                "InteractiveProcessRequest should use the Workspace API to materialize any needed "
+                "files when it runs in the workspace"
             )
 
 
 @side_effecting
 @dataclass(frozen=True)
 class InteractiveRunner:
+    __slots__ = ("_scheduler",)
+
     _scheduler: "SchedulerSession"
 
     def run_local_interactive_process(

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -18,6 +18,8 @@ _default_timeout_seconds = 15 * 60
 
 @dataclass(frozen=True)
 class ProductDescription:
+    __slots__ = ("value",)
+
     value: str
 
 
@@ -25,6 +27,21 @@ class ProductDescription:
 @dataclass(unsafe_hash=True)
 class ExecuteProcessRequest:
     """Request for execution with args and snapshots to extract."""
+
+    __slots__ = (
+        "_is_frozen",
+        "argv",
+        "input_files",
+        "description",
+        "working_directory",
+        "env",
+        "output_files",
+        "output_directories",
+        "timeout_seconds",
+        "unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule",
+        "jdk_home",
+        "is_nailgunnable",
+    )
 
     # TODO: add a method to hack together a `process_executor` invocation command line which
     # reproduces this process execution request to make debugging remote executions effortless!
@@ -73,6 +90,8 @@ class ExecuteProcessRequest:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class MultiPlatformExecuteProcessRequest:
+    __slots__ = ("_is_frozen", "platform_constraints", "execute_process_requests")
+
     # args collects a set of tuples representing platform constraints mapped to a req,
     # just like a dict constructor can.
     platform_constraints: Tuple[str, ...]
@@ -115,6 +134,8 @@ class ExecuteProcessResult:
     Requesting one of these will raise an exception if the exit code is non-zero.
     """
 
+    __slots__ = ("stdout", "stderr", "output_directory_digest")
+
     stdout: bytes
     stderr: bytes
     output_directory_digest: Digest
@@ -126,6 +147,8 @@ class FallibleExecuteProcessResult:
 
     Requesting one of these will not raise an exception if the exit code is non-zero.
     """
+
+    __slots__ = ("stdout", "stderr", "exit_code", "output_directory_digest")
 
     stdout: bytes
     stderr: bytes
@@ -139,6 +162,8 @@ class FallibleExecuteProcessResultWithPlatform:
 
     Contains information about what platform a request ran on.
     """
+
+    __slots__ = ("stdout", "stderr", "exit_code", "output_directory_digest", "platform")
 
     stdout: bytes
     stderr: bytes

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -168,6 +168,8 @@ class Collection(Sequence[T]):
             pass
     """
 
+    __slots__ = ("dependencies",)
+
     def __init__(self, dependencies: Iterable[T]) -> None:
         # TODO: rename to `items`, `elements`, or even make this private. Python consumers should
         #  not directly access this.

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -298,6 +298,8 @@ class UnionRule:
     """Specify that an instance of `union_member` can be substituted wherever `union_base` is
     used."""
 
+    __slots__ = ("union_base", "union_member")
+
     union_base: Type
     union_member: Type
 
@@ -311,6 +313,8 @@ class UnionRule:
 
 @dataclass(frozen=True)
 class UnionMembership:
+    __slots__ = ("union_rules",)
+
     union_rules: Dict[Type, OrderedSet[Type]]
 
     def is_member(self, union_type, putative_member):
@@ -366,6 +370,18 @@ class TaskRule(Rule):
     should always prefer the `@rule` constructor, and in cases where that is too constraining
     (likely due to #4535) please bump or open a ticket to explain the usecase.
     """
+
+    __slots__ = (
+        "_is_frozen",
+        "_output_type",
+        "input_selectors",
+        "input_gets",
+        "func",
+        "_dependency_rules",
+        "_dependency_optionables",
+        "cacheable",
+        "name",
+    )
 
     _output_type: Type
     input_selectors: Tuple[Type, ...]
@@ -428,6 +444,8 @@ class RootRule(Rule):
     might be when a value is provided as a root subject at the beginning of an execution.
     """
 
+    __slots__ = ("_is_frozen", "_output_type")
+
     _output_type: Type
 
     def __init__(self, output_type: Type) -> None:
@@ -448,6 +466,8 @@ class RootRule(Rule):
 
 @dataclass(frozen=True)
 class NormalizedRules:
+    __slots__ = ("rules", "union_rules")
+
     rules: FrozenOrderedSet
     union_rules: Dict[Type, OrderedSet[Type]]
 
@@ -455,6 +475,8 @@ class NormalizedRules:
 @dataclass(frozen=True)
 class RuleIndex:
     """Holds a normalized index of Rules used to instantiate Nodes."""
+
+    __slots__ = ("rules", "roots", "union_rules")
 
     rules: Dict
     roots: FrozenOrderedSet

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -20,8 +20,10 @@ _Product = TypeVar("_Product")
 class Get(Generic[_Product]):
     """Experimental synchronous generator API.
 
-    May be called equivalently as either:   # verbose form: Get[product](subject_declared_type,
-    subject)   # shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
+    May be called equivalently as either:
+
+        * verbose form: Get[product](subject_declared_type,
+        * shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
     """
 
     product: Type[_Product]
@@ -208,6 +210,8 @@ class Params:
 
     Distinct types are enforced at consumption time by the rust type of the same name.
     """
+
+    __slots__ = ("_is_frozen", "params")
 
     params: Tuple[Any, ...]
 

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -68,6 +68,8 @@ class BinaryConfiguration(ABC):
 @union
 @dataclass(frozen=True)
 class CreatedBinary:
+    __slots__ = ("digest", "binary_name")
+
     digest: Digest
     binary_name: str
 

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -27,6 +27,8 @@ from pants.engine.selectors import Get
 class DownloadedClocScript:
     """Cloc script as downloaded from the pantsbuild binaries repo."""
 
+    __slots__ = ("exe",)
+
     exe: SingleFileExecutable
 
     @property

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -24,8 +24,10 @@ from pants.util.meta import frozen_after_init
 @dataclass(frozen=True)
 class SourceFiles:
     """A merged snapshot of the `sources` fields of multiple targets, possibly containing a subset
-    of the `sources` when using `LegacySpecifiedSourceFilesRequest` (instead of
-    `LegacyAllSourceFilesRequest`)."""
+    of the `sources` when using `SpecifiedSourceFilesRequest` (instead of
+    `AllSourceFilesRequest`)."""
+
+    __slots__ = ("snapshot",)
 
     snapshot: Snapshot
 
@@ -37,8 +39,10 @@ class SourceFiles:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class AllSourceFilesRequest:
+    __slots__ = ("sources_fields", "strip_source_roots")
+
     sources_fields: Tuple[SourcesField, ...]
-    strip_source_roots: bool = False
+    strip_source_roots: bool
 
     def __init__(
         self, sources_fields: Iterable[SourcesField], *, strip_source_roots: bool = False
@@ -50,8 +54,10 @@ class AllSourceFilesRequest:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class SpecifiedSourceFilesRequest:
+    __slots__ = ("sources_fields_with_origins", "strip_source_roots")
+
     sources_fields_with_origins: Tuple[Tuple[SourcesField, OriginSpec], ...]
-    strip_source_roots: bool = False
+    strip_source_roots: bool
 
     def __init__(
         self,

--- a/src/python/pants/rules/core/distdir.py
+++ b/src/python/pants/rules/core/distdir.py
@@ -18,6 +18,8 @@ class InvalidDistDir(Exception):
 class DistDir:
     """The directory to which we write distributable files."""
 
+    __slots__ = ("relpath",)
+
     relpath: Path
 
 
@@ -39,6 +41,4 @@ def validate_distdir(distdir: Path, buildroot: Path) -> DistDir:
 
 
 def rules():
-    return [
-        get_distdir,
-    ]
+    return [get_distdir]

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -26,6 +26,8 @@ from pants.rules.core.lint import Linter
 
 @dataclass(frozen=True)
 class FmtResult:
+    __slots__ = ("digest", "stdout", "stderr")
+
     digest: Digest
     stdout: str
     stderr: str

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -17,6 +17,8 @@ from pants.engine.selectors import Get, MultiGet
 
 @dataclass(frozen=True)
 class LintResult:
+    __slots__ = ("exit_code", "stdout", "stderr")
+
     exit_code: int
     stdout: str
     stderr: str

--- a/src/python/pants/rules/core/repl.py
+++ b/src/python/pants/rules/core/repl.py
@@ -51,6 +51,8 @@ class Repl(Goal):
 
 @dataclass(frozen=True)
 class ReplBinary:
+    __slots__ = ("digest", "binary_name")
+
     digest: Digest
     binary_name: str
 
@@ -107,6 +109,4 @@ async def run_repl(
 
 
 def rules():
-    return [
-        run_repl,
-    ]
+    return [run_repl]

--- a/src/python/pants/rules/core/strip_source_roots.py
+++ b/src/python/pants/rules/core/strip_source_roots.py
@@ -25,16 +25,20 @@ from pants.engine.target import Sources as SourcesField
 from pants.engine.target import rules as target_rules
 from pants.rules.core.targets import FilesSources
 from pants.source.source_root import NoSourceRootError, SourceRootConfig
+from pants.util.meta import frozen_after_init
 
 
 @dataclass(frozen=True)
 class SourceRootStrippedSources:
     """Wrapper for a snapshot of files whose source roots have been stripped."""
 
+    __slots__ = ("snapshot",)
+
     snapshot: Snapshot
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class StripSnapshotRequest:
     """A request to strip source roots for every file in the snapshot.
 
@@ -44,11 +48,18 @@ class StripSnapshotRequest:
     rather than every file.
     """
 
+    __slots__ = ("_is_frozen", "snapshot", "representative_path")
+
     snapshot: Snapshot
-    representative_path: Optional[str] = None
+    representative_path: Optional[str]
+
+    def __init__(self, snapshot: Snapshot, *, representative_path: Optional[str] = None) -> None:
+        self.snapshot = snapshot
+        self.representative_path = representative_path
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class StripSourcesFieldRequest:
     """A request to strip source roots for every file in a `Sources` field.
 
@@ -57,8 +68,16 @@ class StripSourcesFieldRequest:
     with precise file arguments.
     """
 
+    __slots__ = ("_is_frozen", "sources_field", "specified_files_snapshot")
+
     sources_field: SourcesField
-    specified_files_snapshot: Optional[Snapshot] = None
+    specified_files_snapshot: Optional[Snapshot]
+
+    def __init__(
+        self, sources_field: SourcesField, *, specified_files_snapshot: Optional[str] = None
+    ) -> None:
+        self.sources_field = sources_field
+        self.specified_files_snapshot = specified_files_snapshot
 
 
 @rule

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -34,10 +34,12 @@ class Status(Enum):
 
 @dataclass(frozen=True)
 class TestResult:
+    __slots__ = ("status", "stdout", "stderr", "coverage_data")
+
     status: Status
     stdout: str
     stderr: str
-    coverage_data: Optional["CoverageData"] = None
+    coverage_data: Optional["CoverageData"]
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -68,7 +68,9 @@ class MockTestRunner(TestRunner, metaclass=ABCMeta):
     @property
     def test_result(self) -> TestResult:
         address = self.adaptor_with_origin.adaptor.address
-        return TestResult(self.status(address), self.stdout(address), self.stderr(address))
+        return TestResult(
+            self.status(address), self.stdout(address), self.stderr(address), coverage_data=None
+        )
 
 
 class SuccessfulTestRunner(MockTestRunner):

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -11,7 +11,7 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import PurePath
 from typing import (
     Any,
     Callable,
@@ -75,7 +75,7 @@ def fast_relpath_optional(path: str, start: str) -> Optional[str]:
     return None
 
 
-def ensure_relative_file_name(path: Path) -> str:
+def ensure_relative_file_name(path: PurePath) -> str:
     """Return a string representing the `path`, with a leading './'.
 
     This ensures that the returned string can be used as the executable file when executing a

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -15,6 +15,8 @@ class FrozenDict(Mapping[K, V]):
     are not safe to use.
     """
 
+    __slots__ = ("_data", "_hash")
+
     def __init__(self, item: Optional[Union[Mapping[K, V], Iterable[Tuple[K, V]]]] = None) -> None:
         """Creates a `FrozenDict` from a mapping object or a sequence of tuples representing
         entries.

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -33,6 +33,8 @@ T = TypeVar("T")
 class _AbstractOrderedSet(AbstractSet[T]):
     """Common functionality shared between OrderedSet and FrozenOrderedSet."""
 
+    __slots__ = ("_items",)
+
     def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
         # Using a dictionary, rather than using the recipe's original `self |= iterable`, results
         # in a ~20% performance increase for the constructor.
@@ -209,6 +211,8 @@ class FrozenOrderedSet(_AbstractOrderedSet[T]):
 
     This is safe to use with the V2 engine.
     """
+
+    __slots__ = ("_hash",)
 
     def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
         super().__init__(iterable)


### PR DESCRIPTION
### Problem

We know that performance is an issue for Pants (https://github.com/pantsbuild/pants/issues/9435, `#performance` Slack channel). Pants fundamentally is a tool designed to _speed up_ a developer's workflow, so performance is a priority.

One of the reasons that Python is notoriously unperformant is that it stores a class's attributes as a dynamic dictionary via `object.__dict__`. This allows for dynamically adding new attributes to a class, e.g. `MyClass().new_attribute = "hello"`. 

Dictionaries are more memory-intensive than something like a `tuple`, especially because dictionaries are mutable and cannot predict how much memory they will need allocated at instantiation.

So, Python has a dunder called [`__slots__`](https://docs.python.org/3/reference/datamodel.html#slots) that enumerates every expected attribute on a class in the class's definition, which allows Python to allocate the precise amount of memory necessary at the expense of boilerplate + no dynamically created attributes.

## Solution

Use `__slots__` for all of our core engine dataclasses.

These dataclasses already are frozen, so we have zero use for dynamically adding attributes.

This does result in more boilerplate, but because the fundamental value proposition of Pants is to speed up developer workflows, we should bias towards more verbosity in our code for the sake of better performance. (https://github.com/pantsbuild/pants/pull/9283 sets this precedent.)

### Awkward interaction with `@dataclass` default values

`__slots__` work well with `@dataclass`, except when you want to use a default value. As described in https://github.com/ericvsmith/dataclasses/issues/28, the solution is to use a custom `__init__`, which is already a common pattern for us thanks to `@frozen_after_init`.

This is clunky, but as explained above, I argue it's worth the tradeoff.

## Result

<img width="644" alt="perf results" src="https://user-images.githubusercontent.com/14852634/78462475-38925c80-7687-11ea-9bc3-d0f1bfbc3a81.png">

(See https://github.com/pantsbuild/pants/pull/9469#issuecomment-609097133 for how this was calculated)

According to [Aaron Hall's StackOverflow post](https://stackoverflow.com/a/28059785), attribute access is also up to 30% faster. 

[ci skip-rust-tests]
[ci skip-jvm-tests]