### PR TITLE
[export-dep-as-jar] Implement runtime_libraries entries for targets

### DIFF
--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -84,6 +84,7 @@ python_library(
     'src/python/pants/java:executor',
     'src/python/pants/task',
     'src/python/pants/util:memo',
+    'src/python/pants/util:ordered_set',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -28,7 +28,7 @@ from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_file
 from pants.util.memo import memoized_property
-from pants.util.ordered_set import  OrderedSet, FrozenOrderedSet
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
 @dataclass()

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -8,8 +8,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Tuple
 
-from twitter.common.collections import OrderedSet
-
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -30,6 +28,7 @@ from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_file
 from pants.util.memo import memoized_property
+from pants.util.ordered_set import  OrderedSet, FrozenOrderedSet
 
 
 @dataclass()
@@ -335,16 +334,12 @@ class ExportDepAsJar(ConsoleTask):
             [self._jar_id(jar) for jar in iter_transitive_jars(current_target)]
         )
         compile_libraries_for_target = libraries_for_target.copy()
-        for dep in sorted(
-            flat_non_modulizable_deps_for_modulizable_targets[current_target].compile_deps
-        ):
+        for dep in flat_non_modulizable_deps_for_modulizable_targets[current_target].compile_deps:
             compile_libraries_for_target.update(_full_library_set_for_target(dep))
         info["compile_libraries"].extend(compile_libraries_for_target)
 
         runtime_libraries_for_target = libraries_for_target.copy()
-        for dep in sorted(
-            flat_non_modulizable_deps_for_modulizable_targets[current_target].runtime_deps
-        ):
+        for dep in flat_non_modulizable_deps_for_modulizable_targets[current_target].runtime_deps:
             runtime_libraries_for_target.update(_full_library_set_for_target(dep))
         info["runtime_libraries"].extend(runtime_libraries_for_target)
 

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -5,7 +5,8 @@ import json
 import os
 import zipfile
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Tuple
 
 from twitter.common.collections import OrderedSet
 
@@ -29,6 +30,34 @@ from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_file
 from pants.util.memo import memoized_property
+
+
+@dataclass()
+class FlatDependenciesInfo:
+    """Holds flat meta information about the runtime and compile time dependencies of a target.
+
+    Compile time dependencies should respect strict_deps, whereas runtime deps should not.
+    """
+
+    compile_deps: FrozenOrderedSet[Target]
+    runtime_deps: FrozenOrderedSet[Target]
+
+    @staticmethod
+    def empty() -> "FlatDependenciesInfo":
+        return FlatDependenciesInfo(
+            compile_deps=FrozenOrderedSet(), runtime_deps=FrozenOrderedSet(),
+        )
+
+    def with_single_taget(target: Target) -> "FlatDependenciesInfo":
+        return FlatDependenciesInfo(
+            compile_deps=FrozenOrderedSet({target}), runtime_deps=FrozenOrderedSet({target}),
+        )
+
+    def __add__(self, other: "FlatDependenciesInfo") -> "FlatDependenciesInfo":
+        return FlatDependenciesInfo(
+            compile_deps=self.compile_deps.union(other.compile_deps),
+            runtime_deps=self.runtime_deps.union(other.runtime_deps),
+        )
 
 
 class ExportDepAsJar(ConsoleTask):
@@ -243,7 +272,7 @@ class ExportDepAsJar(ConsoleTask):
         resource_target_map,
         runtime_classpath,
         zinc_args_for_target,
