### PR TITLE
Add --respect-strict-deps option for export-dep-as-jar as a workaround

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -70,6 +70,13 @@ class ExportDepAsJar(ConsoleTask):
             type=bool,
             help="Causes 3rdparty libraries with javadocs to be output.",
         )
+        register(
+            "--respect-strict-deps",
+            type=bool,
+            default=True,
+            help="If true, strict deps are respected like the JVM compile task; otherwise it is "
+            "ignored, and this can be useful as a workaround or for debugging purposes.",
+        )
 
     @property
     def act_transitively(self):
@@ -428,8 +435,10 @@ class ExportDepAsJar(ConsoleTask):
                 library_entry["sources"] = jarred_sources.name
         return library_entry
 
-    @staticmethod
-    def _is_strict_deps(target: Target) -> bool:
+    def _is_strict_deps(self, target: Target) -> bool:
+        if not self.get_options().respect_strict_deps:
+            return False
+
         return isinstance(
             target, JvmTarget
         ) and DependencyContext.global_instance().defaulted_property(target, "strict_deps")


### PR DESCRIPTION
### Problem

```
$ cat helloworld/BUILD
scala_library(
    name = "b",
    dependencies = ["x/y/z/"],
    sources = ["b/**/*.scala"],
    strict_deps = True
)

scala_library(
    name = "c",
    dependencies = [":b"],
    sources = ["c/**/*.scala"],
    strict_deps = True
)
```
Exporting only {{helloworld/:c}} yields:
```
{
    "version": "1.1.0",
    "targets": {
        "helloworld:c": {
            "targets": [],
            "source_dependencies_in_classpath": [],
            "libraries": [
                "org.scala-lang:scala-library:2.12.10",
                "org.scala-lang.modules:scala-collection-compat_2.12:2.1.2",
                "helloworld.b"
            ],
            ...
        }
    },
    ...
}
```
There is no mention of the dependency from `helloworld:c` to `x/y/z`. We need this information in order to create the runtime classpath for `helloworld:c`.

### Workaround

Temporarily disable respecting strict deps. 

### Result
Example: 
```
$ ./pants export-dep-as-jar --no-respect-strict-deps examples/src/scala/org/pantsbuild/example/strict_deps:d
{
    "version": "1.1.0",
    "targets": {
        "examples/src/scala/org/pantsbuild/example/strict_deps:d": {
            "targets": [],
            "source_dependencies_in_classpath": [
                "examples/src/scala/org/pantsbuild/example/strict_deps:d"
            ],
            "libraries": [
                "org.scala-lang:scala-library:2.12.8",
                "examples.src.scala.org.pantsbuild.example.strict_deps.c",
                "examples.src.scala.org.pantsbuild.example.strict_deps.b",
                "examples.src.scala.org.pantsbuild.example.strict_deps.a"
            ],
            "roots": [
                {
                    "source_root": "/Users/yic/workspace/pants/examples/src/scala/org/pantsbuild/example/strict_deps",
                    "package_prefix": "org.pantsbuild.example.strict_deps"
                }
            ],
...

$ ./pants export-dep-as-jar --respect-strict-deps examples/src/scala/org/pantsbuild/example/strict_deps:d
{
    "version": "1.1.0",
    "targets": {
        "examples/src/scala/org/pantsbuild/example/strict_deps:d": {
            "targets": [],
            "source_dependencies_in_classpath": [],
            "libraries": [
                "examples.src.scala.org.pantsbuild.example.strict_deps.b",
                "org.scala-lang:scala-library:2.12.8",
                "examples.src.scala.org.pantsbuild.example.strict_deps.c"
            ],
            "roots": [
                {
                    "source_root": "/Users/yic/workspace/pants/examples/src/scala/org/pantsbuild/example/strict_deps",
                    "package_prefix": "org.pantsbuild.example.strict_deps"
                }
            ],
            "id": "examples.src.scala.org.pantsbuild.example.strict_deps.d",
            "target_type": "SOURCE",
            "is_synthetic": false,
..
```