### PR TITLE
Change V2 UI sigil from ⚡ to ▶

### DIFF
--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -82,7 +82,7 @@ impl EngineDisplay {
   /// Create a new EngineDisplay
   pub fn new() -> EngineDisplay {
     EngineDisplay {
-      sigil: "⚡",
+      sigil: "▶",
       divider: "▵".to_string(),
       terminal: Console::Uninitialized,
       action_map: BTreeMap::new(),
@@ -239,7 +239,7 @@ impl EngineDisplay {
     // representing the swimlane for this worker and lay down a text label.
     for (n, (_worker_id, action)) in worker_states.iter().enumerate() {
       let line_shortened_output: String = format!(
-        "{blue}{sigil}{reset}{action}",
+        "{blue}{sigil}{reset} {action}",
         blue = color::Fg(color::LightBlue),
         sigil = self.sigil,
         reset = color::Fg(color::Reset),


### PR DESCRIPTION
Before:

<img width="776" alt="before" src="https://user-images.githubusercontent.com/14852634/79641617-86aa6400-814d-11ea-9a9b-076d2c41cc03.png">

After:

<img width="815" alt="after" src="https://user-images.githubusercontent.com/14852634/79641571-392df700-814d-11ea-914b-d42837fddae9.png">

<img width="694" alt="after (white background)" src="https://user-images.githubusercontent.com/14852634/79641773-6c24ba80-814e-11ea-98a1-96e7dc9c48bd.png">

This change is meant to make the V2 UI appear more polished and professional, rather than hipster and cute. While there is abundant usage of emoji in build tools (Black and JavaScript ecosystem), I argue that Pants is better to use a more serious (yet still accessible/friendly) tone.


[ci skip-jvm-tests]