### PR TITLE
Fix `zip_safe` field not being used with V2 binary

### DIFF
--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -56,6 +56,8 @@ class PythonBinaryConfiguration(BinaryConfiguration):
             args.append(f"--inherit-path={self.inherit_path.value}")
         if self.shebang.value is not None:
             args.append(f"--python-shebang={self.shebang.value}")
+        if self.zip_safe.value is False:
+            args.append(f"--not-zip-safe")
         return tuple(args)
 
 


### PR DESCRIPTION
Due to oversight, we weren't actually translating the field into the appropriate Pex argument.

[ci skip-rust-tests]
[ci skip-jvm-tests]