### PR TITLE
Remove `--test-fast` to always have better test caching

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -63,22 +63,12 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
         }
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
-
-            def iter_partitions():
-                for test_target in test_targets:
-                    partition = (test_target,)
-                    args = (self._generate_args_for_targets([test_target]),)
-                    yield partition, args
-
-        else:
-
-            def iter_partitions():
-                if test_targets:
-                    partition = tuple(test_targets)
-                    args = (self._generate_args_for_targets(test_targets),)
-                    yield partition, args
+    def partitions(self, all_targets, test_targets):
+        def iter_partitions():
+            for test_target in test_targets:
+                partition = (test_target,)
+                args = (self._generate_args_for_targets([test_target]),)
+                yield partition, args
 
         yield iter_partitions
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -44,8 +44,8 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
         self.assertIn("=== RUN   TestAdd", pants_run.stdout_data)
         self.assertIn("PASS", pants_run.stdout_data)
 
-    def test_no_fast(self):
-        args = ["test.go", "--no-fast", "contrib/go/examples/src/go/libA"]
+    def test_partitioned_per_target(self):
+        args = ["test.go", "contrib/go/examples/src/go/libA"]
         pants_run = self.run_pants(args)
         self.assert_success(pants_run)
         # libA depends on libB, so both tests should be run.

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -571,28 +571,19 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         return list(files_iter())
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
+    def partitions(self, all_targets, test_targets):
         complete_test_registry = self._collect_test_targets(test_targets)
-        with self._isolation(per_target, all_targets) as (output_dir, reports, coverage):
-            if per_target:
+        with self._isolation(all_targets) as (output_dir, reports, coverage):
 
-                def iter_partitions():
-                    for test_target in test_targets:
-                        partition = (test_target,)
-                        args = (
-                            os.path.join(output_dir, test_target.id),
-                            coverage,
-                            complete_test_registry,
-                        )
-                        yield partition, args
-
-            else:
-
-                def iter_partitions():
-                    if test_targets:
-                        partition = tuple(test_targets)
-                        args = (output_dir, coverage, complete_test_registry)
-                        yield partition, args
+            def iter_partitions():
+                for test_target in test_targets:
+                    partition = (test_target,)
+                    args = (
+                        os.path.join(output_dir, test_target.id),
+                        coverage,
+                        complete_test_registry,
+                    )
+                    yield partition, args
 
             try:
                 yield iter_partitions
@@ -620,9 +611,9 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                     raise TaskError(e)
 
     @contextmanager
-    def _isolation(self, per_target, all_targets):
+    def _isolation(self, all_targets):
         run_dir = "_runs"
-        mode_dir = "isolated" if per_target else "combined"
+        mode_dir = "isolated"
         batch_dir = str(self._batch_size) if self._batched else "all"
         output_dir = os.path.join(
             self.workdir, run_dir, Target.identify(all_targets), mode_dir, batch_dir

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -601,17 +601,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         return relsrc_to_target.get(relsrc)
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
-
-            def iter_partitions():
-                for test_target in test_targets:
-                    yield (test_target,)
-
-        else:
-
-            def iter_partitions():
-                yield tuple(test_targets)
+    def partitions(self, all_targets, test_targets):
+        def iter_partitions():
+            for test_target in test_targets:
+                yield (test_target,)
 
         workdir = self.workdir
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -111,7 +111,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
             self.assertIn("Welcome.scala", html_report_string)
 
     def test_junit_run_with_coverage_succeeds_scoverage(self):
-        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot", "--fast"])
+        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot"])
 
     def do_test_junit_run_with_coverage_succeeds_cobertura(self, tests=(), args=()):
         html_path = (
@@ -214,11 +214,10 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
         self.assert_failure(pants_run)
         self.assertIn("No target found for test specifier", pants_run.stdout_data)
 
-    def test_junit_run_no_fast_multi(self):
+    def test_junit_run_multiple_targets(self):
         pants_run = self.run_pants(
             [
                 "test.junit",
-                "--no-fast",
                 "--test=PassingTest",
                 "testprojects/tests/java/org/pantsbuild/testproject/dummies:passing_target",
                 "testprojects/tests/java/org/pantsbuild/testproject/matcher",

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -514,10 +514,6 @@ python_tests(
     def test_green(self):
         self.run_tests(targets=[self.green])
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_caches_greens_fast(self):
-        self.run_tests(targets=[self.green, self.green2, self.green3], fast=True)
-
     @ensure_cached(PytestRun, expected_num_artifacts=3)
     def test_cache_greens(self):
         self.run_tests(targets=[self.green, self.green2, self.green3])
@@ -529,10 +525,6 @@ python_tests(
             timeout_default=3,
         )
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_out_of_band_deselect_fast_success(self):
-        self.run_tests([self.green, self.red], "-kno_tests_should_match_at_all", fast=True)
-
     # NB: Both red and green are cached. Red because its skipped via deselect and so runs (noops)
     # successfully. This is OK since the -k passthru is part of the task fingerprinting.
     @ensure_cached(PytestRun, expected_num_artifacts=2)
@@ -542,15 +534,6 @@ python_tests(
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_red(self):
         self.run_failing_tests(targets=[self.red], failed_targets=[self.red])
-
-    @ensure_cached(PytestRun, expected_num_artifacts=0)
-    def test_fail_fast_skips_second_red_test_with_single_chroot(self):
-        self.run_failing_tests(
-            targets=[self.red, self.red_in_class],
-            failed_targets=[self.red],
-            fail_fast=True,
-            fast=True,
-        )
 
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_fail_fast_skips_second_red_test(self):


### PR DESCRIPTION
This gives users better caching by default (per-target caching) and prepares them for V2.

In a followup, we likely want to deprecate the `--chroot` option to always chroot. Then, there will be theoretically no blockers for users upgrading to the V2 test runner.

[ci skip-rust-tests]
[ci skip-jvm-tests]