### PR TITLE
Prelude file support

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -4,6 +4,7 @@
 import os
 import re
 import unittest
+from textwrap import dedent
 from typing import Tuple, Type, cast
 
 from pants.base.exceptions import ResolveError
@@ -16,6 +17,7 @@ from pants.engine.internals.build_files import (
     ResolvedTypeMismatchError,
     addresses_with_origins_from_address_families,
     create_graph_rules,
+    evalute_preludes,
     parse_address_family,
     strip_address_origins,
 )
@@ -26,23 +28,29 @@ from pants.engine.internals.examples.parsers import (
 )
 from pants.engine.internals.mapper import AddressFamily, AddressMapper
 from pants.engine.internals.nodes import Return, State, Throw
-from pants.engine.internals.parser import HydratedStruct, SymbolTable
+from pants.engine.internals.parser import BuildFilePreludeSymbols, HydratedStruct, SymbolTable
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.internals.struct import Struct, StructWithDeps
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.rules import rule
+from pants.option.global_options import BuildFileImportsBehavior
 from pants.testutil.engine.util import MockGet, Target, run_rule
+from pants.util.frozendict import FrozenDict
 from pants.util.objects import Exactly
 
 
 class ParseAddressFamilyTest(unittest.TestCase):
     def test_empty(self) -> None:
         """Test that parsing an empty BUILD file results in an empty AddressFamily."""
