### PR TITLE
Refactor V2 Pytest Coverage implementation

### DIFF
--- a/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
+++ b/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
@@ -3,38 +3,41 @@
 
 import json
 import os
-import sys
 
-from coverage import CoveragePlugin, FileTracer
+from coverage import CoveragePlugin
 from coverage.config import DEFAULT_PARTIAL, DEFAULT_PARTIAL_ALWAYS
 from coverage.misc import join_regex
 from coverage.parser import PythonParser
 from coverage.python import PythonFileReporter, get_python_source
 
 
-# Note: This plugin will appear to do nothing at all at test time. This is the correct behavior. The *only* thing
-# coverage does with this plugin at test time is storing the class name in its sql data (see the `tracer` table.)
-# eg: `__coverage_coverage_plugin__.ChrootRemappingPlugin`
-# It will then hot load this plugin from the class name string in its sql data when generate_coverage_report is run.
-# If this data is missing, this plugin will not be used at report time, meaning the reports will fail to be generated
-# as coverage will go looking for `foo/bar.py` instead of `src/python/foo/bar.py`.
+# Note: This plugin will appear to do nothing at all at test time. This is the correct behavior.
+# The *only* thing coverage does with this plugin at test time is storing the class name in its
+# SQL data (see the `tracer` table) eg: `__pants_coverage_plugin__.ChrootRemappingPlugin`.
+#
+# It will then hot load this plugin from the class name string in its SQL data when
+# generate_coverage_report is run. If this data is missing, this plugin will not be used at report
+# time, meaning the reports will fail to be generated as coverage will go looking for `foo/bar.py`
+# instead of `src/python/foo/bar.py`.
 
 
 class PantsPythonFileReporter(PythonFileReporter):
   """Report support for a Python file.
 
-  At test time we run coverage in an environment where all source roots have been stripped from source files.
-  When we read the coverage report, we would like to see the buildroot relative file names.
+  At test time we run coverage in an environment where all source roots have been stripped from
+  source files. When we read the coverage report, we would like to see the buildroot relative file
+  names.
 
-  This class handles mapping from the coverage data stored at test time, which references source root stripped sources
-  to the actual file names we want to see in the reports. In order for this to work, the environment in which we run
-  `coverage html` (to generate a report) must include all of the source files with their source roots still present.
+  This class handles mapping from the coverage data stored at test time, which references source
+  root stripped sources to the actual file names we want to see in the reports. In order for this
+  to work, the environment in which we run `coverage html` (to generate a report) must include all
+  of the source files with their source roots still present.
   """
 
   def __init__(self, relative_source_root, source_root_stripped_filename, test_time, coverage=None):
-    # Note: Do not call `super()` on this class. The __init__ of the super class goes to a lot of effort to
-    # manufacture absolute paths which will break things when the tests are run in one chroot and the report
-    # generation in another.
+    # Note: Do not call `super()` on this class. The __init__ of the super class goes to a lot of
+    # effort to manufacture absolute paths which will break things when the tests are run in one
+    # chroot and the report generation in another.
     self.coverage = coverage
     self.filename_with_source_root = os.path.join(relative_source_root, source_root_stripped_filename)
     self.filename = source_root_stripped_filename
@@ -44,6 +47,7 @@ class PantsPythonFileReporter(PythonFileReporter):
     return self.filename_with_source_root
 
   _parser = None
+
   @property
   def parser(self):
     if self._parser is None:
@@ -59,6 +63,7 @@ class PantsPythonFileReporter(PythonFileReporter):
     )
 
   _source = None
+
   def source(self):
     if self._source is None:
       self._source = get_python_source(self.filename_with_source_root)
@@ -66,8 +71,8 @@ class PantsPythonFileReporter(PythonFileReporter):
 
 
 class SourceRootRemappingPlugin(CoveragePlugin):
-  """A plugin that knows how to map the source root stripped sources used in tests back to sources with source
-  roots for reporting."""
+  """A plugin that knows how to map the source root stripped sources used in tests back to sources
+  with source roots for reporting."""
 
   def __init__(self, src_chroot_path, src_to_target_base, test_time):
     super().__init__()
@@ -76,8 +81,8 @@ class SourceRootRemappingPlugin(CoveragePlugin):
     self.test_time = test_time
 
   def find_executable_files(self, top: str):
