### PR TITLE
Add Target API bindings for `python_dist`, `python_requirement_library`, and `unpacked_whls`

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -18,16 +18,31 @@ from pants.backend.python.rules import (
     repl,
     run_setup_py,
 )
-from pants.backend.python.rules.targets import PythonBinary, PythonLibrary, PythonTests
+from pants.backend.python.rules.targets import (
+    PythonApp,
+    PythonBinary,
+    PythonDistribution,
+    PythonLibrary,
+    PythonRequirementLibrary,
+    PythonRequirementsFile,
+    PythonTests,
+    UnpackedWheels,
+)
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
-from pants.backend.python.targets.python_app import PythonApp
+from pants.backend.python.targets.python_app import PythonApp as PythonAppV1
 from pants.backend.python.targets.python_binary import PythonBinary as PythonBinaryV1
-from pants.backend.python.targets.python_distribution import PythonDistribution
+from pants.backend.python.targets.python_distribution import (
+    PythonDistribution as PythonDistributionV1,
+)
 from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
-from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.backend.python.targets.python_requirements_file import PythonRequirementsFile
+from pants.backend.python.targets.python_requirement_library import (
+    PythonRequirementLibrary as PythonRequirementLibraryV1,
+)
+from pants.backend.python.targets.python_requirements_file import (
+    PythonRequirementsFile as PythonRequirementsFileV1,
+)
 from pants.backend.python.targets.python_tests import PythonTests as PythonTestsV1
-from pants.backend.python.targets.unpacked_whls import UnpackedWheels
+from pants.backend.python.targets.unpacked_whls import UnpackedWheels as UnpackedWheelsV1
 from pants.backend.python.tasks.build_local_python_distributions import (
     BuildLocalPythonDistributions,
 )
@@ -46,7 +61,6 @@ from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.backend.python.tasks.unpack_wheels import UnpackWheels
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.build_graph.resources import Resources
 from pants.goal.task_registrar import TaskRegistrar as task
 from pants.python.pex_build_util import PexBuilderWrapper
 from pants.python.python_requirement import PythonRequirement
