### PR TITLE
Add a flag to prevent the FsEventService and watchman from starting

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -244,6 +244,9 @@ class Scheduler:
     def invalidate_all_files(self):
         return self._native.lib.graph_invalidate_all_paths(self._scheduler)
 
+    def check_invalidation_watcher_liveness(self):
+        return self._native.lib.check_invalidation_watcher_liveness(self._scheduler)
+
     def graph_len(self):
         return self._native.lib.graph_len(self._scheduler)
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -244,8 +244,8 @@ class Scheduler:
     def invalidate_all_files(self):
         return self._native.lib.graph_invalidate_all_paths(self._scheduler)
 
-    def check_invalidation_watcher_liveness(self):
-        return self._native.lib.check_invalidation_watcher_liveness(self._scheduler)
+    def check_invalidation_watcher_liveness(self) -> bool:
+        return cast(bool, self._native.lib.check_invalidation_watcher_liveness(self._scheduler))
 
     def graph_len(self):
         return self._native.lib.graph_len(self._scheduler)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -646,7 +646,7 @@ class GlobalOptions(Subsystem):
 
         # Watchman options.
         register(
-            "--enable-watchman",
+            "--watchman-enable",
             type=bool,
             advanced=True,
             default=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -646,6 +646,14 @@ class GlobalOptions(Subsystem):
 
         # Watchman options.
         register(
+            "--enable-watchman",
+            type=bool,
+            advanced=True,
+            default=True,
+            help="Use the watchman daemon filesystem event watcher to watch for changes "
+            "in the buildroot. Disable this to rely solely on the experimental pants engine filesystem watcher."
+        )
+        register(
             "--watchman-version", advanced=True, default="4.9.0-pants1", help="Watchman version."
         )
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -651,7 +651,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             default=True,
             help="Use the watchman daemon filesystem event watcher to watch for changes "
-            "in the buildroot. Disable this to rely solely on the experimental pants engine filesystem watcher."
+            "in the buildroot. Disable this to rely solely on the experimental pants engine filesystem watcher.",
         )
         register(
             "--watchman-version", advanced=True, default="4.9.0-pants1", help="Watchman version."

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -206,7 +206,9 @@ class PantsDaemon(FingerprintedProcessManager):
             :returns: A PantsServices instance.
             """
             should_shutdown_after_run = bootstrap_options.shutdown_pantsd_after_run
-            fs_event_service = FSEventService(watchman, build_root,) if bootstrap_options.enable_watchman else None
+            fs_event_service = (
+                FSEventService(watchman, build_root,) if bootstrap_options.enable_watchman else None
+            )
 
             pidfile_absolute = PantsDaemon.metadata_file_path(
                 "pantsd", "pid", bootstrap_options.pants_subprocessdir
@@ -243,7 +245,16 @@ class PantsDaemon(FingerprintedProcessManager):
             store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
 
             return PantsServices(
-                services=tuple(service for service in (fs_event_service, scheduler_service, pailgun_service, store_gc_service) if service is not None),
+                services=tuple(
+                    service
+                    for service in (
+                        fs_event_service,
+                        scheduler_service,
+                        pailgun_service,
+                        store_gc_service,
+                    )
+                    if service is not None
+                ),
                 port_map=dict(pailgun=pailgun_service.pailgun_port),
             )
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -206,7 +206,7 @@ class PantsDaemon(FingerprintedProcessManager):
             :returns: A PantsServices instance.
             """
             should_shutdown_after_run = bootstrap_options.shutdown_pantsd_after_run
-            fs_event_service = FSEventService(watchman, build_root,)
+            fs_event_service = FSEventService(watchman, build_root,) if bootstrap_options.enable_watchman else None
 
             pidfile_absolute = PantsDaemon.metadata_file_path(
                 "pantsd", "pid", bootstrap_options.pants_subprocessdir
@@ -221,6 +221,7 @@ class PantsDaemon(FingerprintedProcessManager):
                     "pantsd processes."
                 )
 
+            # TODO make SchedulerService handle fs_event_service_being None
             scheduler_service = SchedulerService(
                 fs_event_service=fs_event_service,
                 legacy_graph_scheduler=legacy_graph_scheduler,
@@ -242,7 +243,7 @@ class PantsDaemon(FingerprintedProcessManager):
             store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
 
             return PantsServices(
-                services=(fs_event_service, scheduler_service, pailgun_service, store_gc_service),
+                services=tuple(service for service in (fs_event_service, scheduler_service, pailgun_service, store_gc_service) if service is not None),
                 port_map=dict(pailgun=pailgun_service.pailgun_port),
             )
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -207,7 +207,7 @@ class PantsDaemon(FingerprintedProcessManager):
             """
             should_shutdown_after_run = bootstrap_options.shutdown_pantsd_after_run
             fs_event_service = (
-                FSEventService(watchman, build_root,) if bootstrap_options.enable_watchman else None
+                FSEventService(watchman, build_root,) if bootstrap_options.watchman_enable else None
             )
 
             pidfile_absolute = PantsDaemon.metadata_file_path(

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -88,7 +88,9 @@ class SchedulerService(PantsService):
             if self._invalidation_globs:
                 self._invalidating_snapshot = self._get_snapshot()
                 self._invalidating_files = self._invalidating_snapshot.files
-                self._logger.info("watching invalidating files: {}".format(self._invalidating_files))
+                self._logger.info(
+                    "watching invalidating files: {}".format(self._invalidating_files)
+                )
 
             if self._pantsd_pidfile:
                 self._fs_event_service.register_pidfile_handler(
@@ -178,7 +180,6 @@ class SchedulerService(PantsService):
         # The first watchman event for all_files is a listing of all files - ignore it.
         if (
             not is_initial_event
-            and self._fs_event_service is not None
             and subscription == self._fs_event_service.PANTS_ALL_FILES_SUBSCRIPTION_NAME
         ):
             self._handle_batch_event(files)
@@ -197,8 +198,9 @@ class SchedulerService(PantsService):
         # racing watchman startup vs invalidation events.
         graph_len = self._scheduler.graph_len()
         if graph_len > 0:
-            self._logger.debug(f"graph len was {graph_len}, waiting for initial watchman event")
-            self._watchman_is_running.wait()
+            if self._fs_event_service is not None:
+                self._logger.debug(f"graph len was {graph_len}, waiting for initial watchman event")
+                self._watchman_is_running.wait()
 
         global_options = options.for_global_scope()
         build_id = RunTracker.global_instance().run_id

--- a/src/python/pants/pantsd/watchman_launcher.py
+++ b/src/python/pants/pantsd/watchman_launcher.py
@@ -36,6 +36,7 @@ class WatchmanLauncher:
             bootstrap_options.watchman_startup_timeout,
             bootstrap_options.watchman_socket_timeout,
             bootstrap_options.watchman_socket_path,
+            bootstrap_options.enable_watchman,
             bootstrap_options.pants_subprocessdir,
         )
 
@@ -47,6 +48,7 @@ class WatchmanLauncher:
         watchman_supportdir,
         startup_timeout,
         socket_timeout,
+        enable_watchman,
         socket_path_override=None,
         metadata_base_dir=None,
     ):
@@ -57,6 +59,7 @@ class WatchmanLauncher:
         :param watchman_supportdir: The supportdir for BinaryUtil.
         :param socket_timeout: The watchman client socket timeout (in seconds).
         :param socket_path_override: The overridden target path of the watchman socket, if any.
+        :param enable_watchman: Whether to start watchman when asked to maybe launch.
         :param metadata_base_dir: The ProcessManager metadata base directory.
         """
         self._binary_util = binary_util
@@ -65,6 +68,7 @@ class WatchmanLauncher:
         self._startup_timeout = startup_timeout
         self._socket_timeout = socket_timeout
         self._socket_path_override = socket_path_override
+        self._enable_watchman = enable_watchman
         self._log_level = log_level
         self._logger = logging.getLogger(__name__)
         self._metadata_base_dir = metadata_base_dir
@@ -93,21 +97,27 @@ class WatchmanLauncher:
         )
 
     def maybe_launch(self):
-        if not self.watchman.is_alive():
+        if self._enable_watchman and not self.watchman.is_alive():
             self._logger.debug("launching watchman")
             try:
                 self.watchman.launch()
             except (Watchman.ExecutionError, Watchman.InvalidCommandOutput) as e:
                 self._logger.critical("failed to launch watchman: {!r})".format(e))
                 raise
-
-        self._logger.debug(
-            "watchman is running, pid={pid} socket={socket}".format(
-                pid=self.watchman.pid, socket=self.watchman.socket
+            self._logger.debug(
+                "watchman is running, pid={pid} socket={socket}".format(
+                    pid=self.watchman.pid, socket=self.watchman.socket
+                )
             )
-        )
 
-        return self.watchman
+            return self.watchman
+        else:
+            self.maybe_terminate()
+
+    def maybe_terminate(self):
+        if not self._enable_watchman and self.watchman.is_alive():
+            self._logger.debug("watchman was running, but will be killed because it was disabled")
+            self.terminate()
 
     def terminate(self):
         self.watchman.terminate()

--- a/src/python/pants/pantsd/watchman_launcher.py
+++ b/src/python/pants/pantsd/watchman_launcher.py
@@ -35,8 +35,8 @@ class WatchmanLauncher:
             bootstrap_options.watchman_supportdir,
             bootstrap_options.watchman_startup_timeout,
             bootstrap_options.watchman_socket_timeout,
-            bootstrap_options.watchman_socket_path,
             bootstrap_options.watchman_enable,
+            bootstrap_options.watchman_socket_path,
             bootstrap_options.pants_subprocessdir,
         )
 
@@ -97,24 +97,24 @@ class WatchmanLauncher:
         )
 
     def maybe_launch(self):
