### PR TITLE
Compute v2 UI times by walking the workunit graph

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,6 +20,7 @@ local_artifact_cache = "%(pants_bootstrapdir)s/artifact_cache"
 [GLOBAL]
 print_exception_stacktrace = true
 v2 = false
+process_execution_local_parallelism = 2
 
 # Enable our own custom loose-source plugins as well as contribs.
 pythonpath = [

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "concrete_time 0.0.1",
  "graph 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graph 0.0.1",
  "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70)",
  "hashing 0.0.1",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3651,6 +3651,7 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time 0.0.1",
+ "graph 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -399,8 +399,13 @@ fn make_core(
   )
 }
 
-fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Value {
+fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Option<Value> {
   use std::time::UNIX_EPOCH;
+
+  if !started_workunit.metadata.display {
+    return None;
+  }
+
   let duration = started_workunit
     .start_time
     .duration_since(UNIX_EPOCH)
@@ -438,10 +443,14 @@ fn started_workunit_to_py_value(started_workunit: &StartedWorkUnit) -> Value {
     ));
   }
 
-  externs::store_dict(&dict_entries.as_slice())
+  Some(externs::store_dict(&dict_entries.as_slice()))
 }
 
-fn workunit_to_py_value(workunit: &WorkUnit) -> Value {
+fn workunit_to_py_value(workunit: &WorkUnit) -> Option<Value> {
+  if !workunit.metadata.display {
+    return None;
+  }
+
   let mut dict_entries = vec![
     (
       externs::store_utf8("name"),
@@ -482,12 +491,12 @@ fn workunit_to_py_value(workunit: &WorkUnit) -> Value {
     ));
   }
 
-  externs::store_dict(&dict_entries.as_slice())
+  Some(externs::store_dict(&dict_entries.as_slice()))
 }
 
 fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>) -> Value {
   let workunit_values = workunits
-    .map(|workunit: &WorkUnit| workunit_to_py_value(workunit))
+    .flat_map(|workunit: &WorkUnit| workunit_to_py_value(workunit))
     .collect::<Vec<_>>();
   externs::store_tuple(&workunit_values)
 }
@@ -496,7 +505,7 @@ fn started_workunits_to_py_tuple_value<'a>(
   workunits: impl Iterator<Item = &'a StartedWorkUnit>,
 ) -> Value {
   let workunit_values = workunits
-    .map(|started_workunit: &StartedWorkUnit| started_workunit_to_py_value(started_workunit))
+    .flat_map(|started_workunit: &StartedWorkUnit| started_workunit_to_py_value(started_workunit))
     .collect::<Vec<_>>();
   externs::store_tuple(&workunit_values)
 }

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -219,10 +219,12 @@ impl ByteStore {
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
       let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
       workunit_state.store.add_completed_workunit(
         workunit_name.clone(),
         TimeSpan::since(&start_time),
         parent_id,
+        metadata,
       );
     }
 
@@ -304,9 +306,10 @@ impl ByteStore {
       let name = workunit_name.clone();
       let time_span = TimeSpan::since(&start_time);
       let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
       workunit_state
         .store
-        .add_completed_workunit(name, time_span, parent_id);
+        .add_completed_workunit(name, time_span, parent_id, metadata);
     }
 
     result
@@ -350,9 +353,10 @@ impl ByteStore {
           let name = workunit_name.clone();
           let time_span = TimeSpan::since(&start_time);
           let parent_id = workunit_state.parent_id;
+          let metadata = workunit_store::WorkunitMetadata::new();
           workunit_state
             .store
-            .add_completed_workunit(name, time_span, parent_id);
+            .add_completed_workunit(name, time_span, parent_id, metadata);
         }
         future
       })

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -664,6 +664,11 @@ impl<N: Node> Graph<N> {
     }
   }
 
