### PR TITLE
Make the pants logging setup flow less confusing

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Mapping, Optional, Tuple
@@ -20,7 +21,7 @@ from pants.engine.rules import UnionMembership
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_printer import HelpPrinter
 from pants.init.engine_initializer import EngineInitializer, LegacyGraphSession
-from pants.init.logging import setup_logging_from_options
+from pants.init.logging import setup_logging
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.init.repro import Repro, Reproducer
 from pants.init.specs_calculator import SpecsCalculator
@@ -31,6 +32,7 @@ from pants.reporting.reporting import Reporting
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import maybe_profiled
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -174,11 +176,20 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         :param daemon_graph_session: The graph helper for this session.
         """
         build_root = get_buildroot()
-
         global_options = options_bootstrapper.bootstrap_options.for_global_scope()
         # This works as expected due to the encapsulated_logger in DaemonPantsRunner and
         # we don't have to gate logging setup anymore.
-        setup_logging_from_options(global_options)
+
+        native = Native()
+        log_dir: Optional[str] = global_options.logdir
+        level = LogLevel.ERROR if getattr(global_options, "quiet", False) else global_options.level
+        setup_logging(
+            level,
+            native=native,
+            log_dir=log_dir,
+            console_stream=sys.stderr,
+            warnings_filter_regexes=global_options.ignore_pants_warnings,
+        )
 
         options, build_config = LocalPantsRunner.parse_options(options_bootstrapper)
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -185,8 +185,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         level = LogLevel.ERROR if getattr(global_options, "quiet", False) else global_options.level
         setup_logging(
             level,
-            native=native,
             log_dir=log_dir,
+            native=native,
             console_stream=sys.stderr,
             warnings_filter_regexes=global_options.ignore_pants_warnings,
         )

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Mapping, Optional, Tuple
@@ -21,7 +20,7 @@ from pants.engine.rules import UnionMembership
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_printer import HelpPrinter
 from pants.init.engine_initializer import EngineInitializer, LegacyGraphSession
-from pants.init.logging import setup_logging
+from pants.init.logging import setup_logging_to_file, setup_logging_to_stderr
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.init.repro import Repro, Reproducer
 from pants.init.specs_calculator import SpecsCalculator
@@ -181,12 +180,12 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # we don't have to gate logging setup anymore.
 
         level = LogLevel.ERROR if getattr(global_options, "quiet", False) else global_options.level
-        setup_logging(
-            level,
-            log_dir=global_options.logdir,
-            console_stream=sys.stderr,
-            warnings_filter_regexes=global_options.ignore_pants_warnings,
-        )
+        ignores = global_options.ignore_pants_warnings
+
+        setup_logging_to_stderr(level, warnings_filter_regexes=ignores)
+        log_dir = global_options.logdir
+        if log_dir:
+            setup_logging_to_file(level, log_dir=log_dir, warnings_filter_regexes=ignores)
 
         options, build_config = LocalPantsRunner.parse_options(options_bootstrapper)
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -180,12 +180,10 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # This works as expected due to the encapsulated_logger in DaemonPantsRunner and
         # we don't have to gate logging setup anymore.
 
-        native = Native()
         level = LogLevel.ERROR if getattr(global_options, "quiet", False) else global_options.level
         setup_logging(
             level,
             log_dir=global_options.logdir,
-            native=native,
             console_stream=sys.stderr,
             warnings_filter_regexes=global_options.ignore_pants_warnings,
         )

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -181,11 +181,10 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # we don't have to gate logging setup anymore.
 
         native = Native()
-        log_dir: Optional[str] = global_options.logdir
         level = LogLevel.ERROR if getattr(global_options, "quiet", False) else global_options.level
         setup_logging(
             level,
-            log_dir=log_dir,
+            log_dir=global_options.logdir,
             native=native,
             console_stream=sys.stderr,
             warnings_filter_regexes=global_options.ignore_pants_warnings,

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -76,7 +76,7 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         # We enable Rust logging here. Anything logged prior to this will be routed through regular Python logging.
         log_level = global_bootstrap_options.level
         init_rust_logger(log_level, global_bootstrap_options.log_show_rust_3rdparty)
-        setup_logging_to_stderr(logging.getLogger(None), log_level)
+        setup_logging_to_stderr(log_level)
 
         ExceptionSink.reset_should_print_backtrace_to_terminal(
             global_bootstrap_options.print_exception_stacktrace

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -31,12 +31,6 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         _DAEMON_KILLING_GOALS = frozenset(["kill-pantsd", "clean-all"])
         return not frozenset(self.args).isdisjoint(_DAEMON_KILLING_GOALS)
 
-    @staticmethod
-    def _enable_rust_logging(global_bootstrap_options: OptionValueContainer) -> None:
-        log_level = global_bootstrap_options.level
-        init_rust_logger(log_level, global_bootstrap_options.log_show_rust_3rdparty)
-        setup_logging_to_stderr(logging.getLogger(None), log_level)
-
     def _should_run_with_pantsd(self, global_bootstrap_options: OptionValueContainer) -> bool:
         # The parent_build_id option is set only for pants commands (inner runs)
         # that were called by other pants command.
@@ -79,9 +73,10 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         workdir_src = init_workdir(global_bootstrap_options)
         ExceptionSink.reset_log_location(workdir_src)
 
-        # We enable Rust logging here,
-        # and everything before it will be routed through regular Python logging.
-        self._enable_rust_logging(global_bootstrap_options)
+        # We enable Rust logging here. Anything logged prior to this will be routed through regular Python logging.
+        log_level = global_bootstrap_options.level
+        init_rust_logger(log_level, global_bootstrap_options.log_show_rust_3rdparty)
+        setup_logging_to_stderr(logging.getLogger(None), log_level)
 
         ExceptionSink.reset_should_print_backtrace_to_terminal(
             global_bootstrap_options.print_exception_stacktrace

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -27,7 +27,6 @@ logging.addLevelName(pants_logging.TRACE, "TRACE")
 class FileLoggingSetupResult:
     """A structured result for file logging setup."""
 
-    log_filename: str
     log_handler: Handler
 
 
@@ -164,6 +163,5 @@ def setup_logging(
     log_path = os.path.join(log_dir, logfile_name)
 
     native_handler = create_native_pantsd_file_log_handler(log_level, native, log_path)
-    file_handler = native_handler
     logger.addHandler(native_handler)
-    return FileLoggingSetupResult(log_path, file_handler)
+    return FileLoggingSetupResult(native_handler)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -81,7 +81,7 @@ def setup_logging(
     native: Native,
     console_stream: Optional[TextIO] = None,
     scope: Optional[str] = None,
-    logfile_name: str = "pants.log",
+    log_filename: str = "pants.log",
     warnings_filter_regexes: Optional[List[str]] = None,
 ) -> Optional[NativeHandler]:
     """Configures logging for a given scope, by default the global scope.
