### PR TITLE
Deprecate the `source` field in favor of the `sources` field

### DIFF
--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -7,6 +7,7 @@ from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 
+from pants.base.deprecated import warn_or_error
 from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
@@ -62,6 +63,20 @@ class TargetAdaptor(StructWithDeps):
                     f"source must be a str containing a path relative to the target, but got {source} of "
                     f"type {type(source)}",
                 )
+            script_instructions = (
+                "curl -L -o convert_source_to_sources.py 'https://git.io/JvbN3' && chmod +x "
+                "convert_source_to_sources.py && ./convert_source_to_sources.py "
+                f"root_folder1/ root_folder2/"
+            )
+            warn_or_error(
+                deprecated_entity_description="using `source` instead of `sources` in a BUILD file",
+                removal_version="1.29.0.dev0",
+                hint=(
+                    f"Instead of `source={repr(source)}`, use `sources=[{repr(source)}]`. We "
+                    "recommend using our migration script to automate fixing your entire "
+                    f"repository by running `{script_instructions}`."
+                ),
+            )
             sources = [source]
 
         # N.B. Here we check specifically for `sources is None`, as it's possible for sources


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/8718. 

As explained there, `source=` is not valuable enough of a special case to justify its existence. And, removing `globs` opens up a weird world where `source='**/*.py'` is perfectly legal.

Example warning:

> 22:46:28 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/legacy/structs.py:102: DeprecationWarning: DEPRECATED: using `source` instead of `sources` in a BUILD file will be removed in version 1.29.0.dev0.
  Instead of `source='check_banned_imports.py'`, use `sources=['check_banned_imports.py']`. We recommend using our migration script to automate fixing your entire repository by running `curl -L -o convert_source_to_sources.py 'https://git.io/JvbN3' && chmod +x convert_source_to_sources.py && ./convert_source_to_sources.py root_folder1/ root_folder2/`.
  conjunction_globs = self.get_sources()

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