-        address_mapper = AddressMapper(JsonParser(TEST_TABLE))
+        address_mapper = AddressMapper(
+            parser=JsonParser(TEST_TABLE),
+            prelude_glob_patterns=(),
+            build_file_imports_behavior=BuildFileImportsBehavior.error,
+        )
         af = run_rule(
             parse_address_family,
-            rule_args=[address_mapper, Dir("/dev/null")],
+            rule_args=[address_mapper, BuildFilePreludeSymbols(FrozenDict()), Dir("/dev/null")],
             mock_gets=[
                 MockGet(
                     product_type=Snapshot,
@@ -61,7 +69,11 @@ class ParseAddressFamilyTest(unittest.TestCase):
 
 class AddressesFromAddressFamiliesTest(unittest.TestCase):
     def _address_mapper(self) -> AddressMapper:
-        return AddressMapper(JsonParser(TEST_TABLE))
+        return AddressMapper(
+            JsonParser(TEST_TABLE),
+            prelude_glob_patterns=(),
+            build_file_imports_behavior=BuildFileImportsBehavior.error,
+        )
 
     def _snapshot(self) -> Snapshot:
         return Snapshot(Digest("xx", 2), ("root/BUILD",), ())
@@ -224,7 +236,12 @@ TEST_TABLE = SymbolTable(
 
 class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     def create(self, build_patterns=None, parser=None) -> SchedulerSession:
-        address_mapper = AddressMapper(build_patterns=build_patterns, parser=parser)
+        address_mapper = AddressMapper(
+            parser=parser,
+            prelude_glob_patterns=(),
+            build_file_imports_behavior=BuildFileImportsBehavior.error,
+            build_patterns=build_patterns,
+        )
 
         @rule
         def symbol_table_singleton() -> SymbolTable:
@@ -417,3 +434,92 @@ class InlinedGraphTest(GraphTestBase):
             expected_type,
             f"type was not {expected_type.__name__}. Instead was {type(failure).__name__}, {failure!r}",
         )
+
+
+class PreludeParsingTest(unittest.TestCase):
+    def test_good_prelude(self) -> None:
+        address_mapper = unittest.mock.Mock()
+        address_mapper.prelude_glob_patterns = ("prelude",)
+        address_mapper.build_file_imports_behavior = BuildFileImportsBehavior.error
+
+        symbols = run_rule(
+            evalute_preludes,
+            rule_args=[address_mapper,],
+            mock_gets=[
+                MockGet(
+                    product_type=Snapshot,
+                    subject_type=PathGlobs,
+                    mock=lambda _: Snapshot(Digest("abc", 10), ("/dev/null/prelude",), ()),
+                ),
+                MockGet(
+                    product_type=FilesContent,
+                    subject_type=Digest,
+                    mock=lambda _: FilesContent(
+                        [FileContent(path="/dev/null/prelude", content=b"def foo(): return 1")]
+                    ),
+                ),
+            ],
+        )
+        assert symbols.symbols["foo"]() == 1
+
+    def test_syntax_error(self) -> None:
+        address_mapper = unittest.mock.Mock()
+        address_mapper.prelude_glob_patterns = ("prelude",)
+        address_mapper.build_file_imports_behavior = BuildFileImportsBehavior.error
+
+        with self.assertRaisesRegex(
+            Exception, "Error parsing prelude file /dev/null/prelude: name 'blah' is not defined"
+        ):
+            run_rule(
+                evalute_preludes,
+                rule_args=[address_mapper,],
+                mock_gets=[
+                    MockGet(
+                        product_type=Snapshot,
+                        subject_type=PathGlobs,
+                        mock=lambda _: Snapshot(Digest("abc", 10), ("/dev/null/prelude",), ()),
+                    ),
+                    MockGet(
+                        product_type=FilesContent,
+                        subject_type=Digest,
+                        mock=lambda _: FilesContent(
+                            [FileContent(path="/dev/null/prelude", content=b"blah")]
+                        ),
+                    ),
+                ],
+            )
+
+    def test_illegal_import(self) -> None:
+        prelude = dedent(
+            """\
+            import os
+            def make_target():
+                python_library()
+            """
+        ).encode()
+
+        address_mapper = unittest.mock.Mock()
+        address_mapper.prelude_glob_patterns = ("prelude",)
+        address_mapper.build_file_imports_behavior = BuildFileImportsBehavior.error
+
+        with self.assertRaisesRegex(
+            Exception, "Import used in /dev/null/prelude at line 1\\. Import statements are banned"
+        ):
+            run_rule(
+                evalute_preludes,
+                rule_args=[address_mapper,],
+                mock_gets=[
+                    MockGet(
+                        product_type=Snapshot,
+                        subject_type=PathGlobs,
+                        mock=lambda _: Snapshot(Digest("abc", 10), ("/dev/null/prelude",), ()),
+                    ),
+                    MockGet(
+                        product_type=FilesContent,
+                        subject_type=Digest,
+                        mock=lambda _: FilesContent(
+                            [FileContent(path="/dev/null/prelude", content=prelude)]
+                        ),
+                    ),
+                ],
+            )

--- a/src/python/pants/engine/internals/examples/parsers.py
+++ b/src/python/pants/engine/internals/examples/parsers.py
@@ -62,7 +62,7 @@ class JsonParser(Parser):
         )
         return JSONDecoder(object_hook=decoder, strict=True)
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, _extra_symbols):
         """Parse the given json encoded string into a list of top-level objects found.
 
         The parser accepts both blank lines and comment lines (those beginning with optional whitespace
@@ -225,7 +225,7 @@ class PythonAssignmentsParser(Parser):
             parse_globals[alias] = functools.partial(aliased, alias, symbol)
         return parse_globals
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, _extra_symbols):
         parse_globals = self._globals
 
         python = filecontent
@@ -287,7 +287,7 @@ class PythonCallbacksParser(Parser):
             parse_globals[alias] = functools.partial(registered, alias, symbol)
         return objects, parse_globals
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, _extra_symbols):
         objects, parse_globals = self._globals
 
         python = filecontent

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -3,9 +3,10 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Type
+from typing import Any, Dict, Type
 
 from pants.engine.internals.struct import Struct
+from pants.util.frozendict import FrozenDict
 
 
 class ParseError(Exception):
@@ -17,6 +18,12 @@ class SymbolTable:
     """A symbol table dict mapping symbol name to implementation class."""
 
     table: Dict[str, Type]
+
+
+# Needs to be in this file to avoid a circular dependency with build_files.
+@dataclass(frozen=True)
+class BuildFilePreludeSymbols:
+    symbols: FrozenDict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -33,11 +40,12 @@ class HydratedStruct:
 
 class Parser(ABC):
     @abstractmethod
-    def parse(self, filepath: str, filecontent: bytes):
+    def parse(self, filepath: str, filecontent: bytes, extra_symbols: BuildFilePreludeSymbols):
         """
         :param filepath: The name of the file being parsed. The parser should not assume that the path
                          is accessible, and should consume the filecontent.
         :param filecontent: The raw byte content to parse.
+        :param extra_symbols: Extra Python symbols to expose to the file when parsing it.
         :returns: A list of decoded addressable, Serializable objects. The callable will
                   raise :class:`ParseError` if there were any problems encountered parsing the filecontent.
         :rtype: :class:`collections.Callable`

--- a/src/python/pants/engine/internals/parsers_test.py
+++ b/src/python/pants/engine/internals/parsers_test.py
@@ -8,6 +8,8 @@ from textwrap import dedent
 from pants.engine.internals import parser
 from pants.engine.internals.examples import parsers
 from pants.engine.internals.objects import Resolvable
+from pants.engine.internals.parser import BuildFilePreludeSymbols
+from pants.util.frozendict import FrozenDict
 
 
 # A duck-typed Serializable with an `==` suitable for ease of testing.
@@ -34,14 +36,14 @@ TEST_TABLE = parser.SymbolTable({"bob": Bob})
 TEST_TABLE2 = parser.SymbolTable({"nancy": Bob})
 
 
-def parse(parser, document, **args):
-    return parser.parse("/dev/null", document, **args)
+def parse(parser, document):
+    return parser.parse("/dev/null", document, BuildFilePreludeSymbols(FrozenDict()))
 
 
 class JsonParserTest(unittest.TestCase):
-    def parse(self, document, symbol_table=None, **kwargs):
+    def parse(self, document, symbol_table=None):
         symbol_table = symbol_table or EMPTY_TABLE
-        return parse(parsers.JsonParser(symbol_table), document, **kwargs)
+        return parse(parsers.JsonParser(symbol_table), document)
 
     def round_trip(self, obj, symbol_table=None):
         document = parsers.encode_json(obj, inline=True)
@@ -240,7 +242,9 @@ class JsonParserTest(unittest.TestCase):
         ).strip()
         filepath = "/dev/null"
         with self.assertRaises(parser.ParseError) as exc:
