### PR TITLE
Only write to the build root when V2 `fmt` makes changes

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -56,6 +56,7 @@ class SetupRequest:
 @dataclass(frozen=True)
 class Setup:
     process: Process
+    original_digest: Digest
 
 
 def generate_args(
@@ -144,7 +145,7 @@ async def setup(
             f"Run Black on {pluralize(len(request.configs), 'target')}: {address_references}."
         ),
     )
-    return Setup(process)
+    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
 
 
 @named_rule(desc="Format using Black")
@@ -153,7 +154,7 @@ async def black_fmt(configs: BlackConfigurations, black: Black) -> FmtResult:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(configs, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result)
+    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint using Black")

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -88,6 +88,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
@@ -96,6 +97,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be reformatted" in lint_result.stderr
         assert "1 file reformatted" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
@@ -104,6 +106,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
         assert "1 file reformatted, 1 file left unchanged", fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -115,6 +118,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
         assert "1 file reformatted, 1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
@@ -125,6 +129,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.did_change is False
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
@@ -135,6 +140,7 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.needs_config_source])
+        assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
@@ -145,9 +151,11 @@ class BlackIntegrationTest(TestBase):
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.digest == self.get_digest([self.needs_config_source])
+        assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         lint_result, fmt_result = self.run_black([target], skip=True)
         assert lint_result == LintResult.noop()
         assert fmt_result == FmtResult.noop()
+        assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -87,7 +87,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
@@ -96,7 +96,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 1
         assert "1 file would be reformatted" in lint_result.stderr
         assert "1 file reformatted" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
@@ -105,7 +105,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 1
         assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
         assert "1 file reformatted, 1 file left unchanged", fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
@@ -117,7 +117,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 1
         assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
         assert "1 file reformatted, 1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
@@ -128,7 +128,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
     def test_respects_config_file(self) -> None:
@@ -139,7 +139,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.needs_config_source])
+        assert fmt_result.output == self.get_digest([self.needs_config_source])
         assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
@@ -150,7 +150,7 @@ class BlackIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert "1 file would be left unchanged" in lint_result.stderr
         assert "1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.digest == self.get_digest([self.needs_config_source])
+        assert fmt_result.output == self.get_digest([self.needs_config_source])
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -53,6 +53,7 @@ class SetupRequest:
 @dataclass(frozen=True)
 class Setup:
     process: Process
+    original_digest: Digest
 
 
 def generate_args(
@@ -122,7 +123,7 @@ async def setup(
             f"{address_references}."
         ),
     )
-    return Setup(process)
+    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
 
 
 @named_rule(desc="Format Python docstrings with docformatter")
@@ -133,7 +134,7 @@ async def docformatter_fmt(
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(configs, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result)
+    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint Python docstrings with docformatter")

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -81,7 +81,7 @@ class DocformatterIntegrationTest(TestBase):
         target = self.make_target_with_origin([self.good_source])
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result == LintResult.noop()
-        assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
@@ -89,7 +89,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
-        assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
@@ -97,7 +97,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
@@ -108,7 +108,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result, fmt_result = self.run_docformatter(targets)
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
@@ -117,7 +117,7 @@ class DocformatterIntegrationTest(TestBase):
         )
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result == LintResult.noop()
-        assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
@@ -130,7 +130,7 @@ class DocformatterIntegrationTest(TestBase):
             [target], passthrough_args="--make-summary-multi-line"
         )
         assert lint_result == LintResult.noop()
-        assert fmt_result.digest == self.get_digest([needs_config])
+        assert fmt_result.output == self.get_digest([needs_config])
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -82,6 +82,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result == LintResult.noop()
         assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
@@ -89,6 +90,7 @@ class DocformatterIntegrationTest(TestBase):
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
         assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
@@ -96,6 +98,7 @@ class DocformatterIntegrationTest(TestBase):
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -106,6 +109,7 @@ class DocformatterIntegrationTest(TestBase):
         assert lint_result.exit_code == 3
         assert lint_result.stderr.strip() == self.bad_source.path
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
@@ -114,6 +118,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result, fmt_result = self.run_docformatter([target])
         assert lint_result == LintResult.noop()
         assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
         needs_config = FileContent(
@@ -126,9 +131,11 @@ class DocformatterIntegrationTest(TestBase):
         )
         assert lint_result == LintResult.noop()
         assert fmt_result.digest == self.get_digest([needs_config])
+        assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         lint_result, fmt_result = self.run_docformatter([target], skip=True)
         assert lint_result == LintResult.noop()
         assert fmt_result == FmtResult.noop()
