### PR TITLE
Bump timeouts for several tests and for remote execution

### DIFF
--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -39,7 +39,7 @@ python_tests(
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
   ],
-  timeout=480,
+  timeout=540,
   tags={'integration', 'partially_type_checked'},
 )
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -374,7 +374,7 @@ async fn main() {
           store.clone(),
           Platform::Linux,
           executor,
-          std::time::Duration::from_secs(300),
+          std::time::Duration::from_secs(320),
           std::time::Duration::from_millis(500),
           std::time::Duration::from_secs(5),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -202,7 +202,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
-            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(320),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?),

--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -32,5 +32,5 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:wire_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 300,
+  timeout = 360,
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -417,7 +417,7 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
   ],
   tags = {'partially_type_checked'},
-  timeout = 120,
+  timeout = 150,
 )
 
 python_tests(
@@ -525,7 +525,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 460,
+  timeout = 540,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -177,7 +177,7 @@ python_tests(
         "testprojects/src/python:python_distribution_directory",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=360,
+    timeout=420,
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -72,14 +72,14 @@ python_tests(
 
 python_tests(
   name = 'goal_rule_integration',
-  sources = [ 'test_goal_rule_integration.py' ],
+  sources = ['test_goal_rule_integration.py'],
   dependencies = [
     'tests/python/pants_test/pantsd:pantsd_integration_test_base',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/tests/python/pants:dummies_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 270,
+  timeout = 330,
 )
 
 python_tests(

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -124,7 +124,7 @@ python_tests(
         "testprojects/src/thrift/org/pantsbuild:all_directories",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=300,
+    timeout=360,
 )
 
 python_tests(


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/9539.

We add 20 seconds to the timeout for all remote tests because we frequently see several tests time out at the same time, signaling that the issue is remote execution not having enough resources, rather than an individual test taking too long.

[ci skip-jvm-tests]