### PR TITLE
Port the fs crate(s) to async-await

### DIFF
--- a/src/rust/engine/ASYNC.md
+++ b/src/rust/engine/ASYNC.md
@@ -1,9 +1,15 @@
 
 # async-await port notes
 
-Many functions at the boundary between ported async-await, stdlib futures code and legacy
-future 0.1 code temporarily return futures 0.3 BoxFuture and use explicit lifetimes, because that
-is easier for a futures 0.1 consumer. stdlib futures consumers can easily call async functions with
-references (because they can remain "on the stack"), but an 0.1 future cannot. These methods can be
-swapped back to async once all callers are using async-await.
+stdlib futures consumers can easily call async functions with references (because they can
+remain "on the stack"), but using 0.1 futures combinators with async functions is challenging in
+the face of references. Rather than using combinators, 0.1 futures callers of stdlib Future/async
+functions can wrap their calls in async blocks that capture (via `move`) any state they need to
+execute:
+
+    // Box and pin a stdlib future, and then convert it to a futures01 future via `compat()`.
+    // The final `to_boxed()` call is necessary for functions that return boxfuture::BoxFuture.
+    Box::pin(async move {
+      // stdlib futures usage goes here.
+    }).compat().to_boxed()
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -209,7 +209,6 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -12,8 +12,7 @@ dirs = "1"
 env_logger = "0.5.4"
 errno = "0.2.3"
 fuse = "0.3.1"
-futures01 = { package = "futures", version = "0.1" }
-futures = { version = "0.3", features = ["compat"] }
+futures = "0.3"
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/brfs/src/syscall_tests.rs
+++ b/src/rust/engine/fs/brfs/src/syscall_tests.rs
@@ -4,7 +4,6 @@
 use super::mount;
 use super::tests::digest_to_filepath;
 use crate::tests::make_dirs;
-use futures::compat::Future01CompatExt;
 use libc;
 use std::ffi::CString;
 use std::path::Path;
@@ -24,7 +23,6 @@ async fn read_file_by_digest_exact_bytes() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
 

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -2,7 +2,6 @@ use tempfile;
 use testutil;
 
 use crate::mount;
