### PR TITLE
Revert "Add link back to source control dir from physical workdir"

### DIFF
--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -4,15 +4,12 @@
 import os
 from typing import cast
 
-from pants.base.build_environment import get_buildroot
 from pants.fs.fs import safe_filename_from_path
 from pants.goal.goal import Goal
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_rmtree, symlink_is_correct
-
-SOURCE_CONTROL_DIRS = (".git", ".hg", ".svn")
+from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_rmtree
 
 
 def init_workdir(global_options: OptionValueContainer) -> str:
@@ -30,33 +27,12 @@ def init_workdir(global_options: OptionValueContainer) -> str:
     workdir_base = global_options.pants_physical_workdir_base
     workdir_dst = os.path.join(workdir_base, safe_filename_from_path(workdir_src))
 
-    def maybe_create_source_control_symlink():
-        """If the buildroot we are working in has a source control administrative directory, we need
-        to add a link to it from the physical workdir we create.
-
-        Tools which run from the physical workdir expect to be able to glean repository information
-        directly. For instance node_binary targets are built using ad-hoc build scripts which can do
-        this.
-        """
-        # Don't link anything unless this option is enabled.
-        if not global_options.pants_physical_workdir_source_control:
-            return
-        for scm_state_dir in SOURCE_CONTROL_DIRS:
-            scm_source_path = os.path.join(get_buildroot(), scm_state_dir)
-            scm_target_path = os.path.join(workdir_dst, scm_state_dir)
-            if os.path.exists(scm_source_path) and not symlink_is_correct(
-                scm_source_path, scm_target_path
-            ):
-                absolute_symlink(scm_source_path, scm_target_path)
-                break
-
     def create_symlink_to_clean_workdir():
         # Executed when no link exists. We treat this as equivalent to a request to have deleted
         # this state. Operations like `clean-all` will already have purged the destination, but in
         # cases like manual removal of the symlink, we want to treat the case as equivalent.
         safe_mkdir(workdir_dst, clean=True)
         absolute_symlink(workdir_dst, workdir_src)
-        maybe_create_source_control_symlink()
 
     if not os.path.lexists(workdir_src):
         # Does not exist.
@@ -69,11 +45,10 @@ def init_workdir(global_options: OptionValueContainer) -> str:
         else:
             # Exists and is correct: ensure that the destination exists.
             safe_mkdir(workdir_dst)
-            maybe_create_source_control_symlink()
     else:
         # Remove existing physical workdir (.pants.d dir)
         safe_rmtree(workdir_src)
-        # Create both symlink workdir (.pants.d dir) and its destination/physical workdir.
+        # Create both symlink workdir (.pants.d dir) and its destination/physical workdir
         create_symlink_to_clean_workdir()
     return workdir_src
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -355,15 +355,6 @@ class GlobalOptions(Subsystem):
             "per-workspace subdirectory.",
         )
         register(
-            "--pants-physical-workdir-source-control",
-            advanced=True,
-            type=bool,
-            default=False,
-            help="If tasks run processes which need access to source control state "
-            "applying this option will add a link from the physical workdir back to "
-            "any existing source control directories.",
-        )
-        register(
             "--pants-supportdir",
             advanced=True,
             metavar="<dir>",

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -524,15 +524,6 @@ def relative_symlink(source_path: str, link_path: str) -> None:
             raise
 
 
-def symlink_is_correct(source_path, target_path):
-    return (
-        os.path.exists(source_path)
-        and os.path.exists(target_path)
-        and os.path.islink(target_path)
-        and os.readlink(target_path) == source_path
-    )
-
-
 def relativize_path(path: str, rootdir: str) -> str:
     """
     :API: public

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -9,26 +9,19 @@ from pants.init.util import init_workdir
 from pants.option.option_value_container import OptionValueContainer
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_mkdir
 
 
 class UtilTest(TestBase):
     @contextmanager
     def physical_workdir_base(self) -> OptionValueContainer:
-        with temporary_dir() as physical_workdir_base:
+        with temporary_dir(cleanup=False) as physical_workdir_base:
             bootstrap_options = self.get_bootstrap_options(
-                [
-                    f"--pants-physical-workdir-base={physical_workdir_base}",
-                    "--pants-physical-workdir-source-control",
-                ]
+                [f"--pants-physical-workdir-base={physical_workdir_base}"]
             )
             yield bootstrap_options
 
     def assert_exists(self, path):
         self.assertTrue(os.path.exists(path))
-
-    def assert_not_exists(self, path):
-        self.assertFalse(os.path.exists(path))
 
     def assert_symlink(self, path):
         self.assertTrue(os.path.islink(path))
@@ -53,24 +46,3 @@ class UtilTest(TestBase):
             self.assert_symlink(self.pants_workdir)
             # Assert symlink target's physical dir exists
             self.assert_exists(os.path.join(self.physical_workdir(bootstrap_options)))
-
-    def test_source_control_repo(self):
-        source_control_dirname = ".git"
-        with self.physical_workdir_base() as bootstrap_options:
-            safe_mkdir(os.path.join(self.build_root, source_control_dirname))
-            init_workdir(bootstrap_options)
-            self.assert_exists(
-                os.path.join(self.physical_workdir(bootstrap_options), source_control_dirname)
-            )
-
-    def test_source_control_disabled(self):
-        source_control_dirname = ".git"
-        with temporary_dir() as physical_workdir_base:
-            bootstrap_options = self.get_bootstrap_options(
-                [f"--pants-physical-workdir-base={physical_workdir_base}"]
-            )
-            safe_mkdir(os.path.join(self.build_root, source_control_dirname))
-            init_workdir(bootstrap_options)
-            self.assert_not_exists(
-                os.path.join(self.physical_workdir(bootstrap_options), source_control_dirname)
-            )

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -35,7 +35,6 @@ from pants.util.dirutil import (
     safe_open,
     safe_rm_oldest_items_in_dir,
     safe_rmtree,
-    symlink_is_correct,
     touch,
 )
 
@@ -397,31 +396,6 @@ class DirutilTest(unittest.TestCase):
                 ValueError, r"Path for link.*overwrite an existing directory*"
             ):
                 relative_symlink(source, link_path)
-
-    def test_symlink_is_correct(self) -> None:
-        with temporary_dir() as tmpdir_1:
-            source = os.path.join(tmpdir_1, "source")
-            link_path = os.path.join(tmpdir_1, "link")
-            touch(source)
-            os.symlink(source, link_path)
-            self.assertTrue(symlink_is_correct(source, link_path))
-
-    def test_symlink_is_not_correct(self) -> None:
-        with temporary_dir() as tmpdir_1:
-            source = os.path.join(tmpdir_1, "source")
-            source2 = os.path.join(tmpdir_1, "source2")
-            link_path = os.path.join(tmpdir_1, "link")
-            touch(source)
-            # link doesnt exist.
-            self.assertFalse(symlink_is_correct(source, link_path))
-            touch(link_path)
-            # link_path exists but isn't a symlink.
-            self.assertFalse(symlink_is_correct(source, link_path))
-            os.remove(link_path)
-            touch(source2)
-            os.symlink(source2, link_path)
-            # link_path and source exist, link is not broken, but link points to the wrong place.
-            self.assertFalse(symlink_is_correct(source, link_path))
 
     def test_get_basedir(self) -> None:
         self.assertEqual(get_basedir("foo/bar/baz"), "foo")


### PR DESCRIPTION
Turns out this way of connecting to git from the workdir doesn't end up working for git in a VCFS workspace.

Reverts pantsbuild/pants#9531