### PR TITLE
Break setup_logger into two functions

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -35,7 +35,7 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     def _enable_rust_logging(global_bootstrap_options: OptionValueContainer) -> None:
         log_level = global_bootstrap_options.level
         init_rust_logger(log_level, global_bootstrap_options.log_show_rust_3rdparty)
-        setup_logging_to_stderr(logging.getLogger(None), log_level)
+        setup_logging_to_stderr(log_level)
 
     def _should_run_with_pantsd(self, global_bootstrap_options: OptionValueContainer) -> bool:
         # The parent_build_id option is set only for pants commands (inner runs)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -37,6 +37,9 @@ def setup_logging_to_stderr(python_logger: Logger, log_level: LogLevel) -> None:
 
 
 class NativeHandler(StreamHandler):
+    """This class is installed as a Python logging module handler (using  the logging.addHandler
+    method) and proxies logs to the Rust logging infrastructure."""
+
     def __init__(
         self,
         log_level: LogLevel,

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 import warnings
-from logging import Logger, LogRecord, StreamHandler
+from logging import LogRecord, StreamHandler
 from typing import List, Optional, TextIO
 
 import pants.util.logging as pants_logging
@@ -27,15 +27,6 @@ def init_rust_logger(log_level: LogLevel, log_show_rust_3rdparty: bool) -> None:
     native.init_rust_logging(log_level.level, log_show_rust_3rdparty)
 
 
-def setup_logging_to_stderr(python_logger: Logger, log_level: LogLevel) -> None:
-    """We setup logging as loose as possible from the Python side, and let Rust do the filtering."""
-    native = Native()
-    handler = NativeHandler.create(log_level, native, stream=sys.stderr)
-    python_logger.addHandler(handler)
-    # Let the rust side filter levels; try to have the python side send everything to the rust logger.
-    LogLevel.TRACE.set_level_for(python_logger)
-
-
 class NativeHandler(StreamHandler):
     """This class is installed as a Python logging module handler (using  the logging.addHandler
     method) and proxies logs to the Rust logging infrastructure."""
@@ -43,14 +34,24 @@ class NativeHandler(StreamHandler):
     def __init__(
         self,
         log_level: LogLevel,
-        native: Native,
         stream: Optional[TextIO] = None,
         native_filename: Optional[str] = None,
     ):
+
+        if stream is not None and native_filename is not None:
+            raise RuntimeError("NativeHandler must output to either a stream or a file, not both")
+
         super().__init__(stream)
-        self.native = native
+        self.native = Native()
         self.native_filename = native_filename
         self.setLevel(log_level.level)
+
+        if stream:
+            try:
+                self.native.setup_stderr_logger(log_level.level)
+            except Exception as e:
+                print(f"Error setting up pantsd logger: {e!r}", file=sys.stderr)
+                raise e
 
     def emit(self, record: LogRecord) -> None:
         self.native.write_log(
@@ -66,71 +67,22 @@ class NativeHandler(StreamHandler):
             f"stream={self.stream})"
         )
 
-    @staticmethod
-    def create(log_level: LogLevel, native: Native, stream: TextIO) -> "NativeHandler":
-        try:
-            native.setup_stderr_logger(log_level.level)
-        except Exception as e:
-            print(f"Error setting up pantsd logger: {e!r}", file=sys.stderr)
-            raise e
 
-        return NativeHandler(log_level, native, stream)
-
-
-def setup_logging(
-    log_level: LogLevel,
-    *,
-    log_dir: Optional[str],
-    native: Native,
-    console_stream: Optional[TextIO] = None,
-    scope: Optional[str] = None,
-    log_filename: str = "pants.log",
-    warnings_filter_regexes: Optional[List[str]] = None,
-) -> Optional[NativeHandler]:
-    """Configures logging for a given scope, by default the global scope.
-
-    :param log_level: The logging level to enable.
-    :param native: An instance of the Native FFI lib, to register rust logging.
-    :param console_stream: The stream to use for default (console) logging. If None (default), this
-                           will disable console logging.
-    :param log_dir: An optional directory to emit logs files in.  If unspecified, no disk logging
-                    will occur.  If supplied, the directory will be created if it does not already
-                    exist and all logs will be tee'd to a rolling set of log files in that
-                    directory.
-    :param scope: A logging scope to configure.  The scopes are hierarchichal logger names, with
-                  The '.' separator providing the scope hierarchy.  By default the root logger is
-                  configured.
-    :param log_filename: The base name of the log file (defaults to 'pants.log').
-
-    :param warnings_filter_regexes: A series of regexes to ignore warnings for, typically from the
-                                    `ignore_pants_warnings` option.
-    :returns: The file logging setup configured if any.
-    """
-
-    # TODO(John Sirois): Consider moving to straight python logging.  The divide between the
-    # context/work-unit logging and standard python logging doesn't buy us anything.
-
-    # TODO(John Sirois): Support logging.config.fileConfig so a site can setup fine-grained
-    # logging control and we don't need to be the middleman plumbing an option for each python
-    # standard logging knob.
-
-    # A custom log handler for sub-debug trace logging.
-    def trace(self, message, *args, **kwargs):
-        if self.isEnabledFor(LogLevel.TRACE.level):
-            self._log(LogLevel.TRACE.level, message, *args, **kwargs)
-
-    logging.Logger.trace = trace  # type: ignore[attr-defined]
-
-    logger = logging.getLogger(scope)
+def clear_previous_loggers() -> None:
+    logger = logging.getLogger(None)
     for handler in logger.handlers:
         logger.removeHandler(handler)
 
-    if console_stream:
-        native_handler = NativeHandler.create(log_level, native, stream=console_stream)
-        logger.addHandler(native_handler)
 
-    log_level.set_level_for(logger)
+def _common_logging_setup(level: LogLevel, warnings_filter_regexes: Optional[List[str]]) -> None:
+    def trace_fn(self, message, *args, **kwargs):
+        if self.isEnabledFor(LogLevel.TRACE.level):
+            self._log(LogLevel.TRACE.level, message, *args, **kwargs)
 
+    logging.Logger.trace = trace_fn  # type: ignore[attr-defined]
+    logger = logging.getLogger(None)
+
+    level.set_level_for(logger)
     # This routes warnings through our loggers instead of straight to raw stderr.
     logging.captureWarnings(True)
 
@@ -143,15 +95,41 @@ def setup_logging(
         LogLevel.TRACE.set_level_for(requests_logger)
         requests_logger.propagate = True
 
-    if not log_dir:
-        return None
+
+def setup_logging_to_stderr(
+    level: LogLevel, *, warnings_filter_regexes: Optional[List[str]] = None
+) -> None:
+    """Sets up Python logging to stderr, proxied to Rust via a NativeHandler.
+
+    We deliberately set the most verbose logging possible (i.e. the TRACE log level), here, and let
+    the Rust logging faculties take care of filtering.
+    """
+    _common_logging_setup(level, warnings_filter_regexes)
+
+    python_logger = logging.getLogger(None)
+    handler = NativeHandler(level, stream=sys.stderr)
+    python_logger.addHandler(handler)
+    LogLevel.TRACE.set_level_for(python_logger)
+
+
+def setup_logging_to_file(
+    level: LogLevel,
+    *,
+    log_dir: str,
+    log_filename: str = "pants.log",
+    warnings_filter_regexes: Optional[List[str]] = None,
+) -> NativeHandler:
+    native = Native()
+    logger = logging.getLogger(None)
+
+    _common_logging_setup(level, warnings_filter_regexes)
 
     safe_mkdir(log_dir)
     log_path = os.path.join(log_dir, log_filename)
 
-    fd = native.setup_pantsd_logger(log_path, log_level.level)
+    fd = native.setup_pantsd_logger(log_path, level.level)
     ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))
