### PR TITLE
Build PEX files in two steps.

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -64,11 +64,11 @@ async def create_python_awslambda(
         )
     )
 
-    pex_result = await Get[TwoStepPex](PexFromTargetsRequest, pex_request).pex
+    pex_result = await Get[TwoStepPex](PexFromTargetsRequest, pex_request)
     merged_input_files = await Get[Digest](
         DirectoriesToMerge(
             directories=(
-                pex_result.directory_digest,
+                pex_result.pex.directory_digest,
                 lambdex_setup.requirements_pex.directory_digest,
             )
         )

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -20,8 +20,12 @@ from pants.backend.python.rules.pex import (
     PexInterpreterConstraints,
     PexRequest,
     PexRequirements,
+    TwoStepPex,
 )
-from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.rules.pex_from_targets import (
+    PexFromTargetsRequest,
+    TwoStepPexFromTargetsRequest,
+)
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.addressable import Addresses
@@ -54,14 +58,19 @@ async def create_python_awslambda(
 ) -> CreatedAWSLambda:
     # TODO: We must enforce that everything is built for Linux, no matter the local platform.
     pex_filename = f"{config.address.target_name}.pex"
-    pex_request = PexFromTargetsRequest(
-        addresses=Addresses([config.address]), entry_point=None, output_filename=pex_filename,
+    pex_request = TwoStepPexFromTargetsRequest(
+        PexFromTargetsRequest(
+            addresses=Addresses([config.address]), entry_point=None, output_filename=pex_filename,
+        )
     )
 
-    pex = await Get[Pex](PexFromTargetsRequest, pex_request)
+    pex_result = await Get[TwoStepPex](PexFromTargetsRequest, pex_request).pex
     merged_input_files = await Get[Digest](
         DirectoriesToMerge(
-            directories=(pex.directory_digest, lambdex_setup.requirements_pex.directory_digest)
+            directories=(
+                pex_result.directory_digest,
+                lambdex_setup.requirements_pex.directory_digest,
+            )
         )
     )
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -64,7 +64,7 @@ async def create_python_awslambda(
         )
     )
 
-    pex_result = await Get[TwoStepPex](PexFromTargetsRequest, pex_request)
+    pex_result = await Get[TwoStepPex](TwoStepPexFromTargetsRequest, pex_request)
     merged_input_files = await Get[Digest](
         DirectoriesToMerge(
             directories=(

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import dataclasses
 import itertools
 import logging
 from dataclasses import dataclass
@@ -30,7 +31,7 @@ from pants.engine.fs import (
 from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -189,7 +190,7 @@ class PexInterpreterConstraints:
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class PexRequest:
-    """Represents a generic request to create a PEX from its inputs."""
+    """A generic request to create a PEX from its inputs."""
 
     output_filename: str
     requirements: PexRequirements
@@ -220,11 +221,37 @@ class PexRequest:
 
 
 @dataclass(frozen=True)
+class TwoStepPexRequest:
+    """A request to create a PEX in two steps.
+
+    First we create a requirements-only pex. Then we create the full pex on top of that
+    requirements pex, instead of having the full pex directly resolve its requirements.
+
+    This allows us to re-use the requirements-only pex when no requirements have changed (which is
+    the overwhelmingly common case), thus avoiding spurious re-resolves of the same requirements
+    over and over again.
+    """
+
+    pex_request: PexRequest
+
+
+@dataclass(frozen=True)
 class Pex(HermeticPex):
     """Wrapper for a digest containing a pex file created with some filename."""
 
     directory_digest: Digest
     output_filename: str
+
+
+@dataclass(frozen=True)
+class TwoStepPex:
+    """The result of creating a PEX in two steps.
+
+    TODO(9320): A workaround for https://github.com/pantsbuild/pants/issues/9320. Really we
+      just want the rules to directly return a Pex.
+    """
+
+    pex: Pex
 
 
 logger = logging.getLogger(__name__)
@@ -375,5 +402,39 @@ async def create_pex(
     )
 
 
+@rule
+async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoStepPex:
+    """Create a pex in two steps: a requirements-only pex and then a full pex from it."""
+    request = two_step_pex_request.pex_request
+    req_pex_name = "__requirements.pex"
+
+    # Create a pex containing just the requirements.
+    requirements_pex_request = PexRequest(
+        output_filename=req_pex_name,
+        requirements=request.requirements,
+        interpreter_constraints=request.interpreter_constraints,
+        # TODO: Do we need to pass all the additional args to the requirements pex creation?
+        #  Some of them may affect resolution behavior, but others may be irrelevant.
+        #  For now we err on the side of caution.
+        additional_args=request.additional_args,
+    )
+    requirements_pex = await Get[Pex](PexRequest, requirements_pex_request)
+
+    # Now create a full pex on top of the requirements pex.
+    full_pex_request = dataclasses.replace(
+        request,
+        requirements=PexRequirements(),
+        additional_inputs=requirements_pex.directory_digest,
+        additional_args=(*request.additional_args, f"--requirements-pex={req_pex_name}"),
+    )
+    full_pex = await Get[Pex](PexRequest, full_pex_request)
+    return TwoStepPex(pex=full_pex)
+
+
 def rules():
-    return [create_pex, subsystem_rule(PythonSetup), subsystem_rule(PythonRepos)]
+    return [
+        create_pex,
+        two_step_create_pex,
+        subsystem_rule(PythonSetup),
+        subsystem_rule(PythonRepos),
+    ]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -31,7 +31,7 @@ from pants.engine.fs import (
 from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import named_rule, rule, subsystem_rule
+from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -435,6 +435,8 @@ def rules():
     return [
         create_pex,
         two_step_create_pex,
+        RootRule(PexRequest),
+        RootRule(TwoStepPexRequest),
         subsystem_rule(PythonSetup),
         subsystem_rule(PythonRepos),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -195,6 +195,7 @@ def rules():
         pex_from_targets,
         two_step_pex_from_targets,
         RootRule(PexFromTargetsRequest),
+        RootRule(TwoStepPexFromTargetsRequest),
         legacy_pex_from_targets,
         RootRule(LegacyPexFromTargetsRequest),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
 from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
-from pants.backend.python.rules.pex import PexInterpreterConstraints, PexRequest, PexRequirements
+from pants.backend.python.rules.pex import (
+    PexInterpreterConstraints,
+    PexRequest,
+    PexRequirements,
+    TwoStepPexRequest,
+)
 from pants.backend.python.rules.targets import (
     PythonInterpreterCompatibility,
     PythonRequirementsField,
@@ -16,7 +21,7 @@ from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.legacy.structs import FilesAdaptor, PythonTargetAdaptor, ResourcesAdaptor
-from pants.engine.rules import RootRule, named_rule
+from pants.engine.rules import RootRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Targets, TransitiveTargets
 from pants.python.python_setup import PythonSetup
@@ -58,6 +63,21 @@ class PexFromTargetsRequest:
         self.include_source_files = include_source_files
         self.additional_sources = additional_sources
         self.additional_inputs = additional_inputs
+
+
+@dataclass(frozen=True)
+class TwoStepPexFromTargetsRequest:
+    """Request to create a PEX from the closure of a set of targets, in two steps.
+
+    First we create a requirements-only pex. Then we create the full pex on top of that
+    requirements pex, instead of having the full pex directly resolve its requirements.
+
+    This allows us to re-use the requirements-only pex when no requirements have changed (which is
+    the overwhelmingly common case), thus avoiding spurious re-resolves of the same requirements
+    over and over again.
+    """
+
+    pex_from_targets_request: PexFromTargetsRequest
 
 
 @named_rule(desc="Create a PEX from targets")
@@ -108,6 +128,12 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         additional_inputs=request.additional_inputs,
         additional_args=request.additional_args,
     )
+
+
+@rule
+async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoStepPexRequest:
+    pex_request = await Get[PexRequest](PexFromTargetsRequest, req.pex_from_targets_request)
+    return TwoStepPexRequest(pex_request=pex_request)
 
 
 @dataclass(frozen=True)
@@ -167,6 +193,7 @@ async def legacy_pex_from_targets(
 def rules():
     return [
         pex_from_targets,
+        two_step_pex_from_targets,
         RootRule(PexFromTargetsRequest),
         legacy_pex_from_targets,
         RootRule(LegacyPexFromTargetsRequest),


### PR DESCRIPTION
First build a PEX containing just the requirements, then
build a full PEX on top of the requirements pex.

Since requirements change rarely, this allows for much faster
rebuilding of PEXes when only sources have changed.

[ci skip-rust-tests]
[ci skip-jvm-tests]
