### PR TITLE
Report workunits that have started but that are not yet complete

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -233,6 +233,7 @@ python_library(
   sources=['scheduler.py'],
   dependencies=[
     '3rdparty/python:dataclasses',
+    '3rdparty/python:typing-extensions',
     ':fs',
     ':isolated_process',
     ':native',

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 WORKUNIT_TY = Dict[str, Any]
 
-
 @dataclass(frozen=True)
 class ExecutionRequest:
     """Holds the roots for an execution, which might have been requested by a user.
@@ -276,7 +275,7 @@ class Scheduler:
         result: Tuple[Tuple[WORKUNIT_TY], Tuple[WORKUNIT_TY]] = self._from_value(
             self._native.lib.poll_session_workunits(self._scheduler, session)
         )
-        return {"started": result[0], "completed": result[1]}
+        return { "started": result[0], "completed": result[1] }
 
     def _run_and_return_roots(self, session, execution_request):
         raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
@@ -370,9 +369,8 @@ class SchedulerSession:
     def scheduler(self):
         return self._scheduler
 
-    def poll_workunits(self) -> Tuple[Dict[str, Any], ...]:
-        result: Tuple[Dict[str, Any], ...] = self._scheduler.poll_workunits(self._session)
-        return result
+    def poll_workunits(self) -> Dict[str, Tuple[WORKUNIT_TY, ...]]:
+        return self._scheduler.poll_workunits(self._session)
 
     def graph_len(self):
         return self._scheduler.graph_len()

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+WORKUNIT_TY = Dict[str, Any]
+
 
 @dataclass(frozen=True)
 class ExecutionRequest:
@@ -270,11 +272,11 @@ class Scheduler:
     def _metrics(self, session):
         return self._from_value(self._native.lib.scheduler_metrics(self._scheduler, session))
 
-    def poll_workunits(self, session) -> Tuple[Dict[str, Any], ...]:
-        result: Tuple[Dict[str, Any], ...] = self._from_value(
+    def poll_workunits(self, session) -> Dict[str, Tuple[WORKUNIT_TY, ...]]:
+        result: Tuple[Tuple[WORKUNIT_TY], Tuple[WORKUNIT_TY]] = self._from_value(
             self._native.lib.poll_session_workunits(self._scheduler, session)
         )
-        return result
+        return {"started": result[0], "completed": result[1]}
 
     def _run_and_return_roots(self, session, execution_request):
         raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 WORKUNIT_TY = Dict[str, Any]
 
+
 @dataclass(frozen=True)
 class ExecutionRequest:
     """Holds the roots for an execution, which might have been requested by a user.
@@ -275,7 +276,7 @@ class Scheduler:
         result: Tuple[Tuple[WORKUNIT_TY], Tuple[WORKUNIT_TY]] = self._from_value(
             self._native.lib.poll_session_workunits(self._scheduler, session)
         )
-        return { "started": result[0], "completed": result[1] }
+        return {"started": result[0], "completed": result[1]}
 
     def _run_and_return_roots(self, session, execution_request):
         raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
@@ -370,7 +371,7 @@ class SchedulerSession:
         return self._scheduler
 
     def poll_workunits(self) -> Dict[str, Tuple[WORKUNIT_TY, ...]]:
-        return self._scheduler.poll_workunits(self._session)
+        return self._scheduler.poll_workunits(self._session)  # type: ignore[no-any-return]
 
     def graph_len(self):
         return self._scheduler.graph_len()

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -37,7 +37,11 @@ class StreamingWorkunitHandler:
         # we report any workunits that were added after the last time the thread polled.
         workunits = self.scheduler.poll_workunits()
         for callback in self.callbacks:
-            callback(workunits=workunits, finished=True)
+            callback(
+                workunits=workunits["completed"],
+                started_workunits=workunits["started"],
+                finished=True,
+            )
 
     @contextmanager
     def session(self) -> Iterator[None]:
@@ -63,7 +67,11 @@ class _InnerHandler(threading.Thread):
         while not self.stop_request.isSet():
             workunits = self.scheduler.poll_workunits()
             for callback in self.callbacks:
-                callback(workunits=workunits, finished=False)
+                callback(
+                    workunits=workunits["completed"],
+                    started_workunits=workunits["started"],
+                    finished=False,
+                )
             self.stop_request.wait(timeout=self.report_interval)
 
     def join(self, timeout=None):

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -61,7 +61,7 @@ use std::panic;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::TempDir;
-use workunit_store::WorkUnit;
+use workunit_store::{StartedWorkUnit, WorkUnit};
 
 #[cfg(test)]
 mod tests;
@@ -399,53 +399,105 @@ fn make_core(
   )
 }
 
+fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Value {
+  use std::time::UNIX_EPOCH;
+  let duration = started_workunit
+    .start_time
+    .duration_since(UNIX_EPOCH)
+    .unwrap_or_else(|_| Duration::default());
+  let mut dict_entries = vec![
+    (
+      externs::store_utf8("name"),
+      externs::store_utf8(&started_workunit.name),
+    ),
+    (
+      externs::store_utf8("start_secs"),
+      externs::store_u64(duration.as_secs()),
+    ),
+    (
+      externs::store_utf8("start_nanos"),
+      externs::store_u64(duration.subsec_nanos() as u64),
+    ),
+    (
+      externs::store_utf8("span_id"),
+      externs::store_utf8(&started_workunit.span_id),
+    ),
+  ];
+
+  if let Some(parent_id) = &started_workunit.parent_id {
+    dict_entries.push((
+      externs::store_utf8("parent_id"),
+      externs::store_utf8(parent_id),
+    ));
+  }
+
+  if let Some(desc) = &started_workunit.metadata.desc.as_ref() {
+    dict_entries.push((
+      externs::store_utf8("description"),
+      externs::store_utf8(desc),
+    ));
+  }
+
+  externs::store_dict(&dict_entries.as_slice())
+}
+
+fn workunit_to_py_value(workunit: &WorkUnit) -> Value {
+  let mut dict_entries = vec![
+    (
+      externs::store_utf8("name"),
+      externs::store_utf8(&workunit.name),
+    ),
+    (
+      externs::store_utf8("start_secs"),
+      externs::store_u64(workunit.time_span.start.secs),
+    ),
+    (
+      externs::store_utf8("start_nanos"),
+      externs::store_u64(u64::from(workunit.time_span.start.nanos)),
+    ),
+    (
+      externs::store_utf8("duration_secs"),
+      externs::store_u64(workunit.time_span.duration.secs),
+    ),
+    (
+      externs::store_utf8("duration_nanos"),
+      externs::store_u64(u64::from(workunit.time_span.duration.nanos)),
+    ),
+    (
+      externs::store_utf8("span_id"),
+      externs::store_utf8(&workunit.span_id),
+    ),
+  ];
+  if let Some(parent_id) = &workunit.parent_id {
+    dict_entries.push((
+      externs::store_utf8("parent_id"),
+      externs::store_utf8(parent_id),
+    ));
+  }
+
+  if let Some(desc) = &workunit.metadata.desc.as_ref() {
+    dict_entries.push((
+      externs::store_utf8("description"),
+      externs::store_utf8(desc),
+    ));
+  }
+
+  externs::store_dict(&dict_entries.as_slice())
+}
+
 fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>) -> Value {
   let workunit_values = workunits
-    .map(|workunit: &WorkUnit| {
-      let mut workunit_zipkin_trace_info = vec![
-        (
-          externs::store_utf8("name"),
-          externs::store_utf8(&workunit.name),
-        ),
-        (
-          externs::store_utf8("start_secs"),
-          externs::store_u64(workunit.time_span.start.secs),
-        ),
-        (
-          externs::store_utf8("start_nanos"),
-          externs::store_u64(u64::from(workunit.time_span.start.nanos)),
-        ),
-        (
-          externs::store_utf8("duration_secs"),
-          externs::store_u64(workunit.time_span.duration.secs),
-        ),
-        (
-          externs::store_utf8("duration_nanos"),
-          externs::store_u64(u64::from(workunit.time_span.duration.nanos)),
-        ),
-        (
-          externs::store_utf8("span_id"),
-          externs::store_utf8(&workunit.span_id),
-        ),
-      ];
-      if let Some(parent_id) = &workunit.parent_id {
-        workunit_zipkin_trace_info.push((
-          externs::store_utf8("parent_id"),
-          externs::store_utf8(parent_id),
-        ));
-      }
-
-      if let Some(desc) = &workunit.metadata.desc.as_ref() {
-        workunit_zipkin_trace_info.push((
-          externs::store_utf8("description"),
-          externs::store_utf8(desc),
-        ));
-      }
-
-      externs::store_dict(&workunit_zipkin_trace_info.as_slice())
-    })
+    .map(|workunit: &WorkUnit| workunit_to_py_value(workunit))
     .collect::<Vec<_>>();
+  externs::store_tuple(&workunit_values)
+}
 
