### PR TITLE
Use rust cpu_count crate to determine v2 UI swim lanes

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -906,7 +906,6 @@ class Native(metaclass=SingletonMetaclass):
         scheduler,
         should_record_zipkin_spans,
         should_render_ui,
-        ui_worker_count,
         build_id,
         should_report_workunits: bool,
     ):
@@ -915,7 +914,6 @@ class Native(metaclass=SingletonMetaclass):
                 scheduler,
                 should_record_zipkin_spans,
                 should_render_ui,
-                ui_worker_count,
                 self.context.utf8_buf(build_id),
                 should_report_workunits,
             ),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-import multiprocessing
 import os
 import sys
 import time
@@ -338,12 +337,7 @@ class Scheduler:
         return SchedulerSession(
             self,
             self._native.new_session(
-                self._scheduler,
-                zipkin_trace_v2,
-                v2_ui,
-                multiprocessing.cpu_count(),
-                build_id,
-                should_report_workunits,
+                self._scheduler, zipkin_trace_v2, v2_ui, build_id, should_report_workunits,
             ),
         )
 

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -761,7 +761,6 @@ pub extern "C" fn session_create(
   scheduler_ptr: *mut Scheduler,
   should_record_zipkin_spans: bool,
   should_render_ui: bool,
-  ui_worker_count: u64,
   build_id: Buffer,
   should_report_workunits: bool,
 ) -> *const Session {
@@ -773,7 +772,6 @@ pub extern "C" fn session_create(
       scheduler,
       should_record_zipkin_spans,
       should_render_ui,
-      ui_worker_count as usize,
       build_id,
       should_report_workunits,
     )))

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -60,13 +60,12 @@ impl Session {
     scheduler: &Scheduler,
     should_record_zipkin_spans: bool,
     should_render_ui: bool,
-    ui_worker_count: usize,
     build_id: String,
     should_report_workunits: bool,
   ) -> Session {
     let display = if should_render_ui && EngineDisplay::stdout_is_tty() {
       let mut display = EngineDisplay::new();
-      display.initialize(ui_worker_count);
+      display.initialize(num_cpus::get());
       Some(Arc::new(Mutex::new(display)))
     } else {
       None


### PR DESCRIPTION
### Problem

The number of swim lanes displayed in the v2 UI is currently set to be the number of cpus on the local system, as determined by python code, and then passed through a couple of functions to the rust code that initializes the UI. It's not clear what the right number of swim lanes to have is; but either way that should be a concern of the rust UI code.

### Solution

Use the rust crate `cpu_count`, which pants rust code is already using, to determine the number of swim lanes when we initialize the v2 UI code; and remove the code paths that determine it in python. This moves the determination of the number of swim lanes closer to the UI code without changing the behavior of the v2 UI yet.