### PR TITLE
Compute process execution times by walking the workunit graph

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3670,6 +3670,7 @@ version = "0.0.1"
 dependencies = [
  "concrete_time 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -399,8 +399,13 @@ fn make_core(
   )
 }
 
-fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Value {
+fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Option<Value> {
   use std::time::UNIX_EPOCH;
+
+  if !started_workunit.metadata.display {
+    return None;
+  }
+
   let duration = started_workunit
     .start_time
     .duration_since(UNIX_EPOCH)
@@ -438,10 +443,14 @@ fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Value {
     ));
   }
 
-  externs::store_dict(&dict_entries.as_slice())
+  Some(externs::store_dict(&dict_entries.as_slice()))
 }
 
-fn workunit_to_py_value(workunit: &WorkUnit) -> Value {
+fn workunit_to_py_value(workunit: &WorkUnit) -> Option<Value> {
+  if !workunit.metadata.display {
+    return None;
+  }
+
   let mut dict_entries = vec![
     (
       externs::store_utf8("name"),
@@ -482,12 +491,12 @@ fn workunit_to_py_value(workunit: &WorkUnit) -> Value {
     ));
   }
 
-  externs::store_dict(&dict_entries.as_slice())
+  Some(externs::store_dict(&dict_entries.as_slice()))
 }
 
 fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>) -> Value {
   let workunit_values = workunits
-    .map(|workunit: &WorkUnit| workunit_to_py_value(workunit))
+    .flat_map(|workunit: &WorkUnit| workunit_to_py_value(workunit))
     .collect::<Vec<_>>();
   externs::store_tuple(&workunit_values)
 }
