### PR TITLE
Upgrade to pex 2.1.9.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==2.1.7
+pex==2.1.9
 psutil==5.6.3
 Pygments==2.3.1
 pyopenssl==17.3.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -37,16 +37,16 @@ class DownloadedPexBin(HermeticPex):
     class Factory(Script):
         options_scope = "download-pex-bin"
         name = "pex"
-        default_version = "v2.1.7"
+        default_version = "v2.1.9"
 
         # Note: You can compute the digest and size using:
         # curl -L https://github.com/pantsbuild/pex/releases/download/vX.Y.Z/pex | tee >(wc -c) >(shasum -a 256) >/dev/null
         default_versions_and_digests = {
             PlatformConstraint.none: ToolForPlatform(
                 digest=Digest(
-                    "375ab4a405a6db57f3afd8d60eca666e61931b44f156dc78ac7d8e47bddc96d6", 2620451
+                    "4e2677ce7270dd04d767e93e1904c90aa8c7f4f53b76f3615215970b45d100d7", 2624111
                 ),
-                version=ToolVersion("v2.1.7"),
+                version=ToolVersion("v2.1.9"),
             ),
         }
 


### PR DESCRIPTION
[ci skip-jvm-tests]  # No JVM changes made.
