### PR TITLE
Temporarily disable `./pants backends` goal due to bug

### DIFF
--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -10,7 +10,6 @@ from pants.core.goals import binary, fmt, lint, repl, run, test
 from pants.core.project_info import (
     cloc,
     filedeps,
-    list_backends,
     list_roots,
     list_target_types,
     list_targets,
@@ -38,7 +37,6 @@ def rules():
         # project_info
         *cloc.rules(),
         *filedeps.rules(),
-        *list_backends.rules(),
         *list_roots.rules(),
         *list_target_types.rules(),
         *list_targets.rules(),


### PR DESCRIPTION
The goal works great when running in Pants' internal repo or repos with their own plugins, but doesn't work at all when Pants is installed as a wheel. This is because the implementation relies on `PathGlobs`, which only inspect the build root; it does not inspect installed wheels.

We need some way to inspect the Pants wheel. A stretch goal would inspect other installed Pants plugins.

For now, we skip it until coming up with a new strategy.

[ci skip-rust-tests]
[ci skip-jvm-tests]
