### PR TITLE
Bump to grpcio 0.5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2000,7 +2000,7 @@ jobs:
     if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Rust tests - OSX
     os: osx
-    osx_image: xcode8.3
+    osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --rust-tests
     - ./build-support/bin/release.sh -f

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -678,10 +678,13 @@ def rust_tests_osx() -> Dict:
         **_RUST_TESTS_BASE,
         "name": "Rust tests - OSX",
         "os": "osx",
-        # We need to use xcode8.3 because newer versions of OSX won't let new kexts be installed
-        # without travis taking some action, and we need the osxfuse kext.
-        # See https://github.com/travis-ci/travis-ci/issues/10017
-        "osx_image": "xcode8.3",
+        # We need to use xcode8 because:
+        # 1) versions of OSX newer than xcode8.3 won't let new kexts be installed without travis
+        #    taking some action, and we need the osxfuse kext.
+        #      See https://github.com/travis-ci/travis-ci/issues/10017
+        # 2) xcode 8.3 fails to compile grpc-sys:
+        #      See https://gist.github.com/stuhood/856a9b09bbaa86141f36c9925c14fae7
+        "osx_image": "xcode8",
         "before_install": [
             './build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"',
             # We don't use the standard travis "addons" section here because it will either silently

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dir-diff 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
+ "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -136,6 +136,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -331,6 +350,14 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +379,16 @@ dependencies = [
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1087,6 +1124,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "globset"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,11 +1159,11 @@ dependencies = [
 
 [[package]]
 name = "grpcio"
-version = "0.3.0"
-source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532#b582ef3dc4e8c7289093c8febff8dadf0997b532"
+version = "0.5.1"
+source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70#d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
+ "grpcio-sys 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -1138,13 +1180,16 @@ dependencies = [
 
 [[package]]
 name = "grpcio-sys"
-version = "0.2.3"
-source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532#b582ef3dc4e8c7289093c8febff8dadf0997b532"
+version = "0.5.1"
+source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70#d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70"
 dependencies = [
+ "bindgen 0.53.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1464,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1757,7 @@ dependencies = [
  "bazel_protos 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
+ "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "hashing 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -1736,6 +1790,15 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1972,6 +2035,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,7 +2151,7 @@ dependencies = [
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
+ "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "hashing 0.0.1",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2523,6 +2591,11 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +2816,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,7 +2907,7 @@ dependencies = [
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)",
+ "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "hashing 0.0.1",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3611,6 +3689,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+"checksum bindgen 0.53.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -3625,9 +3704,11 @@ dependencies = [
 "checksum cargo 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7e90b5f23ae79af3ec0e4dc670349167fd47d6c1134f139cf0627817a4792bf"
 "checksum cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1f861ef68cabbb271d373a7795014052bff37edce22c620d95e395e8719d7dc5"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+"checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+"checksum clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
@@ -3698,10 +3779,11 @@ dependencies = [
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum git2-curl 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d58551e903ed7e2d6fe3a2f3c7efa3a784ec29b19d0fbb035aaf0497c183fbdd"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
-"checksum grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)" = "<none>"
+"checksum grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)" = "<none>"
 "checksum grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63ccc27b0099347d2bea2c3d0f1c79c018a13cfd08b814a1992e341b645d5e1"
-"checksum grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=b582ef3dc4e8c7289093c8febff8dadf0997b532)" = "<none>"
+"checksum grpcio-sys 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -3733,6 +3815,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
+"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libnghttp2-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b359f5ec8106bc297694c9a562ace312be2cfd17a5fc68dc12249845aa144b11"
 "checksum libssh2-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
@@ -3758,6 +3841,7 @@ dependencies = [
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum nails 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbf022f659381fd767684f3f1d46b55a20b3d0902d4c722f9f78589d8afa4156"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum notify 5.0.0-pre.1 (git+https://github.com/notify-rs/notify?rev=fba00891d9105e2f581c69fbe415a58cb7966fdd)" = "<none>"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
@@ -3782,6 +3866,7 @@ dependencies = [
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
@@ -3835,6 +3920,7 @@ dependencies = [
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -3858,6 +3944,7 @@ dependencies = [
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
+"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05a3e303ace6adb0a60a9e9e2fbc6a33e1749d1e43587e2125f7efa9c5e107c5"
 "checksum sized-chunks 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -14,7 +14,8 @@ dirs = "1"
 fs = { path = ".." }
 futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
+# TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457.
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 indexmap = "1.0.2"
 itertools = "0.7.2"

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -277,7 +277,7 @@ impl ByteStore {
               .map(|(_client, bytes)| Some(bytes.freeze()))
               .or_else(|e| match e {
                 grpcio::Error::RpcFailure(grpcio::RpcStatus {
-                  status: grpcio::RpcStatusCode::NotFound,
+                  status: grpcio::RpcStatusCode::NOT_FOUND,
                   ..
                 }) => Ok(None),
                 _ => Err(format!(

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -17,7 +17,8 @@ digest = "0.8"
 fs = { path = "../fs" }
 futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
+# TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457.
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 [dependencies]
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
+# TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457.
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 prost = "0.4"
 prost-derive = "0.4"

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -659,7 +659,7 @@ impl CommandRunner {
         }
 
         let status = execute_response.take_status();
-        if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::Ok {
+        if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::OK {
           let mut execution_attempts = std::mem::replace(&mut attempts.attempts, vec![]);
           execution_attempts.push(attempts.current_attempt);
           return populate_fallible_execution_result(
@@ -678,8 +678,8 @@ impl CommandRunner {
     };
 
     match grpcio::RpcStatusCode::from(status.get_code()) {
-      grpcio::RpcStatusCode::Ok => unreachable!(),
-      grpcio::RpcStatusCode::FailedPrecondition => {
+      grpcio::RpcStatusCode::OK => unreachable!(),
+      grpcio::RpcStatusCode::FAILED_PRECONDITION => {
         if status.get_details().len() != 1 {
           return future::err(ExecutionError::Fatal(format!(
             "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
@@ -750,11 +750,11 @@ impl CommandRunner {
         future::err(ExecutionError::MissingDigests(missing_digests)).to_boxed()
       }
       code => match code {
-        grpcio::RpcStatusCode::Aborted
-        | grpcio::RpcStatusCode::Internal
-        | grpcio::RpcStatusCode::ResourceExhausted
-        | grpcio::RpcStatusCode::Unavailable
-        | grpcio::RpcStatusCode::Unknown => {
+        grpcio::RpcStatusCode::ABORTED
+        | grpcio::RpcStatusCode::INTERNAL
+        | grpcio::RpcStatusCode::RESOURCE_EXHAUSTED
+        | grpcio::RpcStatusCode::UNAVAILABLE
+        | grpcio::RpcStatusCode::UNKNOWN => {
           future::err(ExecutionError::Retryable(status.get_message().to_owned())).to_boxed()
         }
         _ => future::err(ExecutionError::Fatal(format!(
@@ -1184,7 +1184,7 @@ fn rpcerror_recover_cancelled(
 ) -> Result<bazel_protos::operations::Operation, grpcio::Error> {
   // If the error represented cancellation, return an Operation for the given Operation name.
   match &err {
-    &grpcio::Error::RpcFailure(ref rs) if rs.status == grpcio::RpcStatusCode::Cancelled => {
+    &grpcio::Error::RpcFailure(ref rs) if rs.status == grpcio::RpcStatusCode::CANCELLED => {
       let mut next_operation = bazel_protos::operations::Operation::new();
       next_operation.set_name(operation_name);
       return Ok(next_operation);

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -588,7 +588,7 @@ async fn server_rejecting_execute_request_gives_error() {
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
     .expect_err("Want Err");
-  assert_that(&error).contains("InvalidArgument");
+  assert_that(&error).contains("INVALID_ARGUMENT");
   assert_that(&error).contains("Did not expect this request");
 }
 
@@ -1591,7 +1591,7 @@ async fn execute_missing_file_uploads_if_known_status() {
     let op_name = "cat".to_owned();
 
     let status = grpcio::RpcStatus {
-      status: grpcio::RpcStatusCode::FailedPrecondition,
+      status: grpcio::RpcStatusCode::FAILED_PRECONDITION,
       details: None,
       status_proto_bytes: Some(
         make_precondition_failure_status(vec![missing_preconditionfailure_violation(
@@ -1925,14 +1925,14 @@ async fn extract_execute_response_other_status() {
     let mut response = bazel_protos::remote_execution::ExecuteResponse::new();
     response.set_status({
       let mut status = bazel_protos::status::Status::new();
-      status.set_code(grpcio::RpcStatusCode::PermissionDenied as i32);
+      status.set_code(grpcio::RpcStatusCode::PERMISSION_DENIED.into());
       status
     });
     response
   }));
 
   match extract_execute_response(operation, Platform::Linux).await {
-    Err(ExecutionError::Fatal(err)) => assert_contains(&err, "PermissionDenied"),
+    Err(ExecutionError::Fatal(err)) => assert_contains(&err, "PERMISSION_DENIED"),
     other => assert!(false, "Want fatal error, got {:?}", other),
   };
 }
@@ -2396,7 +2396,7 @@ fn make_incomplete_operation(operation_name: &str) -> MockOperation {
 
 fn make_retryable_operation_failure() -> MockOperation {
   let mut status = bazel_protos::status::Status::new();
-  status.set_code(grpcio::RpcStatusCode::Aborted as i32);
+  status.set_code(grpcio::RpcStatusCode::ABORTED.into());
   status.set_message(String::from("the bot running the task appears to be lost"));
 
   let mut operation = bazel_protos::operations::Operation::new();
@@ -2533,7 +2533,7 @@ fn make_precondition_failure_status(
   violations: Vec<bazel_protos::error_details::PreconditionFailure_Violation>,
 ) -> bazel_protos::status::Status {
   let mut status = bazel_protos::status::Status::new();
-  status.set_code(grpcio::RpcStatusCode::FailedPrecondition as i32);
+  status.set_code(grpcio::RpcStatusCode::FAILED_PRECONDITION.into());
   status.mut_details().push(make_any_proto(&{
     let mut precondition_failure = bazel_protos::error_details::PreconditionFailure::new();
     for violation in violations.into_iter() {

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
 futures01 = { package = "futures", version = "0.1" }
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "b582ef3dc4e8c7289093c8febff8dadf0997b532", default_features = false, features = ["protobuf-codec", "secure"] }
+# TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457.
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -110,7 +110,7 @@ impl TestServer {
   /// The address on which this server is listening over insecure HTTP transport.
   ///
   pub fn address(&self) -> String {
-    let bind_addr = self.server_transport.bind_addrs().first().unwrap();
+    let bind_addr = self.server_transport.bind_addrs().next().unwrap();
     format!("{}:{}", bind_addr.0, bind_addr.1)
   }
 }
@@ -216,7 +216,7 @@ impl MockResponder {
       }
     } else {
       sink.fail(grpcio::RpcStatus::new(
-        grpcio::RpcStatusCode::InvalidArgument,
+        grpcio::RpcStatusCode::INVALID_ARGUMENT,
         Some("Did not expect further requests from client.".to_string()),
       ));
     }
@@ -241,7 +241,7 @@ impl MockResponder {
               .map_err(|_| ()),
           )
         } else if let Err(status) = op {
-          sink.fail(status);
+          ctx.spawn(sink.fail(status).then(|_| Ok(())));
         } else {
           // Cancel the request by dropping the sink.
           drop(sink)
@@ -250,7 +250,7 @@ impl MockResponder {
       None => ctx.spawn(
         sink
           .fail(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::InvalidArgument,
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
             Some("Did not expect further requests from client.".to_string()),
           ))
           .map(|_| ())
@@ -275,7 +275,7 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
       ctx.spawn(
         sink
           .fail(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::InvalidArgument,
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
             Some(format!(
               "Did not expect this request. Expected: {:?}, Got: {:?}",
               self.mock_execution.execute_request, req
@@ -318,7 +318,7 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
     sink: grpcio::UnarySink<bazel_protos::operations::ListOperationsResponse>,
   ) {
     sink.fail(grpcio::RpcStatus::new(
-      grpcio::RpcStatusCode::Unimplemented,
+      grpcio::RpcStatusCode::UNIMPLEMENTED,
       None,
     ));
   }
@@ -330,7 +330,7 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
     sink: grpcio::UnarySink<bazel_protos::empty::Empty>,
   ) {
     sink.fail(grpcio::RpcStatus::new(
-      grpcio::RpcStatusCode::Unimplemented,
+      grpcio::RpcStatusCode::UNIMPLEMENTED,
       None,
     ));
   }


### PR DESCRIPTION
### Problem

#9395 occurs within our `grpcio` dependency, which is quite stale. Although #9395 is more likely to be related to changes in our executor (#9071) or to our transitive rust dependencies (#9122), getting on a more recent version of the `grpcio` crate _might_ resolve the issue, or make it easier to report an issue.

### Solution

Bump to `0.5.1` with one patch (https://github.com/tikv/grpc-rs/pull/457) pulled forward from our previous fork. 

[ci skip-jvm-tests]  # No JVM changes made.