### PR TITLE
Align the rust and python PathGlobs objects

### DIFF
--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -357,7 +357,7 @@ fn make_core(
     types,
     intrinsics,
     PathBuf::from(build_root_buf.to_os_string()),
-    &ignore_patterns,
+    ignore_patterns,
     use_gitignore,
     PathBuf::from(local_store_dir_buf.to_os_string()),
     remote_execution,
@@ -906,12 +906,11 @@ pub extern "C" fn match_path_globs(path_globs: Handle, paths_buf: BufferBuffer) 
     }
   };
 
-  let paths = paths_buf
+  let matched = paths_buf
     .to_os_strings()
     .into_iter()
-    .map(PathBuf::from)
-    .collect::<Vec<_>>();
-  externs::store_bool(path_globs.matches(&paths)).into()
+    .any(|s| path_globs.matches(s.as_ref()));
+  externs::store_bool(matched).into()
 }
 
 #[no_mangle]

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -2,20 +2,332 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::{self, TryFutureExt};
-use glob::Pattern;
+use glob::{MatchOptions, Pattern};
+use lazy_static::lazy_static;
 use log::warn;
 use parking_lot::Mutex;
 
 use crate::{
-  Dir, GitignoreStyleExcludes, GlobExpansionConjunction, Link, PathGlob, PathGlobs, PathStat, Stat,
-  StrictGlobMatching, VFS,
+  Dir, GitignoreStyleExcludes, GlobExpansionConjunction, Link, PathStat, Stat, StrictGlobMatching,
+  VFS,
 };