@@ -496,7 +505,7 @@ fn started_workunits_to_py_tuple_value<'a>(
   workunits: impl Iterator<Item = &'a StartedWorkUnit>,
 ) -> Value {
   let workunit_values = workunits
-    .map(|started_workunit: &StartedWorkUnit| started_workunit_to_py_value(started_workunit))
+    .flat_map(|started_workunit: &StartedWorkUnit| started_workunit_to_py_value(started_workunit))
     .collect::<Vec<_>>();
   externs::store_tuple(&workunit_values)
 }

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -401,11 +401,6 @@ fn make_core(
 
 fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Option<Value> {
   use std::time::UNIX_EPOCH;
-
-  if !started_workunit.metadata.display {
-    return None;
-  }
-
   let duration = started_workunit
     .start_time
     .duration_since(UNIX_EPOCH)
@@ -447,10 +442,6 @@ fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Option<Va
 }
 
 fn workunit_to_py_value(workunit: &WorkUnit) -> Option<Value> {
-  if !workunit.metadata.display {
-    return None;
-  }
-
   let mut dict_entries = vec![
     (
       externs::store_utf8("name"),

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -219,10 +219,12 @@ impl ByteStore {
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
       let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
       workunit_state.store.add_completed_workunit(
         workunit_name.clone(),
         TimeSpan::since(&start_time),
         parent_id,
+        metadata,
       );
     }
 
@@ -304,9 +306,10 @@ impl ByteStore {
       let name = workunit_name.clone();
       let time_span = TimeSpan::since(&start_time);
       let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
       workunit_state
         .store
-        .add_completed_workunit(name, time_span, parent_id);
+        .add_completed_workunit(name, time_span, parent_id, metadata);
     }
 
     result
@@ -350,9 +353,10 @@ impl ByteStore {
           let name = workunit_name.clone();
           let time_span = TimeSpan::since(&start_time);
           let parent_id = workunit_state.parent_id;
+          let metadata = workunit_store::WorkunitMetadata::new();
           workunit_state
             .store
-            .add_completed_workunit(name, time_span, parent_id);
+            .add_completed_workunit(name, time_span, parent_id, metadata);
         }
         future
       })

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -441,14 +441,14 @@ impl CommandRunner for BoundedCommandRunner {
     let outer_metadata = WorkunitMetadata {
       desc: Some("Workunit waiting for opportunity to run".to_string()),
       display: false,
-      running: false,
+      blocked: true,
     };
     let inner_context = context.clone();
     let bounded_fut = semaphor.with_acquired(move || {
       let metadata = WorkunitMetadata {
         desc: Some("Workunit executing currently".to_string()),
         display: false,
-        running: true,
+        blocked: false,
       };
       let f = inner.0.run(req, inner_context.clone()).compat();
       with_workunit(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -839,7 +839,8 @@ fn maybe_add_workunit(
   //  TODO: workunits for scheduling, fetching, executing and uploading should be recorded
   //   only if '--reporting-zipkin-trace-v2' is set
   if !result_cached {
-    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id);
+    let metadata = workunit_store::WorkunitMetadata::new();
+    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id, metadata);
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2321,7 +2321,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker input fetching"),
@@ -2331,7 +2331,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker command executing"),
@@ -2341,7 +2341,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker output uploading"),
@@ -2351,7 +2351,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     }
   };
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -345,10 +345,10 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 
   fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0;
-    let execution_context = process_execution::Context {
-      workunit_store: context.session.workunit_store(),
-      build_id: context.session.build_id().to_string(),
-    };
+    let execution_context = process_execution::Context::new(
+      context.session.workunit_store(),
+      context.session.build_id().to_string(),
+    );
     if context
       .core
       .command_runner

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1065,7 +1065,7 @@ impl Node for NodeKey {
       let metadata = WorkunitMetadata {
         desc,
         display,
-        running: true,
+        blocked: false,
       };
 
       context

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1062,7 +1062,11 @@ impl Node for NodeKey {
 
       // We're starting a new workunit: record our parent, and set the current parent to our span.
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-      let metadata = WorkunitMetadata { desc, display };
+      let metadata = WorkunitMetadata {
+        desc,
+        display,
+        running: true,
+      };
 
       context
         .session

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1053,22 +1053,21 @@ impl Node for NodeKey {
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
     let mut workunit_state = workunit_store::expect_workunit_state();
-    let maybe_started_workunit_id: Option<String> = if context.session.should_handle_workunits() {
-      self.user_facing_name().map(|node_name| {
-        let span_id = new_span_id();
-        let desc = self.display_info().and_then(|di| di.desc.as_ref().cloned());
 
-        // We're starting a new workunit: record our parent, and set the current parent to our span.
-        let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-        let metadata = WorkunitMetadata { desc };
+    let started_workunit_id = {
+      let display = context.session.should_handle_workunits() && self.user_facing_name().is_some();
+      let name = self.user_facing_name().unwrap_or(format!("{}", self));
+      let span_id = new_span_id();
+      let desc = self.display_info().and_then(|di| di.desc.as_ref().cloned());
 
-        context
-          .session
-          .workunit_store()
-          .start_workunit(span_id, node_name, parent_id, metadata)
-      })
-    } else {
-      None
+      // We're starting a new workunit: record our parent, and set the current parent to our span.
+      let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
+      let metadata = WorkunitMetadata { desc, display };
+
+      context
+        .session
+        .workunit_store()
+        .start_workunit(span_id, name, parent_id, metadata)
     };
 
     scope_task_workunit_state(Some(workunit_state), async move {
@@ -1100,13 +1099,11 @@ impl Node for NodeKey {
         },
         Err(e) => Err(e),
       };
-      if let Some(id) = maybe_started_workunit_id {
-        context2
-          .session
-          .workunit_store()
-          .complete_workunit(id)
-          .unwrap();
-      }
+      context2
+        .session
+        .workunit_store()
+        .complete_workunit(started_workunit_id)
+        .unwrap();
       result
     })
     .boxed()

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -15,7 +15,7 @@ use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
 use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
 
-use graph::{Graph, InvalidationResult};
+use graph::InvalidationResult;
 use hashing;
 use indexmap::IndexMap;
 use log::{debug, info, warn};
@@ -357,12 +357,6 @@ impl Scheduler {
     let (sender, receiver) = mpsc::channel();
 
     Scheduler::execute_helper(context, sender, request.roots.clone(), 8);
-    let roots: Vec<NodeKey> = request
-      .roots
-      .clone()
-      .into_iter()
-      .map(NodeKey::from)
-      .collect();
 
     // This map keeps the k most relevant jobs in assigned possitions.
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.
@@ -381,12 +375,9 @@ impl Scheduler {
           if let Ok(res) = receiver.recv_timeout(refresh_interval) {
             break res;
           } else {
-            let render_result = Scheduler::display_ongoing_tasks(
-              &self.core.graph,
-              &roots,
-              display,
-              &mut tasks_to_display,
-            );
+            let workunit_store = session.workunit_store().clone();
+            let render_result =
+              Scheduler::display_ongoing_tasks(workunit_store, display, &mut tasks_to_display);
             match render_result {
               Err(e) => warn!("{}", e),
               Ok(KeyboardCommand::CtrlC) => {
@@ -417,8 +408,7 @@ impl Scheduler {
   }
 
   fn display_ongoing_tasks(
-    graph: &Graph<NodeKey>,
-    roots: &[NodeKey],
+    workunit_store: WorkUnitStore,
     display: &Mutex<EngineDisplay>,
     tasks_to_display: &mut IndexMap<String, Duration>,
   ) -> Result<KeyboardCommand, String> {
@@ -428,7 +418,7 @@ impl Scheduler {
       let d = display.lock();
       d.worker_count()
     };
-    let heavy_hitters = graph.heavy_hitters(&roots, worker_count);
+    let heavy_hitters = workunit_store.heavy_hitters(worker_count);
 
     // Insert every one in the set of tasks to display.
     // For tasks already here, the durations are overwritten.

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -410,7 +410,7 @@ impl Scheduler {
   fn display_ongoing_tasks(
     workunit_store: WorkUnitStore,
     display: &Mutex<EngineDisplay>,
-    tasks_to_display: &mut IndexMap<String, Duration>,
+    tasks_to_display: &mut IndexMap<String, Option<Duration>>,
   ) -> Result<KeyboardCommand, String> {
     // Update the graph. To do that, we iterate over heavy hitters.
 
@@ -433,10 +433,16 @@ impl Scheduler {
 
     for (i, item) in tasks_to_display.iter().enumerate() {
       let label = item.0;
-      let duration = item.1;
-      let duration_secs: f64 = (duration.as_millis() as f64) / 1000.0;
+      let maybe_duration = item.1;
+      let duration_label = match maybe_duration {
+        None => "(Waiting) ".to_string(),
+        Some(duration) => {
+          let duration_secs: f64 = (duration.as_millis() as f64) / 1000.0;
+          format!("{:.2}s ", duration_secs)
+        }
+      };
       let mut d = display.lock();
-      d.update(i.to_string(), format!("{:.2}s {}", duration_secs, label));
+      d.update(i.to_string(), format!("{}{}", duration_label, label));
     }
 
     // If the number of ongoing tasks is less than the number of workers,

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -10,3 +10,4 @@ concrete_time = { path = "../concrete_time" }
 parking_lot = "0.6"
 rand = "0.6"
 tokio = { version = "0.2", features = ["rt-util"] }
+petgraph = "0.4.5"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -56,9 +56,19 @@ pub struct StartedWorkUnit {
   pub metadata: WorkunitMetadata,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
+  pub display: bool,
+}
+
+impl WorkunitMetadata {
+  pub fn new() -> WorkunitMetadata {
+    WorkunitMetadata {
+      display: true,
+      desc: None,
+    }
+  }
 }
 
 impl StartedWorkUnit {
@@ -81,7 +91,7 @@ impl WorkUnit {
       time_span,
       span_id,
       parent_id,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     }
   }
 }
@@ -192,6 +202,7 @@ impl WorkUnitStore {
     name: String,
     time_span: TimeSpan,
     parent_id: Option<SpanId>,
+    metadata: WorkunitMetadata,
   ) {
     let inner = &mut self.inner.lock();
     let span_id = new_span_id();
@@ -200,7 +211,7 @@ impl WorkUnitStore {
       time_span,
       span_id: span_id.clone(),
       parent_id,
-      metadata: WorkunitMetadata::default(),
+      metadata,
     });
 
     inner.workunit_records.insert(span_id.clone(), workunit);


### PR DESCRIPTION
### Problem

The V2 UI has been displaying an incorrect amount of time that a process has been running for some time now. The problem is that the time duration displayed in the UI is calculated from the real time at which a `Node` value was created. However, this is not necessarily the same as the time that a `Node` meaningfully starts to execute. Specifically in the case of `Process` nodes executed under the `BoundedCommandRunner`, a given `Node` might be blocked on executing until a previously-scheduled `Node` has finished, continuing to misleadingly count time that it is ostensibly executing even though it is not doing anything. 

### Solution

This commit moves the `heavy_hitters` logic that computes the longest-running node times from the `graph` crate to the `workunit_store` crate, and generally makes computing the amount of time a node has been running a responsibility of `workunit_store`. Similarly to the way the `heavy_hitters` worked previously, the new v2 UI logic creates a directed graph of workunits, then traverses to the sink nodes of the graph, and displays the top *k* of them, ordered by runningtime.

This, along with creating new workunits both within and around the `async_semaphor` lock in `BoundedCommandRunner`, ensures that, once a `Node` is actually running, the workunit used to render its duration will be a child of the workunit node representing the time it was waiting for the opportunity to execute. 

Note that it is still possible for a workunit representing a scheduled but not yet running `Process` to be a sink node of the workunit graph, and thus be displayed in the V2 UI. These workunits have the text "Bounded" in their title, which shows up in the UI (see the 2nd example below). It would be easy enough to filter these out so they are never displayed in the UI - we could for instance add a `display` boolean to `WorkunitMetadata`, set that to `false` on these bounded workunits, and filter for them in the `heavy_hitters` code. But I think it might be useful to end users to display these bounded nodes. Once they do in fact begin to run, the bounded workunit will have a child workunit that will be displayed instead, so the timing information will be accurate.

### Result

Here's what a hopefully-representative invocation of the `test` goal on some targets looks like with this new code:
https://asciinema.org/a/324524

And with the `process_execution_local_parallelism` option deliberately set to the low value of 2, in order to force `Process` nodes to wait on `BoundedCommandRunner`:
https://asciinema.org/a/324539
