### PR TITLE
Multiline V2 UI

### DIFF
--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -65,7 +65,7 @@ impl Session {
     should_report_workunits: bool,
   ) -> Session {
     let display = if should_render_ui && EngineDisplay::stdout_is_tty() {
-      let mut display = EngineDisplay::new(0);
+      let mut display = EngineDisplay::new();
       display.initialize(ui_worker_count);
       Some(Arc::new(Mutex::new(display)))
     } else {

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -37,7 +37,7 @@ use ui::EngineDisplay;
 // N.B. This is purely a demo/testing bin target for exercising the library.
 
 fn main() {
-  let mut display = EngineDisplay::new(0);
+  let mut display = EngineDisplay::new();
   display.start();
 
   let worker_ids = vec![


### PR DESCRIPTION
### Problem

In the v2 UI, we sometimes want to render running processes with long user-facing names. However, the UI currently only displays one process per line, and truncates all the text that won't fit on a line in the terminal.

### Solution

This commit modifies the v2 UI to split long lines across multiple lines in the console.

