### PR TITLE
Upgrade PyYAML 5.1.2 to 5.3.1

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -30,7 +30,7 @@ pyopenssl==17.3.0
 pystache==0.5.3
 python-Levenshtein==0.12.0
 pywatchman==1.4.1
-PyYAML==5.3.1
+PyYAML>=5.3.1,<5.4
 py_zipkin==0.18.4
 requests[security]>=2.20.1
 responses==0.10.4

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -30,7 +30,7 @@ pyopenssl==17.3.0
 pystache==0.5.3
 python-Levenshtein==0.12.0
 pywatchman==1.4.1
-PyYAML==5.1.2
+PyYAML==5.3.1
 py_zipkin==0.18.4
 requests[security]>=2.20.1
 responses==0.10.4


### PR DESCRIPTION
https://github.com/yaml/pyyaml/blob/d0d660d035905d9c49fc0f8dafb579d2cc68c0c8/CHANGES#L7

5.3.1 (2020-03-18)

* https://github.com/yaml/pyyaml/pull/386 -- Prevents arbitrary code execution during python/object/new constructor

5.3 (2020-01-06)

* https://github.com/yaml/pyyaml/pull/290 -- Use `is` instead of equality for comparing with `None`
* https://github.com/yaml/pyyaml/pull/270 -- fix typos and stylistic nit
* https://github.com/yaml/pyyaml/pull/309 -- Fix up small typo
* https://github.com/yaml/pyyaml/pull/161 -- Fix handling of __slots__
* https://github.com/yaml/pyyaml/pull/358 -- Allow calling add_multi_constructor with None
* https://github.com/yaml/pyyaml/pull/285 -- Add use of safe_load() function in README
* https://github.com/yaml/pyyaml/pull/351 -- Fix reader for Unicode code points over 0xFFFF
* https://github.com/yaml/pyyaml/pull/360 -- Enable certain unicode tests when maxunicode not > 0xffff
* https://github.com/yaml/pyyaml/pull/359 -- Use full_load in yaml-highlight example
* https://github.com/yaml/pyyaml/pull/244 -- Document that PyYAML is implemented with Cython
* https://github.com/yaml/pyyaml/pull/329 -- Fix for Python 3.10
* https://github.com/yaml/pyyaml/pull/310 -- increase size of index, line, and column fields
* https://github.com/yaml/pyyaml/pull/260 -- remove some unused imports
* https://github.com/yaml/pyyaml/pull/163 -- Create timezone-aware datetimes when parsed as such
* https://github.com/yaml/pyyaml/pull/363 -- Add tests for timezone

5.2 (2019-12-02)
------------------

* Repair incompatibilities introduced with 5.1. The default Loader was changed,
  but several methods like add_constructor still used the old default
  https://github.com/yaml/pyyaml/pull/279 -- A more flexible fix for custom tag constructors
  https://github.com/yaml/pyyaml/pull/287 -- Change default loader for yaml.add_constructor
  https://github.com/yaml/pyyaml/pull/305 -- Change default loader for add_implicit_resolver, add_path_resolver
* Make FullLoader safer by removing python/object/apply from the default FullLoader
  https://github.com/yaml/pyyaml/pull/347 -- Move constructor for object/apply to UnsafeConstructor
* Fix bug introduced in 5.1 where quoting went wrong on systems with sys.maxunicode <= 0xffff
  https://github.com/yaml/pyyaml/pull/276 -- Fix logic for quoting special characters
* Other PRs:
  https://github.com/yaml/pyyaml/pull/280 -- Update CHANGES for 5.1