### PR TITLE
Don't show V1 bindings when exclusively using V2

### DIFF
--- a/contrib/avro/src/python/pants/contrib/avro/rules/targets.py
+++ b/contrib/avro/src/python/pants/contrib/avro/rules/targets.py
@@ -10,3 +10,4 @@ class JavaAvroLibrary(Target):
 
     alias = "java_avro_library"
     core_fields = (*COMMON_JVM_FIELDS, Sources)
+    v1_only = True

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/rules/targets.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/rules/targets.py
@@ -26,3 +26,4 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaBinaryField,
         PythonAwsLambdaHandler,
     )
+    v1_only = True

--- a/contrib/cpp/src/python/pants/contrib/cpp/rules/targets.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/rules/targets.py
@@ -28,6 +28,7 @@ class CppBinary(Target):
 
     alias = "cpp_binary"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources, CppExternalLibraries)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -40,3 +41,4 @@ class CppLibrary(Target):
 
     alias = "cpp_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+    v1_only = True

--- a/contrib/go/src/python/pants/contrib/go/rules/targets.py
+++ b/contrib/go/src/python/pants/contrib/go/rules/targets.py
@@ -36,6 +36,7 @@ class GoBinary(Target):
 
     alias = "go_binary"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources, GoBuildFlags)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -48,6 +49,7 @@ class GoLibrary(Target):
 
     alias = "go_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoSources)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -70,6 +72,7 @@ class GoProtobufLibrary(Target):
 
     alias = "go_protobuf_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, GoProtobufSources, ProtocPlugins)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -82,6 +85,7 @@ class GoThriftLibrary(Target):
 
     alias = "go_thrift_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -115,6 +119,7 @@ class GoRemoteLibrary(Target):
 
     alias = "go_remote_library"
     core_fields = (*COMMON_TARGET_FIELDS, GoPackage, GoRevision)
+    v1_only = True
 
 
 class GoPackages(StringSequenceField):
@@ -132,3 +137,4 @@ class GoRemoteLibraries(Target):
 
     alias = "go_remote_libraries"
     core_fields = (*COMMON_TARGET_FIELDS, GoPackages, GoRevision)
+    v1_only = True

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/rules/targets.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/rules/targets.py
@@ -22,3 +22,4 @@ class JaxWsLibrary(Target):
 
     alias = "jax_ws_library"
     core_fields = (*COMMON_JVM_FIELDS, Sources, JaxWsXjcArgs, JaxWsExtraArgs)
+    v1_only = True

--- a/contrib/node/src/python/pants/contrib/node/rules/targets.py
+++ b/contrib/node/src/python/pants/contrib/node/rules/targets.py
@@ -69,6 +69,7 @@ class NodeBundle(Target):
 
     alias = "node_bundle"
     core_fields = (*COMMON_NODE_FIELDS, NodeBundleArchiveFormat, NodeBundleRequestedModule)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -193,6 +194,7 @@ class NodeModule(Target):
         NodeBinExecutables,
         NodeScope,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -215,6 +217,7 @@ class NodePreinstalledModule(Target):
 
     alias = "node_preinstalled_module"
     core_fields = (*NodeModule.core_fields, NodeDependenciesArchiveUrl)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -239,6 +242,7 @@ class NodeRemoteModule(Target):
 
     alias = "node_remote_module"
     core_fields = (*COMMON_NODE_FIELDS, NodeRemoteVersion)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -271,3 +275,4 @@ class NodeTest(Target):
         NodeTestScriptName,
         NodeTestTimeout,
     )
+    v1_only = True

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/rules/targets.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/rules/targets.py
@@ -14,6 +14,7 @@ class ScalaJSBinary(Target):
 
     alias = "scala_js_binary"
     core_fields = NodeModule.core_fields
+    v1_only = True
 
 
 class ScalaJSLibrary(Target):
@@ -25,3 +26,4 @@ class ScalaJSLibrary(Target):
 
     alias = "scala_js_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+    v1_only = True

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/targets.py
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/targets.py
@@ -14,3 +14,4 @@ class JavaThriftyLibrary(Target):
 
     alias = "java_thrifty_library"
     core_fields = (*COMMON_JVM_FIELDS, JavaThriftySources)
