### PR TITLE
Remove the fork_context method and support code.

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -276,11 +276,6 @@ class Scheduler:
         )
         return result
 
-    def with_fork_context(self, func):
-        """See the rustdocs for `scheduler_fork_context` for more information."""
-        res = self._native.lib.scheduler_fork_context(self._scheduler, Function(self._to_key(func)))
-        return self._raise_or_return(res)
-
     def _run_and_return_roots(self, session, execution_request):
         raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
         if raw_roots == self._native.ffi.NULL:
@@ -442,9 +437,6 @@ class SchedulerSession:
     @staticmethod
     def engine_workunits(metrics):
         return metrics.get("engine_workunits")
-
-    def with_fork_context(self, func):
-        return self._scheduler.with_fork_context(func)
 
     def _maybe_visualize(self):
         if self._scheduler.visualize_to_dir is not None:

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -493,23 +493,6 @@ pub extern "C" fn scheduler_metrics(
   })
 }
 
-///
-/// Prepares to fork by shutting down any background threads used for execution, and then
-/// calling the given callback function (which should execute the fork) while holding exclusive
-/// access to all relevant locks.
-///
-#[no_mangle]
-pub extern "C" fn scheduler_fork_context(
-  scheduler_ptr: *mut Scheduler,
-  func: Function,
-) -> PyResult {
-  with_scheduler(scheduler_ptr, |_| {
-    externs::exclusive_call(&func.0)
-      .map_err(|f| format!("{:?}", f))
-      .into()
-  })
-}
-
 #[no_mangle]
 pub extern "C" fn scheduler_execute(
   scheduler_ptr: *mut Scheduler,

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -297,17 +297,6 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
 }
 
 ///
-/// Calls the given function with exclusive access to all locks managed by this module.
-/// Used to ensure that the main thread forks with all locks acquired.
-///
-pub fn exclusive_call(func: &Key) -> Result<Value, Failure> {
-  // NB: Acquiring the interns exclusively as well.
-  let interns = INTERNS.write();
-  let func_val = interns.get(func);
-  with_externs_exclusive(|e| (e.call)(e.context, func_val as &Handle, &[].as_ptr(), 0)).into()
-}
-
-///
 /// NB: Panics on failure. Only recommended for use with built-in functions, such as
 /// those configured in types::Types.
 ///
@@ -344,17 +333,6 @@ where
   F: FnOnce(&Externs) -> T,
 {
   let externs_opt = EXTERNS.read();
-  let externs = externs_opt
-    .as_ref()
-    .unwrap_or_else(|| panic!("externs used before static initialization."));
-  f(externs)
-}
-
-fn with_externs_exclusive<F, T>(f: F) -> T
-where
-  F: FnOnce(&Externs) -> T,
-{
-  let externs_opt = EXTERNS.write();
   let externs = externs_opt
     .as_ref()
     .unwrap_or_else(|| panic!("externs used before static initialization."));

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -212,17 +212,6 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             remove_locations_from_traceback(str(cm.exception)),
         )
 
-    def test_fork_context(self):
-        # A smoketest that confirms that we can successfully enter and exit the fork context, which
-        # implies acquiring and releasing all relevant Engine resources.
-        expected = "42"
-
-        def fork_context_body():
-            return expected
-
-        res = self.mk_scheduler().with_fork_context(fork_context_body)
-        self.assertEquals(res, expected)
-
     @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/6829")
     def test_trace_multi(self):
         # Tests that when multiple distinct failures occur, they are each rendered.


### PR DESCRIPTION
### Problem

The fork_context and support code are dead.

### Solution

Delete them. Hooray!

[ci skip-jvm-tests]