### PR TITLE
Fix V2 binary still using the `current` platform when `platforms` is specified

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -189,9 +189,9 @@ class PexPlatforms:
         self.platforms = FrozenOrderedSet(sorted(platforms or ()))
 
     @classmethod
-    def create_from_platforms_fields(cls, fields: Iterable[PythonPlatformsField]) -> "PexPlatforms":
+    def create_from_platforms_field(cls, field: PythonPlatformsField) -> "PexPlatforms":
         # TODO(#9562): wire to `--python-setup-platforms` once we know when/where it should be used.
-        return cls(itertools.chain.from_iterable(field.value or () for field in fields))
+        return cls(field.value or ())
 
     def generate_pex_arg_list(self) -> List[str]:
         args = []

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -8,12 +8,14 @@ from typing import Iterable, Optional, Tuple
 from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
 from pants.backend.python.rules.pex import (
     PexInterpreterConstraints,
+    PexPlatforms,
     PexRequest,
     PexRequirements,
     TwoStepPexRequest,
 )
+from pants.backend.python.rules.targets import PythonInterpreterCompatibility
+from pants.backend.python.rules.targets import PythonPlatforms as PythonPlatformsField
 from pants.backend.python.rules.targets import (
-    PythonInterpreterCompatibility,
     PythonRequirementsField,
     PythonRequirementsFileSources,
     PythonSources,
@@ -107,6 +109,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         ):
             resource_targets.append(tgt)
 
+    platforms = PexPlatforms.create_from_platforms_fields(
+        (tgt.get(PythonPlatformsField) for tgt in python_targets)
+    )
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (tgt.get(PythonInterpreterCompatibility) for tgt in python_targets), python_setup
     )
@@ -129,6 +134,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         output_filename=request.output_filename,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
+        platforms=platforms,
         entry_point=request.entry_point,
         sources=merged_input_digest,
         additional_inputs=request.additional_inputs,

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -14,6 +14,7 @@ from pants.backend.python.rules import download_pex_bin
 from pants.backend.python.rules.pex import (
     Pex,
     PexInterpreterConstraints,
+    PexPlatforms,
     PexRequest,
     PexRequirements,
 )
@@ -168,6 +169,7 @@ class PexTest(TestBase):
         requirements=PexRequirements(),
         entry_point=None,
         interpreter_constraints=PexInterpreterConstraints(),
+        platforms=PexPlatforms(),
         sources: Optional[Digest] = None,
         additional_inputs: Optional[Digest] = None,
         additional_pants_args: Tuple[str, ...] = (),
@@ -177,6 +179,7 @@ class PexTest(TestBase):
             output_filename="test.pex",
             requirements=requirements,
             interpreter_constraints=interpreter_constraints,
+            platforms=platforms,
             entry_point=entry_point,
             sources=sources,
             additional_inputs=additional_inputs,
@@ -210,6 +213,7 @@ class PexTest(TestBase):
         requirements=PexRequirements(),
         entry_point=None,
         interpreter_constraints=PexInterpreterConstraints(),
+        platforms=PexPlatforms(),
         sources: Optional[Digest] = None,
         additional_pants_args: Tuple[str, ...] = (),
         additional_pex_args: Tuple[str, ...] = (),
@@ -220,6 +224,7 @@ class PexTest(TestBase):
                 requirements=requirements,
                 entry_point=entry_point,
                 interpreter_constraints=interpreter_constraints,
+                platforms=platforms,
                 sources=sources,
                 additional_pants_args=additional_pants_args,
                 additional_pex_args=additional_pex_args,
@@ -238,22 +243,22 @@ class PexTest(TestBase):
         pex_output = self.create_pex_and_get_all_data(entry_point="main", sources=sources)
 
         pex_files = pex_output["files"]
-        self.assertTrue("pex" not in pex_files)
-        self.assertTrue("main.py" in pex_files)
-        self.assertTrue("subdir/sub.py" in pex_files)
+        assert "pex" not in pex_files
+        assert "main.py" in pex_files
+        assert "subdir/sub.py" in pex_files
 
         init_subsystem(PythonSetup)
         python_setup = PythonSetup.global_instance()
         env = {"PATH": create_path_env_var(python_setup.interpreter_search_paths)}
 
