### PR TITLE
Get rid of encapsulated_global_logger

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -14,7 +14,6 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.engine.rules import UnionMembership
 from pants.help.help_printer import HelpPrinter
-from pants.init.logging import encapsulated_global_logger
 from pants.init.specs_calculator import SpecsCalculator
 from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import (
@@ -248,7 +247,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
             self.maybe_shutdown_socket, finalizer
         ), hermetic_environment_as(
             **self.env
-        ), encapsulated_global_logger():
+        ):
 
             exit_code = PANTS_SUCCEEDED_EXIT_CODE
             try:

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -1,16 +1,14 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import copy
 import http.client
 import logging
 import os
 import sys
 import warnings
-from contextlib import contextmanager
 from dataclasses import dataclass
 from logging import Handler, Logger, LogRecord, StreamHandler
-from typing import Iterator, List, Optional, TextIO, overload
+from typing import List, Optional, TextIO, overload
 
 import pants.util.logging as pants_logging
 from pants.base.exception_sink import ExceptionSink
@@ -226,23 +224,3 @@ def create_native_stderr_log_handler(
         raise e
 
     return NativeHandler(log_level, native, stream)
-
-
-@contextmanager
-def encapsulated_global_logger() -> Iterator[None]:
-    """Record all the handlers of the current global logger, yield, and reset that logger.
-
-    This is useful in the case where we want to easily restore state after calling setup_logging.
-    For instance, when DaemonPantsRunner creates an instance of LocalPantsRunner it sets up specific
-    nailgunned logging, which we want to undo once the LocalPantsRunner has finished runnnig.
-    """
-    global_logger = logging.getLogger()
-    old_handlers = copy.copy(global_logger.handlers)
-    try:
-        yield
-    finally:
-        new_handlers = global_logger.handlers
-        for handler in new_handlers:
-            global_logger.removeHandler(handler)
-        for handler in old_handlers:
-            global_logger.addHandler(handler)


### PR DESCRIPTION
### Problem

The `encapsulated_global_logger` context manager in the pantsd code doesn't appear to have any effect on what log messages pantsd outputs, and seems to be a remnant from when pantsd worked via forking.

### Solution

Remove this code.

