### PR TITLE
Extract a `watch` crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -692,13 +692,11 @@ dependencies = [
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "concrete_time 0.0.1",
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.0.1",
  "hashing 0.0.1",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -706,7 +704,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
- "notify 5.0.0-pre.1 (git+https://github.com/notify-rs/notify?rev=fba00891d9105e2f581c69fbe415a58cb7966fdd)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -725,6 +722,7 @@ dependencies = [
  "ui 0.0.1",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "watch 0.0.1",
  "workunit_store 0.0.1",
 ]
 
@@ -3564,6 +3562,27 @@ dependencies = [
 name = "wasm-bindgen-shared"
 version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "watch"
+version = "0.0.1"
+dependencies = [
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graph 0.0.1",
+ "hashing 0.0.1",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logging 0.0.1",
+ "notify 5.0.0-pre.1 (git+https://github.com/notify-rs/notify?rev=fba00891d9105e2f581c69fbe415a58cb7966fdd)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "task_executor 0.0.1",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testutil 0.0.1",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "web-sys"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "testutil/local_cas",
   "testutil/local_execution_server",
   "ui",
+  "watch",
   "workunit_store"
 ]
 
@@ -77,6 +78,7 @@ default-members = [
   "testutil/local_cas",
   "testutil/local_execution_server",
   "ui",
+  "watch",
   "workunit_store"
 ]
 
@@ -86,12 +88,10 @@ async-trait = "0.1"
 boxfuture = { path = "boxfuture" }
 bytes = "0.4.5"
 concrete_time = { path = "concrete_time" }
-crossbeam-channel = "0.3"
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
-futures-locks = "0.3.0"
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"
@@ -101,11 +101,6 @@ log = "0.4"
 logging = { path = "logging" }
 num_cpus = "1"
 num_enum = "0.4"
-# notify is currently an experimental API, we are pinning to https://docs.rs/notify/5.0.0-pre.1/notify/
-# because the latest prerelease at time of writing has removed the debounced watcher which we would like to use.
-# The author suggests they will add the debounced watcher back into the stable 5.0.0 release. When that happens
-# we can move to it.
-notify = { git = "https://github.com/notify-rs/notify", rev = "fba00891d9105e2f581c69fbe415a58cb7966fdd" }
 parking_lot = "0.6"
 process_execution = { path = "process_execution" }
 rand = "0.6"
@@ -121,6 +116,7 @@ tokio = { version = "0.2", features = ["rt-threaded"] }
 ui = { path = "ui" }
 url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
+watch = { path = "watch" }
 workunit_store = { path = "workunit_store" }
 
 [dev-dependencies]

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1055,43 +1055,6 @@ impl<N: Node> Graph<N> {
   }
 }
 
-// This module provides a trait which contains functions that
-// should only be used in tests. A user must explicitly import the trait
-// to use the extra test functions, and they should only be imported into
-// test modules.
-pub mod test_support {
-  use super::{EntryId, EntryState, Graph, Node};
-  pub trait TestGraph<N: Node> {
-    fn set_fixture_entry_state_for_id(&self, id: EntryId, state: EntryState<N>);
-    fn add_fixture_entry(&self, node: N) -> EntryId;
-    fn entry_state(&self, id: EntryId) -> &str;
-  }
-  impl<N: Node> TestGraph<N> for Graph<N> {
-    fn set_fixture_entry_state_for_id(&self, id: EntryId, state: EntryState<N>) {
-      let mut inner = self.inner.lock();
-      let entry = inner.entry_for_id_mut(id).unwrap();
-      let mut entry_state = entry.state.lock();
-      *entry_state = state;
-    }
-
-    fn add_fixture_entry(&self, node: N) -> EntryId {
-      let mut inner = self.inner.lock();
-      inner.ensure_entry(node)
-    }
-
-    fn entry_state(&self, id: EntryId) -> &str {
-      let mut inner = self.inner.lock();
-      let entry = inner.entry_for_id_mut(id).unwrap();
-      let entry_state = entry.state.lock();
-      match *entry_state {
-        EntryState::Completed { .. } => "completed",
-        EntryState::Running { .. } => "running",
-        EntryState::NotStarted { .. } => "not started",
-      }
-    }
-  }
-}
-
 ///
 /// Represents the state of a particular walk through a Graph. Implements Iterator and has the same
 /// lifetime as the Graph itself.

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -40,7 +40,6 @@ mod scheduler;
 mod selectors;
 mod tasks;
 mod types;
-mod watch;
 
 pub use crate::context::Core;
 pub use crate::core::{Function, Key, Params, TypeId, Value};
@@ -51,6 +50,3 @@ pub use crate::scheduler::{
 };
 pub use crate::tasks::{Rule, Tasks};
 pub use crate::types::Types;
-
-#[cfg(test)]
-mod watch_tests;

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -14,7 +14,7 @@ use futures01::future::{self, Future};
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
 use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
-use crate::watch::InvalidationWatcher;
+
 use graph::{Graph, InvalidationResult};
 use hashing;
 use indexmap::IndexMap;
@@ -22,6 +22,7 @@ use log::{debug, info, warn};
 use logging::logger::LOGGER;
 use parking_lot::Mutex;
 use ui::{EngineDisplay, KeyboardCommand};
+use watch::Invalidatable;
 use workunit_store::WorkUnitStore;
 
 pub enum ExecutionTermination {
@@ -228,7 +229,7 @@ impl Scheduler {
   /// Invalidate the invalidation roots represented by the given Paths.
   ///
   pub fn invalidate(&self, paths: &HashSet<PathBuf>) -> usize {
-    InvalidationWatcher::invalidate(&self.core.graph, paths, "watchman")
+    self.core.graph.invalidate(paths, "watchman")
   }
 
   ///

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -54,7 +54,7 @@ pub fn make_file(path: &Path, contents: &[u8], mode: u32) {
   file.set_permissions(permissions).unwrap();
 }
 
-pub fn append_to_exisiting_file(path: &Path, contents: &[u8]) {
+pub fn append_to_existing_file(path: &Path, contents: &[u8]) {
   let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
   file.write_all(contents).unwrap();
 }

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+version = "0.0.1"
+edition = "2018"
+name = "watch"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+publish = false
+
+[dependencies]
+crossbeam-channel = "0.3"
+fs = { path = "../fs" }
+futures = { version = "0.3", features = ["compat"] }
+futures-locks = "0.3.0"
+futures01 = { package = "futures", version = "0.1" }
+graph = { path = "../graph" }
+log = "0.4"
+logging = { path = "../logging" }
+# notify is currently an experimental API, we are pinning to https://docs.rs/notify/5.0.0-pre.1/notify/
+# because the latest prerelease at time of writing has removed the debounced watcher which we would like to use.
+# The author suggests they will add the debounced watcher back into the stable 5.0.0 release. When that happens
+# we can move to it.
+notify = { git = "https://github.com/notify-rs/notify", rev = "fba00891d9105e2f581c69fbe415a58cb7966fdd" }
+task_executor = { path = "../task_executor" }
+
+[dev-dependencies]
+hashing = { path = "../hashing" }
+parking_lot = "0.6"
+tempfile = "3"
+testutil = { path = "../testutil" }
+tokio = { version = "0.2", features = ["rt-core", "macros"] }


### PR DESCRIPTION
# Problem

The `watch` module directly accesses the `engine` crate's `Graph`, which makes it more challenging to test.

### Solution

Extract a `watch` crate which is used via an `trait Invalidatable` which is implemented for the engine's `Graph`, as well as independently in tests.

[ci skip-jvm-tests]