-            parsers.JsonParser(EMPTY_TABLE).parse(filepath, document)
+            parsers.JsonParser(EMPTY_TABLE).parse(
+                filepath, document, BuildFilePreludeSymbols(FrozenDict())
+            )
 
         # Strip trailing whitespace from the message since our expected literal below will have
         # trailing ws stripped via editors and code reviews calling for it.

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -11,7 +11,7 @@ from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.build_files import error_on_imports
 from pants.engine.internals.objects import Serializable
-from pants.engine.internals.parser import Parser, SymbolTable
+from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, SymbolTable
 from pants.engine.legacy.structs import BundleAdaptor, TargetAdaptor
 from pants.option.global_options import BuildFileImportsBehavior
 from pants.util.memo import memoized_property
@@ -111,7 +111,24 @@ class LegacyPythonCallbacksParser(Parser):
 
         return symbols, parse_context
 
-    def parse(self, filepath: str, filecontent: bytes):
+    def _make_symbols(self, extra_symbols: BuildFilePreludeSymbols):
+        """Make a full dict of symbols to expose as globals to the BUILD file.
+
+        This is subtle; functions have their own globals set on __globals__ which they derive from
+        the environment where they were executed. So for each extra_symbol which comes from a
+        separate execution environment, we need to to add all of our self._symbols to those
+        __globals__, otherwise those extra symbols will not see our target aliases etc. This also
+        means that if multiple prelude files are present, they probably cannot see each others'
+        symbols. We may choose to change this at some point.
+        """
+        d = dict(self._symbols)
+        for key, value in extra_symbols.symbols.items():
+            if hasattr(value, "__globals__"):
+                value.__globals__.update(d)
+            d[key] = value
+        return d
+
+    def parse(self, filepath: str, filecontent: bytes, extra_symbols: BuildFilePreludeSymbols):
         python = filecontent.decode()
 
         # Mutate the parse context for the new path, then exec, and copy the resulting objects.
@@ -120,7 +137,7 @@ class LegacyPythonCallbacksParser(Parser):
         # _intentional_ mutation would require a deep clone, which doesn't seem worth the cost at
         # this juncture.
         self._parse_context._storage.clear(os.path.dirname(filepath))
-        exec(python, dict(self._symbols))
+        exec(python, self._make_symbols(extra_symbols))
 
         error_on_imports(python, filepath, self._build_file_imports_behavior)
 

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -3,16 +3,15 @@
 
 import logging
 import os
-import tokenize
-from io import StringIO
 from typing import Dict, Tuple
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.base.exceptions import UnaddressableObjectError
 from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.internals.build_files import error_on_imports
 from pants.engine.internals.objects import Serializable
-from pants.engine.internals.parser import ParseError, Parser, SymbolTable
+from pants.engine.internals.parser import Parser, SymbolTable
 from pants.engine.legacy.structs import BundleAdaptor, TargetAdaptor
 from pants.option.global_options import BuildFileImportsBehavior
 from pants.util.memo import memoized_property
