### PR TITLE
Fix `--ignore-pants-warning` not working with deprecated modules when not using Pantsd

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -175,11 +175,12 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         """
         build_root = get_buildroot()
 
-        options, build_config = LocalPantsRunner.parse_options(options_bootstrapper)
-        global_options = options.for_global_scope()
+        global_options = options_bootstrapper.bootstrap_options.for_global_scope()
         # This works as expected due to the encapsulated_logger in DaemonPantsRunner and
         # we don't have to gate logging setup anymore.
         setup_logging_from_options(global_options)
+
+        options, build_config = LocalPantsRunner.parse_options(options_bootstrapper)
 
         # Option values are usually computed lazily on demand,
         # but command line options are eagerly computed for validation.


### PR DESCRIPTION
### Problem

While deprecating some contrib plugins via `deprecated_module()`, I realized that `--ignore-pants-warning` does not do anything.

This is because the deprecations happen _before_ we set up the filters defined in `--ignore-pants-warning`.

### Solution

Reorder the logging and options parsing so that we set up logging before parsing options.

### Result

`--ignore-pants-warning` now works when deprecating the contrib plugins.

_This does not fix Pantsd due to the complexity of that code._ This can be fixed in a followup if we deem it important enough.

[ci skip-rust-tests]
[ci skip-jvm-tests]