### PR TITLE
Move file invalidation handling to rust

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -81,8 +81,13 @@ ignore_pants_warnings = [
   "DEPRECATED: the antlr, jaxb, ragel, and wire codegen backends",
 ]
 
-# The pants script in this repo consumes these files to run pants
-pantsd_invalidation_globs.add = ["src/python/**/*.py"]
+# The invalidation globs cover the PYTHONPATH by default, but we additionally add the rust code.
+pantsd_invalidation_globs.add = [
+  "!*_test.py",
+  # NB: The `target` directory is ignored via `pants_ignore` below.
+  "src/rust/engine/**/*.rs",
+  "src/rust/engine/**/*.toml",
+]
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore.add = [
   # venv directories under build-support.

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -149,6 +149,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         )
 
         v2_ui = options.for_global_scope().get("v2_ui", False)
+        use_colors = options.for_global_scope().get("colors", True)
         zipkin_trace_v2 = options.for_scope("reporting").zipkin_trace_v2
         # TODO(#8658) This should_report_workunits flag must be set to True for
         # StreamingWorkunitHandler to receive WorkUnits. It should eventually
@@ -159,7 +160,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         return graph_scheduler_helper.new_session(
             zipkin_trace_v2,
             RunTracker.global_instance().run_id,
-            v2_ui,
+            v2_ui=v2_ui,
+            use_colors=use_colors,
             should_report_workunits=stream_workunits,
         )
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -30,7 +30,7 @@ from pants.engine.internals.examples.parsers import (
 from pants.engine.internals.mapper import AddressFamily, AddressMapper
 from pants.engine.internals.nodes import Return, State, Throw
 from pants.engine.internals.parser import BuildFilePreludeSymbols, HydratedStruct, SymbolTable
-from pants.engine.internals.scheduler import SchedulerSession
+from pants.engine.internals.scheduler import ExecutionRequest, SchedulerSession
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.internals.struct import Struct, StructWithDeps
 from pants.engine.legacy.structs import TargetAdaptor
@@ -257,7 +257,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
 
     def _populate(
         self, scheduler: SchedulerSession, address: Address,
-    ) -> Tuple[HydratedStruct, State]:
+    ) -> Tuple[ExecutionRequest, State]:
         """Perform an ExecutionRequest to parse the given Address into a Struct."""
         request = scheduler.execution_request([HydratedStruct], [address])
         returns, throws = scheduler.execute(request)

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -518,7 +518,7 @@ class SchedulerSession:
                 unique_exceptions,
             )
 
-    def run_goal_rule(self, product: Type, subject: Union[Any, Params], poll: bool = False,) -> int:
+    def run_goal_rule(self, product: Type, subject: Union[Any, Params], poll: bool = False) -> int:
         """
         :param product: A Goal subtype.
         :param subject: subject for the request.
@@ -549,19 +549,21 @@ class SchedulerSession:
         self,
         product: Type,
         subjects: Sequence[Union[Any, Params]],
+        poll: bool = False,
         timeout: Optional[float] = None,
     ):
         """Executes a request for a single product for some subjects, and returns the products.
 
         :param product: A product type for the request.
         :param subjects: A list of subjects or Params instances for the request.
+        :param poll: See self.execution_request.
         :param timeout: See self.execution_request.
         :returns: A list of the requested products, with length match len(subjects).
         """
         request = None
         raised_exception = None
         try:
-            request = self.execution_request([product], subjects)
+            request = self.execution_request([product], subjects, poll=poll, timeout=timeout)
         except:  # noqa: T803
             # If there are any exceptions during CFFI extern method calls, we want to return an error with
             # them and whatever failure results from it. This typically results from unhashable types.

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -260,8 +260,9 @@ class Scheduler:
     def invalidate_all_files(self):
         return self._native.lib.graph_invalidate_all_paths(self._scheduler)
 
-    def check_invalidation_watcher_liveness(self) -> bool:
-        return cast(bool, self._native.lib.check_invalidation_watcher_liveness(self._scheduler))
+    def check_invalidation_watcher_liveness(self):
+        res = self._native.lib.check_invalidation_watcher_liveness(self._scheduler)
+        self._raise_or_return(res)
 
     def graph_len(self):
         return self._native.lib.graph_len(self._scheduler)

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -107,16 +107,21 @@ class OptionsInitializer:
         """
         pants_ignore = list(global_options.pants_ignore)
 
-        def add_ignore(absolute_path):
+        def add(absolute_path, include=False):
             # To ensure that the path is ignored regardless of whether it is a symlink or a directory, we
             # strip trailing slashes (which would signal that we wanted to ignore only directories).
             maybe_rel_path = fast_relpath_optional(absolute_path, buildroot)
             if maybe_rel_path:
                 rel_path = maybe_rel_path.rstrip(os.path.sep)
-                pants_ignore.append(f"/{rel_path}")
+                prefix = "!" if include else ""
+                pants_ignore.append(f"{prefix}/{rel_path}")
 
-        add_ignore(global_options.pants_workdir)
-        add_ignore(global_options.pants_distdir)
+        add(global_options.pants_workdir)
+        add(global_options.pants_distdir)
+        # NB: We punch a hole in the ignore patterns to allow pants to directly watch process
+        # metadata that is written to disk.
+        add(global_options.pants_subprocessdir, include=True)
+
         return pants_ignore
 
     @staticmethod
