### PR TITLE
Some small logger.rs improvements

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -869,10 +869,9 @@ class Native(metaclass=SingletonMetaclass):
     def setup_stderr_logger(self, level):
         return self.lib.setup_stderr_logger(level)
 
-    def write_log(self, msg, level, target):
-        msg = msg.encode()
-        target = target.encode()
-        return self.lib.write_log(msg, level, target)
+    def write_log(self, msg: str, *, level: int, target: str):
+        """Proxy a log message to the Rust logging faculties."""
+        return self.lib.write_log(msg.encode(), level, target.encode())
 
     def write_stdout(self, session, msg: str):
         return self.lib.write_stdout(session, msg.encode())

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -55,7 +55,7 @@ class NativeHandler(StreamHandler):
 
     def emit(self, record: LogRecord) -> None:
         self.native.write_log(
-            self.format(record), record.levelno, f"{record.name}:pid={os.getpid()}"
+            msg=self.format(record), level=record.levelno, target=f"{record.name}:pid={os.getpid()}"
         )
 
     def flush(self) -> None:

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1222,8 +1222,7 @@ pub extern "C" fn setup_stderr_logger(level: u64) {
 pub extern "C" fn write_log(msg: *const raw::c_char, level: u64, target: *const raw::c_char) {
   let message_str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
   let target_str = unsafe { CStr::from_ptr(target).to_string_lossy() };
-  LOGGER
-    .log_from_python(message_str.borrow(), level, target_str.borrow())
+  Logger::log_from_python(message_str.borrow(), level, target_str.borrow())
     .expect("Error logging message");
 }
 


### PR DESCRIPTION
This is just a few small changes to code around logger.rs:
- get rid of the `level()` method, nothing is using it
- `log_from_python` doesn't need to have a `&self` reference
- add some documentation strings
