### PR TITLE
Distinguish pex sources from additional input files.

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -240,7 +240,7 @@ async def setup_coverage(coverage: PytestCoverage) -> CoverageSetup:
                 coverage.default_interpreter_constraints
             ),
             entry_point=coverage.get_entry_point(),
-            input_files_digest=plugin_file_digest,
+            sources=plugin_file_digest,
         )
     )
     return CoverageSetup(requirements_pex)

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -121,7 +121,7 @@ async def setup_pytest_for_target(
         output_filename="pytest.pex",
         requirements=PexRequirements(pytest.get_requirement_strings()),
         additional_args=additional_args_for_pytest,
-        input_files_digest=plugin_file_digest,
+        sources=plugin_file_digest,
     )
 
     requirements_pex_request = LegacyPexFromTargetsRequest(


### PR DESCRIPTION
Currently all input files in PexRequest are placed under a
`source_files` subdir and passed to the pex binary using
the --sources-directory option.

However we may need to put files in the PEX building environment
that are not source files (e.g., a preamble file, or a prebuilt
requirements PEX).

This change:

- Renames PexRequest.input_files_digest to sources, for emphasis.
- Adds an additional_inputs field, and propagates those
  into the relevant digest.
- Makes corresponding changes in PexFromTargetsRequest.

[ci skip-rust-tests]
[ci skip-jvm-tests]
