### PR TITLE
Avoid recomputing a BuildFileAddress when subclassing will do.

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -105,9 +105,8 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
     Recursively collects any embedded addressables within the Struct, but will not walk into a
     dependencies field, since those should be requested explicitly by rules.
     """
-    build_file_address = await Get[BuildFileAddress](Address, address)
     address_family = await Get[AddressFamily](Dir(address.spec_path))
-    struct = address_family.addressables.get(build_file_address)
+    struct = address_family.addressables_as_address_keyed.get(address)
 
     inline_dependencies = []
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -107,6 +107,8 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
     """
     address_family = await Get[AddressFamily](Dir(address.spec_path))
     struct = address_family.addressables_as_address_keyed.get(address)
+    if struct is None:
+        _raise_did_you_mean(address_family, address.target_name)
 
     inline_dependencies = []
 

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -3,10 +3,10 @@
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Tuple, Union, cast
 
 from pants.base.exceptions import DuplicateNameError, MappingError, UnaddressableObjectError
-from pants.build_graph.address import BuildFileAddress
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
 from pants.util.memo import memoized_property
@@ -136,6 +136,14 @@ class AddressFamily:
             BuildFileAddress(rel_path=path, target_name=name): obj
             for name, (path, obj) in self.objects_by_name.items()
         }
+
+    @property
+    def addressables_as_address_keyed(self) -> Dict[Address, ThinAddressableObject]:
+        """Identical to `addresses`, but with a `cast` to allow for type safe lookup of `Address`es.
+
+        :rtype: dict from `Address` to thin addressable objects.
+        """
+        return cast(Dict[Address, ThinAddressableObject], self.addressables)
 
     def __hash__(self):
         return hash(self.namespace)


### PR DESCRIPTION
### Problem

Struct hydration was using a rule to (re-)compute the `BuildFileAddress` for an `Address` in order to lookup the struct.

### Solution

Use the fact that `BuildFileAddress` and `Address` have compatible eq/hash implementations, and lookup the `Address` directly in the `AddressFamily`.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.