### PR TITLE
Reduce redundant work in Address parsing

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -151,23 +151,22 @@ class Address:
         if path == "":
             return path
 
-        normpath = os.path.normpath(path)
-        components = normpath.split(os.sep)
-        if components[0] in (".", "..") or normpath != path:
+        components = path.split(os.sep)
+        if any(component in (".", "..", "") for component in components):
             raise InvalidSpecPath(
                 "Address spec has un-normalized path part '{path}'".format(path=path)
             )
         if components[-1].startswith("BUILD"):
             raise InvalidSpecPath(
                 "Address spec path {path} has {trailing} as the last path part and BUILD is "
-                "reserved files".format(path=path, trailing=components[-1])
+                "a reserved file".format(path=path, trailing=components[-1])
             )
         if os.path.isabs(path):
             raise InvalidSpecPath(
                 "Address spec has absolute path {path}; expected a path relative "
                 "to the build root.".format(path=path)
             )
-        return normpath if normpath != "." else ""
+        return path
 
     @classmethod
     def check_target_name(cls, spec_path: str, name: str) -> None:


### PR DESCRIPTION
### Problem

In profiles, the `os.path.normpath` call removed here shows up as the most expensive portion of `Address` parsing. The work it is doing is _mostly_ redundant (we check for unix path traversal characters, and can check for empty components).

### Solution

Remove usage of normpath. The existing, fairly-thorough [tests](https://github.com/pantsbuild/pants/blob/bedf92358fb96e24f57a2f1183ccb395f0609c40/tests/python/pants_test/build_graph/test_address.py#L60-L73) continue to pass.

### Result

A 9% speedup for `./pants --changed-diffspec="$sha^..$sha" --changed-include-dependees=transitive list`.

[ci skip-rust-tests]
[ci skip-jvm-tests]