@@ -63,15 +77,14 @@ def global_subsystems():
 def build_file_aliases():
     return BuildFileAliases(
         targets={
-            PythonApp.alias(): PythonApp,
+            PythonAppV1.alias(): PythonAppV1,
             PythonBinaryV1.alias(): PythonBinaryV1,
             PythonLibraryV1.alias(): PythonLibraryV1,
             PythonTestsV1.alias(): PythonTestsV1,
-            PythonDistribution.alias(): PythonDistribution,
-            "python_requirement_library": PythonRequirementLibrary,
-            PythonRequirementsFile.alias(): PythonRequirementsFile,
-            Resources.alias(): Resources,
-            UnpackedWheels.alias(): UnpackedWheels,
+            PythonDistributionV1.alias(): PythonDistributionV1,
+            "python_requirement_library": PythonRequirementLibraryV1,
+            PythonRequirementsFileV1.alias(): PythonRequirementsFileV1,
+            UnpackedWheelsV1.alias(): UnpackedWheelsV1,
         },
         objects={
             "python_requirement": PythonRequirement,
@@ -126,4 +139,13 @@ def rules():
 
 
 def targets2():
-    return [PythonBinary, PythonLibrary, PythonTests]
+    return [
+        PythonApp,
+        PythonBinary,
+        PythonDistribution,
+        PythonLibrary,
+        PythonRequirementLibrary,
+        PythonRequirementsFile,
+        PythonTests,
+        UnpackedWheels,
+    ]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -10,7 +10,7 @@ from pkg_resources import Requirement
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex
-from pants.backend.python.rules.targets import Compatibility
+from pants.backend.python.rules.targets import PythonInterpreterCompatibility
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import (
@@ -140,7 +140,7 @@ class PexInterpreterConstraints:
 
     @classmethod
     def create_from_compatibility_fields(
-        cls, fields: Iterable[Compatibility], python_setup: PythonSetup
+        cls, fields: Iterable[PythonInterpreterCompatibility], python_setup: PythonSetup
     ) -> "PexInterpreterConstraints":
         constraint_sets = {field.value_or_global_default(python_setup) for field in fields}
         # This will OR within each field and AND across fields.
@@ -155,7 +155,9 @@ class PexInterpreterConstraints:
         for adaptor in adaptors:
             if not isinstance(adaptor, PythonTargetAdaptor):
                 continue
-            compatibility_field = Compatibility(adaptor.compatibility, address=adaptor.address)
+            compatibility_field = PythonInterpreterCompatibility(
+                adaptor.compatibility, address=adaptor.address
+            )
             constraint_sets.add(compatibility_field.value_or_global_default(python_setup))
         # This will OR within each target and AND across targets.
         merged_constraints = cls.merge_constraint_sets(constraint_sets)

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -19,7 +19,7 @@ from pants.backend.python.rules.pytest_coverage import (
     PytestCoverageData,
     get_coverage_plugin_input,
 )
-from pants.backend.python.rules.targets import Coverage, Timeout
+from pants.backend.python.rules.targets import PythonCoverage, PythonTestsTimeout
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.addressable import Addresses
@@ -198,14 +198,14 @@ async def setup_pytest_for_target(
             "--cov-report=",  # To not generate any output. https://pytest-cov.readthedocs.io/en/latest/config.html
         ]
         # TODO: replace this with proper usage of the Target API.
-        coverage_field = Coverage(getattr(adaptor, "coverage", None), address=adaptor.address)
+        coverage_field = PythonCoverage(getattr(adaptor, "coverage", None), address=adaptor.address)
         for package in coverage_field.determine_packages_to_cover(
             specified_source_files=specified_source_files
         ):
             coverage_args.extend(["--cov", package])
 
     # TODO: replace this with proper usage of the Target API.
-    timeout_field = Timeout(getattr(adaptor, "timeout", None), address=adaptor.address)
+    timeout_field = PythonTestsTimeout(getattr(adaptor, "timeout", None), address=adaptor.address)
 
     specified_source_file_names = sorted(specified_source_files.snapshot.files)
     return TestTargetSetup(

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-from typing import Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union, cast
 
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.build_graph.address import Address
+from pants.engine.fs import Snapshot
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
@@ -13,13 +14,17 @@ from pants.engine.target import (
     IntField,
     InvalidFieldException,
     ProvidesField,
+    SequenceField,
     Sources,
     StringField,
     StringOrStringSequenceField,
+    StringSequenceField,
     Target,
 )
+from pants.python.python_requirement import PythonRequirement
 from pants.python.python_setup import PythonSetup
 from pants.rules.core.determine_source_files import SourceFiles
+from pants.rules.core.targets import FilesSources
 
 # -----------------------------------------------------------------------------------------------
 # Common fields
@@ -54,6 +59,16 @@ COMMON_PYTHON_FIELDS = (
     ProvidesField,
     PythonInterpreterCompatibility,
 )
+
+
+# -----------------------------------------------------------------------------------------------
+# `python_app` target
+# -----------------------------------------------------------------------------------------------
+
+# TODO: add support for apps, including `bundle`.
+class PythonApp(Target):
+    alias = "python_app"
+    core_fields = ()
 
 
 # -----------------------------------------------------------------------------------------------
@@ -287,3 +302,155 @@ class PythonTests(Target):
 
     alias = "python_tests"
     core_fields = (*COMMON_PYTHON_FIELDS, PythonTestsSources, PythonCoverage, PythonTestsTimeout)
+
+
+# -----------------------------------------------------------------------------------------------
+# `python_distribution` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonDistributionSources(PythonSources):
+    default = ("*.py",)
+
+    def validate_snapshot(self, snapshot: Snapshot) -> None:
+        if "setup.py" not in snapshot.files:
+            raise InvalidFieldException(
+                f"The {repr(self.alias)} field in target {self.address} must include "
+                f"`setup.py`. All resolved files: {sorted(snapshot.files)}."
+            )
+
+
+class PythonDistributionSetupRequires(StringSequenceField):
+    """A list of pip-style requirement strings to provide during the invocation of setup.py."""
+
+    alias = "setup_requires"
+
+
+class PythonDistribution(Target):
+    """A Python distribution target that accepts a user-defined setup.py."""
+
+    alias = "python_dist"
+    core_fields = (
+        *COMMON_PYTHON_FIELDS,
+        PythonDistributionSources,
+        PythonDistributionSetupRequires,
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `python_requirement_library` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonRequirementsField(SequenceField):
+    """A sequence of `python_requirement` objects."""
+
+    alias = "requirements"
+    expected_element_type = PythonRequirement
+    expected_type_description = "an iterable of `python_requirement` objects (e.g. a list)"
+    required = True
+    value: Tuple[PythonRequirement, ...]
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Iterable[PythonRequirement]], *, address: Address
+    ) -> Tuple[PythonRequirement, ...]:
+        return cast(
+            Tuple[PythonRequirement, ...], super().compute_value(raw_value, address=address)
+        )
+
+
+class PythonRequirementLibrary(Target):
+    """A set of Pip requirements."""
+
+    alias = "python_requirement_library"
+    core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsField)
+
+
+# -----------------------------------------------------------------------------------------------
+# `_python_requirements_file` target
+# -----------------------------------------------------------------------------------------------
+
+
+# NB: This subclasses FilesSources to ensure that we still properly handle stripping source roots,
+# but we still new type so that we can distinguish between normal FilesSources vs. this field.
+class PythonRequirementsFileSources(FilesSources):
+    pass
+
+
+# TODO: filter out private targets from `./pants target-types2`? Simply check for `_`. This
+#  probably depends on how common this private target pattern will end being, which is unclear now
+#  that we have Configurations for ad hoc, internal combinations of fields.
+class PythonRequirementsFile(Target):
+    """A private, helper target type for requirements.txt files."""
+
+    alias = "_python_requirements_file"
+    core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `unpacked_wheels` target
+# -----------------------------------------------------------------------------------------------
+
+
+class UnpackedWheelsModuleName(StringField):
+    """The name of the specific Python module containing headers and/or libraries to extract (e.g.
+    'tensorflow')."""
+
+    alias = "module_name"
+    required = True
+
+
+class UnpackedWheelsRequestedLibraries(StringSequenceField):
+    """Addresses of python_requirement_library targets that specify the wheels you want to
+    unpack."""
+
+    alias = "libraries"
+    required = True
+
+
+class UnpackedWheelsIncludePatterns(StringSequenceField):
+    """Fileset patterns to include from the archive."""
+
+    alias = "include_patterns"
+
+
+class UnpackedWheelsExcludePatterns(StringSequenceField):
+    """Fileset patterns to exclude from the archive.
+
+    Exclude patterns are processed before include_patterns.
+    """
+
+    alias = "exclude_patterns"
+
+
+class UnpackedWheelsWithinDataSubdir(BoolField):
+    """If True, descend into '<name>-<version>.data/' when matching `include_patterns`.
+
+    For Python wheels which declare any non-code data, this is usually needed to extract that
+    without manually specifying the relative path, including the package version.
+
+    For example, when `data_files` is used in a setup.py, `within_data_subdir=True` will allow
+    specifying `include_patterns` matching exactly what is specified in the setup.py.
+    """
+
+    alias = "within_data_subdir"
+    default = False
+
+
+class UnpackedWheels(Target):
+    """A set of sources extracted from wheel files.
+
+    Currently, wheels are always resolved for the 'current' platform.
+    """
+
+    alias = "unpacked_whls"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonInterpreterCompatibility,
+        UnpackedWheelsModuleName,
+        UnpackedWheelsRequestedLibraries,
+        UnpackedWheelsIncludePatterns,
+        UnpackedWheelsExcludePatterns,
+        UnpackedWheelsWithinDataSubdir,
+    )

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -30,7 +30,7 @@ class PythonSources(Sources):
     expected_file_extensions = (".py",)
 
 
-class Compatibility(StringOrStringSequenceField):
+class PythonInterpreterCompatibility(StringOrStringSequenceField):
     """A string for Python interpreter constraints on this target.
 
     This should be written in Requirement-style format, e.g. `CPython==2.7.*` or `CPython>=3.6,<4`.
@@ -48,7 +48,12 @@ class Compatibility(StringOrStringSequenceField):
         return python_setup.compatibility_or_constraints(self.value)
 
 
-COMMON_PYTHON_FIELDS = (*COMMON_TARGET_FIELDS, Dependencies, Compatibility, ProvidesField)
+COMMON_PYTHON_FIELDS = (
+    *COMMON_TARGET_FIELDS,
+    Dependencies,
+    ProvidesField,
+    PythonInterpreterCompatibility,
+)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -214,7 +219,7 @@ class PythonTestsSources(PythonSources):
     default = ("test_*.py", "*_test.py", "conftest.py")
 
 
-class Coverage(StringOrStringSequenceField):
+class PythonCoverage(StringOrStringSequenceField):
     """The module(s) whose coverage should be generated, e.g. `['pants.util']`."""
 
     alias = "coverage"
@@ -244,7 +249,7 @@ class Coverage(StringOrStringSequenceField):
         )
 
 
-class Timeout(IntField):
+class PythonTestsTimeout(IntField):
     """A timeout (in seconds) which covers the total runtime of all tests in this target.
 
     This only applies if `--pytest-timeouts` is set to True.
@@ -281,4 +286,4 @@ class PythonTests(Target):
     """Python tests (either Pytest-style or unittest style)."""
 
     alias = "python_tests"
-    core_fields = (*COMMON_PYTHON_FIELDS, PythonTestsSources, Coverage, Timeout)
+    core_fields = (*COMMON_PYTHON_FIELDS, PythonTestsSources, PythonCoverage, PythonTestsTimeout)

--- a/src/python/pants/backend/python/rules/targets_test.py
+++ b/src/python/pants/backend/python/rules/targets_test.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import pytest
 
-from pants.backend.python.rules.targets import Timeout
+from pants.backend.python.rules.targets import PythonTestsTimeout
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.build_graph.address import Address
 from pants.engine.target import InvalidFieldException
@@ -16,10 +16,10 @@ from pants.testutil.test_base import TestBase
 class TestTimeout(TestBase):
     def test_timeout_validation(self) -> None:
         with pytest.raises(InvalidFieldException):
-            Timeout(-100, address=Address.parse(":tests"))
+            PythonTestsTimeout(-100, address=Address.parse(":tests"))
         with pytest.raises(InvalidFieldException):
-            Timeout(0, address=Address.parse(":tests"))
-        assert Timeout(5, address=Address.parse(":tests")).value == 5
+            PythonTestsTimeout(0, address=Address.parse(":tests"))
+        assert PythonTestsTimeout(5, address=Address.parse(":tests")).value == 5
 
     def assert_timeout_calculated(
         self,
@@ -40,7 +40,7 @@ class TestTimeout(TestBase):
                 }
             },
         )