-        flat_non_modulizable_deps_for_modulizable_targets,
+        flat_non_modulizable_deps_for_modulizable_targets: Dict[Target, FlatDependenciesInfo],
     ):
         """
         :type current_target:pants.build_graph.target.Target
@@ -309,7 +338,9 @@ class ExportDepAsJar(ConsoleTask):
         libraries_for_target = set(
             [self._jar_id(jar) for jar in iter_transitive_jars(current_target)]
         )
-        for dep in sorted(flat_non_modulizable_deps_for_modulizable_targets[current_target]):
+        for dep in sorted(
+            flat_non_modulizable_deps_for_modulizable_targets[current_target].compile_deps
+        ):
             libraries_for_target.update(_full_library_set_for_target(dep))
         info["compile_libraries"].extend(libraries_for_target)
 
@@ -453,7 +484,9 @@ class ExportDepAsJar(ConsoleTask):
             target, JvmTarget
         ) and DependencyContext.global_instance().defaulted_property(target, "strict_deps")
 
-    def _flat_non_modulizable_deps_for_modulizable_targets(self, modulizable_targets):
+    def _flat_non_modulizable_deps_for_modulizable_targets(
+        self, modulizable_targets: FrozenOrderedSet[Target]
+    ) -> Dict[Target, FlatDependenciesInfo]:
         """Collect flat dependencies for targets that will end up in libraries. When visiting a
         target, we don't expand the dependencies that are modulizable targets, since we need to
         reflect those relationships in a separate way later on.
@@ -471,30 +504,73 @@ class ExportDepAsJar(ConsoleTask):
         Therefore, when computing the library entries for A, we need to walk the (transitive) modulizable dependency graph,
         and accumulate the entries in the map.
 
