### PR TITLE
Fix typo in V1 Python interpreter selection error message

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -109,7 +109,7 @@ class PythonInterpreterCache(Subsystem):
                     Possible ways to fix this:
                     * Modify your Python interpreter constraints by following https://www.pantsbuild.org/python_readme.html#configure-the-python-version.
                     * Ensure the targeted Python version is installed and discoverable.
-                    * Modify Pants' interpreter search paths via --pants-setup-interpreter-search-paths.""".format(
+                    * Modify Pants' interpreter search paths via --python-setup-interpreter-search-paths.""".format(
                         " && ".join(sorted(unique_compatibilities_strs)),
                         ", ".join(tgts_by_compatibilities_strs),
                         ", ".join(all_interpreter_version_strings),


### PR DESCRIPTION
[ci skip-rust-tests]
[ci skip-jvm-tests]