### PR TITLE
Rename `ChrootedPythonSources` to `ImportablePythonSources` and add Target API support

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -7,9 +7,9 @@ from pants.backend.awslambda.common.awslambda_common_rules import AWSLambdaTarge
 from pants.backend.awslambda.python.lambdex import Lambdex
 from pants.backend.python.rules import (
     download_pex_bin,
+    importable_python_sources,
     pex,
     pex_from_target_closure,
-    prepare_chrooted_python_sources,
 )
 from pants.backend.python.rules.pex import (
     CreatePex,
@@ -94,9 +94,9 @@ def rules():
         UnionRule(AWSLambdaTarget, PythonAWSLambdaAdaptor),
         subsystem_rule(Lambdex),
         *download_pex_bin.rules(),
+        *importable_python_sources.rules(),
         *pex.rules(),
         *pex_from_target_closure.rules(),
-        *prepare_chrooted_python_sources.rules(),
         *python_native_code.rules(),
         *strip_source_roots.rules(),
         *subprocess_environment.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -7,14 +7,14 @@ from typing import Optional, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.lint.python_linter import PythonLinter
-from pants.backend.python.rules import download_pex_bin, pex, prepare_chrooted_python_sources
+from pants.backend.python.rules import download_pex_bin, importable_python_sources, pex
+from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
     PexInterpreterConstraints,
     PexRequirements,
 )
-from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.build_graph.address import Address
@@ -67,7 +67,7 @@ async def lint(
             ht.adaptor.dependencies for ht in hydrated_targets
         )
     )
-    chrooted_python_sources = await Get[ChrootedPythonSources](
+    chrooted_python_sources = await Get[ImportablePythonSources](
         HydratedTargets([*hydrated_targets, *dependencies])
     )
 
@@ -137,7 +137,7 @@ def rules():
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),
-        *prepare_chrooted_python_sources.rules(),
+        *importable_python_sources.rules(),
         *strip_source_roots.rules(),
         *python_native_code.rules(),
         *subprocess_environment.rules(),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -8,10 +8,10 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
     download_pex_bin,
+    importable_python_sources,
     inject_init,
     pex,
     pex_from_target_closure,
-    prepare_chrooted_python_sources,
     pytest_coverage,
     pytest_runner,
     python_create_binary,
