### PR TITLE
Remove `TargetAdaptorWithOrigin`

### DIFF
--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -5,10 +5,9 @@ import logging
 import os.path
 from collections.abc import MutableSequence, MutableSet
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 from pants.base.deprecated import warn_or_error
-from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_sequence
@@ -363,99 +362,6 @@ class PythonRequirementLibraryAdaptor(TargetAdaptor):
 class PantsPluginAdaptor(PythonTargetAdaptor):
     def get_sources(self) -> "GlobsWithConjunction":
         return GlobsWithConjunction.for_literal_files(["register.py"])
-
-
-# TODO(#7490): Remove this once we have multiple params support so that rules can do something
-# like `await Get[TestResult](Params(Address(..), Origin(..)))`.
-@dataclass(frozen=True)
-class TargetAdaptorWithOrigin:
-    adaptor: TargetAdaptor
-    origin: OriginSpec
-
-    @staticmethod
-    def create(adaptor: TargetAdaptor, origin: OriginSpec) -> "TargetAdaptorWithOrigin":
-        adaptor_with_origin_cls: Type["TargetAdaptorWithOrigin"] = {
-            TargetAdaptor: TargetAdaptorWithOrigin,
-            AppAdaptor: AppAdaptorWithOrigin,
-            JvmAppAdaptor: JvmAppAdaptorWithOrigin,
-            JvmBinaryAdaptor: JvmBinaryAdaptorWithOrigin,
-            PythonAppAdaptor: PythonAppAdaptorWithOrigin,
-            ResourcesAdaptor: ResourcesAdaptorWithOrigin,
-            PageAdaptor: PageAdaptorWithOrigin,
-            RemoteSourcesAdaptor: RemoteSourcesAdaptorWithOrigin,
-            PythonTargetAdaptor: PythonTargetAdaptorWithOrigin,
-            PythonBinaryAdaptor: PythonBinaryAdaptorWithOrigin,
-            PythonTestsAdaptor: PythonTestsAdaptorWithOrigin,
-            PythonAWSLambdaAdaptor: PythonAWSLambdaAdaptorWithOrigin,
-            PythonRequirementLibraryAdaptor: PythonRequirementLibraryAdaptorWithOrigin,
-            PantsPluginAdaptor: PantsPluginAdaptorWithOrigin,
-        }.get(type(adaptor), TargetAdaptorWithOrigin)
-        return adaptor_with_origin_cls(adaptor, origin)
-
-
-@dataclass(frozen=True)
-class AppAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: AppAdaptor
-
-
-@dataclass(frozen=True)
-class JvmAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: JvmAppAdaptor
-
-
-@dataclass(frozen=True)
-class JvmBinaryAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: JvmBinaryAdaptor
-
-
-@dataclass(frozen=True)
-class PythonAppAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonAppAdaptor
-
-
-@dataclass(frozen=True)
-class ResourcesAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: ResourcesAdaptor
-
-
-@dataclass(frozen=True)
-class PageAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PageAdaptor
-
-
-@dataclass(frozen=True)
-class RemoteSourcesAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: RemoteSourcesAdaptor
-
-
-@dataclass(frozen=True)
-class PythonTargetAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonTargetAdaptor
-
-
-@dataclass(frozen=True)
-class PythonBinaryAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonBinaryAdaptor
-
-
-@dataclass(frozen=True)
-class PythonTestsAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonTestsAdaptor
-
-
-@dataclass(frozen=True)
-class PythonAWSLambdaAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonAWSLambdaAdaptor
-
-
-@dataclass(frozen=True)
-class PythonRequirementLibraryAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PythonRequirementLibraryAdaptor
-
-
-@dataclass(frozen=True)
-class PantsPluginAdaptorWithOrigin(TargetAdaptorWithOrigin):
-    adaptor: PantsPluginAdaptor
 
 
 class SourceGlobs(Locatable):

--- a/src/python/pants/rules/core/determine_source_files.py
+++ b/src/python/pants/rules/core/determine_source_files.py
@@ -2,11 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Iterable, Tuple, Union, cast
+from typing import Iterable, Tuple, Union
 
 from pants.base.specs import AddressSpec, OriginSpec
 from pants.engine.fs import DirectoriesToMerge, PathGlobs, Snapshot, SnapshotSubset