@@ -97,7 +97,7 @@ def setup_logging(
     :param scope: A logging scope to configure.  The scopes are hierarchichal logger names, with
                   The '.' separator providing the scope hierarchy.  By default the root logger is
                   configured.
-    :param logfile_name: The base name of the log file (defaults to 'pants.log').
+    :param log_filename: The base name of the log file (defaults to 'pants.log').
 
     :param warnings_filter_regexes: A series of regexes to ignore warnings for, typically from the
                                     `ignore_pants_warnings` option.
@@ -144,7 +144,7 @@ def setup_logging(
         return None
 
     safe_mkdir(log_dir)
-    log_path = os.path.join(log_dir, logfile_name)
+    log_path = os.path.join(log_dir, log_filename)
 
     fd = native.setup_pantsd_logger(log_path, log_level.level)
     ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -37,6 +37,9 @@ def setup_logging_to_stderr(python_logger: Logger, log_level: LogLevel) -> None:
 
 
 class NativeHandler(StreamHandler):
+    """This class is installed as a Python logging module handler (using  the logging.addHandler
+    method) and proxies logs to the Rust logging infrastructure."""
+
     def __init__(
         self,
         log_level: LogLevel,

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -91,7 +91,7 @@ def setup_logging(
     scope: Optional[str] = None,
     logfile_name: str = "pants.log",
     warnings_filter_regexes: Optional[List[str]] = None,
-) -> Optional[FileLoggingSetupResult]:
+) -> Optional[NativeHandler]:
     """Configures logging for a given scope, by default the global scope.
 
     :param log_level: The logging level to enable.
@@ -159,4 +159,4 @@ def setup_logging(
     native_handler = NativeHandler(log_level, native, native_filename=log_path)
 
     logger.addHandler(native_handler)
-    return FileLoggingSetupResult(native_handler)
+    return native_handler

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -89,7 +89,6 @@ def setup_logging(
     *,
     log_dir: Optional[str],
     console_stream: Optional[TextIO] = None,
-    scope: Optional[str] = None,
     log_filename: str = "pants.log",
     warnings_filter_regexes: Optional[List[str]] = None,
 ) -> Optional[NativeHandler]:
@@ -128,7 +127,7 @@ def setup_logging(
 
     logging.Logger.trace = trace  # type: ignore[attr-defined]
 
-    logger = logging.getLogger(scope)
+    logger = logging.getLogger(None)
     for handler in logger.handlers:
         logger.removeHandler(handler)
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from logging import Handler, Logger, LogRecord, StreamHandler
-from typing import List, Optional, TextIO, overload
+from typing import List, Optional, TextIO
 
 import pants.util.logging as pants_logging
 from pants.base.exception_sink import ExceptionSink
@@ -91,42 +91,14 @@ def create_native_pantsd_file_log_handler(
     return NativeHandler(log_level, native, native_filename=native_filename)
 
 
-@overload
 def setup_logging(
     log_level: LogLevel,
     *,
-    native: Native,
-    log_dir: str,
-    console_stream: Optional[TextIO] = None,
-    scope: Optional[str] = None,
-    log_name: Optional[str] = None,
-    warnings_filter_regexes: Optional[List[str]] = None,
-) -> FileLoggingSetupResult:
-    ...
-
-
-@overload
-def setup_logging(
-    log_level: LogLevel,
-    *,
-    native: Native,
-    log_dir: None = None,
-    console_stream: Optional[TextIO] = None,
-    scope: Optional[str] = None,
-    log_name: Optional[str] = None,
-    warnings_filter_regexes: Optional[List[str]] = None,
-) -> None:
-    ...
-
-
-def setup_logging(
-    log_level: LogLevel,
-    *,
+    log_dir: Optional[str],
     native: Native,
     console_stream: Optional[TextIO] = None,
-    log_dir: Optional[str] = None,
     scope: Optional[str] = None,
-    log_name: Optional[str] = None,
+    logfile_name: str = "pants.log",
     warnings_filter_regexes: Optional[List[str]] = None,
 ) -> Optional[FileLoggingSetupResult]:
     """Configures logging for a given scope, by default the global scope.
@@ -142,7 +114,7 @@ def setup_logging(
     :param scope: A logging scope to configure.  The scopes are hierarchichal logger names, with
                   The '.' separator providing the scope hierarchy.  By default the root logger is
                   configured.
-    :param log_name: The base name of the log file (defaults to 'pants.log').
+    :param logfile_name: The base name of the log file (defaults to 'pants.log').
 
     :param warnings_filter_regexes: A series of regexes to ignore warnings for, typically from the
                                     `ignore_pants_warnings` option.
@@ -189,9 +161,9 @@ def setup_logging(
         return None
 
     safe_mkdir(log_dir)
-    log_filename = os.path.join(log_dir, log_name or "pants.log")
+    log_path = os.path.join(log_dir, logfile_name)
 
-    native_handler = create_native_pantsd_file_log_handler(log_level, native, log_filename)
+    native_handler = create_native_pantsd_file_log_handler(log_level, native, log_path)
     file_handler = native_handler
     logger.addHandler(native_handler)
-    return FileLoggingSetupResult(log_filename, file_handler)
+    return FileLoggingSetupResult(log_path, file_handler)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -82,14 +82,6 @@ class NativeHandler(StreamHandler):
         return NativeHandler(log_level, native, stream)
 
 
-def create_native_pantsd_file_log_handler(
-    log_level: LogLevel, native: Native, native_filename: str
-) -> NativeHandler:
-    fd = native.setup_pantsd_logger(native_filename, log_level.level)
-    ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))
-    return NativeHandler(log_level, native, native_filename=native_filename)
-
-
 def setup_logging(
     log_level: LogLevel,
     *,
@@ -162,6 +154,9 @@ def setup_logging(
     safe_mkdir(log_dir)
     log_path = os.path.join(log_dir, logfile_name)
 
-    native_handler = create_native_pantsd_file_log_handler(log_level, native, log_path)
+    fd = native.setup_pantsd_logger(log_path, log_level.level)
+    ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))
+    native_handler = NativeHandler(log_level, native, native_filename=log_path)
+
     logger.addHandler(native_handler)
     return FileLoggingSetupResult(native_handler)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -13,7 +13,6 @@ from typing import List, Optional, TextIO, overload
 import pants.util.logging as pants_logging
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.native import Native
-from pants.option.option_value_container import OptionValueContainer
 from pants.util.dirutil import safe_mkdir
 from pants.util.logging import LogLevel
 
@@ -56,24 +55,6 @@ def setup_logging_to_stderr(python_logger: Logger, log_level: LogLevel) -> None:
     python_logger.addHandler(handler)
     # Let the rust side filter levels; try to have the python side send everything to the rust logger.
     LogLevel.TRACE.set_level_for(python_logger)
-
-
-def setup_logging_from_options(
-    bootstrap_options: OptionValueContainer,
-) -> Optional[FileLoggingSetupResult]:
-    # N.B. quiet help says 'Squelches all console output apart from errors'.
-    level = (
-        LogLevel.ERROR if getattr(bootstrap_options, "quiet", False) else bootstrap_options.level
-    )
-    native = Native()
-    log_dir: Optional[str] = bootstrap_options.logdir
-    return setup_logging(
-        level,
-        native=native,
-        log_dir=log_dir,
-        console_stream=sys.stderr,
-        warnings_filter_regexes=bootstrap_options.ignore_pants_warnings,
-    )
 
 
 class NativeHandler(StreamHandler):

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -6,8 +6,7 @@ import logging
 import os
 import sys
 import warnings
-from dataclasses import dataclass
-from logging import Handler, Logger, LogRecord, StreamHandler
+from logging import Logger, LogRecord, StreamHandler
 from typing import List, Optional, TextIO
 
 import pants.util.logging as pants_logging
@@ -21,13 +20,6 @@ from pants.util.logging import LogLevel
 # setup a 'WARN' logging level name that maps to 'WARNING'.
 logging.addLevelName(logging.WARNING, "WARN")
 logging.addLevelName(pants_logging.TRACE, "TRACE")
-
-
-@dataclass(frozen=True)
-class FileLoggingSetupResult:
-    """A structured result for file logging setup."""
-
-    log_handler: Handler
 
 
 def init_rust_logger(log_level: LogLevel, log_show_rust_3rdparty: bool) -> None:

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 import warnings
-from logging import Logger, LogRecord, StreamHandler
+from logging import LogRecord, StreamHandler
 from typing import List, Optional, TextIO
 
 import pants.util.logging as pants_logging
@@ -68,73 +68,18 @@ class NativeHandler(StreamHandler):
         )
 
 
-def setup_logging_to_stderr(python_logger: Logger, level: LogLevel) -> None:
-    """Sets up Python logging to stderr, proxied to Rust via a NativeHandler.
-
-    We deliberately set the most verbose logging possible (i.e. the TRACE log level), here, and let
-    the Rust logging faculties take care of filtering.
-    """
-    handler = NativeHandler(level, stream=sys.stderr)
-    python_logger.addHandler(handler)
-    LogLevel.TRACE.set_level_for(python_logger)
-
-
-def setup_logging_to_file(level: LogLevel) -> None:
-    pass
-
-
-def setup_logging(
-    log_level: LogLevel,
-    *,
-    log_dir: Optional[str],
-    console_stream: Optional[TextIO] = None,
-    log_filename: str = "pants.log",
-    warnings_filter_regexes: Optional[List[str]] = None,
-) -> Optional[NativeHandler]:
-    """Configures logging for a given scope, by default the global scope.
-
-    :param log_level: The logging level to enable.
-    :param console_stream: The stream to use for default (console) logging. If None (default), this
-                           will disable console logging.
-    :param log_dir: An optional directory to emit logs files in.  If unspecified, no disk logging
-                    will occur.  If supplied, the directory will be created if it does not already
-                    exist and all logs will be tee'd to a rolling set of log files in that
-                    directory.
-    :param scope: A logging scope to configure.  The scopes are hierarchichal logger names, with
-                  The '.' separator providing the scope hierarchy.  By default the root logger is
-                  configured.
-    :param log_filename: The base name of the log file (defaults to 'pants.log').
-
-    :param warnings_filter_regexes: A series of regexes to ignore warnings for, typically from the
-                                    `ignore_pants_warnings` option.
-    :returns: The file logging setup configured if any.
-    """
-
-    native = Native()
-
-    # TODO(John Sirois): Consider moving to straight python logging.  The divide between the
-    # context/work-unit logging and standard python logging doesn't buy us anything.
-
-    # TODO(John Sirois): Support logging.config.fileConfig so a site can setup fine-grained
-    # logging control and we don't need to be the middleman plumbing an option for each python
-    # standard logging knob.
-
-    # A custom log handler for sub-debug trace logging.
-    def trace(self, message, *args, **kwargs):
+def _common_logging_setup(level: LogLevel, warnings_filter_regexes: Optional[List[str]]) -> None:
+    def trace_fn(self, message, *args, **kwargs):
         if self.isEnabledFor(LogLevel.TRACE.level):
             self._log(LogLevel.TRACE.level, message, *args, **kwargs)
 
-    logging.Logger.trace = trace  # type: ignore[attr-defined]
+    logging.Logger.trace = trace_fn  # type: ignore[attr-defined]
 
     logger = logging.getLogger(None)
     for handler in logger.handlers:
         logger.removeHandler(handler)
 
-    if console_stream:
-        native_handler = NativeHandler(log_level, stream=console_stream)
-        logger.addHandler(native_handler)
-
-    log_level.set_level_for(logger)
+    level.set_level_for(logger)
 
     # This routes warnings through our loggers instead of straight to raw stderr.
     logging.captureWarnings(True)
@@ -148,15 +93,41 @@ def setup_logging(
         LogLevel.TRACE.set_level_for(requests_logger)
         requests_logger.propagate = True
 
-    if not log_dir:
-        return None
+
+def setup_logging_to_stderr(
+    level: LogLevel, *, warnings_filter_regexes: Optional[List[str]] = None
+) -> None:
+    """Sets up Python logging to stderr, proxied to Rust via a NativeHandler.
+
+    We deliberately set the most verbose logging possible (i.e. the TRACE log level), here, and let
+    the Rust logging faculties take care of filtering.
+    """
+    _common_logging_setup(level, warnings_filter_regexes)
+
+    python_logger = logging.getLogger(None)
+    handler = NativeHandler(level, stream=sys.stderr)
+    python_logger.addHandler(handler)
+    LogLevel.TRACE.set_level_for(python_logger)
+
+
+def setup_logging_to_file(
+    level: LogLevel,
+    *,
+    log_dir: str,
+    log_filename: str = "pants.log",
+    warnings_filter_regexes: Optional[List[str]] = None,
+) -> NativeHandler:
+    native = Native()
+    logger = logging.getLogger(None)
+
+    _common_logging_setup(level, warnings_filter_regexes)
 
     safe_mkdir(log_dir)
     log_path = os.path.join(log_dir, log_filename)
 
-    fd = native.setup_pantsd_logger(log_path, log_level.level)
+    fd = native.setup_pantsd_logger(log_path, level.level)
     ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))
