### PR TITLE
Convert repl goal to the new Targets API

### DIFF
--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from pants.backend.python.rules.pex import Pex
-from pants.backend.python.rules.pex_from_targets import LegacyPexFromTargetsRequest
+from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest, LegacyPexFromTargetsRequest
 from pants.backend.python.subsystems.ipython import IPython
 from pants.engine.addressable import Addresses
 from pants.engine.legacy.graph import TransitiveHydratedTargets
@@ -19,9 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class PythonRepl:
-    name: ClassVar[str] = "python"
-    addresses: Addresses
+class PythonRepl(ReplImplementation):
+    name = "python"
 
 
 @rule
@@ -39,9 +38,8 @@ async def run_python_repl(repl: PythonRepl) -> ReplBinary:
 
 
 @dataclass(frozen=True)
-class IPythonRepl:
-    name: ClassVar[str] = "ipython"
-    addresses: Addresses
+class IPythonRepl(ReplImplementation):
+    name = "ipython"
 
 
 @rule

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -1,62 +1,55 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
-from dataclasses import dataclass
-from typing import ClassVar
-
-from pants.backend.python.rules.pex import Pex
-from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest, LegacyPexFromTargetsRequest
+from pants.backend.python.rules.pex import TwoStepPex
+from pants.backend.python.rules.pex_from_targets import (
+    PexFromTargetsRequest,
+    TwoStepPexFromTargetsRequest,
+)
+from pants.backend.python.rules.targets import PythonSources
 from pants.backend.python.subsystems.ipython import IPython
 from pants.engine.addressable import Addresses
-from pants.engine.legacy.graph import TransitiveHydratedTargets
-from pants.engine.legacy.structs import PythonTargetAdaptor
 from pants.engine.rules import UnionRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.rules.core.repl import ReplBinary, ReplImplementation
 
-logger = logging.getLogger(__name__)
 
-
-@dataclass(frozen=True)
 class PythonRepl(ReplImplementation):
     name = "python"
+    required_fields = (PythonSources,)
 
 
 @rule
 async def run_python_repl(repl: PythonRepl) -> ReplBinary:
-    targets = await Get[TransitiveHydratedTargets](Addresses, repl.addresses)
-    python_addresses = Addresses(
-        ht.adaptor.address for ht in targets.closure if isinstance(ht.adaptor, PythonTargetAdaptor)
+    addresses = Addresses(tgt.address for tgt in repl.targets)
+    two_step_pex = await Get[TwoStepPex](
+        TwoStepPexFromTargetsRequest(
+            PexFromTargetsRequest(addresses=addresses, output_filename="python-repl.pex",)
+        )
     )
-    create_pex = LegacyPexFromTargetsRequest(
-        addresses=python_addresses, output_filename="python-repl.pex",
-    )
-
-    repl_pex = await Get[Pex](LegacyPexFromTargetsRequest, create_pex)
+    repl_pex = two_step_pex.pex
     return ReplBinary(digest=repl_pex.directory_digest, binary_name=repl_pex.output_filename,)
 
 
-@dataclass(frozen=True)
 class IPythonRepl(ReplImplementation):
     name = "ipython"
+    required_fields = (PythonSources,)
 
 
 @rule
 async def run_ipython_repl(repl: IPythonRepl, ipython: IPython) -> ReplBinary:
-    targets = await Get[TransitiveHydratedTargets](Addresses, repl.addresses)
-    python_addresses = Addresses(
-        ht.adaptor.address for ht in targets.closure if isinstance(ht.adaptor, PythonTargetAdaptor)
+    addresses = Addresses(tgt.address for tgt in repl.targets)
+    two_step_pex = await Get[TwoStepPex](
+        TwoStepPexFromTargetsRequest(
+            PexFromTargetsRequest(
+                addresses=addresses,
+                output_filename="ipython-repl.pex",
+                entry_point=ipython.get_entry_point(),
+                additional_requirements=ipython.get_requirement_specs(),
+            )
+        )
     )
-
-    create_pex = LegacyPexFromTargetsRequest(
-        addresses=python_addresses,
-        output_filename="ipython-repl.pex",
-        entry_point=ipython.get_entry_point(),
-        additional_requirements=ipython.get_requirement_specs(),
-    )
-
-    repl_pex = await Get[Pex](LegacyPexFromTargetsRequest, create_pex)
+    repl_pex = two_step_pex.pex
     return ReplBinary(digest=repl_pex.directory_digest, binary_name=repl_pex.output_filename,)
 
 

--- a/src/python/pants/rules/core/repl.py
+++ b/src/python/pants/rules/core/repl.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from abc import ABC
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import ClassVar
@@ -19,11 +20,12 @@ from pants.util.contextutil import temporary_dir
 
 
 @union
-class ReplImplementation:
+@dataclass(frozen=True)
+class ReplImplementation(ABC):
     """This type proxies from the top-level `repl` goal to a specific REPL implementation for a
     specific language or languages."""
 
-    name: ClassVar[str] = ""
+    name: ClassVar[str]
     addresses: Addresses
 
 
@@ -70,7 +72,7 @@ async def run_repl(
     # We can guarantee that we will only even enter this `goal_rule` if there exists an implementer
     # of the `ReplImplementation` union because `LegacyGraphSession.run_goal_rules()` will not
     # execute this rule's body if there are no implementations registered.
-    membership = union_membership.union_rules[ReplImplementation]
+    membership: Iterable[Type[ReplImplementation]] = union_membership.union_rules[ReplImplementation]
     implementations = {impl.name: impl for impl in membership}
 
     default_repl = "python"

--- a/src/python/pants/rules/core/repl_integration_test.py
+++ b/src/python/pants/rules/core/repl_integration_test.py
@@ -9,8 +9,9 @@ from pants.backend.python.rules import (
     repl,
 )
 from pants.backend.python.rules.repl import PythonRepl
+from pants.backend.python.rules.targets import PythonLibrary
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
-from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
@@ -41,7 +42,11 @@ class ReplTest(GoalRuleTestBase):
 
     @classmethod
     def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(targets={"python_library": PythonLibrary})
+        return BuildFileAliases(targets={"python_library": PythonLibraryV1})
+
+    @classmethod
+    def target_types(cls):
+        return [PythonLibrary]
 
     def setup_python_library(self) -> None:
         library_source = FileContent(path="some_lib.py", content=b"class SomeClass:\n  pass\n")


### PR DESCRIPTION
This commit ports the v2 `repl` goal to the new Targets API. It should have no user-visible changes 