### PR TITLE
remoting: ensure oauth token file only has one line

### DIFF
--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -3,7 +3,7 @@
 # to authorize your account). Then, point to this config file and provide the oauth token like this:
 #
 #  $ ./pants --pants-config-files=pants.remote.toml
-#     --remote-oauth-bearer-token-path=<(gcloud auth application-default print-access-token | perl -p -e 'chomp if eof')
+#     --remote-oauth-bearer-token-path=<(gcloud auth application-default print-access-token)
 #     --no-v1 --v2 test tests/python/pants_test/util:strutil
 #
 # Remoting does not work for every goal, so you should not permanently point to this TOML file, e.g.

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -122,7 +122,13 @@ impl Core {
     let oauth_bearer_token = if let Some(path) = remote_oauth_bearer_token_path {
       Some(
         std::fs::read_to_string(&path)
-          .map_err(|err| format!("Error reading OAuth bearer token file {:?}: {}", path, err))?,
+          .map_err(|err| format!("Error reading OAuth bearer token file {:?}: {}", path, err))
+          .map(|v| v.trim_matches(|c| c == '\r' || c == '\n').to_owned())
+          .and_then(|v| if v.find(|c| c == '\r' || c == '\n').is_some() {
+            Err(format!("OAuth bearer token file must not contain multiple lines"))
+          } else {
+            Ok(v)
+          })?
       )
     } else {
       None

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -124,11 +124,13 @@ impl Core {
         std::fs::read_to_string(&path)
           .map_err(|err| format!("Error reading OAuth bearer token file {:?}: {}", path, err))
           .map(|v| v.trim_matches(|c| c == '\r' || c == '\n').to_owned())
-          .and_then(|v| if v.find(|c| c == '\r' || c == '\n').is_some() {
-            Err(format!("OAuth bearer token file must not contain multiple lines"))
-          } else {
-            Ok(v)
-          })?
+          .and_then(|v| {
+            if v.find(|c| c == '\r' || c == '\n').is_some() {
+              Err("OAuth bearer token file must not contain multiple lines".to_string())
+            } else {
+              Ok(v)
+            }
+          })?,
       )
     } else {
       None


### PR DESCRIPTION
### Problem

The `remote_oauth_bearer_token_path` option is used in an Authorization header for remote execution requests, but is not validated to ensure it has only a single line.

### Solution

Validate the contents of the file loaded into the engine as the token, and remove any newlines on that single line.

### Result

I was able to trigger the validation code by invoking Pants with a remote_oauth_bearer_token_path file that had multiple lines.

Testing: I didn't see an existing unit test for this option. Would love to add one, just need suggestions as to where I should add it.