### PR TITLE
Some refactoring in EngineDisplay

### DIFF
--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -65,7 +65,7 @@ impl Session {
     should_report_workunits: bool,
   ) -> Session {
     let display = if should_render_ui && EngineDisplay::stdout_is_tty() {
-      let mut display = EngineDisplay::new(0);
+      let mut display = EngineDisplay::new();
       display.initialize(ui_worker_count);
       Some(Arc::new(Mutex::new(display)))
     } else {

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -37,7 +37,7 @@ use ui::EngineDisplay;
 // N.B. This is purely a demo/testing bin target for exercising the library.
 
 fn main() {
-  let mut display = EngineDisplay::new(0);
+  let mut display = EngineDisplay::new();
   display.start();
 
   let worker_ids = vec![


### PR DESCRIPTION
This commit:

-removes `padding` struct member (nothing is using it)
-removes `remove_workers` method (nothing is using it)
-converts sigil to a static string (in case we want to
make it longer than a single char in the future)
-move `max_log_rows` functionality into its call site
