### PR TITLE
Improve error message when no rules can produce a param

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -279,10 +279,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         )
 
     def test_illegal_root_selection(self):
-        rules = [
-            RootRule(B),
-        ]
-
+        rules = [RootRule(B)]
         scheduler = self.scheduler(rules, include_trace_on_error=False)
 
         # No rules are available to compute A.
@@ -290,7 +287,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             list(scheduler.product_request(A, subjects=[(B())]))
 
         self.assert_equal_with_printing(
-            """No installed @rules return the type A. Is the @rule that you're expecting to run registered?""",
+            "No installed @rules return the type A. Is the @rule that you're expecting to run registered?",
             str(cm.exception),
         )
 
@@ -309,6 +306,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             dedent(
                 f"""
                 Rules with errors: 1
+
                   {fmt_rule(upcast)}:
                     {cannot_compute_param_error}
                 """

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -295,19 +295,22 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         )
 
     def test_non_existing_root_fails_differently(self):
-        rules = [
-            upcast,
-        ]
+        rules = [upcast]
 
         with self.assertRaises(Exception) as cm:
             list(self.mk_scheduler(rules=rules, include_trace_on_error=False))
 
+        cannot_compute_param_error = (
+            f"No rules can compute MyInt. If you expect to inject this type directly into the "
+            "rule graph, rather than deriving it from other rules, then declare "
+            f"RootRule(MyInt)."
+        )
         self.assert_equal_with_printing(
             dedent(
                 f"""
                 Rules with errors: 1
                   {fmt_rule(upcast)}:
-                    No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
+                    {cannot_compute_param_error}
                 """
             ).strip(),
             str(cm.exception),

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -421,6 +421,7 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 1
+
                   {fmt_rule(a_from_b)}:
                     {self.cannot_compute_param_error(B)}
                 """
@@ -457,10 +458,13 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 3
+
                   {fmt_rule(a_from_b_and_c)}:
                     Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
+
                   {fmt_rule(a_from_c_and_b)}:
                     Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
+
                   {fmt_rule(d_from_a)}:
                     Ambiguous rules to compute A with parameter types (B, C):
                       {fmt_graph_rule(a_from_b_and_c)}
@@ -485,6 +489,7 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 1
+
                   {fmt_rule(a_from_b_and_c)}:
                     {self.cannot_compute_param_error(B)}
                     {self.cannot_compute_param_error(C)}
@@ -522,8 +527,10 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 2
+
                   {fmt_rule(a_from_b)}:
                     {self.cannot_compute_param_error(B)}
+
                   {fmt_rule(b_from_suba)}:
                     {self.cannot_compute_param_error(SubA)}
                 """
@@ -554,6 +561,7 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 1
+
                   {fmt_rule(d_from_c)}:
                     {self.cannot_compute_param_error(C)}
                 """
@@ -591,10 +599,13 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 3
+
                   {fmt_rule(a_from_c)}:
                     Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
+
                   {fmt_rule(b_from_d)}:
                     {self.cannot_compute_param_error(D)}
+
                   {fmt_rule(d_from_a_and_suba, gets=[("A", "C")])}:
                     {self.cannot_compute_param_error(A)}
                 """
@@ -626,6 +637,7 @@ class RuleGraphTest(TestBase):
             dedent(
                 f"""\
                 Rules with errors: 1
+
                   {fmt_rule(d_for_b)}:
                     Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
                 """

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -1089,9 +1089,9 @@ impl<R: Rule> RuleGraph<R> {
     msgs.sort();
 
     Err(format!(
-      "Rules with errors: {}\n  {}",
+      "Rules with errors: {}\n\n  {}",
       msgs.len(),
-      msgs.join("\n  ")
+      msgs.join("\n\n  ")
     ))
   }
 

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -435,19 +435,12 @@ impl<'t, R: Rule> GraphMaker<'t, R> {
         // If no candidates were fulfillable, this rule is not fulfillable.
         unfulfillable_diagnostics.push(Diagnostic {
           params: params.clone(),
-          reason: if params.is_empty() {
-            format!(
-              "No rule was available to compute {}. Maybe declare RootRule({})?",
-              dependency_key, product,
-            )
-          } else {
-            format!(
-              "No rule was available to compute {} with parameter type{} {}",
-              dependency_key,
-              if params.len() > 1 { "s" } else { "" },
-              params_str(&params),
-            )
-          },
+          // TODO(#9621)
+          reason: format!(
+            "No rules can compute {}. If you expect to inject this type directly into the rule \
+              graph, rather than deriving it from other rules, then declare RootRule({}).",
+            dependency_key, product,
+          ),
           details: vec![],
         });
       }

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -24,7 +24,7 @@ fn create_and_validate_no_root() {
     .validate()
     .err()
     .unwrap()
-    .contains("No rule was available to compute DependencyKey(\"b\", None)."));
+    .contains("No rules can compute DependencyKey(\"b\", None)."));
 }
 
 impl super::TypeId for &'static str {