+fn started_workunits_to_py_tuple_value<'a>(
+  workunits: impl Iterator<Item = &'a StartedWorkUnit>,
+) -> Value {
+  let workunit_values = workunits
+    .map(|started_workunit: &StartedWorkUnit| started_workunit_to_py_value(started_workunit))
+    .collect::<Vec<_>>();
   externs::store_tuple(&workunit_values)
 }
 
@@ -456,10 +508,17 @@ pub extern "C" fn poll_session_workunits(
 ) -> Handle {
   with_scheduler(scheduler_ptr, |_scheduler| {
     with_session(session_ptr, |session| {
-      let value = session.workunit_store().with_latest_workunits(|workunits| {
-        let mut iter = workunits.iter();
-        workunits_to_py_tuple_value(&mut iter)
-      });
+      let value = session
+        .workunit_store()
+        .with_latest_workunits(|started, completed| {
+          let mut started_iter = started.iter();
+          let started = started_workunits_to_py_tuple_value(&mut started_iter);
+
+          let mut completed_iter = completed.iter();
+          let completed = workunits_to_py_tuple_value(&mut completed_iter);
+
+          externs::store_tuple(&[started, completed])
+        });
       value.into()
     })
   })

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -542,8 +542,7 @@ pub extern "C" fn scheduler_metrics(
         .collect::<Vec<_>>();
       if session.should_record_zipkin_spans() {
         let workunits = session.workunit_store().get_workunits();
-        let locked = workunits.lock();
-        let mut iter = locked.workunits.iter();
+        let mut iter = workunits.iter();
         let value = workunits_to_py_tuple_value(&mut iter);
         values.push((externs::store_utf8("engine_workunits"), value));
       };

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -223,7 +223,7 @@ impl ByteStore {
         workunit_name.clone(),
         TimeSpan::since(&start_time),
         parent_id,
-        );
+      );
     }
 
     result