-    native_handler = NativeHandler(log_level, native, native_filename=log_path)
+    native_handler = NativeHandler(level, native_filename=log_path)
 
     logger.addHandler(native_handler)
     return native_handler

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -356,16 +356,19 @@ class PantsDaemon(FingerprintedProcessManager):
             # We can't statically prove it, but we won't execute `launch()` (which
             # calls `run_sync` which calls `_pantsd_logging`) unless PantsDaemon
             # is launched with full_init=True. If PantsdDaemon is launched with
-            # full_init=True, we can guarantee self._native is non-None.
+            # full_init=True, we can guarantee self._native and self._bootstrap_options
+            # are non-None.
             native = cast(Native, self._native)
+            bootstrap_options = cast(OptionValueContainer, self._bootstrap_options)
 
             level = self._log_level
-            # TODO(gregs) - what is the right value for this warnings_filter_regexes line?
-            # warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
+            ignores = bootstrap_options.for_global_scope().ignore_pants_warnings
             clear_previous_loggers()
-            setup_logging_to_stderr(level)
+            setup_logging_to_stderr(level, warnings_filter_regexes=ignores)
             log_dir = os.path.join(self._work_dir, self.name)
-            log_handler = setup_logging_to_file(level, log_dir=log_dir, log_filename=self.LOG_NAME)
+            log_handler = setup_logging_to_file(
+                level, log_dir=log_dir, log_filename=self.LOG_NAME, warnings_filter_regexes=ignores
+            )
 
             native.override_thread_logging_destination_to_just_pantsd()
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -18,7 +18,12 @@ from pants.bin.daemon_pants_runner import DaemonPantsRunner
 from pants.engine.native import Native
 from pants.engine.unions import UnionMembership
 from pants.init.engine_initializer import EngineInitializer
