### PR TITLE
 Avoid needless instantiation of LocalPantsRunner

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import sys
 import termios
 import time
@@ -11,6 +12,8 @@ from typing import Callable, Iterator, List, Mapping, Optional
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode, Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
+from pants.engine.rules import UnionMembership
+from pants.help.help_printer import HelpPrinter
 from pants.init.logging import encapsulated_global_logger
 from pants.init.specs_calculator import SpecsCalculator
 from pants.init.util import clean_global_runtime_state
@@ -24,6 +27,8 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.service.scheduler_service import SchedulerService
 from pants.util.contextutil import hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket
+
+logger = logging.getLogger(__name__)
 
 
 class PantsRunFailCheckerExiter(Exiter):
@@ -251,7 +256,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                 clean_global_runtime_state(reset_subsystem=True)
 
                 options_bootstrapper = OptionsBootstrapper.create(args=self.args, env=self.env)
-                options, _ = LocalPantsRunner.parse_options(options_bootstrapper)
+                options, build_config = LocalPantsRunner.parse_options(options_bootstrapper)
 
                 global_options = options.for_global_scope()
                 session = self.scheduler_service.prepare_graph(options)
@@ -263,16 +268,31 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                     tags=tuple(global_options.tag) if global_options.tag else (),
                 )
 
-                exit_code = self.scheduler_service.graph_run_v2(
-                    session, specs, options, options_bootstrapper
-                )
-                with ExceptionSink.exiter_as_until_exception(lambda _: PantsRunFailCheckerExiter()):
-                    runner = LocalPantsRunner.create(self.env, options_bootstrapper, specs, session)
+                if options.help_request:
+                    help_printer = HelpPrinter(
+                        options=options,
+                        union_membership=UnionMembership(build_config.union_rules()),
+                    )
+                    exit_code = help_printer.print_help()
+                else:
+                    exit_code = self.scheduler_service.graph_run_v2(
+                        session, specs, options, options_bootstrapper
+                    )
 
-                    env_start_time = self.env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
-                    start_time = float(env_start_time) if env_start_time else None
-                    runner.set_start_time(start_time)
-                    runner.run()
+                # self.scheduler_service.graph_run_v2 will already run v2 or ambiguous goals. We should
+                # only enter this code path if v1 is set.
+                if global_options.v1:
+                    with ExceptionSink.exiter_as_until_exception(
+                        lambda _: PantsRunFailCheckerExiter()
+                    ):
+                        runner = LocalPantsRunner.create(
+                            self.env, options_bootstrapper, specs, session
+                        )
+
+                        env_start_time = self.env.pop("PANTSD_RUNTRACKER_CLIENT_START_TIME", None)
+                        start_time = float(env_start_time) if env_start_time else None
+                        runner.set_start_time(start_time)
+                        runner.run()
 
             except KeyboardInterrupt:
                 self._exiter.exit_and_fail("Interrupted by user.\n")

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -200,7 +200,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 # The runner can sometimes exit more slowly than the thin client caller.
                 time.sleep(3)
 
-    def test_pantsd_aligned_output(self):
+    def test_pantsd_aligned_output(self) -> None:
         # Set for pytest output display.
         self.maxDiff = None
 
@@ -216,8 +216,12 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             print(f"(cmd, run) = ({cmd}, {run.stdout_data}, {run.stderr_data})")
             self.assertNotEqual(run.stdout_data, "", f"Empty stdout for {cmd}")
 
-        for run_pairs in zip(non_daemon_runs, daemon_runs):
-            self.assertEqual(*(run.stdout_data for run in run_pairs))
+        for run_pair in zip(non_daemon_runs, daemon_runs):
+            non_daemon_stdout = run_pair[0].stdout_data
+            daemon_stdout = run_pair[1].stdout_data
+
+            for line_pair in zip(non_daemon_stdout.splitlines(), daemon_stdout.splitlines()):
+                assert line_pair[0] == line_pair[1]
 
     @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/7622")
     def test_pantsd_filesystem_invalidation(self):


### PR DESCRIPTION
### Problem

Currently when pants is run against pantsd, the `DaemonPantsRunner.run` method will use some class methods on `LocalPantsRunner` and a few other classes to do argument-parsing as well as other preparation for a run, and then pass the values created in this process to `graph_run_v2` on `SchedulerService`, which actually runs v2 and ambiguous goals. Once this is complete, the `run` method will then instantiate a new copy of `LocalPantsRunner`, which will re-do a bunch of that same initialization work, and then execute only the v1 goals using the normal `LocalPantsRunner` flow. Since options parsing takes a noticeably long time to happen (very roughly a quarter-second), this doubled work is noticeable to end users.

### Solution

Only instantiate an instance of `LocalPantsRunner` if v1 is set.

### Result

Testing locally against a warm instance of pantsd with `--v2 --no-v1`, I can see the reduction in the number of calls made to the options-parsing methods as recorded by a profiler such as `py-spy`. Running `time ./pants` shows that with this change, the average amount of time it takes for the pants binary to return with a result and exit seems to decrease by very roughly half a second.

Note: an earlier version of this PR (9450) was merged and then reverted because it seemed to have made CI seriously unstable. This version has a small refactor to the pantsd test that became unreliable, which seems to have fixed things.