-        This function takes strict_deps into account when generating the graph.
+        Each entry in the map returned from this function contains two pieces of information:
+            - compile_deps contains the dependencies needed to form the compile classpath.
+                These respect strict_deps.
+            - runtime_deps contains the dependencies needed to form the runtime classpath.
+                These do not respect strict_deps.
         """
-        flat_deps: Dict[Target, OrderedSet[Target]] = {}
+        flat_deps: Dict[Target, FlatDependenciesInfo] = {}
 
-        def create_entry_for_target(target: Target) -> None:
-            target_key = target
+        def _aggregate_entries_from_dependencies(
+            dep_list: List[Target],
+            field_accessor: Callable[[FlatDependenciesInfo], FrozenOrderedSet[Target]],
+        ) -> FrozenOrderedSet[Target]:
+            aggregated_entries = OrderedSet()
+            for dep in dep_list:
+                dep_entry: FrozenOrderedSet[Target] = field_accessor(
+                    flat_deps.get(dep, FlatDependenciesInfo.empty())
+                )
+                aggregated_entries.update(dep_entry.union({dep}))
+            return aggregated_entries
+
+        def insert_entry_for_target(target: Target) -> None:
+            # Compile dependencies take into account strict_deps...
             if self._is_strict_deps(target):
-                dependencies = target.strict_dependencies(DependencyContext.global_instance())
+                compile_dependencies = target.strict_dependencies(
+                    DependencyContext.global_instance()
+                )
             else:
-                dependencies = target.dependencies
-            non_modulizable_deps = [dep for dep in dependencies if dep not in modulizable_targets]
-            entry: OrderedSet[Target] = OrderedSet()
-            for dep in non_modulizable_deps:
-                entry.update(OrderedSet([*flat_deps.get(dep, set()), dep]))
-            flat_deps[target_key] = OrderedSet(entry)
+                compile_dependencies = target.dependencies
+            non_modulizable_compile_deps = [
+                dep for dep in compile_dependencies if dep not in modulizable_targets
+            ]
+            compile_entry = _aggregate_entries_from_dependencies(
+                non_modulizable_compile_deps, lambda fdi: fdi.compile_deps
+            )
 
+            # Whereas runtime dependencies do not
+            non_modulizable_runtime_deps = [
+                dep for dep in target.dependencies if dep not in modulizable_targets
+            ]
+            runtime_entry = _aggregate_entries_from_dependencies(
+                non_modulizable_runtime_deps, lambda fdi: fdi.runtime_deps
+            )
+
+            flat_deps[target] = FlatDependenciesInfo(
+                compile_deps=compile_entry, runtime_deps=runtime_entry,
+            )
+
+        # We pre-seed the map with entries for targets with strict deps.
+        # This avoids expanding the strict_deps targets in the latter traversal.
+        # N.B. This takes M*N time, where
+        #  - N is the size of the transitive dep graph of targets with strict_deps
+        #  - M is the number of targets with strict_deps.
         targets_with_strict_deps = [t for t in modulizable_targets if self._is_strict_deps(t)]
         for t in targets_with_strict_deps:
-            flat_deps[t] = OrderedSet(t.strict_dependencies(DependencyContext.global_instance()))
+            flat_deps[t] = FlatDependenciesInfo(
+                compile_deps=FrozenOrderedSet(
+                    t.strict_dependencies(DependencyContext.global_instance())
+                ),
+                runtime_deps=FrozenOrderedSet(
+                    [dep for dep in t.closure() if dep not in modulizable_targets]
+                ),
+            )
 
         self.context.build_graph.walk_transitive_dependency_graph(
             addresses=[t.address for t in modulizable_targets if not self._is_strict_deps(t)],
             # Work is to populate the entry of the map by merging the entries of all of the deps.
-            work=create_entry_for_target,
+            work=insert_entry_for_target,
             # We pre-populate the dict according to several principles (e.g. strict_deps),
             # so a target being there means that there is no need to expand.
             predicate=lambda target: target not in flat_deps.keys(),
@@ -536,7 +612,7 @@ class ExportDepAsJar(ConsoleTask):
             )
 
         flat_non_modulizable_deps_for_modulizable_targets: Dict[
-            Target, OrderedSet[Target]
+            Target, FlatDependenciesInfo
         ] = self._flat_non_modulizable_deps_for_modulizable_targets(modulizable_targets)
 
         for target in modulizable_targets:

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -252,7 +252,7 @@ class ExportDepAsJar(ConsoleTask):
             # this means 'dependencies'
             "targets": [],
             "source_dependencies_in_classpath": [],
-            "libraries": [],
+            "compile_libraries": [],
             "roots": [],
             "id": current_target.id,
             "target_type": ExportDepAsJar._get_target_type(
@@ -311,7 +311,7 @@ class ExportDepAsJar(ConsoleTask):
         )
         for dep in sorted(flat_non_modulizable_deps_for_modulizable_targets[current_target]):
             libraries_for_target.update(_full_library_set_for_target(dep))
-        info["libraries"].extend(libraries_for_target)
+        info["compile_libraries"].extend(libraries_for_target)
 
         info["roots"] = [
             {

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -1,6 +1,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_tests(
+  name='tests',
+  dependencies=[
+    ':ordered_set',
+  ],
+  tags = {'type_checked'},
+)
+
 python_library(
   name = 'argutil',
   sources = ['argutil.py'],
@@ -98,6 +106,12 @@ python_library(
   name = 'objects',
   sources = ['objects.py'],
   tags = {'partially_type_checked'},
+)
+
+python_library(
+  name = 'ordered_set',
+  sources = ['ordered_set.py'],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -1,0 +1,325 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""An OrderedSet is a set that remembers its insertion order, and a FrozenOrderedSet is one that is
+also immutable.
+
+Based on the library `ordered-set` developed by Robyn Speer and released under the MIT license:
+https://github.com/LuminosoInsight/ordered-set.
+
+The library `ordered-set` is itself originally based on a recipe originally posted to ActivateState
+Recipes by Raymond Hettiger and released under the MIT license:
+http://code.activestate.com/recipes/576694/.
+"""
+
+import itertools
+from abc import ABC, abstractmethod
+from typing import (
+    AbstractSet,
+    Any,
+    Iterable,
+    Iterator,
+    List,
+    MutableSet,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+
+T = TypeVar("T")
+
+
+class _AbstractOrderedSet(ABC, AbstractSet[T], Sequence[T]):
+    """Common functionality shared between OrderedSet and FrozenOrderedSet."""
+
+    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
+        # Using a dictionary, rather than using the recipe's original `self |= iterable`, results
+        # in a ~20% performance increase for the constructor.
+        #
+        # NB: Dictionaries are ordered in Python 3.6+. While this was not formalized until Python
+        # 3.7, Python 3.6 uses this behavior; Pants requires CPython 3.6+ to run, so this
+        # assumption is safe for us to rely on.
+        deduplicated_items = {v: None for v in iterable or ()}.keys()
+        self._items_buffer: Sequence[T] = tuple(deduplicated_items)
+
+    @property
+    @abstractmethod
+    def _items(self) -> Sequence[T]:
+        """This stores the de-duplicated elements in order."""
+
+    def __len__(self) -> int:
+        """Returns the number of unique elements in the set."""
+        return len(self._items)
+
+    def copy(self) -> "_AbstractOrderedSet[T]":
+        """Return a shallow copy of this object."""
+        return self.__class__(self)
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "_AbstractOrderedSet[T]":
+        ...
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[T, "_AbstractOrderedSet[T]"]:  # noqa: F811
+        """Get the item at a given index.
+
+        If `index` is a slice, you will get back that slice of items, as a new OrderedSet.
+        """
+        if isinstance(index, slice):
+            return self.__class__(self._items[index])
+        return self._items[index]
+
+    def __contains__(self, key: Any) -> bool:
+        """Test if the item is in this ordered set."""
+        return key in self._items
+
+    def index(self, key: T, start: int = 0, end: Optional[int] = None) -> int:
+        """Get the index of a given entry, raising a ValueError if it's not present."""
+        try:
+            if end is None:
+                return self._items.index(key, start)
+            return self._items.index(key, start, end)
+        except ValueError:
+            raise ValueError(f"{key} is not in {self.__class__.__name__}.")
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._items)
+
+    def __reversed__(self) -> Iterator[T]:
+        return reversed(self._items)
+
+    def __repr__(self) -> str:
+        name = self.__class__.__name__
+        if not self:
+            return f"{name}()"
+        return f"{name}({list(self)!r})"
+
+    def __eq__(self, other: Any) -> bool:
+        """Returns True if other is the same type with the same elements and same order."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._items == other._items
+
+    def union(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Combines all unique items.
+
+        Each item's order is defined by its first appearance.
+        """
+        merged_iterables = itertools.chain([self], others)
+        return self.__class__(itertools.chain.from_iterable(merged_iterables))
+
+    def __and__(self, other: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        # The parent class's implementation of this is backwards.
+        return self.intersection(other)
+
+    def intersection(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Returns elements in common between all sets.
+
+        Order is defined only by the first set.
+        """
+        cls = self.__class__
+        if not others:
+            return cls(self)
+        common = set.intersection(*(set(other) for other in others))
+        return cls(item for item in self if item in common)
+
+    def difference(self, *others: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Returns all elements that are in this set but not the others."""
+        cls = self.__class__
+        if not others:
+            return cls(self)
+        other = set.union(*(set(other) for other in others))
+        return cls(item for item in self if item not in other)
+
+    def issubset(self, other: Iterable[T]) -> bool:
+        """Report whether another set contains this set."""
+        try:
+            # Fast check for obvious cases
+            if len(self) > len(other):  # type: ignore[arg-type]
+                return False
+        except TypeError:
+            pass
+        return all(item in other for item in self)
+
+    def issuperset(self, other: Iterable[T]) -> bool:
+        """Report whether this set contains another set."""
+        try:
+            # Fast check for obvious cases
+            if len(self) < len(other):  # type: ignore[arg-type]
+                return False
+        except TypeError:
+            pass
+        return all(item in self for item in other)
+
+    def symmetric_difference(self, other: Iterable[T]) -> "_AbstractOrderedSet[T]":
+        """Return the symmetric difference of this OrderedSet and another set as a new OrderedSet.
+        That is, the new set will contain all elements that are in exactly one of the sets.
+
+        Their order will be preserved, with elements from `self` preceding elements from `other`.
+        """
+        cls = self.__class__
+        diff1 = cls(self).difference(other)
+        diff2 = cls(other).difference(self)
+        return diff1.union(diff2)
+
+
+class OrderedSet(_AbstractOrderedSet[T], MutableSet[T]):
+    """A mutable set that retains its order.
+
+    This is not safe to use with the V2 engine.
+    """
+
+    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
+        super().__init__(iterable)
+        self._items_buffer: List[T] = list(self._items_buffer)
+
+    @property
+    def _items(self) -> List[T]:
+        return self._items_buffer
+
+    @_items.setter
+    def _items(self, new_items: List[T]) -> None:
+        self._items_buffer = new_items
+
+    def copy(self) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().copy())
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "OrderedSet[T]":
+        ...
+
+    def __getitem__(self, index: Union[int, slice]) -> Union[T, "OrderedSet[T]"]:  # noqa: F811
+        return cast(Union[T, OrderedSet[T]], super().__getitem__(index))
+
+    def union(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().union(*others))
+
+    def __and__(self, other: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().__and__(other))
+
+    def intersection(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().intersection(*others))
+
+    def difference(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().difference(*others))
+
+    def symmetric_difference(self, *others: Iterable[T]) -> "OrderedSet[T]":
+        return cast(OrderedSet[T], super().symmetric_difference(*others))
+
+    def add(self, key: T) -> None:
+        """Add `key` as an item to this OrderedSet."""
+        if key in self:
+            return
+        self._items.append(key)
+
+    append = add
+
+    def update(self, iterable: Iterable[T]) -> None:
+        """Update the set with the given iterable sequence."""
+        for item in iterable:
+            self.add(item)
+
+    extend = update
+
+    def pop(self) -> T:
+        """Remove and return the last element from the set.
+
+        Raises KeyError if the set is empty.
+        """
+        if not self._items:
+            raise KeyError("OrderedSet is empty")
+        return self._items.pop()
+
+    def discard(self, key: T) -> None:
+        """Remove an element. Do not raise an exception if absent.
+
+        The MutableSet mixin uses this to implement the .remove() method, which
+        *does* raise an error when asked to remove a non-existent item.
+        """
+        if key not in self:
+            return
+        self._items.remove(key)
+
+    def clear(self) -> None:
+        """Remove all items from this OrderedSet."""
+        self._items.clear()
+
+    def difference_update(self, *others: Iterable[T]) -> None:
+        """Update this OrderedSet to remove items from one or more other sets."""
+        items_to_remove: Set[T] = set()
+        for other in others:
+            items_as_set = set(other)
+            items_to_remove |= items_as_set
+        self._items = [item for item in self._items if item not in items_to_remove]
+
+    def intersection_update(self, other: Iterable[T]) -> None:
+        """Update this OrderedSet to keep only items in another set, preserving their order in this
+        set."""
+        other = set(other)
+        self._items = [item for item in self._items if item in other]
+
+    def symmetric_difference_update(self, other: Iterable[T]) -> None:
+        """Update this OrderedSet to remove items from another set, then add items from the other
+        set that were not present in this set."""
+        items_to_add = [item for item in other if item not in self]
+        items_to_remove = cast(Set[T], set(other))
+        self._items = [item for item in self._items if item not in items_to_remove] + items_to_add
+
+
+class FrozenOrderedSet(_AbstractOrderedSet[T]):
+    """A frozen (i.e. immutable) set that retains its order.
+
+    This is safe to use with the V2 engine.
+    """
+
+    @property
+    def _items(self) -> Tuple[T, ...]:
+        return cast(Tuple[T, ...], self._items_buffer)
+
+    def copy(self) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().copy())
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # noqa: F811
+    def __getitem__(self, index: slice) -> "FrozenOrderedSet[T]":
+        ...
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[T, "FrozenOrderedSet[T]"]:  # noqa: F811
+        return cast(Union[T, FrozenOrderedSet[T]], super().__getitem__(index))
+
+    def union(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().union(*others))
+
+    def __and__(self, other: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().__and__(other))
+
+    def intersection(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().intersection(*others))
+
+    def difference(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().difference(*others))
+
+    def symmetric_difference(self, *others: Iterable[T]) -> "FrozenOrderedSet[T]":
+        return cast(FrozenOrderedSet[T], super().symmetric_difference(*others))
+
+    def __hash__(self) -> int:
+        return hash(self._items)

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -1,0 +1,358 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+import random
+from typing import AbstractSet, Iterator, Sequence, Tuple, Type, Union
+
+import pytest
+
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+
+OrderedSetInstance = Union[OrderedSet, FrozenOrderedSet]
+OrderedSetCls = Union[Type[OrderedSet], Type[FrozenOrderedSet]]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_stable_order(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert len(set1) == 5
+    assert list(set1) == ["a", "b", "r", "c", "d"]
+    assert list(reversed(set1)) == ["d", "c", "r", "b", "a"]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_contains(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert "a" in set1
+    assert "r" in set1
+    assert "z" not in set1
+    assert 0 not in set1
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_copy(cls: OrderedSetCls) -> None:
+    set1 = cls("abc")
+    set2 = set1.copy()
+    assert set1 == set2
+    assert set1 is set1
+    assert set2 is set2
+    assert set1 is not set2
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_get_by_index(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert set1[0] == "a"
+    assert set1[1] == "b"
+    assert set1[2] == "r"
+    assert set1[3] == "c"
+    assert set1[4] == "d"
+    with pytest.raises(IndexError):
+        set1[5]
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_slices(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    assert set1[:] == set1
+    assert set1[:] is not set1
+    assert set1[1:3] == cls(["b", "r"])
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_find_index(cls: OrderedSetCls) -> None:
+    set1 = cls("abc")
+    assert set1.index("a") == 0
+    assert set1.index("b") == 1
+    assert set1.index("c") == 2
+
+    with pytest.raises(ValueError):
+        set1.index("z")
+    with pytest.raises(ValueError):
+        set1.index("a", start=1)
+    with pytest.raises(ValueError):
+        set1.index("c", end=2)
+    with pytest.raises(ValueError):
+        set1.index("b", start=1, end=1)
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_tuples(cls: OrderedSetCls) -> None:
+    tup = ("tuple", 1)
+    set1 = OrderedSet([tup])
+    assert set1.index(tup) == 0
+    assert set1[0] == tup
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_repr(cls: OrderedSetCls) -> None:
+    set1 = cls()
+    assert repr(set1) == f"{cls.__name__}()"
+
+    set2 = cls("abcabc")
+    assert repr(set2) == f"{cls.__name__}(['a', 'b', 'c'])"
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_equality(cls: OrderedSetCls) -> None:
+    set1 = cls([1, 2])
+
+    assert set1 == cls([1, 2])
+    assert set1 == cls([1, 1, 2, 2])
+
+    assert set1 != cls([2, 1])
+    assert set1 != [2, 1]
+    assert set1 != [2, 1, 1]
+
+    assert set1 != [1, 2]
+    assert set1 != (1, 2)
+    assert set1 != {1, 2}
+    assert set1 != {1: None, 2: None}
+
+    # We are strict in enforcing that FrozenOrderedSet != OrderedSet. This is important for the
+    # engine, where we should never use OrderedSet.
+    other_cls = FrozenOrderedSet if cls == OrderedSet else OrderedSet
+    assert set1 != other_cls([1, 2])
+
+
+def test_frozen_is_hashable() -> None:
+    set1 = FrozenOrderedSet("abcabc")
+    assert hash(set1) == hash(set1.copy())
+    assert hash(set1) == hash(("a", "b", "c"))
+
+    set2 = FrozenOrderedSet("abcd")
+    assert hash(set1) != hash(set2)
+    assert hash(set1) != hash(("a", "b", "c", "d"))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_binary_operations(cls: OrderedSetCls) -> None:
+    set1 = cls("abracadabra")
+    set2 = cls("simsalabim")
+    assert set1 != set2
+
+    assert set1 & set2 == cls(["a", "b"])
+    assert set1 | set2 == cls(["a", "b", "r", "c", "d", "s", "i", "m", "l"])
+    assert set1 - set2 == cls(["r", "c", "d"])
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_comparisons(cls: OrderedSetCls) -> None:
+    # Comparison operators on sets actually test for subset and superset.
+    assert cls([1, 2]) < cls([1, 2, 3])
+    assert cls([1, 2]) > cls([1])
+
+
+def test_add() -> None:
+    set1: OrderedSet[str] = OrderedSet()
+
+    set1.add("a")
+    assert set1 == OrderedSet("a")
+
+    set1.add("b")
+    assert set1 == OrderedSet("ab")
+
+    set1.add("a")
+    assert set1 == OrderedSet("ab")
+
+
+def test_update() -> None:
+    set1 = OrderedSet("abcd")
+    set1.update("efgh")
+
+    assert len(set1) == 8
+    assert "".join(set1) == "abcdefgh"
+
+    set2 = OrderedSet("abcd")
+    set2.update("cdef")
+    assert len(set2) == 6
+    assert "".join(set2) == "abcdef"
+
+
+def test_remove() -> None:
+    set1 = OrderedSet("abracadabra")
+
+    set1.remove("a")
+    set1.remove("b")
+
+    assert set1 == OrderedSet("rcd")
+    assert set1[0] == "r"
+    assert set1[1] == "c"
+    assert set1[2] == "d"
+
+    assert set1.index("r") == 0
+    assert set1.index("c") == 1
+    assert set1.index("d") == 2
+
+    assert "a" not in set1
+    assert "b" not in set1
+    assert "r" in set1
+
+    # Make sure we can .discard() something that's already gone, plus something that was never
+    # there.
+    set1.discard("a")
+    set1.discard("a")
+
+    # If we .remove() an element that's not there, we get a KeyError.
+    with pytest.raises(KeyError):
+        set1.remove("z")
+
+
+def test_pop() -> None:
+    set1 = OrderedSet("ab")
+    elem = set1.pop()
+
+    assert elem == "b"
+    assert set1 == OrderedSet("a")
+    elem = set1.pop()
+
+    assert elem == "a"
+    assert set1 == OrderedSet()
+
+    with pytest.raises(KeyError):
+        set1.pop()
+
+
+def test_clear() -> None:
+    set1 = OrderedSet("abracadabra")
+    set1.clear()
+
+    assert len(set1) == 0
+    assert set1 == OrderedSet()
+
+
+def assert_results_are_the_same(
+    results: Union[Sequence[AbstractSet], Sequence[bool]],
+    *,
+    sets: Tuple[OrderedSetInstance, OrderedSetInstance],
+) -> None:
+    """Check that all results have the same value, but are different items."""
+    assert all(
+        result == results[0] for result in results
+    ), f"Not all results are the same.\nResults: {results}\nTest data: {sets}"
+    for a, b in itertools.combinations(results, r=2):
+        if isinstance(a, bool):
+            continue
+        assert a is not b, (
+            "The results should all be distinct OrderedSet or FrozenOrderedSet instances. "
+            f"{a} is the same object as {b}."
+        )
+
+
+def generate_testdata(
+    cls: OrderedSetCls,
+) -> Iterator[Tuple[OrderedSetInstance, OrderedSetInstance]]:
+    data1 = cls([5, 3, 1, 4])
+    data2 = cls([1, 4])
+    yield data1, data2
+
+    # First set is empty
+    data1 = cls([])
+    data2 = cls([3, 1, 2])
+    yield data1, data2
+
+    # Second set is empty
+    data1 = cls([3, 1, 2])
+    data2 = cls([])
+    yield data1, data2
+
+    # Both sets are empty
+    data1 = cls([])
+    data2 = cls([])
+    yield data1, data2
+
+    # Random test cases
+    rng = random.Random(0)
+    a, b = 20, 20
+    for _ in range(10):
+        data1 = cls(rng.randint(0, a) for _ in range(b))
+        data2 = cls(rng.randint(0, a) for _ in range(b))
+        yield data1, data2
+        yield data2, data1
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_intersection(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 & set2, set1.intersection(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.intersection_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 &= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_difference(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 - set2, set1.difference(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.difference_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 -= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_xor(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 ^ set2, set1.symmetric_difference(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.symmetric_difference_update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 ^= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_union(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        results = [set1 | set2, set1.union(set2)]
+        if isinstance(set1, OrderedSet):
+            mutation_result1 = set1.copy()
+            mutation_result1.update(set2)
+            results.append(mutation_result1)
+
+            mutation_result2 = set1.copy()
+            mutation_result2 |= set2  # type: ignore[misc]
+            results.append(mutation_result2)
+        assert_results_are_the_same(results, sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_subset(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1 <= set2
+        result2 = set1.issubset(set2)
+        result3 = set(set1).issubset(set(set2))
+        assert_results_are_the_same([result1, result2, result3], sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_superset(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1 >= set2
+        result2 = set1.issuperset(set2)
+        result3 = set(set1).issuperset(set(set2))
+        assert_results_are_the_same([result1, result2, result3], sets=(set1, set2))
+
+
+@pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
+def test_disjoint(cls: OrderedSetCls) -> None:
+    for set1, set2 in generate_testdata(cls):
+        result1 = set1.isdisjoint(set2)
+        result2 = len(set1.intersection(set2)) == 0
+        assert_results_are_the_same([result1, result2], sets=(set1, set2))

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -624,7 +624,7 @@ class ExportDepAsJarTestSuiteOne(ExportDepAsJarTest):
             "org.apache:apache-jar:12.12.2012", result["targets"][spec]["compile_libraries"]
         )
 
-    def test_libraries_respect_strict_deps(self):
+    def test_compile_libraries_respect_strict_deps(self):
         enabled_spec = self.strict_deps_enabled.address.spec
         enabled_result = self.execute_export_json(enabled_spec)["targets"][enabled_spec]
         disabled_spec = self.strict_deps_disabled.address.spec
@@ -636,6 +636,19 @@ class ExportDepAsJarTestSuiteOne(ExportDepAsJarTest):
 
         assert transitive_dependency_library_entry in disabled_result["compile_libraries"]
         assert transitive_dependency_library_entry not in enabled_result["compile_libraries"]
+
+    def test_runtime_libraries_ignore_strict_deps(self):
+        enabled_spec = self.strict_deps_enabled.address.spec
+        enabled_result = self.execute_export_json(enabled_spec)["targets"][enabled_spec]
+        disabled_spec = self.strict_deps_disabled.address.spec
+        disabled_result = self.execute_export_json(disabled_spec)["targets"][disabled_spec]
+
+        # Both the targets under test transitively depend on this target
+        # which shouldn't be in the compile classpath, but it should be in the runtime_classpath
+        transitive_dependency_library_entry = self.jvm_target_with_sources.id
+
+        assert transitive_dependency_library_entry in disabled_result["runtime_libraries"]
+        assert transitive_dependency_library_entry in enabled_result["runtime_libraries"]
 
     def test_transitive_targets(self):
         # Address of the dependency that shouldn't appear in the strict deps case.

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -40,6 +40,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_open
 from pants.util.osutil import get_os_name, normalize_os_name
 
+# In the absence of explicit scoping (https://www.pantsbuild.org/jvm_projects.html#setting-target-scopes),
 # runtime_libraries should be the same as compile_libraries for non-strict-deps targets,
 # so we'll often test them together.
 LIBRARIES_ENTRIES = ["compile_libraries", "runtime_libraries"]

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -161,7 +161,7 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
                 "examples.src.scala.org.pantsbuild.example.several_scala_targets.node.names_to_greet",
                 export_output["targets"][
                     "examples/src/scala/org/pantsbuild/example/several_scala_targets:greet_json"
-                ]["libraries"],
+                ]["compile_libraries"],
             )
 
     def test_jars_resolve_sources_javadocs(self):


### PR DESCRIPTION
### Problem

In #9145, we made the `libraries` field in a `target` entry respect `stric_deps`. While this is correct to construct an accurate compile classpath, there are certain cases where it now becomes impossible to reconstruct a runtime classpath.

Runtime classpaths shouldn't respect strict deps, so we need to store that information somewhere.

### Solution

Implementation:
- We implement this by storing extra information when we compute the flat non-modulizable dependency list. We introduce a new type to hold that information:
```
@dataclass()
class FlatDependenciesInfo:
    """Holds flat meta information about the runtime and compile time dependencies of a target.

    Compile time dependencies should respect strict_deps, whereas runtime deps should not.
    """

    compile_deps: FrozenOrderedSet[Target]
    runtime_deps: FrozenOrderedSet[Target]
```
- We modify `_flat_non_modulizable_deps_for_modulizable_targets` so that it returns a `Dict[Target, FlatDependenciesInfo]` (instead of the previous `Dict[Target, FrozenOrderedSet[Target]]`).
- In that function, when we pre-seed the dict with targets that have `strict_deps` enabled, we calculate the `runtime_deps` with the target's `closure()`. This is potentially expensive, but the implementation remains significantly cleaner this way, because we can keep avoiding expanding `strict_deps` targets. This can be changed if needed.

### Result

Introduce API changes to `export-dep-as-jar`:
- `libraries` entries for targets will now be named `compile_libraries`.
- There is a new entry in a target, called `runtime_libraries`, which will include all non-modulizable targets that are dependencies, not restricting strict_deps. This field should be combined with the values of `runtime_libraries` of all dependencies under the `targets` field to create the runtime classpath.

**Note** Depends on https://github.com/pantsbuild/pants/pull/9748