### PR TITLE
Rename ExecuteProcessRequest to Process and ExecuteProcessResult to ProcessResult

### DIFF
--- a/src/docs/architecture_pantsd.md
+++ b/src/docs/architecture_pantsd.md
@@ -27,7 +27,7 @@ Initialization is encapsulated in the `PantsDaemon.Factory.create()` method.
 Pailgun
 -------
 
-The [Nailgun Protocol](http://www.martiansoftware.com/nailgun/protocol.html) is a protocol designed to allow clients to make command-line requests to a [Nailgun Server](http://www.martiansoftware.com/nailgun/index.html). It supports an interface similar to [`ExecuteProcessRequest`](https://github.com/pantsbuild/pants/blob/master/src/python/pants/engine/isolated_process.py#22), except for it having no concern about making operations hermetic, and the Nailgun Protocol supports streaming access to stdin/stdout. Pailgun is an extension of the Nailgun Protocol, which is clients use to ask the Pants Daemon to spawn pants invocations.
+The [Nailgun Protocol](http://www.martiansoftware.com/nailgun/protocol.html) is a protocol designed to allow clients to make command-line requests to a [Nailgun Server](http://www.martiansoftware.com/nailgun/index.html). It supports an interface similar to [`Process`](https://github.com/pantsbuild/pants/blob/master/src/python/pants/engine/isolated_process.py#22), except for it having no concern about making operations hermetic, and the Nailgun Protocol supports streaming access to stdin/stdout. Pailgun is an extension of the Nailgun Protocol, which is clients use to ask the Pants Daemon to spawn pants invocations.
 
 The protocol is subject to change slightly in [#6579](https://github.com/pantsbuild/pants/pull/6579).
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -30,7 +30,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ExecuteProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
@@ -85,7 +85,7 @@ async def create_python_awslambda(
         output_files=(pex_filename,),
         description=f"Run Lambdex for {config.address.reference()}",
     )
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, process_request)
+    result = await Get[ExecuteProcessResult](Process, process_request)
     return CreatedAWSLambda(digest=result.output_directory_digest, name=pex_filename)
 
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -30,7 +30,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.isolated_process import Process, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
@@ -85,7 +85,7 @@ async def create_python_awslambda(
         output_files=(pex_filename,),
         description=f"Run Lambdex for {config.address.reference()}",
     )
-    result = await Get[ExecuteProcessResult](Process, process_request)
+    result = await Get[ProcessResult](Process, process_request)
     return CreatedAWSLambda(digest=result.output_directory_digest, name=pex_filename)
 
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -76,7 +76,7 @@ async def create_python_awslambda(
 
     # NB: Lambdex modifies its input pex in-place, so the input file is also the output file.
     lambdex_args = ("build", "-e", config.handler.value, pex_filename)
-    process_request = lambdex_setup.requirements_pex.create_execute_request(
+    process = lambdex_setup.requirements_pex.create_execute_request(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./lambdex.pex",
@@ -85,7 +85,7 @@ async def create_python_awslambda(
         output_files=(pex_filename,),
         description=f"Run Lambdex for {config.address.reference()}",
     )
-    result = await Get[ProcessResult](Process, process_request)
+    result = await Get[ProcessResult](Process, process)
     return CreatedAWSLambda(digest=result.output_directory_digest, name=pex_filename)
 
 

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -6,7 +6,7 @@ import os
 from pants.backend.graph_info.subsystems.cloc_binary import ClocBinary
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import FilesContent, PathGlobs, PathGlobsAndRoot
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_dir
 
@@ -78,7 +78,7 @@ class CountLinesOfCode(ConsoleTask):
         )
 
         # The cloc script reaches into $PATH to look up perl. Let's assume it's in /usr/bin.
-        req = ExecuteProcessRequest(
+        req = Process(
             argv=cmd,
             input_files=directory_digest,
             output_files=("ignored", "report"),

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries.binary_tool import NativeTool
 from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.java.distribution.distribution import Distribution
 from pants.java.jar.jar_dependency import JarDependency
 from pants.util.dirutil import fast_relpath, safe_delete, safe_mkdir, safe_mkdir_for
@@ -352,7 +352,7 @@ class Zinc:
             + ["-cp", bootstrapper, Zinc.ZINC_BOOTSTRAPER_MAIN]
             + bootstrapper_args
         )
-        req = ExecuteProcessRequest(
+        req = Process(
             argv=argv,
             input_files=inputs_digest,
             output_files=(self._relative_to_buildroot(bridge_jar),),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -15,7 +15,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.fs import DirectoryToMaterialize
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.java.distribution.distribution import DistributionLocator
 from pants.util.dirutil import fast_relpath, safe_walk
 from pants.util.meta import classproperty
@@ -245,7 +245,7 @@ class JavacCompile(JvmCompile):
             if f.endswith(".java")
         )
 
-        exec_process_request = ExecuteProcessRequest(
+        exec_process_request = Process(
             argv=tuple(cmd),
             input_files=input_snapshot.directory_digest,
             output_files=output_files,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -245,14 +245,14 @@ class JavacCompile(JvmCompile):
             if f.endswith(".java")
         )
 
-        exec_process_request = Process(
+        process = Process(
             argv=tuple(cmd),
             input_files=input_snapshot.directory_digest,
             output_files=output_files,
             description=f"Compiling {ctx.target.address.spec} with javac",
         )
         exec_result = self.context.execute_process_synchronously_without_raising(
-            exec_process_request, "javac", (WorkUnitLabel.TASK, WorkUnitLabel.JVM),
+            process, "javac", (WorkUnitLabel.TASK, WorkUnitLabel.JVM),
         )
 
         # Dump the output to the .pants.d directory where it's expected by downstream tasks.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -27,7 +27,7 @@ from pants.engine.fs import (
     PathGlobs,
     PathGlobsAndRoot,
 )
-from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.task.scm_publish_mixin import Semver
@@ -54,7 +54,7 @@ def fast_relpath_collection(collection):
 
 
 def stdout_contents(wu):
-    if isinstance(wu, FallibleExecuteProcessResult):
+    if isinstance(wu, FallibleProcessResult):
         return wu.stdout.rstrip()
     with open(wu.output_paths()["stdout"]) as f:
         return f.read().rstrip()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -27,7 +27,7 @@ from pants.engine.fs import (
     PathGlobs,
     PathGlobsAndRoot,
 )
-from pants.engine.isolated_process import Process, FallibleProcessResult
+from pants.engine.isolated_process import FallibleProcessResult, Process
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.task.scm_publish_mixin import Semver

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -27,7 +27,7 @@ from pants.engine.fs import (
     PathGlobs,
     PathGlobsAndRoot,
 )
-from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.task.scm_publish_mixin import Semver
@@ -900,7 +900,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             + (argfile_snapshot.directory_digest,)
         )
 
-        epr = ExecuteProcessRequest(
+        epr = Process(
             argv=tuple(cmd),
             input_files=epr_input_files,
             output_files=(fast_relpath(ctx.rsc_jar_file.path, get_buildroot()),),
@@ -909,7 +909,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             description=f"run {tool_name} for {ctx.target}",
             # TODO: These should always be unicodes
             # Since this is always hermetic, we need to use `underlying.home` because
-            # ExecuteProcessRequest requires an existing, local jdk location.
+            # Process requires an existing, local jdk location.
             jdk_home=distribution.underlying_home,
             is_nailgunnable=True,
         )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -35,7 +35,7 @@ from pants.engine.fs import (
     PathGlobs,
     PathGlobsAndRoot,
 )
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath
 from pants.util.enums import match
@@ -749,7 +749,7 @@ class BaseZincCompile(JvmCompile):
         #   2) allow jars to be materialized at the end of the run.
         output_directories = () if self.get_options().use_classpath_jars else (classes_dir,)
 
-        req = ExecuteProcessRequest(
+        req = Process(
             argv=tuple(argv),
             input_files=merged_input_digest,
             output_files=(jar_file, relpath_to_analysis),
@@ -772,7 +772,7 @@ class BaseZincCompile(JvmCompile):
         return res.output_directory_digest
 
     def _compute_local_only_inputs(self, classes_dir, relpath_to_analysis, jar_file):
-        """Compute for the scratch inputs for ExecuteProcessRequest.
+        """Compute for the scratch inputs for Process.
 
         If analysis file exists, then incremental compile is enabled. Otherwise, the compile is not
         incremental, an empty digest will be returned.

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -115,7 +115,7 @@ async def bandit_lint(
         input_files=merged_input_files,
         description=f"Run Bandit for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](Process, request)
+    result = await Get[FallibleProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -116,7 +116,7 @@ async def bandit_lint(
         description=f"Run Bandit for {address_references}",
     )
     result = await Get[FallibleProcessResult](Process, request)
-    return LintResult.from_fallible_execute_process_result(result)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleProcessResult
+from pants.engine.isolated_process import FallibleProcessResult, Process
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -115,7 +115,7 @@ async def bandit_lint(
         input_files=merged_input_files,
         description=f"Run Bandit for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[FallibleExecuteProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
-    ExecuteProcessRequest,
+    Process,
     ExecuteProcessResult,
     FallibleExecuteProcessResult,
 )
@@ -50,7 +50,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: ExecuteProcessRequest
+    process_request: Process
 
 
 def generate_args(
@@ -154,7 +154,7 @@ async def black_fmt(formatter: BlackFormatter, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[ExecuteProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -163,7 +163,7 @@ async def black_lint(formatter: BlackFormatter, black: Black) -> LintResult:
     if black.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -18,11 +18,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import (
-    Process,
-    ProcessResult,
-    FallibleProcessResult,
-)
+from pants.engine.isolated_process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -20,8 +20,8 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
     Process,
-    ExecuteProcessResult,
-    FallibleExecuteProcessResult,
+    ProcessResult,
+    FallibleProcessResult,
 )
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -154,7 +154,7 @@ async def black_fmt(formatter: BlackFormatter, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](Process, setup.process_request)
+    result = await Get[ProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -163,7 +163,7 @@ async def black_lint(formatter: BlackFormatter, black: Black) -> LintResult:
     if black.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
+    result = await Get[FallibleProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -46,7 +46,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: Process
+    process: Process
 
 
 def generate_args(
@@ -129,7 +129,7 @@ async def setup(
         )
     )
 
-    process_request = requirements_pex.create_execute_request(
+    process = requirements_pex.create_execute_request(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./black.pex",
@@ -142,7 +142,7 @@ async def setup(
         output_files=all_source_files_snapshot.files,
         description=f"Run black for {address_references}",
     )
-    return Setup(process_request)
+    return Setup(process)
 
 
 @named_rule(desc="Format using Black")
@@ -150,8 +150,8 @@ async def black_fmt(formatter: BlackFormatter, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ProcessResult](Process, setup.process_request)
-    return FmtResult.from_execute_process_result(result)
+    result = await Get[ProcessResult](Process, setup.process)
+    return FmtResult.from_process_result(result)
 
 
 @named_rule(desc="Lint using Black")
@@ -159,8 +159,8 @@ async def black_lint(formatter: BlackFormatter, black: Black) -> LintResult:
     if black.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleProcessResult](Process, setup.process_request)
-    return LintResult.from_fallible_execute_process_result(result)
+    result = await Get[FallibleProcessResult](Process, setup.process)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -18,8 +18,8 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import (
     Process,
-    ExecuteProcessResult,
-    FallibleExecuteProcessResult,
+    ProcessResult,
+    FallibleProcessResult,
 )
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -133,7 +133,7 @@ async def docformatter_fmt(
     if docformatter.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](Process, setup.process_request)
+    result = await Get[ProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -144,7 +144,7 @@ async def docformatter_lint(
     if docformatter.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
+    result = await Get[FallibleProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -16,11 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.isolated_process import (
-    Process,
-    ProcessResult,
-    FallibleProcessResult,
-)
+from pants.engine.isolated_process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -43,7 +43,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: Process
+    process: Process
 
 
 def generate_args(
@@ -106,7 +106,7 @@ async def setup(
         )
     )
 
-    process_request = requirements_pex.create_execute_request(
+    process = requirements_pex.create_execute_request(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./docformatter.pex",
@@ -119,7 +119,7 @@ async def setup(
         output_files=all_source_files_snapshot.files,
         description=f"Run docformatter for {address_references}",
     )
-    return Setup(process_request)
+    return Setup(process)
 
 
 @named_rule(desc="Format Python docstrings with docformatter")
@@ -129,8 +129,8 @@ async def docformatter_fmt(
     if docformatter.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ProcessResult](Process, setup.process_request)
-    return FmtResult.from_execute_process_result(result)
+    result = await Get[ProcessResult](Process, setup.process)
+    return FmtResult.from_process_result(result)
 
 
 @named_rule(desc="Lint Python docstrings with docformatter")
@@ -140,8 +140,8 @@ async def docformatter_lint(
     if docformatter.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleProcessResult](Process, setup.process_request)
-    return LintResult.from_fallible_execute_process_result(result)
+    result = await Get[FallibleProcessResult](Process, setup.process)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import (
-    ExecuteProcessRequest,
+    Process,
     ExecuteProcessResult,
     FallibleExecuteProcessResult,
 )
@@ -47,7 +47,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: ExecuteProcessRequest
+    process_request: Process
 
 
 def generate_args(
@@ -133,7 +133,7 @@ async def docformatter_fmt(
     if docformatter.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[ExecuteProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -144,7 +144,7 @@ async def docformatter_lint(
     if docformatter.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -116,7 +116,7 @@ async def flake8_lint(
         description=f"Run Flake8 for {address_references}",
     )
     result = await Get[FallibleProcessResult](Process, request)
-    return LintResult.from_fallible_execute_process_result(result)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -115,7 +115,7 @@ async def flake8_lint(
         input_files=merged_input_files,
         description=f"Run Flake8 for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[FallibleExecuteProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleProcessResult
+from pants.engine.isolated_process import FallibleProcessResult, Process
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleProcessResult
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -115,7 +115,7 @@ async def flake8_lint(
         input_files=merged_input_files,
         description=f"Run Flake8 for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](Process, request)
+    result = await Get[FallibleProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -18,8 +18,8 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
     Process,
-    ExecuteProcessResult,
-    FallibleExecuteProcessResult,
+    ProcessResult,
+    FallibleProcessResult,
 )
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -147,7 +147,7 @@ async def isort_fmt(formatter: IsortFormatter, isort: Isort) -> FmtResult:
     if isort.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](Process, setup.process_request)
+    result = await Get[ProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -156,7 +156,7 @@ async def isort_lint(formatter: IsortFormatter, isort: Isort) -> LintResult:
     if isort.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
+    result = await Get[FallibleProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -16,11 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import (
-    Process,
-    ProcessResult,
-    FallibleProcessResult,
-)
+from pants.engine.isolated_process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.option.custom_types import GlobExpansionConjunction

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
-    ExecuteProcessRequest,
+    Process,
     ExecuteProcessResult,
     FallibleExecuteProcessResult,
 )
@@ -49,7 +49,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: ExecuteProcessRequest
+    process_request: Process
 
 
 def generate_args(
@@ -147,7 +147,7 @@ async def isort_fmt(formatter: IsortFormatter, isort: Isort) -> FmtResult:
     if isort.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[ExecuteProcessResult](Process, setup.process_request)
     return FmtResult.from_execute_process_result(result)
 
 
@@ -156,7 +156,7 @@ async def isort_lint(formatter: IsortFormatter, isort: Isort) -> LintResult:
     if isort.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, setup.process_request)
+    result = await Get[FallibleExecuteProcessResult](Process, setup.process_request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -45,7 +45,7 @@ class SetupRequest:
 
 @dataclass(frozen=True)
 class Setup:
-    process_request: Process
+    process: Process
 
 
 def generate_args(
@@ -122,7 +122,7 @@ async def setup(
         )
     )
 
-    process_request = requirements_pex.create_execute_request(
+    process = requirements_pex.create_execute_request(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./isort.pex",
@@ -135,7 +135,7 @@ async def setup(
         output_files=all_source_files_snapshot.files,
         description=f"Run isort for {address_references}",
     )
-    return Setup(process_request)
+    return Setup(process)
 
 
 @named_rule(desc="Format using isort")
@@ -143,8 +143,8 @@ async def isort_fmt(formatter: IsortFormatter, isort: Isort) -> FmtResult:
     if isort.options.skip:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=False))
-    result = await Get[ProcessResult](Process, setup.process_request)
-    return FmtResult.from_execute_process_result(result)
+    result = await Get[ProcessResult](Process, setup.process)
+    return FmtResult.from_process_result(result)
 
 
 @named_rule(desc="Lint using isort")
@@ -152,8 +152,8 @@ async def isort_lint(formatter: IsortFormatter, isort: Isort) -> LintResult:
     if isort.options.skip:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(formatter, check_only=True))
-    result = await Get[FallibleProcessResult](Process, setup.process_request)
-    return LintResult.from_fallible_execute_process_result(result)
+    result = await Get[FallibleProcessResult](Process, setup.process)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleProcessResult
+from pants.engine.isolated_process import FallibleProcessResult, Process
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleProcessResult
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -125,7 +125,7 @@ async def pylint_lint(
         input_files=merged_input_files,
         description=f"Run Pylint for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](Process, request)
+    result = await Get[FallibleProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -126,7 +126,7 @@ async def pylint_lint(
         description=f"Run Pylint for {address_references}",
     )
     result = await Get[FallibleProcessResult](Process, request)
-    return LintResult.from_fallible_execute_process_result(result)
+    return LintResult.from_fallible_process_result(result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
-from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -125,7 +125,7 @@ async def pylint_lint(
         input_files=merged_input_files,
         description=f"Run Pylint for {address_references}",
     )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[FallibleExecuteProcessResult](Process, request)
     return LintResult.from_fallible_execute_process_result(result)
 
 

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -10,7 +10,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.binaries.binary_tool import BinaryToolFetchRequest, Script, ToolForPlatform, ToolVersion
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.fs import Digest, SingleFileExecutable, Snapshot
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.engine.platform import PlatformConstraint
 from pants.engine.rules import rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -64,8 +64,8 @@ class DownloadedPexBin(HermeticPex):
         input_files: Optional[Digest] = None,
         env: Optional[Mapping[str, str]] = None,
         **kwargs: Any,
-    ) -> ExecuteProcessRequest:
-        """Creates an ExecuteProcessRequest that will run the pex CLI tool hermetically.
+    ) -> Process:
+        """Creates an Process that will run the pex CLI tool hermetically.
 
         :param python_setup: The parameters for selecting python interpreters to use when invoking
                              the pex tool.
@@ -79,7 +79,7 @@ class DownloadedPexBin(HermeticPex):
                             tool itself. To merge in additional files, include the
                             `directory_digest` in `DirectoriesToMerge` request.
         :param env: The environment to run the PEX in.
-        :param kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
+        :param kwargs: Any additional :class:`Process` kwargs to pass through.
         """
 
         env = dict(env) if env else {}

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, Mapping, Optional
 
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.engine.fs import Digest
-from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.isolated_process import Process
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import create_path_env_var
 
@@ -24,8 +24,8 @@ class HermeticPex:
         input_files: Digest,
         env: Optional[Mapping[str, str]] = None,
         **kwargs: Any
-    ) -> ExecuteProcessRequest:
-        """Creates an ExecuteProcessRequest that will run a PEX hermetically.
+    ) -> Process:
+        """Creates an Process that will run a PEX hermetically.
 
         :param python_setup: The parameters for selecting python interpreters to use when invoking
                              the PEX.
@@ -37,7 +37,7 @@ class HermeticPex:
         :param input_files: The files that contain the pex itself and any input files it needs to
                             run against.
         :param env: The environment to run the PEX in.
-        :param **kwargs: Any additional :class:`ExecuteProcessRequest` kwargs to pass through.
+        :param **kwargs: Any additional :class:`Process` kwargs to pass through.
         """
 
         # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
@@ -59,6 +59,6 @@ class HermeticPex:
         if env:
             hermetic_env.update(env)
 
-        return ExecuteProcessRequest(
+        return Process(
             argv=argv, input_files=input_files, description=description, env=hermetic_env, **kwargs
         )

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -28,7 +28,7 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
+from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformProcess
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
@@ -380,7 +380,7 @@ async def create_pex(
             description = f"Resolving {', '.join(request.requirements.requirements)}"
         else:
             description = f"Building PEX"
-    execute_process_request = MultiPlatformExecuteProcessRequest(
+    execute_process_request = MultiPlatformProcess(
         {
             (
                 PlatformConstraint(platform.value),
@@ -398,7 +398,7 @@ async def create_pex(
     )
 
     result = await Get[ExecuteProcessResult](
-        MultiPlatformExecuteProcessRequest, execute_process_request
+        MultiPlatformProcess, execute_process_request
     )
 
     if pex_debug.might_log:

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -28,7 +28,7 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.isolated_process import ProcessResult, MultiPlatformProcess
+from pants.engine.isolated_process import MultiPlatformProcess, ProcessResult
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
@@ -397,9 +397,7 @@ async def create_pex(
         }
     )
 
-    result = await Get[ProcessResult](
-        MultiPlatformProcess, execute_process_request
-    )
+    result = await Get[ProcessResult](MultiPlatformProcess, execute_process_request)
 
     if pex_debug.might_log:
         lines = result.stderr.decode().splitlines()

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -28,7 +28,7 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformProcess
+from pants.engine.isolated_process import ProcessResult, MultiPlatformProcess
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
@@ -397,7 +397,7 @@ async def create_pex(
         }
     )
 
-    result = await Get[ExecuteProcessResult](
+    result = await Get[ProcessResult](
         MultiPlatformProcess, execute_process_request
     )
 

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -380,7 +380,7 @@ async def create_pex(
             description = f"Resolving {', '.join(request.requirements.requirements)}"
         else:
             description = f"Building PEX"
-    execute_process_request = MultiPlatformProcess(
+    process = MultiPlatformProcess(
         {
             (
                 PlatformConstraint(platform.value),
@@ -397,12 +397,12 @@ async def create_pex(
         }
     )
 
-    result = await Get[ProcessResult](MultiPlatformProcess, execute_process_request)
+    result = await Get[ProcessResult](MultiPlatformProcess, process)
 
     if pex_debug.might_log:
         lines = result.stderr.decode().splitlines()
         if lines:
-            pex_debug.log(f"Debug output from Pex for: {execute_process_request}")
+            pex_debug.log(f"Debug output from Pex for: {process}")
             for line in lines:
                 pex_debug.log(line)
 

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -20,7 +20,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.pex import rules as pex_rules
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.engine.fs import Digest, DirectoryToMaterialize, FileContent, InputFilesContent
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ExecuteProcessResult
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.python.python_setup import PythonSetup
@@ -246,7 +246,7 @@ class PexTest(TestBase):
         python_setup = PythonSetup.global_instance()
         env = {"PATH": create_path_env_var(python_setup.interpreter_search_paths)}
 
-        req = ExecuteProcessRequest(
+        req = Process(
             argv=("python", "test.pex"),
             env=env,
             input_files=pex_output["pex"].directory_digest,

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -20,7 +20,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.pex import rules as pex_rules
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.engine.fs import Digest, DirectoryToMaterialize, FileContent, InputFilesContent
-from pants.engine.isolated_process import Process, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ProcessResult
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.python.python_setup import PythonSetup
@@ -252,7 +252,7 @@ class PexTest(TestBase):
             input_files=pex_output["pex"].directory_digest,
             description="Run the pex and make sure it works",
         )
-        result = self.request_single_product(ExecuteProcessResult, req)
+        result = self.request_single_product(ProcessResult, req)
         self.assertEqual(result.stdout, b"from main\n")
 
     def test_resolves_dependencies(self) -> None:

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -30,7 +30,7 @@ from pants.engine.fs import (
     FilesContent,
     InputFilesContent,
 )
-from pants.engine.isolated_process import Process, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.rules import RootRule, UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -315,7 +315,7 @@ async def merge_coverage_data(
         description=f"Merge coverage reports.",
     )
 
-    result = await Get[ExecuteProcessResult](Process, request)
+    result = await Get[ProcessResult](Process, request)
     return MergedCoverageData(coverage_data=result.output_directory_digest)
 
 
@@ -379,7 +379,7 @@ async def generate_coverage_report(
         description=f"Generate coverage report.",
     )
 
-    result = await Get[ExecuteProcessResult](Process, request)
+    result = await Get[ProcessResult](Process, request)
     if report_type == ReportType.CONSOLE:
         return ConsoleCoverageReport(result.stdout.decode())
 

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -30,7 +30,7 @@ from pants.engine.fs import (
     FilesContent,
     InputFilesContent,
 )
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
 from pants.engine.rules import RootRule, UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -315,7 +315,7 @@ async def merge_coverage_data(
         description=f"Merge coverage reports.",
     )
 
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[ExecuteProcessResult](Process, request)
     return MergedCoverageData(coverage_data=result.output_directory_digest)
 
 
@@ -379,7 +379,7 @@ async def generate_coverage_report(
         description=f"Generate coverage report.",
     )
 
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[ExecuteProcessResult](Process, request)
     if report_type == ReportType.CONSOLE:
         return ConsoleCoverageReport(result.stdout.decode())
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -32,7 +32,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge, InputFilesContent
 from pants.engine.interactive_runner import InteractiveProcessRequest
-from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -249,7 +249,7 @@ async def run_python_test(
         ),
         env=env,
     )
-    result = await Get[FallibleExecuteProcessResult](Process, request)
+    result = await Get[FallibleProcessResult](Process, request)
     coverage_data = PytestCoverageData(result.output_directory_digest) if run_coverage else None
     return TestResult.from_fallible_execute_process_result(result, coverage_data=coverage_data)
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -251,7 +251,7 @@ async def run_python_test(
     )
     result = await Get[FallibleProcessResult](Process, request)
     coverage_data = PytestCoverageData(result.output_directory_digest) if run_coverage else None
-    return TestResult.from_fallible_execute_process_result(result, coverage_data=coverage_data)
+    return TestResult.from_fallible_process_result(result, coverage_data=coverage_data)
 
 
 @named_rule(desc="Run pytest in an interactive process")

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -32,7 +32,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge, InputFilesContent
 from pants.engine.interactive_runner import InteractiveProcessRequest
-from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.isolated_process import Process, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
@@ -249,7 +249,7 @@ async def run_python_test(
         ),
         env=env,
     )
-    result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[FallibleExecuteProcessResult](Process, request)
     coverage_data = PytestCoverageData(result.output_directory_digest) if run_coverage else None
     return TestResult.from_fallible_execute_process_result(result, coverage_data=coverage_data)
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -32,7 +32,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge, InputFilesContent
 from pants.engine.interactive_runner import InteractiveProcessRequest
-from pants.engine.isolated_process import Process, FallibleProcessResult
+from pants.engine.isolated_process import FallibleProcessResult, Process
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -41,7 +41,7 @@ from pants.engine.fs import (
     Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ExecuteProcessResult
 from pants.engine.legacy.graph import (
     HydratedTarget,
     HydratedTargets,
@@ -376,7 +376,7 @@ async def run_setup_py(
         output_directories=(dist_dir,),
         description=f"Run setuptools for {req.exported_target.hydrated_target.adaptor.address.reference()}",
     )
-    result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+    result = await Get[ExecuteProcessResult](Process, request)
     output_digest = await Get[Digest](
         DirectoryWithPrefixToStrip(result.output_directory_digest, dist_dir)
     )

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -41,7 +41,7 @@ from pants.engine.fs import (
     Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import Process, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ProcessResult
 from pants.engine.legacy.graph import (
     HydratedTarget,
     HydratedTargets,
@@ -376,7 +376,7 @@ async def run_setup_py(
         output_directories=(dist_dir,),
         description=f"Run setuptools for {req.exported_target.hydrated_target.adaptor.address.reference()}",
     )
-    result = await Get[ExecuteProcessResult](Process, request)
+    result = await Get[ProcessResult](Process, request)
     output_digest = await Get[Digest](
         DirectoryWithPrefixToStrip(result.output_directory_digest, dist_dir)
     )

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -406,7 +406,7 @@ async def fetch_binary_tool(req: BinaryToolFetchRequest, url_set: BinaryToolUrlS
             f"urls for the request {req}"
         )
     # TODO: allow fetching a UrlToFetch with failure! Consider FallibleUrlToFetch analog to
-    # FallibleExecuteProcessResult!
+    # FallibleProcessResult!
     url_to_fetch = urls[0]
 
     return await Get[Snapshot](UrlToFetch(url_to_fetch, digest))

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -79,13 +79,10 @@ class MultiPlatformProcess:
     execute_process_requests: Tuple[Process, ...]
 
     def __init__(
-        self,
-        request_dict: Dict[Tuple[PlatformConstraint, PlatformConstraint], Process],
+        self, request_dict: Dict[Tuple[PlatformConstraint, PlatformConstraint], Process],
     ) -> None:
         if len(request_dict) == 0:
-            raise ValueError(
-                "At least one platform constrained Process must be passed."
-            )
+            raise ValueError("At least one platform constrained Process must be passed.")
         validated_constraints = tuple(
             constraint.value
             for pair in request_dict.keys()
@@ -174,21 +171,14 @@ stderr:
 
 
 @rule
-def get_multi_platform_request_description(
-    req: MultiPlatformProcess,
-) -> ProductDescription:
+def get_multi_platform_request_description(req: MultiPlatformProcess,) -> ProductDescription:
     return req.product_description
 
 
 @rule
-def upcast_execute_process_request(
-    req: Process,
-) -> MultiPlatformProcess:
-    """This rule allows an Process to be run as a platform compatible
-    MultiPlatformProcess."""
-    return MultiPlatformProcess(
-        {(PlatformConstraint.none, PlatformConstraint.none): req}
-    )
+def upcast_execute_process_request(req: Process,) -> MultiPlatformProcess:
+    """This rule allows an Process to be run as a platform compatible MultiPlatformProcess."""
+    return MultiPlatformProcess({(PlatformConstraint.none, PlatformConstraint.none): req})
 
 
 @rule
@@ -211,9 +201,7 @@ def fallible_to_exec_result_or_raise(
 
 
 @rule
-def remove_platform_information(
-    res: FallibleProcessResultWithPlatform,
-) -> FallibleProcessResult:
+def remove_platform_information(res: FallibleProcessResultWithPlatform,) -> FallibleProcessResult:
     return FallibleProcessResult(
         exit_code=res.exit_code,
         stdout=res.stdout,

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -109,7 +109,7 @@ class MultiPlatformProcess:
 
 
 @dataclass(frozen=True)
-class ExecuteProcessResult:
+class ProcessResult:
     """Result of successfully executing a process.
 
     Requesting one of these will raise an exception if the exit code is non-zero.
@@ -121,7 +121,7 @@ class ExecuteProcessResult:
 
 
 @dataclass(frozen=True)
-class FallibleExecuteProcessResult:
+class FallibleProcessResult:
     """Result of executing a process.
 
     Requesting one of these will not raise an exception if the exit code is non-zero.
@@ -134,7 +134,7 @@ class FallibleExecuteProcessResult:
 
 
 @dataclass(frozen=True)
-class FallibleExecuteProcessResultWithPlatform:
+class FallibleProcessResultWithPlatform:
     """Result of executing a process.
 
     Contains information about what platform a request ran on.
@@ -193,12 +193,12 @@ def upcast_execute_process_request(
 
 @rule
 def fallible_to_exec_result_or_raise(
-    fallible_result: FallibleExecuteProcessResult, description: ProductDescription
-) -> ExecuteProcessResult:
-    """Converts a FallibleExecuteProcessResult to a ExecuteProcessResult or raises an error."""
+    fallible_result: FallibleProcessResult, description: ProductDescription
+) -> ProcessResult:
+    """Converts a FallibleProcessResult to a ProcessResult or raises an error."""
 
     if fallible_result.exit_code == 0:
-        return ExecuteProcessResult(
+        return ProcessResult(
             fallible_result.stdout, fallible_result.stderr, fallible_result.output_directory_digest,
         )
     else:
@@ -212,9 +212,9 @@ def fallible_to_exec_result_or_raise(
 
 @rule
 def remove_platform_information(
-    res: FallibleExecuteProcessResultWithPlatform,
-) -> FallibleExecuteProcessResult:
-    return FallibleExecuteProcessResult(
+    res: FallibleProcessResultWithPlatform,
+) -> FallibleProcessResult:
+    return FallibleProcessResult(
         exit_code=res.exit_code,
         stdout=res.stdout,
         stderr=res.stderr,

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -33,10 +33,7 @@ from pants.engine.fs import (
     UrlToFetch,
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
-from pants.engine.isolated_process import (
-    FallibleProcessResultWithPlatform,
-    MultiPlatformProcess,
-)
+from pants.engine.isolated_process import FallibleProcessResultWithPlatform, MultiPlatformProcess
 from pants.engine.objects import union
 from pants.engine.platform import Platform
 from pants.engine.selectors import Get

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -34,7 +34,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.isolated_process import (
-    FallibleExecuteProcessResultWithPlatform,
+    FallibleProcessResultWithPlatform,
     MultiPlatformProcess,
 )
 from pants.engine.objects import union
@@ -951,7 +951,7 @@ class Native(metaclass=SingletonMetaclass):
             construct_file_content=func(FileContent),
             construct_files_content=func(FilesContent),
             files_content=ti(FilesContent),
-            construct_process_result=func(FallibleExecuteProcessResultWithPlatform),
+            construct_process_result=func(FallibleProcessResultWithPlatform),
             construct_materialize_directories_results=func(MaterializeDirectoriesResult),
             construct_materialize_directory_result=func(MaterializeDirectoryResult),
             address=ti(Address),
@@ -965,7 +965,7 @@ class Native(metaclass=SingletonMetaclass):
             link=ti(Link),
             platform=ti(Platform),
             multi_platform_process_request=ti(MultiPlatformProcess),
-            process_result=ti(FallibleExecuteProcessResultWithPlatform),
+            process_result=ti(FallibleProcessResultWithPlatform),
             coroutine=ti(CoroutineType),
             url_to_fetch=ti(UrlToFetch),
             string=ti(str),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -577,14 +577,14 @@ class EngineTypes(NamedTuple):
     file: TypeId
     link: TypeId
     platform: TypeId
-    multi_platform_process_request: TypeId
+    multi_platform_process: TypeId
     process_result: TypeId
     coroutine: TypeId
     url_to_fetch: TypeId
     string: TypeId
     bytes: TypeId
     construct_interactive_process_result: Function
-    interactive_process_request: TypeId
+    interactive_process: TypeId
     interactive_process_result: TypeId
     snapshot_subset: TypeId
     construct_platform: Function
@@ -961,14 +961,14 @@ class Native(metaclass=SingletonMetaclass):
             file=ti(File),
             link=ti(Link),
             platform=ti(Platform),
-            multi_platform_process_request=ti(MultiPlatformProcess),
+            multi_platform_process=ti(MultiPlatformProcess),
             process_result=ti(FallibleProcessResultWithPlatform),
             coroutine=ti(CoroutineType),
             url_to_fetch=ti(UrlToFetch),
             string=ti(str),
             bytes=ti(bytes),
             construct_interactive_process_result=func(InteractiveProcessResult),
-            interactive_process_request=ti(InteractiveProcessRequest),
+            interactive_process=ti(InteractiveProcessRequest),
             interactive_process_result=ti(InteractiveProcessResult),
             snapshot_subset=ti(SnapshotSubset),
             construct_platform=func(Platform),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -35,7 +35,7 @@ from pants.engine.fs import (
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.isolated_process import (
     FallibleExecuteProcessResultWithPlatform,
-    MultiPlatformExecuteProcessRequest,
+    MultiPlatformProcess,
 )
 from pants.engine.objects import union
 from pants.engine.platform import Platform
@@ -964,7 +964,7 @@ class Native(metaclass=SingletonMetaclass):
             file=ti(File),
             link=ti(Link),
             platform=ti(Platform),
-            multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
+            multi_platform_process_request=ti(MultiPlatformProcess),
             process_result=ti(FallibleExecuteProcessResultWithPlatform),
             coroutine=ti(CoroutineType),
             url_to_fetch=ti(UrlToFetch),

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -4,7 +4,7 @@
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
 from pants.engine.isolated_process import (
     Process,
-    FallibleExecuteProcessResultWithPlatform,
+    FallibleProcessResultWithPlatform,
 )
 from pants.engine.platform import Platform
 from pants.testutil.test_base import TestBase
@@ -20,6 +20,6 @@ class PlatformTest(TestBase):
             input_files=EMPTY_DIRECTORY_DIGEST,
             description="Run some program that will exit cleanly.",
         )
-        result = self.request_single_product(FallibleExecuteProcessResultWithPlatform, req)
+        result = self.request_single_product(FallibleProcessResultWithPlatform, req)
         assert result.exit_code == 0
         assert result.platform == this_platform

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -2,10 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
-from pants.engine.isolated_process import (
-    Process,
-    FallibleProcessResultWithPlatform,
-)
+from pants.engine.isolated_process import FallibleProcessResultWithPlatform, Process
 from pants.engine.platform import Platform
 from pants.testutil.test_base import TestBase
 

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -3,7 +3,7 @@
 
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
 from pants.engine.isolated_process import (
-    ExecuteProcessRequest,
+    Process,
     FallibleExecuteProcessResultWithPlatform,
 )
 from pants.engine.platform import Platform
@@ -15,7 +15,7 @@ class PlatformTest(TestBase):
 
         this_platform = Platform.current
 
-        req = ExecuteProcessRequest(
+        req = Process(
             argv=("/bin/echo", "test"),
             input_files=EMPTY_DIRECTORY_DIGEST,
             description="Run some program that will exit cleanly.",

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -408,7 +408,7 @@ class Context:
     ):
         """Executes a process (possibly remotely), and returns information about its output.
 
-        :param execute_process_request: The ExecuteProcessRequest to run.
+        :param execute_process_request: The Process to run.
         :param name: A descriptive name representing the process being executed.
         :param labels: A tuple of WorkUnitLabels.
         :return: An ExecuteProcessResult with information about the execution.

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -12,7 +12,7 @@ from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.engine.isolated_process import (
-    FallibleExecuteProcessResult,
+    FallibleProcessResult,
     ProductDescription,
     fallible_to_exec_result_or_raise,
 )
@@ -411,7 +411,7 @@ class Context:
         :param execute_process_request: The Process to run.
         :param name: A descriptive name representing the process being executed.
         :param labels: A tuple of WorkUnitLabels.
-        :return: An ExecuteProcessResult with information about the execution.
+        :return: An ProcessResult with information about the execution.
 
         Note that this is an unstable, experimental API, which is subject to change with no notice.
         """
@@ -419,7 +419,7 @@ class Context:
             name=name, labels=labels, cmd=" ".join(execute_process_request.argv),
         ) as workunit:
             result = self._scheduler.product_request(
-                FallibleExecuteProcessResult, [execute_process_request]
+                FallibleProcessResult, [execute_process_request]
             )[0]
             workunit.output("stdout").write(result.stdout)
             workunit.output("stderr").write(result.stderr)

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -403,37 +403,29 @@ class Context:
             build_graph.inject_address_closure(address)
         return build_graph
 
-    def execute_process_synchronously_without_raising(
-        self, execute_process_request, name, labels=None
-    ):
+    def execute_process_synchronously_without_raising(self, process, name, labels=None):
         """Executes a process (possibly remotely), and returns information about its output.
 
-        :param execute_process_request: The Process to run.
+        :param process: The Process to run.
         :param name: A descriptive name representing the process being executed.
         :param labels: A tuple of WorkUnitLabels.
         :return: An ProcessResult with information about the execution.
 
         Note that this is an unstable, experimental API, which is subject to change with no notice.
         """
-        with self.new_workunit(
-            name=name, labels=labels, cmd=" ".join(execute_process_request.argv),
-        ) as workunit:
-            result = self._scheduler.product_request(
-                FallibleProcessResult, [execute_process_request]
-            )[0]
+        with self.new_workunit(name=name, labels=labels, cmd=" ".join(process.argv),) as workunit:
+            result = self._scheduler.product_request(FallibleProcessResult, [process])[0]
             workunit.output("stdout").write(result.stdout)
             workunit.output("stderr").write(result.stderr)
             workunit.set_outcome(WorkUnit.FAILURE if result.exit_code else WorkUnit.SUCCESS)
             return result
 
-    def execute_process_synchronously_or_raise(self, execute_process_request, name, labels=None):
+    def execute_process_synchronously_or_raise(self, process, name, labels=None):
         """Execute process synchronously, and throw if the return code is not 0.
 
         See execute_process_synchronously for the api docs.
         """
-        fallible_result = self.execute_process_synchronously_without_raising(
-            execute_process_request, name, labels
-        )
+        fallible_result = self.execute_process_synchronously_without_raising(process, name, labels)
         return fallible_to_exec_result_or_raise(
-            fallible_result, ProductDescription(execute_process_request.description)
+            fallible_result, ProductDescription(process.description)
         )

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -17,7 +17,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import Process, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ProcessResult
 from pants.engine.legacy.graph import SourcesSnapshots
 from pants.engine.rules import goal_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -113,7 +113,7 @@ async def run_cloc(
         description="cloc",
     )
 
-    exec_result = await Get[ExecuteProcessResult](Process, req)
+    exec_result = await Get[ProcessResult](Process, req)
     files_content = await Get[FilesContent](Digest, exec_result.output_directory_digest)
 
     file_outputs = {fc.path: fc.content.decode() for fc in files_content}

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -17,7 +17,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import Process, ExecuteProcessResult
 from pants.engine.legacy.graph import SourcesSnapshots
 from pants.engine.rules import goal_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -106,14 +106,14 @@ async def run_cloc(
         f"--report-file={report_filename}",  # Write the output to this file rather than stdout.
         f"--list-file={input_files_filename}",  # Read an exhaustive list of files to process from this file.
     )
-    req = ExecuteProcessRequest(
+    req = Process(
         argv=cmd,
         input_files=digest,
         output_files=(report_filename, ignore_filename),
         description="cloc",
     )
 
-    exec_result = await Get[ExecuteProcessResult](ExecuteProcessRequest, req)
+    exec_result = await Get[ExecuteProcessResult](Process, req)
     files_content = await Get[FilesContent](Digest, exec_result.output_directory_digest)
 
     file_outputs = {fc.path: fc.content.decode() for fc in files_content}

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -35,7 +35,7 @@ class FmtResult:
         return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="")
 
     @staticmethod
-    def from_execute_process_result(process_result: ProcessResult) -> "FmtResult":
+    def from_process_result(process_result: ProcessResult) -> "FmtResult":
         return FmtResult(
             digest=process_result.output_directory_digest,
             stdout=process_result.stdout.decode(),

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -15,7 +15,7 @@ from pants.engine.fs import (
     Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import ExecuteProcessResult
+from pants.engine.isolated_process import ProcessResult
 from pants.engine.legacy.graph import HydratedTargetsWithOrigins
 from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
@@ -35,7 +35,7 @@ class FmtResult:
         return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="")
 
     @staticmethod
-    def from_execute_process_result(process_result: ExecuteProcessResult) -> "FmtResult":
+    def from_execute_process_result(process_result: ProcessResult) -> "FmtResult":
         return FmtResult(
             digest=process_result.output_directory_digest,
             stdout=process_result.stdout.decode(),

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -179,7 +179,7 @@ async def fmt(
             console.print_stderr(result.stderr)
 
     # Since the rules to produce FmtResult should use ExecuteRequest, rather than
-    # FallibleExecuteProcessRequest, we assume that there were no failures.
+    # FallibleProcess, we assume that there were no failures.
     return Fmt(exit_code=0)
 
 

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -26,9 +26,7 @@ class LintResult:
         return LintResult(exit_code=0, stdout="", stderr="")
 
     @staticmethod
-    def from_fallible_execute_process_result(
-        process_result: FallibleProcessResult,
-    ) -> "LintResult":
+    def from_fallible_process_result(process_result: FallibleProcessResult,) -> "LintResult":
         return LintResult(
             exit_code=process_result.exit_code,
             stdout=process_result.stdout.decode(),

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -7,7 +7,7 @@ from typing import Iterable, Tuple, Type
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import FallibleExecuteProcessResult
+from pants.engine.isolated_process import FallibleProcessResult
 from pants.engine.legacy.graph import HydratedTargetsWithOrigins
 from pants.engine.legacy.structs import TargetAdaptorWithOrigin
 from pants.engine.objects import union
@@ -27,7 +27,7 @@ class LintResult:
 
     @staticmethod
     def from_fallible_execute_process_result(
-        process_result: FallibleExecuteProcessResult,
+        process_result: FallibleProcessResult,
     ) -> "LintResult":
         return LintResult(
             exit_code=process_result.exit_code,

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -54,9 +54,7 @@ class TestResult:
 
     @staticmethod
     def from_fallible_execute_process_result(
-        process_result: FallibleProcessResult,
-        *,
-        coverage_data: Optional["CoverageData"] = None,
+        process_result: FallibleProcessResult, *, coverage_data: Optional["CoverageData"] = None,
     ) -> "TestResult":
         return TestResult(
             status=Status.SUCCESS if process_result.exit_code == 0 else Status.FAILURE,

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -18,7 +18,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
-from pants.engine.isolated_process import FallibleExecuteProcessResult
+from pants.engine.isolated_process import FallibleProcessResult
 from pants.engine.objects import union
 from pants.engine.rules import UnionMembership, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -54,7 +54,7 @@ class TestResult:
 
     @staticmethod
     def from_fallible_execute_process_result(
-        process_result: FallibleExecuteProcessResult,
+        process_result: FallibleProcessResult,
         *,
         coverage_data: Optional["CoverageData"] = None,
     ) -> "TestResult":

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -53,7 +53,7 @@ class TestResult:
     __test__ = False
 
     @staticmethod
-    def from_fallible_execute_process_result(
+    def from_fallible_process_result(
         process_result: FallibleProcessResult, *, coverage_data: Optional["CoverageData"] = None,
     ) -> "TestResult":
         return TestResult(

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
   Context, Process, ProcessMetadata,
-  FallibleExecuteProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
 };
 use std::sync::Arc;
 
@@ -62,7 +62,7 @@ impl crate::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let digest = crate::digest(req.clone(), &self.metadata);
     let key = digest.0;
 
@@ -108,7 +108,7 @@ impl CommandRunner {
   fn lookup(
     &self,
     fingerprint: Fingerprint,
-  ) -> impl Future<Item = Option<FallibleExecuteProcessResultWithPlatform>, Error = String> {
+  ) -> impl Future<Item = Option<FallibleProcessResultWithPlatform>, Error = String> {
     use bazel_protos::remote_execution::ExecuteResponse;
     let file_store = self.file_store.clone();
 
@@ -151,7 +151,7 @@ impl CommandRunner {
   fn store(
     &self,
     fingerprint: Fingerprint,
-    result: &FallibleExecuteProcessResultWithPlatform,
+    result: &FallibleProcessResultWithPlatform,
   ) -> impl Future<Item = (), Error = String> {
     let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
     execute_response.set_cached_result(true);

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
-  Context, Process, ProcessMetadata,
-  FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, Process,
+  ProcessMetadata,
 };
 use std::sync::Arc;
 
@@ -50,10 +50,7 @@ impl CommandRunner {
 }
 
 impl crate::CommandRunner for CommandRunner {
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     self.underlying.extract_compatible_request(req)
   }
 

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -1,6 +1,6 @@
 use crate::{
-  Context, ExecuteProcessRequest, ExecuteProcessRequestMetadata,
-  FallibleExecuteProcessResultWithPlatform, MultiPlatformExecuteProcessRequest, Platform,
+  Context, Process, ProcessMetadata,
+  FallibleExecuteProcessResultWithPlatform, MultiPlatformProcess, Platform,
 };
 use std::sync::Arc;
 
@@ -30,7 +30,7 @@ pub struct CommandRunner {
   underlying: Arc<dyn crate::CommandRunner>,
   process_execution_store: ShardedLmdb,
   file_store: Store,
-  metadata: ExecuteProcessRequestMetadata,
+  metadata: ProcessMetadata,
 }
 
 impl CommandRunner {
@@ -38,7 +38,7 @@ impl CommandRunner {
     underlying: Arc<dyn crate::CommandRunner>,
     process_execution_store: ShardedLmdb,
     file_store: Store,
-    metadata: ExecuteProcessRequestMetadata,
+    metadata: ProcessMetadata,
   ) -> CommandRunner {
     CommandRunner {
       underlying,
@@ -52,15 +52,15 @@ impl CommandRunner {
 impl crate::CommandRunner for CommandRunner {
   fn extract_compatible_request(
     &self,
-    req: &MultiPlatformExecuteProcessRequest,
-  ) -> Option<ExecuteProcessRequest> {
+    req: &MultiPlatformProcess,
+  ) -> Option<Process> {
     self.underlying.extract_compatible_request(req)
   }
 
   // TODO: Maybe record WorkUnits for local cache checks.
   fn run(
     &self,
-    req: MultiPlatformExecuteProcessRequest,
+    req: MultiPlatformProcess,
     context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let digest = crate::digest(req.clone(), &self.metadata);

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, Process,
-  ProcessMetadata, FallibleProcessResultWithPlatform, PlatformConstraint,
+  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
+  PlatformConstraint, Process, ProcessMetadata,
 };
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  ExecuteProcessRequestMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
+  CommandRunner as CommandRunnerTrait, Context, Process,
+  ProcessMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
 };
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
@@ -45,7 +45,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     })
     .unwrap();
 
-  let request = ExecuteProcessRequest {
+  let request = Process {
     argv: vec![
       testutil::path::find_bash(),
       format!("{}", script_path.display()),
@@ -75,7 +75,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   let process_execution_store =
     ShardedLmdb::new(cache_dir.path().to_owned(), max_lmdb_size, runtime.clone()).unwrap();
 
-  let metadata = ExecuteProcessRequestMetadata {
+  let metadata = ProcessMetadata {
     instance_name: None,
     cache_key_gen_version: None,
     platform_properties: vec![],

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, Process,
-  ProcessMetadata, FallibleExecuteProcessResultWithPlatform, PlatformConstraint,
+  ProcessMetadata, FallibleProcessResultWithPlatform, PlatformConstraint,
 };
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
@@ -16,8 +16,8 @@ use testutil::data::TestData;
 use tokio::runtime::Handle;
 
 struct RoundtripResults {
-  uncached: Result<FallibleExecuteProcessResultWithPlatform, String>,
-  maybe_cached: Result<FallibleExecuteProcessResultWithPlatform, String>,
+  uncached: Result<FallibleProcessResultWithPlatform, String>,
+  maybe_cached: Result<FallibleProcessResultWithPlatform, String>,
 }
 
 async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -308,7 +308,7 @@ pub struct ProcessMetadata {
 /// The result of running a process.
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FallibleExecuteProcessResultWithPlatform {
+pub struct FallibleProcessResultWithPlatform {
   pub stdout: Bytes,
   pub stderr: Bytes,
   pub exit_code: i32,
@@ -322,7 +322,7 @@ pub struct FallibleExecuteProcessResultWithPlatform {
 }
 
 #[cfg(test)]
-impl FallibleExecuteProcessResultWithPlatform {
+impl FallibleProcessResultWithPlatform {
   pub fn without_execution_attempts(mut self) -> Self {
     self.execution_attempts = vec![];
     self
@@ -364,7 +364,7 @@ pub trait CommandRunner: Send + Sync {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String>;
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String>;
 
   ///
   /// Given a multi platform request which may have some platform
@@ -430,7 +430,7 @@ impl CommandRunner for BoundedCommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let inner = self.inner.clone();
     self
       .inner

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -268,9 +268,7 @@ impl TryFrom<MultiPlatformProcess> for Process {
 /// A container of platform constrained processes.
 ///
 #[derive(Derivative, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct MultiPlatformProcess(
-  pub BTreeMap<(PlatformConstraint, PlatformConstraint), Process>,
-);
+pub struct MultiPlatformProcess(pub BTreeMap<(PlatformConstraint, PlatformConstraint), Process>);
 
 impl MultiPlatformProcess {
   pub fn user_facing_name(&self) -> Option<String> {
@@ -372,10 +370,7 @@ pub trait CommandRunner: Send + Sync {
   /// with the current command runners platform configuration. If so return the
   /// first candidate that will be run if the multi platform request is submitted to
   /// `fn run(..)`
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process>;
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process>;
 
   fn num_waiters(&self) -> usize {
     panic!("This method is abstract and not implemented for this type")
@@ -383,10 +378,7 @@ pub trait CommandRunner: Send + Sync {
 }
 
 // TODO(#8513) possibly move to the MEPR struct, or to the hashing crate?
-pub fn digest(
-  req: MultiPlatformProcess,
-  metadata: &ProcessMetadata,
-) -> Digest {
+pub fn digest(req: MultiPlatformProcess, metadata: &ProcessMetadata) -> Digest {
   let mut hashes: Vec<String> = req
     .0
     .values()
@@ -442,10 +434,7 @@ impl CommandRunner for BoundedCommandRunner {
       .to_boxed()
   }
 
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     self.inner.0.extract_compatible_request(&req)
   }
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -24,8 +24,8 @@ use tokio::time::timeout;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::{
-  Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
-  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
+  Context, Process, FallibleExecuteProcessResultWithPlatform,
+  MultiPlatformProcess, Platform, PlatformConstraint,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -222,8 +222,8 @@ impl ChildResults {
 impl super::CommandRunner for CommandRunner {
   fn extract_compatible_request(
     &self,
-    req: &MultiPlatformExecuteProcessRequest,
-  ) -> Option<ExecuteProcessRequest> {
+    req: &MultiPlatformProcess,
+  ) -> Option<Process> {
     for compatible_constraint in vec![
       &(PlatformConstraint::None, PlatformConstraint::None),
       &(self.platform.into(), PlatformConstraint::None),
@@ -248,7 +248,7 @@ impl super::CommandRunner for CommandRunner {
   ///
   fn run(
     &self,
-    req: MultiPlatformExecuteProcessRequest,
+    req: MultiPlatformProcess,
     context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let req = self.extract_compatible_request(&req).unwrap();
@@ -267,7 +267,7 @@ impl CapturedWorkdir for CommandRunner {
   fn run_in_workdir<'a, 'b, 'c>(
     &'a self,
     workdir_path: &'b Path,
-    req: ExecuteProcessRequest,
+    req: Process,
     _context: Context,
   ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String> {
     StreamedHermeticCommand::new(&req.argv[0])
@@ -285,7 +285,7 @@ impl CapturedWorkdir for CommandRunner {
 pub trait CapturedWorkdir {
   fn run_and_capture_workdir(
     &self,
-    req: ExecuteProcessRequest,
+    req: Process,
     context: Context,
     store: Store,
     executor: task_executor::Executor,
@@ -454,7 +454,7 @@ pub trait CapturedWorkdir {
   fn run_in_workdir<'a, 'b, 'c>(
     &'a self,
     workdir_path: &'b Path,
-    req: ExecuteProcessRequest,
+    req: Process,
     context: Context,
   ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String>;
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -422,7 +422,7 @@ pub trait CapturedWorkdir {
           );
         } // Else, workdir gets dropped here
         match result {
-          Ok(fallible_execute_process_result) => Ok(fallible_execute_process_result),
+          Ok(fallible_process_result) => Ok(fallible_process_result),
           Err(msg) => {
             if msg == "deadline has elapsed" {
               Ok(FallibleProcessResultWithPlatform {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -24,7 +24,7 @@ use tokio::time::timeout;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::{
-  Context, Process, FallibleExecuteProcessResultWithPlatform,
+  Context, Process, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, PlatformConstraint,
 };
 
@@ -250,7 +250,7 @@ impl super::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let req = self.extract_compatible_request(&req).unwrap();
     self.run_and_capture_workdir(
       req,
@@ -292,7 +292,7 @@ pub trait CapturedWorkdir {
     cleanup_local_dirs: bool,
     workdir_base: &Path,
     platform: Platform,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String>
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String>
   where
     Self: Send + Sync + Clone + 'static,
   {
@@ -403,7 +403,7 @@ pub trait CapturedWorkdir {
         };
 
         output_snapshot
-          .map(move |snapshot| FallibleExecuteProcessResultWithPlatform {
+          .map(move |snapshot| FallibleProcessResultWithPlatform {
             stdout: child_results.stdout,
             stderr: child_results.stderr,
             exit_code: child_results.exit_code,
@@ -428,7 +428,7 @@ pub trait CapturedWorkdir {
           Ok(fallible_execute_process_result) => Ok(fallible_execute_process_result),
           Err(msg) => {
             if msg == "deadline has elapsed" {
-              Ok(FallibleExecuteProcessResultWithPlatform {
+              Ok(FallibleProcessResultWithPlatform {
                 stdout: Bytes::from(format!(
                   "Exceeded timeout of {:?} for local process execution, {}",
                   req_timeout, req_description

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -24,8 +24,8 @@ use tokio::time::timeout;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::{
-  Context, Process, FallibleProcessResultWithPlatform,
-  MultiPlatformProcess, Platform, PlatformConstraint,
+  Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, PlatformConstraint,
+  Process,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -220,10 +220,7 @@ impl ChildResults {
 }
 
 impl super::CommandRunner for CommandRunner {
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     for compatible_constraint in vec![
       &(PlatformConstraint::None, PlatformConstraint::None),
       &(self.platform.into(), PlatformConstraint::None),

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -2,8 +2,8 @@ use tempfile;
 use testutil;
 
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, Process,
-  FallibleProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
+  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, Platform,
+  PlatformConstraint, Process, RelativePath,
 };
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
@@ -795,9 +795,7 @@ async fn working_directory() {
   );
 }
 
-async fn run_command_locally(
-  req: Process,
-) -> Result<FallibleProcessResultWithPlatform, String> {
+async fn run_command_locally(req: Process) -> Result<FallibleProcessResultWithPlatform, String> {
   let work_dir = TempDir::new().unwrap();
   run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned()).await
 }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, Process,
-  FallibleExecuteProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
+  FallibleProcessResultWithPlatform, Platform, PlatformConstraint, RelativePath,
 };
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
@@ -40,7 +40,7 @@ async fn stdout() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -72,7 +72,7 @@ async fn stdout_and_stderr_and_exit_code() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes("bar"),
       exit_code: 1,
@@ -105,7 +105,7 @@ async fn capture_exit_code_signal() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: -15,
@@ -225,7 +225,7 @@ async fn output_files_none() {
   .await;
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -260,7 +260,7 @@ async fn output_files_one() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -300,7 +300,7 @@ async fn output_dirs() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -341,7 +341,7 @@ async fn output_files_many() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -380,7 +380,7 @@ async fn output_files_execution_failure() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 1,
@@ -417,7 +417,7 @@ async fn output_files_partial_output() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -452,7 +452,7 @@ async fn output_overlapping_file_and_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -486,7 +486,7 @@ async fn jdk_symlink() {
   .await;
   assert_eq!(
     result,
-    Ok(FallibleExecuteProcessResultWithPlatform {
+    Ok(FallibleProcessResultWithPlatform {
       stdout: roland,
       stderr: as_bytes(""),
       exit_code: 0,
@@ -606,7 +606,7 @@ async fn all_containing_directories_for_outputs_are_created() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -641,7 +641,7 @@ async fn output_empty_dir() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -698,7 +698,7 @@ async fn local_only_scratch_files_materialized() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes(""),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -784,7 +784,7 @@ async fn working_directory() {
 
   assert_eq!(
     result.unwrap(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("roland\n"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -797,7 +797,7 @@ async fn working_directory() {
 
 async fn run_command_locally(
   req: Process,
-) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
+) -> Result<FallibleProcessResultWithPlatform, String> {
   let work_dir = TempDir::new().unwrap();
   run_command_locally_in_dir_with_cleanup(req, work_dir.path().to_owned()).await
 }
@@ -805,7 +805,7 @@ async fn run_command_locally(
 async fn run_command_locally_in_dir_with_cleanup(
   req: Process,
   dir: PathBuf,
-) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
+) -> Result<FallibleProcessResultWithPlatform, String> {
   run_command_locally_in_dir(req, dir, true, None, None).await
 }
 
@@ -815,7 +815,7 @@ async fn run_command_locally_in_dir(
   cleanup: bool,
   store: Option<Store>,
   executor: Option<task_executor::Executor>,
-) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
+) -> Result<FallibleProcessResultWithPlatform, String> {
   let store_dir = TempDir::new().unwrap();
   let executor = executor.unwrap_or_else(|| task_executor::Executor::new(Handle::current()));
   let store =

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -15,9 +15,8 @@ use tokio::net::TcpStream;
 use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
-  Context, Process, ProcessMetadata,
-  FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
-  PlatformConstraint,
+  Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, PlatformConstraint,
+  Process, ProcessMetadata,
 };
 
 #[cfg(test)]
@@ -198,10 +197,7 @@ impl super::CommandRunner for CommandRunner {
     )
   }
 
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     // Request compatibility should be the same as for the local runner, so we just delegate this.
     self.inner.extract_compatible_request(req)
   }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -16,7 +16,7 @@ use crate::local::CapturedWorkdir;
 use crate::nailgun::nailgun_pool::NailgunProcessName;
 use crate::{
   Context, Process, ProcessMetadata,
-  FallibleExecuteProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
   PlatformConstraint,
 };
 
@@ -168,7 +168,7 @@ impl super::CommandRunner for CommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let original_request = self.extract_compatible_request(&req).unwrap();
 
     if !original_request.is_nailgunnable {

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use hashing::{Digest, Fingerprint};
 use lazy_static::lazy_static;
 
-use crate::ExecuteProcessRequest;
+use crate::Process;
 use digest::Digest as DigestTrait;
 use sha2::Sha256;
 use store::Store;
@@ -87,7 +87,7 @@ impl NailgunPool {
   }
 
   ///
-  /// Given a `NailgunProcessName` and a `ExecuteProcessRequest` configuration,
+  /// Given a `NailgunProcessName` and a `Process` configuration,
   /// return a port of a nailgun server running under that name and configuration.
   ///
   /// If the server is not running, or if it's running with a different configuration,
@@ -96,7 +96,7 @@ impl NailgunPool {
   pub fn connect(
     &self,
     name: NailgunProcessName,
-    startup_options: ExecuteProcessRequest,
+    startup_options: Process,
     workdir_path: PathBuf,
     nailgun_req_digest: Digest,
     build_id_requesting_connection: String,
@@ -227,7 +227,7 @@ impl NailgunPool {
   fn start_new_nailgun(
     processes: &mut NailgunProcessMap,
     name: String,
-    startup_options: ExecuteProcessRequest,
+    startup_options: Process,
     workdir_path: &PathBuf,
     nailgun_server_fingerprint: NailgunProcessFingerprint,
     build_id: String,
@@ -286,7 +286,7 @@ fn read_port(child: &mut std::process::Child) -> Result<Port, String> {
 impl NailgunProcess {
   fn start_new(
     name: NailgunProcessName,
-    startup_options: ExecuteProcessRequest,
+    startup_options: Process,
     workdir_path: &PathBuf,
     nailgun_server_fingerprint: NailgunProcessFingerprint,
     build_id: String,

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use std::slice::Iter;
 
-/// Represents the result of parsing the args of a nailgunnable ExecuteProcessRequest
+/// Represents the result of parsing the args of a nailgunnable Process
 /// TODO(#8481) We may want to split the classpath by the ":", and store it as a Vec<String>
 ///         to allow for deep fingerprinting.
 #[derive(PartialEq, Eq, Debug)]

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -1,5 +1,5 @@
 use crate::nailgun::{CommandRunner, ARGS_TO_START_NAILGUN, NAILGUN_MAIN_CLASS};
-use crate::{Process, ProcessMetadata, PlatformConstraint};
+use crate::{PlatformConstraint, Process, ProcessMetadata};
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use std::fs::read_link;

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -1,5 +1,5 @@
 use crate::nailgun::{CommandRunner, ARGS_TO_START_NAILGUN, NAILGUN_MAIN_CLASS};
-use crate::{ExecuteProcessRequest, ExecuteProcessRequestMetadata, PlatformConstraint};
+use crate::{Process, ProcessMetadata, PlatformConstraint};
 use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use std::fs::read_link;
@@ -15,7 +15,7 @@ fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
   let local_runner =
     crate::local::CommandRunner::new(store, executor.clone(), std::env::temp_dir(), true);
-  let metadata = ExecuteProcessRequestMetadata {
+  let metadata = ProcessMetadata {
     instance_name: None,
     cache_key_gen_version: None,
     platform_properties: vec![],
@@ -32,8 +32,8 @@ fn unique_temp_dir(base_dir: PathBuf, prefix: Option<String>) -> TempDir {
     .expect("Error making tempdir for local process execution: {:?}")
 }
 
-fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> ExecuteProcessRequest {
-  ExecuteProcessRequest {
+fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> Process {
+  Process {
     argv: vec![],
     env: Default::default(),
     working_directory: None,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -23,9 +23,8 @@ use store::{Snapshot, Store, StoreFileByDigest};
 use tokio::time::delay_for;
 
 use crate::{
-  Context, Process, ProcessMetadata, ExecutionStats,
-  FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
-  PlatformConstraint,
+  Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  PlatformConstraint, Process, ProcessMetadata,
 };
 use std;
 use std::cmp::min;
@@ -199,10 +198,7 @@ impl CommandRunner {
 // we cancel a potential RPC. So we need to distinguish local vs. remote
 // requests and save enough state to BoxFuture or another abstraction around our execution results
 impl super::CommandRunner for CommandRunner {
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     for compatible_constraint in vec![
       &(PlatformConstraint::None, PlatformConstraint::None),
       &(self.platform.into(), PlatformConstraint::None),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -18,9 +18,8 @@ use testutil::{as_bytes, owned_string_vec};
 
 use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOrStatus};
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, Process,
-  ProcessMetadata, FallibleProcessResultWithPlatform,
-  MultiPlatformProcess, Platform, PlatformConstraint,
+  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
+  MultiPlatformProcess, Platform, PlatformConstraint, Process, ProcessMetadata,
 };
 use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -19,7 +19,7 @@ use testutil::{as_bytes, owned_string_vec};
 use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOrStatus};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, Process,
-  ProcessMetadata, FallibleExecuteProcessResultWithPlatform,
+  ProcessMetadata, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, PlatformConstraint,
 };
 use maplit::{btreemap, hashset};
@@ -627,7 +627,7 @@ async fn successful_execution_after_one_getoperation() {
 
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -677,7 +677,7 @@ async fn retries_retriable_errors() {
 
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -859,7 +859,7 @@ async fn extract_response_with_digest_stdout() {
     .await
     .unwrap()
     .without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: testdata.bytes(),
       stderr: testdata_empty.bytes(),
       exit_code: 0,
@@ -891,7 +891,7 @@ async fn extract_response_with_digest_stderr() {
     .await
     .unwrap()
     .without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: testdata_empty.bytes(),
       stderr: testdata.bytes(),
       exit_code: 0,
@@ -923,7 +923,7 @@ async fn extract_response_with_digest_stdout_osx_remote() {
     .await
     .unwrap()
     .without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: testdata.bytes(),
       stderr: testdata_empty.bytes(),
       exit_code: 0,
@@ -1005,7 +1005,7 @@ async fn ensure_inline_stdio_is_stored() {
     .unwrap();
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: test_stdout.bytes(),
       stderr: test_stderr.bytes(),
       exit_code: 0,
@@ -1076,7 +1076,7 @@ async fn successful_execution_after_four_getoperations() {
 
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -1195,7 +1195,7 @@ async fn dropped_request_cancels() {
     Platform::Linux,
   );
 
-  let successful_mock_result = FallibleExecuteProcessResultWithPlatform {
+  let successful_mock_result = FallibleProcessResultWithPlatform {
     stdout: as_bytes("foo-fast"),
     stderr: as_bytes(""),
     exit_code: 0,
@@ -1265,7 +1265,7 @@ async fn retry_for_cancelled_channel() {
 
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: as_bytes("foo"),
       stderr: as_bytes(""),
       exit_code: 0,
@@ -1562,7 +1562,7 @@ async fn execute_missing_file_uploads_if_known() {
     .unwrap();
   assert_eq!(
     result.without_execution_attempts(),
-    FallibleExecuteProcessResultWithPlatform {
+    FallibleProcessResultWithPlatform {
       stdout: roland.bytes(),
       stderr: Bytes::from(""),
       exit_code: 0,
@@ -1668,7 +1668,7 @@ async fn execute_missing_file_uploads_if_known_status() {
   .wait();
   assert_eq!(
     result,
-    Ok(FallibleExecuteProcessResultWithPlatform {
+    Ok(FallibleProcessResultWithPlatform {
       stdout: roland.bytes(),
       stderr: Bytes::from(""),
       exit_code: 0,
@@ -1778,7 +1778,7 @@ async fn extract_execute_response_unknown_code() {
 
 #[tokio::test]
 async fn extract_execute_response_success() {
-  let want_result = FallibleExecuteProcessResultWithPlatform {
+  let want_result = FallibleProcessResultWithPlatform {
     stdout: as_bytes("roland"),
     stderr: Bytes::from("simba"),
     exit_code: 17,
@@ -2546,7 +2546,7 @@ fn make_precondition_failure_status(
 async fn run_command_remote(
   address: String,
   request: MultiPlatformProcess,
-) -> Result<FallibleExecuteProcessResultWithPlatform, String> {
+) -> Result<FallibleProcessResultWithPlatform, String> {
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())
@@ -2611,7 +2611,7 @@ fn make_store(store_dir: &Path, cas: &mock::StubCAS, executor: task_executor::Ex
 async fn extract_execute_response(
   operation: bazel_protos::operations::Operation,
   remote_platform: Platform,
-) -> Result<FallibleExecuteProcessResultWithPlatform, ExecutionError> {
+) -> Result<FallibleProcessResultWithPlatform, ExecutionError> {
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -1,6 +1,5 @@
 use crate::{
-  CommandRunner, Context, Process, FallibleProcessResultWithPlatform,
-  MultiPlatformProcess,
+  CommandRunner, Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Process,
 };
 use boxfuture::{BoxFuture, Boxable};
 use futures::future::{FutureExt, TryFutureExt};
@@ -61,8 +60,7 @@ impl SpeculatingCommandRunner {
         Ok(either_success) => {
           // .split() takes out the homogeneous success type for either primary or
           // secondary successes.
-          ok::<FallibleProcessResultWithPlatform, String>(either_success.split().0)
-            .to_boxed()
+          ok::<FallibleProcessResultWithPlatform, String>(either_success.split().0).to_boxed()
         }
         Err(Either::A((failed_primary_res, _))) => {
           debug!("primary request FAILED, aborting");
@@ -90,10 +88,7 @@ impl SpeculatingCommandRunner {
 }
 
 impl CommandRunner for SpeculatingCommandRunner {
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     match (
       self.primary.extract_compatible_request(req),
       self.secondary.extract_compatible_request(req),

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -1,5 +1,5 @@
 use crate::{
-  CommandRunner, Context, Process, FallibleExecuteProcessResultWithPlatform,
+  CommandRunner, Context, Process, FallibleProcessResultWithPlatform,
   MultiPlatformProcess,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -34,7 +34,7 @@ impl SpeculatingCommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let delay = delay_for(self.speculation_timeout)
       .unit_error()
       .boxed()
@@ -61,12 +61,12 @@ impl SpeculatingCommandRunner {
         Ok(either_success) => {
           // .split() takes out the homogeneous success type for either primary or
           // secondary successes.
-          ok::<FallibleExecuteProcessResultWithPlatform, String>(either_success.split().0)
+          ok::<FallibleProcessResultWithPlatform, String>(either_success.split().0)
             .to_boxed()
         }
         Err(Either::A((failed_primary_res, _))) => {
           debug!("primary request FAILED, aborting");
-          err::<FallibleExecuteProcessResultWithPlatform, String>(failed_primary_res).to_boxed()
+          err::<FallibleProcessResultWithPlatform, String>(failed_primary_res).to_boxed()
         }
         // We handle the case of the secondary failing specially. We only want to show
         // a failure to the user if the primary execution source fails. This maintains
@@ -108,7 +108,7 @@ impl CommandRunner for SpeculatingCommandRunner {
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     match (
       self.primary.extract_compatible_request(&req),
       self.secondary.extract_compatible_request(&req),

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -1,6 +1,6 @@
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
-  MultiPlatformExecuteProcessRequest,
+  CommandRunner, Context, Process, FallibleExecuteProcessResultWithPlatform,
+  MultiPlatformProcess,
 };
 use boxfuture::{BoxFuture, Boxable};
 use futures::future::{FutureExt, TryFutureExt};
@@ -32,7 +32,7 @@ impl SpeculatingCommandRunner {
 
   fn speculate(
     &self,
-    req: MultiPlatformExecuteProcessRequest,
+    req: MultiPlatformProcess,
     context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = delay_for(self.speculation_timeout)
@@ -92,8 +92,8 @@ impl SpeculatingCommandRunner {
 impl CommandRunner for SpeculatingCommandRunner {
   fn extract_compatible_request(
     &self,
-    req: &MultiPlatformExecuteProcessRequest,
-  ) -> Option<ExecuteProcessRequest> {
+    req: &MultiPlatformProcess,
+  ) -> Option<Process> {
     match (
       self.primary.extract_compatible_request(req),
       self.secondary.extract_compatible_request(req),
@@ -106,7 +106,7 @@ impl CommandRunner for SpeculatingCommandRunner {
 
   fn run(
     &self,
-    req: MultiPlatformExecuteProcessRequest,
+    req: MultiPlatformProcess,
     context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     match (

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -1,7 +1,7 @@
 use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
-  CommandRunner, Context, Process, FallibleExecuteProcessResultWithPlatform,
+  CommandRunner, Context, Process, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
@@ -106,7 +106,7 @@ async fn run_speculation_test(
   r1_is_compatible: bool,
   r2_is_compatible: bool,
 ) -> (
-  Result<FallibleExecuteProcessResultWithPlatform, String>,
+  Result<FallibleProcessResultWithPlatform, String>,
   Arc<Mutex<u32>>,
   Arc<Mutex<u32>>,
 ) {
@@ -153,7 +153,7 @@ fn make_delayed_command_runner(
   let result = if is_err {
     Err(msg.into())
   } else {
-    Ok(FallibleExecuteProcessResultWithPlatform {
+    Ok(FallibleProcessResultWithPlatform {
       stdout: msg.into(),
       stderr: "".into(),
       exit_code: 0,
@@ -174,7 +174,7 @@ fn make_delayed_command_runner(
 #[derive(Clone)]
 struct DelayedCommandRunner {
   delay: Duration,
-  result: Result<FallibleExecuteProcessResultWithPlatform, String>,
+  result: Result<FallibleProcessResultWithPlatform, String>,
   is_compatible: bool,
   call_counter: Arc<Mutex<u32>>,
   finished_counter: Arc<Mutex<u32>>,
@@ -183,7 +183,7 @@ struct DelayedCommandRunner {
 impl DelayedCommandRunner {
   pub fn new(
     delay: Duration,
-    result: Result<FallibleExecuteProcessResultWithPlatform, String>,
+    result: Result<FallibleProcessResultWithPlatform, String>,
     is_compatible: bool,
     call_counter: Arc<Mutex<u32>>,
     finished_counter: Arc<Mutex<u32>>,
@@ -211,7 +211,7 @@ impl CommandRunner for DelayedCommandRunner {
     &self,
     _req: MultiPlatformProcess,
     _context: Context,
-  ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
+  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
     let delay = delay_for(self.delay).unit_error().compat();
     let exec_result = self.result.clone();
     let command_runner = self.clone();

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -1,8 +1,8 @@
 use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
-  CommandRunner, Context, ExecuteProcessRequest, FallibleExecuteProcessResultWithPlatform,
-  MultiPlatformExecuteProcessRequest, Platform, PlatformConstraint,
+  CommandRunner, Context, Process, FallibleExecuteProcessResultWithPlatform,
+  MultiPlatformProcess, Platform, PlatformConstraint,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -209,7 +209,7 @@ impl DelayedCommandRunner {
 impl CommandRunner for DelayedCommandRunner {
   fn run(
     &self,
-    _req: MultiPlatformExecuteProcessRequest,
+    _req: MultiPlatformProcess,
     _context: Context,
   ) -> BoxFuture<FallibleExecuteProcessResultWithPlatform, String> {
     let delay = delay_for(self.delay).unit_error().compat();
@@ -230,8 +230,8 @@ impl CommandRunner for DelayedCommandRunner {
 
   fn extract_compatible_request(
     &self,
-    req: &MultiPlatformExecuteProcessRequest,
-  ) -> Option<ExecuteProcessRequest> {
+    req: &MultiPlatformProcess,
+  ) -> Option<Process> {
     if self.is_compatible {
       Some(
         req

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -1,8 +1,8 @@
 use crate::remote_tests::echo_foo_request;
 use crate::speculate::SpeculatingCommandRunner;
 use crate::{
-  CommandRunner, Context, Process, FallibleProcessResultWithPlatform,
-  MultiPlatformProcess, Platform, PlatformConstraint,
+  CommandRunner, Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  PlatformConstraint, Process,
 };
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -228,10 +228,7 @@ impl CommandRunner for DelayedCommandRunner {
       .to_boxed()
   }
 
-  fn extract_compatible_request(
-    &self,
-    req: &MultiPlatformProcess,
-  ) -> Option<Process> {
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     if self.is_compatible {
       Some(
         req

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -6,8 +6,8 @@ use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
 #[test]
-fn execute_process_request_equality() {
-  let execute_process_request_generator =
+fn process_equality() {
+  let process_generator =
         |description: String, timeout: Duration, unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: hashing::Digest| Process {
             argv: vec![],
             env: BTreeMap::new(),
@@ -29,22 +29,22 @@ fn execute_process_request_equality() {
     hasher.finish()
   }
 
-  let a = execute_process_request_generator(
+  let a = process_generator(
     "One thing".to_string(),
     Duration::new(0, 0),
     hashing::EMPTY_DIGEST,
   );
-  let b = execute_process_request_generator(
+  let b = process_generator(
     "Another".to_string(),
     Duration::new(0, 0),
     hashing::EMPTY_DIGEST,
   );
-  let c = execute_process_request_generator(
+  let c = process_generator(
     "One thing".to_string(),
     Duration::new(5, 0),
     hashing::EMPTY_DIGEST,
   );
-  let d = execute_process_request_generator(
+  let d = process_generator(
     "One thing".to_string(),
     Duration::new(0, 0),
     Digest(

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ExecuteProcessRequest, PlatformConstraint, RelativePath};
+use crate::{Process, PlatformConstraint, RelativePath};
 use hashing::{Digest, Fingerprint};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[test]
 fn execute_process_request_equality() {
   let execute_process_request_generator =
-        |description: String, timeout: Duration, unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: hashing::Digest| ExecuteProcessRequest {
+        |description: String, timeout: Duration, unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: hashing::Digest| Process {
             argv: vec![],
             env: BTreeMap::new(),
             working_directory: None,
@@ -56,7 +56,7 @@ fn execute_process_request_equality() {
     ),
   );
 
-  // ExecuteProcessRequest should derive a PartialEq and Hash that ignores the description
+  // Process should derive a PartialEq and Hash that ignores the description
   assert!(a == b);
   assert!(hash(&a) == hash(&b));
 

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Process, PlatformConstraint, RelativePath};
+use crate::{PlatformConstraint, Process, RelativePath};
 use hashing::{Digest, Fingerprint};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -33,9 +33,7 @@ use process_execution;
 use clap::{value_t, App, AppSettings, Arg};
 use futures::compat::Future01CompatExt;
 use hashing::{Digest, Fingerprint};
-use process_execution::{
-  Context, ProcessMetadata, Platform, PlatformConstraint, RelativePath,
-};
+use process_execution::{Context, Platform, PlatformConstraint, ProcessMetadata, RelativePath};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -34,7 +34,7 @@ use clap::{value_t, App, AppSettings, Arg};
 use futures::compat::Future01CompatExt;
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  Context, ExecuteProcessRequestMetadata, Platform, PlatformConstraint, RelativePath,
+  Context, ProcessMetadata, Platform, PlatformConstraint, RelativePath,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
@@ -328,7 +328,7 @@ async fn main() {
     .map(|path| RelativePath::new(path).expect("working-directory must be a relative path"));
   let is_nailgunnable: bool = args.value_of("use-nailgun").unwrap().parse().unwrap();
 
-  let request = process_execution::ExecuteProcessRequest {
+  let request = process_execution::Process {
     argv,
     env,
     working_directory,
@@ -365,7 +365,7 @@ async fn main() {
       Box::new(
         process_execution::remote::CommandRunner::new(
           address,
-          ExecuteProcessRequestMetadata {
+          ProcessMetadata {
             instance_name: remote_instance_arg,
             cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
             platform_properties,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -24,8 +24,7 @@ use core::clone::Clone;
 use fs::{safe_create_dir_all_ioerror, GitignoreStyleExcludes, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
-  self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ProcessMetadata,
-  Platform,
+  self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, Platform, ProcessMetadata,
 };
 use rand::seq::SliceRandom;
 use reqwest;

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -24,7 +24,7 @@ use core::clone::Clone;
 use fs::{safe_create_dir_all_ioerror, GitignoreStyleExcludes, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
 use process_execution::{
-  self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ExecuteProcessRequestMetadata,
+  self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, ProcessMetadata,
   Platform,
 };
 use rand::seq::SliceRandom;
@@ -156,7 +156,7 @@ impl Core {
       })
       .map_err(|e| format!("Could not initialize Store: {:?}", e))?;
 
-    let process_execution_metadata = ExecuteProcessRequestMetadata {
+    let process_execution_metadata = ProcessMetadata {
       instance_name: remote_instance_name,
       cache_key_gen_version: remote_execution_process_cache_namespace,
       platform_properties: remote_execution_extra_platform_properties,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -314,18 +314,18 @@ impl MultiPlatformExecuteProcess {
         )
       })
       .collect();
-    let requests = externs::project_multi(&value, "execute_process_requests");
-    if constraint_parts.len() / 2 != requests.len() {
+    let processes = externs::project_multi(&value, "processes");
+    if constraint_parts.len() / 2 != processes.len() {
       return Err(format!(
-        "Size of constraint keys and requests does not match: {} vs. {}",
+        "Sizes of constraint keys and processes do not match: {} vs. {}",
         constraint_parts.len() / 2,
-        requests.len()
+        processes.len()
       ));
     }
 
     let mut request_by_constraint: BTreeMap<(PlatformConstraint, PlatformConstraint), Process> =
       BTreeMap::new();
-    for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(requests.iter()) {
+    for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(processes.iter()) {
       let underlying_req =
         MultiPlatformExecuteProcess::lift_execute_process(execute_process, constraint_key.1)?;
       request_by_constraint.insert(constraint_key.clone(), underlying_req.clone());

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -30,7 +30,7 @@ use fs::{
 };
 use hashing;
 use process_execution::{
-  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, PlatformConstraint, RelativePath,
+  self, Process, MultiPlatformProcess, PlatformConstraint, RelativePath,
 };
 use rule_graph;
 
@@ -226,13 +226,13 @@ pub fn lift_digest(digest: &Value) -> Result<hashing::Digest, String> {
 /// A Node that represents a set of processes to execute on specific platforms.
 ///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct MultiPlatformExecuteProcess(MultiPlatformExecuteProcessRequest);
+pub struct MultiPlatformExecuteProcess(MultiPlatformProcess);
 
 impl MultiPlatformExecuteProcess {
   fn lift_execute_process(
     value: &Value,
     target_platform: PlatformConstraint,
-  ) -> Result<ExecuteProcessRequest, String> {
+  ) -> Result<Process, String> {
     let env = externs::project_tuple_encoded_map(&value, "env")?;
 
     let working_directory = {
@@ -286,7 +286,7 @@ impl MultiPlatformExecuteProcess {
       ))
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
-    Ok(process_execution::ExecuteProcessRequest {
+    Ok(process_execution::Process {
       argv: externs::project_multi_strs(&value, "argv"),
       env,
       working_directory,
@@ -327,7 +327,7 @@ impl MultiPlatformExecuteProcess {
 
     let mut request_by_constraint: BTreeMap<
       (PlatformConstraint, PlatformConstraint),
-      ExecuteProcessRequest,
+      Process,
     > = BTreeMap::new();
     for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(requests.iter()) {
       let underlying_req =
@@ -335,7 +335,7 @@ impl MultiPlatformExecuteProcess {
       request_by_constraint.insert(constraint_key.clone(), underlying_req.clone());
     }
     Ok(MultiPlatformExecuteProcess(
-      MultiPlatformExecuteProcessRequest(request_by_constraint),
+      MultiPlatformProcess(request_by_constraint),
     ))
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -29,9 +29,7 @@ use fs::{
   PathGlobs, PathStat, StrictGlobMatching, VFS,
 };
 use hashing;
-use process_execution::{
-  self, Process, MultiPlatformProcess, PlatformConstraint, RelativePath,
-};
+use process_execution::{self, MultiPlatformProcess, PlatformConstraint, Process, RelativePath};
 use rule_graph;
 
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
@@ -325,18 +323,16 @@ impl MultiPlatformExecuteProcess {
       ));
     }
 
-    let mut request_by_constraint: BTreeMap<
-      (PlatformConstraint, PlatformConstraint),
-      Process,
-    > = BTreeMap::new();
+    let mut request_by_constraint: BTreeMap<(PlatformConstraint, PlatformConstraint), Process> =
+      BTreeMap::new();
     for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(requests.iter()) {
       let underlying_req =
         MultiPlatformExecuteProcess::lift_execute_process(execute_process, constraint_key.1)?;
       request_by_constraint.insert(constraint_key.clone(), underlying_req.clone());
     }
-    Ok(MultiPlatformExecuteProcess(
-      MultiPlatformProcess(request_by_constraint),
-    ))
+    Ok(MultiPlatformExecuteProcess(MultiPlatformProcess(
+      request_by_constraint,
+    )))
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -378,7 +378,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProcessResult(pub process_execution::FallibleExecuteProcessResultWithPlatform);
+pub struct ProcessResult(pub process_execution::FallibleProcessResultWithPlatform);
 
 ///
 /// A Node that represents reading the destination of a symlink (non-recursively).

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -16,10 +16,10 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.isolated_process import (
-    Process,
-    ProcessResult,
     FallibleProcessResult,
+    Process,
     ProcessExecutionFailure,
+    ProcessResult,
 )
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
@@ -48,9 +48,9 @@ class ShellCat:
     generate an argv instead of doing it all in CatExecutionRequest.
 
     This can be used to encapsulate operations such as sanitizing command-line arguments which are
-    specific to the executable, which can reduce boilerplate for generating Process
-    instances if the executable is used in different ways across multiple different types of process
-    execution requests.
+    specific to the executable, which can reduce boilerplate for generating Process instances if the
+    executable is used in different ways across multiple different types of process execution
+    requests.
     """
 
     binary_location: BinaryLocation
@@ -129,9 +129,7 @@ async def get_javac_version_output(
         description=javac_version_command.description,
         input_files=EMPTY_DIRECTORY_DIGEST,
     )
-    javac_version_proc_result = await Get[ProcessResult](
-        Process, javac_version_proc_req,
-    )
+    javac_version_proc_result = await Get[ProcessResult](Process, javac_version_proc_req,)
 
     return JavacVersionOutput(javac_version_proc_result.stderr.decode())
 

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -83,12 +83,12 @@ class CatExecutionRequest:
 async def cat_files_process_result_concatted(cat_exe_req: CatExecutionRequest) -> Concatted:
     cat_bin = cat_exe_req.shell_cat
     cat_files_snapshot = await Get[Snapshot](PathGlobs, cat_exe_req.path_globs)
-    process_request = Process(
+    process = Process(
         argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
         input_files=cat_files_snapshot.directory_digest,
         description="cat some files",
     )
-    cat_process_result = await Get[ProcessResult](Process, process_request)
+    cat_process_result = await Get[ProcessResult](Process, process)
     return Concatted(cat_process_result.stdout.decode())
 
 
@@ -184,13 +184,13 @@ async def javac_compile_process_result(
             raise ValueError(f"Can only compile .java files but got {java_file}")
     sources_snapshot = await Get[Snapshot](PathGlobs, PathGlobs(java_files))
     output_dirs = tuple({os.path.dirname(java_file) for java_file in java_files})
-    process_request = Process(
+    process = Process(
         argv=javac_compile_req.argv_from_source_snapshot(sources_snapshot),
         input_files=sources_snapshot.directory_digest,
         output_directories=output_dirs,
         description="javac compilation",
     )
-    javac_proc_result = await Get[ProcessResult](Process, process_request)
+    javac_proc_result = await Get[ProcessResult](Process, process)
 
     return JavacCompileResult(
         javac_proc_result.stdout.decode(),
@@ -333,10 +333,10 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
             input_files=EMPTY_DIRECTORY_DIGEST,
         )
 
-        execute_process_result = self.request_single_product(ProcessResult, request)
+        process_result = self.request_single_product(ProcessResult, request)
 
         self.assertEqual(
-            execute_process_result.output_directory_digest,
+            process_result.output_directory_digest,
             Digest(
                 fingerprint="63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
                 serialized_bytes_length=80,
@@ -344,7 +344,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
         )
 
         files_content_result = self.request_single_product(
-            FilesContent, execute_process_result.output_directory_digest,
+            FilesContent, process_result.output_directory_digest,
         )
 
         self.assertEqual(


### PR DESCRIPTION
### Problem

For as widely used as they are, the names `ExecuteProcessRequest` and `ExecuteProcessResult` are very verbose. That verbosity has also propagated into the variants of these APIs (`MultiPlatform`, `Falliable`, etc), and [there is a plan](https://docs.google.com/document/d/1hS0n6vp-hBxy4Xo-q9QA_elofzQtOubjfN4nSeIgp90/edit#) to add another variant soon (`CrossPlatform`).

### Solution

Rename `*ExecuteProcessRequest` to `*Process` and `*ExecuteProcessResult` to `*ProcessResult`.