-    # Coverage uses this to associate files with this plugin. We only want to be associated with the sources we
-    # know about.
+    # Coverage uses this to associate files with this plugin. We only want to be associated with
+    # the sources we know about.
     if top.startswith(self._src_chroot_path):
       for dirname, _, filenames in os.walk(top):
         reldir = os.path.relpath(dirname, self._src_chroot_path)
@@ -88,7 +93,9 @@ class SourceRootRemappingPlugin(CoveragePlugin):
   def file_reporter(self, filename: str):
     src = os.path.relpath(filename, self._src_chroot_path)
     target_base = self._src_to_target_base.get(src)
-    return PantsPythonFileReporter(relative_source_root=target_base, source_root_stripped_filename=src, test_time=self.test_time)
+    return PantsPythonFileReporter(
+      relative_source_root=target_base, source_root_stripped_filename=src, test_time=self.test_time
+    )
 
 
 def coverage_init(reg, options):

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -137,7 +137,7 @@ class CoverageConfig:
 
 
 @rule
-async def construct_coverage_config(
+async def create_coverage_config(
     coverage_config_request: CoverageConfigRequest, source_root_config: SourceRootConfig
 ) -> CoverageConfig:
     sources = await Get[SourceFiles](
@@ -394,7 +394,7 @@ async def generate_coverage_report(
 
 def rules():
     return [
-        construct_coverage_config,
+        create_coverage_config,
         generate_coverage_report,
         merge_coverage_data,
         setup_coverage,

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -250,7 +250,9 @@ async def run_python_test(
         env=env,
     )
     result = await Get[FallibleProcessResult](Process, request)
-    coverage_data = PytestCoverageData(result.output_directory_digest) if run_coverage else None
+    coverage_data = (
+        PytestCoverageData(config.address, result.output_directory_digest) if run_coverage else None
+    )
     return TestResult.from_fallible_process_result(result, coverage_data=coverage_data)
 
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -15,8 +15,8 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.pex_from_targets import LegacyPexFromTargetsRequest
 from pants.backend.python.rules.pytest_coverage import (
     COVERAGE_PLUGIN_INPUT,
-    Coveragerc,
-    CoveragercRequest,
+    CoverageConfig,
+    CoverageConfigRequest,
     PytestCoverageData,
 )
 from pants.backend.python.rules.targets import (
@@ -171,8 +171,8 @@ async def setup_pytest_for_target(
             Addresses(tgt.address for tgt in python_targets)
         )
         requests.append(
-            Get[Coveragerc](
-                CoveragercRequest(HydratedTargets(hydrated_python_targets), test_time=True)
+            Get[CoverageConfig](
+                CoverageConfigRequest(HydratedTargets(hydrated_python_targets), is_test_time=True)
             ),
         )
 
@@ -186,7 +186,7 @@ async def setup_pytest_for_target(
     ) = cast(
         Union[
             Tuple[Pex, Pex, Pex, ImportablePythonSources, SourceFiles],
-            Tuple[Pex, Pex, Pex, ImportablePythonSources, SourceFiles, Coveragerc],
+            Tuple[Pex, Pex, Pex, ImportablePythonSources, SourceFiles, CoverageConfig],
         ],
         await MultiGet(requests),
     )
@@ -198,8 +198,8 @@ async def setup_pytest_for_target(
         test_runner_pex.directory_digest,
     ]
     if run_coverage:
-        coveragerc = rest[0]
-        directories_to_merge.append(coveragerc.digest)
+        coverage_config = rest[0]
+        directories_to_merge.append(coverage_config.digest)
 
     merged_input_files = await Get[Digest](
         DirectoriesToMerge(directories=tuple(directories_to_merge))

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -11,9 +11,9 @@ from pants.backend.python.rules import (
     importable_python_sources,
     pex,
     pex_from_targets,
-    pytest_coverage,
     pytest_runner,
 )
+from pants.backend.python.rules.pytest_coverage import CoverageConfigRequest, create_coverage_config
 from pants.backend.python.rules.pytest_runner import PythonTestConfiguration
 from pants.backend.python.rules.targets import PythonLibrary, PythonRequirementLibrary, PythonTests
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
@@ -116,7 +116,7 @@ class PytestRunnerIntegrationTest(TestBase):
     def rules(cls):
         return (
             *super().rules(),
-            *pytest_coverage.rules(),
+            create_coverage_config,
             *pytest_runner.rules(),
             *download_pex_bin.rules(),
             *determine_source_files.rules(),
@@ -127,6 +127,7 @@ class PytestRunnerIntegrationTest(TestBase):
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
             subsystem_rule(TestOptions),
+            RootRule(CoverageConfigRequest),
             RootRule(PythonTestConfiguration),
         )
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -8,7 +8,7 @@ from abc import ABC
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import ClassVar, Dict, Iterable, Optional, Tuple, Type
+from typing import ClassVar, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import OriginSpec
@@ -19,7 +19,7 @@ from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.isolated_process import FallibleProcessResult
-from pants.engine.objects import union
+from pants.engine.objects import Collection, union
 from pants.engine.rules import UnionMembership, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
@@ -144,12 +144,13 @@ class CoverageData(ABC):
     etc.
     """
 
-    batch_cls: ClassVar[Type["CoverageDataBatch"]]
+
+_CD = TypeVar("_CD", bound=CoverageData)
 
 
 @union
-class CoverageDataBatch:
-    pass
+class CoverageDataCollection(Collection[_CD]):
+    element_type: Type[_CD]
 
 
 class CoverageReport(ABC):
@@ -332,22 +333,26 @@ async def run_tests(
         exit_code = PANTS_SUCCEEDED_EXIT_CODE
 
     if options.values.run_coverage:
-        # TODO: consider warning if a user uses `--coverage` but the language backend does not
-        # provide coverage support. This might be too chatty to be worth doing?
-        results_with_coverage = [x for x in results if x.test_result.coverage_data is not None]
-        coverage_data_collections = itertools.groupby(
-            results_with_coverage,
-            lambda address_and_test_result: (
-                address_and_test_result.test_result.coverage_data.batch_cls  # type: ignore[union-attr]
-            ),
-        )
+        all_coverage_data: Iterable[CoverageData] = [
+            result.test_result.coverage_data
+            for result in results
+            if result.test_result.coverage_data is not None
+        ]
+
+        coverage_types_to_collection_types: Dict[
+            Type[CoverageData], Type[CoverageDataCollection]
+        ] = {
+            collection_cls.element_type: collection_cls
+            for collection_cls in union_membership.union_rules[CoverageDataCollection]
+        }
+        coverage_collections: List[CoverageDataCollection] = []
+        for data_cls, data in itertools.groupby(all_coverage_data, lambda data: type(data)):
+            collection_cls = coverage_types_to_collection_types[data_cls]
+            coverage_collections.append(collection_cls(data))
 
         coverage_reports = await MultiGet(
-            Get[CoverageReport](
-                CoverageDataBatch,
-                coverage_batch_cls(tuple(addresses_and_test_results)),  # type: ignore[call-arg]
-            )
-            for coverage_batch_cls, addresses_and_test_results in coverage_data_collections
+            Get[CoverageReport](CoverageDataCollection, coverage_collection)
+            for coverage_collection in coverage_collections
         )
 
         coverage_report_files = []

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -4,7 +4,7 @@
 import dataclasses
 import itertools
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
@@ -140,13 +140,11 @@ class AddressAndTestResult:
 class CoverageData(ABC):
     """Base class for inputs to a coverage report.
 
-    Subclasses should add whichever fields they require - snapshots of coverage output or xml files, etc.
+    Subclasses should add whichever fields they require - snapshots of coverage output, XML files,
+    etc.
     """
 
-    @property
-    @abstractmethod
-    def batch_cls(self) -> Type["CoverageDataBatch"]:
-        pass
+    batch_cls: ClassVar[Type["CoverageDataBatch"]]
 
 
 @union

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -33,7 +33,7 @@ from pants.rules.core.filter_empty_sources import (
 )
 from pants.rules.core.test import (
     AddressAndTestResult,
-    CoverageDataBatch,
+    CoverageDataCollection,
     CoverageReport,
     FilesystemCoverageReport,
     Status,
@@ -197,7 +197,7 @@ class TestTest(TestBase):
                 ),
                 MockGet(
                     product_type=CoverageReport,
-                    subject_type=CoverageDataBatch,
+                    subject_type=CoverageDataCollection,
                     mock=lambda _: FilesystemCoverageReport(
                         result_digest=EMPTY_DIRECTORY_DIGEST,
                         directory_to_materialize_to=PurePath("mockety/mock"),


### PR DESCRIPTION
* `PytestCoverageData` now stores an `Address`, which allows us to remove that from `PytestCoverageDataCollection`.
* Change `CoverageDataCollection` to point to its `CoverageData`, rather than the other way around.
* Inline several CovergeRC related variables/methods.
* Rename some variables.
* Reformat comments to use <= 100 columns.

[ci skip-rust-tests]
[ci skip-jvm-tests]