@@ -126,23 +131,28 @@ class OptionsInitializer:
         Combines --pythonpath and --pants-config-files files that are in {buildroot} dir with those
         invalidation_globs provided by users.
         """
-        invalidation_globs = []
-        globs = (
-            bootstrap_options.pythonpath
+        invalidation_globs = set()
+        globs = set(
+            sys.path
+            + bootstrap_options.pythonpath
             + bootstrap_options.pants_config_files
             + bootstrap_options.pantsd_invalidation_globs
         )
 
         for glob in globs:
-            glob_relpath = os.path.relpath(glob, buildroot)
-            if glob_relpath and (not glob_relpath.startswith("../")):
-                invalidation_globs.extend([glob_relpath, glob_relpath + "/**"])
+            if glob.startswith("!"):
+                invalidation_globs.add(glob)
+                continue
+
+            glob_relpath = fast_relpath_optional(glob, buildroot) if os.path.isabs(glob) else glob
+            if glob_relpath:
+                invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
             else:
-                logging.getLogger(__name__).warning(
+                logger.debug(
                     f"Changes to {glob}, outside of the buildroot, will not be invalidated."
                 )
 
-        return invalidation_globs
+        return list(sorted(invalidation_globs))
 
     @classmethod
     def create(cls, options_bootstrapper, build_configuration, init_subsystems=True):

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import re
 import sys
 
 import pkg_resources
@@ -112,9 +111,7 @@ class OptionsInitializer:
             # To ensure that the path is ignored regardless of whether it is a symlink or a directory, we
             # strip trailing slashes (which would signal that we wanted to ignore only directories).
             maybe_rel_path = fast_relpath_optional(absolute_path, buildroot)
-            # Exclude temp workdir from <pants_ignore>.
-            # temp workdir is /path/to/<pants_workdir>/tmp/tmp<process_id>.pants.d
-            if maybe_rel_path and not re.search("tmp/tmp(.+).pants.d", maybe_rel_path):
+            if maybe_rel_path:
                 rel_path = maybe_rel_path.rstrip(os.path.sep)
                 pants_ignore.append(f"/{rel_path}")
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -657,7 +657,7 @@ class GlobalOptions(Subsystem):
             type=list,
             default=[],
             help="Filesystem events matching any of these globs will trigger a daemon restart. "
-            "The `--pythonpath` and `--pants-config-files` are inherently invalidated.",
+            "Pants' own code, plugins, and `--pants-config-files` are inherently invalidated.",
         )
 
         # Watchman options.

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -198,11 +198,11 @@ class SchedulerService(PantsService):
 
     def _check_invalidation_watcher_liveness(self):
         time.sleep(self.INVALIDATION_WATCHER_LIVENESS_CHECK_INTERVAL)
-        if not self._scheduler.check_invalidation_watcher_liveness():
+        try:
+            self._scheduler.check_invalidation_watcher_liveness()
+        except Exception as e:
             # Watcher failed for some reason
-            self._logger.critical(
-                "The graph invalidation watcher failed, so we are shutting down. Check the pantsd.log for details"
-            )
+            self._logger.critical(f"The scheduler was invalidated: {e}")
             self.terminate()
 
     def prepare_graph(self, options: Options) -> LegacyGraphSession:

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1142,6 +1142,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1009,16 +1009,6 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures-locks"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3159,24 +3149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-io"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,9 +3542,7 @@ version = "0.0.1"
 dependencies = [
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.0.1",
  "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3787,7 +3757,6 @@ dependencies = [
 "checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
 "checksum futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
 "checksum futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
-"checksum futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5658075ca5ae3918993c5bc95b43fcf22f927227660556a947da598f9f8981"
 "checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 "checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 "checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
@@ -3995,8 +3964,6 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
-"checksum tokio-current-thread 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-"checksum tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -674,8 +674,8 @@ pub extern "C" fn graph_invalidate_all_paths(scheduler_ptr: *mut Scheduler) -> u
 }
 
 #[no_mangle]
-pub extern "C" fn check_invalidation_watcher_liveness(scheduler_ptr: *mut Scheduler) -> bool {
-  with_scheduler(scheduler_ptr, |scheduler| scheduler.core.watcher.is_alive())
+pub extern "C" fn check_invalidation_watcher_liveness(scheduler_ptr: *mut Scheduler) -> PyResult {
+  with_scheduler(scheduler_ptr, |scheduler| scheduler.is_valid().into())
 }
 
 #[no_mangle]

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -633,6 +633,16 @@ pub extern "C" fn execution_set_poll(execution_request_ptr: *mut ExecutionReques
 }
 
 #[no_mangle]
+pub extern "C" fn execution_set_poll_delay(
+  execution_request_ptr: *mut ExecutionRequest,
+  poll_delay_in_ms: u64,
+) {
+  with_execution_request(execution_request_ptr, |execution_request| {
+    execution_request.poll_delay = Some(Duration::from_millis(poll_delay_in_ms));
+  })
+}
+
+#[no_mangle]
 pub extern "C" fn execution_set_timeout(
   execution_request_ptr: *mut ExecutionRequest,
   timeout_in_ms: u64,
@@ -821,6 +831,11 @@ pub extern "C" fn session_create(
       should_report_workunits,
     )))
   })
+}
+
+#[no_mangle]
+pub extern "C" fn session_new_run_id(session_ptr: *mut Session) {
+  with_session(session_ptr, |session| session.new_run_id())
 }
 
 #[no_mangle]

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -8,13 +8,14 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 fnv = "1.0.5"
-futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
+futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../hashing" }
 indexmap = "1.0.2"
 log = "0.4"
 parking_lot = "0.6"
 petgraph = "0.4.5"
+tokio = { version = "0.2", features = ["time"] }
 
 [dev-dependencies]
 rand = "0.6"

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -19,3 +19,4 @@ petgraph = "0.4.5"
 [dev-dependencies]
 rand = "0.6"
 env_logger = "0.5.4"
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -61,11 +61,17 @@ impl Generation {
 /// If the value is Uncacheable it may only be consumed in the Session that produced it, and should
 /// be recomputed in a new Session.
 ///
+/// A value of type UncacheableDependencies has Uncacheable dependencies, and is treated as
+/// equivalent to Dirty in all cases except when `poll`d: since `poll` requests are waiting for
+/// meaningful work to do, they need to differentiate between a truly invalidated/changed (Dirty)
+/// Node and a Node that would be re-cleaned once per session.
+///
 /// If the value is Clean, the consumer can simply use the value as-is.
 ///
 #[derive(Clone, Debug)]
 pub enum EntryResult<N: Node> {
   Clean(Result<N::Item, N::Error>),
+  UncacheableDependencies(Result<N::Item, N::Error>),
   Dirty(Result<N::Item, N::Error>),
   Uncacheable(
     Result<N::Item, N::Error>,
@@ -79,6 +85,24 @@ impl<N: Node> EntryResult<N> {
       EntryResult::Clean(..) => true,
       EntryResult::Uncacheable(_, session_id) => context.session_id() == session_id,
       EntryResult::Dirty(..) => false,
+      EntryResult::UncacheableDependencies(..) => false,
+    }
+  }
+
+  fn has_uncacheable_deps(&self) -> bool {
+    match self {
+      EntryResult::Uncacheable(_, _) | EntryResult::UncacheableDependencies(_) => true,
+      EntryResult::Clean(..) | EntryResult::Dirty(..) => false,
+    }
+  }
+
+  /// Returns true if this result should block for polling (because there is no work to do
+  /// currently to clean it).
+  fn poll_should_wait(&self, context: &N::Context) -> bool {
+    match self {
+      EntryResult::Uncacheable(_, session_id) => context.session_id() == session_id,
+      EntryResult::Dirty(..) => false,
+      EntryResult::UncacheableDependencies(_) | EntryResult::Clean(..) => true,
     }
   }
 
@@ -90,17 +114,27 @@ impl<N: Node> EntryResult<N> {
     }
   }
 
-  /// Iff the value is Clean, mark it Dirty.
+  /// If the value is in a Clean state, mark it Dirty.
   fn dirty(&mut self) {
-    if let EntryResult::Clean(value) = self {
-      *self = EntryResult::Dirty(value.clone())
+    match self {
+      EntryResult::Clean(v) | EntryResult::UncacheableDependencies(v) => {
+        *self = EntryResult::Dirty(v.clone());
+      }
+      EntryResult::Dirty(_) | EntryResult::Uncacheable(_, _) => {}
     }
   }
 
-  /// Iff the value is Dirty, mark it Clean.
+  /// If the value is Dirty, mark it Clean.
   fn clean(&mut self) {
     if let EntryResult::Dirty(value) = self {
       *self = EntryResult::Clean(value.clone())
+    }
+  }
+
+  /// If the value is Dirty, mark it UncacheableDependencies.
+  fn uncacheable_deps(&mut self) {
+    if let EntryResult::Dirty(value) = self {
+      *self = EntryResult::UncacheableDependencies(value.clone())
     }
   }
 }
@@ -111,6 +145,7 @@ impl<N: Node> AsRef<Result<N::Item, N::Error>> for EntryResult<N> {
       EntryResult::Clean(v) => v,
       EntryResult::Dirty(v) => v,
       EntryResult::Uncacheable(v, _) => v,
+      EntryResult::UncacheableDependencies(v) => v,
     }
   }
 }
@@ -144,9 +179,13 @@ pub enum EntryState<N: Node> {
   // A node that has completed, and then possibly been marked dirty. Because marking a node
   // dirty does not eagerly re-execute any logic, it will stay this way until a caller moves it
   // back to Running.
+  //
+  // A Completed entry can have "pollers" whom are waiting for the Node to either be dirtied or
+  // otherwise invalidated.
   Completed {
     run_token: RunToken,
     generation: Generation,
+    pollers: Vec<oneshot::Sender<()>>,
     result: EntryResult<N>,
     dep_generations: Vec<Generation>,
   },
@@ -190,6 +229,42 @@ impl<N: Node> Entry<N> {
 
   pub fn node(&self) -> &N {
     &self.node
+  }
+
+  ///
+  /// If this Node is currently complete and clean with the given Generation, then return a Future
+  /// that will be satisfied when it is changed in any way. If the node is not clean, or the
+  /// generation mismatches, returns immediately.
+  ///
+  /// NB: The returned Future is infalliable.
+  ///
+  pub fn poll(&self, context: &N::Context, last_seen_generation: Generation) -> BoxFuture<(), ()> {
+    let mut state = self.state.lock();
+    match *state {
+      EntryState::Completed {
+        ref result,
+        generation,
+        ref mut pollers,
+        ..
+      } => {
+        if generation == last_seen_generation && result.poll_should_wait(context) {
+          // The Node is currently clean with the observed generation: add a poller on the
+          // Completed node that will be notified when it is dirtied or dropped. If the Node moves
+          // to another state, the received will be notified that the sender was dropped, and it
+          // will be converted into a successful result.
+          let (send, recv) = oneshot::channel();
+          pollers.push(send);
+          recv.then(|_| Ok(())).to_boxed()
+        } else {
+          // The Node is not clean, or the generation has changed.
+          future::ok(()).to_boxed()
+        }
+      }
+      _ => {
+        // The Node is not Completed, and should be requested.
+        future::ok(()).to_boxed()
+      }
+    }
   }
 
   ///
@@ -342,6 +417,7 @@ impl<N: Node> Entry<N> {
         EntryState::Completed {
           run_token,
           generation,
+          pollers,
           result,
           dep_generations,
         } => {
@@ -355,6 +431,8 @@ impl<N: Node> Entry<N> {
             "A clean Node should not reach this point: {:?}",
             result
           );
+          // NB: Explicitly drop the pollers: would happen anyway, but avoids an unused variable.
+          mem::drop(pollers);
           // The Node has already completed but needs to re-run. If the Node is dirty, we are the
           // first caller to request it since it was marked dirty. We attempt to clean it (which
           // will cause it to re-run if the dep_generations mismatch).
@@ -406,7 +484,7 @@ impl<N: Node> Entry<N> {
     result_run_token: RunToken,
     dep_generations: Vec<Generation>,
     result: Option<Result<N::Item, N::Error>>,
-    has_dirty_dependencies: bool,
+    has_uncacheable_deps: bool,
     _graph: &mut super::InnerGraph<N>,
   ) {
     let mut state = self.state.lock();
@@ -472,8 +550,8 @@ impl<N: Node> Entry<N> {
           let (generation, next_result) = if let Some(result) = result {
             let next_result = if !self.node.cacheable() {
               EntryResult::Uncacheable(result, context.session_id().clone())
-            } else if has_dirty_dependencies {
-              EntryResult::Dirty(result)
+            } else if has_uncacheable_deps {
+              EntryResult::UncacheableDependencies(result)
             } else {
               EntryResult::Clean(result)
             };
@@ -484,12 +562,12 @@ impl<N: Node> Entry<N> {
               (generation.next(), next_result)
             }
           } else {
-            // Node was marked clean.
+            // Node was clean.
             // NB: The `expect` here avoids a clone and a comparison: see the method docs.
             let mut result =
               previous_result.expect("A Node cannot be marked clean without a previous result.");
-            if has_dirty_dependencies {
-              result.dirty();
+            if has_uncacheable_deps {
+              result.uncacheable_deps();
             } else {
               result.clean();
             }
@@ -511,6 +589,7 @@ impl<N: Node> Entry<N> {
           }
           EntryState::Completed {
             result: next_result,
+            pollers: Vec::new(),
             dep_generations,
             run_token,
             generation,
@@ -611,9 +690,20 @@ impl<N: Node> Entry<N> {
     trace!("Dirtying node {:?}", self.node);
     match state {
       &mut EntryState::Running { ref mut dirty, .. } => {
-        *dirty = true;
+        // An uncacheable node can never be marked dirty.
+        if self.node.cacheable() {
+          *dirty = true;
+        }
       }
-      &mut EntryState::Completed { ref mut result, .. } => {
+      &mut EntryState::Completed {
+        ref mut result,
+        ref mut pollers,
+        ..
+      } => {
+        // Notify all pollers (ignoring any that have gone away.)
+        for poller in pollers.drain(..) {
+          let _ = poller.send(());
+        }
         result.dirty();
       }
       &mut EntryState::NotStarted { .. } => {}
@@ -637,6 +727,13 @@ impl<N: Node> Entry<N> {
         }
       }
       EntryState::Completed { ref result, .. } => result.is_clean(context),
+    }
+  }
+
+  pub fn has_uncacheable_deps(&self) -> bool {
+    match *self.state.lock() {
+      EntryState::Completed { ref result, .. } => result.has_uncacheable_deps(),
+      EntryState::NotStarted { .. } | EntryState::Running { .. } => false,
     }
   }
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -337,7 +337,7 @@ impl<N: Node> InnerGraph<N> {
       .walk(
         root_ids.iter().cloned().collect(),
         Direction::Incoming,
-        |id| !self.entry_for_id(*id).unwrap().node().cacheable(),
+        |_| false,
       )
       .filter(|eid| !root_ids.contains(eid))
       .collect();
@@ -613,18 +613,12 @@ impl<N: Node> Graph<N> {
     inner.nodes.len()
   }
 
-  ///
-  /// Request the given dst Node, optionally in the context of the given src Node.
-  ///
-  /// If there is no src Node, or the src Node is not cacheable, this method will retry for
-  /// invalidation until the Node completes.
-  ///
-  pub fn get(
+  fn get_inner(
     &self,
     src_id: Option<EntryId>,
     context: &N::Context,
     dst_node: N,
-  ) -> BoxFuture<N::Item, N::Error> {
+  ) -> BoxFuture<(N::Item, Generation), N::Error> {
     // Compute information about the dst under the Graph lock, and then release it.
     let (dst_retry, mut entry, entry_id) = {
       // Get or create the destination, and then insert the dep and return its state.
@@ -683,11 +677,7 @@ impl<N: Node> Graph<N> {
           if counter == 0 {
             break Err(N::Error::exhausted());
           }
-          let dep_res = entry
-            .get(&context, entry_id)
-            .map(|(res, _)| res)
-            .compat()
-            .await;
+          let dep_res = entry.get(&context, entry_id).compat().await;
           match dep_res {
             Ok(r) => break Ok(r),
             Err(err) if err == N::Error::invalidated() => continue,
@@ -698,8 +688,26 @@ impl<N: Node> Graph<N> {
       uncached_node.boxed().compat().to_boxed()
     } else {
       // Not retriable.
-      entry.get(context, entry_id).map(|(res, _)| res).to_boxed()
+      entry.get(context, entry_id)
     }
+  }
+
+  ///
+  /// Request the given dst Node, optionally in the context of the given src Node.
+  ///
+  /// If there is no src Node, or the src Node is not cacheable, this method will retry for
+  /// invalidation until the Node completes.
+  ///
+  pub fn get(
+    &self,
+    src_id: Option<EntryId>,
+    context: &N::Context,
+    dst_node: N,
+  ) -> BoxFuture<N::Item, N::Error> {
+    self
+      .get_inner(src_id, context, dst_node)
+      .map(|(res, _generation)| res)
+      .to_boxed()
   }
 
   ///
@@ -707,6 +715,36 @@ impl<N: Node> Graph<N> {
   ///
   pub fn create(&self, node: N, context: &N::Context) -> BoxFuture<N::Item, N::Error> {
     self.get(None, context, node)
+  }
+
+  ///
+  /// Gets the value of the given Node (optionally waiting for it to have changed since the given
+  /// LastObserved token), and then returns its new value and a new LastObserved token.
+  ///
+  pub async fn poll(
+    &self,
+    node: N,
+    token: Option<LastObserved>,
+    context: &N::Context,
+  ) -> Result<(N::Item, LastObserved), N::Error> {
+    // If the node is currently clean at the given token, Entry::poll will delay until it has
+    // changed in some way.
+    if let Some(LastObserved(generation)) = token {
+      let entry = {
+        let mut inner = self.inner.lock();
+        let entry_id = inner.ensure_entry(node.clone());
+        inner.unsafe_entry_for_id(entry_id).clone()
+      };
+      entry
+        .poll(context, generation)
+        .compat()
+        .await
+        .expect("Poll is infalliable.");
+    };
+
+    // Re-request the Node.
+    let (res, generation) = self.get_inner(None, context, node).compat().await?;
+    Ok((res, LastObserved(generation)))
   }
 
   fn report_cycle(
@@ -870,9 +908,9 @@ impl<N: Node> Graph<N> {
     run_token: RunToken,
     result: Option<Result<N::Item, N::Error>>,
   ) {
-    let (entry, has_dirty_dependencies, dep_generations) = {
+    let (entry, has_uncacheable_deps, dep_generations) = {
       let inner = self.inner.lock();
-      let mut has_dirty_dependencies = false;
+      let mut has_uncacheable_deps = false;
       // Get the Generations of all dependencies of the Node. We can trust that these have not changed
       // since we began executing, as long as we are not currently marked dirty (see the method doc).
       let dep_generations = inner
@@ -880,18 +918,19 @@ impl<N: Node> Graph<N> {
         .neighbors_directed(entry_id, Direction::Outgoing)
         .filter_map(|dep_id| inner.entry_for_id(dep_id))
         .map(|entry| {
-          // If a dependency is uncacheable or currently dirty, this Node should complete as dirty,
-          // independent of matching Generation values. This is to allow for the behaviour that an
-          // uncacheable Node should always have dirty dependents, transitively.
-          if !entry.node().cacheable() || !entry.is_clean(context) {
-            has_dirty_dependencies = true;
+          // If a dependency is itself uncacheable or has uncacheable deps, this Node should
+          // also complete as having uncacheable dpes, independent of matching Generation values.
+          // This is to allow for the behaviour that an uncacheable Node should always have "dirty"
+          // (marked as UncacheableDependencies) dependents, transitively.
+          if !entry.node().cacheable() || entry.has_uncacheable_deps() {
+            has_uncacheable_deps = true;
           }
           entry.generation()
         })
         .collect();
       (
         inner.entry_for_id(entry_id).cloned(),
-        has_dirty_dependencies,
+        has_uncacheable_deps,
         dep_generations,
       )
     };
@@ -903,7 +942,7 @@ impl<N: Node> Graph<N> {
         run_token,
         dep_generations,
         result,
-        has_dirty_dependencies,
+        has_uncacheable_deps,
         &mut inner,
       );
     }
@@ -984,6 +1023,12 @@ impl<N: Node> Graph<N> {
     }
   }
 }
+
+///
+/// An opaque token that represents a particular observed "version" of a Node.
+///
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LastObserved(Generation);
 
 ///
 /// Represents the state of a particular walk through a Graph. Implements Iterator and has the same

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -113,11 +113,11 @@ pub trait NodeContext: Clone + Send + Sync + 'static {
   type Node: Node;
 
   ///
-  /// The Session ID type for this Context. Some Node behaviours (in particular: Node::cacheable)
-  /// have Session-specific semantics. More than one context object might be associated with a
-  /// single caller "session".
+  /// The Run ID type for this Context. Some Node behaviours have Run-specific semantics. In
+  /// particular: an uncacheable (Node::cacheable) Node will execute once per Run, regardless
+  /// of other invalidation.
   ///
-  type SessionId: Clone + Debug + Eq + Send;
+  type RunId: Clone + Debug + Eq + Send;
 
   ///
   /// Creates a clone of this NodeContext to be used for a different Node.
@@ -127,10 +127,10 @@ pub trait NodeContext: Clone + Send + Sync + 'static {
   fn clone_for(&self, entry_id: EntryId) -> <Self::Node as Node>::Context;
 
   ///
-  /// Returns the SessionId for this Context, which should uniquely identify a caller's run for the
-  /// purposes of "once per Session" behaviour.
+  /// Returns the RunId for this Context, which should uniquely identify a caller's run for the
+  /// purposes of "once per Run" behaviour.
   ///
-  fn session_id(&self) -> &Self::SessionId;
+  fn run_id(&self) -> &Self::RunId;
 
   ///
   /// Returns a reference to the Graph for this Context.

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -23,7 +23,7 @@ use tokio::task_local;
 use ui::EngineDisplay;
 use uuid::Uuid;
 
-const TIME_FORMAT_STR: &str = "%H:%M:%S";
+const TIME_FORMAT_STR: &str = "%H:%M:%S:%3f";
 
 lazy_static! {
   pub static ref LOGGER: Logger = Logger::new();

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -42,11 +42,9 @@ mod tasks;
 mod types;
 
 pub use crate::context::Core;
-pub use crate::core::{Function, Key, Params, TypeId, Value};
+pub use crate::core::{Failure, Function, Key, Params, TypeId, Value};
 pub use crate::handles::Handle;
 pub use crate::intrinsics::Intrinsics;
-pub use crate::scheduler::{
-  ExecutionRequest, ExecutionTermination, RootResult, Scheduler, Session,
-};
+pub use crate::scheduler::{ExecutionRequest, ExecutionTermination, Scheduler, Session};
 pub use crate::tasks::{Rule, Tasks};
 pub use crate::types::Types;

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -271,6 +271,18 @@ impl Scheduler {
   }
 
   ///
+  /// Return unit if the Scheduler is still valid, or an error string if something has invalidated
+  /// the Scheduler, indicating that it should re-initialize. See InvalidationWatcher.
+  ///
+  pub fn is_valid(&self) -> Result<(), String> {
+    let core = self.core.clone();
+    self.core.executor.block_on(async move {
+      // Confirm that our InvalidationWatcher is still alive.
+      core.watcher.is_valid().await
+    })
+  }
+
+  ///
   /// Return all Digests currently in memory in this Scheduler.
   ///
   pub fn all_digests(&self, session: &Session) -> Vec<hashing::Digest> {

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -51,8 +51,16 @@ struct InnerSession {
   should_record_zipkin_spans: bool,
   // A place to store info about workunits in rust part
   workunit_store: WorkUnitStore,
-  // The unique id for this run. Used as the id of the session, and for metrics gathering purposes.
+  // The unique id for this Session: used for metrics gathering purposes.
   build_id: String,
+  // An id used to control the visibility of uncacheable rules. Generally this is identical for an
+  // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
+  // same Session while still observing new values for uncacheable rules like Goals.
+  //
+  // TODO: Figure out how the `--loop` interplays with metrics. It's possible that for metrics
+  // purposes, each iteration of a loop should be considered to be a new Session, but for now the
+  // Session/build_id would be stable.
+  run_id: Mutex<Uuid>,
   should_report_workunits: bool,
 }
 
@@ -82,6 +90,7 @@ impl Session {
       should_record_zipkin_spans,
       workunit_store: WorkUnitStore::new(),
       build_id,
+      run_id: Mutex::new(Uuid::new_v4()),
       should_report_workunits,
     };
     Session(Arc::new(inner_session))
@@ -96,7 +105,10 @@ impl Session {
     let roots = self.0.roots.lock();
     inputs
       .iter()
-      .map(|root| (root.clone(), roots.get(root).cloned().unwrap_or(None)))
+      .map(|root| {
+        let last_observed = roots.get(root).cloned().unwrap_or(None);
+        (root.clone(), last_observed)
+      })
       .collect()
   }
 
@@ -127,6 +139,16 @@ impl Session {
 
   pub fn build_id(&self) -> &String {
     &self.0.build_id
+  }
+
+  pub fn run_id(&self) -> Uuid {
+    let run_id = self.0.run_id.lock();
+    *run_id
+  }
+
+  pub fn new_run_id(&self) {
+    let mut run_id = self.0.run_id.lock();
+    *run_id = Uuid::new_v4();
   }
 
   pub fn write_stdout(&self, msg: &str) {
@@ -176,9 +198,13 @@ pub struct ExecutionRequest {
   // complete. The second request will check whether the roots have changed, and if they haven't
   // changed, will wait until they have (or until the timeout elapses) before re-requesting them.
   //
-  // TODO: The "all" roots behavior is a bit peculiar, but was easiest to expose with the existing
-  // API.  In general, polled requests will probably only be for a single root.
+  // TODO: The `poll`, `poll_delay`, and `timeout` parameters exist to support a coarse-grained API
+  // for synchronous Node-watching to Python. Rather than further expanding this `execute` API, we
+  // should likely port those usecases to rust.
   pub poll: bool,
+  // If poll is set, a delay to apply after having noticed that Nodes have changed and before
+  // requesting them.
+  pub poll_delay: Option<Duration>,
   // A timeout applied globally to the request. When a request times out, work is _not_ cancelled,
   // and will continue to completion in the background.
   pub timeout: Option<Duration>,
@@ -189,6 +215,7 @@ impl ExecutionRequest {
     ExecutionRequest {
       roots: Vec::new(),
       poll: false,
+      poll_delay: None,
       timeout: None,
     }
   }
@@ -322,12 +349,13 @@ impl Scheduler {
     root: Root,
     last_observed: Option<LastObserved>,
     poll: bool,
+    poll_delay: Option<Duration>,
   ) -> ObservedValueResult {
     let (result, last_observed) = if poll {
       let (result, last_observed) = context
         .core
         .graph
-        .poll(root.into(), last_observed, &context)
+        .poll(root.into(), last_observed, poll_delay, &context)
         .await?;
       (result, Some(last_observed))
     } else {
@@ -354,17 +382,23 @@ impl Scheduler {
   /// on a Future.
   ///
   fn execute_helper(
-    context: Context,
+    &self,
+    request: &ExecutionRequest,
+    session: &Session,
     sender: mpsc::Sender<Vec<ObservedValueResult>>,
-    roots: Vec<(Root, Option<LastObserved>)>,
-    poll: bool,
   ) {
+    let context = Context::new(self.core.clone(), session.clone());
+    let roots = session.zip_last_observed(&request.roots);
+    let poll = request.poll;
+    let poll_delay = request.poll_delay;
     let core = context.core.clone();
     let _join = core.executor.spawn(async move {
       let res = future::join_all(
         roots
           .into_iter()
-          .map(|(root, last_observed)| Self::poll_or_create(&context, root, last_observed, poll))
+          .map(|(root, last_observed)| {
+            Self::poll_or_create(&context, root, last_observed, poll, poll_delay)
+          })
           .collect::<Vec<_>>(),
       )
       .await;
@@ -406,18 +440,16 @@ impl Scheduler {
     request: &ExecutionRequest,
     session: &Session,
   ) -> Result<Vec<Result<Value, Failure>>, ExecutionTermination> {
-    debug!("Launching {} roots.", request.roots.len());
+    debug!(
+      "Launching {} roots (poll={}).",
+      request.roots.len(),
+      request.poll
+    );
 
     // Spawn and wait for all roots to complete. Failure here should be impossible, because each
     // individual Future in the join was (eventually) mapped into success.
-    let context = Context::new(self.core.clone(), session.clone());
     let (sender, receiver) = mpsc::channel();
-    Scheduler::execute_helper(
-      context,
-      sender,
-      session.zip_last_observed(&request.roots),
-      request.poll,
-    );
+    self.execute_helper(request, session, sender);
 
     // This map keeps the k most relevant jobs in assigned possitions.
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -8,10 +8,9 @@ publish = false
 [dependencies]
 crossbeam-channel = "0.3"
 fs = { path = "../fs" }
-futures = { version = "0.3", features = ["compat"] }
-futures-locks = "0.3.0"
-futures01 = { package = "futures", version = "0.1" }
+futures = "0.3"
 graph = { path = "../graph" }
+hashing = { path = "../hashing" }
 log = "0.4"
 logging = { path = "../logging" }
 # notify is currently an experimental API, we are pinning to https://docs.rs/notify/5.0.0-pre.1/notify/
@@ -19,11 +18,10 @@ logging = { path = "../logging" }
 # The author suggests they will add the debounced watcher back into the stable 5.0.0 release. When that happens
 # we can move to it.
 notify = { git = "https://github.com/notify-rs/notify", rev = "fba00891d9105e2f581c69fbe415a58cb7966fdd" }
+parking_lot = "0.6"
 task_executor = { path = "../task_executor" }
 
 [dev-dependencies]
-hashing = { path = "../hashing" }
-parking_lot = "0.6"
 tempfile = "3"
 testutil = { path = "../testutil" }
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 
 use crossbeam_channel::{self, Receiver, RecvTimeoutError, TryRecvError};
 use fs::GitignoreStyleExcludes;
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use logging;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::Mutex;
@@ -179,7 +179,7 @@ impl InvalidationWatcher {
                   &path_relative_to_build_root,
                   /* is_dir */ false,
                 ) {
-                  debug!("notify ignoring {:?}", path_relative_to_build_root);
+                  trace!("notify ignoring {:?}", path_relative_to_build_root);
                   None
                 } else {
                   Some(path_relative_to_build_root)

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -179,6 +179,7 @@ impl InvalidationWatcher {
                   &path_relative_to_build_root,
                   /* is_dir */ false,
                 ) {
+                  debug!("notify ignoring {:?}", path_relative_to_build_root);
                   None
                 } else {
                   Some(path_relative_to_build_root)

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -35,14 +35,12 @@ use std::thread;
 use std::time::Duration;
 
 use crossbeam_channel::{self, Receiver, RecvTimeoutError, TryRecvError};
-use futures::compat::Future01CompatExt;
-use futures_locks::Mutex;
-use log::{debug, error, warn};
-use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use task_executor::Executor;
-
 use fs::GitignoreStyleExcludes;
+use log::{debug, warn};
 use logging;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use parking_lot::Mutex;
+use task_executor::Executor;
 
 ///
 /// An InvalidationWatcher maintains a Thread that receives events from a notify Watcher.
@@ -51,23 +49,33 @@ use logging;
 /// and the caller should create a new InvalidationWatcher (or shut down, in some cases). Generally
 /// this will mean polling.
 ///
-/// TODO: Need the above polling
-///
-pub struct InvalidationWatcher {
-  watcher: Arc<Mutex<RecommendedWatcher>>,
+struct Inner {
+  watcher: RecommendedWatcher,
   executor: Executor,
-  liveness: Receiver<()>,
+  liveness: Receiver<String>,
   enabled: bool,
+  // Until the background task has started, contains the relevant inputs to launch it via
+  // start_background_thread. The decoupling of creating the `InvalidationWatcher` and starting it
+  // is to allow for testing of the background thread.
+  background_task_inputs: Option<WatcherTaskInputs>,
 }
 
+type WatcherTaskInputs = (
+  Arc<GitignoreStyleExcludes>,
+  PathBuf,
+  crossbeam_channel::Sender<String>,
+  Receiver<notify::Result<notify::Event>>,
+);
+
+pub struct InvalidationWatcher(Mutex<Inner>);
+
 impl InvalidationWatcher {
-  pub fn new<I: Invalidatable>(
-    invalidatable: Weak<I>,
+  pub fn new(
     executor: Executor,
     build_root: PathBuf,
     ignorer: Arc<GitignoreStyleExcludes>,
     enabled: bool,
-  ) -> Result<InvalidationWatcher, String> {
+  ) -> Result<Arc<InvalidationWatcher>, String> {
     // Inotify events contain canonical paths to the files being watched.
     // If the build_root contains a symlink the paths returned in notify events
     // wouldn't have the build_root as a prefix, and so we would miss invalidating certain nodes.
@@ -78,7 +86,7 @@ impl InvalidationWatcher {
     let mut watcher: RecommendedWatcher = Watcher::new(watch_sender, Duration::from_millis(50))
       .map_err(|e| format!("Failed to begin watching the filesystem: {}", e))?;
 
-    let (thread_liveness_sender, thread_liveness_receiver) = crossbeam_channel::unbounded();
+    let (liveness_sender, liveness_receiver) = crossbeam_channel::unbounded();
     if enabled {
       // On darwin the notify API is much more efficient if you watch the build root
       // recursively, so we set up that watch here and then return early when watch() is
@@ -96,20 +104,37 @@ impl InvalidationWatcher {
       }
     }
 
+    Ok(Arc::new(InvalidationWatcher(Mutex::new(Inner {
+      watcher,
+      executor,
+      liveness: liveness_receiver,
+      enabled,
+      background_task_inputs: Some((
+        ignorer,
+        canonical_build_root,
+        liveness_sender,
+        watch_receiver,
+      )),
+    }))))
+  }
+
+  ///
+  /// Starts the background task that monitors watch events. Panics if called more than once.
+  ///
+  pub fn start<I: Invalidatable>(&self, invalidatable: &Arc<I>) {
+    let mut inner = self.0.lock();
+    let (ignorer, canonical_build_root, liveness_sender, watch_receiver) = inner
+      .background_task_inputs
+      .take()
+      .expect("An InvalidationWatcher can only be started once.");
+
     InvalidationWatcher::start_background_thread(
-      invalidatable,
+      Arc::downgrade(&invalidatable),
       ignorer,
       canonical_build_root,
-      thread_liveness_sender,
+      liveness_sender,
       watch_receiver,
     );
-
-    Ok(InvalidationWatcher {
-      watcher: Arc::new(Mutex::new(watcher)),
-      executor,
-      liveness: thread_liveness_receiver,
-      enabled,
-    })
   }
 
   // Public for testing purposes.
@@ -117,18 +142,18 @@ impl InvalidationWatcher {
     invalidatable: Weak<I>,
     ignorer: Arc<GitignoreStyleExcludes>,
     canonical_build_root: PathBuf,
-    liveness_sender: crossbeam_channel::Sender<()>,
+    liveness_sender: crossbeam_channel::Sender<String>,
     watch_receiver: Receiver<notify::Result<notify::Event>>,
-  ) {
+  ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
       logging::set_thread_destination(logging::Destination::Pantsd);
-      loop {
+      let exit_msg = loop {
         let event_res = watch_receiver.recv_timeout(Duration::from_millis(10));
         let invalidatable = if let Some(g) = invalidatable.upgrade() {
           g
         } else {
           // The Invalidatable has been dropped: we're done.
-          break;
+          break "The watcher was shut down.".to_string();
         };
         match event_res {
           Ok(Ok(ev)) => {
@@ -159,7 +184,7 @@ impl InvalidationWatcher {
                   Some(path_relative_to_build_root)
                 }
               })
-              .map(|path_relative_to_build_root| {
+              .flat_map(|path_relative_to_build_root| {
                 let mut paths_to_invalidate: Vec<PathBuf> = vec![];
                 if let Some(parent_dir) = path_relative_to_build_root.parent() {
                   paths_to_invalidate.push(parent_dir.to_path_buf());
@@ -167,8 +192,8 @@ impl InvalidationWatcher {
                 paths_to_invalidate.push(path_relative_to_build_root);
                 paths_to_invalidate
               })
-              .flatten()
               .collect();
+
             // Only invalidate stuff if we have paths that weren't filtered out by gitignore.
             if !paths.is_empty() {
               debug!("notify invalidating {:?} because of {:?}", paths, ev.kind);
@@ -180,69 +205,71 @@ impl InvalidationWatcher {
               warn!("Path(s) did not exist: {:?}", err.paths);
               continue;
             } else {
-              error!("File watcher failing with: {}", err);
-              break;
+              break format!("Watch error: {}", err);
             }
           }
           Err(RecvTimeoutError::Timeout) => continue,
           Err(RecvTimeoutError::Disconnected) => {
-            // The Watcher is gone: we're done.
-            break;
+            break "The watch provider exited.".to_owned();
           }
         };
+      };
+
+      // Log and send the exit code.
+      warn!("File watcher exiting with: {}", exit_msg);
+      let _ = liveness_sender.send(exit_msg);
+    })
+  }
+
+  ///
+  /// An InvalidationWatcher will never restart on its own: a consumer should re-initialize if this
+  /// method returns an error.
+  ///
+  /// NB: This is currently polled by pantsd, but it could be long-polled or a callback.
+  ///
+  pub async fn is_valid(&self) -> Result<(), String> {
+    // Confirm that the Watcher itself is still alive.
+    let watcher = self.0.lock();
+    match watcher.liveness.try_recv() {
+      Ok(msg) => {
+        // The watcher background task set the exit condition.
+        Err(msg)
       }
-      debug!("Watch thread exiting.");
-      // Signal that we're exiting (which we would also do by just dropping the channel).
-      let _ = liveness_sender.send(());
-    });
-  }
-
-  pub fn is_alive(&self) -> bool {
-    if let Ok(()) = self.liveness.try_recv() {
-      // The watcher background thread set the exit condition. Return false to signal that
-      // the watcher is not alive.
-      false
-    } else {
-      true
-    }
-  }
-
-  ///
-  /// Watch the given path non-recursively.
-  ///
-  pub async fn watch(&self, path: PathBuf) -> Result<(), notify::Error> {
-    // Short circuit here if we are on a Darwin platform because we should be watching
-    // the entire build root recursively already, or if we are not enabled.
-    if cfg!(target_os = "macos") || !self.enabled {
-      Ok(())
-    } else {
-      // Using a futurized mutex here because for some reason using a regular mutex
-      // to block the io pool causes the v2 ui to not update which nodes its working
-      // on properly.
-      let watcher_lock = self.watcher.lock().compat().await;
-      match watcher_lock {
-        Ok(mut watcher_lock) => {
-          self
-            .executor
-            .spawn_blocking(move || watcher_lock.watch(path, RecursiveMode::NonRecursive))
-            .await
-        }
-        Err(()) => Err(notify::Error::new(notify::ErrorKind::Generic(
-          "Couldn't lock mutex for invalidation watcher".to_string(),
-        ))),
+      Err(TryRecvError::Disconnected) => {
+        // The watcher background task died (panic, possible?).
+        Err(
+          "The filesystem watcher exited abnormally: please see the log for more information."
+            .to_owned(),
+        )
+      }
+      Err(TryRecvError::Empty) => {
+        // Still alive.
+        Ok(())
       }
     }
   }
 
   ///
-  /// Returns true if this InvalidationWatcher is still valid: if it is not valid, it will have
-  /// already logged some sort of error, and will never restart on its own.
+  /// Add a path to the set of paths being watched by this invalidation watcher, non-recursively.
   ///
-  pub fn running(&self) -> bool {
-    match self.liveness.try_recv() {
-      Ok(()) | Err(TryRecvError::Disconnected) => false,
-      Err(TryRecvError::Empty) => true,
-    }
+  pub async fn watch(self: &Arc<Self>, path: PathBuf) -> Result<(), notify::Error> {
+    let executor = {
+      let inner = self.0.lock();
+      if cfg!(target_os = "macos") || !inner.enabled {
+        // Short circuit here if we are on a Darwin platform because we should be watching
+        // the entire build root recursively already, or if we are not enabled.
+        return Ok(());
+      }
+      inner.executor.clone()
+    };
+
+    let watcher = self.clone();
+    executor
+      .spawn_blocking(move || {
+        let mut inner = watcher.0.lock();
+        inner.watcher.watch(path, RecursiveMode::NonRecursive)
+      })
+      .await
   }
 }
 

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -7,12 +7,13 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 
-use crossbeam_channel;
+use crossbeam_channel::{self, RecvTimeoutError};
 use fs::GitignoreStyleExcludes;
 use notify;
 use parking_lot::Mutex;
 use task_executor::Executor;
 use testutil::{append_to_existing_file, make_file};
+use tokio::runtime::Handle;
 
 fn setup_fs() -> (tempfile::TempDir, PathBuf) {
   // setup a build_root with a file in it to watch.
@@ -25,28 +26,21 @@ fn setup_fs() -> (tempfile::TempDir, PathBuf) {
   (tempdir, file_path)
 }
 
-fn setup_watch(
+/// Create (but don't start) an InvalidationWatcher.
+async fn setup_watch(
   ignorer: Arc<GitignoreStyleExcludes>,
-  invalidatable: Arc<TestInvalidatable>,
   build_root: PathBuf,
   file_path: PathBuf,
-) -> InvalidationWatcher {
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
-  let executor = Executor::new(rt.handle().clone());
-  let watcher = InvalidationWatcher::new(
-    Arc::downgrade(&invalidatable),
-    executor,
-    build_root,
-    ignorer,
-    /*enabled*/ true,
-  )
-  .expect("Couldn't create InvalidationWatcher");
-  rt.block_on(watcher.watch(file_path)).unwrap();
+) -> Arc<InvalidationWatcher> {
+  let executor = Executor::new(Handle::current());
+  let watcher = InvalidationWatcher::new(executor, build_root, ignorer, /*enabled*/ true)
+    .expect("Couldn't create InvalidationWatcher");
+  watcher.watch(file_path).await.unwrap();
   watcher
 }
 
-#[test]
-fn receive_watch_event_on_file_change() {
+#[tokio::test]
+async fn receive_watch_event_on_file_change() {
   // Instantiate a watcher and watch the file in question.
   let (tempdir, file_path) = setup_fs();
   let build_root = tempdir.path().to_path_buf();
@@ -58,12 +52,8 @@ fn receive_watch_event_on_file_change() {
 
   let invalidatable = Arc::new(TestInvalidatable::default());
   let ignorer = GitignoreStyleExcludes::empty();
-  let _watcher = setup_watch(
-    ignorer,
-    invalidatable.clone(),
-    build_root.clone(),
-    file_path.clone(),
-  );
+  let watcher = setup_watch(ignorer, build_root.clone(), file_path.clone()).await;
+  watcher.start(&invalidatable);
 
   // Update the content of the file being watched.
   let new_content = "stnetnoc".as_bytes().to_vec();
@@ -79,14 +69,11 @@ fn receive_watch_event_on_file_change() {
     }
   }
   // If we didn't find a new state fail the test.
-  assert!(
-    false,
-    "Nodes EntryState was not invalidated, or reset to NotStarted."
-  )
+  assert!(false, "Did not observe invalidation.")
 }
 
-#[test]
-fn ignore_file_events_matching_patterns_in_pants_ignore() {
+#[tokio::test]
+async fn ignore_file_events_matching_patterns_in_pants_ignore() {
   let (tempdir, file_path) = setup_fs();
   let build_root = tempdir.path().to_path_buf();
   let file_path_rel = file_path
@@ -97,12 +84,8 @@ fn ignore_file_events_matching_patterns_in_pants_ignore() {
 
   let invalidatable = Arc::new(TestInvalidatable::default());
   let ignorer = GitignoreStyleExcludes::create(vec!["/foo".to_string()]).unwrap();
-  let _watcher = setup_watch(
-    ignorer,
-    invalidatable.clone(),
-    build_root.clone(),
-    file_path.clone(),
-  );
+  let watcher = setup_watch(ignorer, build_root, file_path.clone()).await;
+  watcher.start(&invalidatable);
 
   // Update the content of the file being watched.
   let new_content = "stnetnoc".as_bytes().to_vec();
@@ -118,30 +101,42 @@ fn ignore_file_events_matching_patterns_in_pants_ignore() {
   }
 }
 
-#[test]
-fn test_liveness() {
-  let (tempdir, _) = setup_fs();
+#[tokio::test]
+async fn liveness_watch_error() {
+  let (tempdir, file_path) = setup_fs();
   let build_root = tempdir.path().to_path_buf();
 
   let invalidatable = Arc::new(TestInvalidatable::default());
   let ignorer = GitignoreStyleExcludes::empty();
+  // NB: We create this watcher, but we don't call start: instead we create the background thread
+  // directly.
+  let _watcher = setup_watch(ignorer.clone(), build_root.clone(), file_path.clone()).await;
   let (liveness_sender, liveness_receiver) = crossbeam_channel::unbounded();
   let (event_sender, event_receiver) = crossbeam_channel::unbounded();
-  InvalidationWatcher::start_background_thread(
+  let join_handle = InvalidationWatcher::start_background_thread(
     Arc::downgrade(&invalidatable),
     ignorer,
     build_root,
     liveness_sender,
     event_receiver,
   );
+
+  // Should not exit.
+  assert_eq!(
+    Err(RecvTimeoutError::Timeout),
+    liveness_receiver.recv_timeout(Duration::from_millis(100))
+  );
   event_sender
     .send(Err(notify::Error::generic(
       "This should kill the background thread",
     )))
     .unwrap();
+
+  // Should exit.
   assert!(liveness_receiver
-    .recv_timeout(Duration::from_millis(100))
+    .recv_timeout(Duration::from_millis(1000))
     .is_ok());
+  join_handle.join().unwrap();
 }
 
 #[derive(Default)]

--- a/tests/python/pants_test/integration/goal_rule_integration_test.py
+++ b/tests/python/pants_test/integration/goal_rule_integration_test.py
@@ -61,18 +61,29 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
 
             # Launch the loop as a background process.
             handle = self.run_pants_with_workdir_without_waiting(
-                ["--no-v1", "--v2", "--loop", "--loop-max=3", "list", f"{tmpdir}:"],
+                # NB: We disable watchman here because in the context of `--loop`, the total count
+                # of invalidations matters, and with both `notify` and `watchman` enabled we get
+                # twice as many.
+                [
+                    "--no-v1",
+                    "--v2",
+                    "--no-watchman-enable",
+                    "--loop",
+                    "--loop-max=3",
+                    "list",
+                    f"{tmpdir}:",
+                ],
                 workdir,
                 config,
             )
 
-            # Wait for the loop to stabilize.
-            time.sleep(10)
+            # Wait for pantsd to come up and for the loop to stabilize.
             checker.assert_started()
+            time.sleep(10)
 
             # Replace the BUILD file content twice.
             dump('target(name="two")')
-            time.sleep(5)
+            time.sleep(10)
             dump('target(name="three")')
 
             # Verify that the three different target states were listed, and that the process exited.

--- a/tests/python/pants_test/pantsd/service/test_fs_event_service.py
+++ b/tests/python/pants_test/pantsd/service/test_fs_event_service.py
@@ -12,40 +12,22 @@ from pants.testutil.test_base import TestBase
 class TestFSEventService(TestBase):
     BUILD_ROOT = "/build_root"
     EMPTY_EVENT = (None, None)
-    FAKE_EVENT = ("test", dict(subscription="test", files=["a/BUILD", "b/BUILD"]))
-    FAKE_EVENT_STREAM = [FAKE_EVENT, EMPTY_EVENT, EMPTY_EVENT, FAKE_EVENT, EMPTY_EVENT]
+    FAKE_EVENT = dict(subscription="test", files=["a/BUILD", "b/BUILD"])
+    FAKE_EVENT_STREAM = [
+        ("ignored", ev) for ev in [FAKE_EVENT, EMPTY_EVENT, EMPTY_EVENT, FAKE_EVENT, EMPTY_EVENT]
+    ]
     WORKER_COUNT = 1
 
     def setUp(self):
         super().setUp()
         self.mock_watchman = unittest.mock.create_autospec(Watchman, spec_set=True)
-        self.service = FSEventService(self.mock_watchman, self.BUILD_ROOT)
+        self.service = FSEventService(self.mock_watchman, self.scheduler.scheduler, self.BUILD_ROOT)
         self.service.setup(None)
-        self.service.register_all_files_handler(lambda x: True, name="test")
-        self.service.register_all_files_handler(lambda x: False, name="test2")
-
-    def test_registration(self):
-        # N.B. This test implicitly tests register_handler; no need to duplicate work.
-        self.assertTrue("test" in self.service._handlers)
-        self.assertTrue("test2" in self.service._handlers)
-        self.assertIsInstance(self.service._handlers["test"], Watchman.EventHandler)
-        self.assertIsInstance(self.service._handlers["test2"], Watchman.EventHandler)
-
-    def test_register_handler_duplicate(self):
-        with self.assertRaises(AssertionError):
-            self.service.register_handler("test", "test", lambda x: True)
-
-        with self.assertRaises(AssertionError):
-            self.service.register_handler("test", dict(test=1), lambda x: True)
-
-    def test_fire_callback(self):
-        self.assertTrue(self.service.fire_callback("test", {}))
-        self.assertFalse(self.service.fire_callback("test2", {}))
 
     @contextmanager
     def mocked_run(self, asserts=True):
-        self.service.fire_callback = unittest.mock.Mock()
-        yield self.service.fire_callback
+        self.service._handle_all_files_event = unittest.mock.Mock()
+        yield self.service._handle_all_files_event
         if asserts:
             self.mock_watchman.watch_project.assert_called_once_with(self.BUILD_ROOT)
 
@@ -59,17 +41,7 @@ class TestFSEventService(TestBase):
             self.mock_watchman.subscribed.return_value = self.FAKE_EVENT_STREAM
             self.service.run()
             mock_callback.assert_has_calls(
-                [unittest.mock.call(*self.FAKE_EVENT), unittest.mock.call(*self.FAKE_EVENT)],
-                any_order=True,
-            )
-
-    def test_run_failed_callback(self):
-        with self.mocked_run() as mock_callback:
-            self.mock_watchman.subscribed.return_value = self.FAKE_EVENT_STREAM
-            mock_callback.side_effect = [False, True]
-            self.service.run()
-            mock_callback.assert_has_calls(
-                [unittest.mock.call(*self.FAKE_EVENT), unittest.mock.call(*self.FAKE_EVENT)],
+                [unittest.mock.call(self.FAKE_EVENT), unittest.mock.call(self.FAKE_EVENT)],
                 any_order=True,
             )
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -303,7 +303,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             # Check the logs.
             ctx.checker.assert_running()
             self.assertRegex(
-                full_pantsd_log(), r"watching invalidating files:.*{}".format(test_dir)
+                full_pantsd_log(), r"watching invalidation patterns:.*{}".format(test_dir)
             )
 
             # Create a new file in test_dir
@@ -313,7 +313,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
                 ctx.checker.assert_stopped()
 
-            self.assertIn("saw file events covered by invalidation globs", full_pantsd_log())
+            self.assertIn("saw filesystem changes covered by invalidation globs", full_pantsd_log())
 
     def test_pantsd_invalidation_pants_toml_file(self):
         # Test tmp_pants_toml (--pants-config-files=$tmp_pants_toml)'s removal


### PR DESCRIPTION
### Problem

A few different kinds of file watching span the boundary between the `SchedulerService` and `FSEventService`:
1. pantsd invalidation globs - how `pantsd` detects that its implementing code or config has changed
2. pidfile - watches `pantsd`'s pidfile to ensure that the daemon exits if it loses exclusivity
3. graph invalidation - any files changing in the workspace should invalidate the engine's `Graph`
4. `--loop` - implemented directly in the `SchedulerService`

Because of the semi-cyclic nature of the relationship between the `SchedulerService` and `FSEventService`, it's challenging to understand the interplay of these usecases. And, unsurprisingly, that lead to the `notify` crate implementation only satisfying one of them.

### Solution

The fundamental change in this PR is to add support for two new parameters to engine executions which are implemented by the `Graph`:
* `poll: bool` - When `poll` is enabled, a `product_request` will wait for the requested Nodes to have changed from their last-observed values before returning. When a poll waits, an optional `poll_delay` is applied before it returns to "debounce" polls.
* `timeout: Optional[Duration]` - When a `timeout` is set, a `product_request` will wait up to the given duration for the requested Node(s) to complete (including any time `poll`ing).

These features are then used by:
* `--loop`: uses `poll` (with a `poll_delay`, but without a `timeout`) to immediately re-run a `Goal` when its inputs have changed.
* invalidation globs and pidfile watching: use `poll` (with no `poll_delay`) and `timeout` to block their `SchedulerService` thread and watch for changes to those files.

### Result

The `FSEventService` and `SchedulerService` are decoupled, and each now interacts only with the `Scheduler`: `FSEventService` to push `watchman` events to the `Graph`, and the `SchedulerService` to pull invalidation information from the `Graph`.

Because all events now flow through the `Graph`, the `notify` crate has reached feature parity with `watchman`.

In followup changes we can remove the experimental flag, disable `watchman` (and thus the `FSEventService`) by default, and remove the dependency between `--loop` and `pantsd`.