### PR TITLE
Refactor filtering of valid targets via the engine

### DIFF
--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -57,7 +57,9 @@ async def create_awslambda(
 ) -> AWSLambdaGoal:
     targets_to_valid_configs = await Get[TargetsToValidConfigurations](
         TargetsToValidConfigurationsRequest(
-            AWSLambdaConfiguration, goal_name=options.name, error_if_no_valid_targets=True
+            AWSLambdaConfiguration,
+            goal_description=f"the `{options.name}` goal",
+            error_if_no_valid_targets=True,
         )
     )
     awslambdas = await MultiGet(

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -54,7 +54,9 @@ async def create_binary(
 ) -> Binary:
     targets_to_valid_configs = await Get[TargetsToValidConfigurations](
         TargetsToValidConfigurationsRequest(
-            BinaryConfiguration, goal_name=options.name, error_if_no_valid_targets=True
+            BinaryConfiguration,
+            goal_description=f"the `{options.name}` goal",
+            error_if_no_valid_targets=True,
         )
     )
     binaries = await MultiGet(

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -12,8 +12,12 @@ from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, 
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
-from pants.engine.target import Configuration, RegisteredTargetTypes, TargetsWithOrigins
-from pants.engine.unions import UnionMembership, union
+from pants.engine.target import (
+    Configuration,
+    TargetsToValidConfigurations,
+    TargetsToValidConfigurationsRequest,
+)
+from pants.engine.unions import union
 
 
 @union
@@ -42,26 +46,20 @@ class Binary(Goal):
 
 @goal_rule
 async def create_binary(
-    targets_with_origins: TargetsWithOrigins,
     console: Console,
     workspace: Workspace,
     options: BinaryOptions,
     distdir: DistDir,
     buildroot: BuildRoot,
-    union_membership: UnionMembership,
-    registered_target_types: RegisteredTargetTypes,
 ) -> Binary:
-    targets_to_valid_configs = BinaryConfiguration.group_targets_to_valid_subclass_configs(
-        targets_with_origins,
-        union_membership=union_membership,
-        registered_target_types=registered_target_types,
-        goal_name=options.name,
-        error_if_no_valid_targets=True,
+    targets_to_valid_configs = await Get[TargetsToValidConfigurations](
+        TargetsToValidConfigurationsRequest(
+            BinaryConfiguration, goal_name=options.name, error_if_no_valid_targets=True
+        )
     )
     binaries = await MultiGet(
         Get[CreatedBinary](BinaryConfiguration, config)
-        for valid_configs in targets_to_valid_configs.values()
-        for config in valid_configs
+        for config in targets_to_valid_configs.configurations
     )
     merged_digest = await Get[Digest](
         DirectoriesToMerge(tuple(binary.digest for binary in binaries))

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -6,7 +6,6 @@ import logging
 from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
 from pathlib import PurePath
 from typing import Dict, Iterable, List, Optional, Type, TypeVar
 
@@ -27,9 +26,9 @@ from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     ConfigurationWithOrigin,
-    RegisteredTargetTypes,
     Sources,
-    TargetsWithOrigins,
+    TargetsToValidConfigurations,
+    TargetsToValidConfigurationsRequest,
 )
 from pants.engine.unions import UnionMembership, union
 
@@ -199,52 +198,48 @@ async def run_tests(
     console: Console,
     options: TestOptions,
     interactive_runner: InteractiveRunner,
-    targets_with_origins: TargetsWithOrigins,
     workspace: Workspace,
     union_membership: UnionMembership,
-    registered_target_types: RegisteredTargetTypes,
 ) -> Test:
-    group_targets_to_configs = partial(
-        TestConfiguration.group_targets_to_valid_subclass_configs,
-        targets_with_origins,
-        union_membership=union_membership,
-        registered_target_types=registered_target_types,
-        goal_name=options.name,
-    )
-
-    bulleted_list_sep = "\n  * "
-
     if options.values.debug:
-        targets_to_valid_configs = group_targets_to_configs(error_if_no_valid_targets=True)
-        if len(targets_to_valid_configs) > 1:
+        bulleted_list_sep = "\n  * "
+        targets_to_valid_configs = await Get[TargetsToValidConfigurations](
+            TargetsToValidConfigurationsRequest(
+                TestConfiguration, goal_name=options.name, error_if_no_valid_targets=True
+            )
+        )
+        if len(targets_to_valid_configs.targets) > 1:
             test_target_addresses = sorted(
-                tgt_with_origin.target.address.spec for tgt_with_origin in targets_to_valid_configs
+                tgt.address.spec for tgt in targets_to_valid_configs.targets
             )
             raise ValueError(
                 f"`test --debug` only works on one test target but was given multiple test "
                 f"targets: {bulleted_list_sep}{bulleted_list_sep.join(test_target_addresses)}\n\n"
                 f"Please select one of these targets to run or do not use the `--debug` option."
             )
-        target_with_origin, valid_configs = list(targets_to_valid_configs.items())[0]
-        target = target_with_origin.target
-        if len(valid_configs) > 1:
-            possible_config_types = sorted(config.__class__.__name__ for config in valid_configs)
+        target = targets_to_valid_configs.targets[0]
+        if len(targets_to_valid_configs.configurations) > 1:
+            possible_config_types = sorted(
+                config.__class__.__name__ for config in targets_to_valid_configs.configurations
+            )
             raise ValueError(
                 f"Multiple of the registered test implementations work for {target.address} "
                 f"(target type {repr(target.alias)}). It is ambiguous which implementation to use. "
                 f"Possible implementations: {possible_config_types}."
             )
+        config = targets_to_valid_configs.configurations[0]
         logger.info(f"Starting test in debug mode: {target.address.reference()}")
-        request = await Get[TestDebugRequest](TestConfiguration, valid_configs[0])
+        request = await Get[TestDebugRequest](TestConfiguration, config)
         debug_result = interactive_runner.run_local_interactive_process(request.ipr)
         return Test(debug_result.process_exit_code)
 
-    targets_to_valid_configs = group_targets_to_configs(error_if_no_valid_targets=False)
-    configs = itertools.chain.from_iterable(
-        configs_per_target for configs_per_target in targets_to_valid_configs.values()
+    targets_to_valid_configs = await Get[TargetsToValidConfigurations](
+        TargetsToValidConfigurationsRequest(
+            TestConfiguration, goal_name=options.name, error_if_no_valid_targets=False
+        )
     )
     configs_with_sources = await Get[ConfigurationsWithSources](
-        ConfigurationsWithSourcesRequest(configs)
+        ConfigurationsWithSourcesRequest(targets_to_valid_configs.configurations)
     )
 
     results = await MultiGet(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -6,8 +6,6 @@ from pathlib import PurePath
 from textwrap import dedent
 from typing import List, Optional, Tuple, Type, cast
 
-import pytest
-
 from pants.base.specs import SingleAddress
 from pants.core.goals.test import (
     AddressAndTestResult,
@@ -254,19 +252,8 @@ class TestTest(TestBase):
             """
         )
 
-    def test_single_debug_target(self) -> None:
+    def test_debug_target(self) -> None:
         exit_code, stdout = self.run_test_rule(
             config=SuccessfulConfiguration, targets=[self.make_target_with_origin()], debug=True,
         )
         assert exit_code == 0
-
-    def test_multiple_debug_targets_fail(self) -> None:
-        with pytest.raises(ValueError):
-            self.run_test_rule(
-                config=SuccessfulConfiguration,
-                targets=[
-                    self.make_target_with_origin(Address.parse(":t1")),
-                    self.make_target_with_origin(Address.parse(":t2")),
-                ],
-                debug=True,
-            )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -756,22 +756,24 @@ class TargetsToValidConfigurations:
 @dataclass(unsafe_hash=True)
 class TargetsToValidConfigurationsRequest:
     configuration_superclass: Type[_AbstractConfiguration]
-    goal_name: str
+    goal_description: str
     error_if_no_valid_targets: bool
+    expect_single_config: bool
     # TODO: Add a `require_sources` field. To do this, figure out the dependency cycle with
     #  `util_rules/filter_empty_sources.py`.
-    # TODO: add a "expect_only_one_config" bool option. The tricky part is the error message.
 
     def __init__(
         self,
         configuration_superclass: Type[_AbstractConfiguration],
         *,
-        goal_name: str,
+        goal_description: str,
         error_if_no_valid_targets: bool,
+        expect_single_config: bool = False,
     ) -> None:
         self.configuration_superclass = configuration_superclass
-        self.goal_name = goal_name
+        self.goal_description = goal_description
         self.error_if_no_valid_targets = error_if_no_valid_targets
+        self.expect_single_config = expect_single_config
 
 
 @rule
@@ -797,15 +799,24 @@ def find_valid_configurations(
         ]
         if valid_configs:
             targets_to_valid_configs[tgt_with_origin] = valid_configs
-    if not targets_to_valid_configs and request.error_if_no_valid_targets:
-        raise NoValidTargets.create_from_configs(
+    if request.error_if_no_valid_targets and not targets_to_valid_configs:
+        raise NoValidTargetsException.create_from_configs(
             targets_with_origins,
             config_types=config_types,
-            goal_name=request.goal_name,
+            goal_description=request.goal_description,
             union_membership=union_membership,
             registered_target_types=registered_target_types,
         )
-    return TargetsToValidConfigurations(targets_to_valid_configs)
+    result = TargetsToValidConfigurations(targets_to_valid_configs)
+    if not request.expect_single_config:
+        return result
+    if len(result.targets) > 1:
+        raise TooManyTargetsException(result.targets, goal_description=request.goal_description)
+    if len(result.configurations) > 1:
+        raise AmbiguousImplementationsException(
+            result.targets[0], result.configurations, goal_description=request.goal_description
+        )
+    return result
 
 
 # -----------------------------------------------------------------------------------------------
@@ -856,13 +867,13 @@ class InvalidFieldChoiceException(InvalidFieldException):
 
 
 # NB: This has a tight coupling to goals. Feel free to change this if necessary.
-class NoValidTargets(Exception):
+class NoValidTargetsException(Exception):
     def __init__(
         self,
         targets_with_origins: TargetsWithOrigins,
         *,
         valid_target_types: Iterable[Type[Target]],
-        goal_name: str,
+        goal_description: str,
     ) -> None:
         valid_target_aliases = sorted({target_type.alias for target_type in valid_target_types})
         invalid_target_aliases = sorted({tgt.alias for tgt in targets_with_origins.targets})
@@ -874,7 +885,7 @@ class NoValidTargets(Exception):
         )
         bulleted_list_sep = "\n  * "
         super().__init__(
-            f"The `{goal_name}` goal only works with the following target types:"
+            f"{goal_description.capitalize()} only works with the following target types:"
             f"{bulleted_list_sep}{bulleted_list_sep.join(valid_target_aliases)}\n\n"
             f"You specified `{' '.join(specs)}`, which only included the following target types:"
             f"{bulleted_list_sep}{bulleted_list_sep.join(invalid_target_aliases)}"
@@ -886,10 +897,10 @@ class NoValidTargets(Exception):
         targets_with_origins: TargetsWithOrigins,
         *,
         config_types: Iterable[Type[_AbstractConfiguration]],
-        goal_name: str,
+        goal_description: str,
         union_membership: UnionMembership,
         registered_target_types: RegisteredTargetTypes,
-    ) -> "NoValidTargets":
+    ) -> "NoValidTargetsException":
         valid_target_types = {
             target_type
             for config_type in config_types
@@ -897,7 +908,47 @@ class NoValidTargets(Exception):
                 registered_target_types.types, union_membership=union_membership
             )
         }
-        return cls(targets_with_origins, valid_target_types=valid_target_types, goal_name=goal_name)
+        return cls(
+            targets_with_origins,
+            valid_target_types=valid_target_types,
+            goal_description=goal_description,
+        )
+
+
+# NB: This has a tight coupling to goals. Feel free to change this if necessary.
+class TooManyTargetsException(Exception):
+    def __init__(self, targets: Iterable[Target], *, goal_description: str) -> None:
+        bulleted_list_sep = "\n  * "
+        addresses = sorted(tgt.address.spec for tgt in targets)
+        super().__init__(
+            f"{goal_description.capitalize()} only works with one valid target, but was given "
+            f"multiple valid targets:{bulleted_list_sep}{bulleted_list_sep.join(addresses)}\n\n"
+            "Please select one of these targets to run."
+        )
+
+
+# NB: This has a tight coupling to goals. Feel free to change this if necessary.
+class AmbiguousImplementationsException(Exception):
+    """Exception for when a single target has multiple valid Configurations, but the goal only
+    expects there to be one Configuration."""
+
+    def __init__(
+        self,
+        target: Target,
+        configurations: Iterable[_AbstractConfiguration],
+        *,
+        goal_description: str,
+    ) -> None:
+        # TODO: improve this error message. A better error message would explain to users how they
+        #  can resolve the issue.
+        possible_config_types = sorted(config.__class__.__name__ for config in configurations)
+        bulleted_list_sep = "\n  * "
+        super().__init__(
+            f"Multiple of the registered implementations for {goal_description} work for "
+            f"{target.address} (target type {repr(target.alias)}).\n\n"
+            "It is ambiguous which implementation to use. Possible implementations:"
+            f"{bulleted_list_sep}{bulleted_list_sep.join(possible_config_types)}"
+        )
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This builds on top of https://github.com/pantsbuild/pants/pull/9605 to better support the pattern of a `@goal_rule` filtering out irrelevant targets and converting them into its subclass' configurations. 

Note that this pattern does not apply to every `@goal_rule`. Many `@goal_rule`s are simpler and have no downstream rules - they can avoid configurations entirely, like `list_targets.py`. Others are more complex, like `lint.py` and `fmt.py` needing to batch Configurations, rather than working on a per-target basis.