### PR TITLE
Fix test import and generic alias failures.

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -4,6 +4,7 @@
 import os
 import re
 import unittest
+import unittest.mock
 from textwrap import dedent
 from typing import Tuple, Type, cast
 

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -153,7 +153,8 @@ class AddressFamilyTest(unittest.TestCase):
             )
 
 
-HydratedStructs = Collection[HydratedStruct]
+class HydratedStructs(Collection[HydratedStruct]):
+    pass
 
 
 @rule


### PR DESCRIPTION
### Problem

Two tests are failing on master, one of which affected #9593, and both of which repro locally. Not sure if this is Python version differences.

[ci skip-rust-tests]
[ci skip-jvm-tests]