### PR TITLE
Fix python 3.8 runtime type error

### DIFF
--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -109,7 +109,7 @@ class TestConfiguration(ABC):
         all_expected_fields: Dict[str, Type[Field]] = {
             dataclass_field.name: dataclass_field.type
             for dataclass_field in dataclasses.fields(cls)
-            if issubclass(dataclass_field.type, Field)
+            if isinstance(dataclass_field.type, type) and issubclass(dataclass_field.type, Field)  # type: ignore[misc]
         }
         tgt = target_with_origin.target
         return cls(


### PR DESCRIPTION
### Problem

In the `create` method of `core/test.py` there is a call to `issubclass` with a value that can in principle be a `typing.Union`. In Python 3.6 this works fine; however Python 3.8 changed the type of `typing.Union` in such a way as cause the `issubclass` call to throw an exception at runtime.

### Solution

Add a check to ensure that the value being checked by `issubclass` is an instance of `type` to avoid this error.
