### PR TITLE
Factor out a util function to parse a requirement constraint.

### DIFF
--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -13,14 +13,14 @@ from pants.backend.python.rules.pex import (
     PexRequest,
     PexRequirements,
 )
-from pants.backend.python.rules.setup_py_util import (
+from pants.backend.python.rules.setuptools import Setuptools
+from pants.backend.python.rules.util import (
     PackageDatum,
     distutils_repr,
     find_packages,
     is_python2,
     source_root_or_raise,
 )
-from pants.backend.python.rules.setuptools import Setuptools
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.base.specs import AddressSpecs, AscendantAddresses, SingleAddress
 from pants.build_graph.address import Address

--- a/src/python/pants/backend/python/rules/util_test.py
+++ b/src/python/pants/backend/python/rules/util_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.backend.python.rules.setup_py_util import (
+from pants.backend.python.rules.util import (
     declares_pkg_resources_namespace_package,
     distutils_repr,
     is_python2,

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -13,7 +13,7 @@ python_library(
     'src/python/pants/backend/native/tasks',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python/lint/isort',
-    'src/python/pants/backend/python/rules',  # For setup_py_util.py.
+    'src/python/pants/backend/python/rules',  # For util.py.
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks/coverage:plugin',

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -18,7 +18,7 @@ from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 from twitter.common.dirutil.chroot import Chroot
 
-from pants.backend.python.rules.setup_py_util import distutils_repr
+from pants.backend.python.rules.util import distutils_repr
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget


### PR DESCRIPTION
This function supports our shorthand for omitting the interpreter
type (e.g., '>=3.7' means 'CPython>=3.7').

We needed this functionality in a second place, and so it made
sense to factor it out.

Instead of creating a new util.py, this change renames the existing
setup_py_util.py. Some of its existing functions were more general
purpose than the name implied anyway.  This change then adds the
new function to this repurposed util.py, and calls it from the
original location and from the new consumer (which happens to be
some other function in util.py.)

[ci skip-rust-tests]
[ci skip-jvm-tests]