+
+lazy_static! {
+  static ref PARENT_DIR: &'static str = "..";
+  static ref SINGLE_STAR_GLOB: Pattern = Pattern::new("*").unwrap();
+  static ref DOUBLE_STAR: &'static str = "**";
+  static ref DOUBLE_STAR_GLOB: Pattern = Pattern::new(*DOUBLE_STAR).unwrap();
+  static ref MISSING_GLOB_SOURCE: GlobParsedSource = GlobParsedSource(String::from(""));
+  static ref PATTERN_MATCH_OPTIONS: MatchOptions = MatchOptions {
+    require_literal_separator: true,
+    ..MatchOptions::default()
+  };
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PathGlob {
+  Wildcard {
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    wildcard: Pattern,
+  },
+  DirWildcard {
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    wildcard: Pattern,
+    remainder: Vec<Pattern>,
+  },
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct GlobParsedSource(String);
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PathGlobIncludeEntry {
+  pub input: GlobParsedSource,
+  pub globs: Vec<PathGlob>,
+}
+
+impl PathGlob {
+  fn wildcard(canonical_dir: Dir, symbolic_path: PathBuf, wildcard: Pattern) -> PathGlob {
+    PathGlob::Wildcard {
+      canonical_dir: canonical_dir,
+      symbolic_path: symbolic_path,
+      wildcard: wildcard,
+    }
+  }
+
+  fn dir_wildcard(
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    wildcard: Pattern,
+    remainder: Vec<Pattern>,
+  ) -> PathGlob {
+    PathGlob::DirWildcard {
+      canonical_dir: canonical_dir,
+      symbolic_path: symbolic_path,
+      wildcard: wildcard,
+      remainder: remainder,
+    }
+  }
+
+  pub fn create(filespecs: Vec<String>) -> Result<Vec<PathGlob>, String> {
+    // Getting a Vec<PathGlob> per filespec is needed to create a `PreparedPathGlobs`, but we don't
+    // need that here.
+    let filespecs_globs = Self::spread_filespecs(filespecs)?;
+    let all_globs = Self::flatten_entries(filespecs_globs);
+    Ok(all_globs)
+  }
+
+  fn flatten_entries(entries: Vec<PathGlobIncludeEntry>) -> Vec<PathGlob> {
+    entries.into_iter().flat_map(|entry| entry.globs).collect()
+  }
+
+  pub(crate) fn spread_filespecs(
+    filespecs: Vec<String>,
+  ) -> Result<Vec<PathGlobIncludeEntry>, String> {
+    let mut spec_globs_map = Vec::new();
+    for filespec in filespecs {
+      let canonical_dir = Dir(PathBuf::new());
+      let symbolic_path = PathBuf::new();
+      let globs = PathGlob::parse(canonical_dir, symbolic_path, &filespec)?;
+      spec_globs_map.push(PathGlobIncludeEntry {
+        input: GlobParsedSource(filespec),
+        globs,
+      });
+    }
+    Ok(spec_globs_map)
+  }
+
+  ///
+  /// Normalize the given glob pattern string by splitting it into path components, and dropping
+  /// references to the current directory, and consecutive '**'s.
+  ///
+  fn normalize_pattern(pattern: &str) -> Result<Vec<&OsStr>, String> {
+    let mut parts = Vec::new();
+    let mut prev_was_doublestar = false;
+    for component in Path::new(pattern).components() {
+      let part = match component {
+        Component::Prefix(..) | Component::RootDir => {
+          return Err(format!("Absolute paths not supported: {:?}", pattern));
+        }
+        Component::CurDir => continue,
+        c => c.as_os_str(),
+      };
+
+      // Ignore repeated doublestar instances.
+      let cur_is_doublestar = *DOUBLE_STAR == part;
+      if prev_was_doublestar && cur_is_doublestar {
+        continue;
+      }
+      prev_was_doublestar = cur_is_doublestar;
+
+      parts.push(part);
+    }
+    Ok(parts)
+  }
+
+  ///
+  /// Given a filespec String relative to a canonical Dir and path, parse it to a normalized
+  /// series of PathGlob objects.
+  ///
+  fn parse(
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    filespec: &str,
+  ) -> Result<Vec<PathGlob>, String> {
+    // NB: Because the filespec is a String input, calls to `to_str_lossy` are not lossy; the
+    // use of `Path` is strictly for os-independent Path parsing.
+    let parts = Self::normalize_pattern(filespec)?
+      .into_iter()
+      .map(|part| {
+        Pattern::new(&part.to_string_lossy())
+          .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", filespec, e))
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+
+    PathGlob::parse_globs(canonical_dir, symbolic_path, &parts)
+  }
+
+  ///
+  /// Given a filespec as Patterns, create a series of PathGlob objects.
+  ///
+  fn parse_globs(
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    parts: &[Pattern],
+  ) -> Result<Vec<PathGlob>, String> {
+    if parts.is_empty() {
+      Ok(vec![])
+    } else if *DOUBLE_STAR == parts[0].as_str() {
+      if parts.len() == 1 {
+        // Per https://git-scm.com/docs/gitignore:
+        //  "A trailing '/**' matches everything inside. For example, 'abc/**' matches all files
+        //  inside directory "abc", relative to the location of the .gitignore file, with infinite
+        //  depth."
+        return Ok(vec![
+          PathGlob::dir_wildcard(
+            canonical_dir.clone(),
+            symbolic_path.clone(),
+            SINGLE_STAR_GLOB.clone(),
+            vec![DOUBLE_STAR_GLOB.clone()],
+          ),
+          PathGlob::wildcard(canonical_dir, symbolic_path, SINGLE_STAR_GLOB.clone()),
+        ]);
+      }
+
+      // There is a double-wildcard in a dirname of the path: double wildcards are recursive,
+      // so there are two remainder possibilities: one with the double wildcard included, and the
+      // other without.
+      let pathglob_with_doublestar = PathGlob::dir_wildcard(
+        canonical_dir.clone(),
+        symbolic_path.clone(),
+        SINGLE_STAR_GLOB.clone(),
+        parts[0..].to_vec(),
+      );
+      let pathglob_no_doublestar = if parts.len() == 2 {
+        PathGlob::wildcard(canonical_dir, symbolic_path, parts[1].clone())
+      } else {
+        PathGlob::dir_wildcard(
+          canonical_dir,
+          symbolic_path,
+          parts[1].clone(),
+          parts[2..].to_vec(),
+        )
+      };
+      Ok(vec![pathglob_with_doublestar, pathglob_no_doublestar])
+    } else if *PARENT_DIR == parts[0].as_str() {
+      // A request for the parent of `canonical_dir`: since we've already expanded the directory
+      // to make it canonical, we can safely drop it directly and recurse without this component.
+      // The resulting symbolic path will continue to contain a literal `..`.
+      let mut canonical_dir_parent = canonical_dir;
+      let mut symbolic_path_parent = symbolic_path;
+      if !canonical_dir_parent.0.pop() {
+        let mut symbolic_path = symbolic_path_parent;
+        symbolic_path.extend(parts.iter().map(Pattern::as_str));
+        return Err(format!(
+          "Globs may not traverse outside of the buildroot: {:?}",
+          symbolic_path,
+        ));
+      }
+      symbolic_path_parent.push(Path::new(*PARENT_DIR));
+      PathGlob::parse_globs(canonical_dir_parent, symbolic_path_parent, &parts[1..])
+    } else if parts.len() == 1 {
+      // This is the path basename.
+      Ok(vec![PathGlob::wildcard(
+        canonical_dir,
+        symbolic_path,
+        parts[0].clone(),
+      )])
+    } else {
+      // This is a path dirname.
+      Ok(vec![PathGlob::dir_wildcard(
+        canonical_dir,
+        symbolic_path,
+        parts[0].clone(),
+        parts[1..].to_vec(),
+      )])
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct PreparedPathGlobs {
+  pub(crate) include: Vec<PathGlobIncludeEntry>,
+  pub(crate) exclude: Arc<GitignoreStyleExcludes>,
+  strict_match_behavior: StrictGlobMatching,
+  conjunction: GlobExpansionConjunction,
+  patterns: Vec<glob::Pattern>,
+}
+
+impl PreparedPathGlobs {
+  fn parse_patterns_from_include(
+    include: &[PathGlobIncludeEntry],
+  ) -> Result<Vec<glob::Pattern>, String> {
+    include
+      .iter()
+      .map(|pattern| {
+        PathGlob::normalize_pattern(&pattern.input.0).and_then(|components| {
+          let normalized_pattern: PathBuf = components.into_iter().collect();
+          Pattern::new(normalized_pattern.to_str().unwrap())
+            .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", pattern.input.0, e))
+        })
+      })
+      .collect::<Result<Vec<_>, String>>()
+  }
+
+  pub fn create(
+    globs: Vec<String>,
+    strict_match_behavior: StrictGlobMatching,
+    conjunction: GlobExpansionConjunction,
+  ) -> Result<PreparedPathGlobs, String> {
+    let mut include_globs = Vec::new();
+    let mut exclude_globs = Vec::new();
+    for glob in globs {
+      if glob.starts_with('!') {
+        let normalized_exclude: String = glob.chars().skip(1).collect();
+        exclude_globs.push(normalized_exclude);
+      } else {
+        include_globs.push(glob);
+      }
+    }
+    let include = PathGlob::spread_filespecs(include_globs)?;
+    let exclude = GitignoreStyleExcludes::create(exclude_globs)?;
+    let patterns = PreparedPathGlobs::parse_patterns_from_include(&include)?;
+
+    Ok(PreparedPathGlobs {
+      include,
+      exclude,
+      strict_match_behavior,
+      conjunction,
+      patterns,
+    })
+  }
+
+  fn from_globs(include: Vec<PathGlob>) -> Result<PreparedPathGlobs, String> {
+    let include: Vec<PathGlobIncludeEntry> = include
+      .into_iter()
+      .map(|glob| PathGlobIncludeEntry {
+        input: MISSING_GLOB_SOURCE.clone(),
+        globs: vec![glob],
+      })
+      .collect();
+
+    let patterns = PreparedPathGlobs::parse_patterns_from_include(&include.as_slice())?;
+    Ok(PreparedPathGlobs {
+      include,
+      // An empty exclude becomes EMPTY_IGNORE.
+      exclude: GitignoreStyleExcludes::create(vec![])?,
+      strict_match_behavior: StrictGlobMatching::Ignore,
+      conjunction: GlobExpansionConjunction::AllMatch,
+      patterns,
+    })
+  }
+
+  ///
+  /// Matches these PreparedPathGlobs against the given paths.
+  ///
+  /// NB: This implementation is independent from GlobMatchingImplementation::expand, and must be
+  /// kept in sync via unit tests (in particular: the python FilespecTest) in order to allow for
+  /// owners detection of deleted files (see #6790 and #5636 for more info). The lazy filesystem
+  /// traversal in expand is (currently) too expensive to use for that in-memory matching (such as
+  /// via MemFS).
+  ///
+  pub fn matches(&self, path: &Path) -> bool {
+    self
+      .patterns
+      .iter()
+      .any(|pattern| pattern.matches_path_with(path, &PATTERN_MATCH_OPTIONS))
+      && !self.exclude.is_ignored_path(path, false)
+  }
+}
 
 #[async_trait]
 pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
@@ -34,7 +346,7 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// Recursively expands PathGlobs into PathStats while applying excludes.
   ///
-  async fn expand(&self, path_globs: PathGlobs) -> Result<Vec<PathStat>, E> {
+  async fn expand(&self, path_globs: PreparedPathGlobs) -> Result<Vec<PathStat>, E> {
     GlobMatchingImplementation::expand(self, path_globs).await
   }
 }
@@ -102,8 +414,8 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     Ok(path_stats.into_iter().filter_map(|pso| pso).collect())
   }
 
-  async fn expand(&self, path_globs: PathGlobs) -> Result<Vec<PathStat>, E> {
-    let PathGlobs {
+  async fn expand(&self, path_globs: PreparedPathGlobs) -> Result<Vec<PathStat>, E> {
+    let PreparedPathGlobs {
       include,
       exclude,
       strict_match_behavior,
@@ -309,11 +621,12 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
       .to_str()
       .and_then(|dest_str| {
         // Escape any globs in the parsed dest, which should guarantee one output PathGlob.
-        PathGlob::create(&[Pattern::escape(dest_str)]).ok()
+        PathGlob::create(vec![Pattern::escape(dest_str)]).ok()
       })
       .unwrap_or_else(|| vec![]);
 
-    let path_globs = PathGlobs::from_globs(link_globs).map_err(|e| Self::mk_error(e.as_str()))?;
+    let path_globs =
+      PreparedPathGlobs::from_globs(link_globs).map_err(|e| Self::mk_error(e.as_str()))?;
     let mut path_stats = context
       .expand(path_globs)
       .map_err(move |e| Self::mk_error(&format!("While expanding link {:?}: {}", link.0, e)))

--- a/src/rust/engine/fs/src/glob_matching_tests.rs
+++ b/src/rust/engine/fs/src/glob_matching_tests.rs
@@ -1,34 +1,33 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use super::GitignoreStyleExcludes;
-use super::PathGlob;
-use super::PathGlobs;
-use crate::{GlobExpansionConjunction, StrictGlobMatching};
+use crate::glob_matching::PathGlob;
+use crate::{GitignoreStyleExcludes, GlobExpansionConjunction, PathGlobs, StrictGlobMatching};
 
 #[test]
 fn path_globs_create_distinguishes_between_includes_and_excludes() {
-  let include_globs = ["foo.rs".to_string(), "bar.rs".to_string()];
-  let parsed_exclude_globs = ["ignore.rs".to_string(), "**/*.rs".to_string()];
+  let include_globs = vec!["foo.rs".to_string(), "bar.rs".to_string()];
+  let parsed_exclude_globs = vec!["ignore.rs".to_string(), "**/*.rs".to_string()];
 
   let mut glob_inputs: Vec<String> = vec![];
   glob_inputs.extend_from_slice(&include_globs);
   glob_inputs.extend(parsed_exclude_globs.iter().map(|glob| format!("!{}", glob)));
 
-  let pg = PathGlobs::create(
-    glob_inputs.as_slice(),
+  let pg = PathGlobs::new(
+    glob_inputs,
     StrictGlobMatching::Ignore,
     GlobExpansionConjunction::AllMatch,
   )
+  .parse()
   .expect("Path globs failed to be created");
 
   assert_eq!(
     pg.include,
-    PathGlob::spread_filespecs(&include_globs).expect("Include globs failed to expand")
+    PathGlob::spread_filespecs(include_globs).expect("Include globs failed to expand")
   );
   assert_eq!(
     pg.exclude.patterns,
-    GitignoreStyleExcludes::create(&parsed_exclude_globs)
+    GitignoreStyleExcludes::create(parsed_exclude_globs)
       .expect("Exclude globs failed to expand")
       .patterns
   );

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -33,7 +33,7 @@ fn setup() -> (
   )
   .unwrap();
   let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();
-  let ignorer = GitignoreStyleExcludes::create(&[]).unwrap();
+  let ignorer = GitignoreStyleExcludes::create(vec![]).unwrap();
   let posix_fs = Arc::new(PosixFS::new(dir.path(), ignorer, executor).unwrap());
   let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone());
   (store, dir, posix_fs, file_saver)
@@ -485,11 +485,12 @@ async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
   let mut v = posix_fs
     .expand(
       // Don't error or warn if there are no paths matched -- that is a valid state.
-      PathGlobs::create(
-        &["**".to_owned()],
+      PathGlobs::new(
+        vec!["**".to_owned()],
         StrictGlobMatching::Ignore,
         GlobExpansionConjunction::AllMatch,
       )
+      .parse()
       .unwrap(),
     )
     .await

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -69,7 +69,7 @@ impl Core {
     types: Types,
     intrinsics: Intrinsics,
     build_root: PathBuf,
-    ignore_patterns: &[String],
+    ignore_patterns: Vec<String>,
     use_gitignore: bool,
     local_store_dir: PathBuf,
     remote_execution: bool,
@@ -257,13 +257,8 @@ impl Core {
       None
     };
     let ignorer =
-      GitignoreStyleExcludes::create_with_gitignore_file(&ignore_patterns, gitignore_file)
-        .map_err(|e| {
-          format!(
-            "Could not parse build ignore inputs {:?}: {:?}",
-            ignore_patterns, e
-          )
-        })?;
+      GitignoreStyleExcludes::create_with_gitignore_file(ignore_patterns, gitignore_file)
+        .map_err(|e| format!("Could not parse build ignore patterns: {:?}", e))?;
 
     let watcher = InvalidationWatcher::new(
       Arc::downgrade(&graph),

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -57,7 +57,7 @@ fn receive_watch_event_on_file_change() {
     .to_path_buf();
 
   let invalidatable = Arc::new(TestInvalidatable::default());
-  let ignorer = GitignoreStyleExcludes::create(&[]).unwrap();
+  let ignorer = GitignoreStyleExcludes::empty();
   let _watcher = setup_watch(
     ignorer,
     invalidatable.clone(),
@@ -96,7 +96,7 @@ fn ignore_file_events_matching_patterns_in_pants_ignore() {
     .to_path_buf();
 
   let invalidatable = Arc::new(TestInvalidatable::default());
-  let ignorer = GitignoreStyleExcludes::create(&["/foo".to_string()]).unwrap();
+  let ignorer = GitignoreStyleExcludes::create(vec!["/foo".to_string()]).unwrap();
   let _watcher = setup_watch(
     ignorer,
     invalidatable.clone(),
@@ -124,7 +124,7 @@ fn test_liveness() {
   let build_root = tempdir.path().to_path_buf();
 
   let invalidatable = Arc::new(TestInvalidatable::default());
-  let ignorer = GitignoreStyleExcludes::create(&[]).unwrap();
+  let ignorer = GitignoreStyleExcludes::empty();
   let (liveness_sender, liveness_receiver) = crossbeam_channel::unbounded();
   let (event_sender, event_receiver) = crossbeam_channel::unbounded();
   InvalidationWatcher::start_background_thread(


### PR DESCRIPTION
### Problem

The rust-side `PathGlobs` object is not analogous to the python-side definition, which means that conversions between them are impossible (the parsed form that rust is holding is not easily convertible back to the unparsed form). Additionally, lots of implementation details existed outside of the `glob_matching` module.

### Solution

Align the rust-side `PathGlobs` with the python-side by extracting a `PreparedPathGlobs` struct to hold the parsed form.

This allowed a lot more of the structs involved in parsing and applying globs to become private to the `glob_matching` module, which helped rustc to detect some dead code.

### Result

Cleaner public API, better alignment between rust and python for a critical type.

[ci skip-jvm-tests]