-        if self._watchman_enable and not self.watchman.is_alive():
-            self._logger.debug("launching watchman")
-            try:
-                self.watchman.launch()
-            except (Watchman.ExecutionError, Watchman.InvalidCommandOutput) as e:
-                self._logger.critical("failed to launch watchman: {!r})".format(e))
-                raise
+        if self._watchman_enable:
+            if not self.watchman.is_alive():
+                self._logger.debug("launching watchman")
+                try:
+                    self.watchman.launch()
+                except (Watchman.ExecutionError, Watchman.InvalidCommandOutput) as e:
+                    self._logger.critical("failed to launch watchman: {!r})".format(e))
+                    raise
             self._logger.debug(
                 "watchman is running, pid={pid} socket={socket}".format(
                     pid=self.watchman.pid, socket=self.watchman.socket
                 )
             )
-
             return self.watchman
         else:
             self.maybe_terminate()
 
-    def maybe_terminate(self):
+    def maybe_terminate(self) -> None:
         if not self._watchman_enable and self.watchman.is_alive():
             self._logger.info("Watchman was running, but will be killed because it was disabled.")
             self.terminate()

--- a/src/python/pants/pantsd/watchman_launcher.py
+++ b/src/python/pants/pantsd/watchman_launcher.py
@@ -36,7 +36,7 @@ class WatchmanLauncher:
             bootstrap_options.watchman_startup_timeout,
             bootstrap_options.watchman_socket_timeout,
             bootstrap_options.watchman_socket_path,