-from pants.engine.legacy.structs import TargetAdaptor, TargetAdaptorWithOrigin
+from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
@@ -160,22 +160,6 @@ class LegacyAllSourceFilesRequest:
         self.strip_source_roots = strip_source_roots
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class LegacySpecifiedSourceFilesRequest:
-    adaptors_with_origins: Tuple[TargetAdaptorWithOrigin, ...]
-    strip_source_roots: bool = False
-
-    def __init__(
-        self,
-        adaptors_with_origins: Iterable[TargetAdaptorWithOrigin],
-        *,
-        strip_source_roots: bool = False
-    ) -> None:
-        self.adaptors_with_origins = tuple(adaptors_with_origins)
-        self.strip_source_roots = strip_source_roots
-
-
 @rule
 async def legacy_determine_all_source_files(request: LegacyAllSourceFilesRequest) -> SourceFiles:
     """Merge all the `sources` for targets into one snapshot."""
@@ -195,67 +179,6 @@ async def legacy_determine_all_source_files(request: LegacyAllSourceFilesRequest
     return SourceFiles(result)
 
 
-def legacy_determine_specified_sources_for_target(
-    adaptor_with_origin: TargetAdaptorWithOrigin,
-) -> Union[Snapshot, SnapshotSubset]:
-    adaptor = adaptor_with_origin.adaptor
-    origin = adaptor_with_origin.origin
-    sources_snapshot = cast(Snapshot, adaptor.sources.snapshot)
-    # AddressSpecs simply use the entire `sources` field.
-    if isinstance(origin, AddressSpec):
-        return sources_snapshot
-    # NB: we ensure that `precise_files_specified` is a subset of the original target's
-    # `sources`. It's possible when given a glob filesystem spec that the spec will have
-    # resolved files not belonging to this target - those must be filtered out.
-    precise_files_specified = set(sources_snapshot.files).intersection(origin.resolved_files)
-    return SnapshotSubset(
-        directory_digest=sources_snapshot.directory_digest,
-        globs=PathGlobs(sorted(precise_files_specified)),
-    )
-
-
-@rule
-async def legacy_determine_specified_source_files(
-    request: LegacySpecifiedSourceFilesRequest,
-) -> SourceFiles:
-    """Determine the specified `sources` for targets, possibly finding a subset of the original
-    `sources` fields if the user supplied file arguments."""
-    full_snapshots = {}
-    snapshot_subset_requests = {}
-    for adaptor_with_origin in request.adaptors_with_origins:
-        adaptor = adaptor_with_origin.adaptor
-        if not adaptor.has_sources():
-            continue
-        result = calculate_specified_sources(
-            adaptor_with_origin.adaptor.sources.snapshot, adaptor_with_origin.origin
-        )
-        if isinstance(result, Snapshot):
-            full_snapshots[adaptor] = result
-        else:
-            snapshot_subset_requests[adaptor] = result
-
-    snapshot_subsets: Tuple[Snapshot, ...] = ()
-    if snapshot_subset_requests:
-        snapshot_subsets = await MultiGet(
-            Get[Snapshot](SnapshotSubset, request) for request in snapshot_subset_requests.values()
-        )
-
-    all_snapshots: Iterable[Snapshot] = (*full_snapshots.values(), *snapshot_subsets)
-    if request.strip_source_roots:
-        all_adaptors = (*full_snapshots.keys(), *snapshot_subset_requests.keys())
-        stripped_snapshots = await MultiGet(
-            Get[LegacySourceRootStrippedSources](
-                LegacyStripTargetRequest(adaptor, specified_files_snapshot=snapshot)
-            )
-            for adaptor, snapshot in zip(all_adaptors, all_snapshots)
-        )
-        all_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
-    result = await Get[Snapshot](
-        DirectoriesToMerge(tuple(snapshot.directory_digest for snapshot in all_snapshots))
-    )
-    return SourceFiles(result)
-
-
 def rules():
     return [
         determine_all_source_files,
@@ -264,7 +187,5 @@ def rules():
         RootRule(SpecifiedSourceFilesRequest),
         *strip_source_roots.rules(),
         legacy_determine_all_source_files,
-        legacy_determine_specified_source_files,
         RootRule(LegacyAllSourceFilesRequest),
-        RootRule(LegacySpecifiedSourceFilesRequest),
     ]


### PR DESCRIPTION
Superseded by `TargetWithOrigin`. We will soon be able to also remove `HydratedTargetWithOrigin`.

[ci skip-rust-tests]
[ci skip-jvm-tests]