### PR TITLE
Revert allowing Python targets to include `.c` files in their sources

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -13,12 +13,9 @@ python_library(
 
 python_library(
   name='pants-packaged',
-  # NB: we must include at least one file in `sources` to avoid clang/gcc complaining
-  # `error: no input files`. We don't actually need to put any meaningful files here,
-  # though, because we use `with_binaries()` to link to the actual native code,
-  # so clang/gcc do not need to build any native code. Instead, we pass a dummy file.
-  sources=['dummy.c'],
+  sources=[],
   dependencies=[
+    ':dummy_c',
     ':entry_point',
     ':version',
   ],
@@ -36,6 +33,15 @@ python_library(
   ).with_binaries(
     pants='src/python/pants/bin:pants',
   )
+)
+
+# NB: we use this to avoid clang/gcc complaining `error: no input files` when building
+# `:pants-packaged`. We don't actually need to use any meaningful file here, though, because we
+# use `with_binaries()` to link to the actual native code, so clang/gcc do not need to build any
+# native code. This is just a dummy file.
+resources(
+  name="dummy_c",
+  sources=['dummy.c'],
 )
 
 page(

--- a/src/python/pants/backend/python/rules/targets.py
+++ b/src/python/pants/backend/python/rules/targets.py
@@ -36,9 +36,7 @@ from pants.python.python_setup import PythonSetup
 
 
 class PythonSources(Sources):
-    # We allow `.c` for compatibility with native wheels, e.g. `src/python/pants:pants-packaged`.
-    # This should possibly be revisited.
-    expected_file_extensions = (".py", ".c")
+    expected_file_extensions = (".py",)
 
 
 class PythonInterpreterCompatibility(StringOrStringSequenceField):


### PR DESCRIPTION
It was a hack to use a C file in the `python_library` `sources` value for `:pants-packaged`. Instead, we can use a `resources()` target.

A Python library should never include `.c` directly. It should instead use `backend/native` or include the files as `resources`, as done here.

[ci skip-rust-tests]
[ci skip-jvm-tests]