### PR TITLE
Use sysconfig.get_platform()

### DIFF
--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -5,7 +5,6 @@ python_library(
   dependencies=[
     '3rdparty/python:dataclasses',
     '3rdparty/python:pex',
-    '3rdparty/python:wheel',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/native/config',
     'src/python/pants/backend/native/subsystems',

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -5,10 +5,10 @@ import glob
 import os
 import re
 import shutil
+import sysconfig
 from pathlib import Path
 
 from pex.interpreter import PythonInterpreter
-from wheel import pep425tags
 
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
@@ -248,7 +248,8 @@ class BuildLocalPythonDistributions(Task):
         egg_info_snapshot_tag_args = ["egg_info", f"--tag-build=+{snapshot_fingerprint}"]
         bdist_whl_args = ["bdist_wheel"]
         if is_platform_specific:
-            platform_args = ["--plat-name", pep425tags.get_platform()]
+            platform = sysconfig.get_platform().replace(".", "_").replace("-", "_")
+            platform_args = ["--plat-name", platform]
         else:
             platform_args = []
 

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python:wheel',
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/engine/internals:scheduler_test_base',

--- a/tests/python/pants_test/backend/python/tasks/util/wheel.py
+++ b/tests/python/pants_test/backend/python/tasks/util/wheel.py
@@ -2,14 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import sysconfig
 from os import PathLike
 from typing import Tuple, Union
 
-from wheel import pep425tags
-
 
 def _normalize_platform_tag(platform_tag: str) -> str:
-    return platform_tag.replace("-", "_")
+    return platform_tag.replace("-", "_").replace(".", "_")
 
 
 def name_and_platform(whl: Union[str, PathLike]) -> Tuple[str, str, str]:
@@ -26,4 +25,4 @@ def name_and_platform(whl: Union[str, PathLike]) -> Tuple[str, str, str]:
 
 
 def normalized_current_platform() -> str:
-    return _normalize_platform_tag(pep425tags.get_platform())
+    return _normalize_platform_tag(sysconfig.get_platform())


### PR DESCRIPTION
https://docs.python.org/3.7/library/sysconfig.html#sysconfig.get_platform
https://github.com/pypa/wheel/pull/346
https://github.com/pypa/wheel/issues/335#issuecomment-580155195


### Problem

We are calling what is effectively deprecated/dead code.
See https://github.com/pypa/wheel/issues/335#issuecomment-580155195  and https://github.com/pypa/wheel/pull/346
This currently prevents us from upgrading to a newer version of wheel (in which get_platform takes a param)

### Solution

Use the python's standard library solution: https://docs.python.org/3/library/sysconfig.html and normalize the return value

### Result

Being able to upgrade wheel, using more supported code, thus making things more robust.