### PR TITLE
Use `FrozenDict` and `FrozenOrderedSet` for type safety with `UnionMembership` and `RegisteredTargetTypes`

### DIFF
--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -27,7 +27,6 @@ from pants.engine.target import Sources, Target, TargetsWithOrigins, TargetWithO
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
 from pants.testutil.test_base import TestBase
-from pants.util.ordered_set import OrderedSet
 
 
 class FortranSources(Sources):
@@ -129,9 +128,7 @@ class FmtTest(TestBase):
         include_sources: bool = True,
     ) -> str:
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership(
-            {LanguageFmtTargets: OrderedSet(language_target_collection_types)}
-        )
+        union_membership = UnionMembership({LanguageFmtTargets: language_target_collection_types})
         result: Fmt = run_rule(
             fmt,
             rule_args=[

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -22,7 +22,6 @@ from pants.engine.target import Sources, Target, TargetsWithOrigins, TargetWithO
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
 from pants.testutil.test_base import TestBase
-from pants.util.ordered_set import OrderedSet
 
 
 class MockTarget(Target):
@@ -124,9 +123,7 @@ class LintTest(TestBase):
         include_sources: bool = True,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
-        union_membership = UnionMembership(
-            {LinterConfigurations: OrderedSet(config_collection_types)}
-        )
+        union_membership = UnionMembership({LinterConfigurations: config_collection_types})
         result: Lint = run_rule(
             lint,
             rule_args=[

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -21,7 +21,6 @@ from pants.testutil.engine.util import (
     run_rule,
 )
 from pants.testutil.test_base import TestBase
-from pants.util.ordered_set import OrderedSet
 
 
 class RunTest(TestBase):
@@ -64,9 +63,7 @@ class RunTest(TestBase):
                 ),
                 create_goal_subsystem(RunOptions, args=[]),
                 create_subsystem(GlobalOptions, pants_workdir=self.pants_workdir),
-                UnionMembership(
-                    union_rules={BinaryConfiguration: OrderedSet([TestBinaryConfiguration])}
-                ),
+                UnionMembership({BinaryConfiguration: [TestBinaryConfiguration]}),
                 RegisteredTargetTypes.create([TestBinaryTarget]),
             ],
             mock_gets=[

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -46,7 +46,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
 from pants.testutil.test_base import TestBase
-from pants.util.ordered_set import OrderedSet
 
 
 class MockTarget(Target):
@@ -152,7 +151,7 @@ class TestTest(TestBase):
         options = create_goal_subsystem(TestOptions, debug=debug, run_coverage=False)
         interactive_runner = InteractiveRunner(self.scheduler)
         workspace = Workspace(self.scheduler)
-        union_membership = UnionMembership({TestConfiguration: OrderedSet([config])})
+        union_membership = UnionMembership({TestConfiguration: [config]})
 
         def mock_coordinator_of_tests(
             wrapped_config: WrappedTestConfiguration,

--- a/src/python/pants/core/project_info/list_target_types_test.py
+++ b/src/python/pants/core/project_info/list_target_types_test.py
@@ -15,7 +15,6 @@ from pants.testutil.engine.util import (
     create_subsystem,
     run_rule,
 )
-from pants.util.ordered_set import OrderedSet
 
 
 # Note no docstring.
@@ -126,7 +125,7 @@ def test_list_single() -> None:
         required = True
 
     tests_target_stdout = run_goal(
-        union_membership=UnionMembership({FortranTests.PluginField: OrderedSet([CustomField])}),
+        union_membership=UnionMembership({FortranTests.PluginField: [CustomField]}),
         details_target=FortranTests.alias,
     )
     assert tests_target_stdout == dedent(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -191,8 +191,9 @@ python_library(
   name='unions',
   sources=['unions.py'],
   dependencies=[
-    'src/python/pants/util:meta',
+    'src/python/pants/util:frozendict',
     'src/python/pants/util:ordered_set',
+    'src/python/pants/util:meta',
   ],
   tags = {'type_checked'},
 )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -585,11 +585,13 @@ class TransitiveTargets:
     closure: FrozenOrderedSet[Target]
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class RegisteredTargetTypes:
-    # TODO: add `FrozenDict` as a light-weight wrapper around `dict` that de-registers the
-    #  mutation entry points.
-    aliases_to_types: Dict[str, Type[Target]]
+    aliases_to_types: FrozenDict[str, Type[Target]]
+
+    def __init__(self, aliases_to_types: Mapping[str, Type[Target]]) -> None:
+        self.aliases_to_types = FrozenDict(aliases_to_types)
 
     @classmethod
     def create(cls, target_types: Iterable[Type[Target]]) -> "RegisteredTargetTypes":

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -275,7 +275,7 @@ def test_add_custom_fields() -> None:
         alias: ClassVar = "custom_field"
         default: ClassVar = False
 
-    union_membership = UnionMembership({FortranTarget.PluginField: OrderedSet([CustomField])})
+    union_membership = UnionMembership({FortranTarget.PluginField: [CustomField]})
     tgt_values = {CustomField.alias: True}
     tgt = FortranTarget(
         tgt_values, address=Address.parse(":lib"), union_membership=union_membership
@@ -516,8 +516,8 @@ def test_configuration_group_targets_to_valid_config_types() -> None:
 
     union_membership = UnionMembership(
         {
-            ConfigSuperclass: OrderedSet([ConfigSubclass1, ConfigSubclass2]),
-            ConfigSuperclassWithOrigin: OrderedSet([ConfigSubclassWithOrigin]),
+            ConfigSuperclass: [ConfigSubclass1, ConfigSubclass2],
+            ConfigSuperclassWithOrigin: [ConfigSubclassWithOrigin],
         }
     )
     registered_target_types = RegisteredTargetTypes.create([FortranTarget, InvalidTarget])


### PR DESCRIPTION
Without this change, a new test I'm adding was failing due to trying to hash a `dict`.

We use the flexible constructor pattern so that no call sites need to update for this change. This pattern allows us to also simplify tests so that they no longer need to explicitly use `OrderedSet`.

[ci skip-rust-tests]
[ci skip-jvm-tests]