### PR TITLE
Deprecate unused plugins

### DIFF
--- a/contrib/avro/src/python/pants/contrib/avro/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/BUILD
@@ -11,7 +11,7 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.avro',
-  description='Avro Java code generation support for pants',
+  description='Avro Java code generation support for pants (deprecated)',
   build_file_aliases=True,
   register_goals=True,
   tags = {"partially_type_checked"},

--- a/contrib/avro/src/python/pants/contrib/avro/register.py
+++ b/contrib/avro/src/python/pants/contrib/avro/register.py
@@ -1,8 +1,9 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Code generation from the Apache Avro format into Java targets."""
+"""Code generation from the Apache Avro format into Java targets (deprecated)."""
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
@@ -13,6 +14,9 @@ from pants.contrib.avro.tasks.avro_gen import AvroJavaGenTask
 
 def build_file_aliases():
     return BuildFileAliases(targets={JavaAvroLibraryV1.alias(): JavaAvroLibraryV1})
+
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.avro")
 
 
 def register_goals():

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -12,7 +12,7 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.cpp',
-  description='C++ pants plugin.',
+  description='C++ pants plugin (deprecated).',
   build_file_aliases=True,
   register_goals=True,
   tags = {"partially_type_checked"},

--- a/contrib/cpp/src/python/pants/contrib/cpp/register.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/register.py
@@ -1,9 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Support for C++."""
+"""Support for C++ (deprecated)."""
 
-
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
@@ -14,6 +14,8 @@ from pants.contrib.cpp.tasks.cpp_binary_create import CppBinaryCreate
 from pants.contrib.cpp.tasks.cpp_compile import CppCompile
 from pants.contrib.cpp.tasks.cpp_library_create import CppLibraryCreate
 from pants.contrib.cpp.tasks.cpp_run import CppRun
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.cpp")
 
 
 def build_file_aliases():

--- a/contrib/errorprone/src/python/pants/contrib/errorprone/BUILD
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/BUILD
@@ -9,7 +9,7 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.errorprone',
-  description='Error Prone pants plugin',
+  description='Error Prone pants plugin (deprecated)',
   register_goals=True,
   tags = {"partially_type_checked"},
 )

--- a/contrib/errorprone/src/python/pants/contrib/errorprone/register.py
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/register.py
@@ -1,14 +1,17 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Linter for Java.
+"""Linter for Java (deprecated).
 
 See https://errorprone.info.
 """
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.errorprone.tasks.errorprone import ErrorProne
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.errorprone")
 
 
 def register_goals():

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
@@ -9,7 +9,7 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.findbugs',
-  description='FindBugs pants plugin',
+  description='FindBugs pants plugin (deprecated)',
   register_goals=True,
   tags = {"partially_type_checked"},
 )

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/register.py
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/register.py
@@ -1,14 +1,16 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Linter for Java.
+"""Linter for Java (deprecated).
 
 See http://findbugs.sourceforge.net.
 """
-
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.findbugs.tasks.findbugs import FindBugs
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.findbugs")
 
 
 def register_goals():

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
@@ -14,7 +14,7 @@ contrib_plugin(
   ],
   tags = {'partially_type_checked'},
   distribution_name='pantsbuild.pants.contrib.googlejavaformat',
-  description='Google Java Format code formatter pants plugins.',
+  description='Google Java Format code formatter pants plugins (deprecated).',
   additional_classifiers=[
     'Topic :: Software Development :: Pre-processors'
   ],

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/register.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/register.py
@@ -1,17 +1,20 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Autoformatter for Java to follow Google's Java Style guide.
+"""Autoformatter for Java to follow Google's Java Style guide (deprecated).
 
 See https://github.com/google/google-java-format.
 """
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.googlejavaformat.googlejavaformat import (
     GoogleJavaFormatLintTask,
     GoogleJavaFormatTask,
 )
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.googlejavaformat")
 
 
 def register_goals():

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
@@ -11,7 +11,7 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.jax_ws',
-  description='JAX-WS Pants plugin',
+  description='JAX-WS Pants plugin (deprecated)',
   build_file_aliases=True,
   register_goals=True,
   tags = {"partially_type_checked"},

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
@@ -2,14 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 """Generate web service client stubs from a Web Services Description Language (WSDL) file for
-calling a JAX-WS web service."""
+calling a JAX-WS web service (deprecated)."""
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.jax_ws.rules.targets import JaxWsLibrary
 from pants.contrib.jax_ws.targets.jax_ws_library import JaxWsLibrary as JaxWsLibraryV1
 from pants.contrib.jax_ws.tasks.jax_ws_gen import JaxWsGen
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.jax_ws")
 
 
 def build_file_aliases():

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/BUILD
@@ -14,7 +14,7 @@ contrib_plugin(
   ],
   tags = {'partially_type_checked'},
   distribution_name='pantsbuild.pants.contrib.scalajs',
-  description='scala.js support for pants.',
+  description='scala.js support for pants (deprecated).',
   build_file_aliases=True,
   register_goals=True,
   global_subsystems=True

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/register.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/register.py
@@ -1,8 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Support for Scala.js."""
+"""Support for Scala.js (deprecated)."""
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
@@ -13,6 +14,8 @@ from pants.contrib.scalajs.targets.scala_js_binary import ScalaJSBinary as Scala
 from pants.contrib.scalajs.targets.scala_js_library import ScalaJSLibrary as ScalaJSLibraryV1
 from pants.contrib.scalajs.tasks.scala_js_link import ScalaJSLink
 from pants.contrib.scalajs.tasks.scala_js_zinc_compile import ScalaJSZincCompile
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.scalajs")
 
 
 def build_file_aliases():

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
@@ -18,7 +18,7 @@ contrib_plugin(
   ],
   tags = {"partially_type_checked"},
   distribution_name='pantsbuild.pants.contrib.thrifty',