-use futures::compat::Future01CompatExt;
 use hashing;
 use store::Store;
 use testutil::{
@@ -40,7 +39,6 @@ async fn read_file_by_digest() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
 
@@ -66,12 +64,10 @@ async fn list_directory() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .record_directory(&test_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
 
@@ -96,12 +92,10 @@ async fn read_file_from_directory() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .record_directory(&test_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
 
@@ -130,22 +124,18 @@ async fn list_recursive_directory() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .store_file_bytes(treat_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .record_directory(&test_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
   store
     .record_directory(&recursive_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
 
@@ -173,22 +163,18 @@ async fn read_file_from_recursive_directory() {
 
   store
     .store_file_bytes(test_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .store_file_bytes(treat_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .record_directory(&test_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
   store
     .record_directory(&recursive_directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
 
@@ -219,12 +205,10 @@ async fn files_are_correctly_executable() {
 
   store
     .store_file_bytes(treat_bytes.bytes(), false)
-    .compat()
     .await
     .expect("Storing bytes");
   store
     .record_directory(&directory.directory(), false)
-    .compat()
     .await
     .expect("Storing directory");
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::future::{self, BoxFuture, TryFutureExt};
+use futures::future::{self, TryFutureExt};
 use glob::Pattern;
 use log::warn;
 use parking_lot::Mutex;
@@ -34,11 +34,8 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// Recursively expands PathGlobs into PathStats while applying excludes.
   ///
-  /// TODO: See the note on references in ASYNC.md.
-  ///
-  fn expand<'a, 'b>(&'a self, path_globs: PathGlobs) -> BoxFuture<'b, Result<Vec<PathStat>, E>> {
-    let fs = self.clone();
-    Box::pin(async move { GlobMatchingImplementation::expand(&fs, path_globs).await })
+  async fn expand(&self, path_globs: PathGlobs) -> Result<Vec<PathStat>, E> {
+    GlobMatchingImplementation::expand(self, path_globs).await
   }
 }
 

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -1,10 +1,11 @@
 use super::{BackoffConfig, EntryType};
 
 use bazel_protos::{self, call_option};
-use boxfuture::{try_future, BoxFuture, Boxable};
+use boxfuture::{try_future, Boxable};
 use bytes::{Bytes, BytesMut};
 use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
+use futures::compat::Future01CompatExt;
 use futures01::{future, Future, IntoFuture, Sink, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
@@ -112,11 +113,11 @@ impl ByteStore {
     )
   }
 
-  pub fn store_bytes(
+  pub async fn store_bytes(
     &self,
     bytes: Bytes,
     workunit_store: WorkUnitStore,
-  ) -> BoxFuture<Digest, String> {
+  ) -> Result<Digest, String> {
     let start_time = std::time::SystemTime::now();
 
     let mut hasher = Sha256::default();
@@ -132,110 +133,115 @@ impl ByteStore {
       digest.1,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
-    let workunit_store = workunit_store;
     let store = self.clone();
-    self
-      .with_byte_stream_client(move |client| {
-        match client
-          .write_opt(try_future!(call_option(&store.headers, None)).timeout(store.upload_timeout))
-          .map(|v| (v, client))
-        {
-          Err(err) => future::err(format!(
-            "Error attempting to connect to upload digest {:?}: {:?}",
-            digest, err
-          ))
-          .to_boxed(),
-          Ok(((sender, receiver), _client)) => {
-            let chunk_size_bytes = store.chunk_size_bytes;
-            let resource_name = resource_name.clone();
-            let bytes = bytes.clone();
-            let stream =
-              futures01::stream::unfold::<_, _, future::FutureResult<_, grpcio::Error>, _>(
-                (0, false),
-                move |(offset, has_sent_any)| {
-                  if offset >= bytes.len() && has_sent_any {
-                    None
-                  } else {
-                    let mut req = bazel_protos::bytestream::WriteRequest::new();
-                    req.set_resource_name(resource_name.clone());
-                    req.set_write_offset(offset as i64);
-                    let next_offset = min(offset + chunk_size_bytes, bytes.len());
-                    req.set_finish_write(next_offset == bytes.len());
-                    req.set_data(bytes.slice(offset, next_offset));
-                    Some(future::ok((
-                      (req, grpcio::WriteFlags::default()),
-                      (next_offset, true),
-                    )))
-                  }
-                },
-              );
 
-            sender
-              .send_all(stream)
-              .map(|_| ())
-              .or_else(move |e| {
-                match e {
-                  // Some implementations of the remote execution API early-return if the blob has
-                  // been concurrently uploaded by another client. In this case, they return a
-                  // WriteResponse with a committed_size equal to the digest's entire size before
-                  // closing the stream.
-                  // Because the server then closes the stream, the client gets an RpcFinished
-                  // error in this case. We ignore this, and will later on verify that the
-                  // committed_size we received from the server is equal to the expected one. If
-                  // these are not equal, the upload will be considered a failure at that point.
-                  // Whether this type of response will become part of the official API is up for
-                  // discussion: see
-                  // https://groups.google.com/d/topic/remote-execution-apis/NXUe3ItCw68/discussion.
-                  grpcio::Error::RpcFinished(None) => Ok(()),
-                  e => Err(format!(
-                    "Error attempting to upload digest {:?}: {:?}",
-                    digest, e
-                  )),
-                }
-              })
-              .and_then(move |()| {
-                receiver.map_err(move |e| {
-                  format!(
-                    "Error from server when uploading digest {:?}: {:?}",
-                    digest, e
-                  )
+    let result =
+      self
+        .with_byte_stream_client(move |client| {
+          match client
+            .write_opt(try_future!(call_option(&store.headers, None)).timeout(store.upload_timeout))
+            .map(|v| (v, client))
+          {
+            Err(err) => future::err(format!(
+              "Error attempting to connect to upload digest {:?}: {:?}",
+              digest, err
+            ))
+            .to_boxed(),
+            Ok(((sender, receiver), _client)) => {
+              let chunk_size_bytes = store.chunk_size_bytes;
+              let resource_name = resource_name.clone();
+              let bytes = bytes.clone();
+              let stream =
+                futures01::stream::unfold::<_, _, future::FutureResult<_, grpcio::Error>, _>(
+                  (0, false),
+                  move |(offset, has_sent_any)| {
+                    if offset >= bytes.len() && has_sent_any {
+                      None
+                    } else {
+                      let mut req = bazel_protos::bytestream::WriteRequest::new();
+                      req.set_resource_name(resource_name.clone());
+                      req.set_write_offset(offset as i64);
+                      let next_offset = min(offset + chunk_size_bytes, bytes.len());
+                      req.set_finish_write(next_offset == bytes.len());
+                      req.set_data(bytes.slice(offset, next_offset));
+                      Some(future::ok((
+                        (req, grpcio::WriteFlags::default()),
+                        (next_offset, true),
+                      )))
+                    }
+                  },
+                );
+
+              sender
+                .send_all(stream)
+                .map(|_| ())
+                .or_else(move |e| {
+                  match e {
+                    // Some implementations of the remote execution API early-return if the blob has
+                    // been concurrently uploaded by another client. In this case, they return a
+                    // WriteResponse with a committed_size equal to the digest's entire size before
+                    // closing the stream.
+                    // Because the server then closes the stream, the client gets an RpcFinished
+                    // error in this case. We ignore this, and will later on verify that the
+                    // committed_size we received from the server is equal to the expected one. If
+                    // these are not equal, the upload will be considered a failure at that point.
+                    // Whether this type of response will become part of the official API is up for
+                    // discussion: see
+                    // https://groups.google.com/d/topic/remote-execution-apis/NXUe3ItCw68/discussion.
+                    grpcio::Error::RpcFinished(None) => Ok(()),
+                    e => Err(format!(
+                      "Error attempting to upload digest {:?}: {:?}",
+                      digest, e
+                    )),
+                  }
                 })
-              })
-              .and_then(move |received| {
-                if received.get_committed_size() == len as i64 {
-                  Ok(digest)
-                } else {
-                  Err(format!(
-                    "Uploading file with digest {:?}: want commited size {} but got {}",
-                    digest,
-                    len,
-                    received.get_committed_size()
-                  ))
-                }
-              })
-              .to_boxed()
+                .and_then(move |()| {
+                  receiver.map_err(move |e| {
+                    format!(
+                      "Error from server when uploading digest {:?}: {:?}",
+                      digest, e
+                    )
+                  })
+                })
+                .and_then(move |received| {
+                  if received.get_committed_size() == len as i64 {
+                    Ok(digest)
+                  } else {
+                    Err(format!(
+                      "Uploading file with digest {:?}: want commited size {} but got {}",
+                      digest,
+                      len,
+                      received.get_committed_size()
+                    ))
+                  }
+                })
+                .to_boxed()
+            }
           }
-        }
-      })
-      .then(move |future| {
-        let workunit = WorkUnit::new(
-          workunit_name.clone(),
-          TimeSpan::since(&start_time),
-          workunit_store::get_parent_id(),
-        );
-        workunit_store.add_workunit(workunit);
-        future
-      })
-      .to_boxed()
+        })
+        .compat()
+        .await;
+
+    let workunit = WorkUnit::new(
+      workunit_name.clone(),
+      TimeSpan::since(&start_time),
+      workunit_store::get_parent_id(),
+    );
+    workunit_store.add_workunit(workunit);
+
+    result
   }
 
-  pub fn load_bytes_with<T: Send + 'static, F: Fn(Bytes) -> T + Send + Sync + Clone + 'static>(
+  pub async fn load_bytes_with<
+    T: Send + 'static,
+    F: Fn(Bytes) -> T + Send + Sync + Clone + 'static,
+  >(
     &self,
     _entry_type: EntryType,
     digest: Digest,
     f: F,
     workunit_store: WorkUnitStore,
-  ) -> BoxFuture<Option<T>, String> {
+  ) -> Result<Option<T>, String> {
     let start_time = std::time::SystemTime::now();
 
     let store = self.clone();
@@ -246,8 +252,8 @@ impl ByteStore {
       digest.1
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
-    let workunit_store = workunit_store;
-    self
+
+    let result = self
       .with_byte_stream_client(move |client| {
         match client
           .read_opt(
@@ -295,16 +301,17 @@ impl ByteStore {
           .to_boxed(),
         }
       })
-      .then(move |future| {
-        let workunit = WorkUnit::new(
-          workunit_name.clone(),
-          TimeSpan::since(&start_time),
-          workunit_store::get_parent_id(),
-        );
-        workunit_store.add_workunit(workunit);
-        future
-      })
-      .to_boxed()
+      .compat()
+      .await;
+
+    let workunit = WorkUnit::new(
+      workunit_name.clone(),
+      TimeSpan::since(&start_time),
+      workunit_store::get_parent_id(),
+    );
+    workunit_store.add_workunit(workunit);
+
+    result
   }
 
   ///

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -142,7 +142,6 @@ async fn write_file_one_chunk() {
   assert_eq!(
     store
       .store_bytes(testdata.bytes(), WorkUnitStore::new())
-      .compat()
       .await,
     Ok(testdata.digest())
   );
@@ -176,7 +175,6 @@ async fn write_file_multiple_chunks() {
   assert_eq!(
     store
       .store_bytes(all_the_henries.clone(), WorkUnitStore::new())
-      .compat()
       .await,
     Ok(big_file_digest())
   );
@@ -207,7 +205,6 @@ async fn write_empty_file() {
   assert_eq!(
     store
       .store_bytes(empty_file.bytes(), WorkUnitStore::new())
-      .compat()
       .await,
     Ok(empty_file.digest())
   );
@@ -226,7 +223,6 @@ async fn write_file_errors() {
   let store = new_byte_store(&cas);
   let error = store
     .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
-    .compat()
     .await
     .expect_err("Want error");
   assert!(
@@ -256,7 +252,6 @@ async fn write_connection_error() {
   .unwrap();
   let error = store
     .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
-    .compat()
     .await
     .expect_err("Want error");
   assert!(
@@ -395,6 +390,5 @@ async fn load_bytes(
 ) -> Result<Option<Bytes>, String> {
   store
     .load_bytes_with(entry_type, digest, |b| b, WorkUnitStore::new())
-    .compat()
     .await
 }

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -176,12 +176,10 @@ async fn merge_directories_two_files() {
 
   store
     .record_directory(&containing_roland.directory(), false)
-    .compat()
     .await
     .expect("Storing roland directory");
   store
     .record_directory(&containing_treats.directory(), false)
-    .compat()
     .await
     .expect("Storing treats directory");
 
@@ -208,12 +206,10 @@ async fn merge_directories_clashing_files() {
 
   store
     .record_directory(&containing_roland.directory(), false)
-    .compat()
     .await
     .expect("Storing roland directory");
   store
     .record_directory(&containing_wrong_roland.directory(), false)
-    .compat()
     .await
     .expect("Storing wrong roland directory");
 
@@ -242,12 +238,10 @@ async fn merge_directories_same_files() {
 
   store
     .record_directory(&containing_roland.directory(), false)
-    .compat()
     .await
     .expect("Storing roland directory");
   store
     .record_directory(&containing_roland_and_treats.directory(), false)
-    .compat()
     .await
     .expect("Storing treats directory");
 
@@ -315,7 +309,6 @@ async fn snapshot_merge_two_files() {
     .unwrap();
   let merged_root_directory = store
     .load_directory(merged.digest, WorkUnitStore::new())
-    .compat()
     .await
     .unwrap()
     .unwrap()
@@ -330,7 +323,6 @@ async fn snapshot_merge_two_files() {
     merged_child_dirnode.get_digest().into();
   let merged_child_directory = store
     .load_directory(merged_child_dirnode_digest.unwrap(), WorkUnitStore::new())
-    .compat()
     .await
     .unwrap()
     .unwrap()
@@ -393,7 +385,6 @@ async fn strip_empty_prefix() {
   let dir = TestDirectory::nested();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
 
@@ -411,12 +402,10 @@ async fn strip_non_empty_prefix() {
   let dir = TestDirectory::nested();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   store
     .record_directory(&TestDirectory::containing_roland().directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
 
@@ -438,7 +427,6 @@ async fn strip_prefix_empty_subdir() {
   let dir = TestDirectory::containing_falcons_dir();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
 
@@ -470,7 +458,6 @@ async fn strip_subdir_not_in_store() {
   let dir = TestDirectory::nested();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   let result = super::Snapshot::strip_prefix(
@@ -497,12 +484,10 @@ async fn strip_prefix_non_matching_file() {
   let child_dir = TestDirectory::containing_roland();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   store
     .record_directory(&child_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   let result = super::Snapshot::strip_prefix(
@@ -524,12 +509,10 @@ async fn strip_prefix_non_matching_dir() {
   let child_dir = TestDirectory::nested_dir_and_file();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   store
     .record_directory(&child_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   let result = super::Snapshot::strip_prefix(
@@ -550,12 +533,10 @@ async fn strip_subdir_not_in_dir() {
   let dir = TestDirectory::nested();
   store
     .record_directory(&dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   store
     .record_directory(&TestDirectory::containing_roland().directory(), false)
-    .compat()
     .await
     .expect("Error storing directory");
   let result = super::Snapshot::strip_prefix(

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -1,5 +1,3 @@
-use futures::compat::Future01CompatExt;
-use futures01::future::Future;
 use hashing::{Digest, Fingerprint};
 use tempfile;
 use testutil::data::TestDirectory;
@@ -51,8 +49,7 @@ async fn snapshot_one_file() {
 
   let path_stats = expand_all_sorted(posix_fs).await;
   let snapshot =
-    Snapshot::from_path_stats(store, &digester, path_stats.clone(), WorkUnitStore::new())
-      .compat()
+    Snapshot::from_path_stats(store, digester, path_stats.clone(), WorkUnitStore::new())
       .await
       .unwrap();
   assert_eq!(
@@ -81,8 +78,7 @@ async fn snapshot_recursive_directories() {
 
   let path_stats = expand_all_sorted(posix_fs).await;
   let snapshot =
-    Snapshot::from_path_stats(store, &digester, path_stats.clone(), WorkUnitStore::new())
-      .compat()
+    Snapshot::from_path_stats(store, digester, path_stats.clone(), WorkUnitStore::new())
       .await
       .unwrap();
   assert_eq!(
@@ -112,17 +108,15 @@ async fn snapshot_from_digest() {
   let path_stats = expand_all_sorted(posix_fs).await;
   let expected_snapshot = Snapshot::from_path_stats(
     store.clone(),
-    &digester,
+    digester,
     path_stats.clone(),
     WorkUnitStore::new(),
   )
-  .compat()
   .await
   .unwrap();
   assert_eq!(
     expected_snapshot,
     Snapshot::from_digest(store, expected_snapshot.digest, WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
   );
@@ -147,11 +141,10 @@ async fn snapshot_recursive_directories_including_empty() {
   assert_eq!(
     Snapshot::from_path_stats(
       store,
-      &digester,
+      digester,
       unsorted_path_stats.clone(),
       WorkUnitStore::new(),
     )
-    .compat()
     .await
     .unwrap(),
     Snapshot {
@@ -188,7 +181,6 @@ async fn merge_directories_two_files() {
     vec![containing_treats.digest(), containing_roland.digest()],
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
 
   assert_eq!(
@@ -218,7 +210,6 @@ async fn merge_directories_clashing_files() {
     vec![containing_roland.digest(), containing_wrong_roland.digest()],
     WorkUnitStore::new(),
   )
-  .compat()
   .await
   .expect_err("Want error merging");
 
@@ -253,7 +244,6 @@ async fn merge_directories_same_files() {
     ],
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
 
   assert_eq!(
@@ -285,26 +275,23 @@ async fn snapshot_merge_two_files() {
 
   let snapshot1 = Snapshot::from_path_stats(
     store.clone(),
-    &digester,
+    digester.clone(),
     vec![dir.clone(), file1.clone()],
     WorkUnitStore::new(),
   )
-  .compat()
   .await
   .unwrap();
 
   let snapshot2 = Snapshot::from_path_stats(
     store.clone(),
-    &digester,
+    digester,
     vec![dir.clone(), file2.clone()],
     WorkUnitStore::new(),
   )
-  .compat()
   .await
   .unwrap();
 
   let merged = Snapshot::merge(store.clone(), &[snapshot1, snapshot2], WorkUnitStore::new())
-    .compat()
     .await
     .unwrap();
   let merged_root_directory = store
@@ -352,22 +339,20 @@ async fn snapshot_merge_colliding() {
 
   let snapshot1 = Snapshot::from_path_stats(
     store.clone(),
-    &digester,
+    digester.clone(),
     vec![file.clone()],
     WorkUnitStore::new(),
   )
-  .compat()
   .await
   .unwrap();
 
   let snapshot2 =
-    Snapshot::from_path_stats(store.clone(), &digester, vec![file], WorkUnitStore::new())
-      .compat()
+    Snapshot::from_path_stats(store.clone(), digester, vec![file], WorkUnitStore::new())
       .await
       .unwrap();
 
   let merged_res =
-    Snapshot::merge(store.clone(), &[snapshot1, snapshot2], WorkUnitStore::new()).wait();
+    Snapshot::merge(store.clone(), &[snapshot1, snapshot2], WorkUnitStore::new()).await;
 
   match merged_res {
     Err(ref msg) if msg.contains("contained duplicate path") && msg.contains("roland") => (),
@@ -390,7 +375,6 @@ async fn strip_empty_prefix() {
 
   let result =
     super::Snapshot::strip_prefix(store, dir.digest(), PathBuf::from(""), WorkUnitStore::new())
-      .compat()
       .await;
   assert_eq!(result, Ok(dir.digest()));
 }
@@ -415,7 +399,6 @@ async fn strip_non_empty_prefix() {
     PathBuf::from("cats"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
   assert_eq!(result, Ok(TestDirectory::containing_roland().digest()));
 }
@@ -436,7 +419,6 @@ async fn strip_prefix_empty_subdir() {
     PathBuf::from("falcons/peregrine"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
   assert_eq!(result, Ok(TestDirectory::empty().digest()));
 }
@@ -446,9 +428,7 @@ async fn strip_dir_not_in_store() {
   let (store, _, _, _) = setup();
   let digest = TestDirectory::nested().digest();
   let result =
-    super::Snapshot::strip_prefix(store, digest, PathBuf::from("cats"), WorkUnitStore::new())
-      .compat()
-      .await;
+    super::Snapshot::strip_prefix(store, digest, PathBuf::from("cats"), WorkUnitStore::new()).await;
   assert_eq!(result, Err(format!("{:?} was not known", digest)));
 }
 
@@ -466,7 +446,6 @@ async fn strip_subdir_not_in_store() {
     PathBuf::from("cats"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
   assert_eq!(
     result,
@@ -496,7 +475,6 @@ async fn strip_prefix_non_matching_file() {
     PathBuf::from("cats"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
 
   assert_eq!(result, Err(format!("Cannot strip prefix cats from root directory {:?} - root directory contained non-matching file named: treats", dir.digest())));
@@ -521,7 +499,6 @@ async fn strip_prefix_non_matching_dir() {
     PathBuf::from("animals/cats"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
 
   assert_eq!(result, Err(format!("Cannot strip prefix animals/cats from root directory {:?} - subdirectory animals contained non-matching directory named: birds", dir.digest())));
@@ -545,7 +522,6 @@ async fn strip_subdir_not_in_dir() {
     PathBuf::from("cats/ugly"),
     WorkUnitStore::new(),
   )
-  .compat()
   .await;
   assert_eq!(result, Err(format!("Cannot strip prefix cats/ugly from root directory {:?} - subdirectory cats didn't contain a directory named ugly but did contain file named: roland", dir.digest())));
 }

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -74,7 +74,6 @@ pub fn extra_big_file_bytes() -> Bytes {
 pub async fn load_file_bytes(store: &Store, digest: Digest) -> Result<Option<Bytes>, String> {
   let option = store
     .load_file_bytes_with(digest, |bytes| bytes, WorkUnitStore::new())
-    .compat()
     .await?;
   Ok(option.map(|(bytes, _metadata)| bytes))
 }
@@ -127,7 +126,6 @@ async fn load_file_prefers_local() {
 
   crate::local_tests::new_store(dir.path())
     .store_bytes(EntryType::File, testdata.bytes(), false)
-    .compat()
     .await
     .expect("Store failed");
 
@@ -147,7 +145,6 @@ async fn load_directory_prefers_local() {
 
   crate::local_tests::new_store(dir.path())
     .store_bytes(EntryType::Directory, testdir.bytes(), false)
-    .compat()
     .await
     .expect("Store failed");
 
@@ -155,7 +152,6 @@ async fn load_directory_prefers_local() {
   assert_eq!(
     new_store(dir.path(), cas.address())
       .load_directory(testdir.digest(), WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -200,7 +196,6 @@ async fn load_directory_falls_back_and_backfills() {
   assert_eq!(
     new_store(dir.path(), cas.address())
       .load_directory(testdir.digest(), WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -255,7 +250,6 @@ async fn load_recursive_directory() {
   assert_eq!(
     new_local_store(dir.path())
       .load_directory(testdir_digest, WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -265,7 +259,6 @@ async fn load_recursive_directory() {
   assert_eq!(
     new_local_store(dir.path())
       .load_directory(recursive_testdir_digest, WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -301,7 +294,6 @@ async fn load_directory_missing_is_none() {
         TestDirectory::containing_roland().digest(),
         WorkUnitStore::new()
       )
-      .compat()
       .await,
     Ok(None)
   );
@@ -337,7 +329,6 @@ async fn load_directory_remote_error_is_error() {
   let cas = StubCAS::always_errors();
   let error = new_store(dir.path(), cas.address())
     .load_directory(TestData::roland().digest(), WorkUnitStore::new())
-    .compat()
     .await
     .expect_err("Want error");
   assert!(
@@ -360,7 +351,6 @@ async fn malformed_remote_directory_is_error() {
   let cas = new_cas(1024);
   new_store(dir.path(), cas.address())
     .load_directory(testdata.digest(), WorkUnitStore::new())
-    .compat()
     .await
     .expect_err("Want error");
 
@@ -408,7 +398,6 @@ async fn non_canonical_remote_directory_is_error() {
     .build();
   new_store(dir.path(), cas.address())
     .load_directory(directory_digest.clone(), WorkUnitStore::new())
-    .compat()
     .await
     .expect_err("Want error");
 
@@ -500,7 +489,6 @@ async fn expand_flat_directory() {
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
 
@@ -529,12 +517,10 @@ async fn expand_recursive_directory() {
 
   new_local_store(dir.path())
     .record_directory(&recursive_testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
 
@@ -578,7 +564,6 @@ async fn expand_directory_missing_subdir() {
 
   new_local_store(dir.path())
     .record_directory(&recursive_testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
 
@@ -606,7 +591,6 @@ async fn uploads_files() {
 
   new_local_store(dir.path())
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -634,12 +618,10 @@ async fn uploads_directories_recursively() {
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -672,12 +654,10 @@ async fn uploads_files_recursively_when_under_three_digests_ignoring_items_alrea
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -718,17 +698,14 @@ async fn does_not_reupload_file_already_in_cas_when_requested_with_three_other_d
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .store_file_bytes(roland.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
   new_local_store(dir.path())
     .store_file_bytes(catnip.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -773,7 +750,6 @@ async fn does_not_reupload_big_file_already_in_cas() {
 
   new_local_store(dir.path())
     .store_file_bytes(extra_big_file_bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -831,7 +807,6 @@ async fn upload_missing_file_in_directory() {
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
 
@@ -862,7 +837,6 @@ async fn uploading_digest_with_wrong_size_is_error() {
 
   new_local_store(dir.path())
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -891,17 +865,14 @@ async fn instance_name_upload() {
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .store_file_bytes(TestData::roland().bytes(), false)
-    .compat()
     .await
     .expect("Error storing roland locally");
   new_local_store(dir.path())
     .store_file_bytes(TestData::catnip().bytes(), false)
-    .compat()
     .await
     .expect("Error storing catnip locally");
 
@@ -955,7 +926,6 @@ async fn instance_name_download() {
   assert_eq!(
     store_with_remote
       .load_file_bytes_with(TestData::roland().digest(), |b| b, WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -976,17 +946,14 @@ async fn auth_upload() {
 
   new_local_store(dir.path())
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   new_local_store(dir.path())
     .store_file_bytes(TestData::roland().bytes(), false)
-    .compat()
     .await
     .expect("Error storing roland locally");
   new_local_store(dir.path())
     .store_file_bytes(TestData::catnip().bytes(), false)
-    .compat()
     .await
     .expect("Error storing catnip locally");
 
@@ -1040,7 +1007,6 @@ async fn auth_download() {
   assert_eq!(
     store_with_remote
       .load_file_bytes_with(TestData::roland().digest(), |b| b, WorkUnitStore::new())
-      .compat()
       .await
       .unwrap()
       .unwrap()
@@ -1079,7 +1045,6 @@ async fn materialize_file() {
   let store = new_local_store(store_dir.path());
   store
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error saving bytes");
   store
@@ -1102,7 +1067,6 @@ async fn materialize_file_executable() {
   let store = new_local_store(store_dir.path());
   store
     .store_file_bytes(testdata.bytes(), false)
-    .compat()
     .await
     .expect("Error saving bytes");
   store
@@ -1144,22 +1108,18 @@ async fn materialize_directory() {
   let store = new_local_store(store_dir.path());
   store
     .record_directory(&recursive_testdir.directory(), false)
-    .compat()
     .await
     .expect("Error saving recursive Directory");
   store
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error saving Directory");
   store
     .store_file_bytes(roland.bytes(), false)
-    .compat()
     .await
     .expect("Error saving file bytes");
   store
     .store_file_bytes(catnip.bytes(), false)
-    .compat()
     .await
     .expect("Error saving catnip file bytes");
 
@@ -1199,12 +1159,10 @@ async fn materialize_directory_executable() {
   let store = new_local_store(store_dir.path());
   store
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error saving Directory");
   store
     .store_file_bytes(catnip.bytes(), false)
-    .compat()
     .await
     .expect("Error saving catnip file bytes");
 
@@ -1256,22 +1214,18 @@ async fn contents_for_directory() {
   let store = new_local_store(store_dir.path());
   store
     .record_directory(&recursive_testdir.directory(), false)
-    .compat()
     .await
     .expect("Error saving recursive Directory");
   store
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error saving Directory");
   store
     .store_file_bytes(roland.bytes(), false)
-    .compat()
     .await
     .expect("Error saving file bytes");
   store
     .store_file_bytes(catnip.bytes(), false)
-    .compat()
     .await
     .expect("Error saving catnip file bytes");
 
@@ -1382,17 +1336,14 @@ async fn returns_upload_summary_on_empty_cas() {
   let local_store = new_local_store(dir.path());
   local_store
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   local_store
     .store_file_bytes(testroland.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
   local_store
     .store_file_bytes(testcatnip.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
   let mut summary = new_store(dir.path(), cas.address())
@@ -1434,17 +1385,14 @@ async fn summary_does_not_count_things_in_cas() {
   let local_store = new_local_store(dir.path());
   local_store
     .record_directory(&testdir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   local_store
     .store_file_bytes(testroland.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
   local_store
     .store_file_bytes(testcatnip.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -1501,22 +1449,18 @@ async fn materialize_directory_metadata_all_local() {
   let store = new_local_store(dir.path());
   store
     .record_directory(&outer_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   store
     .record_directory(&nested_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   store
     .record_directory(&inner_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   store
     .store_file_bytes(file.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 
@@ -1569,17 +1513,14 @@ async fn materialize_directory_metadata_mixed() {
   let store = new_store(dir.path(), cas.address());
   store
     .record_directory(&outer_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   store
     .record_directory(&inner_dir.directory(), false)
-    .compat()
     .await
     .expect("Error storing directory locally");
   store
     .store_file_bytes(file.bytes(), false)
-    .compat()
     .await
     .expect("Error storing file locally");
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -88,19 +88,22 @@ impl CommandRunner {
       GlobExpansionConjunction::AllMatch,
     ));
 
-    posix_fs
-      .expand(output_globs)
-      .compat()
-      .map_err(|err| format!("Error expanding output globs: {}", err))
-      .and_then(|path_stats| {
-        Snapshot::from_path_stats(
-          store.clone(),
-          &OneOffStoreFileByDigest::new(store, posix_fs),
-          path_stats,
-          WorkUnitStore::new(),
-        )
-      })
-      .to_boxed()
+    let store = store.clone();
+    Box::pin(async move {
+      let path_stats = posix_fs
+        .expand(output_globs)
+        .map_err(|err| format!("Error expanding output globs: {}", err))
+        .await?;
+      Snapshot::from_path_stats(
+        store.clone(),
+        OneOffStoreFileByDigest::new(store, posix_fs),
+        path_stats,
+        WorkUnitStore::new(),
+      )
+      .await
+    })
+    .compat()
+    .to_boxed()
   }
 }
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -88,7 +88,6 @@ impl CommandRunner {
       GlobExpansionConjunction::AllMatch,
     ));
 
-    let store = store.clone();
     Box::pin(async move {
       let path_stats = posix_fs
         .expand(output_globs)

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -665,12 +665,10 @@ async fn local_only_scratch_files_materialized() {
   let roland_directory_digest = TestDirectory::containing_roland().digest();
   store
     .record_directory(&TestDirectory::containing_roland().directory(), true)
-    .compat()
     .await
     .expect("Error saving directory");
   store
     .store_file_bytes(TestData::roland().bytes(), false)
-    .compat()
     .await
     .expect("Error saving file bytes");
 
@@ -750,17 +748,14 @@ async fn working_directory() {
   // from the ./cats directory.
   store
     .store_file_bytes(TestData::roland().bytes(), false)
-    .compat()
     .await
     .expect("Error saving file bytes");
   store
     .record_directory(&TestDirectory::containing_roland().directory(), true)
-    .compat()
     .await
     .expect("Error saving directory");
   store
     .record_directory(&TestDirectory::nested().directory(), true)
-    .compat()
     .await
     .expect("Error saving directory");
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1021,7 +1021,6 @@ async fn ensure_inline_stdio_is_stored() {
     assert_eq!(
       local_store
         .load_file_bytes_with(test_stdout.digest(), |v| v, WorkUnitStore::new())
-        .compat()
         .await
         .unwrap()
         .unwrap()
@@ -1031,7 +1030,6 @@ async fn ensure_inline_stdio_is_stored() {
     assert_eq!(
       local_store
         .load_file_bytes_with(test_stderr.digest(), |v| v, WorkUnitStore::new())
-        .compat()
         .await
         .unwrap()
         .unwrap()
@@ -1536,12 +1534,10 @@ async fn execute_missing_file_uploads_if_known() {
   .expect("Failed to make store");
   store
     .store_file_bytes(roland.bytes(), false)
-    .compat()
     .await
     .expect("Saving file bytes to store");
   store
     .record_directory(&TestDirectory::containing_roland().directory(), false)
-    .compat()
     .await
     .expect("Saving directory bytes to store");
   let command_runner = CommandRunner::new(
@@ -1651,7 +1647,7 @@ async fn execute_missing_file_uploads_if_known_status() {
   .expect("Failed to make store");
   store
     .store_file_bytes(roland.bytes(), false)
-    .wait()
+    .await
     .expect("Saving file bytes to store");
 
   let result = CommandRunner::new(


### PR DESCRIPTION
Continue to propagate async/await syntax up from our bottom-most crates by porting the `fs` crate and its subcrates.

This adjusts the strategy for compatibility at the `futures-0.1 -> stdlib-futures` boundary: see the edit to `ASYNC.md`.