### PR TITLE
Remove several unused `TargetAdaptor` utility rules

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -104,7 +104,4 @@ async def download_pex_bin(pex_binary_tool: DownloadedPexBin.Factory) -> Downloa
 
 
 def rules():
-    return [
-        download_pex_bin,
-        subsystem_rule(DownloadedPexBin.Factory),
-    ]
+    return [download_pex_bin, subsystem_rule(DownloadedPexBin.Factory)]

--- a/src/python/pants/backend/python/rules/importable_python_sources.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources.py
@@ -6,16 +6,11 @@ from dataclasses import dataclass
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
 from pants.engine.fs import Snapshot
-from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Sources, Targets
 from pants.rules.core import determine_source_files
-from pants.rules.core.determine_source_files import (
-    AllSourceFilesRequest,
-    LegacyAllSourceFilesRequest,
-    SourceFiles,
-)
+from pants.rules.core.determine_source_files import AllSourceFilesRequest, SourceFiles
 
 
 @dataclass(frozen=True)
@@ -45,23 +40,9 @@ async def prepare_python_sources(targets: Targets) -> ImportablePythonSources:
     return ImportablePythonSources(init_injected.snapshot)
 
 
-@rule
-async def legacy_prepare_python_sources(
-    hydrated_targets: HydratedTargets,
-) -> ImportablePythonSources:
-    stripped_sources = await Get[SourceFiles](
-        LegacyAllSourceFilesRequest(
-            (ht.adaptor for ht in hydrated_targets), strip_source_roots=True
-        )
-    )
-    init_injected = await Get[InitInjectedSnapshot](InjectInitRequest(stripped_sources.snapshot))
-    return ImportablePythonSources(init_injected.snapshot)
-
-
 def rules():
     return [
         prepare_python_sources,
-        legacy_prepare_python_sources,
         *determine_source_files.rules(),
         *inject_init_rules(),
         RootRule(Targets),

--- a/src/python/pants/backend/python/rules/importable_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources_test.py
@@ -1,17 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pathlib import PurePath
-from typing import List, Optional, Type
-from unittest.mock import Mock
+from typing import List, Type
 
 from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
 from pants.backend.python.rules.importable_python_sources import (
     rules as importable_python_sources_rules,
 )
 from pants.build_graph.address import Address
-from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
-from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.engine.target import Sources, Target, Targets
 from pants.rules.core.targets import Files
@@ -27,7 +23,7 @@ class MockTarget(Target):
 class ImportablePythonSourcesTest(TestBase):
     @classmethod
     def rules(cls):
-        return (*super().rules(), *importable_python_sources_rules(), RootRule(HydratedTargets))
+        return (*super().rules(), *importable_python_sources_rules())
 
     def create_target(
         self, *, parent_directory: str, files: List[str], target_cls: Type[Target] = MockTarget
@@ -52,46 +48,6 @@ class ImportablePythonSourcesTest(TestBase):
             ImportablePythonSources,
             Params(
                 Targets([target_with_init, target_without_init, files_target]),
-                create_options_bootstrapper(),
-            ),
-        )
-        assert sorted(result.snapshot.files) == sorted(
-            [
-                "project/lib.py",
-                "project/__init__.py",
-                "test_project/f1.py",
-                "test_project/f2.py",
-                "test_project/__init__.py",
-                "src/python/project/resources/loose_file.txt",
-            ]
-        )
-
-    def make_hydrated_target(
-        self, *, source_paths: List[str], type_alias: Optional[str] = None,
-    ) -> HydratedTarget:
-        adaptor = Mock()
-        adaptor.type_alias = type_alias
-        adaptor.sources = Mock()
-        adaptor.sources.snapshot = self.make_snapshot_of_empty_files(source_paths)
-        adaptor.address = Address(
-            spec_path=PurePath(source_paths[0]).parent.as_posix(), target_name="target"
-        )
-        return HydratedTarget(adaptor)
-
-    def test_legacy_adds_missing_inits_and_strips_source_roots(self) -> None:
-        target_with_init = self.make_hydrated_target(
-            source_paths=["src/python/project/lib.py", "src/python/project/__init__.py"],
-        )
-        target_without_init = self.make_hydrated_target(
-            source_paths=["tests/python/test_project/f1.py", "tests/python/test_project/f2.py"],
-        )
-        files_target = self.make_hydrated_target(
-            source_paths=["src/python/project/resources/loose_file.txt"], type_alias=Files.alias,
-        )
-        result = self.request_single_product(
-            ImportablePythonSources,
-            Params(
-                HydratedTargets([target_with_init, target_without_init, files_target]),
                 create_options_bootstrapper(),
             ),
         )

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -20,8 +20,6 @@ from pants.backend.python.rules.targets import (
 )
 from pants.engine.addressable import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
-from pants.engine.legacy.structs import FilesAdaptor, PythonTargetAdaptor, ResourcesAdaptor
 from pants.engine.rules import RootRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Targets, TransitiveTargets
@@ -143,66 +141,10 @@ async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoSte
     return TwoStepPexRequest(pex_request=pex_request)
 
 
-@dataclass(frozen=True)
-class LegacyPexFromTargetsRequest:
-    """Represents a request to create a PEX from the closure of a set of targets."""
-
-    addresses: Addresses
-    output_filename: str
-    entry_point: Optional[str] = None
-    additional_requirements: Tuple[str, ...] = ()
-    include_source_files: bool = True
-    additional_args: Tuple[str, ...] = ()
-    additional_sources: Optional[Digest] = None
-
-
-@named_rule(desc="Create PEX from targets")
-async def legacy_pex_from_targets(
-    request: LegacyPexFromTargetsRequest, python_setup: PythonSetup
-) -> PexRequest:
-    transitive_hydrated_targets = await Get[TransitiveHydratedTargets](Addresses, request.addresses)
-    all_targets = transitive_hydrated_targets.closure
-
-    python_targets = [t for t in all_targets if isinstance(t.adaptor, PythonTargetAdaptor)]
-    resource_targets = [
-        t for t in all_targets if isinstance(t.adaptor, (FilesAdaptor, ResourcesAdaptor))
-    ]
-
-    all_target_adaptors = [t.adaptor for t in all_targets]
-
-    interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
-        adaptors=all_target_adaptors, python_setup=python_setup
-    )
-
-    source_digests = []
-    if request.additional_sources:
-        source_digests.append(request.additional_sources)
-    if request.include_source_files:
-        prepared_sources = await Get[ImportablePythonSources](
-            HydratedTargets(python_targets + resource_targets)
-        )
-        source_digests.append(prepared_sources.snapshot.directory_digest)
-    merged_sources_digest = await Get[Digest](DirectoriesToMerge(directories=tuple(source_digests)))
-    requirements = PexRequirements.create_from_adaptors(
-        adaptors=all_target_adaptors, additional_requirements=request.additional_requirements
-    )
-
-    return PexRequest(
-        output_filename=request.output_filename,
-        requirements=requirements,
-        interpreter_constraints=interpreter_constraints,
-        entry_point=request.entry_point,
-        sources=merged_sources_digest,
-        additional_args=request.additional_args,
-    )
-
-
 def rules():
     return [
         pex_from_targets,
         two_step_pex_from_targets,
         RootRule(PexFromTargetsRequest),
         RootRule(TwoStepPexFromTargetsRequest),
-        legacy_pex_from_targets,
-        RootRule(LegacyPexFromTargetsRequest),
     ]

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -61,8 +61,4 @@ async def list_roots(console: Console, options: RootsOptions, all_roots: AllSour
 
 
 def rules():
-    return [
-        subsystem_rule(SourceRootConfig),
-        all_roots,
-        list_roots,
-    ]
+    return [all_roots, list_roots, subsystem_rule(SourceRootConfig)]

--- a/src/python/pants/rules/core/repl.py
+++ b/src/python/pants/rules/core/repl.py
@@ -122,6 +122,4 @@ async def run_repl(
 
 
 def rules():
-    return [
-        run_repl,
-    ]
+    return [run_repl]


### PR DESCRIPTION
Now that every V2 goal is using the Target API, we can safely remove these utilities.

[ci skip-rust-tests]
[ci skip-jvm-tests]