### PR TITLE
WIP: Automatically inject OptionsBootstrapper in tests

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -410,6 +410,11 @@ class EngineInitializer:
         def build_root_singleton() -> BuildRoot:
             return cast(BuildRoot, BuildRoot.instance)
 
+        @rule
+        def options_bootstrapper_singleton() -> OptionsBootstrapper:
+            print("Rule returning options_bootstrapper: {}".format(options_bootstrapper))
+            return options_bootstrapper
+
         # Create a Scheduler containing graph and filesystem rules, with no installed goals. The
         # LegacyBuildGraph will explicitly request the products it needs.
         rules = (
@@ -420,6 +425,7 @@ class EngineInitializer:
             registered_target_types_singleton,
             union_membership_singleton,
             build_root_singleton,
+            options_bootstrapper_singleton,
             *graph.rules(),
             *options_parsing.rules(),
             *create_legacy_graph_tasks(),


### PR DESCRIPTION
# Delete this line to force CI to run Clippy and the Rust tests.
[ci skip-rust-tests]
# Delete this line to force CI to run the JVM tests.
[ci skip-jvm-tests]

### Problem

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)