@@ -112,7 +112,7 @@ def rules():
     return (
         *download_pex_bin.rules(),
         *inject_init.rules(),
-        *prepare_chrooted_python_sources.rules(),
+        *importable_python_sources.rules(),
         *pex.rules(),
         *pex_from_target_closure.rules(),
         *pytest_coverage.rules(),

--- a/src/python/pants/backend/python/rules/importable_python_sources.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources.py
@@ -14,29 +14,39 @@ from pants.rules.core.determine_source_files import LegacyAllSourceFilesRequest,
 
 
 @dataclass(frozen=True)
-class ChrootedPythonSources:
+class ImportablePythonSources:
+    """Sources that can be imported and used by Python, e.g. with tools like Pytest or with `./pants
+    run`.
+
+    Specifically, this will strip source roots, e.g. `src/python/f.py` -> `f.py`; and it will add
+    any missing `__init__.py` files to ensure that modules are recognized correctly.
+
+    Not every file need be a Python file. For example, this can include `files()` and
+    `resources()` targets.
+
+    Not every Python application will need to request this type. For example, autoformatters like
+    Black never need to actually import and run the Python code, so they do not need to use this.
+    """
+
     snapshot: Snapshot
 
 
 @rule
-async def prepare_chrooted_python_sources(
+async def legacy_prepare_python_sources(
     hydrated_targets: HydratedTargets,
-) -> ChrootedPythonSources:
-    """Prepares Python sources by stripping the source root and injecting missing __init__.py files.
-
-    NB: This is useful for Pytest or ./pants run, but not every Python rule will need this.
-    For example, autoformatters like Black do not need to understand relative imports or
-    execute the code, so they can safely operate on the original source files without
-    stripping source roots.
-    """
+) -> ImportablePythonSources:
     stripped_sources = await Get[SourceFiles](
         LegacyAllSourceFilesRequest(
             (ht.adaptor for ht in hydrated_targets), strip_source_roots=True
         )
     )
     init_injected = await Get[InitInjectedSnapshot](InjectInitRequest(stripped_sources.snapshot))
-    return ChrootedPythonSources(init_injected.snapshot)
+    return ImportablePythonSources(init_injected.snapshot)
 
 
 def rules():
-    return [prepare_chrooted_python_sources, *determine_source_files.rules(), *inject_init_rules()]
+    return [
+        legacy_prepare_python_sources,
+        *determine_source_files.rules(),
+        *inject_init_rules(),
+    ]

--- a/src/python/pants/backend/python/rules/importable_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources_test.py
@@ -5,9 +5,9 @@ from pathlib import PurePath
 from typing import List, Optional
 from unittest.mock import Mock
 
-from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
-from pants.backend.python.rules.prepare_chrooted_python_sources import (
-    rules as prepare_chrooted_python_sources_rules,
+from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
+from pants.backend.python.rules.importable_python_sources import (
+    rules as importable_python_sources_rules,
 )
 from pants.build_graph.address import Address
 from pants.build_graph.files import Files
@@ -18,14 +18,10 @@ from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
 
-class PrepareChrootedPythonSourcesTest(TestBase):
+class ImportablePythonSourcesTest(TestBase):
     @classmethod
     def rules(cls):
-        return (
-            *super().rules(),
-            *prepare_chrooted_python_sources_rules(),
-            RootRule(HydratedTargets),
-        )
+        return (*super().rules(), *importable_python_sources_rules(), RootRule(HydratedTargets))
 
     def make_hydrated_target(
         self, *, source_paths: List[str], type_alias: Optional[str] = None,
@@ -50,7 +46,7 @@ class PrepareChrootedPythonSourcesTest(TestBase):
             source_paths=["src/python/project/resources/loose_file.txt"], type_alias=Files.alias(),
         )
         result = self.request_single_product(
-            ChrootedPythonSources,
+            ImportablePythonSources,
             Params(
                 HydratedTargets([target_with_init, target_without_init, files_target]),
                 create_options_bootstrapper(),

--- a/src/python/pants/backend/python/rules/importable_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pathlib import PurePath
-from typing import List, Optional
+from typing import List, Optional, Type
 from unittest.mock import Mock
 
 from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
@@ -10,18 +10,61 @@ from pants.backend.python.rules.importable_python_sources import (
     rules as importable_python_sources_rules,
 )
 from pants.build_graph.address import Address
-from pants.build_graph.files import Files
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
+from pants.engine.target import Sources, Target, Targets
+from pants.rules.core.targets import Files
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
+
+
+class MockTarget(Target):
+    alias = "mock_target"
+    core_fields = (Sources,)
 
 
 class ImportablePythonSourcesTest(TestBase):
     @classmethod
     def rules(cls):
         return (*super().rules(), *importable_python_sources_rules(), RootRule(HydratedTargets))
+
+    def create_target(
+        self, *, parent_directory: str, files: List[str], target_cls: Type[Target] = MockTarget
+    ) -> Target:
+        self.create_files(parent_directory, files=files)
+        address = Address(spec_path=parent_directory, target_name="target")
+        return target_cls({Sources.alias: files}, address=address)
+
+    def test_adds_missing_inits_and_strips_source_roots(self) -> None:
+        target_with_init = self.create_target(
+            parent_directory="src/python/project", files=["lib.py", "__init__.py"]
+        )
+        target_without_init = self.create_target(
+            parent_directory="src/python/test_project", files=["f1.py", "f2.py"]
+        )
+        files_target = self.create_target(
+            parent_directory="src/python/project/resources",
+            files=["loose_file.txt"],
+            target_cls=Files,
+        )
+        result = self.request_single_product(
+            ImportablePythonSources,
+            Params(
+                Targets([target_with_init, target_without_init, files_target]),
+                create_options_bootstrapper(),
+            ),
+        )
+        assert sorted(result.snapshot.files) == sorted(
+            [
+                "project/lib.py",
+                "project/__init__.py",
+                "test_project/f1.py",
+                "test_project/f2.py",
+                "test_project/__init__.py",
+                "src/python/project/resources/loose_file.txt",
+            ]
+        )
 
     def make_hydrated_target(
         self, *, source_paths: List[str], type_alias: Optional[str] = None,
@@ -35,7 +78,7 @@ class ImportablePythonSourcesTest(TestBase):
         )
         return HydratedTarget(adaptor)
 
-    def test_adds_missing_inits_and_strips_source_roots(self) -> None:
+    def test_legacy_adds_missing_inits_and_strips_source_roots(self) -> None:
         target_with_init = self.make_hydrated_target(
             source_paths=["src/python/project/lib.py", "src/python/project/__init__.py"],
         )
@@ -43,7 +86,7 @@ class ImportablePythonSourcesTest(TestBase):
             source_paths=["tests/python/test_project/f1.py", "tests/python/test_project/f2.py"],
         )
         files_target = self.make_hydrated_target(
-            source_paths=["src/python/project/resources/loose_file.txt"], type_alias=Files.alias(),
+            source_paths=["src/python/project/resources/loose_file.txt"], type_alias=Files.alias,
         )
         result = self.request_single_product(
             ImportablePythonSources,

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -5,6 +5,7 @@ import functools
 from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple, Union, cast
 
+from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
 from pants.backend.python.rules.pex import (
     CreatePex,
     Pex,
@@ -12,7 +13,6 @@ from pants.backend.python.rules.pex import (
     PexRequirements,
 )
 from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
-from pants.backend.python.rules.prepare_chrooted_python_sources import ChrootedPythonSources
 from pants.backend.python.rules.pytest_coverage import (
     Coveragerc,
     CoveragercRequest,
@@ -155,7 +155,7 @@ async def setup_pytest_for_target(
         Get[Pex](CreatePex, create_pytest_pex_request),
         Get[Pex](CreatePexFromTargetClosure, create_requirements_pex_request),
         Get[Pex](CreatePex, create_test_runner_pex),
-        Get[ChrootedPythonSources](HydratedTargets(python_targets + resource_targets)),
+        Get[ImportablePythonSources](HydratedTargets(python_targets + resource_targets)),
         Get[SourceFiles](LegacySpecifiedSourceFilesRequest, specified_source_files_request),
     ]
     if run_coverage:
@@ -172,8 +172,8 @@ async def setup_pytest_for_target(
         *rest,
     ) = cast(
         Union[
-            Tuple[Pex, Pex, Pex, ChrootedPythonSources, SourceFiles],
-            Tuple[Pex, Pex, Pex, ChrootedPythonSources, SourceFiles, Coveragerc],
+            Tuple[Pex, Pex, Pex, ImportablePythonSources, SourceFiles],
+            Tuple[Pex, Pex, Pex, ImportablePythonSources, SourceFiles, Coveragerc],
         ],
         await MultiGet(requests),
     )

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -8,9 +8,9 @@ from typing import List, Optional
 
 from pants.backend.python.rules import (
     download_pex_bin,
+    importable_python_sources,
     pex,
     pex_from_target_closure,
-    prepare_chrooted_python_sources,
     pytest_coverage,
     pytest_runner,
 )
@@ -112,7 +112,7 @@ class PythonTestRunnerIntegrationTest(TestBase):
             *determine_source_files.rules(),
             *pex.rules(),
             *pex_from_target_closure.rules(),
-            *prepare_chrooted_python_sources.rules(),
+            *importable_python_sources.rules(),
             *python_native_code.rules(),
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),

--- a/src/python/pants/rules/core/repl_integration_test.py
+++ b/src/python/pants/rules/core/repl_integration_test.py
@@ -3,9 +3,9 @@
 
 from pants.backend.python.rules import (
     download_pex_bin,
+    importable_python_sources,
     pex,
     pex_from_target_closure,
-    prepare_chrooted_python_sources,
     repl,
 )
 from pants.backend.python.rules.repl import PythonRepl
@@ -31,8 +31,8 @@ class ReplTest(GoalRuleTestBase):
             run_repl,
             *pex.rules(),
             *download_pex_bin.rules(),
+            *importable_python_sources.rules(),
             *pex_from_target_closure.rules(),
-            *prepare_chrooted_python_sources.rules(),
             *python_native_code.rules(),
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),


### PR DESCRIPTION
`Chrooted` was a misnomer. This rule didn't have much to do with a chroot. Rather, the rule is really _preparing Python sources so that they may be imported and be run_ by something like Pytest.