### PR TITLE
Stop using `Collection.dependencies` internally

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -19,7 +19,7 @@ class ListAndDieForTesting(Goal):
 
 @goal_rule
 def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> ListAndDieForTesting:
-    for address in addresses.dependencies:
+    for address in addresses:
         console.print_stdout(address.spec)
     return ListAndDieForTesting(exit_code=42)
 

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -66,7 +66,7 @@ class GoalRunnerFactory:
         self._kill_nailguns = self._global_options.kill_nailguns
 
         # V1 tasks do not understand FilesystemSpecs, so we eagerly convert them into AddressSpecs.
-        if self._specs.filesystem_specs.dependencies:
+        if self._specs.filesystem_specs:
             (owned_addresses,) = self._graph_session.scheduler_session.product_request(
                 Addresses, [Params(self._specs.filesystem_specs, self._options_bootstrapper)]
             )

--- a/src/python/pants/core/project_info/list_targets.py
+++ b/src/python/pants/core/project_info/list_targets.py
@@ -48,7 +48,7 @@ class List(Goal):
 
 @goal_rule
 async def list_targets(addresses: Addresses, options: ListOptions, console: Console) -> List:
-    if not addresses.dependencies:
+    if not addresses:
         console.print_stderr(f"WARNING: No targets were matched in goal `{options.name}`.")
         return List(exit_code=0)
 

--- a/src/python/pants/core/project_info/list_targets_old.py
+++ b/src/python/pants/core/project_info/list_targets_old.py
@@ -89,7 +89,7 @@ async def list_targets(console: Console, list_options: ListOptions, addresses: A
         print_fn = lambda address: address.spec
 
     with list_options.line_oriented(console) as print_stdout:
-        if not collection.dependencies:
+        if not collection:
             console.print_stderr("WARNING: No targets were matched in goal `{}`.".format("list"))
 
         for item in collection:

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -25,8 +25,8 @@ def assert_single_address(addresses: Sequence[Address]) -> None:
 
 class Addresses(Collection[Address]):
     def expect_single(self) -> Address:
-        assert_single_address(self.dependencies)
-        return self.dependencies[0]
+        assert_single_address(self)
+        return self[0]
 
 
 @dataclass(frozen=True)
@@ -39,10 +39,8 @@ class AddressWithOrigin:
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):
     def expect_single(self) -> AddressWithOrigin:
-        assert_single_address(
-            [address_with_origin.address for address_with_origin in self.dependencies]
-        )
-        return self.dependencies[0]
+        assert_single_address([address_with_origin.address for address_with_origin in self])
+        return self[0]
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -650,7 +650,7 @@ class SchedulerSession:
         If you need to materialize multiple, you should use the parallel materialize_directories()
         instead.
         """
-        return self.materialize_directories((directory_to_materialize,)).dependencies[0]
+        return self.materialize_directories((directory_to_materialize,))[0]
 
     def materialize_directories(
         self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -542,8 +542,8 @@ class Targets(Collection[Target]):
     """
 
     def expect_single(self) -> Target:
-        assert_single_address([tgt.address for tgt in self.dependencies])
-        return self.dependencies[0]
+        assert_single_address([tgt.address for tgt in self])
+        return self[0]
 
 
 class TargetsWithOrigins(Collection[TargetWithOrigin]):
@@ -555,10 +555,8 @@ class TargetsWithOrigins(Collection[TargetWithOrigin]):
     """
 
     def expect_single(self) -> TargetWithOrigin:
-        assert_single_address(
-            [tgt_with_origin.target.address for tgt_with_origin in self.dependencies]
-        )
-        return self.dependencies[0]
+        assert_single_address([tgt_with_origin.target.address for tgt_with_origin in self])
+        return self[0]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -94,7 +94,7 @@ class FileSystemTest(TestBase):
         output = workspace.materialize_directories((DirectoryToMaterialize(digest),))
 
         assert type(output) == MaterializeDirectoriesResult
-        materialize_result = output.dependencies[0]
+        materialize_result = output[0]
         assert type(materialize_result) == MaterializeDirectoryResult
         assert materialize_result.output_paths == tuple(
             str(Path(self.build_root, p)) for p in [path1, path2]

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -81,7 +81,7 @@ class SpecsCalculator:
         logger.debug("specs are: %s", specs)
         logger.debug("changed_options are: %s", changed_options)
 
-        if changed_options.is_actionable() and specs.provided_specs.dependencies:
+        if changed_options.is_actionable() and specs.provided_specs:
             # We've been provided both a change request and specs.
             raise InvalidSpecConstraint(
                 "Multiple target selection methods provided. Please use only one of "

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -97,8 +97,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
             address_specs, address_family, snapshot, self._address_mapper()
         )
 
-        self.assertEqual(len(addresses.dependencies), 1)
-        self.assertEqual(addresses.dependencies[0].spec, "a:a")
+        self.assertEqual(len(addresses), 1)
+        self.assertEqual(addresses[0].spec, "a:a")
 
     def test_tag_filter(self) -> None:
         """Test that targets are filtered based on `tags`."""
@@ -116,8 +116,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
 
-        self.assertEqual(len(targets.dependencies), 1)
-        self.assertEqual(targets.dependencies[0].spec, "root:b")
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].spec, "root:b")
 
     def test_fails_on_nonexistent_specs(self) -> None:
         """Test that address specs referring to nonexistent targets raise a ResolveError."""
@@ -157,8 +157,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
 
-        self.assertEqual(len(targets.dependencies), 1)
-        self.assertEqual(targets.dependencies[0].spec, "root:not_me")
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].spec, "root:not_me")
 
     def test_exclude_pattern_with_single_address(self) -> None:
         """Test that single address targets are filtered based on exclude patterns."""
@@ -171,7 +171,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
 
-        self.assertEqual(len(targets.dependencies), 0)
+        self.assertEqual(len(targets), 0)
 
 
 class ApacheThriftConfiguration(StructWithDeps):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -68,7 +68,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         result = self.execute_expecting_one_result(
             scheduler, FilesContent, snapshot.directory_digest
         ).value
-        return {f.path: f.content for f in result.dependencies}
+        return {f.path: f.content for f in result}
 
     def assert_walk_dirs(self, filespecs_or_globs, paths, **kwargs):
         self.assert_walk_snapshot("dirs", filespecs_or_globs, paths, **kwargs)

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -348,7 +348,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
         )
 
         self.assertEqual(
-            files_content_result.dependencies, (FileContent("roland", b"European Burmese", False),)
+            files_content_result, FilesContent([FileContent("roland", b"European Burmese", False)])
         )
 
     def test_timeout(self):
@@ -379,9 +379,7 @@ class Simple {
         )
 
         result = self.request_single_product(JavacCompileResult, request)
-        files_content = self.request_single_product(
-            FilesContent, result.directory_digest
-        ).dependencies
+        files_content = self.request_single_product(FilesContent, result.directory_digest)
 
         self.assertEqual(
             tuple(sorted(("simple/Simple.java", "simple/Simple.class",))),

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -144,7 +144,8 @@ class AddressFamilyTest(unittest.TestCase):
             )
 
 
-HydratedStructs = Collection[HydratedStruct]
+class HydratedStructs(Collection[HydratedStruct]):
+    pass
 
 
 @rule


### PR DESCRIPTION
We recently made `Collection` more powerful so that it acts like a `Sequence` and you don't need to access the underlying `.dependencies` tuple. This updates all call sites.

[ci skip-rust-tests]  # No Rust changes made.
[ci skip-jvm-tests]  # No JVM changes made.