+        assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -55,6 +55,7 @@ class SetupRequest:
 @dataclass(frozen=True)
 class Setup:
     process: Process
+    original_digest: Digest
 
 
 def generate_args(
@@ -137,7 +138,7 @@ async def setup(
             f"Run isort on {pluralize(len(request.configs), 'target')}: {address_references}."
         ),
     )
-    return Setup(process)
+    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
 
 
 @named_rule(desc="Format using isort")
@@ -146,7 +147,7 @@ async def isort_fmt(configs: IsortConfigurations, isort: Isort) -> FmtResult:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(configs, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result)
+    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint using isort")

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -95,6 +95,7 @@ class IsortIntegrationTest(TestBase):
         assert lint_result.stdout == ""
         assert fmt_result.stdout == ""
         assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
@@ -104,6 +105,7 @@ class IsortIntegrationTest(TestBase):
         assert "Fixing" in fmt_result.stdout
         assert "bad.py" in fmt_result.stdout
         assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
@@ -114,6 +116,7 @@ class IsortIntegrationTest(TestBase):
         assert "Fixing" in fmt_result.stdout and "bad.py" in fmt_result.stdout
         assert "good.py" not in fmt_result.stdout
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -127,6 +130,7 @@ class IsortIntegrationTest(TestBase):
         assert "Fixing" in fmt_result.stdout and "bad.py" in fmt_result.stdout
         assert "good.py" not in fmt_result.stdout
         assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
@@ -137,6 +141,7 @@ class IsortIntegrationTest(TestBase):
         assert lint_result.stdout == ""
         assert fmt_result.stdout == ""
         assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.did_change is False
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
@@ -148,6 +153,7 @@ class IsortIntegrationTest(TestBase):
         assert "Fixing" in fmt_result.stdout
         assert "config.py" in fmt_result.stdout
         assert fmt_result.digest == self.get_digest([self.fixed_needs_config_source])
+        assert fmt_result.did_change is True
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
@@ -157,9 +163,11 @@ class IsortIntegrationTest(TestBase):
         assert "Fixing" in fmt_result.stdout
         assert "config.py" in fmt_result.stdout
         assert fmt_result.digest == self.get_digest([self.fixed_needs_config_source])
+        assert fmt_result.did_change is True
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         lint_result, fmt_result = self.run_isort([target], skip=True)
         assert lint_result == LintResult.noop()
         assert fmt_result == FmtResult.noop()
+        assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -94,7 +94,7 @@ class IsortIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert lint_result.stdout == ""
         assert fmt_result.stdout == ""
-        assert fmt_result.digest == self.get_digest([self.good_source])
+        assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
@@ -104,7 +104,7 @@ class IsortIntegrationTest(TestBase):
         assert "bad.py Imports are incorrectly sorted" in lint_result.stdout
         assert "Fixing" in fmt_result.stdout
         assert "bad.py" in fmt_result.stdout