-    native_handler = NativeHandler(log_level, native_filename=log_path)
+    native_handler = NativeHandler(level, native_filename=log_path)
 
     logger.addHandler(native_handler)
     return native_handler

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -290,7 +290,6 @@ class PantsDaemon(FingerprintedProcessManager):
             else True
         )
 
-        self._log_dir = os.path.join(work_dir, self.name)
         self._logger = logging.getLogger(__name__)
         # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
         self._kill_switch = threading.Event()
@@ -359,9 +358,9 @@ class PantsDaemon(FingerprintedProcessManager):
             # warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
 
             setup_logging_to_stderr(level)
-            log_handler = setup_logging_to_file(
-                level, log_dir=self._log_dir, log_filename=self.LOG_NAME
-            )
+
+            log_dir = os.path.join(self._work_dir, self.name)
+            log_handler = setup_logging_to_file(level, log_dir=log_dir, log_filename=self.LOG_NAME)
             native.override_thread_logging_destination_to_just_pantsd()
 
             # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -7,7 +7,7 @@ import sys
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Optional
+from typing import IO, Iterator, Optional, cast
 
 from setproctitle import setproctitle as set_process_title
 
@@ -18,7 +18,7 @@ from pants.bin.daemon_pants_runner import DaemonPantsRunner
 from pants.engine.native import Native
 from pants.engine.rules import UnionMembership
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.logging import init_rust_logger, setup_logging
+from pants.init.logging import NativeHandler, init_rust_logger, setup_logging
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -329,7 +329,7 @@ class PantsDaemon(FingerprintedProcessManager):
             os.close(file_no)
 
     @contextmanager
