### PR TITLE
Add `DeduplicatedCollection` to newtype `FrozenOrderedSet` in rules

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -15,6 +15,7 @@ from pants.backend.python.rules.targets import PythonRequirementsField
 from pants.backend.python.rules.util import parse_interpreter_constraint
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import (
     EMPTY_DIRECTORY_DIGEST,
     EMPTY_SNAPSHOT,
@@ -27,7 +28,6 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.isolated_process import MultiPlatformProcess, ProcessResult
-from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
 from pants.engine.selectors import Get
@@ -36,16 +36,10 @@ from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
-from pants.util.ordered_set import FrozenOrderedSet
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class PexRequirements:
-    requirements: FrozenOrderedSet[str]
-
-    def __init__(self, requirements: Optional[Iterable[str]] = None) -> None:
-        self.requirements = FrozenOrderedSet(sorted(requirements or ()))
+class PexRequirements(DeduplicatedCollection[str]):
+    sort_input = True
 
     @classmethod
     def create_from_requirement_fields(
@@ -58,22 +52,6 @@ class PexRequirements:
             str(python_req.requirement) for field in fields for python_req in field.value
         }
         return PexRequirements({*field_requirements, *additional_requirements})
-
-    @classmethod
-    def create_from_adaptors(
-        cls, adaptors: Iterable[TargetAdaptor], additional_requirements: Iterable[str] = ()
-    ) -> "PexRequirements":
-        all_target_requirements = set()
-        for maybe_python_req_lib in adaptors:
-            # This is a python_requirement()-like target.
-            if hasattr(maybe_python_req_lib, "requirement"):
-                all_target_requirements.add(str(maybe_python_req_lib.requirement))
-            # This is a python_requirement_library()-like target.
-            if hasattr(maybe_python_req_lib, "requirements"):
-                for py_req in maybe_python_req_lib.requirements:
-                    all_target_requirements.add(str(py_req.requirement))
-        all_target_requirements.update(additional_requirements)
-        return PexRequirements(all_target_requirements)
 
 
 Spec = Tuple[str, str]  # e.g. (">=", "3.6")
@@ -90,13 +68,8 @@ class ParsedConstraint(NamedTuple):
         return f"{self.interpreter}{specs}"
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class PexInterpreterConstraints:
-    constraints: FrozenOrderedSet[str]
-
-    def __init__(self, constraints: Optional[Iterable[str]] = None) -> None:
-        self.constraints = FrozenOrderedSet(sorted(constraints or ()))
+class PexInterpreterConstraints(DeduplicatedCollection[str]):
+    sort_input = True
 
     @staticmethod
     def merge_constraint_sets(constraint_sets: Iterable[Iterable[str]]) -> List[str]:
@@ -157,36 +130,15 @@ class PexInterpreterConstraints:
         merged_constraints = cls.merge_constraint_sets(constraint_sets)
         return PexInterpreterConstraints(merged_constraints)
 
-    @classmethod
-    def create_from_adaptors(
-        cls, adaptors: Iterable[TargetAdaptor], python_setup: PythonSetup
-    ) -> "PexInterpreterConstraints":
-        constraint_sets: Set[Iterable[str]] = set()
-        for adaptor in adaptors:
-            if not isinstance(adaptor, PythonTargetAdaptor):
-                continue
-            compatibility_field = PythonInterpreterCompatibility(
-                adaptor.compatibility, address=adaptor.address
-            )
-            constraint_sets.add(compatibility_field.value_or_global_default(python_setup))
-        # This will OR within each target and AND across targets.
-        merged_constraints = cls.merge_constraint_sets(constraint_sets)
-        return PexInterpreterConstraints(merged_constraints)
-
     def generate_pex_arg_list(self) -> List[str]:
         args = []
-        for constraint in sorted(self.constraints):
+        for constraint in self:
             args.extend(["--interpreter-constraint", constraint])
         return args
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class PexPlatforms:
-    platforms: FrozenOrderedSet[str]
-
-    def __init__(self, platforms: Optional[Iterable[str]] = None) -> None:
-        self.platforms = FrozenOrderedSet(sorted(platforms or ()))
+class PexPlatforms(DeduplicatedCollection[str]):
+    sort_input = True
 
     @classmethod
     def create_from_platforms_field(cls, field: PythonPlatformsField) -> "PexPlatforms":
@@ -195,7 +147,7 @@ class PexPlatforms:
 
     def generate_pex_arg_list(self) -> List[str]:
         args = []
-        for platform in sorted(self.platforms):
+        for platform in self:
             args.extend(["--platform", platform])
         return args
 
@@ -334,7 +286,7 @@ async def create_pex(
     # NB: If `--platform` is specified, this signals that the PEX should not be built locally.
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
     # flags are mutually exclusive. See https://github.com/pantsbuild/pex/issues/957.
-    if request.platforms.platforms:
+    if request.platforms:
         # TODO(#9560): consider validating that these platforms are valid with the interpreter
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())
@@ -361,7 +313,7 @@ async def create_pex(
     source_dir_name = "source_files"
     argv.append(f"--sources-directory={source_dir_name}")
 
-    argv.extend(request.requirements.requirements)
+    argv.extend(request.requirements)
 
     constraint_file_snapshot = EMPTY_SNAPSHOT
     if python_setup.requirement_constraints is not None:
@@ -401,8 +353,8 @@ async def create_pex(
     # constraint`".
     description = request.description
     if description is None:
-        if request.requirements.requirements:
-            description = f"Resolving {', '.join(request.requirements.requirements)}"
+        if request.requirements:
+            description = f"Resolving {', '.join(request.requirements)}"
         else:
             description = f"Building PEX"
     process = MultiPlatformProcess(
@@ -445,7 +397,7 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
     additional_inputs: Optional[Digest]
 
     # Create a pex containing just the requirements.
-    if request.requirements.requirements:
+    if request.requirements:
         requirements_pex_request = PexRequest(
             output_filename=req_pex_name,
             requirements=request.requirements,
@@ -455,7 +407,7 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
             #  Some of them may affect resolution behavior, but others may be irrelevant.
             #  For now we err on the side of caution.
             additional_args=request.additional_args,
-            description=f"Resolving {', '.join(request.requirements.requirements)}",
+            description=f"Resolving {', '.join(request.requirements)}",
         )
         requirements_pex = await Get[Pex](PexRequest, requirements_pex_request)
         additional_inputs = requirements_pex.directory_digest

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -265,7 +265,7 @@ class PexTest(TestBase):
         pex_info = self.create_pex_and_get_pex_info(requirements=requirements)
         # NB: We do not check for transitive dependencies, which PEX-INFO will include. We only check
         # that at least the dependencies we requested are included.
-        assert set(parse_requirements(requirements.requirements)).issubset(
+        assert set(parse_requirements(requirements)).issubset(
             set(parse_requirements(pex_info["requirements"]))
         )
 
@@ -297,7 +297,7 @@ class PexTest(TestBase):
     def test_interpreter_constraints(self) -> None:
         constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
         pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
-        assert set(pex_info["interpreter_constraints"]) == set(constraints.constraints)
+        assert set(pex_info["interpreter_constraints"]) == set(constraints)
 
     def test_additional_args(self) -> None:
         pex_info = self.create_pex_and_get_pex_info(additional_pex_args=("--not-zip-safe",))

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -331,7 +331,7 @@ class TestGetRequirements(TestSetupPyBase):
         reqs = self.request_single_product(
             ExportedTargetRequirements, Params(DependencyOwner(ExportedTarget(self.tgt(addr))))
         )
-        assert sorted(expected_req_strs) == sorted(reqs.requirement_strs)
+        assert sorted(expected_req_strs) == list(reqs)
 
     def test_get_requirements(self) -> None:
         self.create_file(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -124,6 +124,9 @@ python_library(
 python_library(
   name='collection',
   sources=['collection.py'],
+  dependencies=[
+    'src/python/pants/util:ordered_set',
+  ],
   tags = {'type_checked'},
 )
 

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Iterable, Sequence, TypeVar, Union, overload
+from typing import Any, ClassVar, Iterable, Sequence, TypeVar, Union, overload
+
+from pants.util.ordered_set import FrozenOrderedSet
 
 T = TypeVar("T")
 
@@ -50,3 +52,28 @@ class Collection(Sequence[T]):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self.dependencies)})"
+
+
+class DeduplicatedCollection(FrozenOrderedSet[T]):
+    """A light newtype around FrozenOrderedSet for use with the V2 engine.
+
+    This should be subclassed when you want to create a distinct collection type, such as:
+
+        @dataclass(frozen=True)
+        class Example:
+            val1: str
+
+        class Examples(DeduplicatedCollection[Example]):
+            pass
+
+    If it is safe to sort the inputs, you should do so for more cache hits by setting the class
+    property `sort_input = True`.
+    """
+
+    sort_input: ClassVar[bool] = False
+
+    def __init__(self, iterable: Iterable[T] = ()) -> None:
+        super().__init__(iterable if not self.sort_input else sorted(iterable))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({list(self._items)})"

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -54,6 +54,9 @@ class Collection(Sequence[T]):
         return f"{self.__class__.__name__}({list(self.dependencies)})"
 
 
+# NB: This name is clunky. It would be more appropriate to call it `Set`, but that is claimed by
+#  `typing.Set` already. See
+#  https://github.com/pantsbuild/pants/pull/9590#pullrequestreview-395970440.
 class DeduplicatedCollection(FrozenOrderedSet[T]):
     """A light newtype around FrozenOrderedSet for use with the V2 engine.
 

--- a/src/python/pants/engine/collection_test.py
+++ b/src/python/pants/engine/collection_test.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.collection import Collection
+from pants.engine.collection import Collection, DeduplicatedCollection
 
 
 class Examples(Collection[int]):
@@ -77,3 +77,46 @@ def test_collection_repr() -> None:
     assert repr(Examples([])) == "Examples([])"
     assert repr(Collection([1, 2, 3])) == "Collection([1, 2, 3])"
     assert repr(Examples([1, 2, 3])) == "Examples([1, 2, 3])"
+
+
+def test_deduplicated_collection() -> None:
+    # NB: most of the functionality, like testing .union() and .intersection(), is tested
+    # exhaustively in the tests for FrozenOrderedSet. Here, we only have a couple basic
+    # smoke-screen tests to ensure things work properly.
+    class DedupedExamples(DeduplicatedCollection[int]):
+        sort_input = True
+
+    class DedupedExamples2(DeduplicatedCollection[int]):
+        sort_input = False
+
+    # Test deduplication
+    assert len(DeduplicatedCollection([1, 1, 1, 2])) == 2
+
+    # Test equality, especially that object identity matters
+    assert DedupedExamples([0]) == DedupedExamples([0])
+    assert DedupedExamples([0]) != DedupedExamples2([0])
+
+    # Test hash
+    c = DeduplicatedCollection([0, 1, 2])
+    assert hash(c) == hash(DeduplicatedCollection([0, 1, 2]))
+    assert hash(c) != hash(DeduplicatedCollection([0, 1]))
+
+    # Test contains
+    assert 2 in DeduplicatedCollection([0, 1, 2])
+    assert 20 not in DeduplicatedCollection([0, 1, 2])
+
+    # Test sorting
+    assert list(DedupedExamples([2, 1])) == [1, 2]
+    assert list(DedupedExamples2([2, 1])) == [2, 1]
+
+    # Test the interaction of sorting with equality
+    assert DedupedExamples([2, 1]) == DedupedExamples([1, 2])
+    assert DedupedExamples2([2, 1]) != DedupedExamples2([1, 2])
+
+    # Test bool
+    assert bool(DeduplicatedCollection([])) is False
+    assert bool(DeduplicatedCollection([1])) is True
+
+    # Test repr
+    assert repr(DedupedExamples()) == "DedupedExamples([])"
+    assert repr(DedupedExamples([0, 1])) == "DedupedExamples([0, 1])"


### PR DESCRIPTION
## Problem

We already have `Collection` to create newtypes of single elements that work with the engine.

But, often, we need to deduplicate those elements for better cache hits, such as deduplicating the requirements we pass to Pex. Further, we often will want to sort the inputs for more cache hits.

## Solution

Add `engine.collection.DeduplicatedCollection` as a light wrapper around `FrozenOrderedSet`. Subclasses will inherit from this, just like `Collection`. 

It includes a mechanism for subclasses to signal that the inputs to their constructor should be sorted. This must be opted-into because it would be surprising to sort by default.

Note: we technically could just have classes directly subclass `FrozenOrderedSet`. But, this abstraction is more discoverable because it is colocated with `pants.engine.Collection` and it has some niceties like allowing sorting + giving a default value of an empty collection.

[ci skip-jvm-tests]
[ci skip-rust-tests]