### PR TITLE
Leverage `PEX_ROOT` for Pex CLI.

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -89,7 +89,7 @@ class DownloadedPexBin(HermeticPex):
             python_setup=python_setup,
             subprocess_encoding_environment=subprocess_encoding_environment,
             pex_path=self.executable,
-            pex_args=list(pex_args),
+            pex_args=pex_args,
             description=description,
             input_files=input_files or self.directory_digest,
             env=env,

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -83,18 +83,13 @@ class DownloadedPexBin(HermeticPex):
         """
 
         env = dict(env) if env else {}
-        env.update(
-            # We ask Pex to --disable-cache so we shouldn't also set a PEX_ROOT (asking it to
-            # cache).
-            PEX_ROOT="",
-            **pex_build_environment.invocation_environment_dict,
-        )
+        env.update(**pex_build_environment.invocation_environment_dict,)
 
         return super().create_execute_request(
             python_setup=python_setup,
             subprocess_encoding_environment=subprocess_encoding_environment,
             pex_path=self.executable,
-            pex_args=["--disable-cache"] + list(pex_args),
+            pex_args=list(pex_args),
             description=description,
             input_files=input_files or self.directory_digest,
             env=env,


### PR DESCRIPTION
Previously we specially set up `--disable-cache` when running the Pex
CLI and overrode `HermeticPex` setup of an ephemeral EPR-local
`PEX_ROOT`. Now that Pex supports uniform `PEX_ROOT` cache control for
PEX files and the Pex CLI, leverage `HermeticPex` and a sandbox-local
`PEX_ROOT` to allow uniform control of EPR disk usage.

[ci skip-rust-tests]
[ci skip-jvm-tests]