### PR TITLE
Fix targets that do not have a `dependencies` field with the Target API 

### DIFF
--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -50,7 +50,8 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         if tgt.has_field(PythonRequirementsField):
             python_requirement_fields.append(tgt[PythonRequirementsField])
         # NB: PythonRequirementsFileSources is a subclass of FilesSources. We filter it out so that
-        # requirements.txt is not included in the PEX.
+        # requirements.txt is not included in the PEX and so that irrelevant changes to it (e.g.
+        # whitespace changes) do not invalidate the PEX.
         if tgt.has_field(ResourcesSources) or (
             tgt.has_field(FilesSources) and not tgt.has_field(PythonRequirementsFileSources)
         ):

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -385,10 +385,7 @@ class PythonRequirementsFile(Target):
     """A private, helper target type for requirements.txt files."""
 
     alias = "_python_requirements_file"
-    # TODO: fix handling of Dependencies. This target shouldn't actually have to register the
-    #  Dependencies field but we need to because StructWithDependencies will try always passing the
-    #  value to the Target constructor.
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonRequirementsFileSources)
+    core_fields = (*COMMON_TARGET_FIELDS, PythonRequirementsFileSources)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -310,7 +310,6 @@ class Target(ABC):
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
                 raise InvalidFieldException(
-                    address,
                     f"Unrecognized field `{alias}={value}` in target {address}. Valid fields for "
                     f"the target type `{self.alias}`: {sorted(aliases_to_field_types.keys())}.",
                 )


### PR DESCRIPTION
### Problem

Several targets do not have the `dependencies` field because it does not make sense for them. For example, in V1, it is an error to define `dependencies` on an `alias` target:

> ERROR: Build graph construction failed: ExecutionError 1 Exception encountered:
  MappingError: Failed to parse src/python/pants/util/BUILD:
TypeError("create_object() got multiple values for keyword argument 'dependencies'",)

Likewise, it does not make sense to allow `dependencies` for the private target type `_python_requirements_file`.

--

However, `TargetAdaptor` subclasses `StructWithDeps`, which we use to resolve `dependencies` to actual `Addresses`. This means that every single `HydratedStruct`/`TargetAdaptor` will have a `dependencies` value in its `struct.kwargs()`, even if the user left off the field.

So, we then try passing `dependencies=None` to the `Target` constructor and it fails that it's an unrecognized field for that target type.

### Solution

In the `HydratedStruct -> Target` code, explicitly check if the field does not register `Dependencies` (or a subclass) and discard the `dependencies=None` if so.