-        assert fmt_result.digest == self.get_digest([self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
@@ -115,7 +115,7 @@ class IsortIntegrationTest(TestBase):
         assert "good.py" not in lint_result.stdout
         assert "Fixing" in fmt_result.stdout and "bad.py" in fmt_result.stdout
         assert "good.py" not in fmt_result.stdout
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_multiple_targets(self) -> None:
@@ -129,7 +129,7 @@ class IsortIntegrationTest(TestBase):
         assert "good.py" not in lint_result.stdout
         assert "Fixing" in fmt_result.stdout and "bad.py" in fmt_result.stdout
         assert "good.py" not in fmt_result.stdout
-        assert fmt_result.digest == self.get_digest([self.good_source, self.fixed_bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_precise_file_args(self) -> None:
@@ -140,7 +140,7 @@ class IsortIntegrationTest(TestBase):
         assert lint_result.exit_code == 0
         assert lint_result.stdout == ""
         assert fmt_result.stdout == ""
-        assert fmt_result.digest == self.get_digest([self.good_source, self.bad_source])
+        assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
     def test_respects_config_file(self) -> None:
@@ -152,7 +152,7 @@ class IsortIntegrationTest(TestBase):
         assert "config.py Imports are incorrectly sorted" in lint_result.stdout
         assert "Fixing" in fmt_result.stdout
         assert "config.py" in fmt_result.stdout
-        assert fmt_result.digest == self.get_digest([self.fixed_needs_config_source])
+        assert fmt_result.output == self.get_digest([self.fixed_needs_config_source])
         assert fmt_result.did_change is True
 
     def test_respects_passthrough_args(self) -> None:
@@ -162,7 +162,7 @@ class IsortIntegrationTest(TestBase):
         assert "config.py Imports are incorrectly sorted" in lint_result.stdout
         assert "Fixing" in fmt_result.stdout
         assert "config.py" in fmt_result.stdout
-        assert fmt_result.digest == self.get_digest([self.fixed_needs_config_source])
+        assert fmt_result.output == self.get_digest([self.fixed_needs_config_source])
         assert fmt_result.did_change is True
 
     def test_skip(self) -> None:

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -58,9 +58,14 @@ async def format_python_target(
         )
         if result != FmtResult.noop():
             results.append(result)
+        if result.did_change:
             prior_formatter_result = await Get[Snapshot](Digest, result.digest)
     return LanguageFmtResults(
-        tuple(results), combined_digest=prior_formatter_result.directory_digest
+        tuple(results),
+        combined_digest=prior_formatter_result.directory_digest,
+        did_change=(
+            prior_formatter_result.directory_digest != original_sources.snapshot.directory_digest
+        ),
     )
 
 

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -59,13 +59,11 @@ async def format_python_target(
         if result != FmtResult.noop():
             results.append(result)
         if result.did_change:
-            prior_formatter_result = await Get[Snapshot](Digest, result.digest)
+            prior_formatter_result = await Get[Snapshot](Digest, result.output)
     return LanguageFmtResults(
         tuple(results),
-        combined_digest=prior_formatter_result.directory_digest,
-        did_change=(
-            prior_formatter_result.directory_digest != original_sources.snapshot.directory_digest
-        ),
+        input=original_sources.snapshot.directory_digest,
+        output=prior_formatter_result.directory_digest,
     )
 
 

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -62,6 +62,7 @@ class PythonFmtIntegrationTest(TestBase):
         )
         results = self.run_black_and_isort([original_source], name="same_file")
         assert results.combined_digest == self.get_digest([fixed_source])
+        assert results.did_change is True
 
     def test_multiple_formatters_changing_different_files(self) -> None:
         original_sources = [
@@ -74,6 +75,7 @@ class PythonFmtIntegrationTest(TestBase):
         ]
         results = self.run_black_and_isort(original_sources, name="different_file")
         assert results.combined_digest == self.get_digest(fixed_sources)
+        assert results.did_change is True
 
     def test_skipped_formatter(self) -> None:
         """Ensure that a skipped formatter does not interfere with other formatters."""
@@ -87,3 +89,12 @@ class PythonFmtIntegrationTest(TestBase):
             [original_source], name="skipped", extra_args=["--black-skip"]
         )
         assert results.combined_digest == self.get_digest([fixed_source])
+        assert results.did_change is True
+
+    def test_no_changes(self) -> None:
+        source = FileContent(
+            "test/skipped.py", content=b"from animals import dog, cat\n\nprint('hello')\n",
+        )
+        results = self.run_black_and_isort([source], name="different_file")
+        assert results.combined_digest == self.get_digest([source])
+        assert results.did_change is False

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -61,7 +61,7 @@ class PythonFmtIntegrationTest(TestBase):
             "test/target.py", content=b'from animals import cat, dog\n\nprint("hello")\n',
         )
         results = self.run_black_and_isort([original_source], name="same_file")
-        assert results.combined_digest == self.get_digest([fixed_source])
+        assert results.output == self.get_digest([fixed_source])
         assert results.did_change is True
 
     def test_multiple_formatters_changing_different_files(self) -> None:
@@ -74,7 +74,7 @@ class PythonFmtIntegrationTest(TestBase):
             FileContent("test/black.py", content=b'print("hello")\n'),
         ]
         results = self.run_black_and_isort(original_sources, name="different_file")
-        assert results.combined_digest == self.get_digest(fixed_sources)
+        assert results.output == self.get_digest(fixed_sources)
         assert results.did_change is True
 
     def test_skipped_formatter(self) -> None:
@@ -88,7 +88,7 @@ class PythonFmtIntegrationTest(TestBase):
         results = self.run_black_and_isort(
             [original_source], name="skipped", extra_args=["--black-skip"]
         )
-        assert results.combined_digest == self.get_digest([fixed_source])
+        assert results.output == self.get_digest([fixed_source])
         assert results.did_change is True
 
     def test_no_changes(self) -> None:
@@ -96,5 +96,5 @@ class PythonFmtIntegrationTest(TestBase):
             "test/skipped.py", content=b"from animals import dog, cat\n\nprint('hello')\n",
         )
         results = self.run_black_and_isort([source], name="different_file")