@@ -123,34 +122,6 @@ class LegacyPythonCallbacksParser(Parser):
         self._parse_context._storage.clear(os.path.dirname(filepath))
         exec(python, dict(self._symbols))
 
-        # Perform this check after successful execution, so we know the python is valid (and should
-        # tokenize properly!)
-        # Note that this is incredibly poor sandboxing. There are many ways to get around it.
-        # But it's sufficient to tell most users who aren't being actively malicious that they're doing
-        # something wrong, and it has a low performance overhead.
-        if "import" in python:
-            io_wrapped_python = StringIO(python)
-            for token in tokenize.generate_tokens(io_wrapped_python.readline):
-                token_str = token[1]
-                lineno, _ = token[2]
-
-                if token_str != "import":
-                    continue
-
-                if self._build_file_imports_behavior == BuildFileImportsBehavior.warn:
-                    logger.warning(
-                        f"Import used in {filepath} at line {lineno}. Import statements should "
-                        f"be avoided in BUILD files because they can easily break Pants caching and lead to "
-                        f"stale results. Instead, consider rewriting your code into a Pants plugin: "
-                        f"https://www.pantsbuild.org/howto_plugin.html"
-                    )
-                else:
-                    raise ParseError(
-                        f"Import used in {filepath} at line {lineno}. Import statements are banned in "
-                        f"BUILD files in this repository and should generally be avoided because "
-                        f"they can easily break Pants caching and lead to stale results. Instead, consider "
-                        f"rewriting your code into a Pants plugin: "
-                        f"https://www.pantsbuild.org/howto_plugin.html"
-                    )
+        error_on_imports(python, filepath, self._build_file_imports_behavior)
 
         return list(self._parse_context._storage.objects)

--- a/src/python/pants/engine/legacy/parser_test.py
+++ b/src/python/pants/engine/legacy/parser_test.py
@@ -4,9 +4,10 @@
 import unittest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.internals.parser import SymbolTable
+from pants.engine.internals.parser import BuildFilePreludeSymbols, SymbolTable
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.option.global_options import BuildFileImportsBehavior
+from pants.util.frozendict import FrozenDict
 
 
 class LegacyPythonCallbacksParserTest(unittest.TestCase):
@@ -18,7 +19,13 @@ class LegacyPythonCallbacksParserTest(unittest.TestCase):
             build_file_imports_behavior=BuildFileImportsBehavior.warn,
         )
         # Call to import a module should succeed.
-        parser.parse("/dev/null", b"""import os; os.path.join('x', 'y')""")
+        parser.parse(
+            "/dev/null",
+            b"""import os; os.path.join('x', 'y')""",
+            BuildFilePreludeSymbols(FrozenDict()),
+        )
         # But the imported module should not be visible as a symbol in further parses.
         with self.assertRaises(NameError):
-            parser.parse("/dev/null", b"""os.path.join('x', 'y')""")
+            parser.parse(
+                "/dev/null", b"""os.path.join('x', 'y')""", BuildFilePreludeSymbols(FrozenDict())
+            )

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -25,6 +25,7 @@ from pants.engine.rules import (
     rule,
 )
 from pants.engine.selectors import Get
+from pants.option.global_options import BuildFileImportsBehavior
 from pants.testutil.engine.util import (
     TARGET_TABLE,
     MockGet,
@@ -652,7 +653,12 @@ class RuleGraphTest(TestBase):
         )
 
     def test_full_graph_for_planner_example(self):
-        address_mapper = AddressMapper(JsonParser(TARGET_TABLE), "*.BUILD.json")
+        address_mapper = AddressMapper(
+            JsonParser(TARGET_TABLE),
+            prelude_glob_patterns=(),
+            build_file_imports_behavior=BuildFileImportsBehavior.error,
+            build_patterns="*.BUILD.json",
+        )
         rules = create_graph_rules(address_mapper) + create_fs_rules()
 
         fullgraph_str = self.create_full_graph(rules)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -307,6 +307,7 @@ class EngineInitializer:
             OptionsInitializer.compute_pants_ignore(build_root, bootstrap_options),
             use_gitignore,
             bootstrap_options.local_store_dir,
+            bootstrap_options.build_file_prelude_globs,
             bootstrap_options.build_file_imports,
             options_bootstrapper,
             build_configuration,
