### PR TITLE
Do not mix platforms and interpreter constraints while building release pexes

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -562,18 +562,18 @@ function build_pex() {
   case "${mode}" in
     build)
       # NB: When building locally, we explicitly target our local Py3.
-      local platform_flags=("--python=$(which "$PY")")
+      local distribution_target_flags=("--python=$(command -v "$PY")")
       local dest="${ROOT}/dist/pants.${PANTS_UNSTABLE_VERSION}.${platform}.${dest_suffix}"
       local stable_dest="${DEPLOY_DIR}/pex/pants.${PANTS_STABLE_VERSION}.${platform}.${dest_suffix}"
       ;;
     fetch)
-      local platform_flags=()
+      local distribution_target_flags=()
       # TODO: once we add Python 3.7 PEX support, which requires first building Py37 wheels,
       # we'll want to release one big flexible Pex that works with Python 3.6+.
       abis=("cp-36-m")
       for platform in "${linux_platform_noabi}" "${osx_platform_noabi}"; do
         for abi in "${abis[@]}"; do
-          platform_flags=("${platform_flags[@]}" "--platform=${platform}-${abi}")
+          distribution_target_flags=("${distribution_target_flags[@]}" "--platform=${platform}-${abi}")
         done
       done
       local dest="${ROOT}/dist/pants.${PANTS_UNSTABLE_VERSION}.${dest_suffix}"
@@ -608,7 +608,7 @@ function build_pex() {
     --no-emit-warnings \
     --no-strip-pex-env \
     --script=pants \
-    "${platform_flags[@]}" \
+    "${distribution_target_flags[@]}" \
     "${requirements[@]}"
 
   if [[ "${PANTS_PEX_RELEASE}" == "stable" ]]; then


### PR DESCRIPTION
### Problem

The `release.sh -p` and `release.sh -q` modes build pexes from prebuilt wheels and from locally built wheels (respectively). But the mix of PEX flags that were in use in these two modes did not have the intended behavior for use with prebuilt wheels.

### Solution

When building from pre-built wheels, we're attempting to target a precise set of tags that match the wheels that were built. To do this, we should pass _only_ the `--platform` args that will match those wheels, but we were additionally passing `--interpreter-constraints`, which had the effect of additionally building for any other local pythons that we could find on the host machine.

When building wheels locally, we will have done so in the context of the python 3 binary located by the release script. In that case, we don't need intepreter constraints either, and can instead pass a particular python to PEX to target.

### Result

Consuming prebuilt wheels should succeed even in cases where a host machine has multiple python3 installs, some of which might have strange tag sets.

[ci skip-rust-tests]
[ci skip-jvm-tests]