+    v1_only = True

--- a/src/python/pants/backend/codegen/antlr/java/targets.py
+++ b/src/python/pants/backend/codegen/antlr/java/targets.py
@@ -33,3 +33,4 @@ class JavaAntlrLibrary(Target):
 
     alias = "java_antlr_library"
     core_fields = (*COMMON_JVM_FIELDS, JavaAntlrSources, AntlrCompiler, AntlrPackage)
+    v1_only = True

--- a/src/python/pants/backend/codegen/antlr/python/targets.py
+++ b/src/python/pants/backend/codegen/antlr/python/targets.py
@@ -27,3 +27,4 @@ class PythonAntlrLibrary(Target):
 
     alias = "python_antlr_library"
     core_fields = (*COMMON_PYTHON_FIELDS, Sources, AntlrModule, AntlrVersion)
+    v1_only = True

--- a/src/python/pants/backend/codegen/grpcio/python/targets.py
+++ b/src/python/pants/backend/codegen/grpcio/python/targets.py
@@ -10,3 +10,4 @@ class PythonGrpcioLibrary(Target):
 
     alias = "python_grpcio_library"
     core_fields = (*COMMON_PYTHON_FIELDS, Sources)
+    v1_only = True

--- a/src/python/pants/backend/codegen/jaxb/targets.py
+++ b/src/python/pants/backend/codegen/jaxb/targets.py
@@ -30,3 +30,4 @@ class JaxbLibrary(Target):
 
     alias = "jaxb_library"
     core_fields = (*COMMON_JVM_FIELDS, Sources, JaxbJavaPackage, JaxbLanguage)
+    v1_only = True

--- a/src/python/pants/backend/codegen/protobuf/java/targets.py
+++ b/src/python/pants/backend/codegen/protobuf/java/targets.py
@@ -10,3 +10,4 @@ class JavaProtobufLibrary(Target):
 
     alias = "java_protobuf_library"
     core_fields = (*COMMON_JVM_FIELDS, Sources)
+    v1_only = True

--- a/src/python/pants/backend/codegen/ragel/java/targets.py
+++ b/src/python/pants/backend/codegen/ragel/java/targets.py
@@ -10,3 +10,4 @@ class JavaRagelLibrary(Target):
 
     alias = "java_ragel_library"
     core_fields = (*COMMON_JVM_FIELDS, Sources)
+    v1_only = True

--- a/src/python/pants/backend/codegen/thrift/java/targets.py
+++ b/src/python/pants/backend/codegen/thrift/java/targets.py
@@ -79,3 +79,4 @@ class JavaThriftLibrary(Target):
         JavaThriftIncludePaths,
         JavaThriftCompilerArgs,
     )
+    v1_only = True

--- a/src/python/pants/backend/codegen/thrift/python/targets.py
+++ b/src/python/pants/backend/codegen/thrift/python/targets.py
@@ -10,3 +10,4 @@ class PythonThriftLibrary(Target):
 
     alias = "python_thrift_library"
     core_fields = (*COMMON_PYTHON_FIELDS, Sources)
+    v1_only = True

--- a/src/python/pants/backend/codegen/wire/java/targets.py
+++ b/src/python/pants/backend/codegen/wire/java/targets.py
@@ -85,3 +85,4 @@ class JavaWireLibrary(Target):
         JavaWireNoOptionsToggle,
         JavaWireOrderedSources,
     )
+    v1_only = True

--- a/src/python/pants/backend/docgen/rules/targets.py
+++ b/src/python/pants/backend/docgen/rules/targets.py
@@ -78,3 +78,4 @@ class Page(Target):
 
     alias = "page"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PageSources, PageSourcesFormat, PageLinks)
+    v1_only = True