@@ -327,6 +328,7 @@ class EngineInitializer:
         pants_ignore_patterns: List[str],
         use_gitignore: bool,
         local_store_dir,
+        build_file_prelude_globs: Tuple[str, ...],
         build_file_imports_behavior: BuildFileImportsBehavior,
         options_bootstrapper: OptionsBootstrapper,
         build_configuration: BuildConfiguration,
@@ -342,6 +344,7 @@ class EngineInitializer:
         """Construct and return the components necessary for LegacyBuildGraph construction.
 
         :param local_store_dir: The directory to use for storing the engine's LMDB store in.
+        :param build_file_prelude_globs: Globs to match files to be prepended to all BUILD files.
         :param build_file_imports_behavior: How to behave if a BUILD file being parsed tries to use
                                             import statements.
         :param build_root: A path to be used as the build root. If None, then default is used.
@@ -381,6 +384,8 @@ class EngineInitializer:
         )
         address_mapper = AddressMapper(
             parser=parser,
+            prelude_glob_patterns=build_file_prelude_globs,
+            build_file_imports_behavior=build_file_imports_behavior,
             build_ignore_patterns=build_ignore_patterns,
             exclude_target_regexps=exclude_target_regexps,
             subproject_roots=subproject_roots,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -729,6 +729,17 @@ class GlobalOptions(Subsystem):
         )
 
         register(
+            "--build-file-prelude-globs",
+            advanced=True,
+            type=list,
+            default=[],
+            help="Python files to evaluate and whose symbols should be exposed to all BUILD files ."
+            "This allows for writing functions which create multiple rules, or set default "
+            "arguments for rules. The order these files will be evaluated is undefined - they should not rely on each "
+            "other, or override symbols from each other.",
+        )
+
+        register(
             "--local-store-dir",
             advanced=True,
             help="Directory to use for engine's local file store.",

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -415,6 +415,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             pants_ignore_patterns=[],
             use_gitignore=False,
             local_store_dir=local_store_dir,
+            build_file_prelude_globs=(),
             build_file_imports_behavior=BuildFileImportsBehavior.error,
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             native=init_native(),

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -21,7 +21,7 @@ class FrozenDict(Mapping[K, V]):
 
         These values must be hashable, which we proactively validate.
         """
-        self._data: Dict[K, V] = dict(item)  # type: ignore[arg-type]
+        self._data: Dict[K, V] = dict(item) if item else dict()
         # NB: We eagerly compute the hash to validate that the values are hashable and to avoid
         # performing the calculation multiple times. This can be revisited if it's found to be a
         # performance bottleneck.

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -136,3 +136,12 @@ python_tests(
   tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )
+
+python_tests(
+  name = 'prelude_integration',
+  sources = [ 'test_prelude_integration.py' ],
+  dependencies = [
+    'src/python/pants/testutil:int-test',
+  ],
+  tags = {'integration', 'partially_type_checked'},
+)

--- a/tests/python/pants_test/integration/test_prelude_integration.py
+++ b/tests/python/pants_test/integration/test_prelude_integration.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PreludeIntegrationTest(PantsRunIntegrationTest):
+    """Tests the functionality build file preludes."""
+
+    def test_build_file_prelude(self):
+        prelude = b"""def make_target():
+    python_binary(name = "main", sources = ["main.py"])
+"""
+        build = b"make_target()"
+        python = b"print('Unique output here!!')"
+
+        with self.temporary_file_content("prelude", prelude), self.temporary_file_content(
+            "BUILD", build
+        ), self.temporary_file_content("main.py", python):
+            run = self.run_pants(["--build-file-prelude-globs=prelude", "run", ":main"])
+            self.assert_success(run)
+            assert "Unique output here!!" in run.stdout_data


### PR DESCRIPTION
Allow python files to be evaluated before BUILD files, with the same
symbols available to them as BUILD files, and for them to inject symbols
into the global scope of all BUILD files.

# Example usage:
In a file used as a prelude:
```python
def python3_library(**kwargs):
    kwargs["compatibility"] = ["CPython>=3"]
    python_library(**kwargs)
```

In a BUILD file:
```python
python3_library(
    name = "bin",
    sources = ["main.py"],
)
```

That BUILD file will be equivalent to this one:
```python
python_library(
    name = "bin",
    sources = ["main.py"],
    compatibility = ["CPython>=3"],
)
```

[ci skip-rust-tests]
[ci skip-jvm-tests]