### PR TITLE
Fix selectors test for Python 3.8

### DIFF
--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -74,7 +74,6 @@ class Get(Generic[_Product]):
             )
         if len(args) == 2:
             product, subject = args
-
             if isinstance(subject, (type, TypeConstraint)):
                 raise TypeError(
                     dedent(


### PR DESCRIPTION
### Problem

The `test_extract_constriants` test hard-coded the names of several ast nodes as reported by the Python standard library `ast` module, using the versions of these names for Python 3.6. Between Python 3.6 and Python 3.8, the names of these nodes changed slightly ("Num" and "Str" both became "Constant"). So the test was breaking on Python 3.8.

### Solution

Have the test compute the versions of these names according to the local interpreter version, ensuring that this test will pass for both versions of Python. This was tested locally under both Python 3.6 and Python 3.8.
