### PR TITLE
Add source_root field to the project info export task

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -33,6 +33,7 @@ from pants.python.pex_build_util import has_python_requirements
 from pants.task.console_task import ConsoleTask
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import OrderedSet
+from pants.source.source_root import SourceRootConfig
 
 
 class SourceRootTypes:
@@ -181,6 +182,7 @@ class ExportTask(ResolveRequirementsTaskBase, CoursierMixin):
         targets_map = {}
         resource_target_map = {}
         python_interpreter_targets_mapping = defaultdict(list)
+        source_roots = SourceRootConfig.global_instance().get_source_roots()
 
         if self.get_options().libraries:
             # NB(gmalmquist): This supports mocking the classpath_products in tests.
@@ -305,6 +307,9 @@ class ExportTask(ResolveRequirementsTaskBase, CoursierMixin):
 
             if classpath_products:
                 info["libraries"] = [self._jar_id(lib) for lib in target_libraries]
+
+            # Source root for the current target as provided by SourceRootConfig
+            info["source_root"] = source_roots.find_by_path(current_target.address.spec).path
             targets_map[current_target.address.spec] = info
 
         for target in targets:

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -240,7 +240,7 @@ class ExportTask(ResolveRequirementsTaskBase, CoursierMixin):
             if isinstance(current_target, PythonRequirementLibrary):
                 reqs = current_target.payload.get_field_value("requirements", set())
                 """:type : set[pants.python.python_requirement.PythonRequirement]"""
-                info["requirements"] = [req.key for req in reqs]
+                info["requirements"] = [str(req.requirement) for req in reqs]
 
             if isinstance(current_target, PythonTarget):
                 interpreter_for_target = self._interpreter_cache.select_interpreter_for_targets(

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -30,10 +30,10 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.python.pex_build_util import has_python_requirements
+from pants.source.source_root import SourceRootConfig
 from pants.task.console_task import ConsoleTask
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import OrderedSet
-from pants.source.source_root import SourceRootConfig
 
 
 class SourceRootTypes:

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -418,6 +418,7 @@ class ExportTest(ConsoleTaskTestBase):
                 },
             ],
             "scope": "default",
+            "source_root": "project_info:jvm_target",
             "target_type": "SOURCE",
             "transitive": True,
             "pants_target_type": "scala_library",


### PR DESCRIPTION
### Problem

The `export` task does not provide the source root as seen by `SourceRootConfig` for a provided target.

### Solution

Added the `source_root` field to a target's info resolving it using the `SourceRootConfig`'s `find_by_path` method.

### Result

The exported project info now contains a source root as seen by the `SourceRootConfig`