-        field = Timeout(field_value, address=Address.parse(":tests"))
+        field = PythonTestsTimeout(field_value, address=Address.parse(":tests"))
         assert field.calculate_from_global_options(pytest) == expected
 
     def test_valid_field_timeout(self) -> None:

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class UnpackedWheels(ImportWheelsMixin, Target):
-    """A set of sources extracted from JAR files.
+    """A set of sources extracted from wheel files.
 
     NB: Currently, wheels are always resolved for the 'current' platform.
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -601,7 +601,12 @@ class RegisteredTargetTypes:
 
 
 class InvalidFieldException(Exception):
-    pass
+    """Use when there's an issue with a particular field.
+
+    Suggested template:
+
+         f"The {repr(alias)} field in target {address} must ..., but ..."
+    """
 
 
 class InvalidFieldTypeException(InvalidFieldException):

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
+from pants.build_graph.resources import Resources
 from pants.testutil.subsystem.util import init_subsystem
 from pants.testutil.task_test_base import TaskTestBase
 
@@ -19,9 +20,11 @@ class PythonTaskTestBase(TaskTestBase):
     @classmethod
     def alias_groups(cls):
         """
-    :API: public
-    """
-        return register_python()
+        :API: public
+        """
+        aliases = register_python()
+        aliases.target_types["resources"] = Resources
+        return aliases
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
We defer `python_app` for a follow-up.

[ci skip-rust-tests]
[ci skip-jvm-tests]