-  description='Microsoft Thrifty thrift generator pants plugins.',
+  description='Microsoft Thrifty thrift generator pants plugins (deprecated).',
   additional_classifiers=[
     'Topic :: Software Development :: Code Generators'
   ],

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/register.py
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/register.py
@@ -1,17 +1,20 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Thrift code generator for Android.
+"""Thrift code generator for Android (deprecated).
 
 See https://github.com/microsoft/thrifty.
 """
 
+from pants.base.deprecated import _deprecated_contrib_plugin
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.thrifty.java_thrifty_gen import JavaThriftyGen
 from pants.contrib.thrifty.java_thrifty_library import JavaThriftyLibrary as JavaThriftyLibraryV1
 from pants.contrib.thrifty.targets import JavaThriftyLibrary
+
+_deprecated_contrib_plugin("pantsbuild.pants.contrib.thrifty")
 
 
 def build_file_aliases():

--- a/pants.toml
+++ b/pants.toml
@@ -76,6 +76,9 @@ backend_packages2 = [
   "pants.backend.native",
   "internal_backend.rules_for_testing",
 ]
+ignore_pants_warnings = [
+  "DEPRECATED: the pantsbuild.pants.contrib"
+]
 
 # The pants script in this repo consumes these files to run pants
 pantsd_invalidation_globs.add = ["src/python/**/*.py"]

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -328,3 +328,16 @@ def resolve_conflicting_options(
     if old_configured:
         return old_container.get(old_option)
     return new_container.get(new_option)
+
+
+def _deprecated_contrib_plugin(plugin_name: str) -> None:
+    warn_or_error(
+        removal_version="1.29.0.dev0",
+        deprecated_entity_description=f"the {plugin_name} plugin",
+        hint=(
+            f"The {repr(plugin_name)} plugin is being removed due to low usage.\n\nTo prepare for "
+            f"this change, please remove {repr(plugin_name)} from 'plugins' in `pants.toml` or "
+            "`pants.ini`.\n\nIf you still depend on this plugin, please email us at "
+            "pantsbuild@gmail.com or message us on Slack and we will keep this plugin."
+        ),
+    )

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -179,9 +179,6 @@ def setup_logging(
     # logging control and we don't need to be the middleman plumbing an option for each python
     # standard logging knob.
 
-    log_filename = None
-    file_handler = None
-
     # A custom log handler for sub-debug trace logging.
     def trace(self, message, *args, **kwargs):
         if self.isEnabledFor(LogLevel.TRACE.level):


### PR DESCRIPTION
See https://groups.google.com/d/msg/pants-devel/ngMZRIJvwHM/NOtqPcssBgAJ.

Deprecation message:

> 04:30:01 [WARN] /Users/eric/DocsLocal/code/projects/pants/contrib/thrifty/src/python/pants/contrib/thrifty/register.py:17: DeprecationWarning: DEPRECATED: the pantsbuild.pants.contrib.thrifty plugin will be removed in version 1.29.0.dev0.
>  The 'pantsbuild.pants.contrib.thrifty' plugin is being removed due to low usage.
>
> To prepare for this change, please remove 'pantsbuild.pants.contrib.thrifty' from 'plugins' in `pants.toml` or `pants.ini`.
>
> If you still depend on this plugin, please email us at pantsbuild@gmail.com or message us on Slack and we will keep this plugin.
>   _deprecated_contrib_plugin("pantsbuild.pants.contrib.thrifty")

[ci skip-jvm-tests]
[ci skip-rust-tests