+  pub fn entry_id(&self, node: &N) -> Option<EntryId> {
+    let inner = self.inner.lock();
+    inner.entry_id(node).cloned()
+  }
+
   pub fn len(&self) -> usize {
     let inner = self.inner.lock();
     inner.nodes.len()

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -19,6 +19,7 @@ futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
 # TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457.
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "d16fcfb4afbdd4c791e7c7e64e9748319ed8ad70", default_features = false, features = ["protobuf-codec", "secure"] }
+graph = { path = "../graph" }
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -450,6 +450,7 @@ impl CommandRunner for BoundedCommandRunner {
         let metadata = WorkunitMetadata {
           desc,
           display: false,
+          waiting: false,
           entry_id: context.entry_id,
         };
         let started_id = context

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -349,8 +349,17 @@ impl AddAssign<UploadSummary> for ExecutionStats {
 
 #[derive(Clone, Default)]
 pub struct Context {
-  pub workunit_store: WorkUnitStore,
-  pub build_id: String,
+  workunit_store: WorkUnitStore,
+  build_id: String,
+}
+
+impl Context {
+  pub fn new(workunit_store: WorkUnitStore, build_id: String) -> Context {
+    Context {
+      workunit_store,
+      build_id
+    }
+  }
 }
 
 pub trait CommandRunner: Send + Sync {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -450,6 +450,7 @@ impl CommandRunner for BoundedCommandRunner {
         let metadata = WorkunitMetadata {
           desc,
           display: false,
+          entry_id: context.entry_id,
         };
         let started_id = context
           .workunit_store

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -839,7 +839,8 @@ fn maybe_add_workunit(
   //  TODO: workunits for scheduling, fetching, executing and uploading should be recorded
   //   only if '--reporting-zipkin-trace-v2' is set
   if !result_cached {
-    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id);
+    let metadata = workunit_store::WorkunitMetadata::new();
+    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id, metadata);
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2321,7 +2321,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker input fetching"),
@@ -2331,7 +2331,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker command executing"),
@@ -2341,7 +2341,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     },
     WorkUnit {
       name: String::from("remote execution worker output uploading"),
@@ -2351,7 +2351,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     }
   };
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -797,6 +797,7 @@ async fn sends_headers() {
   let context = Context {
     workunit_store: WorkUnitStore::default(),
     build_id: String::from("marmosets"),
+    entry_id: None,
   };
   command_runner
     .run(execute_request, context)

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -297,7 +297,7 @@ impl Core {
 
 #[derive(Clone)]
 pub struct Context {
-  entry_id: Option<EntryId>,
+  pub entry_id: Option<EntryId>,
   pub core: Arc<Core>,
   pub session: Session,
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -345,10 +345,10 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 
   fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0;
-    let execution_context = process_execution::Context {
-      workunit_store: context.session.workunit_store(),
-      build_id: context.session.build_id().to_string(),
-    };
+    let execution_context = process_execution::Context::new(
+      context.session.workunit_store(),
+      context.session.build_id().to_string(),
+    );
     if context
       .core
       .command_runner

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1063,7 +1063,7 @@ impl Node for NodeKey {
 
       // We're starting a new workunit: record our parent, and set the current parent to our span.
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-      let metadata = WorkunitMetadata { desc, display, entry_id: context.entry_id };
+      let metadata = WorkunitMetadata { desc, display, entry_id: context.entry_id, waiting: false };
 
       context
         .session

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -348,6 +348,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
     let execution_context = process_execution::Context::new(
       context.session.workunit_store(),
       context.session.build_id().to_string(),
+      context.entry_id.clone(),
     );
     if context
       .core

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1063,7 +1063,7 @@ impl Node for NodeKey {
 
       // We're starting a new workunit: record our parent, and set the current parent to our span.
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-      let metadata = WorkunitMetadata { desc, display };
+      let metadata = WorkunitMetadata { desc, display, entry_id: context.entry_id };
 
       context
         .session

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1053,22 +1053,21 @@ impl Node for NodeKey {
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
     let mut workunit_state = workunit_store::expect_workunit_state();
-    let maybe_started_workunit_id: Option<String> = if context.session.should_handle_workunits() {
-      self.user_facing_name().map(|node_name| {
-        let span_id = new_span_id();
-        let desc = self.display_info().and_then(|di| di.desc.as_ref().cloned());
 
-        // We're starting a new workunit: record our parent, and set the current parent to our span.
-        let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-        let metadata = WorkunitMetadata { desc };
+    let started_workunit_id = {
+      let display = context.session.should_handle_workunits() && self.user_facing_name().is_some();
+      let name = self.user_facing_name().unwrap_or(format!("{}", self));
+      let span_id = new_span_id();
+      let desc = self.display_info().and_then(|di| di.desc.as_ref().cloned());
 
-        context
-          .session
-          .workunit_store()
-          .start_workunit(span_id, node_name, parent_id, metadata)
-      })
-    } else {
-      None
+      // We're starting a new workunit: record our parent, and set the current parent to our span.
+      let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
+      let metadata = WorkunitMetadata { desc, display };
+
+      context
+        .session
+        .workunit_store()
+        .start_workunit(span_id, name, parent_id, metadata)
     };
 
     scope_task_workunit_state(Some(workunit_state), async move {
@@ -1100,13 +1099,11 @@ impl Node for NodeKey {
         },
         Err(e) => Err(e),
       };
-      if let Some(id) = maybe_started_workunit_id {
-        context2
-          .session
-          .workunit_store()
-          .complete_workunit(id)
-          .unwrap();
-      }
+      context2
+        .session
+        .workunit_store()
+        .complete_workunit(started_workunit_id)
+        .unwrap();
       result
     })
     .boxed()

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -11,3 +11,4 @@ parking_lot = "0.6"
 rand = "0.6"
 tokio = { version = "0.2", features = ["rt-util"] }
 graph = { path = "../graph" }
+petgraph = "0.4.5"

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -10,3 +10,4 @@ concrete_time = { path = "../concrete_time" }
 parking_lot = "0.6"
 rand = "0.6"
 tokio = { version = "0.2", features = ["rt-util"] }
+graph = { path = "../graph" }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -66,6 +66,7 @@ pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub display: bool,
   pub entry_id: Option<EntryId>,
+  pub waiting: bool
 }
 
 impl WorkunitMetadata {
@@ -74,6 +75,7 @@ impl WorkunitMetadata {
       display: true,
       desc: None,
       entry_id: None,
+      waiting: false,
     }
   }
 }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -31,7 +31,7 @@ use rand::thread_rng;
 use rand::Rng;
 use std::collections::{BinaryHeap, HashMap};
 use tokio::task_local;
-use graph::{EntryId, Node};
+use graph::EntryId;
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use std::cell::RefCell;
@@ -162,7 +162,7 @@ impl WorkUnitStore {
       .collect()
   }
 
-  pub fn heavy_hitters<N: Node>(&self, k: usize) -> HashMap<String, Duration> {
+  pub fn heavy_hitters(&self, k: usize) -> HashMap<String, Duration> {
     use petgraph::Direction;
 
     let now = SystemTime::now();

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -56,9 +56,19 @@ pub struct StartedWorkUnit {
   pub metadata: WorkunitMetadata,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
+  pub display: bool,
+}
+
+impl WorkunitMetadata {
+  pub fn new() -> WorkunitMetadata {
+    WorkunitMetadata {
+      display: true,
+      desc: None,
+    }
+  }
 }
 
 impl StartedWorkUnit {
@@ -81,7 +91,7 @@ impl WorkUnit {
       time_span,
       span_id,
       parent_id,
-      metadata: WorkunitMetadata::default(),
+      metadata: WorkunitMetadata::new(),
     }
   }
 }
@@ -192,6 +202,7 @@ impl WorkUnitStore {
     name: String,
     time_span: TimeSpan,
     parent_id: Option<SpanId>,
+    metadata: WorkunitMetadata,
   ) {
     let inner = &mut self.inner.lock();
     let span_id = new_span_id();
@@ -200,7 +211,7 @@ impl WorkUnitStore {
       time_span,
       span_id: span_id.clone(),
       parent_id,
-      metadata: WorkunitMetadata::default(),
+      metadata,
     });
 
     inner.workunit_records.insert(span_id.clone(), workunit);

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -31,6 +31,7 @@ use rand::thread_rng;
 use rand::Rng;
 use std::collections::HashMap;
 use tokio::task_local;
+use graph::EntryId;
 
 use std::cell::RefCell;
 use std::future::Future;
@@ -60,6 +61,7 @@ pub struct StartedWorkUnit {
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub display: bool,
+  pub entry_id: Option<EntryId>,
 }
 
 impl WorkunitMetadata {
@@ -67,6 +69,7 @@ impl WorkunitMetadata {
     WorkunitMetadata {
       display: true,
       desc: None,
+      entry_id: None,
     }
   }
 }


### PR DESCRIPTION
### Problem

The current v2 UI reports the run times of currently-executing processes inaccurately.

### Solution

Use the workunit store rather than the graph as the authoritative source for how long it takes for a Node to execute.