-        assert results.combined_digest == self.get_digest([source])
+        assert results.output == self.get_digest([source])
         assert results.did_change is False

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -28,25 +28,31 @@ from pants.engine.unions import UnionMembership, union
 
 @dataclass(frozen=True)
 class FmtResult:
-    digest: Digest
+    input: Digest
+    output: Digest
     stdout: str
     stderr: str
-    did_change: bool
 
     @staticmethod
     def noop() -> "FmtResult":
-        return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="", did_change=False)
+        return FmtResult(
+            input=EMPTY_DIRECTORY_DIGEST, output=EMPTY_DIRECTORY_DIGEST, stdout="", stderr=""
+        )
 
     @staticmethod
     def from_process_result(
         process_result: ProcessResult, *, original_digest: Digest
     ) -> "FmtResult":
         return FmtResult(
-            digest=process_result.output_directory_digest,
+            input=original_digest,
+            output=process_result.output_directory_digest,
             stdout=process_result.stdout.decode(),
             stderr=process_result.stderr.decode(),
-            did_change=process_result.output_directory_digest != original_digest,
         )
+
+    @property
+    def did_change(self) -> bool:
+        return self.output != self.input
 
 
 class FmtConfiguration(LinterConfiguration, metaclass=ABCMeta):
@@ -92,15 +98,19 @@ class LanguageFmtTargets:
 class LanguageFmtResults:
     """This collection allows us to safely aggregate multiple `FmtResult`s for a language.
 
-    The `combined_digest` is used to ensure that none of the formatters overwrite each other. The
+    The `output` digest is used to ensure that none of the formatters overwrite each other. The
     language implementation should run each formatter one at a time and pipe the resulting digest of
-    one formatter into the next. The `combined_digest` must contain all files for the target,
-    including any which were not re-formatted.
+    one formatter into the next. The `input` and `output` digests must contain all files for the
+    target(s), including any which were not re-formatted.
     """
 
     results: Tuple[FmtResult, ...]
-    combined_digest: Digest
-    did_change: bool
+    input: Digest
+    output: Digest
+
+    @property
+    def did_change(self) -> bool:
+        return self.input != self.output
 
 
 class FmtOptions(GoalSubsystem):
@@ -217,16 +227,16 @@ async def fmt(
     if not individual_results:
         return Fmt(exit_code=0)
 
-    changed_combined_digests = tuple(
-        language_result.combined_digest
+    changed_digests = tuple(
+        language_result.output
         for language_result in per_language_results
         if language_result.did_change
     )
-    if changed_combined_digests:
+    if changed_digests:
         # NB: this will fail if there are any conflicting changes, which we want to happen rather
         # than silently having one result override the other. In practicality, this should never
-        # happen due to us grouping each language's formatters into a single combined_digest.
-        merged_formatted_digest = await Get[Digest](DirectoriesToMerge(changed_combined_digests))
+        # happen due to us grouping each language's formatters into a single digest.
+        merged_formatted_digest = await Get[Digest](DirectoriesToMerge(changed_digests))
         workspace.materialize_directory(DirectoryToMaterialize(merged_formatted_digest))
 
     for result in individual_results:

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -66,8 +66,9 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
         # not matter.
         digest = EMPTY_DIRECTORY_DIGEST
         return LanguageFmtResults(
-            (FmtResult(digest=digest, stdout=self.stdout(addresses), stderr=""),),
+            (FmtResult(digest=digest, stdout=self.stdout(addresses), stderr="", did_change=True),),
             combined_digest=digest,
+            did_change=True,
         )
 
 


### PR DESCRIPTION
We were always calling `workspace.materialize_directory`, even if no changes were made. Beyond this causing a hit to performance, this creates a negative experience for text editors, as they notice that the files have changed on disk so must reload their buffer.

Now, we track if changes were made by comparing the original digest to the resulting digest, and we only write if changes were made.

This improves the performance of `./v2 fmt src/python::` by roughly 2x in the case of a warm cache:

![benchmark](https://user-images.githubusercontent.com/14852634/80563808-f536bf80-89a0-11ea-90b2-966c050475db.png)

(See https://docs.google.com/spreadsheets/d/1_7wC0qYCrEYqVb0LKHfV8QreApoMRn2EpzF8ytneU-8/edit#gid=574760760. Note that this assumes a warm cache, i.e. that you already ran `./v2 fmt src/python::`.)

This will also allow us to do more intelligent things with the output in a followup.

[ci skip-rust-tests]
[ci skip-jvm-tests]