### PR TITLE
Factor up filtering out non-Python targets

### DIFF
--- a/src/python/pants/backend/python/rules/importable_python_sources.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources.py
@@ -5,12 +5,14 @@ from dataclasses import dataclass
 
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
+from pants.backend.python.target_types import PythonRequirementsFileSources, PythonSources
+from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Snapshot
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
-from pants.engine.target import Sources, Targets
+from pants.engine.target import Sources, Target, Targets
 
 
 @dataclass(frozen=True)
@@ -18,11 +20,9 @@ class ImportablePythonSources:
     """Sources that can be imported and used by Python, e.g. with tools like Pytest or with `./pants
     run`.
 
-    Specifically, this will strip source roots, e.g. `src/python/f.py` -> `f.py`; and it will add
-    any missing `__init__.py` files to ensure that modules are recognized correctly.
-
-    Not every file need be a Python file. For example, this can include `files()` and
-    `resources()` targets.
+    Specifically, this will filter out to only have Python, resources(), and files() targets; will
+    strip source roots, e.g. `src/python/f.py` -> `f.py`; and will add any missing
+    `__init__.py` files to ensure that modules are recognized correctly.
 
     Not every Python application will need to request this type. For example, autoformatters like
     Black never need to actually import and run the Python code, so they do not need to use this.
@@ -33,8 +33,20 @@ class ImportablePythonSources:
 
 @rule
 async def prepare_python_sources(targets: Targets) -> ImportablePythonSources:
+    def is_relevant(tgt: Target) -> bool:
+        # NB: PythonRequirementsFileSources is a subclass of FilesSources. We filter it out so that
+        # requirements.txt is not included. If the user intended for the file to be included, they
+        # should use a normal `files()` target rather than `python_requirements()`.
+        return (
+            tgt.has_field(PythonSources)
+            or tgt.has_field(ResourcesSources)
+            or (tgt.has_field(FilesSources) and not tgt.has_field(PythonRequirementsFileSources))
+        )
+
     stripped_sources = await Get[SourceFiles](
-        AllSourceFilesRequest((tgt.get(Sources) for tgt in targets), strip_source_roots=True)
+        AllSourceFilesRequest(
+            (tgt.get(Sources) for tgt in targets if is_relevant(tgt)), strip_source_roots=True
+        )
     )
     init_injected = await Get[InitInjectedSnapshot](InjectInitRequest(stripped_sources.snapshot))
     return ImportablePythonSources(init_injected.snapshot)

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -24,13 +24,11 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.backend.python.target_types import (
     PythonCoverage,
     PythonInterpreterCompatibility,
-    PythonRequirementsFileSources,
     PythonSources,
     PythonTestsSources,
     PythonTestsTimeout,
 )
 from pants.core.goals.test import TestConfiguration, TestDebugRequest, TestOptions, TestResult
-from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DirectoriesToMerge, InputFilesContent
@@ -76,27 +74,16 @@ async def setup_pytest_for_target(
 
     test_addresses = Addresses((config.address,))
 
-    # TODO(John Sirois): PexInterpreterConstraints are gathered in the same way by the
-    #  `create_pex_from_target_closure` rule, factor up.
     transitive_targets = await Get[TransitiveTargets](Addresses, test_addresses)
     all_targets = transitive_targets.closure
 
-    # TODO: factor this up? It's mostly duplicated with pex_from_targets.py.
-    python_targets = []
-    resource_targets = []
-    for tgt in all_targets:
-        if tgt.has_field(PythonSources):
-            python_targets.append(tgt)
-        # NB: PythonRequirementsFileSources is a subclass of FilesSources. We filter it out so that
-        # requirements.txt is not included in the PEX and so that irrelevant changes to it (e.g.
-        # whitespace changes) do not invalidate the PEX.
-        if tgt.has_field(ResourcesSources) or (
-            tgt.has_field(FilesSources) and not tgt.has_field(PythonRequirementsFileSources)
-        ):
-            resource_targets.append(tgt)
-
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (tgt.get(PythonInterpreterCompatibility) for tgt in python_targets), python_setup
+        (
+            tgt[PythonInterpreterCompatibility]
+            for tgt in all_targets
+            if tgt.has_field(PythonInterpreterCompatibility)
+        ),
+        python_setup,
     )
 
     # Ensure all pexes we merge via PEX_PATH to form the test runner use the interpreter constraints
@@ -162,12 +149,17 @@ async def setup_pytest_for_target(
         Get[Pex](PexRequest, pytest_pex_request),
         Get[Pex](PexFromTargetsRequest, requirements_pex_request),
         Get[Pex](PexRequest, test_runner_pex_request),
-        Get[ImportablePythonSources](Targets(python_targets + resource_targets)),
+        Get[ImportablePythonSources](Targets(all_targets)),
         Get[SourceFiles](SpecifiedSourceFilesRequest, specified_source_files_request),
     ]
     if run_coverage:
         requests.append(
-            Get[CoverageConfig](CoverageConfigRequest(Targets(python_targets), is_test_time=True)),
+            Get[CoverageConfig](
+                CoverageConfigRequest(
+                    Targets((tgt for tgt in all_targets if tgt.has_field(PythonSources))),
+                    is_test_time=True,
+                )
+            ),
         )
 
     (


### PR DESCRIPTION
In two places, we duplicated the pattern of filtering out only `resources()`, `files()`, and Python targets, then calling `await Get[ImportablePythonSources]`. This filtering is to avoid including irrelevant things in the PEX, like avoiding including `java_library`.

This PR factors up the filtering to happen directly in the rule to return `ImportablePythonSources`.

[ci skip-rust-tests]
[ci skip-jvm-tests]