### PR TITLE
Remove "Executing process" text from V2 UI

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -276,7 +276,7 @@ impl MultiPlatformProcess {
       .0
       .iter()
       .next()
-      .map(|(_platforms, epr)| format!("Executing process: {}", epr.description))
+      .map(|(_platforms, epr)| epr.description.clone())
   }
 }
 


### PR DESCRIPTION
## Problem

The V2 UI needlessly displays the text "Executing process:" before the string associated with an executing process. This takes up valuable space in the terminal while providing no useful information.

### Solution

Simply remove this text.