### PR TITLE
Upgrade wheel from 0.33.6 to 0.34.2

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -38,5 +38,5 @@ setproctitle==1.1.10
 setuptools==44.0.0
 toml==0.10.0
 typing-extensions==3.7.4
-wheel==0.33.6
+wheel==0.34.2
 www-authenticate==0.9.2

--- a/src/python/pants/python/setup_py_runner.py
+++ b/src/python/pants/python/setup_py_runner.py
@@ -43,7 +43,7 @@ class SetupPyRunner:
                 "--wheel-version",
                 advanced=True,
                 fingerprint=True,
-                default="0.33.6",
+                default="0.34.2",
                 help="The wheel version to use when executing `setup.py` scripts.",
             )
 


### PR DESCRIPTION
[Release notes](https://github.com/pypa/wheel/blob/master/docs/news.rst):

**0.34.2 (2020-01-30)**

- Fixed installation of ``wheel`` from sdist on environments without Unicode
  file name support

**0.34.1 (2020-01-27)**

- Fixed installation of ``wheel`` from sdist which was broken due to a chicken
  and egg problem with PEP 517 and setuptools_scm

**0.34.0 (2020-01-27)**

- Dropped Python 3.4 support
- Added automatic platform tag detection for macOS binary wheels
  (PR by Grzegorz Bokota)
- Added the ``--compression=`` option to the ``bdist_wheel`` command
- Fixed PyPy tag generation to work with the updated semantics (#328)
- Updated project packaging and testing configuration for :pep:`517`
- Moved the contents of setup.py to setup.cfg
- Fixed duplicate RECORD file when using ``wheel pack`` on Windows
- Fixed bdist_wheel failing at cleanup on Windows with a read-only source tree
- Fixed ``wheel pack`` not respecting the existing build tag in ``WHEEL``
- Switched the project to use the "src" layout
- Switched to setuptools_scm_ for versioning