### PR TITLE
quiet black formatter in CI

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,6 +8,9 @@ execution_strategy = "subprocess"
 # overhead or else just generally thrash the container and slow things down.
 travis_parallelism = 4
 
+[black]
+args = ["--quiet"]
+
 [compile.rsc]
 worker_count = "%(travis_parallelism)s"
 


### PR DESCRIPTION
[ci skip-rust-tests]
[ci skip-jvm-tests]

### Problem

Black produces > 1000 lines of output for passing lint runs with our current config.

### Solution

Add --quiet to black's CI args.

### Result

This makes it so that only errors will be printed by black lint runs.