-    def _pantsd_logging(self):
+    def _pantsd_logging(self) -> Iterator[IO[str]]:
         """A context manager that runs with pantsd logging.
 
         Asserts that stdio (represented by file handles 0, 1, 2) is closed to ensure that we can
@@ -349,23 +349,31 @@ class PantsDaemon(FingerprintedProcessManager):
         with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
             # Reinitialize logging for the daemon context.
             init_rust_logger(self._log_level, self._log_show_rust_3rdparty)
-            result = setup_logging(
+            # We can't statically prove it, but we won't execute `launch()` which
+            # calls `run_sync` which calls `_pantsd_logging` unless PantsDaemon
+            # is launched with full_init=True, which sets a non-None value for
+            # self._native.
+            native = cast(Native, self._native)
+            log_handler = setup_logging(
                 self._log_level,
-                native=self._native,
+                native=native,
                 log_dir=self._log_dir,
-                log_name=self.LOG_NAME,
-                warnings_filter_regexes=self._bootstrap_options.for_global_scope(),
+                logfile_name=self.LOG_NAME,
+                warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
             )
-            self._native.override_thread_logging_destination_to_just_pantsd()
+            # We know log_handler is never None because we did pass a non-None `log_dir`
+            # to setup_logging.
+            log_handler = cast(NativeHandler, log_handler)
+            native.override_thread_logging_destination_to_just_pantsd()
 
             # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.
             # TODO: Consider giving these pipes/actual fds, in order to make them "deep" replacements
             # for `1,2`, and allow them to be used via `stdio_as`.
-            sys.stdout = _LoggerStream(logging.getLogger(), logging.INFO, result.log_handler)
-            sys.stderr = _LoggerStream(logging.getLogger(), logging.WARN, result.log_handler)
+            sys.stdout = _LoggerStream(logging.getLogger(), logging.INFO, log_handler)  # type: ignore[assignment]
+            sys.stderr = _LoggerStream(logging.getLogger(), logging.WARN, log_handler)  # type: ignore[assignment]
 
             self._logger.debug("logging initialized")
-            yield (result.log_handler.stream, result.log_handler.native_filename)
+            yield log_handler.stream
 
     def _setup_services(self, pants_services):
         for service in pants_services.services:
@@ -435,7 +443,7 @@ class PantsDaemon(FingerprintedProcessManager):
         # Switch log output to the daemon's log stream from here forward.
         # Also, register an exiter using os._exit to ensure we only close stdio streams once.
         self._close_stdio()
-        with self._pantsd_logging() as (log_stream, log_filename), ExceptionSink.exiter_as(
+        with self._pantsd_logging() as log_stream, ExceptionSink.exiter_as(
             lambda _: Exiter(exiter=os._exit)
         ):
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -349,16 +349,16 @@ class PantsDaemon(FingerprintedProcessManager):
         with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
             # Reinitialize logging for the daemon context.
             init_rust_logger(self._log_level, self._log_show_rust_3rdparty)
-            # We can't statically prove it, but we won't execute `launch()` which
-            # calls `run_sync` which calls `_pantsd_logging` unless PantsDaemon
-            # is launched with full_init=True, which sets a non-None value for
-            # self._native.
+            # We can't statically prove it, but we won't execute `launch()` (which
+            # calls `run_sync` which calls `_pantsd_logging`) unless PantsDaemon
+            # is launched with full_init=True. If PantsdDaemon is launched with
+            # full_init=True, we can guarantee self._native is non-None.
             native = cast(Native, self._native)
             log_handler = setup_logging(
                 self._log_level,
                 native=native,
                 log_dir=self._log_dir,
-                logfile_name=self.LOG_NAME,
+                log_filename=self.LOG_NAME,
                 warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
             )
             # We know log_handler is never None because we did pass a non-None `log_dir`

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -18,7 +18,7 @@ from pants.bin.daemon_pants_runner import DaemonPantsRunner
 from pants.engine.native import Native
 from pants.engine.rules import UnionMembership
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.logging import NativeHandler, init_rust_logger, setup_logging
+from pants.init.logging import init_rust_logger, setup_logging_to_file, setup_logging_to_stderr
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -355,15 +355,13 @@ class PantsDaemon(FingerprintedProcessManager):
             # full_init=True, we can guarantee self._native is non-None.
             native = cast(Native, self._native)
 
-            log_handler = setup_logging(
-                self._log_level,
-                log_dir=self._log_dir,
-                log_filename=self.LOG_NAME,
-                warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
+            level = self._log_level
+            # warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
+
+            setup_logging_to_stderr(level)
+            log_handler = setup_logging_to_file(
+                level, log_dir=self._log_dir, log_filename=self.LOG_NAME
             )
-            # We know log_handler is never None because we did pass a non-None `log_dir`
-            # to setup_logging.
-            log_handler = cast(NativeHandler, log_handler)
             native.override_thread_logging_destination_to_just_pantsd()
 
             # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -354,9 +354,9 @@ class PantsDaemon(FingerprintedProcessManager):
             # is launched with full_init=True. If PantsdDaemon is launched with
             # full_init=True, we can guarantee self._native is non-None.
             native = cast(Native, self._native)
+
             log_handler = setup_logging(
                 self._log_level,
-                native=native,
                 log_dir=self._log_dir,
                 log_filename=self.LOG_NAME,
                 warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -7,7 +7,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Iterator, Tuple
 
-from pants.init.logging import FileLoggingSetupResult, setup_logging
+from pants.init.logging import NativeHandler, setup_logging
 from pants.testutil.engine.util import init_native
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
@@ -29,15 +29,13 @@ class LoggingTest(TestBase):
         )
 
     @contextmanager
-    def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, FileLoggingSetupResult, Path]]:
+    def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
         native = self.scheduler._scheduler._native
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as tmpdir:
-            logging_setup_result = setup_logging(
-                log_level, log_dir=tmpdir, native=native, scope=logger.name
-            )
+            handler = setup_logging(log_level, log_dir=tmpdir, native=native, scope=logger.name)
             log_file = Path(tmpdir, "pants.log")
-            yield logger, logging_setup_result, log_file
+            yield logger, handler, log_file
 
     def test_utf8_logging(self) -> None:
         with self.logger(LogLevel.INFO) as (file_logger, logging_setup_result, log_file):

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -33,23 +33,23 @@ class LoggingTest(TestBase):
         native = self.scheduler._scheduler._native
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as tmpdir:
-            handler = setup_logging(log_level, log_dir=tmpdir, native=native, scope=logger.name)
+            handler = setup_logging(log_level, log_dir=tmpdir, scope=logger.name)
             log_file = Path(tmpdir, "pants.log")
             yield logger, handler, log_file
 
     def test_utf8_logging(self) -> None:
-        with self.logger(LogLevel.INFO) as (file_logger, logging_setup_result, log_file):
+        with self.logger(LogLevel.INFO) as (file_logger, log_handler, log_file):
             cat = "🐈"
             file_logger.info(cat)
-            logging_setup_result.log_handler.flush()
+            log_handler.flush()
             self.assertIn(cat, log_file.read_text())
 
     def test_file_logging(self) -> None:
-        with self.logger(LogLevel.INFO) as (file_logger, logging_setup_result, log_file):
+        with self.logger(LogLevel.INFO) as (file_logger, log_handler, log_file):
             file_logger.warning("this is a warning")
             file_logger.info("this is some info")
             file_logger.debug("this is some debug info")
-            logging_setup_result.log_handler.flush()
+            log_handler.flush()
 
             loglines = log_file.read_text().splitlines()
             self.assertEqual(2, len(loglines))

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -30,10 +30,9 @@ class LoggingTest(TestBase):
 
     @contextmanager
     def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
-        native = self.scheduler._scheduler._native
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as tmpdir:
-            handler = setup_logging(log_level, log_dir=tmpdir, scope=logger.name)
+            handler = setup_logging(log_level, log_dir=tmpdir)
             log_file = Path(tmpdir, "pants.log")
             yield logger, handler, log_file
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -7,7 +7,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Iterator, Tuple
 
-from pants.init.logging import NativeHandler, setup_logging
+from pants.init.logging import NativeHandler, setup_logging_to_file
 from pants.testutil.engine.util import init_native
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
@@ -36,7 +36,7 @@ class LoggingTest(TestBase):
 
         logger = logging.getLogger(None)
         with temporary_dir() as tmpdir:
-            handler = setup_logging(log_level, log_dir=tmpdir)
+            handler = setup_logging_to_file(log_level, log_dir=tmpdir)
             log_file = Path(tmpdir, "pants.log")
             yield logger, handler, log_file
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -34,7 +34,7 @@ class LoggingTest(TestBase):
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as log_dir:
             logging_setup_result = setup_logging(
-                log_level, log_dir=log_dir, scope=logger.name, native=native
+                log_level, log_dir=log_dir, native=native, scope=logger.name
             )
             yield logger, logging_setup_result
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -30,7 +30,10 @@ class LoggingTest(TestBase):
 
     @contextmanager
     def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
-        logger = logging.getLogger("my_file_logger")
+        native = self.scheduler._scheduler._native
+        print(f"Native: {native}")
+
+        logger = logging.getLogger(None)
         with temporary_dir() as tmpdir:
             handler = setup_logging(log_level, log_dir=tmpdir)
             log_file = Path(tmpdir, "pants.log")

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -30,6 +30,7 @@ class LoggingTest(TestBase):
 
     @contextmanager
     def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
+        # This line needs to be here in order for tests to pass.
         native = self.scheduler._scheduler._native
         print(f"Native: {native}")
 


### PR DESCRIPTION
### Problem

The code paths around setting up logging are confusing.

### Solution

Break the `setup_logging` method into two separate methods, one for initializing logging to a file, the other for initializing logging to stdout.

