### PR TITLE
Fix mistakes with Target API bindings

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -76,7 +76,7 @@ python_binary(
 
 python_binary(
   name = 'generate_travis_yml',
-  sources = 'generate_travis_yml.py',
+  sources = ['generate_travis_yml.py'],
   dependencies = [
     '3rdparty/python:PyYAML',
   ],
@@ -85,7 +85,7 @@ python_binary(
 
 python_binary(
   name = 'get_rbe_token',
-  sources = 'get_rbe_token.py',
+  sources = ['get_rbe_token.py'],
   dependencies = [
     '3rdparty/python:ansicolors',
     '3rdparty/python:requests',

--- a/examples/src/java/org/pantsbuild/example/hello/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/main/BUILD
@@ -29,6 +29,8 @@ jvm_binary(name = 'main-bin',
 
 # README page:
 
-page(name="readme",
-  source="README.md")
+page(
+  name="readme",
+  sources=["README.md"],
+)
 

--- a/src/python/pants/backend/codegen/antlr/python/targets.py
+++ b/src/python/pants/backend/codegen/antlr/python/targets.py
@@ -5,6 +5,15 @@ from pants.backend.python.rules.targets import COMMON_PYTHON_FIELDS
 from pants.engine.target import Sources, StringField, Target
 
 
+class AntlrModule(StringField):
+    """Everything beneath module is relative to this module name.
+
+    Do not define if the root namespace.
+    """
+
+    alias = "module"
+
+
 class AntlrVersion(StringField):
     """A Python library generated from Antlr grammar files."""
 
@@ -17,4 +26,4 @@ class PythonAntlrLibrary(Target):
     """A Python library generated from Antlr grammar files."""
 
     alias = "python_antlr_library"
-    core_fields = (*COMMON_PYTHON_FIELDS, Sources, AntlrVersion)
+    core_fields = (*COMMON_PYTHON_FIELDS, Sources, AntlrModule, AntlrVersion)

--- a/src/python/pants/backend/codegen/thrift/java/targets.py
+++ b/src/python/pants/backend/codegen/thrift/java/targets.py
@@ -18,7 +18,7 @@ class JavaThriftCompiler(StringField):
     The default is defined in the global options under `--thrift-default-compiler`.
     """
 
-    alias = "compilers"
+    alias = "compiler"
     valid_choices = ("thrift", "scrooge")
 
 
@@ -40,7 +40,7 @@ class JavaThriftNamespaceMap(DictStringToStringField):
 class JavaThriftLinterStrict(BoolField):
     """If True, fail if thrift linter produces any warnings."""
 
-    alias = "namespace_map"
+    alias = "thrift_linter_strict"
     default = False
 
 
@@ -52,6 +52,10 @@ class JavaThriftDefaultNamespace(StringField):
     """
 
     alias = "default_java_namespace"
+
+
+class JavaThriftIncludePaths(StringSequenceField):
+    alias = "include_paths"
 
 
 class JavaThriftCompilerArgs(StringSequenceField):
@@ -72,5 +76,6 @@ class JavaThriftLibrary(Target):
         JavaThriftNamespaceMap,
         JavaThriftLinterStrict,
         JavaThriftDefaultNamespace,
+        JavaThriftIncludePaths,
         JavaThriftCompilerArgs,
     )

--- a/src/python/pants/backend/docgen/rules/targets.py
+++ b/src/python/pants/backend/docgen/rules/targets.py
@@ -7,6 +7,7 @@ from pants.backend.docgen.targets.doc import WikiArtifact
 from pants.build_graph.address import Address
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    Dependencies,
     SequenceField,
     Sources,
     StringField,
@@ -76,4 +77,4 @@ class Page(Target):
     """
 
     alias = "page"
-    core_fields = (*COMMON_TARGET_FIELDS, PageSources, PageSourcesFormat, PageLinks)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PageSources, PageSourcesFormat, PageLinks)

--- a/src/python/pants/backend/jvm/rules/targets.py
+++ b/src/python/pants/backend/jvm/rules/targets.py
@@ -441,6 +441,7 @@ class JunitTests(Target):
         ExtraJvmOptions,
         JunitTestsSources,
         JunitTestsCwd,
+        JunitTimeout,
         JunitExtraEnvVars,
         JunitConcurrency,
         JunitNumThreads,
@@ -559,7 +560,7 @@ class JvmBinaryManifestEntries(DictStringToStringField):
     """A dict that specifies entries for `ManifestEntries` for adding to MANIFEST.MF when packaging
     this binary."""
 
-    alias = "manifset_entries"
+    alias = "manifest_entries"
 
 
 class JvmBinaryShadingRules(PrimitiveField):

--- a/src/python/pants/backend/native/rules/targets.py
+++ b/src/python/pants/backend/native/rules/targets.py
@@ -42,14 +42,13 @@ class CtypesNativeLibrary(ScalarField):
     alias = "ctypes_native_library"
     expected_type = NativeArtifact
     expected_type_description = "a `native_artifact` object"
-    value: NativeArtifact
-    required = True
+    value: Optional[NativeArtifact]
 
     @classmethod
     def compute_value(
         cls, raw_value: Optional[NativeArtifact], *, address: Address
-    ) -> NativeArtifact:
-        return cast(NativeArtifact, super().compute_value(raw_value, address=address))
+    ) -> Optional[NativeArtifact]:
+        return super().compute_value(raw_value, address=address)
 
 
 class NativeFatalWarnings(BoolField):
@@ -81,7 +80,7 @@ class ToolchainVariantField(StringField):
 
 
 class NativeCompilerOptionSets(StringSequenceField):
-    alias = "compiler_options_sets"
+    alias = "compiler_option_sets"
 
 
 NATIVE_LIBRARY_COMMON_FIELDS = (

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -480,7 +480,7 @@ class UnpackedWheelsWithinDataSubdir(BoolField):
     default = False
 
     @classmethod
-    def compute_value(
+    def compute_value(  # type: ignore[override]
         cls, raw_value: Optional[Union[bool, str]], *, address: Address
     ) -> Union[bool, str]:
         if isinstance(raw_value, str):

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -66,6 +66,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
                                         `include_patterns` matching exactly what is specified in the
                                         setup.py.
         """
+        # NB: Update python/rules/targets.py to no longer allow `str` when removing this deprecation.
         deprecated_conditional(
             lambda: type(within_data_subdir) not in (bool, type(None)),
             removal_version="1.28.0.dev2",

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -909,7 +909,24 @@ class NoCacheField(BoolField):
     default = False
 
 
-COMMON_TARGET_FIELDS = (Tags, DescriptionField, NoCacheField)
+# TODO(#9388): remove?
+class ScopeField(StringField):
+    """A V1-only field for the scope of the target, which is used by the JVM to determine the
+    target's inclusion in the class path.
+
+    See `pants.build_graph.target_scopes.Scopes`.
+    """
+
+    alias = "scope"
+
+
+# TODO(#9388): Remove.
+class IntransitiveField(BoolField):
+    alias = "_transitive"
+    default = False
+
+
+COMMON_TARGET_FIELDS = (Tags, DescriptionField, NoCacheField, ScopeField, IntransitiveField)
 
 
 # NB: To hydrate the dependencies into Targets, use

--- a/src/python/pants/rules/core/list_target_types.py
+++ b/src/python/pants/rules/core/list_target_types.py
@@ -188,7 +188,11 @@ class VerboseTargetInfo:
         output.extend(
             [
                 "Valid fields:\n",
-                *sorted(f"{field.format_for_cli(console)}\n" for field in self.fields),
+                *sorted(
+                    f"{field.format_for_cli(console)}\n"
+                    for field in self.fields
+                    if not field.alias.startswith("_")
+                ),
             ]
         )
         return "\n".join(output).rstrip()
@@ -236,6 +240,7 @@ def list_target_types(
                 *(
                     target_info.format_for_cli(console, longest_target_alias=longest_target_alias)
                     for target_info in target_infos
+                    if not target_info.alias.startswith("_")
                 ),
             ]
             print_stdout("\n".join(lines).rstrip())

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -87,7 +87,13 @@ class AliasTargetRequestedAddress(StringField):
     `src/python/project:lib`."""
 
     alias = "target"
-    required = True
+
+
+class AliasDependencies(Dependencies):
+    """This field must not be explicitly defined for `alias` targets.
+
+    The `alias()` macro will fill in the value automatically.
+    """
 
 
 # TODO: figure out how to support aliases in V2. Is this a simple example of codegen, perhaps?
@@ -98,7 +104,7 @@ class AliasTarget(Target):
     """
 
     alias = "alias"
-    core_fields = (*COMMON_TARGET_FIELDS, AliasTargetRequestedAddress)
+    core_fields = (*COMMON_TARGET_FIELDS, AliasDependencies, AliasTargetRequestedAddress)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/testprojects/src/java/org/pantsbuild/testproject/page/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/page/BUILD
@@ -16,5 +16,7 @@ page(name="circular",
      ]
 )
 
-page(name="senserst",
-     source="sense.rst")
+page(
+  name="senserst",
+  sources=["sense.rst"],
+)


### PR DESCRIPTION
`./v2 filedeps2 ::` now works in the Pants repo.

We also hide private fields and targets in `target-types2` now, such as `_python_requirements_file`.