### PR TITLE
More flexible binary and run rules.

### DIFF
--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -1,9 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
 from pathlib import PurePath
-from typing import Dict, Iterable, List, Type
 
 from pants.base.build_root import BuildRoot
 from pants.engine.console import Console
@@ -12,10 +10,14 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.rules import UnionMembership, goal_rule
 from pants.engine.selectors import Get
-from pants.engine.target import RegisteredTargetTypes, Target, Targets
+from pants.engine.target import RegisteredTargetTypes, TargetsWithOrigins
 from pants.option.custom_types import shell_str
 from pants.option.global_options import GlobalOptions
-from pants.rules.core.binary import BinaryConfiguration, CreatedBinary
+from pants.rules.core.binary import (
+    BinaryConfiguration,
+    CreatedBinary,
+    gather_valid_binary_configuration_types,
+)
 from pants.util.contextutil import temporary_dir
 
 
@@ -50,36 +52,20 @@ async def run(
     workspace: Workspace,
     runner: InteractiveRunner,
     build_root: BuildRoot,
-    targets: Targets,
+    targets_with_origins: TargetsWithOrigins,
     options: RunOptions,
     global_options: GlobalOptions,
     union_membership: UnionMembership,
     registered_target_types: RegisteredTargetTypes,
 ) -> Run:
-    config_types: Iterable[Type[BinaryConfiguration]] = union_membership.union_rules[
-        BinaryConfiguration
-    ]
-    valid_config_types_by_target: Dict[Target, List[Type[BinaryConfiguration]]] = {}
-    for target in targets:
-        for config_type in config_types:
-            if config_type.is_valid(target):
-                valid_config_types_by_target.setdefault(target, []).append(config_type)
+    valid_config_types_by_target = gather_valid_binary_configuration_types(
+        goal_subsytem=options,
+        targets_with_origins=targets_with_origins,
+        union_membership=union_membership,
+        registered_target_types=registered_target_types,
+    )
 
-    if not valid_config_types_by_target:
-        all_valid_target_types = itertools.chain.from_iterable(
-            config_type.valid_target_types(
-                registered_target_types.types, union_membership=union_membership
-            )
-            for config_type in config_types
-        )
-        valid_target_type_aliases = sorted(
-            target_type.alias for target_type in all_valid_target_types
-        )
-        raise ValueError(
-            f"The `run` goal only works with the following target types: "
-            f"{', '.join(valid_target_type_aliases)}\n\nYou used {target.address} with target type "
-            f"{target.alias}."
-        )
+    bulleted_list_sep = "\n  * "
 
     if len(valid_config_types_by_target) > 1:
         binary_target_addresses = sorted(
@@ -87,11 +73,12 @@ async def run(
         )
         raise ValueError(
             f"The `run` goal only works on one binary target but was given multiple targets that "
-            f"can produce a binary: {', '.join(binary_target_addresses)}\n\nPlease select one of "
-            f"these targets to run."
+            f"can produce a binary:"
+            f"{bulleted_list_sep}{bulleted_list_sep.join(binary_target_addresses)}\n\n"
+            f"Please select one of these targets to run."
         )
 
-    target, valid_config_types = valid_config_types_by_target.popitem()
+    target, valid_config_types = list(valid_config_types_by_target.items())[0]
     if len(valid_config_types) > 1:
         possible_config_types = sorted(config_type.__name__ for config_type in valid_config_types)
         # TODO: improve this error message. (It's never actually triggered yet because we only have
@@ -99,8 +86,9 @@ async def run(
         #  resolve the issue.
         raise ValueError(
             f"Multiple of the registered binary implementations work for {target.address} "
-            f"(target type {repr(target.alias)}). It is ambiguous which implementation to use. "
-            f"Possible implementations: {possible_config_types}."
+            f"(target type {repr(target.alias)}).\n\n"
+            f"It is ambiguous which implementation to use. Possible implementations:"
+            f"{bulleted_list_sep}{bulleted_list_sep.join(possible_config_types)}."
         )
     config_type = valid_config_types[0]
 

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -5,20 +5,21 @@ from typing import cast
 
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address
-from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
+from pants.engine.rules import UnionMembership
+from pants.engine.target import RegisteredTargetTypes, Target, Targets
 from pants.option.global_options import GlobalOptions
-from pants.rules.core.binary import CreatedBinary
-from pants.rules.core.run import Run, RunOptions, run
+from pants.rules.core.run import RunOptions
 from pants.testutil.engine.util import (
-    MockConsole,
-    MockGet,
     create_goal_subsystem,
     create_subsystem,
-    run_rule,
 )
+from pants.rules.core.binary import BinaryConfiguration, CreatedBinary
+from pants.rules.core.run import Run, run
+from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
+from pants.util.ordered_set import OrderedSet
 
 
 class RunTest(TestBase):
@@ -34,7 +35,14 @@ class RunTest(TestBase):
     ) -> Run:
         workspace = Workspace(self.scheduler)
         interactive_runner = InteractiveRunner(self.scheduler)
-        BuildRoot().path = self.build_root
+
+        class TestBinaryConfiguration(BinaryConfiguration):
+            required_fields = ()
+
+        class TestBinaryTarget(Target):
+            alias = "binary"
+            core_fields = ()
+
         res = run_rule(
             run,
             rule_args=[
@@ -42,14 +50,20 @@ class RunTest(TestBase):
                 workspace,
                 interactive_runner,
                 BuildRoot(),
-                Addresses([Address.parse(address_spec)]),
+                Targets(
+                    [TestBinaryTarget(unhydrated_values={}, address=Address.parse(address_spec))]
+                ),
                 create_goal_subsystem(RunOptions, args=[]),
                 create_subsystem(GlobalOptions, pants_workdir=self.pants_workdir),
+                UnionMembership(
+                    union_rules={BinaryConfiguration: OrderedSet([TestBinaryConfiguration])}
+                ),
+                RegisteredTargetTypes(aliases_to_types={TestBinaryTarget.alias: TestBinaryTarget}),
             ],
             mock_gets=[
                 MockGet(
                     product_type=CreatedBinary,
-                    subject_type=Address,
+                    subject_type=TestBinaryConfiguration,
                     mock=lambda _: self.create_mock_binary(program_text),
                 ),
             ],


### PR DESCRIPTION
Kill coordinator_of_binaries and implement binary and run validation
separately.

The `binary` goal now supports both globbing that includes targets that do not
produce a binary as well as production of multiple binaries per target.

The `run` goal now also supports globbing as long as exactly one of the globbed
targets can produce a binary.

[ci skip-rust-tests]
[ci skip-jvm-tests]