### PR TITLE
Remove our custom .tar.xz workaround.

### DIFF
--- a/build-support/docker/remote_execution/Dockerfile
+++ b/build-support/docker/remote_execution/Dockerfile
@@ -14,12 +14,13 @@
 
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729
 
-RUN apt-get update
+RUN apt-get update --fix-missing
 RUN apt-get install -y \
   build-essential \
   gcc-multilib \
   g++-multilib \
   libbz2-dev \
+  liblzma-dev \
   libreadline-dev \
   libssl-dev \
   libsqlite3-dev \

--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -20,7 +20,7 @@ remote_instance_name = "projects/pants-remoting-beta/instances/default_instance"
 remote_execution_extra_platform_properties = [
   # This allows network requests, e.g. to resolve dependencies with Pex.
   "dockerNetwork=standard",
-  "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:5d818cd71c9180d977e16ca7a20e90ced14211621b69fe1d6c3fc4c42c537a14",
+  "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:ec94526d1aa0604b7f693a0b1fb224ca7822a0d821ce20dff50ec808cad597b6",
 ]
 
 # This should correspond to the number of workers running in Google RBE. See

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -319,6 +319,11 @@ class SingleFileExecutable:
 
 
 @dataclass(frozen=True)
+class ExpandedArchive:
+    digest: Digest
+
+
+@dataclass(frozen=True)
 class SourcesSnapshot:
     """Sources matched by command line specs, either directly via FilesystemSpecs or indirectly via
     AddressSpecs.

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -52,11 +52,10 @@ class ArchiveTest(unittest.TestCase):
         test_round_trip(concurrency_safe=True)
 
     def test_tar(self):
-        # TODO: test XZCompressedTarArchiver? Needs an xz BinaryTool, so hard to see how to do in a
-        # unit test.
         self.round_trip(create_archiver("tar"), expected_ext="tar", empty_dirs=True)
         self.round_trip(create_archiver("tgz"), expected_ext="tar.gz", empty_dirs=True)
         self.round_trip(create_archiver("tbz2"), expected_ext="tar.bz2", empty_dirs=True)
+        self.round_trip(create_archiver("txz"), expected_ext="tar.xz", empty_dirs=True)
 
     def test_zip(self):
         self.round_trip(create_archiver("zip"), expected_ext="zip", empty_dirs=False)


### PR DESCRIPTION
We no longer run on Python 2.7, and Python 3 has
built-in support for lzma compression of tarfiles.

[ci skip-rust-tests]
[ci skip-jvm-tests]
