### PR TITLE
Propagate the owners_not_found_behavior to FilesystemSpec expansion.

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -878,10 +878,15 @@ async def sources_snapshots_from_address_specs(address_specs: AddressSpecs) -> S
 
 @rule
 async def sources_snapshots_from_filesystem_specs(
-    filesystem_specs: FilesystemSpecs,
+    filesystem_specs: FilesystemSpecs, global_options: GlobalOptions,
 ) -> SourcesSnapshots:
     """Resolve the snapshot associated with the provided filesystem specs."""
-    snapshot = await Get[Snapshot](PathGlobs, filesystem_specs.to_path_globs())
+    snapshot = await Get[Snapshot](
+        PathGlobs,
+        filesystem_specs.to_path_globs(
+            global_options.options.owners_not_found_behavior.to_glob_match_error_behavior()
+        ),
+    )
     return SourcesSnapshots([SourcesSnapshot(snapshot)])
 
 
@@ -896,7 +901,10 @@ async def addresses_with_origins_from_filesystem_specs(
     FilesystemMergedSpec.
     """
     pathglobs_per_include = (
-        filesystem_specs.path_globs_for_spec(spec) for spec in filesystem_specs.includes
+        filesystem_specs.path_globs_for_spec(
+            spec, global_options.options.owners_not_found_behavior.to_glob_match_error_behavior(),
+        )
+        for spec in filesystem_specs.includes
     )
     snapshot_per_include = await MultiGet(
         Get[Snapshot](PathGlobs, pg) for pg in pathglobs_per_include

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -64,6 +64,9 @@ class OwnersNotFoundBehavior(Enum):
     warn = "warn"
     error = "error"
 
+    def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
+        return GlobMatchErrorBehavior(self.value)
+
 
 class BuildFileImportsBehavior(Enum):
     warn = "warn"

--- a/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filesystem_specs_integration.py
@@ -36,6 +36,13 @@ class FilesystemSpecsIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(["list", "src/fake.py"])
         self.assert_failure(pants_run)
         assert 'Unmatched glob from file arguments: "src/fake.py"' in pants_run.stderr_data
+        pants_run = self.run_pants(["--owners-not-found-behavior=ignore", "list", "src/fake.py"])
+        self.assert_success(pants_run)
+        assert 'Unmatched glob from file arguments: "src/fake.py"' not in pants_run.stderr_data
+        assert (
+            "No owning targets could be found for the file `src/fake.py`"
+            not in pants_run.stderr_data
+        )
 
     def test_no_owner(self) -> None:
         """Literal file args should fail when there is no owner, but globs should be fine."""


### PR DESCRIPTION
### Problem

As described in #9500, a command like:
```
./pants --owners-not-found-behavior=ignore --pants-ignore='["/dir/**"]' list dir/BUILD
```
...will fail during the initial glob expansion.

### Solution

Propagate the `owners_not_found_behavior` to the creation of the `PathGlobs` for a `FilesystemSpec`.

### Result

Fixes #9500 so that the repro example passes.