--- a/src/python/pants/backend/jvm/rules/targets.py
+++ b/src/python/pants/backend/jvm/rules/targets.py
@@ -196,6 +196,7 @@ class AnnotationProcessor(Target):
         ScalacPluginArgs,
         AnnotationProcessorsField,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -217,6 +218,7 @@ class JvmBenchmark(Target):
         ScalacPluginArgs,
         JvmRuntimePlatform,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -248,6 +250,7 @@ class JvmCredentials(Target):
 
     alias = "credentials"
     core_fields = (*COMMON_TARGET_FIELDS, CredentialsUsername, CredentialsPassword)
+    v1_only = True
 
 
 class NetrcCredentials(Target):
@@ -258,6 +261,7 @@ class NetrcCredentials(Target):
 
     alias = "netrc_credentials"
     core_fields = COMMON_TARGET_FIELDS
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -296,6 +300,7 @@ class JarLibrary(Target):
 
     alias = "jar_library"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, JarsField, ManagedJarDependenciesAddress)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -312,6 +317,7 @@ class JavaLibrary(Target):
 
     alias = "java_library"
     core_fields = (*COMMON_JVM_FIELDS, JavaLibrarySources)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -371,6 +377,7 @@ class JavaAgent(Target):
         JavaAgentCanRetransform,
         JavaAgentCanSetNativeMethodPrefix,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -446,6 +453,7 @@ class JunitTests(Target):
         JunitConcurrency,
         JunitNumThreads,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -505,6 +513,7 @@ class JvmApp(Target):
         JvmAppArchiveFormat,
         JvmAppDeployJarToggle,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -604,6 +613,7 @@ class JvmBinary(Target):
         JvmBinaryManifestEntries,
         JvmBinaryShadingRules,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -670,6 +680,7 @@ class JvmPrepCommand(Target):
         JvmPrepCommandGoal,
         JvmPrepCommandOptions,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -701,6 +712,7 @@ class ManagedJarDependencies(Target):
 
     alias = "managed_jar_dependencies"
     core_fields = (*COMMON_TARGET_FIELDS, ManagedJarDependenciesArtifacts)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -734,6 +746,7 @@ class ScalaLibrary(Target):
         ScalaSources,
         JavaSourcesForScala,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -762,6 +775,7 @@ class JavacPlugin(Target):
 
     alias = "javac_plugin"
     core_fields = (*JavaLibrary.core_fields, JvmPluginClassname, JvmPluginName)
+    v1_only = True
 
 
 class ScalacPlugin(Target):
@@ -769,6 +783,7 @@ class ScalacPlugin(Target):
 
     alias = "scalac_plugin"
     core_fields = (*ScalaLibrary.core_fields, JvmPluginClassname, JvmPluginName)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -816,3 +831,4 @@ class UnpackedJars(Target):
         UnpackedJarsExcludePatterns,
         UnpackedJarsIntransitiveToggle,
     )
+    v1_only = True

--- a/src/python/pants/backend/native/rules/targets.py
+++ b/src/python/pants/backend/native/rules/targets.py
@@ -99,6 +99,7 @@ class CLibrary(Target):
 
     alias = "ctypes_compatible_c_library"
     core_fields = (*NATIVE_LIBRARY_COMMON_FIELDS, CSources)
+    v1_only = True
 
 
 class CppLibrary(Target):
@@ -106,6 +107,7 @@ class CppLibrary(Target):
 
     alias = "ctypes_compatible_cpp_library"
     core_fields = (*NATIVE_LIBRARY_COMMON_FIELDS, CppSources)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -134,6 +136,7 @@ class ConanNativeLibrary(Target):
 
     alias = "external_native_library"
     core_fields = (*COMMON_TARGET_FIELDS, ConanPackages)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -223,3 +226,4 @@ class PackagedNativeLibrary(Target):
         NativeLibRelpath,
         NativeLibNames,
     )
+    v1_only = True

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -111,6 +111,7 @@ class PythonApp(Target):
         PythonAppBasename,
         PythonAppArchiveFormat,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -359,6 +360,7 @@ class PythonDistribution(Target):
         PythonDistributionSources,
         PythonDistributionSetupRequires,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -486,3 +488,4 @@ class UnpackedWheels(Target):
         UnpackedWheelsExcludePatterns,
         UnpackedWheelsWithinDataSubdir,
     )