-            bootstrap_options.enable_watchman,
+            bootstrap_options.watchman_enable,
             bootstrap_options.pants_subprocessdir,
         )
 
@@ -48,7 +48,7 @@ class WatchmanLauncher:
         watchman_supportdir,
         startup_timeout,
         socket_timeout,
-        enable_watchman,
+        watchman_enable,
         socket_path_override=None,
         metadata_base_dir=None,
     ):
@@ -59,7 +59,7 @@ class WatchmanLauncher:
         :param watchman_supportdir: The supportdir for BinaryUtil.
         :param socket_timeout: The watchman client socket timeout (in seconds).
         :param socket_path_override: The overridden target path of the watchman socket, if any.
-        :param enable_watchman: Whether to start watchman when asked to maybe launch.
+        :param watchman_enable: Whether to start watchman when asked to maybe launch.
         :param metadata_base_dir: The ProcessManager metadata base directory.
         """
         self._binary_util = binary_util
@@ -68,7 +68,7 @@ class WatchmanLauncher:
         self._startup_timeout = startup_timeout
         self._socket_timeout = socket_timeout
         self._socket_path_override = socket_path_override
-        self._enable_watchman = enable_watchman
+        self._watchman_enable = watchman_enable
         self._log_level = log_level
         self._logger = logging.getLogger(__name__)
         self._metadata_base_dir = metadata_base_dir
@@ -97,7 +97,7 @@ class WatchmanLauncher:
         )
 
     def maybe_launch(self):
-        if self._enable_watchman and not self.watchman.is_alive():
+        if self._watchman_enable and not self.watchman.is_alive():
             self._logger.debug("launching watchman")
             try:
                 self.watchman.launch()
@@ -115,8 +115,8 @@ class WatchmanLauncher:
             self.maybe_terminate()
 
     def maybe_terminate(self):
-        if not self._enable_watchman and self.watchman.is_alive():
-            self._logger.debug("watchman was running, but will be killed because it was disabled")
+        if not self._watchman_enable and self.watchman.is_alive():
+            self._logger.info("Watchman was running, but will be killed because it was disabled.")
             self.terminate()
 
     def terminate(self):

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -614,6 +614,11 @@ pub extern "C" fn graph_invalidate_all_paths(scheduler_ptr: *mut Scheduler) -> u
 }
 
 #[no_mangle]
+pub extern "C" fn check_invalidation_watcher_liveness(scheduler_ptr: *mut Scheduler) -> bool {
+  with_scheduler(scheduler_ptr, |scheduler| scheduler.core.watcher.is_alive())
+}
+
+#[no_mangle]
 pub extern "C" fn graph_len(scheduler_ptr: *mut Scheduler) -> u64 {
   with_scheduler(scheduler_ptr, |scheduler| scheduler.core.graph.len() as u64)
 }

--- a/src/rust/engine/src/watch.rs
+++ b/src/rust/engine/src/watch.rs
@@ -97,7 +97,7 @@ impl InvalidationWatcher {
   }
 
   // Public for testing purposes.
-  pub fn start_background_thread(
+  pub(crate) fn start_background_thread(
     graph: Weak<Graph<NodeKey>>,
     ignorer: Arc<GitignoreStyleExcludes>,
     canonical_build_root: PathBuf,


### PR DESCRIPTION
### Problem

We now have duplicate invalidation schemes in pantsd. The legacy fs watcher (watchman) and the new solution (inotify kernel events). 

### Solution

To ease the transition to the new solution I have added a flag to allow some users to disable watchman and rely only on the schedulers built in invalidator. When watchman is disabled pantsd needs to check the engine invalidation thread and exit if the engine watcher has failed.

### Result

Pantsd is fully usable without watchman.