-from pants.init.logging import NativeHandler, init_rust_logger, setup_logging
+from pants.init.logging import (
+    clear_previous_loggers,
+    init_rust_logger,
+    setup_logging_to_file,
+    setup_logging_to_stderr,
+)
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -290,7 +295,6 @@ class PantsDaemon(FingerprintedProcessManager):
             else True
         )
 
-        self._log_dir = os.path.join(work_dir, self.name)
         self._logger = logging.getLogger(__name__)
         # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
         self._kill_switch = threading.Event()
@@ -354,16 +358,15 @@ class PantsDaemon(FingerprintedProcessManager):
             # is launched with full_init=True. If PantsdDaemon is launched with
             # full_init=True, we can guarantee self._native is non-None.
             native = cast(Native, self._native)
-            log_handler = setup_logging(
-                self._log_level,
-                native=native,
-                log_dir=self._log_dir,
-                log_filename=self.LOG_NAME,
-                warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
-            )
-            # We know log_handler is never None because we did pass a non-None `log_dir`
-            # to setup_logging.
-            log_handler = cast(NativeHandler, log_handler)
+
+            level = self._log_level
+            # TODO(gregs) - what is the right value for this warnings_filter_regexes line?
+            # warnings_filter_regexes=self._bootstrap_options.for_global_scope(),  # type: ignore[union-attr]
+            clear_previous_loggers()
+            setup_logging_to_stderr(level)
+            log_dir = os.path.join(self._work_dir, self.name)
+            log_handler = setup_logging_to_file(level, log_dir=log_dir, log_filename=self.LOG_NAME)
+
             native.override_thread_logging_destination_to_just_pantsd()
 
             # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -30,8 +30,8 @@ class LoggingTest(TestBase):
 
     @contextmanager
     def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
-        # TODO(gregorys) - if this line isn't here this test fails with no stdout. Figure out why.
         native = self.scheduler._scheduler._native
+        # TODO(gregorys) - if this line isn't here this test fails with no stdout. Figure out why.
         print(f"Native: {native}")
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as tmpdir:

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -7,7 +7,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Iterator, Tuple
 
-from pants.init.logging import NativeHandler, setup_logging
+from pants.init.logging import NativeHandler, setup_logging_to_file
 from pants.testutil.engine.util import init_native
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
@@ -30,10 +30,12 @@ class LoggingTest(TestBase):
 
     @contextmanager
     def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
+        # TODO(gregorys) - if this line isn't here this test fails with no stdout. Figure out why.
         native = self.scheduler._scheduler._native
+        print(f"Native: {native}")
         logger = logging.getLogger("my_file_logger")
         with temporary_dir() as tmpdir:
-            handler = setup_logging(log_level, log_dir=tmpdir, native=native, scope=logger.name)
+            handler = setup_logging_to_file(log_level, log_dir=tmpdir)
             log_file = Path(tmpdir, "pants.log")
             yield logger, handler, log_file
 


### PR DESCRIPTION
### Problem

Pants previously initialized Python logging in three different places - `pants_runner.py`, `local_pants_runner.py`, and `pants_daemon.py`, all with slightly different combinations of arguments to the `setup_logging` and `setup_logging_to_stderr` functions.  `setup_logging` itself had a complicated argument structure with lots of Optionals toggling different function-internal behavior. This was confusing to reason about.

### Solution

This PR gets rid of the `setup_logging` function in lieu of the existing `setup_logging_to_stderr` function, and a new `setup_logging_to_file` function. These two new functions each have a more straightforward argument structure. Each of the three logging setup locations will call one or the other of them as needed. The functionality to clear out previous Python logging handlers was also isolated into a separate function, so it could only be invoked when necessary.