### PR TITLE
Only show executing processes in the v2 UI

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -47,6 +47,12 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   fn user_facing_name(&self) -> Option<String> {
     None
   }
+
+  /// Used to determine whether this Node is expected to run long enough for it to
+  /// be worthwhile to graph its running time.
+  fn long_running(&self) -> bool {
+    false
+  }
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -278,7 +278,7 @@ impl MultiPlatformExecuteProcessRequest {
       .0
       .iter()
       .next()
-      .map(|(_platforms, epr)| format!("Executing process: {}", epr.description))
+      .map(|(_platforms, epr)| epr.description.clone())
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1149,6 +1149,19 @@ impl Node for NodeKey {
       NodeKey::Select(..) => None,
     }
   }
+
+  fn long_running(&self) -> bool {
+    match self {
+      NodeKey::MultiPlatformExecuteProcess(_) => true,
+      NodeKey::Task(_) => false,
+      NodeKey::Snapshot(_) => false,
+      NodeKey::DigestFile(..) => false,
+      NodeKey::DownloadedFile(..) => false,
+      NodeKey::ReadLink(..) => false,
+      NodeKey::Scandir(..) => false,
+      NodeKey::Select(..) => false,
+    }
+  }
 }
 
 impl Display for NodeKey {


### PR DESCRIPTION
### Problem

The V2 UI previous to this commit worked by periodically iterating over every node in the currently-executing graph to grab the "heavy hitters" - i.e. the n nodes that have been running for the longest time without completing, where n is arbitrary-decided by Python code to be the number reported by Python `multiprocessing.cpu_count()`. This means that the V2 UI often displays the names of nodes that are not very useful for the end user to know what is currently going on in a given pants run.

### Solution

This commit adds a new method `long_running` on the `Node` trait, which is only implemented by `MultiProcessExecuteRequest` nodes. The `heavy_hitters` code that determines which node names to return to the V2 UI to display will filter based on this method, and so only end up printing process executions.

This commit also gets rid of the text "Executing process" from the beginning of the `user_facing_name`, since this adds little information and takes up valuable horizontal space in each line of the V2 UI swim lane display.
