### PR TITLE
Revert "quiet black formatter in CI (#9536)"

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,9 +8,6 @@ execution_strategy = "subprocess"
 # overhead or else just generally thrash the container and slow things down.
 travis_parallelism = 4
 
-[black]
-args = ["--quiet"]
-
 [compile.rsc]
 worker_count = "%(travis_parallelism)s"
 


### PR DESCRIPTION
We skipped several CI shards and it turned out that one integration test was failing. I can't figure out how to fix the test https://travis-ci.com/github/pantsbuild/pants/jobs/319454777#L935, so we revert for now.

[ci skip-rust-tests]
[ci skip-jvm-tests]