+    v1_only = True

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -246,6 +246,8 @@ class PythonLibrarySources(PythonSources):
 
 
 class PythonLibrary(Target):
+    """A Python library that may be imported by other targets."""
+
     alias = "python_library"
     core_fields = (*COMMON_PYTHON_FIELDS, PythonLibrarySources)
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -53,9 +53,12 @@ ImmutableValue = Any
 
 
 class Field(ABC):
+    # Subclasses must define these.
     alias: ClassVar[str]
     default: ClassVar[ImmutableValue]
+    # Subclasses may define these.
     required: ClassVar[bool] = False
+    v1_only: ClassVar[bool] = False
 
     # This is a little weird to have an abstract __init__(). We do this to ensure that all
     # subclasses have this exact type signature for their constructor.
@@ -287,6 +290,8 @@ class Target(ABC):
     # Subclasses must define these
     alias: ClassVar[str]
     core_fields: ClassVar[Tuple[Type[Field], ...]]
+    # Subclasses may define these
+    v1_only: ClassVar[bool] = False
 
     # These get calculated in the constructor
     address: Address
@@ -913,6 +918,7 @@ class NoCacheField(BoolField):
 
     alias = "no_cache"
     default = False
+    v1_only = True
 
 
 # TODO(#9388): remove?
@@ -924,12 +930,14 @@ class ScopeField(StringField):
     """
 
     alias = "scope"
+    v1_only = True
 
 
 # TODO(#9388): Remove.
 class IntransitiveField(BoolField):
     alias = "_transitive"
     default = False
+    v1_only = True
 
 
 COMMON_TARGET_FIELDS = (Tags, DescriptionField, NoCacheField, ScopeField, IntransitiveField)

--- a/src/python/pants/rules/core/list_target_types_test.py
+++ b/src/python/pants/rules/core/list_target_types_test.py
@@ -91,6 +91,7 @@ def run_goal(
             RegisteredTargetTypes.create([FortranBinary, FortranLibrary, FortranTests]),
             union_membership or UnionMembership({}),
             MockOptions(details=details_target),
+            Mock(),
             console,
         ],
     )

--- a/src/python/pants/rules/core/targets.py
+++ b/src/python/pants/rules/core/targets.py
@@ -96,7 +96,7 @@ class AliasDependencies(Dependencies):
     """
 
 
-# TODO: figure out how to support aliases in V2. Is this a simple example of codegen, perhaps?
+# TODO: figure out how to support aliases in V2. When adding support, unmark this as `v1_only`.
 class AliasTarget(Target):
     """A target that gets replaced by the address specified in the `target` field.
 
@@ -105,6 +105,7 @@ class AliasTarget(Target):
 
     alias = "alias"
     core_fields = (*COMMON_TARGET_FIELDS, AliasDependencies, AliasTargetRequestedAddress)
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -166,6 +167,7 @@ class PrepCommand(Target):
         PrepCommandEnviron,
         PrepCommandGoals,
     )
+    v1_only = True
 
 
 # -----------------------------------------------------------------------------------------------
@@ -240,3 +242,4 @@ class RemoteSources(Target):
         RemoteSourcesTargetType,
         RemoteSourcesArgs,
     )
+    v1_only = True


### PR DESCRIPTION
### Problem

Now that we have bindings for every single core target and field, V2-only users have lots of irrelevant information presented in `target-types2`, such as this field being described on `python_library`:

```
    no_cache
        type: bool | None, default: False
        If True, don't store results for this target in the V1 cache.
```

### Solution

Just like we filter `./v2 goals` to only show V2 goals, this PR does the same thing for Fields and Targets.

If the user has `--v1` enabled, we will still show all V1 bindings. So, the default case does not change.

--

This solely impacts the output of `target-types2`. The V1 targets will still be registered and recognized when encountered in a BUILD file. This is important for mixed repos.

### Result

All the V2 targets can fit on one screen again!

![Screen Shot 2020-04-10 at 11 08 19 AM](https://user-images.githubusercontent.com/14852634/79012633-97d6ed80-7b1b-11ea-92ef-6bf7b6fd66b7.png)

[ci skip-rust-tests]
[ci skip-jvm-tests]