### PR TITLE
Use ExitStack from python standard library.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,6 @@
 ansicolors==1.1.8
 beautifulsoup4>=4.6.0,<4.7
 cffi==1.13.2
-contextlib2==0.5.5
 coverage>=4.5,<4.6
 dataclasses==0.6
 docutils==0.14

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -32,7 +32,6 @@ python_library(
   name = 'nailgun_io',
   sources = ['nailgun_io.py'],
   dependencies = [
-    '3rdparty/python:contextlib2',
     ':nailgun_protocol'
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -5,9 +5,7 @@ import io
 import os
 import select
 import threading
-from contextlib import contextmanager
-
-from contextlib2 import ExitStack
+from contextlib import ExitStack, contextmanager
 
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 


### PR DESCRIPTION
### Problem

We have an external dependency that we don't need.

### Solution

This is the only (last?) place we were using contextlib2, the ExitStack class was added to the standard library in Python 3.3
https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack

### Result
One less external dependency.