@@ -304,7 +304,9 @@ impl ByteStore {
       let name = workunit_name.clone();
       let time_span = TimeSpan::since(&start_time);
       let parent_id = workunit_state.parent_id;
-      workunit_state.store.add_completed_workunit(name, time_span, parent_id);
+      workunit_state
+        .store
+        .add_completed_workunit(name, time_span, parent_id);
     }
 
     result
@@ -348,7 +350,9 @@ impl ByteStore {
           let name = workunit_name.clone();
           let time_span = TimeSpan::since(&start_time);
           let parent_id = workunit_state.parent_id;
-          workunit_state.store.add_completed_workunit(name, time_span, parent_id);
+          workunit_state
+            .store
+            .add_completed_workunit(name, time_span, parent_id);
         }
         future
       })

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use uuid;
-use workunit_store::WorkUnit;
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -219,12 +218,12 @@ impl ByteStore {
         .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let workunit = WorkUnit::new(
+      let parent_id = workunit_state.parent_id;
+      workunit_state.store.add_completed_workunit(
         workunit_name.clone(),
         TimeSpan::since(&start_time),
-        workunit_state.parent_id,
-      );
-      workunit_state.store.add_workunit(workunit);
+        parent_id,
+        );
     }
 
     result
@@ -302,12 +301,10 @@ impl ByteStore {
       .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let workunit = WorkUnit::new(
-        workunit_name.clone(),
-        TimeSpan::since(&start_time),
-        workunit_state.parent_id,
-      );
-      workunit_state.store.add_workunit(workunit);
+      let name = workunit_name.clone();
+      let time_span = TimeSpan::since(&start_time);
+      let parent_id = workunit_state.parent_id;
+      workunit_state.store.add_completed_workunit(name, time_span, parent_id);
     }
 
     result
