### PR TITLE
Fix workdir symlink's destination/physical dir not created issue

### DIFF
--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -62,3 +62,12 @@ target(
     'src/python/pants/backend/native',
   ],
 )
+
+python_library(
+  name = 'util',
+  sources = ['util.py'],
+  dependencies=[
+    ':init',
+    'src/python/pants/testutil:test_base'
+  ]
+)

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -46,8 +46,10 @@ def init_workdir(global_options: OptionValueContainer) -> str:
             # Exists and is correct: ensure that the destination exists.
             safe_mkdir(workdir_dst)
     else:
+        # Remove existing physical workdir (.pants.d dir)
         safe_rmtree(workdir_src)
-        absolute_symlink(workdir_dst, workdir_src)
+        # Create both symlink workdir (.pants.d dir) and its destination/physical workdir
+        create_symlink_to_clean_workdir()
     return workdir_src
 
 

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -13,6 +13,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
+    'src/python/pants/fs',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
     'src/python/pants/init',
@@ -29,4 +30,13 @@ python_tests(
     'src/python/pants/util:logging',
   ],
   tags = {"partially_type_checked"},
+)
+
+python_tests(
+  name = 'test_util',
+  sources = ['test_util.py'],
+  dependencies = [
+    'src/python/pants/init:util',
+    # 'src/python/pants/testutil:int-test-for-export'
+  ]
 )

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -19,11 +19,11 @@ class UtilTest(TestBase):
             )
             yield bootstrap_options
 
-    def assertExists(self, path):
+    def assert_exists(self, path):
         self.assertTrue(os.path.exists(path))
 
     def assert_symlink(self, path):
-        assert os.path.islink(path)
+        self.assertTrue(os.path.islink(path))
 
     def physical_workdir(self, bootstrap_options):
         if bootstrap_options.pants_physical_workdir_base:

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
+from contextlib import contextmanager
+
+from pants.fs.fs import safe_filename_from_path
+from pants.init.util import init_workdir
+from pants.option.option_value_container import OptionValueContainer
+from pants.testutil.test_base import TestBase
+from pants.util.contextutil import temporary_dir
+
+
+class UtilTest(TestBase):
+    @contextmanager
+    def physical_workdir_base(self) -> OptionValueContainer:
+        with temporary_dir(cleanup=False) as physical_workdir_base:
+            bootstrap_options = self.get_bootstrap_options(
+                [f"--pants-physical-workdir-base={physical_workdir_base}"]
+            )
+            yield bootstrap_options
+
+    def assertExists(self, path):
+        self.assertTrue(os.path.exists(path))
+
+    def assert_symlink(self, path):
+        assert os.path.islink(path)
+
+    def physical_workdir(self, bootstrap_options):
+        if bootstrap_options.pants_physical_workdir_base:
+            return os.path.join(
+                bootstrap_options.pants_physical_workdir_base,
+                safe_filename_from_path(self.pants_workdir),
+            )
+        else:
+            return self.pants_workdir
+
+    def test_init_workdir(self) -> None:
+        with self.physical_workdir_base() as bootstrap_options:
+            # Assert pants_workdir exists
+            self.assertExists(self.pants_workdir)
+
+            init_workdir(bootstrap_options)
+
+            # Assert pants_workdir is a symlink after init_workdir above
+            self.assert_symlink(self.pants_workdir)
+            # Assert symlink target's physical dir exists
+            self.assertExists(os.path.join(self.physical_workdir(bootstrap_options)))

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -37,11 +37,11 @@ class UtilTest(TestBase):
     def test_init_workdir(self) -> None:
         with self.physical_workdir_base() as bootstrap_options:
             # Assert pants_workdir exists
-            self.assertExists(self.pants_workdir)
+            self.assert_exists(self.pants_workdir)
 
             init_workdir(bootstrap_options)
 
             # Assert pants_workdir is a symlink after init_workdir above
             self.assert_symlink(self.pants_workdir)
             # Assert symlink target's physical dir exists
-            self.assertExists(os.path.join(self.physical_workdir(bootstrap_options)))
+            self.assert_exists(os.path.join(self.physical_workdir(bootstrap_options)))

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
 from contextlib import contextmanager
 

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os
 from contextlib import contextmanager


### PR DESCRIPTION
### Problem

When `workdir symlink` (`pants_physical_workdir_base`) is enabled and existing physical `workdir` (`.pants.d`) is still there, the first time running `pants` would not create the destination/physical workdir of the symlink. This causes `pants` to fail with following error message:
`[Errno 2] No such file or directory: '~/.pants.d/.pids'`
Although running `pants` the second time would fix the issue, but that won't work for CI jobs because they run on different machine each time.

### Solution

After existing phyical `workdir` (`.pants.d`) is removed, make sure both workdir symlink (.pants.d dir) and its destination/physical workdir are created successfully.

### Result
Both `workdir symlink` (`.pants.d dir`) and its destination/physical workdir will always be created successfully when `workdir symlink` (`pants_physical_workdir_base`) is enabled.

