### PR TITLE
Attach a description to PexRequests.

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -419,6 +419,8 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
     request = two_step_pex_request.pex_request
     req_pex_name = "__requirements.pex"
 
+    additional_inputs: Optional[Digest]
+
     # Create a pex containing just the requirements.
     if request.requirements.requirements:
         requirements_pex_request = PexRequest(

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -433,15 +433,17 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
         )
         requirements_pex = await Get[Pex](PexRequest, requirements_pex_request)
         additional_inputs = requirements_pex.directory_digest
+        additional_args = (*request.additional_args, f"--requirements-pex={req_pex_name}")
     else:
         additional_inputs = None
+        additional_args = request.additional_args
 
     # Now create a full pex on top of the requirements pex.
     full_pex_request = dataclasses.replace(
         request,
         requirements=PexRequirements(),
         additional_inputs=additional_inputs,
-        additional_args=(*request.additional_args, f"--requirements-pex={req_pex_name}"),
+        additional_args=additional_args,
     )
     full_pex = await Get[Pex](PexRequest, full_pex_request)
     return TwoStepPex(pex=full_pex)

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -199,6 +199,9 @@ class PexRequest:
     additional_inputs: Optional[Digest]
     entry_point: Optional[str]
     additional_args: Tuple[str, ...]
+    # A human-readable description to use in the UI.  This field doesn't participate
+    # in comparison (and therefore hashing), as it doesn't affect the result.
+    description: Optional[str] = dataclasses.field(compare=False)
 
     def __init__(
         self,
@@ -210,6 +213,7 @@ class PexRequest:
         additional_inputs: Optional[Digest] = None,
         entry_point: Optional[str] = None,
         additional_args: Iterable[str] = (),
+        description: Optional[str] = None,
     ) -> None:
         self.output_filename = output_filename
         self.requirements = requirements
@@ -218,6 +222,7 @@ class PexRequest:
         self.additional_inputs = additional_inputs
         self.entry_point = entry_point
         self.additional_args = tuple(additional_args)
+        self.description = description
 
 
 @dataclass(frozen=True)
@@ -369,6 +374,12 @@ async def create_pex(
     # (execution_platform_constraint, target_platform_constraint) of this dictionary is "The output of
     # this command is intended for `target_platform_constraint` iff it is run on `execution_platform
     # constraint`".
+    description = request.description
+    if description is None:
+        if request.requirements.requirements:
+            description = f"Resolving {', '.join(request.requirements.requirements)}"
+        else:
+            description = f"Building PEX"
     execute_process_request = MultiPlatformExecuteProcessRequest(
         {
             (
@@ -380,7 +391,7 @@ async def create_pex(
                 pex_build_environment=pex_build_environment,
                 pex_args=argv,
                 input_files=merged_digest,
-                description=f"Resolving {', '.join(request.requirements.requirements)}",
+                description=description,
                 output_files=(request.output_filename,),
             )
         }
@@ -409,22 +420,27 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
     req_pex_name = "__requirements.pex"
 
     # Create a pex containing just the requirements.
-    requirements_pex_request = PexRequest(
-        output_filename=req_pex_name,
-        requirements=request.requirements,
-        interpreter_constraints=request.interpreter_constraints,
-        # TODO: Do we need to pass all the additional args to the requirements pex creation?
-        #  Some of them may affect resolution behavior, but others may be irrelevant.
-        #  For now we err on the side of caution.
-        additional_args=request.additional_args,
-    )
-    requirements_pex = await Get[Pex](PexRequest, requirements_pex_request)
+    if request.requirements.requirements:
+        requirements_pex_request = PexRequest(
+            output_filename=req_pex_name,
+            requirements=request.requirements,
+            interpreter_constraints=request.interpreter_constraints,
+            # TODO: Do we need to pass all the additional args to the requirements pex creation?
+            #  Some of them may affect resolution behavior, but others may be irrelevant.
+            #  For now we err on the side of caution.
+            additional_args=request.additional_args,
+            description=f"Resolving {', '.join(request.requirements.requirements)}",
+        )
+        requirements_pex = await Get[Pex](PexRequest, requirements_pex_request)
+        additional_inputs = requirements_pex.directory_digest
+    else:
+        additional_inputs = None
 
     # Now create a full pex on top of the requirements pex.
     full_pex_request = dataclasses.replace(
         request,
         requirements=PexRequirements(),
-        additional_inputs=requirements_pex.directory_digest,
+        additional_inputs=additional_inputs,
         additional_args=(*request.additional_args, f"--requirements-pex={req_pex_name}"),
     )
     full_pex = await Get[Pex](PexRequest, full_pex_request)

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import dataclasses
 from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
@@ -42,6 +42,9 @@ class PexFromTargetsRequest:
     include_source_files: bool
     additional_sources: Optional[Digest]
     additional_inputs: Optional[Digest]
+    # A human-readable description to use in the UI.  This field doesn't participate
+    # in comparison (and therefore hashing), as it doesn't affect the result.
+    description: Optional[str] = dataclasses.field(compare=False)
 
     def __init__(
         self,
@@ -53,7 +56,8 @@ class PexFromTargetsRequest:
         additional_requirements: Iterable[str] = (),
         include_source_files: bool = True,
         additional_sources: Optional[Digest] = None,
-        additional_inputs: Optional[Digest] = None
+        additional_inputs: Optional[Digest] = None,
+        description: Optional[str] = None
     ) -> None:
         self.addresses = addresses
         self.output_filename = output_filename
@@ -63,6 +67,7 @@ class PexFromTargetsRequest:
         self.include_source_files = include_source_files
         self.additional_sources = additional_sources
         self.additional_inputs = additional_inputs
+        self.description = description
 
 
 @dataclass(frozen=True)
@@ -127,6 +132,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         sources=merged_input_digest,
         additional_inputs=request.additional_inputs,
         additional_args=request.additional_args,
+        description=request.description,
     )
 
 

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -1,5 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import dataclasses
 from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -76,13 +76,15 @@ async def create_python_binary(config: PythonBinaryConfiguration) -> CreatedBina
         else:
             entry_point = None
 
+    output_filename = f"{config.address.target_name}.pex"
     two_step_pex = await Get[TwoStepPex](
         TwoStepPexFromTargetsRequest(
             PexFromTargetsRequest(
                 addresses=Addresses([config.address]),
                 entry_point=entry_point,
-                output_filename=f"{config.address.target_name}.pex",
+                output_filename=output_filename,
                 additional_args=config.generate_additional_args(),
+                description=f"Building {output_filename}",
             )
         )
     )


### PR DESCRIPTION
The description doesn't participate in caching, as it's
only used for UI purposes. It allows us to show a less generic
message to the end user.

If unspecified, we continue to use a sensible generic default.

[ci skip-rust-tests]
[ci skip-jvm-tests]
