### PR TITLE
Don't report diagnostics for cached targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -373,10 +373,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         """Classpath entries containing scalac plugins."""
         return []
 
-    def always_do_after_compile(self, compile_context):
-        """Perform an action after compilation, whether cached or not."""
-        return
-
     def post_compile_extra_resources(self, compile_context):
         """Produces a dictionary of any extra, out-of-band resources for a target.
 
@@ -656,9 +652,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
                 exec_graph.execute(worker_pool, self.context.log)
             except ExecutionFailure as e:
                 raise TaskError(f"Compilation failure: {e!r}")
-        for vt in invalidation_check.all_vts:
-            compile_context = self.select_runtime_context(compile_contexts[vt.target])
-            self.always_do_after_compile(compile_context)
 
     def _record_compile_classpath(self, classpath, target, outdir):
         relative_classpaths = [
@@ -1060,6 +1053,10 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         record("sources_len", sources_len)
         record("incremental", is_incremental)
 
+    def record_extra_target_stats(self, ctx):
+        """Report some additional stats for one of the subclasses by overriding this method."""
+        return
+
     def _collect_invalid_compile_dependencies(self, compile_target, invalid_target_set):
         all_strict_deps = DependencyContext.global_instance().dependencies_respecting_strict_deps(
             compile_target
@@ -1236,6 +1233,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
                 is_incremental,
                 "compile",
             )
+            self.record_extra_target_stats(ctx)
 
         # Update the products with the latest classes.
         output_classpath_product.add_for_target(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -332,6 +332,9 @@ class BaseZincCompile(JvmCompile):
                     )
 
     def post_compile_extra_resources(self, compile_context):
+        """Send the diagnostic counts to the reporting server."""
+        self._pass_diagnostics_to_reporting_server(compile_context)
+
         """Override `post_compile_extra_resources` to additionally include scalac_plugin info."""
         result = super().post_compile_extra_resources(compile_context)
         target = compile_context.target
@@ -569,7 +572,7 @@ class BaseZincCompile(JvmCompile):
             },
         )()
 
-    def always_do_after_compile(self, ctx):
+    def record_extra_target_stats(self, ctx):
         self._pass_diagnostics_to_reporting_server(ctx)
 
     def _aggregate_diagnostics(self, lsp_data):


### PR DESCRIPTION
### Problem

We tried reporting diagnostics for all target whether the cache was hit
or not, but this was observed not to scale in Twitter's infrastructure.

The amount of data written to the reporting server was simply too much.

### Solution

To avoid this problem, handle the diagnostic counts as any other metric
(such as compile time) and only publish it to the metrics server on
recompiling a target.

### Result

The ownace is then on the queries to browse the history for relevant
context if necessary.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
