### PR TITLE
Simplify excluding the `requirements.txt` file generated from python_requirements()

### DIFF
--- a/src/python/pants/backend/python/rules/importable_python_sources.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
-from pants.backend.python.target_types import PythonRequirementsFileSources, PythonSources
+from pants.backend.python.target_types import PythonSources
 from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
@@ -34,13 +34,8 @@ class ImportablePythonSources:
 @rule
 async def prepare_python_sources(targets: Targets) -> ImportablePythonSources:
     def is_relevant(tgt: Target) -> bool:
-        # NB: PythonRequirementsFileSources is a subclass of FilesSources. We filter it out so that
-        # requirements.txt is not included. If the user intended for the file to be included, they
-        # should use a normal `files()` target rather than `python_requirements()`.
-        return (
-            tgt.has_field(PythonSources)
-            or tgt.has_field(ResourcesSources)
-            or (tgt.has_field(FilesSources) and not tgt.has_field(PythonRequirementsFileSources))
+        return any(
+            tgt.has_field(field) for field in (PythonSources, ResourcesSources, FilesSources)
         )
 
     stripped_sources = await Get[SourceFiles](

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -414,9 +414,7 @@ class PythonRequirementLibrary(Target):
 # -----------------------------------------------------------------------------------------------
 
 
-# NB: This subclasses FilesSources to ensure that we still properly handle stripping source roots,
-# but we still new type so that we can distinguish between normal FilesSources vs. this field.
-class PythonRequirementsFileSources(FilesSources):
+class PythonRequirementsFileSources(Sources):
     pass
 
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -6,7 +6,6 @@ from typing import Iterable, Optional, Tuple, Union, cast
 
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
-from pants.core.target_types import FilesSources
 from pants.core.util_rules.determine_source_files import SourceFiles
 from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot


### PR DESCRIPTION
We never want to include the generated `requirements.txt` created by `python_requirements()`. 

Previously, we had to explicitly exclude it because we had `PythonRequirementsFileSources` subclass `FilesSources`. There was no good reason for this. Instead, it can simply subclass  `Sources` so be a stand-alone type.

[ci skip-jvm-tests]
[ci skip-rust-tests]