### PR TITLE
Move the WorkUnitStore to a thread/task local

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -50,7 +50,6 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use workunit_store::WorkUnitStore;
 
 use parking_lot::Mutex;
 
@@ -287,11 +286,7 @@ impl Store {
     }
 
     impl StoreFileByDigest<String> for Digester {
-      fn store_by_digest(
-        &self,
-        _: fs::File,
-        _: WorkUnitStore,
-      ) -> BoxFuture<hashing::Digest, String> {
+      fn store_by_digest(&self, _: fs::File) -> BoxFuture<hashing::Digest, String> {
         future::ok(self.digest).to_boxed()
       }
     }
@@ -306,7 +301,6 @@ impl Store {
           is_executable: is_executable,
         },
       }],
-      WorkUnitStore::new(),
     )
     .await
   }
@@ -323,7 +317,6 @@ impl Store {
     &self,
     digest: Digest,
     f: F,
-    workunit_store: WorkUnitStore,
   ) -> Result<Option<(T, LoadMetadata)>, String> {
     // No transformation or verification is needed for files, so we pass in a pair of functions
     // which always succeed, whether the underlying bytes are coming from a local or remote store.
@@ -336,7 +329,6 @@ impl Store {
         digest,
         move |v: Bytes| Ok(f_local(v)),
         move |v: Bytes| Ok(f_remote(v)),
-        workunit_store,
       )
       .await
   }