-        req = Process(
+        process = Process(
             argv=("python", "test.pex"),
             env=env,
             input_files=pex_output["pex"].directory_digest,
             description="Run the pex and make sure it works",
         )
-        result = self.request_single_product(ProcessResult, req)
-        self.assertEqual(result.stdout, b"from main\n")
+        result = self.request_single_product(ProcessResult, process)
+        assert result.stdout == b"from main\n"
 
     def test_resolves_dependencies(self) -> None:
         requirements = PexRequirements(["six==1.12.0", "jsonschema==2.6.0", "requests==2.23.0"])
@@ -297,6 +302,26 @@ class PexTest(TestBase):
     def test_additional_args(self) -> None:
         pex_info = self.create_pex_and_get_pex_info(additional_pex_args=("--not-zip-safe",))
         assert pex_info["zip_safe"] is False
+
+    def test_platforms(self) -> None:
+        # We use Python 2.7, rather than Python 3, to ensure that the specified platform is
+        # actually used.
+        platforms = PexPlatforms(["linux-x86_64-cp-27-cp27mu"])
+        constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
+        pex_output = self.create_pex_and_get_all_data(
+            requirements=PexRequirements(["cryptography==2.9"]),
+            platforms=platforms,
+            interpreter_constraints=constraints,
+        )
+        assert any(
+            "cryptography-2.9-cp27-cp27mu-manylinux2010_x86_64.whl" in fp
+            for fp in pex_output["files"]
+        )
+        assert not any("cryptography-2.9-cp27-cp27m-" in fp for fp in pex_output["files"])
+        assert not any("cryptography-2.9-cp35-abi3" in fp for fp in pex_output["files"])
+
+        # NB: Platforms override interpreter constraints.
+        assert pex_output["info"]["interpreter_constraints"] == []
 
     def test_additional_inputs(self) -> None:
         # We use pex's --preamble-file option to set a custom premable from a file.

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-from pants.backend.python.rules.pex import TwoStepPex
+from pants.backend.python.rules.pex import PexPlatforms, TwoStepPex
 from pants.backend.python.rules.pex_from_targets import (
     PexFromTargetsRequest,
     TwoStepPexFromTargetsRequest,
@@ -19,6 +19,7 @@ from pants.backend.python.rules.targets import (
     PythonBinarySources,
     PythonEntryPoint,
 )
+from pants.backend.python.rules.targets import PythonPlatforms as PythonPlatformsField
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.engine.addressable import Addresses
 from pants.engine.rules import UnionRule, rule
@@ -40,6 +41,7 @@ class PythonBinaryConfiguration(BinaryConfiguration):
     inherit_path: PexInheritPath
     shebang: PexShebang
     zip_safe: PexZipSafe
+    platforms: PythonPlatformsField
 
     def generate_additional_args(self) -> Tuple[str, ...]:
         args = []
@@ -78,6 +80,7 @@ async def create_python_binary(config: PythonBinaryConfiguration) -> CreatedBina
             PexFromTargetsRequest(
                 addresses=Addresses([config.address]),
                 entry_point=entry_point,
+                platforms=PexPlatforms.create_from_platforms_field(config.platforms),
                 output_filename=output_filename,
                 additional_args=config.generate_additional_args(),
                 description=f"Building {output_filename}",

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -18,7 +18,6 @@ from pants.backend.python.rules.targets import (
     PexZipSafe,
     PythonBinarySources,
     PythonEntryPoint,
-    PythonPlatforms,
 )
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.engine.addressable import Addresses
@@ -41,7 +40,6 @@ class PythonBinaryConfiguration(BinaryConfiguration):
     inherit_path: PexInheritPath
     shebang: PexShebang
     zip_safe: PexZipSafe
-    platforms: PythonPlatforms
 
     def generate_additional_args(self) -> Tuple[str, ...]:
         args = []
@@ -55,8 +53,6 @@ class PythonBinaryConfiguration(BinaryConfiguration):
             args.append(f"--inherit-path={self.inherit_path.value}")
         if self.shebang.value is not None:
             args.append(f"--python-shebang={self.shebang.value}")
-        if self.platforms.value is not None:
-            args.extend([f"--platform={platform}" for platform in self.platforms.value])
         return tuple(args)
 
 


### PR DESCRIPTION
### Problem

When specifying `platforms` on a `python_binary`, you'd expect the built wheel to only have those specified platforms. But, it currently will always include the `current` platform.

This is because we are unconditionally passing the flag `--interpreter-constraint` to Pex, which forces `current` to be used, per https://github.com/pantsbuild/pex/issues/957. As explained there, Pex is behaving correctly; the issue is with Pants.

### Solution

When `platforms` are set, ignore interpreter constraints. 

Platforms already embed interpreter constraints in them, e.g. `linux-x86_64-cp-37-cp37m` saying that it needs compatibility with CPython 3.7. So, `platforms` is an override over interpreter constraints.

This change only applies when using the target with `./pants run` and `./pants binary`. Other goals like `./pants test` will ignore the `platforms` value and use interpreter constraints like normal.

[ci skip-rust-tests]
[ci skip-jvm-tests]