### PR DESCRIPTION
Before:

```
Exception message: Rules with errors: 1
  @rule(pants.core.goals.run:55:sample_rule(SampleRequest) -> SampleResult):
    No rule was available to compute SampleRequest with parameter types (Address, AddressSpecs, AddressWithOrigin, AllSourceFilesRequest, BinaryToolFetchRequest, ChangedRequest, ConfigurationsWithSourcesRequest, Console, CoverageConfigRequest, Digest, DirectoriesToMerge, DirectoryWithPrefixToAdd, DirectoryWithPrefixToStrip, FilesystemSpecs, HydrateSourcesRequest, InjectInitRequest, InputFilesContent, InteractiveRunner, LLVM, MultiPlatformProcess, NativeToolchain, OptionsBootstrapper, OwnersRequest, PathGlobs, PexFromTargetsRequest, PexRequest, PlatformConstraint, Process, Scope, SnapshotSubset, SpecifiedSourceFilesRequest, StripSnapshotRequest, StripSourcesFieldRequest, Targets, TargetsToValidConfigurationsRequest, TargetsWithSourcesRequest, ToolchainVariantRequest, TwoStepPexFromTargetsRequest, TwoStepPexRequest, UrlToFetch, Workspace)
```

After:

```
Exception message: Rules with errors: 1

  @rule(pants.core.goals.run:55:sample_rule(SampleRequest) -> SampleResult):
    No rule can compute SampleRequest. If you expect to inject this type directly into the rule graph, rather than deriving it from other rules, then declare RootRule(SampleRequest).
```

Listing all the Params is a good idea when we only have a couple `RootRule`s, but its signal-to-noise value has gone down substantially now that we have so many registered.

### Also adds new lines between bad rules

Before:

```
Exception message: Rules with errors: 3
  @rule(pants.core.goals.run:59:sample_rule(SampleRequest, RunOptions) -> SampleResult):
    Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
  @rule(pants.core.goals.run:64:ambiguous_rule(RunOptions, SampleRequest) -> SampleResult):
    Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
  @rule(pants.core.goals.run:69:use_result(SampleResult) -> WrappedResult):
    Ambiguous rules to compute SampleResult with parameter types (OptionsBootstrapper, SampleRequest):
      @rule(RunOptions, SampleRequest) -> SampleResult
pants.core.goals.run:64:ambiguous_rule
for (OptionsBootstrapper, SampleRequest)
      @rule(SampleRequest, RunOptions) -> SampleResult
pants.core.goals.run:59:sample_rule
for (OptionsBootstrapper, SampleRequest)
```

After:

```
Exception message: Rules with errors: 3

  @rule(pants.core.goals.run:59:sample_rule(SampleRequest, RunOptions) -> SampleResult):
    Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.

  @rule(pants.core.goals.run:64:ambiguous_rule(RunOptions, SampleRequest) -> SampleResult):
    Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.

  @rule(pants.core.goals.run:69:use_result(SampleResult) -> WrappedResult):
    Ambiguous rules to compute SampleResult with parameter types (OptionsBootstrapper, SampleRequest):
      @rule(RunOptions, SampleRequest) -> SampleResult
pants.core.goals.run:64:ambiguous_rule
for (OptionsBootstrapper, SampleRequest)
      @rule(SampleRequest, RunOptions) -> SampleResult
pants.core.goals.run:59:sample_rule
for (OptionsBootstrapper, SampleRequest)
```