### PR TITLE
Port the finding of owning targets to the Target API

### DIFF
--- a/src/python/pants/engine/internals/BUILD
+++ b/src/python/pants/engine/internals/BUILD
@@ -96,7 +96,6 @@ python_library(
     '3rdparty/python:dataclasses',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:specs',
-    'src/python/pants/engine/legacy:address_mapper',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/engine/legacy:structs',
     'src/python/pants/engine:addresses',

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -25,14 +25,16 @@ from pants.engine.addresses import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot, SourcesSnapshot, SourcesSnapshots
 from pants.engine.internals.parser import HydratedStruct
-from pants.engine.legacy.address_mapper import LegacyAddressMapper
-from pants.engine.legacy.graph import HydratedField, HydratedTarget, HydratedTargets, logger
+from pants.engine.legacy.graph import HydratedField, logger
 from pants.engine.legacy.structs import HydrateableField, SourcesField, TargetAdaptor
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
+    HydratedSources,
+    HydrateSourcesRequest,
     RegisteredTargetTypes,
+    Sources,
     Target,
     Targets,
     TargetsWithOrigins,
@@ -199,33 +201,24 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
     sources_set = FrozenOrderedSet(owners_request.sources)
     dirs_set = FrozenOrderedSet(os.path.dirname(source) for source in sources_set)
 
-    # Walk up the buildroot looking for targets that would conceivably claim changed sources.
     candidate_specs = tuple(AscendantAddresses(directory=d) for d in dirs_set)
-    candidate_targets = await Get[HydratedTargets](AddressSpecs(candidate_specs))
+    candidate_targets = await Get[Targets](AddressSpecs(candidate_specs))
+    candidate_hydrated_sources = await MultiGet(
+        Get[HydratedSources](HydrateSourcesRequest(tgt.get(Sources))) for tgt in candidate_targets
+    )
 
-    # Match the source globs against the expanded candidate targets.
-    def owns_any_source(legacy_target: HydratedTarget) -> bool:
-        """Given a `HydratedTarget` instance, check if it owns the given source file."""
-        target_kwargs = legacy_target.adaptor.kwargs()
-
-        # Handle `sources`-declaring targets.
-        # NB: Deleted files can only be matched against the 'filespec' (ie, `PathGlobs`) for a target,
-        # so we don't actually call `fileset.matches` here.
-        # TODO: This matching logic should be implemented using the rust `fs` crate for two reasons:
-        #  1) having two implementations isn't great
-        #  2) we're expanding sources via HydratedTarget, but it isn't necessary to do that to match
-        target_sources = target_kwargs.get("sources", None)
-        return target_sources and any_matches_filespec(
-            paths=sources_set, spec=target_sources.filespec
-        )
+    def owns_any_source(hydrated_sources: HydratedSources) -> bool:
+        intersecting_files = sources_set.intersection(hydrated_sources.snapshot.files)
+        return bool(intersecting_files)
 
     build_file_addresses = await MultiGet(
-        Get[BuildFileAddress](Address, ht.adaptor.address) for ht in candidate_targets
+        Get[BuildFileAddress](Address, tgt.address) for tgt in candidate_targets
     )
+
     owners = Addresses(
-        ht.adaptor.address
-        for ht, bfa in zip(candidate_targets, build_file_addresses)
-        if LegacyAddressMapper.any_is_declaring_file(bfa, sources_set) or owns_any_source(ht)
+        bfa.to_address()
+        for bfa, hydrated_sources in zip(build_file_addresses, candidate_hydrated_sources)
+        if owns_any_source(hydrated_sources) or bfa.rel_path in sources_set
     )
     return Owners(owners)
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -31,8 +31,6 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
-    HydratedSources,
-    HydrateSourcesRequest,
     RegisteredTargetTypes,
     Sources,
     Target,

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -4,7 +4,8 @@
 from textwrap import dedent
 
 # TODO: Create a dummy target type in this test and remove this dep.
-from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.target_types import JavaLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary as JavaLibraryV1
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.graph import Owners, OwnersRequest
 from pants.testutil.test_base import TestBase
@@ -13,7 +14,11 @@ from pants.testutil.test_base import TestBase
 class SourceMapperTest(TestBase):
     @classmethod
     def alias_groups(cls):
-        return BuildFileAliases(targets={"java_library": JavaLibrary})
+        return BuildFileAliases(targets={"java_library": JavaLibraryV1})
+
+    @classmethod
+    def target_types(cls):
+        return [JavaLibrary]
 
     def owner(self, owner, f):
         request = OwnersRequest(sources=(f,))

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -84,7 +84,6 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 40,
 )
 
 python_tests(


### PR DESCRIPTION
Results in a ~15% speedup running `./v2 list-v2 '**/*'`, likely from no longer hydrating the `Sources` field. Note that the benchmark uses file args to ensure the rule `owner_of` gets executed.

![benchmark](https://user-images.githubusercontent.com/14852634/80551027-e76c4480-8976-11ea-8186-5735df7af3f0.png)

(See https://docs.google.com/spreadsheets/d/1_7wC0qYCrEYqVb0LKHfV8QreApoMRn2EpzF8ytneU-8/edit?usp=sharing for original data. I ran `./v2 list-v2 '**/*'` 5 times each.)

[ci skip-rust-tests]
[ci skip-jvm-tests]