@@ -370,7 +362,6 @@ impl Store {
   pub async fn load_directory(
     &self,
     digest: Digest,
-    workunit_store: WorkUnitStore,
   ) -> Result<Option<(bazel_protos::remote_execution::Directory, LoadMetadata)>, String> {
     self
       .load_bytes_with(
@@ -401,7 +392,6 @@ impl Store {
           bazel_protos::verify_directory_canonical(&directory)?;
           Ok(directory)
         },
-        workunit_store,
       )
       .await
   }
@@ -421,7 +411,6 @@ impl Store {
     digest: Digest,
     f_local: FLocal,
     f_remote: FRemote,
-    workunit_store: WorkUnitStore,
   ) -> Result<Option<(T, LoadMetadata)>, String> {
     let local = self.local.clone();
     let maybe_remote = self.remote.clone();
@@ -436,12 +425,7 @@ impl Store {
       (None, None) => Ok(None),
       (None, Some(remote)) => {
         let maybe_bytes = remote
-          .load_bytes_with(
-            entry_type,
-            digest,
-            move |bytes: Bytes| bytes,
-            workunit_store.clone(),
-          )
+          .load_bytes_with(entry_type, digest, move |bytes: Bytes| bytes)
           .await?;
 
         match maybe_bytes {
@@ -473,7 +457,6 @@ impl Store {
   pub fn ensure_remote_has_recursive(
     &self,
     digests: Vec<Digest>,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<UploadSummary, String> {
     let start_time = Instant::now();
 
@@ -492,7 +475,7 @@ impl Store {
           expanded_digests.insert(digest, EntryType::File);
         }
         Ok(Some(EntryType::Directory)) => {
-          expanding_futures.push(self.expand_directory(digest, workunit_store.clone()));
+          expanding_futures.push(self.expand_directory(digest));
         }
         Ok(None) => {
           return future::err(format!("Failed to upload digest {:?}: Not found", digest))
@@ -508,7 +491,6 @@ impl Store {
     let local = self.local.clone();
     let remote = remote.clone();
     let remote2 = remote.clone();
-    let workunit_store2 = workunit_store.clone();
     future::join_all(expanding_futures)
       .map(move |futures| {
         for mut digests in futures {
@@ -524,7 +506,7 @@ impl Store {
             .to_boxed();
         }
         let request = remote.find_missing_blobs_request(ingested_digests.keys());
-        let f = remote.list_missing_digests(request, workunit_store.clone());
+        let f = remote.list_missing_digests(request);
         f.map(move |digests_to_upload| (digests_to_upload, ingested_digests))
           .to_boxed()
       })
@@ -536,15 +518,12 @@ impl Store {
               let entry_type = ingested_digests[&digest];
               let local = local.clone();
               let remote = remote2.clone();
-              let workunit_store = workunit_store2.clone();
 
               Box::pin(async move {
                 let maybe_upload = local
                   .load_bytes_with(entry_type, digest, move |bytes| {
                     let remote = remote.clone();
-                    let workunit_store = workunit_store.clone();
-                    Box::pin(async move { remote.store_bytes(bytes, workunit_store).await })
-                      .compat()
+                    Box::pin(async move { remote.store_bytes(bytes).await }).compat()
                   })
                   .await?;
                 match maybe_upload {
@@ -579,15 +558,10 @@ impl Store {
   /// Download a directory from Remote ByteStore recursively to the local one. Called only with the
   /// Digest of a Directory.
   ///
-  pub fn ensure_local_has_recursive_directory(
-    &self,
-    dir_digest: Digest,
-    workunit_store: WorkUnitStore,
-  ) -> BoxFuture<(), String> {
+  pub fn ensure_local_has_recursive_directory(&self, dir_digest: Digest) -> BoxFuture<(), String> {
     let loaded_directory = {
       let store = self.clone();
-      let workunit_store = workunit_store.clone();
-      let res = async move { store.load_directory(dir_digest, workunit_store).await };
+      let res = async move { store.load_directory(dir_digest).await };
       res.boxed().compat()
     };
 
@@ -606,16 +580,9 @@ impl Store {
           .map(|file_node| {
             let file_digest = try_future!(file_node.get_digest().into());
             let store = store.clone();
-            let workunit_store = workunit_store.clone();
             Box::pin(async move {
               store
-                .load_bytes_with(
-                  EntryType::File,
-                  file_digest,
-                  |_| Ok(()),
-                  |_| Ok(()),
-                  workunit_store,
-                )
+                .load_bytes_with(EntryType::File, file_digest, |_| Ok(()), |_| Ok(()))
                 .await
             })
             .compat()
@@ -629,7 +596,7 @@ impl Store {
           .iter()
           .map(move |child_dir| {
             let child_digest = try_future!(child_dir.get_digest().into());
-            store.ensure_local_has_recursive_directory(child_digest, workunit_store.clone())
+            store.ensure_local_has_recursive_directory(child_digest)
           })
           .collect::<Vec<_>>();
         future::join_all(file_futures)
@@ -683,24 +650,16 @@ impl Store {
     }
   }
 
-  pub fn expand_directory(
-    &self,
-    digest: Digest,
-    workunit_store: WorkUnitStore,
-  ) -> BoxFuture<HashMap<Digest, EntryType>, String> {
+  pub fn expand_directory(&self, digest: Digest) -> BoxFuture<HashMap<Digest, EntryType>, String> {
     self
-      .walk(
-        digest,
-        |_, _, digest, directory| {
-          let mut digest_types = Vec::new();
-          digest_types.push((digest, EntryType::Directory));
-          for file in directory.get_files() {
-            digest_types.push((try_future!(file.get_digest().into()), EntryType::File));
-          }
-          future::ok(digest_types).to_boxed()
-        },
-        workunit_store,
-      )
+      .walk(digest, |_, _, digest, directory| {
+        let mut digest_types = Vec::new();
+        digest_types.push((digest, EntryType::Directory));
+        for file in directory.get_files() {
+          digest_types.push((try_future!(file.get_digest().into()), EntryType::File));
+        }
+        future::ok(digest_types).to_boxed()
+      })
       .map(|digest_pairs_per_directory| {
         Iterator::flatten(digest_pairs_per_directory.into_iter().map(Vec::into_iter)).collect()
       })
@@ -715,7 +674,6 @@ impl Store {
     &self,
     destination: PathBuf,
     digest: Digest,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<DirectoryMaterializeMetadata, String> {
     let root = Arc::new(Mutex::new(None));
     self
@@ -723,7 +681,6 @@ impl Store {
         destination,
         RootOrParentMetadataBuilder::Root(root.clone()),
         digest,
-        workunit_store,
       )
       .map(|()| Arc::try_unwrap(root).unwrap().into_inner().unwrap().build())
       .to_boxed()
@@ -734,7 +691,6 @@ impl Store {
     destination: PathBuf,
     root_or_parent_metadata: RootOrParentMetadataBuilder,
     digest: Digest,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<(), String> {
     if let RootOrParentMetadataBuilder::Root(..) = root_or_parent_metadata {
       try_future!(fs::safe_create_dir_all(&destination));
@@ -744,8 +700,7 @@ impl Store {
 
     let loaded_directory = {
       let store = self.clone();
-      let workunit_store = workunit_store.clone();
-      let res = async move { store.load_directory(digest, workunit_store).await };
+      let res = async move { store.load_directory(digest).await };
       res.boxed().compat()
     };
 
@@ -787,12 +742,7 @@ impl Store {
             let child_files = child_files.clone();
             let name = file_node.get_name().to_owned();
             store
-              .materialize_file(
-                path,
-                digest,
-                file_node.is_executable,
-                workunit_store.clone(),
-              )
+              .materialize_file(path, digest, file_node.is_executable)
               .map(move |metadata| child_files.lock().insert(name, metadata))
               .to_boxed()
           })
@@ -811,7 +761,7 @@ impl Store {
               child_files.clone(),
             ));
 
-            store.materialize_directory_helper(path, builder, digest, workunit_store.clone())
+            store.materialize_directory_helper(path, builder, digest)
           })
           .collect::<Vec<_>>();
         future::join_all(file_futures)
@@ -826,37 +776,32 @@ impl Store {
     destination: PathBuf,
     digest: Digest,
     is_executable: bool,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<LoadMetadata, String> {
     let store = self.clone();
     let res = async move {
       let write_result = store
-        .load_file_bytes_with(
-          digest,
-          move |bytes| {
-            if destination.exists() {
-              std::fs::remove_file(&destination)
-            } else {
-              Ok(())
-            }
-            .and_then(|_| {
-              OpenOptions::new()
-                .create(true)
-                .write(true)
-                .mode(if is_executable { 0o755 } else { 0o644 })
-                .open(&destination)
-            })
-            .and_then(|mut f| {
-              f.write_all(&bytes)?;
-              // See `materialize_directory`, but we fundamentally materialize files for other
-              // processes to read; as such, we must ensure data is flushed to disk and visible
-              // to them as opposed to just our process.
-              f.sync_all()
-            })
-            .map_err(|e| format!("Error writing file {:?}: {:?}", destination, e))
-          },
-          workunit_store,
-        )
+        .load_file_bytes_with(digest, move |bytes| {
+          if destination.exists() {
+            std::fs::remove_file(&destination)
+          } else {
+            Ok(())
+          }
+          .and_then(|_| {
+            OpenOptions::new()
+              .create(true)
+              .write(true)
+              .mode(if is_executable { 0o755 } else { 0o644 })
+              .open(&destination)
+          })
+          .and_then(|mut f| {
+            f.write_all(&bytes)?;
+            // See `materialize_directory`, but we fundamentally materialize files for other
+            // processes to read; as such, we must ensure data is flushed to disk and visible
+            // to them as opposed to just our process.
+            f.sync_all()
+          })
+          .map_err(|e| format!("Error writing file {:?}: {:?}", destination, e))
+        })
         .await?;
 
       match write_result {
@@ -869,46 +814,34 @@ impl Store {
   }
 
   // Returns files sorted by their path.
-  pub fn contents_for_directory(
-    &self,
-    digest: Digest,
-    workunit_store: WorkUnitStore,
-  ) -> BoxFuture<Vec<FileContent>, String> {
-    let workunit_store_clone = workunit_store.clone();
+  pub fn contents_for_directory(&self, digest: Digest) -> BoxFuture<Vec<FileContent>, String> {
     self
-      .walk(
-        digest,
-        move |store, path_so_far, _, directory| {
-          future::join_all(
-            directory
-              .get_files()
-              .iter()
-              .map(|file_node| {
-                let path = path_so_far.join(file_node.get_name());
-                let is_executable = file_node.is_executable;
-                let file_node_digest: Result<_, _> = file_node.get_digest().into();
-                let store = store.clone();
-                let workunit_store = workunit_store.clone();
-                let res = async move {
-                  let maybe_bytes = store
-                    .load_file_bytes_with(file_node_digest?, |b| b, workunit_store)
-                    .await?;
-                  maybe_bytes
-                    .ok_or_else(|| format!("Couldn't find file contents for {:?}", path))
-                    .map(|(content, _metadata)| FileContent {
-                      path,
-                      content,
-                      is_executable,
-                    })
-                };
-                res.boxed().compat().to_boxed()
-              })
-              .collect::<Vec<_>>(),
-          )
-          .to_boxed()
-        },
-        workunit_store_clone,
-      )
+      .walk(digest, move |store, path_so_far, _, directory| {
+        future::join_all(
+          directory
+            .get_files()
+            .iter()
+            .map(|file_node| {
+              let path = path_so_far.join(file_node.get_name());
+              let is_executable = file_node.is_executable;
+              let file_node_digest: Result<_, _> = file_node.get_digest().into();
+              let store = store.clone();
+              let res = async move {
+                let maybe_bytes = store.load_file_bytes_with(file_node_digest?, |b| b).await?;
+                maybe_bytes
+                  .ok_or_else(|| format!("Couldn't find file contents for {:?}", path))
+                  .map(|(content, _metadata)| FileContent {
+                    path,
+                    content,
+                    is_executable,
+                  })
+              };
+              res.boxed().compat().to_boxed()
+            })
+            .collect::<Vec<_>>(),
+        )
+        .to_boxed()
+      })
       .map(|file_contents_per_directory| {
         let mut vec =
           Iterator::flatten(file_contents_per_directory.into_iter().map(Vec::into_iter))
@@ -941,18 +874,11 @@ impl Store {
     &self,
     digest: Digest,
     f: F,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<Vec<T>, String> {
     let f = Arc::new(f);
     let accumulator = Arc::new(Mutex::new(Vec::new()));
     self
-      .walk_helper(
-        digest,
-        PathBuf::new(),
-        f,
-        accumulator.clone(),
-        workunit_store,
-      )
+      .walk_helper(digest, PathBuf::new(), f, accumulator.clone())
       .map(|()| {
         Arc::try_unwrap(accumulator)
           .unwrap_or_else(|_| panic!("walk_helper violated its contract."))
@@ -978,11 +904,10 @@ impl Store {
     path_so_far: PathBuf,
     f: Arc<F>,
     accumulator: Arc<Mutex<Vec<T>>>,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<(), String> {
     let store = self.clone();
     let res = async move {
-      let maybe_directory = store.load_directory(digest, workunit_store.clone()).await?;
+      let maybe_directory = store.load_directory(digest).await?;
       match maybe_directory {
         Some((directory, _metadata)) => {
           let result_for_directory = f(&store, &path_so_far, digest, &directory).compat().await?;
@@ -997,13 +922,7 @@ impl Store {
               .map(move |dir_node| {
                 let subdir_digest = try_future!(dir_node.get_digest().into());
                 let path = path_so_far.join(dir_node.get_name());
-                store.walk_helper(
-                  subdir_digest,
-                  path,
-                  f.clone(),
-                  accumulator.clone(),
-                  workunit_store.clone(),
-                )
+                store.walk_helper(subdir_digest, path, f.clone(), accumulator.clone())
               })
               .collect::<Vec<_>>(),
           )

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use uuid;
-use workunit_store::{WorkUnit, WorkUnitStore};
+use workunit_store::WorkUnit;
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -113,11 +113,7 @@ impl ByteStore {
     )
   }
 
-  pub async fn store_bytes(
-    &self,
-    bytes: Bytes,
-    _workunit_store: WorkUnitStore,
-  ) -> Result<Digest, String> {
+  pub async fn store_bytes(&self, bytes: Bytes) -> Result<Digest, String> {
     let start_time = std::time::SystemTime::now();
 
     let mut hasher = Sha256::default();
@@ -242,7 +238,6 @@ impl ByteStore {
     _entry_type: EntryType,
     digest: Digest,
     f: F,
-    _workunit_store: WorkUnitStore,
   ) -> Result<Option<T>, String> {
     let start_time = std::time::SystemTime::now();
 
@@ -325,7 +320,6 @@ impl ByteStore {
   pub fn list_missing_digests(
     &self,
     request: bazel_protos::remote_execution::FindMissingBlobsRequest,
-    workunit_store: WorkUnitStore,
   ) -> impl Future<Item = HashSet<Digest>, Error = String> {
     let start_time = std::time::SystemTime::now();
 
@@ -334,7 +328,6 @@ impl ByteStore {
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
-    let _workunit_store = workunit_store;
     self
       .with_cas_client(move |client| {
         client

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -116,7 +116,7 @@ impl ByteStore {
   pub async fn store_bytes(
     &self,
     bytes: Bytes,
-    workunit_store: WorkUnitStore,
+    _workunit_store: WorkUnitStore,
   ) -> Result<Digest, String> {
     let start_time = std::time::SystemTime::now();
 
@@ -222,12 +222,14 @@ impl ByteStore {
         .compat()
         .await;
 
-    let workunit = WorkUnit::new(
-      workunit_name.clone(),
-      TimeSpan::since(&start_time),
-      workunit_store::get_parent_id(),
-    );
-    workunit_store.add_workunit(workunit);
+    if let Some(workunit_state) = workunit_store::get_workunit_state() {
+      let workunit = WorkUnit::new(
+        workunit_name.clone(),
+        TimeSpan::since(&start_time),
+        workunit_state.parent_id,
+      );
+      workunit_state.store.add_workunit(workunit);
+    }
 
     result
   }
@@ -240,7 +242,7 @@ impl ByteStore {
     _entry_type: EntryType,
     digest: Digest,
     f: F,
-    workunit_store: WorkUnitStore,
+    _workunit_store: WorkUnitStore,
   ) -> Result<Option<T>, String> {
     let start_time = std::time::SystemTime::now();
 
@@ -304,12 +306,14 @@ impl ByteStore {
       .compat()
       .await;
 
-    let workunit = WorkUnit::new(
-      workunit_name.clone(),
-      TimeSpan::since(&start_time),
-      workunit_store::get_parent_id(),
-    );
-    workunit_store.add_workunit(workunit);
+    if let Some(workunit_state) = workunit_store::get_workunit_state() {
+      let workunit = WorkUnit::new(
+        workunit_name.clone(),
+        TimeSpan::since(&start_time),
+        workunit_state.parent_id,
+      );
+      workunit_state.store.add_workunit(workunit);
+    }
 
     result
   }
@@ -330,7 +334,7 @@ impl ByteStore {
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
-    let workunit_store = workunit_store;
+    let _workunit_store = workunit_store;
     self
       .with_cas_client(move |client| {
         client
@@ -350,12 +354,14 @@ impl ByteStore {
           })
       })
       .then(move |future| {
-        let workunit = WorkUnit::new(
-          workunit_name.clone(),
-          TimeSpan::since(&start_time),
-          workunit_store::get_parent_id(),
-        );
-        workunit_store.add_workunit(workunit);
+        if let Some(workunit_state) = workunit_store::get_workunit_state() {
+          let workunit = WorkUnit::new(
+            workunit_name.clone(),
+            TimeSpan::since(&start_time),
+            workunit_state.parent_id,
+          );
+          workunit_state.store.add_workunit(workunit);
+        }
         future
       })
   }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -8,7 +8,6 @@ use serverset::BackoffConfig;
 use std::collections::HashSet;
 use std::time::Duration;
 use testutil::data::{TestData, TestDirectory};
-use workunit_store::WorkUnitStore;
 
 use crate::tests::{big_file_bytes, big_file_digest, big_file_fingerprint, new_cas};
 
@@ -140,9 +139,7 @@ async fn write_file_one_chunk() {
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    store
-      .store_bytes(testdata.bytes(), WorkUnitStore::new())
-      .await,
+    store.store_bytes(testdata.bytes()).await,
     Ok(testdata.digest())
   );
 
@@ -173,9 +170,7 @@ async fn write_file_multiple_chunks() {
   let fingerprint = big_file_fingerprint();
 
   assert_eq!(
-    store
-      .store_bytes(all_the_henries.clone(), WorkUnitStore::new())
-      .await,
+    store.store_bytes(all_the_henries.clone()).await,
     Ok(big_file_digest())
   );
 
@@ -203,9 +198,7 @@ async fn write_empty_file() {
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    store
-      .store_bytes(empty_file.bytes(), WorkUnitStore::new())
-      .await,
+    store.store_bytes(empty_file.bytes()).await,
     Ok(empty_file.digest())
   );
 
@@ -222,7 +215,7 @@ async fn write_file_errors() {
 
   let store = new_byte_store(&cas);
   let error = store
-    .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
+    .store_bytes(TestData::roland().bytes())
     .await
     .expect_err("Want error");
   assert!(
@@ -251,7 +244,7 @@ async fn write_connection_error() {
   )
   .unwrap();
   let error = store
-    .store_bytes(TestData::roland().bytes(), WorkUnitStore::new())
+    .store_bytes(TestData::roland().bytes())
     .await
     .expect_err("Want error");
   assert!(
@@ -269,7 +262,6 @@ async fn list_missing_digests_none_missing() {
     store
       .list_missing_digests(
         store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-        WorkUnitStore::new(),
       )
       .compat()
       .await,
@@ -290,10 +282,7 @@ async fn list_missing_digests_some_missing() {
 
   assert_eq!(
     store
-      .list_missing_digests(
-        store.find_missing_blobs_request(vec![digest].iter()),
-        WorkUnitStore::new(),
-      )
+      .list_missing_digests(store.find_missing_blobs_request(vec![digest].iter()),)
       .compat()
       .await,
     Ok(digest_set)
@@ -309,7 +298,6 @@ async fn list_missing_digests_error() {
   let error = store
     .list_missing_digests(
       store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-      WorkUnitStore::new(),
     )
     .compat()
     .await
@@ -388,7 +376,5 @@ async fn load_bytes(
   entry_type: EntryType,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  store
-    .load_bytes_with(entry_type, digest, |b| b, WorkUnitStore::new())
-    .await
+  store.load_bytes_with(entry_type, digest, |b| b).await
 }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -68,7 +68,7 @@ impl crate::CommandRunner for CommandRunner {
 
     let command_runner = self.clone();
     self
-      .lookup(key, context.clone())
+      .lookup(key)
       .then(move |maybe_result| {
         match maybe_result {
           Ok(Some(result)) => return future::ok(result).to_boxed(),
@@ -108,7 +108,6 @@ impl CommandRunner {
   fn lookup(
     &self,
     fingerprint: Fingerprint,
-    context: Context,
   ) -> impl Future<Item = Option<FallibleExecuteProcessResultWithPlatform>, Error = String> {
     use bazel_protos::remote_execution::ExecuteResponse;
     let file_store = self.file_store.clone();
@@ -137,7 +136,6 @@ impl CommandRunner {
           file_store,
           execute_response,
           vec![],
-          context.workunit_store,
           platform,
         )
         .map(Some)

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -29,7 +29,6 @@ use crate::{
 };
 
 use bytes::{Bytes, BytesMut};
-use workunit_store::WorkUnitStore;
 
 #[derive(Clone)]
 pub struct CommandRunner {
@@ -97,7 +96,6 @@ impl CommandRunner {
         store.clone(),
         OneOffStoreFileByDigest::new(store, posix_fs),
         path_stats,
-        WorkUnitStore::new(),
       )
       .await
     })
@@ -327,18 +325,12 @@ pub trait CapturedWorkdir {
       req.unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule;
 
     store
-      .materialize_directory(
-        workdir_path.clone(),
-        req.input_files,
-        context.workunit_store.clone(),
-      )
+      .materialize_directory(workdir_path.clone(), req.input_files)
       .and_then({
-        let workunit_store = context.workunit_store.clone();
         move |_metadata| {
           store2.materialize_directory(
             workdir_path4,
             unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
-            workunit_store,
           )
         }
       })

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -246,9 +246,8 @@ impl CapturedWorkdir for CommandRunner {
     let nailgun_pool = self.nailgun_pool.clone();
     let req2 = req.clone();
     let workdir_for_this_nailgun = self.get_nailgun_workdir(&nailgun_name)?;
-    let build_id = context.build_id.clone();
+    let build_id = context.build_id;
     let store = self.inner.store.clone();
-    let workunit_store = context.workunit_store;
 
     // Streams to read child output from
     let (stdio_write, stdio_read) = child_channel::<ChildOutput>();
@@ -268,7 +267,6 @@ impl CapturedWorkdir for CommandRunner {
             build_id,
             store,
             req.input_files,
-            workunit_store,
           )
           .compat()
       })

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use store::Store;
 use tempfile::TempDir;
 use tokio::runtime::Handle;
-use workunit_store::WorkUnitStore;
 
 fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
   let store_dir = TempDir::new().unwrap();
@@ -120,7 +119,6 @@ async fn materialize_with_jdk(
     dir,
     jdk_path,
     EMPTY_DIGEST,
-    WorkUnitStore::new(),
   );
   materializer.compat().await
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use std;
 use std::cmp::min;
-use workunit_store::{get_parent_id, WorkUnit, WorkUnitStore};
+use workunit_store::{WorkUnit, WorkUnitStore};
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an ExecuteProcessRequest, and may be populated only by the
@@ -587,7 +587,7 @@ impl CommandRunner {
         trace!("Got (nested) execute response: {:?}", execute_response);
         if execute_response.get_result().has_execution_metadata() {
           let metadata = execute_response.get_result().get_execution_metadata();
-          let parent_id = get_parent_id();
+          let parent_id = workunit_store::expect_workunit_state().parent_id;
           let result_cached = execute_response.get_cached_result();
 
           match TimeSpan::from_start_and_end(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -272,11 +272,9 @@ impl super::CommandRunner for CommandRunner {
           .join(self.store_proto_locally(&action))
           .and_then({
             let store = store.clone();
-            let workunit_store = context.workunit_store.clone();
             move |(command_digest, action_digest)| {
               store.ensure_remote_has_recursive(
                 vec![command_digest, action_digest, input_files],
-                workunit_store,
               )
             }
           })
@@ -323,10 +321,9 @@ impl super::CommandRunner for CommandRunner {
                   let operations_client = operations_client.clone();
                   let command_runner = command_runner.clone();
                   let build_id = context.build_id.to_string();
-                  let workunit_store = context.workunit_store.clone();
 
                   let f = command_runner
-                    .extract_execute_response(operation, &mut history, context.workunit_store.clone());
+                    .extract_execute_response(operation, &mut history);
                   f.then(move |value| {
                     match value {
                       Ok(result) => {
@@ -370,7 +367,7 @@ impl super::CommandRunner for CommandRunner {
 
                             command_runner.retry_execution(
                               execute_request,
-                              store.ensure_remote_has_recursive(missing_digests, workunit_store.clone()).map(|_| ()).to_boxed(),
+                              store.ensure_remote_has_recursive(missing_digests).map(|_| ()).to_boxed(),
                               build_id,
                               history,
                               maybe_cancel_remote_exec_token,
@@ -560,7 +557,6 @@ impl CommandRunner {
     &self,
     operation_or_status: OperationOrStatus,
     attempts: &mut ExecutionHistory,
-    workunit_store: WorkUnitStore,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, ExecutionError> {
     trace!("Got operation response: {:?}", operation_or_status);
 
@@ -587,7 +583,9 @@ impl CommandRunner {
         trace!("Got (nested) execute response: {:?}", execute_response);
         if execute_response.get_result().has_execution_metadata() {
           let metadata = execute_response.get_result().get_execution_metadata();
-          let parent_id = workunit_store::expect_workunit_state().parent_id;
+          let workunit_state = workunit_store::expect_workunit_state();
+          let workunit_store = workunit_state.store;
+          let parent_id = workunit_state.parent_id;
           let result_cached = execute_response.get_cached_result();
 
           match TimeSpan::from_start_and_end(
@@ -672,7 +670,6 @@ impl CommandRunner {
             self.store.clone(),
             execute_response,
             execution_attempts,
-            workunit_store,
             self.platform,
           )
           .map_err(ExecutionError::Fatal)
@@ -959,20 +956,11 @@ pub fn populate_fallible_execution_result(
   store: Store,
   execute_response: bazel_protos::remote_execution::ExecuteResponse,
   execution_attempts: Vec<ExecutionStats>,
-  workunit_store: WorkUnitStore,
   platform: Platform,
 ) -> impl Future<Item = FallibleExecuteProcessResultWithPlatform, Error = String> {
-  extract_stdout(&store, &execute_response, workunit_store.clone())
-    .join(extract_stderr(
-      &store,
-      &execute_response,
-      workunit_store.clone(),
-    ))
-    .join(extract_output_files(
-      store,
-      &execute_response,
-      workunit_store,
-    ))
+  extract_stdout(&store, &execute_response)
+    .join(extract_stderr(&store, &execute_response))
+    .join(extract_output_files(store, &execute_response))
     .and_then(move |((stdout, stderr), output_directory)| {
       Ok(FallibleExecuteProcessResultWithPlatform {
         stdout: stdout,
@@ -988,7 +976,6 @@ pub fn populate_fallible_execution_result(
 fn extract_stdout(
   store: &Store,
   execute_response: &bazel_protos::remote_execution::ExecuteResponse,
-  workunit_store: WorkUnitStore,
 ) -> BoxFuture<Bytes, String> {
   if execute_response.get_result().has_stdout_digest() {
     let store = store.clone();
@@ -998,7 +985,7 @@ fn extract_stdout(
       try_future!(stdout_digest_result.map_err(|err| format!("Error extracting stdout: {}", err)));
     Box::pin(async move {
       let (bytes, _metadata) = store
-        .load_file_bytes_with(stdout_digest, |v| v, workunit_store)
+        .load_file_bytes_with(stdout_digest, |v| v)
         .map_err(move |error| {
           format!(
             "Error fetching stdout digest ({:?}): {:?}",
@@ -1035,7 +1022,6 @@ fn extract_stdout(
 fn extract_stderr(
   store: &Store,
   execute_response: &bazel_protos::remote_execution::ExecuteResponse,
-  workunit_store: WorkUnitStore,
 ) -> BoxFuture<Bytes, String> {
   if execute_response.get_result().has_stderr_digest() {
     let store = store.clone();
@@ -1046,7 +1032,7 @@ fn extract_stderr(
 
     Box::pin(async move {
       let (bytes, _metadata) = store
-        .load_file_bytes_with(stderr_digest, |v| v, workunit_store)
+        .load_file_bytes_with(stderr_digest, |v| v)
         .map_err(move |error| {
           format!(
             "Error fetching stderr digest ({:?}): {:?}",
@@ -1083,7 +1069,6 @@ fn extract_stderr(
 pub fn extract_output_files(
   store: Store,
   execute_response: &bazel_protos::remote_execution::ExecuteResponse,
-  workunit_store: WorkUnitStore,
 ) -> BoxFuture<Digest, String> {
   // Get Digests of output Directories.
   // Then we'll make a Directory for the output files, and merge them.
@@ -1156,7 +1141,7 @@ pub fn extract_output_files(
   }
 
   impl StoreFileByDigest<String> for StoreOneOffRemoteDigest {
-    fn store_by_digest(&self, file: File, _: WorkUnitStore) -> BoxFuture<Digest, String> {
+    fn store_by_digest(&self, file: File) -> BoxFuture<Digest, String> {
       match self.map_of_paths_to_digests.get(&file.path) {
         Some(digest) => future::ok(*digest),
         None => future::err(format!(
@@ -1173,7 +1158,6 @@ pub fn extract_output_files(
       store.clone(),
       StoreOneOffRemoteDigest::new(path_map),
       &path_stats,
-      workunit_store.clone(),
     )
     .map_err(move |error| {
       format!(
@@ -1186,7 +1170,7 @@ pub fn extract_output_files(
       future03::try_join(files_digest, future03::try_join_all(directory_digests)).await?;
 
     directory_digests.push(files_digest);
-    Snapshot::merge_directories(store, directory_digests, workunit_store)
+    Snapshot::merge_directories(store, directory_digests)
       .map_err(|err| format!("Error when merging output files and directories: {}", err))
       .await
   })

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1020,7 +1020,7 @@ async fn ensure_inline_stdio_is_stored() {
   {
     assert_eq!(
       local_store
-        .load_file_bytes_with(test_stdout.digest(), |v| v, WorkUnitStore::new())
+        .load_file_bytes_with(test_stdout.digest(), |v| v,)
         .await
         .unwrap()
         .unwrap()
@@ -1029,7 +1029,7 @@ async fn ensure_inline_stdio_is_stored() {
     );
     assert_eq!(
       local_store
-        .load_file_bytes_with(test_stderr.digest(), |v| v, WorkUnitStore::new())
+        .load_file_bytes_with(test_stderr.digest(), |v| v,)
         .await
         .unwrap()
         .unwrap()
@@ -2299,12 +2299,10 @@ async fn remote_workunits_are_stored() {
     Platform::Linux,
   );
 
-  let workunit_store_2 = workunit_store.clone();
   future::lazy(move || {
     command_runner.extract_execute_response(
       OperationOrStatus::Operation(operation),
       &mut ExecutionHistory::default(),
-      workunit_store_2,
     )
   })
   .compat()
@@ -2630,7 +2628,6 @@ async fn extract_execute_response(
     .extract_execute_response(
       OperationOrStatus::Operation(operation),
       &mut ExecutionHistory::default(),
-      WorkUnitStore::new(),
     )
     .compat()
     .await
@@ -2646,7 +2643,7 @@ async fn extract_output_files_from_response(
   let executor = task_executor::Executor::new(Handle::current());
   let store_dir = TempDir::new().unwrap();
   let store = make_store(store_dir.path(), &cas, executor.clone());
-  crate::remote::extract_output_files(store, &execute_response, WorkUnitStore::new())
+  crate::remote::extract_output_files(store, &execute_response)
     .compat()
     .await
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2277,6 +2277,7 @@ fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSet<Wo
 #[tokio::test]
 async fn remote_workunits_are_stored() {
   let workunit_store = WorkUnitStore::new();
+  workunit_store.init_thread_state(None);
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -44,7 +44,6 @@ use std::process::exit;
 use std::time::Duration;
 use store::{BackoffConfig, Store};
 use tokio::runtime::Handle;
-use workunit_store::WorkUnitStore;
 
 /// A binary which takes args of format:
 ///  process_executor --env=FOO=bar --env=SOME=value --input-digest=abc123 --input-digest-length=80
@@ -400,7 +399,7 @@ async fn main() {
 
   if let Some(output) = args.value_of("materialize-output-to").map(PathBuf::from) {
     store
-      .materialize_directory(output, result.output_directory, WorkUnitStore::new())
+      .materialize_directory(output, result.output_directory)
       .compat()
       .await
       .unwrap();

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -127,12 +127,12 @@ impl Executor {
     f: F,
   ) -> R {
     let logging_destination = logging::get_destination();
-    let workunit_parent_id = workunit_store::get_parent_id();
+    let workunit_state = workunit_store::get_workunit_state();
     // NB: We unwrap here because the only thing that should cause an error in a spawned task is a
     // panic, in which case we want to propagate that.
     tokio::task::spawn_blocking(move || {
       logging::set_thread_destination(logging_destination);
-      workunit_store::set_thread_parent_id(workunit_parent_id);
+      workunit_store::set_thread_workunit_state(workunit_state);
       f()
     })
     .await
@@ -147,14 +147,14 @@ impl Executor {
   ///
   fn future_with_correct_context<F: Future>(future: F) -> impl Future<Output = F::Output> {
     let logging_destination = logging::get_destination();
-    let workunit_parent_id = workunit_store::get_parent_id();
+    let workunit_state = workunit_store::get_workunit_state();
 
     // NB: It is important that the first portion of this method is synchronous (meaning that this
     // method cannot be `async`), because that means that it will run on the thread that calls it.
     // The second, async portion of the method will run in the spawned Task.
 
     logging::scope_task_destination(logging_destination, async move {
-      workunit_store::scope_task_parent_id(workunit_parent_id, future).await
+      workunit_store::scope_task_workunit_state(workunit_state, future).await
     })
   }
 }


### PR DESCRIPTION
### Problem

We would like to use the `WorkUnitStore` to add tracing information in more places, but there is a significant amount of boilerplate involved in propagating it to new callsites.

### Solution

Move the `WorkUnitStore` into the same thread/task local variables that currently propagate the `WorkUnit` span parent_id.

### Result

Less boilerplate, and better alignment with other tracing frameworks (like the `tracing` crate, where we would likely install a `Subscriber` that utilized this thread/task local to record `WorkUnits`).