### PR TITLE
Flatten execution and target PlatformConstraints in MultiPlatformProcess

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -376,10 +376,7 @@ async def create_pex(
             description = f"Building PEX"
     process = MultiPlatformProcess(
         {
-            (
-                PlatformConstraint(platform.value),
-                PlatformConstraint(platform.value),
-            ): pex_bin.create_execute_request(
+            PlatformConstraint(platform.value): pex_bin.create_execute_request(
                 python_setup=python_setup,
                 subprocess_encoding_environment=subprocess_encoding_environment,
                 pex_build_environment=pex_build_environment,

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -78,15 +78,12 @@ class MultiPlatformProcess:
     platform_constraints: Tuple[str, ...]
     processes: Tuple[Process, ...]
 
-    def __init__(
-        self, request_dict: Dict[Tuple[PlatformConstraint, PlatformConstraint], Process],
-    ) -> None:
+    def __init__(self, request_dict: Dict[PlatformConstraint, Process],) -> None:
         if len(request_dict) == 0:
             raise ValueError("At least one platform constrained Process must be passed.")
         validated_constraints = tuple(
             constraint.value
-            for pair in request_dict.keys()
-            for constraint in pair
+            for constraint in request_dict.keys()
             if PlatformConstraint(constraint.value)
         )
         if len({req.description for req in request_dict.values()}) != 1:
@@ -178,7 +175,7 @@ def get_multi_platform_request_description(req: MultiPlatformProcess,) -> Produc
 @rule
 def upcast_process(req: Process,) -> MultiPlatformProcess:
     """This rule allows an Process to be run as a platform compatible MultiPlatformProcess."""
-    return MultiPlatformProcess({(PlatformConstraint.none, PlatformConstraint.none): req})
+    return MultiPlatformProcess({PlatformConstraint.none: req})
 
 
 @rule

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -252,10 +252,7 @@ impl TryFrom<MultiPlatformProcess> for Process {
   type Error = String;
 
   fn try_from(req: MultiPlatformProcess) -> Result<Self, Self::Error> {
-    match req
-      .0
-      .get(&(PlatformConstraint::None, PlatformConstraint::None))
-    {
+    match req.0.get(&PlatformConstraint::None) {
       Some(crossplatform_req) => Ok(crossplatform_req.clone()),
       None => Err(String::from(
         "Cannot coerce to a simple Process, no cross platform request exists.",
@@ -268,7 +265,7 @@ impl TryFrom<MultiPlatformProcess> for Process {
 /// A container of platform constrained processes.
 ///
 #[derive(Derivative, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct MultiPlatformProcess(pub BTreeMap<(PlatformConstraint, PlatformConstraint), Process>);
+pub struct MultiPlatformProcess(pub BTreeMap<PlatformConstraint, Process>);
 
 impl MultiPlatformProcess {
   pub fn user_facing_name(&self) -> Option<String> {
@@ -282,11 +279,7 @@ impl MultiPlatformProcess {
 
 impl From<Process> for MultiPlatformProcess {
   fn from(req: Process) -> Self {
-    MultiPlatformProcess(
-      vec![((PlatformConstraint::None, PlatformConstraint::None), req)]
-        .into_iter()
-        .collect(),
-    )
+    MultiPlatformProcess(vec![(PlatformConstraint::None, req)].into_iter().collect())
   }
 }
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -221,16 +221,7 @@ impl ChildResults {
 
 impl super::CommandRunner for CommandRunner {
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
-    for compatible_constraint in vec![
-      &(PlatformConstraint::None, PlatformConstraint::None),
-      &(self.platform.into(), PlatformConstraint::None),
-      &(
-        self.platform.into(),
-        PlatformConstraint::current_platform_constraint().unwrap(),
-      ),
-    ]
-    .iter()
-    {
+    for compatible_constraint in vec![PlatformConstraint::None, self.platform.into()].iter() {
       if let Some(compatible_req) = req.0.get(compatible_constraint) {
         return Some(compatible_req.clone());
       }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -199,16 +199,7 @@ impl CommandRunner {
 // requests and save enough state to BoxFuture or another abstraction around our execution results
 impl super::CommandRunner for CommandRunner {
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
-    for compatible_constraint in vec![
-      &(PlatformConstraint::None, PlatformConstraint::None),
-      &(self.platform.into(), PlatformConstraint::None),
-      &(
-        self.platform.into(),
-        PlatformConstraint::current_platform_constraint().unwrap(),
-      ),
-    ]
-    .iter()
-    {
+    for compatible_constraint in vec![PlatformConstraint::None, self.platform.into()].iter() {
       if let Some(compatible_req) = req.0.get(compatible_constraint) {
         return Some(compatible_req.clone());
       }

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -230,13 +230,7 @@ impl CommandRunner for DelayedCommandRunner {
 
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     if self.is_compatible {
-      Some(
-        req
-          .0
-          .get(&(PlatformConstraint::None, PlatformConstraint::None))
-          .unwrap()
-          .clone(),
-      )
+      Some(req.0.get(&PlatformConstraint::None).unwrap().clone())
     } else {
       None
     }


### PR DESCRIPTION
### Problem

`MultiPlatformProcess` currently has both execution and target constraints for processes, in order to allow for platform-dependent inputs with platform-agnostic outputs (or vice versa).

But as described in [multi-platform speculation](https://docs.google.com/document/d/1hS0n6vp-hBxy4Xo-q9QA_elofzQtOubjfN4nSeIgp90/edit), we'd like to move in a direction where we have one (optional) concrete execution `Platform` in any subgraph. If an output is valid for another `Platform` than it might have been computed on (ie, if it has been cross-compiled, or is agnostic), the caller can request for one `Platform`, and then project the output into another subgraph for the target `Platform`.

### Solution

Given this, we remove the "target" platform designation to simplify things before pushing further into per-subgraph `Platform`s. 

[ci skip-jvm-tests]