### PR TITLE
Remove broken `indices` and `repos` fields from `python_binary`

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -10,9 +10,7 @@ from pants.backend.python.rules.targets import (
     PexAlwaysWriteCache,
     PexEmitWarnings,
     PexIgnoreErrors,
-    PexIndexes,
     PexInheritPath,
-    PexRepositories,
     PexShebang,
     PexZipSafe,
     PythonBinarySources,
@@ -37,9 +35,7 @@ class PythonBinaryConfiguration(BinaryConfiguration):
     always_write_cache: PexAlwaysWriteCache
     emit_warnings: PexEmitWarnings
     ignore_errors: PexIgnoreErrors
-    indexes: PexIndexes
     inherit_path: PexInheritPath
-    repositories: PexRepositories
     shebang: PexShebang
     zip_safe: PexZipSafe
     platforms: PythonPlatforms
@@ -52,15 +48,8 @@ class PythonBinaryConfiguration(BinaryConfiguration):
             args.append("--no-emit-warnings")
         if self.ignore_errors.value is True:
             args.append("--ignore-errors")
-        if self.indexes.value is not None:
-            if not self.indexes.value:
-                args.append("--no-index")
-            else:
-                args.extend([f"--index={index}" for index in self.indexes.value])
         if self.inherit_path.value is not None:
             args.append(f"--inherit-path={self.inherit_path.value}")
-        if self.repositories.value is not None:
-            args.extend([f"--repo={repo}" for repo in self.repositories.value])
         if self.shebang.value is not None:
             args.append(f"--python-shebang={self.shebang.value}")
         if self.platforms.value is not None:

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -187,22 +187,6 @@ class PexAlwaysWriteCache(BoolField):
     default = False
 
 
-class PexRepositories(StringOrStringSequenceField):
-    """Repositories for Pex to query for dependencies."""
-
-    alias = "repositories"
-
-
-class PexIndexes(StringOrStringSequenceField):
-    """Additional indices for Pex to use for packages.
-
-    If set to an empty list, i.e. `indices=[]`, then Pex will use no indices (meaning it will not
-    use PyPI).
-    """
-
-    alias = "indices"
-
-
 class PexIgnoreErrors(BoolField):
     """Should we ignore when Pex cannot resolve dependencies?"""
 
@@ -243,8 +227,6 @@ class PythonBinary(Target):
         PexInheritPath,
         PexZipSafe,
         PexAlwaysWriteCache,
-        PexRepositories,
-        PexIndexes,
         PexIgnoreErrors,
         PexShebang,
         PexEmitWarnings,

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -67,8 +67,6 @@ class PythonBinary(PythonTarget):
         inherit_path=False,  # pex option
         zip_safe=True,  # pex option
         always_write_cache=False,  # pex option
-        repositories=None,  # pex option
-        indices=None,  # pex option
         ignore_errors=False,  # pex option
         shebang=None,  # pex option
         emit_warnings=None,  # pex option
@@ -87,8 +85,6 @@ class PythonBinary(PythonTarget):
         :param zip_safe: whether or not this binary is safe to run in compacted (zip-file) form
         :param always_write_cache: whether or not the .deps cache of this PEX file should always
           be written to disk.
-        :param repositories: a list of repositories to query for dependencies.
-        :param indices: a list of indices to use for packages.
         :param ignore_errors: should we ignore inability to resolve dependencies?
         :param str shebang: Use this shebang for the generated pex.
         :param bool emit_warnings: Whether or not to emit pex warnings.
@@ -109,10 +105,6 @@ class PythonBinary(PythonTarget):
                 "inherit_path": PrimitiveField(inherit_path),
                 "zip_safe": PrimitiveField(bool(zip_safe)),
                 "always_write_cache": PrimitiveField(bool(always_write_cache)),
-                "repositories": PrimitiveField(
-                    ensure_str_list(repositories or [], allow_single_str=True)
-                ),
-                "indices": PrimitiveField(ensure_str_list(indices or [], allow_single_str=True)),
                 "ignore_errors": PrimitiveField(bool(ignore_errors)),
                 "platforms": PrimitiveField(
                     tuple(ensure_str_list(platforms or [], allow_single_str=True))
@@ -148,16 +140,6 @@ class PythonBinary(PythonTarget):
     def platforms(self):
         return self.payload.platforms
 
-    # TODO(wickman) These should likely be attributes on PythonLibrary targets
-    # and not PythonBinary targets, or at the very worst, both.
-    @property
-    def repositories(self):
-        return self.payload.repositories
-
-    @property
-    def indices(self):
-        return self.payload.indices
-
     @classmethod
     def translate_source_path_to_py_module_specifier(self, source: str) -> str:
         source_base, _ = os.path.splitext(source)
@@ -181,10 +163,6 @@ class PythonBinary(PythonTarget):
     @property
     def pexinfo(self):
         info = PexInfo.default()
-        for repo in self.repositories:
-            info.add_repository(repo)
-        for index in self.indices:
-            info.add_index(index)
         info.zip_safe = self.payload.zip_safe
         info.always_write_cache = self.payload.always_write_cache
         info.inherit_path = self.payload.inherit_path

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -793,6 +793,8 @@ class SequenceField(Generic[T], PrimitiveField, metaclass=ABCMeta):
 
 
 class StringSequenceField(SequenceField, metaclass=ABCMeta):
+    value: Optional[Tuple[str, ...]]
+    default: ClassVar[Optional[Tuple[str, ...]]] = None
     expected_element_type = str
     expected_type_description = "an iterable of strings (e.g. a list of strings)"
 
@@ -812,6 +814,8 @@ class StringOrStringSequenceField(SequenceField, metaclass=ABCMeta):
     Generally, this should not be used by any new Fields. This mechanism is a misfeature.
     """
 
+    value: Optional[Tuple[str, ...]]
+    default: ClassVar[Optional[Tuple[str, ...]]] = None
     expected_element_type = str
     expected_type_description = (
         "either a single string or an iterable of strings (e.g. a list of strings)"


### PR DESCRIPTION
As pointed out by @jsirois in https://github.com/pantsbuild/pants/pull/9449#discussion_r402019192, these fields never worked to begin with. If they were defined, Pants would blow up due to outdated glue code with Pex.

Further, John makes a good argument that these fields should not exist in the first place.

Because the fields were already broken, we are able to remove them without a deprecation cycle.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