@@ -348,12 +345,10 @@ impl ByteStore {
       })
       .then(move |future| {
         if let Some(workunit_state) = workunit_store::get_workunit_state() {
-          let workunit = WorkUnit::new(
-            workunit_name.clone(),
-            TimeSpan::since(&start_time),
-            workunit_state.parent_id,
-          );
-          workunit_state.store.add_workunit(workunit);
+          let name = workunit_name.clone();
+          let time_span = TimeSpan::since(&start_time);
+          let parent_id = workunit_state.parent_id;
+          workunit_state.store.add_completed_workunit(name, time_span, parent_id);
         }
         future
       })

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use std;
 use std::cmp::min;
-use workunit_store::{WorkUnit, WorkUnitStore};
+use workunit_store::WorkUnitStore;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the
@@ -839,8 +839,7 @@ fn maybe_add_workunit(
   //  TODO: workunits for scheduling, fetching, executing and uploading should be recorded
   //   only if '--reporting-zipkin-trace-v2' is set
   if !result_cached {
-    let workunit = WorkUnit::new(name.to_string(), time_span, parent_id);
-    workunit_store.add_workunit(workunit);
+    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id);
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2261,15 +2261,15 @@ async fn extract_output_files_from_response_no_prefix() {
 }
 
 fn workunits_with_constant_span_id(workunit_store: &mut WorkUnitStore) -> HashSet<WorkUnit> {
-  workunit_store
-    .with_latest_workunits(|workunits|
-      workunits.iter()
+  workunit_store.with_latest_workunits(|workunits| {
+    workunits
+      .iter()
       .map(|workunit| WorkUnit {
         span_id: String::from("ignore"),
         ..workunit.clone()
       })
       .collect()
-    )
+  })
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2261,8 +2261,8 @@ async fn extract_output_files_from_response_no_prefix() {
 }
 
 fn workunits_with_constant_span_id(workunit_store: &mut WorkUnitStore) -> HashSet<WorkUnit> {
-  workunit_store.with_latest_workunits(|workunits| {
-    workunits
+  workunit_store.with_latest_workunits(|_, completed_workunits| {
+    completed_workunits
       .iter()
       .map(|workunit| WorkUnit {
         span_id: String::from("ignore"),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2260,22 +2260,21 @@ async fn extract_output_files_from_response_no_prefix() {
   )
 }
 
-fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSet<WorkUnit> {
+fn workunits_with_constant_span_id(workunit_store: &mut WorkUnitStore) -> HashSet<WorkUnit> {
   workunit_store
-    .get_workunits()
-    .lock()
-    .workunits
-    .iter()
-    .map(|workunit| WorkUnit {
-      span_id: String::from("ignore"),
-      ..workunit.clone()
-    })
-    .collect()
+    .with_latest_workunits(|workunits|
+      workunits.iter()
+      .map(|workunit| WorkUnit {
+        span_id: String::from("ignore"),
+        ..workunit.clone()
+      })
+      .collect()
+    )
 }
 
 #[tokio::test]
 async fn remote_workunits_are_stored() {
-  let workunit_store = WorkUnitStore::new();
+  let mut workunit_store = WorkUnitStore::new();
   workunit_store.init_thread_state(None);
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
@@ -2308,7 +2307,7 @@ async fn remote_workunits_are_stored() {
   .await
   .unwrap();
 
-  let got_workunits = workunits_with_constant_span_id(&workunit_store);
+  let got_workunits = workunits_with_constant_span_id(&mut workunit_store);
 
   use concrete_time::Duration;
   use concrete_time::TimeSpan;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -34,9 +34,7 @@ use rule_graph;
 
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 use store::{self, StoreFileByDigest};
-use workunit_store::{
-  new_span_id, scope_task_workunit_state, WorkunitMetadata,
-};
+use workunit_store::{new_span_id, scope_task_workunit_state, WorkunitMetadata};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 
@@ -1064,7 +1062,10 @@ impl Node for NodeKey {
         let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
         let metadata = WorkunitMetadata { desc };
 
-        context.session.workunit_store().start_workunit(span_id, node_name, parent_id, metadata)
+        context
+          .session
+          .workunit_store()
+          .start_workunit(span_id, node_name, parent_id, metadata)
       })
     } else {
       None
@@ -1100,7 +1101,11 @@ impl Node for NodeKey {
         Err(e) => Err(e),
       };
       if let Some(id) = maybe_started_workunit_id {
-        let _ = context2.session.workunit_store().complete_workunit(id).unwrap();
+        context2
+          .session
+          .workunit_store()
+          .complete_workunit(id)
+          .unwrap();
       }
       result
     })

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -30,20 +30,24 @@ use parking_lot::Mutex;
 use rand::thread_rng;
 use rand::Rng;
 use tokio::task_local;
+use std::collections::HashMap;
 
 use std::cell::RefCell;
 use std::future::Future;
 use std::sync::Arc;
 
+pub type SpanId = String;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkUnit {
   pub name: String,
   pub time_span: TimeSpan,
-  pub span_id: String,
+  pub span_id: SpanId,
   pub parent_id: Option<String>,
   pub metadata: WorkunitMetadata,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StartedWorkUnit {
   pub name: String,
   pub start_time: std::time::SystemTime,
@@ -82,6 +86,12 @@ impl WorkUnit {
   }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum WorkunitRecord {
+  Started(StartedWorkUnit),
+  Completed(WorkUnit),
+}
+
 #[derive(Clone, Default)]
 pub struct WorkUnitStore {
   inner: Arc<Mutex<WorkUnitInnerStore>>,
@@ -89,6 +99,9 @@ pub struct WorkUnitStore {
 
 #[derive(Default)]
 pub struct WorkUnitInnerStore {
+  workunit_records: HashMap<SpanId, WorkunitRecord>,
+  started_ids: Vec<SpanId>,
+  completed_ids: Vec<SpanId>,
   pub workunits: Vec<WorkUnit>,
   last_seen_workunit: usize,
 }
@@ -97,6 +110,9 @@ impl WorkUnitStore {
   pub fn new() -> WorkUnitStore {
     WorkUnitStore {
       inner: Arc::new(Mutex::new(WorkUnitInnerStore {
+        workunit_records: HashMap::new(),
+        started_ids: Vec::new(),
+        completed_ids: Vec::new(),
         workunits: Vec::new(),
         last_seen_workunit: 0,
       })),
@@ -114,6 +130,40 @@ impl WorkUnitStore {
     self.inner.clone()
   }
 
+  pub fn start_workunit(&self, name: String, parent_id: Option<SpanId>, metadata: WorkunitMetadata,) -> SpanId {
+    let span_id = new_span_id();
+    let started = StartedWorkUnit {
+      name,
+      span_id: span_id.clone(),
+      parent_id,
+      start_time: std::time::SystemTime::now(),
+      metadata,
+    };
+    let mut inner = self.inner.lock();
+    inner.workunit_records.insert(span_id.clone(), WorkunitRecord::Started(started));
+    inner.started_ids.push(span_id.clone());
+    span_id
+  }
+
+  pub fn complete_workunit(&self, span_id: SpanId) -> Result<(), String> {
+    use std::collections::hash_map::Entry;
+    let inner = &mut self.inner.lock();
+    match inner.workunit_records.entry(span_id.clone()) {
+      Entry::Vacant(_) => Err(format!("No previously-started workunit found for id: {}", span_id)),
+      Entry::Occupied(o) => {
+        match o.remove_entry() {
+          (span_id, WorkunitRecord::Started(started)) => {
+            let finished = started.finish();
+            inner.workunit_records.insert(span_id.clone(), WorkunitRecord::Completed(finished));
+            inner.completed_ids.push(span_id);
+            Ok(())
+          },
+          (span_id, WorkunitRecord::Completed(_)) => Err(format!("Workunit {} was already completed.", span_id)),
+        }
+      }
+    }
+  }
+
   pub fn add_workunit(&self, workunit: WorkUnit) {
     self.inner.lock().workunits.push(workunit);
   }
@@ -124,11 +174,23 @@ impl WorkUnitStore {
   {
     let mut inner_guard = (*self.inner).lock();
     let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
-    let workunits = &inner_store.workunits;
-    let cur_len = workunits.len();
+
+    let workunit_records = &inner_store.workunit_records;
+    let completed_ids = &inner_store.completed_ids;
+    let cur_len = completed_ids.len();
     let latest: usize = inner_store.last_seen_workunit;
 
-    let output = f(&workunits[latest..cur_len]);
+    let workunits: Vec<WorkUnit> = inner_store
+      .completed_ids[latest..cur_len]
+      .iter()
+      .flat_map(|id| workunit_records.get(id))
+      .flat_map(|record| match record {
+        WorkunitRecord::Started(_) => None,
+        WorkunitRecord::Completed(c) => Some(c.clone()),
+      })
+      .collect();
+
+    let output = f(&workunits);
     inner_store.last_seen_workunit = cur_len;
     output
   }

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -104,7 +104,7 @@ async def rule_one_function(i: Input) -> Beta:
     a = Alpha()
     o = await Get[Omega](Alpha, a)
     b = await Get[Beta](Omega, o)
-    time.sleep(3)
+    time.sleep(1)
     return b
 
 
@@ -315,11 +315,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     @dataclass
     class WorkunitTracker:
-        """This class records every non-empty batch of started and completed workunits.
-
-        that the engine passes to it, saving them - in the order received from
-        the engine - in the _chunks members.
-        """
+        """This class records every non-empty batch of started and completed workunits received from
+        the engine."""
 
         finished_workunit_chunks: List[List[dict]] = field(default_factory=list)
         started_workunit_chunks: List[List[dict]] = field(default_factory=list)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -315,9 +315,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     @dataclass
     class WorkunitTracker:
-        """This class records every non-empty batch of started and completed workunits
+        """This class records every non-empty batch of started and completed workunits.
+
         that the engine passes to it, saving them - in the order received from
-        the engine - in the _chunks members."""
+        the engine - in the _chunks members.
+        """
 
         finished_workunit_chunks: List[List[dict]] = field(default_factory=list)
         started_workunit_chunks: List[List[dict]] = field(default_factory=list)
@@ -330,7 +332,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             started_workunits = kwargs.get("started_workunits")
             if started_workunits:
                 self.started_workunit_chunks.append(started_workunits)
-            
+
             if workunits:
                 self.finished_workunit_chunks.append(workunits)
 
@@ -387,7 +389,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         # Because of the artifical delay in rule_one, it should have time to be reported as
         # started but not yet finished.
         started = list(itertools.chain.from_iterable(tracker.started_workunit_chunks))
-        assert len(list(item for item in started if item["name"] == "rule_one")) > 0 
+        assert len(list(item for item in started if item["name"] == "rule_one")) > 0
 
         assert {item["name"] for item in tracker.finished_workunit_chunks[1]} == {"rule_one"}
 


### PR DESCRIPTION
### Problem

Clients of the StreamingWorkunits functionality should be able to get information about a workunit that has started but is not yet complete.

### Solution

Modify the workunit store to keep track of both when a workunit has been started, and when it has been marked as complete. This entailed a reasonably-substantial refactor of the workunit_store code, but also had the side effect of reducing the number of other crates that need to depend on `workunit_store`-internal data structures (with a little more refactoring around tests, we could probably make the `WorkUnit` type private). When the workunit store periodically calls a python FFI to update `StreamingWorkunit` clients, it now passes a list of started workunits as well as finished ones.