### PR TITLE
Rename `Snapshot.directory_digest` to `Snapshot.digest`

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
@@ -26,7 +26,7 @@ class NodeBuild(NodeTask):
         (classes_dir_snapshot,) = self.context._scheduler.capture_snapshots(
             [PathGlobsAndRoot(PathGlobs([relpath]), get_buildroot(), Digest.load(relpath))]
         )
-        return ClasspathEntry(results_dir, classes_dir_snapshot.directory_digest)
+        return ClasspathEntry(results_dir, classes_dir_snapshot.digest)
 
     @classmethod
     def product_types(cls):

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -82,9 +82,7 @@ async def create_python_awslambda(
 
     pex_result = await Get[TwoStepPex](TwoStepPexFromTargetsRequest, pex_request)
     merged_input_files = await Get[Digest](
-        MergeDigests(
-            (pex_result.pex.directory_digest, lambdex_setup.requirements_pex.directory_digest)
-        )
+        MergeDigests((pex_result.pex.digest, lambdex_setup.requirements_pex.digest))
     )
 
     # NB: Lambdex modifies its input pex in-place, so the input file is also the output file.
@@ -102,7 +100,7 @@ async def create_python_awslambda(
     # Note that the AWS-facing handler function is always lambdex_handler.handler, which
     # is the wrapper injected by lambdex that manages invocation of the actual handler.
     return CreatedAWSLambda(
-        digest=result.output_directory_digest,
+        digest=result.output_digest,
         name=pex_filename,
         runtime=config.runtime.value,
         handler="lambdex_handler.handler",

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.addresses import Addresses
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import named_rule, subsystem_rule
@@ -37,7 +37,7 @@ async def generate_python_from_protobuf(
         Process(
             (f"/bin/mkdir", output_dir),
             description=f"Create the directory {output_dir}",
-            input_files=EMPTY_DIRECTORY_DIGEST,
+            input_files=EMPTY_DIGEST,
             output_directories=(output_dir,),
         )
     )
@@ -81,9 +81,9 @@ async def generate_python_from_protobuf(
     input_digest = await Get[Digest](
         MergeDigests(
             (
-                all_sources.snapshot.directory_digest,
+                all_sources.snapshot.digest,
                 downloaded_protoc_binary.digest,
-                create_output_dir_result.output_directory_digest,
+                create_output_dir_result.output_digest,
             )
         )
     )
@@ -101,9 +101,7 @@ async def generate_python_from_protobuf(
             output_directories=(output_dir,),
         )
     )
-    normalized_snapshot = await Get[Snapshot](
-        RemovePrefix(result.output_directory_digest, output_dir)
-    )
+    normalized_snapshot = await Get[Snapshot](RemovePrefix(result.output_digest, output_dir))
     return GeneratedSources(normalized_snapshot)
 
 

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -52,7 +52,7 @@ class PyThriftNamespaceClashCheck(Task):
     def _get_python_thrift_library_sources(self, py_thrift_targets):
         """Get file contents for python thrift library targets."""
         target_snapshots = OrderedDict(
-            (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
+            (t, t.sources_snapshot(scheduler=self.context._scheduler).digest)
             for t in py_thrift_targets
         )
         filescontent_by_target = OrderedDict(

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -67,10 +67,8 @@ class CountLinesOfCode(ConsoleTask):
         )[0]
         cloc_snapshot = self.context._scheduler.product_request(Snapshot, [cloc_binary.digest])[0]
 
-        directory_digest = self.context._scheduler.merge_directories(
-            tuple(
-                s.directory_digest for s in input_snapshots + (cloc_snapshot, list_file_snapshot,)
-            )
+        input_digest = self.context._scheduler.merge_directories(
+            tuple(s.digest for s in input_snapshots + (cloc_snapshot, list_file_snapshot,))
         )
 
         cmd = (
@@ -85,7 +83,7 @@ class CountLinesOfCode(ConsoleTask):
         # The cloc script reaches into $PATH to look up perl. Let's assume it's in /usr/bin.
         req = Process(
             argv=cmd,
-            input_files=directory_digest,
+            input_files=input_digest,
             output_files=("ignored", "report"),
             description="cloc",
         )
@@ -94,7 +92,7 @@ class CountLinesOfCode(ConsoleTask):
         )
 
         files_content_tuple = self.context._scheduler.product_request(
-            FilesContent, [exec_result.output_directory_digest]
+            FilesContent, [exec_result.output_digest]
         )[0].dependencies
 
         files_content = {fc.path: fc.content.decode() for fc in files_content_tuple}

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -399,15 +399,13 @@ class Zinc:
 
         if not os.path.exists(bridge_jar):
             res = self._run_bootstrapper(bridge_jar, context)
-            context._scheduler.materialize_directory(
-                DirectoryToMaterialize(res.output_directory_digest)
-            )
+            context._scheduler.materialize_directory(DirectoryToMaterialize(res.output_digest))
             # For the workaround above to work, we need to store a copy of the bridge in
             # the bootstrapdir cache (.cache).
             safe_mkdir(global_bridge_cache_dir)
             safe_hardlink_or_copy(bridge_jar, globally_cached_bridge_jar)
 
-            return ClasspathEntry(bridge_jar, res.output_directory_digest)
+            return ClasspathEntry(bridge_jar, res.output_digest)
         else:
             bridge_jar_snapshot = context._scheduler.capture_snapshots(
                 (
@@ -416,7 +414,7 @@ class Zinc:
                     ),
                 )
             )[0]
-            bridge_jar_digest = bridge_jar_snapshot.directory_digest
+            bridge_jar_digest = bridge_jar_snapshot.digest
             return ClasspathEntry(bridge_jar, bridge_jar_digest)
 
     @memoized_method

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -373,8 +373,8 @@ class BootstrapJvmTools(CoursierMixin, JarTask):
                 )
             ]
         )[0]
-        snapshot.directory_digest.dump(shaded_jar)
-        return ClasspathEntry(shaded_jar, directory_digest=snapshot.directory_digest)
+        snapshot.digest.dump(shaded_jar)
+        return ClasspathEntry(shaded_jar, directory_digest=snapshot.digest)
 
     def check_artifact_cache_for(self, invalidation_check):
         tool_vts = self.tool_vts(invalidation_check)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -243,7 +243,7 @@ class JavacCompile(JvmCompile):
 
         process = Process(
             argv=tuple(cmd),
-            input_files=input_snapshot.directory_digest,
+            input_files=input_snapshot.digest,
             output_files=output_files,
             description=f"Compiling {ctx.target.address.spec} with javac",
         )
@@ -254,7 +254,7 @@ class JavacCompile(JvmCompile):
         # Dump the output to the .pants.d directory where it's expected by downstream tasks.
         merged_directories = self.context._scheduler.merge_directories(
             [
-                exec_result.output_directory_digest,
+                exec_result.output_digest,
                 self.post_compile_extra_resources_digest(
                     ctx, prepend_post_merge_relative_path=False
                 ),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -36,7 +36,7 @@ from pants.base.exceptions import TaskError
 from pants.base.worker_pool import WorkerPool
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, PathGlobs, PathGlobsAndRoot
+from pants.engine.fs import EMPTY_DIGEST, PathGlobs, PathGlobsAndRoot
 from pants.java.distribution.distribution import DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
@@ -399,7 +399,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         # TODO: Switch to using #7739 once it is available.
         extra_resources = self.post_compile_extra_resources(compile_context)
         if not extra_resources:
-            return EMPTY_DIRECTORY_DIGEST
+            return EMPTY_DIGEST
 
         def _snapshot_resources(resources, prefix="."):
             with temporary_dir() as root_dir:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -415,7 +415,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
                     [PathGlobsAndRoot(PathGlobs(extra_resources_relative_to_rootdir), root_dir)]
                 )
 
-            return snapshot.directory_digest
+            return snapshot.digest
 
         if prepend_post_merge_relative_path:
             rel_post_compile_merge_dir = fast_relpath(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -683,7 +683,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         )
         for target, snapshot in list(zip(valid_targets, snapshots)):
             cc = self.select_runtime_context(compile_contexts[target])
-            self._set_directory_digest_for_compile_context(cc, snapshot.directory_digest)
+            self._set_directory_digest_for_compile_context(cc, snapshot.digest)
 
     def _set_directory_digest_for_compile_context(self, ctx, directory_digest):
         if self.get_options().use_classpath_jars:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -734,7 +734,7 @@ class BaseZincCompile(JvmCompile):
         argv = image_specific_argv + [f"@{argfile_snapshot.files[0]}"]
 
         merged_input_digest = self.context._scheduler.merge_directories(
-            [self._zinc.zinc.digest]
+            [self._zinc.zinc.directory_digest]
             + [s.digest for s in snapshots]
             + digests
             + native_image_snapshots

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -38,12 +38,12 @@ class JvmResolverBase(TaskBase):
             )
         )
         for snapshot, jar_path in zip(snapshots, jar_paths):
-            snapshot.directory_digest.dump(jar_path)
+            snapshot.digest.dump(jar_path)
 
         # We want to map back the list[Snapshot] to targets_and_jars
         # We assume that (1) jars_to_snapshot has the same number of ResolveJars as snapshots does Snapshots,
         # and that (2) capture_snapshots preserves ordering.
-        digests = [snapshot.directory_digest for snapshot in snapshots]
+        digests = [snapshot.digest for snapshot in snapshots]
         digest_iterator = iter(digests)
 
         snapshotted_targets_and_jars = []

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -96,8 +96,8 @@ class ResourcesTask(Task):
         )
         result = []
         for vt, snapshot in zip(vts, snapshots):
-            snapshot.directory_digest.dump(vt.current_results_dir)
-            result.append((vt, snapshot.directory_digest))
+            snapshot.digest.dump(vt.current_results_dir)
+            result.append((vt, snapshot.digest))
         return result
 
     @abstractmethod

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -288,7 +288,7 @@ async def match_regexes_for_one_snapshot(
     sources_snapshot: SourcesSnapshot, source_file_validation: SourceFileValidation,
 ) -> RegexMatchResults:
     multi_matcher = source_file_validation.get_multi_matcher()
-    files_content = await Get[FilesContent](Digest, sources_snapshot.snapshot.directory_digest)
+    files_content = await Get[FilesContent](Digest, sources_snapshot.snapshot.digest)
     return RegexMatchResults(
         multi_matcher.check_source_file(file_content.path, file_content.content)
         for file_content in files_content

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -95,11 +95,7 @@ async def bandit_lint(
 
     merged_input_files = await Get[Digest](
         MergeDigests(
-            (
-                all_source_files.snapshot.directory_digest,
-                requirements_pex.directory_digest,
-                config_snapshot.directory_digest,
-            )
+            (all_source_files.snapshot.digest, requirements_pex.digest, config_snapshot.digest)
         ),
     )
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -120,11 +120,7 @@ async def setup(
 
     merged_input_files = await Get[Digest](
         MergeDigests(
-            (
-                all_source_files_snapshot.directory_digest,
-                requirements_pex.directory_digest,
-                config_snapshot.directory_digest,
-            )
+            (all_source_files_snapshot.digest, requirements_pex.digest, config_snapshot.digest)
         ),
     )
 
@@ -145,7 +141,7 @@ async def setup(
             f"Run Black on {pluralize(len(request.configs), 'target')}: {address_references}."
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
+    return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
 @named_rule(desc="Format using Black")

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -97,9 +97,7 @@ async def setup(
     )
 
     merged_input_files = await Get[Digest](
-        MergeDigests(
-            (all_source_files_snapshot.directory_digest, requirements_pex.directory_digest)
-        ),
+        MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest)),
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
@@ -120,7 +118,7 @@ async def setup(
             f"{address_references}."
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
+    return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
 @named_rule(desc="Format Python docstrings with docformatter")

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -96,11 +96,7 @@ async def flake8_lint(
 
     merged_input_files = await Get[Digest](
         MergeDigests(
-            (
-                all_source_files.snapshot.directory_digest,
-                requirements_pex.directory_digest,
-                config_snapshot.directory_digest,
-            )
+            (all_source_files.snapshot.digest, requirements_pex.digest, config_snapshot.digest)
         ),
     )
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -113,11 +113,7 @@ async def setup(
 
     merged_input_files = await Get[Digest](
         MergeDigests(
-            (
-                all_source_files_snapshot.directory_digest,
-                requirements_pex.directory_digest,
-                config_snapshot.directory_digest,
-            )
+            (all_source_files_snapshot.digest, requirements_pex.digest, config_snapshot.digest)
         ),
     )
 
@@ -138,7 +134,7 @@ async def setup(
             f"Run isort on {pluralize(len(request.configs), 'target')}: {address_references}."
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.directory_digest)
+    return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
 @named_rule(desc="Format using isort")

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -70,7 +70,7 @@ async def pylint_lint(
         addresses.append(config.address)
         addresses.extend(config.dependencies.value or ())
     targets = await Get[Targets](Addresses(addresses))
-    chrooted_python_sources = await Get[ImportablePythonSources](Targets, targets)
+    prepared_python_sources = await Get[ImportablePythonSources](Targets, targets)
 
     # NB: Pylint output depends upon which Python interpreter version it's run with. We ensure that
     # each target runs with its own interpreter constraints. See
@@ -99,9 +99,9 @@ async def pylint_lint(
     merged_input_files = await Get[Digest](
         MergeDigests(
             (
-                requirements_pex.directory_digest,
-                config_snapshot.directory_digest,
-                chrooted_python_sources.snapshot.directory_digest,
+                requirements_pex.digest,
+                config_snapshot.digest,
+                prepared_python_sources.snapshot.digest,
             )
         ),
     )

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -62,8 +62,8 @@ async def format_python_target(
             prior_formatter_result = await Get[Snapshot](Digest, result.output)
     return LanguageFmtResults(
         tuple(results),
-        input=original_sources.snapshot.directory_digest,
-        output=prior_formatter_result.directory_digest,
+        input=original_sources.snapshot.digest,
+        output=prior_formatter_result.digest,
     )
 
 

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -31,8 +31,9 @@ class DownloadedPexBin(HermeticPex):
         return self.exe.exe_filename
 
     @property
-    def directory_digest(self) -> Digest:
-        return self.exe.directory_digest
+    def digest(self) -> Digest:
+        """A directory digest containing the Pex executable."""
+        return self.exe.digest
 
     class Factory(Script):
         options_scope = "download-pex-bin"
@@ -77,7 +78,7 @@ class DownloadedPexBin(HermeticPex):
         :param input_files: The files that contain the pex CLI tool itself and any input files it
                             needs to run against. By default, this is just the files that contain
                             the PEX CLI tool itself. To merge in additional files, include
-                            `self.directory_digest` in a `MergeDigests` request.
+                            `self.digest` in a `MergeDigests` request.
         :param env: The environment to run the PEX in.
         :param kwargs: Any additional :class:`Process` kwargs to pass through.
         """
@@ -91,7 +92,7 @@ class DownloadedPexBin(HermeticPex):
             pex_path=self.executable,
             pex_args=pex_args,
             description=description,
-            input_files=input_files or self.directory_digest,
+            input_files=input_files or self.digest,
             env=env,
             **kwargs,
         )

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -33,7 +33,7 @@ async def inject_missing_init_files(request: InjectInitRequest) -> InitInjectedS
     generated_inits_digest = await Get[Digest](
         InputFilesContent(FileContent(path=fp, content=b"") for fp in missing_init_files)
     )
-    result = await Get[Snapshot](MergeDigests((snapshot.directory_digest, generated_inits_digest)))
+    result = await Get[Snapshot](MergeDigests((snapshot.digest, generated_inits_digest)))
     return InitInjectedSnapshot(result)
 
 

--- a/src/python/pants/backend/python/rules/inject_init_test.py
+++ b/src/python/pants/backend/python/rules/inject_init_test.py
@@ -32,7 +32,7 @@ class InjectInitTest(TestBase):
         # Ensure all original `__init__.py` are preserved with their original content.
         materialized_original_inits = [
             fc
-            for fc in self.request_single_product(FilesContent, result.directory_digest)
+            for fc in self.request_single_product(FilesContent, result.digest)
             if fc.path in original_files and fc.path.endswith("__init__.py")
         ]
         for original_init in materialized_original_inits:

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -95,7 +95,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         input_digests.append(request.additional_sources)
     if request.include_source_files:
         prepared_sources = await Get[ImportablePythonSources](Targets(all_targets))
-        input_digests.append(prepared_sources.snapshot.directory_digest)
+        input_digests.append(prepared_sources.snapshot.digest)
     merged_input_digest = await Get[Digest](MergeDigests(input_digests))
 
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -194,7 +194,7 @@ class PexTest(TestBase):
                 ),
             ),
         )
-        self.scheduler.materialize_directory(DirectoryToMaterialize(pex.directory_digest),)
+        self.scheduler.materialize_directory(DirectoryToMaterialize(pex.digest))
         pex_path = os.path.join(self.build_root, "test.pex")
         with zipfile.ZipFile(pex_path, "r") as zipfp:
             with zipfp.open("PEX-INFO", "r") as pex_info:
@@ -254,7 +254,7 @@ class PexTest(TestBase):
         process = Process(
             argv=("python", "test.pex"),
             env=env,
-            input_files=pex_output["pex"].directory_digest,
+            input_files=pex_output["pex"].digest,
             description="Run the pex and make sure it works",
         )
         result = self.request_single_product(ProcessResult, process)

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -291,9 +291,9 @@ async def merge_coverage_data(
         MergeDigests(
             (
                 *coverage_digests,
-                sources_with_inits.snapshot.directory_digest,
+                sources_with_inits.snapshot.digest,
                 coverage_config.digest,
-                coverage_setup.requirements_pex.directory_digest,
+                coverage_setup.requirements_pex.digest,
             )
         ),
     )
@@ -311,7 +311,7 @@ async def merge_coverage_data(
     )
 
     result = await Get[ProcessResult](Process, process)
-    return MergedCoverageData(coverage_data=result.output_directory_digest)
+    return MergedCoverageData(coverage_data=result.output_digest)
 
 
 @named_rule(desc="Generate Pytest coverage report")
@@ -345,8 +345,8 @@ async def generate_coverage_report(
             (
                 merged_coverage_data.coverage_data,
                 coverage_config.digest,
-                requirements_pex.directory_digest,
-                sources_with_inits_snapshot.snapshot.directory_digest,
+                requirements_pex.digest,
+                sources_with_inits_snapshot.snapshot.digest,
             )
         ),
     )
@@ -378,7 +378,7 @@ async def generate_coverage_report(
         report_file = report_dir / "coverage.xml"
 
     return FilesystemCoverageReport(
-        result_digest=result.output_directory_digest,
+        result_digest=result.output_digest,
         directory_to_materialize_to=report_dir,
         report_file=report_file,
     )

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -90,7 +90,7 @@ async def create_python_binary(config: PythonBinaryConfiguration) -> CreatedBina
         )
     )
     pex = two_step_pex.pex
-    return CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
+    return CreatedBinary(digest=pex.digest, binary_name=pex.output_filename)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -29,7 +29,7 @@ async def run_python_repl(repl: PythonRepl) -> ReplBinary:
         )
     )
     repl_pex = two_step_pex.pex
-    return ReplBinary(digest=repl_pex.directory_digest, binary_name=repl_pex.output_filename,)
+    return ReplBinary(digest=repl_pex.digest, binary_name=repl_pex.output_filename)
 
 
 class IPythonRepl(ReplImplementation):
@@ -51,7 +51,7 @@ async def run_ipython_repl(repl: IPythonRepl, ipython: IPython) -> ReplBinary:
         )
     )
     repl_pex = two_step_pex.pex
-    return ReplBinary(digest=repl_pex.directory_digest, binary_name=repl_pex.output_filename,)
+    return ReplBinary(digest=repl_pex.digest, binary_name=repl_pex.output_filename)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -378,7 +378,7 @@ async def run_setup_py(
 ) -> RunSetupPyResult:
     """Run a setup.py command on a single exported target."""
     merged_input_files = await Get[Digest](
-        MergeDigests((req.chroot.digest, setuptools_setup.requirements_pex.directory_digest))
+        MergeDigests((req.chroot.digest, setuptools_setup.requirements_pex.digest))
     )
     # The setuptools dist dir, created by it under the chroot (not to be confused with
     # pants's own dist dir, at the buildroot).
@@ -395,7 +395,7 @@ async def run_setup_py(
         description=f"Run setuptools for {req.exported_target.target.address.reference()}",
     )
     result = await Get[ProcessResult](Process, process)
-    output_digest = await Get[Digest](RemovePrefix(result.output_directory_digest, dist_dir))
+    output_digest = await Get[Digest](RemovePrefix(result.output_digest, dist_dir))
     return RunSetupPyResult(output_digest)
 
 
@@ -487,7 +487,7 @@ async def get_sources(
     # targets, whether or not they are in the target set for this run - basically the entire repo.
     # So it's the repo owners' responsibility to ensure __init__.py hygiene.
     stripped_srcs_digests = [
-        stripped_sources.snapshot.directory_digest for stripped_sources in stripped_srcs_list
+        stripped_sources.snapshot.digest for stripped_sources in stripped_srcs_list
     ]
     ancestor_init_pys = await Get[AncestorInitPyFiles](Targets, targets)
     sources_digest = await Get[Digest](
@@ -496,7 +496,7 @@ async def get_sources(
     init_pys_snapshot = await Get[Snapshot](
         SnapshotSubset(sources_digest, PathGlobs(["**/__init__.py"]))
     )
-    init_py_contents = await Get[FilesContent](Digest, init_pys_snapshot.directory_digest)
+    init_py_contents = await Get[FilesContent](Digest, init_pys_snapshot.digest)
 
     packages, namespace_packages, package_data = find_packages(
         source_roots=source_root_config.get_source_roots(),
@@ -548,7 +548,7 @@ async def get_ancestor_init_py(
     )
 
     source_root_stripped_ancestor_init_pys = await MultiGet[Digest](
-        Get[Digest](RemovePrefix(snapshot.directory_digest, source_dir_ancestor[0]))
+        Get[Digest](RemovePrefix(snapshot.digest, source_dir_ancestor[0]))
         for snapshot, source_dir_ancestor in zip(
             ancestor_init_py_snapshots, source_dir_ancestors_list
         )

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -11,7 +11,7 @@ from pants.core.util_rules.filter_empty_sources import TargetsWithSources, Targe
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
+    EMPTY_DIGEST,
     Digest,
     DirectoryToMaterialize,
     MergeDigests,
@@ -35,9 +35,7 @@ class FmtResult:
 
     @staticmethod
     def noop() -> "FmtResult":
-        return FmtResult(
-            input=EMPTY_DIRECTORY_DIGEST, output=EMPTY_DIRECTORY_DIGEST, stdout="", stderr=""
-        )
+        return FmtResult(input=EMPTY_DIGEST, output=EMPTY_DIGEST, stdout="", stderr="")
 
     @staticmethod
     def from_process_result(
@@ -45,7 +43,7 @@ class FmtResult:
     ) -> "FmtResult":
         return FmtResult(
             input=original_digest,
-            output=process_result.output_directory_digest,
+            output=process_result.output_digest,
             stdout=process_result.stdout.decode(),
             stderr=process_result.stderr.decode(),
         )

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -16,7 +16,7 @@ from pants.core.goals.fmt import (
 )
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FileContent, MergeDigests, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.target import Sources, Target, TargetsWithOrigins, TargetWithOrigin
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
@@ -60,13 +60,13 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
         return LanguageFmtResults(
             (
                 FmtResult(
-                    input=EMPTY_DIRECTORY_DIGEST,
-                    output=EMPTY_DIRECTORY_DIGEST,
+                    input=EMPTY_DIGEST,
+                    output=EMPTY_DIGEST,
                     stdout=self.stdout(addresses),
                     stderr="",
                 ),
             ),
-            input=EMPTY_DIRECTORY_DIGEST,
+            input=EMPTY_DIGEST,
             output=result_digest,
         )
 
@@ -102,10 +102,10 @@ class FmtTest(TestBase):
         self.smalltalk_file = FileContent("formatted.st", b"y := self size + super size.')\n")
         self.fortran_digest = self.make_snapshot(
             {self.fortran_file.path: self.fortran_file.content.decode()}
-        ).directory_digest
+        ).digest
         self.merged_digest = self.make_snapshot(
             {fc.path: fc.content.decode() for fc in (self.fortran_file, self.smalltalk_file)}
-        ).directory_digest
+        ).digest
 
     @staticmethod
     def make_target_with_origin(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -26,13 +26,7 @@ from pants.core.util_rules.filter_empty_sources import (
     ConfigurationsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
-    Digest,
-    FileContent,
-    InputFilesContent,
-    Workspace,
-)
+from pants.engine.fs import EMPTY_DIGEST, Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.target import (
     Sources,
@@ -189,7 +183,7 @@ class TestTest(TestBase):
                     product_type=CoverageReport,
                     subject_type=CoverageDataCollection,
                     mock=lambda _: FilesystemCoverageReport(
-                        result_digest=EMPTY_DIRECTORY_DIGEST,
+                        result_digest=EMPTY_DIGEST,
                         directory_to_materialize_to=PurePath("mockety/mock"),
                         report_file=None,
                     ),

--- a/src/python/pants/core/project_info/cloc.py
+++ b/src/python/pants/core/project_info/cloc.py
@@ -35,7 +35,7 @@ class DownloadedClocScript:
 
     @property
     def digest(self) -> Digest:
-        return self.exe.directory_digest
+        return self.exe.digest
 
 
 class CountLinesOfCodeOptions(GoalSubsystem):
@@ -86,7 +86,7 @@ async def run_cloc(
             (
                 input_file_digest,
                 downloaded_cloc_binary.digest,
-                *(snapshot.directory_digest for snapshot in snapshots),
+                *(snapshot.digest for snapshot in snapshots),
             )
         )
     )
@@ -110,7 +110,7 @@ async def run_cloc(
     )
 
     exec_result = await Get[ProcessResult](Process, req)
-    files_content = await Get[FilesContent](Digest, exec_result.output_directory_digest)
+    files_content = await Get[FilesContent](Digest, exec_result.output_digest)
 
     file_outputs = {fc.path: fc.content.decode() for fc in files_content}
 

--- a/src/python/pants/core/project_info/list_backends.py
+++ b/src/python/pants/core/project_info/list_backends.py
@@ -166,7 +166,7 @@ async def list_backends(
 ) -> Backends:
     source_roots = source_roots_config.get_source_roots()
     discovered_register_pys = await Get[Snapshot](PathGlobs(["**/*/register.py"]))
-    register_pys_content = await Get[FilesContent](Digest, discovered_register_pys.directory_digest)
+    register_pys_content = await Get[FilesContent](Digest, discovered_register_pys.digest)
 
     backend_infos = tuple(
         BackendInfo.create(fc, source_roots, global_options) for fc in register_pys_content

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -56,9 +56,7 @@ async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
                 output_directories=(output_dir,),
             )
             result = await Get[ProcessResult](Process, proc)
-            strip_output_dir = await Get[Digest](
-                RemovePrefix(result.output_directory_digest, output_dir)
-            )
+            strip_output_dir = await Get[Digest](RemovePrefix(result.output_digest, output_dir))
             return ExtractedDigest(strip_output_dir)
     return ExtractedDigest(digest)
 

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -35,7 +35,7 @@ class ArchiveTest(TestBase):
         io.flush()
         input_snapshot = self.make_snapshot({"test.zip": io.getvalue()})
         extracted_digest = self.request_single_product(
-            ExtractedDigest, Params(MaybeExtractable(input_snapshot.directory_digest))
+            ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
         files_content = self.request_single_product(FilesContent, Params(extracted_digest.digest))
@@ -60,7 +60,7 @@ class ArchiveTest(TestBase):
         ext = f"tar.{compression}" if compression else "tar"
         input_snapshot = self.make_snapshot({f"test.{ext}": io.getvalue()})
         extracted_digest = self.request_single_product(
-            ExtractedDigest, Params(MaybeExtractable(input_snapshot.directory_digest))
+            ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
         files_content = self.request_single_product(FilesContent, Params(extracted_digest.digest))
@@ -81,7 +81,7 @@ class ArchiveTest(TestBase):
     def test_non_archive(self) -> None:
         input_snapshot = self.make_snapshot({"test.sh": b"# A shell script"})
         extracted_digest = self.request_single_product(
-            ExtractedDigest, Params(MaybeExtractable(input_snapshot.directory_digest))
+            ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
         files_content = self.request_single_product(FilesContent, Params(extracted_digest.digest))

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -85,10 +85,7 @@ def calculate_specified_sources(
     # It's possible when given a glob filesystem spec that the spec will have
     # resolved files not belonging to this target - those must be filtered out.
     precise_files_specified = set(sources_snapshot.files).intersection(origin.resolved_files)
-    return SnapshotSubset(
-        directory_digest=sources_snapshot.directory_digest,
-        globs=PathGlobs(sorted(precise_files_specified)),
-    )
+    return SnapshotSubset(sources_snapshot.digest, PathGlobs(sorted(precise_files_specified)))
 
 
 @rule
@@ -106,7 +103,7 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
             for sources_field in request.sources_fields
         )
         digests_to_merge = tuple(
-            stripped_snapshot.snapshot.directory_digest for stripped_snapshot in stripped_snapshots
+            stripped_snapshot.snapshot.digest for stripped_snapshot in stripped_snapshots
         )
     else:
         all_hydrated_sources = await MultiGet(
@@ -120,7 +117,7 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
             for sources_field in request.sources_fields
         )
         digests_to_merge = tuple(
-            hydrated_sources.snapshot.directory_digest for hydrated_sources in all_hydrated_sources
+            hydrated_sources.snapshot.digest for hydrated_sources in all_hydrated_sources
         )
     result = await Get[Snapshot](MergeDigests(digests_to_merge))
     return SourceFiles(result)
@@ -176,9 +173,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
             for sources_field, snapshot in zip(all_sources_fields, all_snapshots)
         )
         all_snapshots = (stripped_snapshot.snapshot for stripped_snapshot in stripped_snapshots)
-    result = await Get[Snapshot](
-        MergeDigests(snapshot.directory_digest for snapshot in all_snapshots)
-    )
+    result = await Get[Snapshot](MergeDigests(snapshot.digest for snapshot in all_snapshots))
     return SourceFiles(result)
 
 

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -223,7 +223,7 @@ class ExternalTool(Subsystem):
         )[0]
         context._scheduler.materialize_directory(
             DirectoryToMaterialize(
-                directory_digest=downloaded_external_tool.digest, path_prefix=rel_bindir.as_posix()
+                downloaded_external_tool.digest, path_prefix=rel_bindir.as_posix()
             )
         )
         return (PurePath(get_buildroot()) / rel_bindir / req.exe).as_posix()
@@ -232,7 +232,7 @@ class ExternalTool(Subsystem):
 @rule
 async def download_external_tool(request: ExternalToolRequest) -> DownloadedExternalTool:
     snapshot = await Get[Snapshot](UrlToFetch, request.url_to_fetch)
-    extracted_digest = await Get[ExtractedDigest](MaybeExtractable(snapshot.directory_digest))
+    extracted_digest = await Get[ExtractedDigest](MaybeExtractable(snapshot.digest))
     return DownloadedExternalTool(extracted_digest.digest, request.exe)
 
 

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -96,8 +96,7 @@ async def strip_source_roots_from_snapshot(
     if request.representative_path is not None:
         resulting_digest = await Get[Digest](
             RemovePrefix(
-                request.snapshot.directory_digest,
-                determine_source_root(request.representative_path),
+                request.snapshot.digest, determine_source_root(request.representative_path),
             )
         )
         resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
@@ -110,15 +109,11 @@ async def strip_source_roots_from_snapshot(
         )
     }
     snapshot_subsets = await MultiGet(
-        Get[Snapshot](
-            SnapshotSubset(
-                directory_digest=request.snapshot.directory_digest, globs=PathGlobs(files),
-            )
-        )
+        Get[Snapshot](SnapshotSubset(request.snapshot.digest, PathGlobs(files)))
         for files in files_grouped_by_source_root.values()
     )
     resulting_digests = await MultiGet(
-        Get[Digest](RemovePrefix(snapshot.directory_digest, source_root))
+        Get[Digest](RemovePrefix(snapshot.digest, source_root))
         for snapshot, source_root in zip(snapshot_subsets, files_grouped_by_source_root.keys())
     )
 

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -16,7 +16,7 @@ from typing import Callable
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
+    EMPTY_DIGEST,
     AddPrefix,
     Digest,
     DirectoryToMaterialize,
@@ -67,9 +67,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         snapshot = self.execute_expecting_one_result(
             scheduler, Snapshot, self.path_globs(filespecs_or_globs)
         ).value
-        result = self.execute_expecting_one_result(
-            scheduler, FilesContent, snapshot.directory_digest
-        ).value
+        result = self.execute_expecting_one_result(scheduler, FilesContent, snapshot.digest).value
         return {f.path: f.content for f in result.dependencies}
 
     def assert_walk_dirs(self, filespecs_or_globs, paths, **kwargs):
@@ -100,7 +98,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
             # Confirm all expected files were digested.
             self.assertEqual(set(expected_files), set(result.files))
-            self.assertTrue(result.directory_digest.fingerprint is not None)
+            self.assertTrue(result.digest.fingerprint is not None)
 
     def test_walk_literal(self):
         self.assert_walk_files(["4.txt"], ["4.txt"])
@@ -284,7 +282,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 ["susannah"],
                 Digest("d3539cfc21eb4bab328ca9173144a8e932c515b1b9e26695454eeedbc5a95f6f", 82),
             )
-            self.assert_snapshot_equals(snapshots[2], [], EMPTY_DIRECTORY_DIGEST)
+            self.assert_snapshot_equals(snapshots[2], [], EMPTY_DIGEST)
 
     def test_snapshot_from_outside_buildroot_failure(self):
         with temporary_dir() as temp_dir:
@@ -296,14 +294,14 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 )
             self.assertIn("doesnotexist", str(cm.exception))
 
-    def assert_snapshot_equals(self, snapshot, files, directory_digest):
+    def assert_snapshot_equals(self, snapshot, files, digest):
         self.assertEqual(list(snapshot.files), files)
-        self.assertEqual(snapshot.directory_digest, directory_digest)
+        self.assertEqual(snapshot.digest, digest)
 
     def test_merge_zero_directories(self):
         scheduler = self.mk_scheduler(rules=create_fs_rules())
         dir = scheduler.merge_directories(())
-        self.assertEqual(EMPTY_DIRECTORY_DIGEST, dir)
+        self.assertEqual(EMPTY_DIGEST, dir)
 
     def test_synchronously_merge_directories(self):
         with temporary_dir() as temp_dir:
@@ -325,23 +323,21 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 )
             )
 
-            empty_merged = self.scheduler.merge_directories((empty_snapshot.directory_digest,))
+            empty_merged = self.scheduler.merge_directories((empty_snapshot.digest,))
             self.assertEqual(
-                empty_snapshot.directory_digest, empty_merged,
+                empty_snapshot.digest, empty_merged,
             )
 
             roland_merged = self.scheduler.merge_directories(
-                (roland_snapshot.directory_digest, empty_snapshot.directory_digest,)
+                (roland_snapshot.digest, empty_snapshot.digest)
             )
-            self.assertEqual(
-                roland_snapshot.directory_digest, roland_merged,
-            )
+            self.assertEqual(roland_snapshot.digest, roland_merged)
 
             both_merged = self.scheduler.merge_directories(
-                (roland_snapshot.directory_digest, susannah_snapshot.directory_digest,)
+                (roland_snapshot.digest, susannah_snapshot.digest)
             )
 
-            self.assertEqual(both_snapshot.directory_digest, both_merged)
+            self.assertEqual(both_snapshot.digest, both_merged)
 
     def test_asynchronously_merge_digests(self):
         with temporary_dir() as temp_dir:
@@ -364,26 +360,22 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
 
             empty_merged = self.request_single_product(
-                Digest, MergeDigests((empty_snapshot.directory_digest,)),
+                Digest, MergeDigests((empty_snapshot.digest,)),
             )
-            self.assertEqual(empty_snapshot.directory_digest, empty_merged)
+            self.assertEqual(empty_snapshot.digest, empty_merged)
 
             roland_merged = self.request_single_product(
-                Digest,
-                MergeDigests((roland_snapshot.directory_digest, empty_snapshot.directory_digest)),
+                Digest, MergeDigests((roland_snapshot.digest, empty_snapshot.digest)),
             )
             self.assertEqual(
-                roland_snapshot.directory_digest, roland_merged,
+                roland_snapshot.digest, roland_merged,
             )
 
             both_merged = self.request_single_product(
-                Digest,
-                MergeDigests(
-                    (roland_snapshot.directory_digest, susannah_snapshot.directory_digest)
-                ),
+                Digest, MergeDigests((roland_snapshot.digest, susannah_snapshot.digest)),
             )
 
-            self.assertEqual(both_snapshot.directory_digest, both_merged)
+            self.assertEqual(both_snapshot.digest, both_merged)
 
     def test_materialize_directories(self):
         self.prime_store_with_roland_digest()
@@ -449,13 +441,13 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
             # Strip empty prefix:
             zero_prefix_stripped_digest = self.request_single_product(
-                Digest, RemovePrefix(snapshot.directory_digest, ""),
+                Digest, RemovePrefix(snapshot.digest, ""),
             )
-            self.assertEquals(snapshot.directory_digest, zero_prefix_stripped_digest)
+            self.assertEquals(snapshot.digest, zero_prefix_stripped_digest)
 
             # Strip a non-empty prefix shared by all files:
             stripped_digest = self.request_single_product(
-                Digest, RemovePrefix(snapshot.directory_digest, "characters/dark_tower"),
+                Digest, RemovePrefix(snapshot.digest, "characters/dark_tower"),
             )
             self.assertEquals(
                 stripped_digest,
@@ -468,7 +460,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 self.scheduler.capture_snapshots((PathGlobsAndRoot(PathGlobs(["*"]), tower_dir),))
             )
             self.assertEquals(expected_snapshot.files, ("roland", "susannah"))
-            self.assertEquals(stripped_digest, expected_snapshot.directory_digest)
+            self.assertEquals(stripped_digest, expected_snapshot.digest)
 
             # Try to strip a prefix which isn't shared by all files:
             with self.assertRaisesWithMessageContaining(
@@ -478,17 +470,14 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 "contained non-matching directory named: books and file named: index",
             ):
                 self.request_single_product(
-                    Digest,
-                    RemovePrefix(
-                        snapshot_with_extra_files.directory_digest, "characters/dark_tower"
-                    ),
+                    Digest, RemovePrefix(snapshot_with_extra_files.digest, "characters/dark_tower"),
                 )
 
-    def test_lift_directory_digest_to_snapshot(self):
+    def test_lift_digest_to_snapshot(self):
         digest = self.prime_store_with_roland_digest()
         snapshot = self.request_single_product(Snapshot, digest)
         self.assertEquals(snapshot.files, ("roland",))
-        self.assertEquals(snapshot.directory_digest, digest)
+        self.assertEquals(snapshot.digest, digest)
 
     def test_error_lifting_file_digest_to_snapshot(self):
         self.prime_store_with_roland_digest()
@@ -657,16 +646,15 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         return self.request_single_product(Digest, input_files_content)
 
     def test_empty_snapshot_subset(self) -> None:
-        ss = SnapshotSubset(directory_digest=self.generate_original_digest(), globs=PathGlobs(()),)
+        ss = SnapshotSubset(self.generate_original_digest(), PathGlobs(()),)
         subset_snapshot = self.request_single_product(Snapshot, ss)
-        assert subset_snapshot.directory_digest == EMPTY_DIRECTORY_DIGEST
+        assert subset_snapshot.directory_digest == EMPTY_DIGEST
         assert subset_snapshot.files == ()
         assert subset_snapshot.dirs == ()
 
     def test_snapshot_subset_globs(self) -> None:
         ss = SnapshotSubset(
-            directory_digest=self.generate_original_digest(),
-            globs=PathGlobs(("a.txt", "c.txt", "subdir2/**")),
+            self.generate_original_digest(), PathGlobs(("a.txt", "c.txt", "subdir2/**")),
         )
 
         subset_snapshot = self.request_single_product(Snapshot, ss)
@@ -688,12 +676,11 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
         )
         subset_digest = self.request_single_product(Digest, subset_input)
-        assert subset_snapshot.directory_digest == subset_digest
+        assert subset_snapshot.digest == subset_digest
 
     def test_snapshot_subset_globs_2(self) -> None:
         ss = SnapshotSubset(
-            directory_digest=self.generate_original_digest(),
-            globs=PathGlobs(("a.txt", "c.txt", "subdir2/*")),
+            self.generate_original_digest(), PathGlobs(("a.txt", "c.txt", "subdir2/*"))
         )
 
         subset_snapshot = self.request_single_product(Snapshot, ss)
@@ -703,8 +690,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     def test_nonexistent_filename_globs(self) -> None:
         # We expect to ignore, rather than error, on files that don't exist in the original snapshot.
         ss = SnapshotSubset(
-            directory_digest=self.generate_original_digest(),
-            globs=PathGlobs(("some_file_not_in_snapshot.txt", "a.txt")),
+            self.generate_original_digest(), PathGlobs(("some_file_not_in_snapshot.txt", "a.txt")),
         )
 
         subset_snapshot = self.request_single_product(Snapshot, ss)
@@ -714,7 +700,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         subset_input = InputFilesContent((FileContent(path="a.txt", content=content),))
 
         subset_digest = self.request_single_product(Digest, subset_input)
-        assert subset_snapshot.directory_digest == subset_digest
+        assert subset_snapshot.digest == subset_digest
 
     def test_file_content_invalidated(self) -> None:
         """Test that we can update files and have the native engine invalidate previous operations
@@ -766,7 +752,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                     f"Deleting parent dir and could still read file from original snapshot."
                 )
 
-    def assert_mutated_directory_digest(
+    def assert_mutated_digest(
         self, mutation_function: Callable[[FileSystemProjectTree, str], Exception]
     ):
         with self.mk_project_tree() as project_tree:
@@ -784,7 +770,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                     scheduler, Snapshot, self.path_globs([dir_glob])
                 ).value
                 assert not new_snapshot.is_empty
-                if initial_snapshot.directory_digest != new_snapshot.directory_digest:
+                if initial_snapshot.digest != new_snapshot.digest:
                     # successfully invalidated snapshot and got a new digest
                     return True
                 return False
@@ -800,7 +786,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 return True
         return False
 
-    def test_directory_digest_invalidated_by_child_removal(self):
+    def test_digest_invalidated_by_child_removal(self):
         def mutation_function(project_tree, dir_path):
             removed_path = os.path.join(project_tree.build_root, dir_path, "3.txt")
             os.remove(removed_path)
@@ -808,9 +794,9 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 f"Did not find a new directory snapshot after adding file {removed_path}."
             )
 
-        self.assert_mutated_directory_digest(mutation_function)
+        self.assert_mutated_digest(mutation_function)
 
-    def test_directory_digest_invalidated_by_child_change(self):
+    def test_digest_invalidated_by_child_change(self):
         def mutation_function(project_tree, dir_path):
             new_file_path = os.path.join(project_tree.build_root, dir_path, "new_file.txt")
             with open(new_file_path, "w") as f:
@@ -819,7 +805,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 f"Did not find a new directory snapshot after adding file {new_file_path}."
             )
 
-        self.assert_mutated_directory_digest(mutation_function)
+        self.assert_mutated_digest(mutation_function)
 
 
 class StubHandler(BaseHTTPRequestHandler):

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -648,7 +648,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     def test_empty_snapshot_subset(self) -> None:
         ss = SnapshotSubset(self.generate_original_digest(), PathGlobs(()),)
         subset_snapshot = self.request_single_product(Snapshot, ss)
-        assert subset_snapshot.directory_digest == EMPTY_DIGEST
+        assert subset_snapshot.digest == EMPTY_DIGEST
         assert subset_snapshot.files == ()
         assert subset_snapshot.dirs == ()
 

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple
 
 from pants.base.exception_sink import ExceptionSink
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
+from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.rules import RootRule, side_effecting
 
 if TYPE_CHECKING:
@@ -21,11 +21,11 @@ class InteractiveProcessResult:
 class InteractiveProcessRequest:
     argv: Tuple[str, ...]
     env: Tuple[str, ...] = ()
-    input_files: Digest = EMPTY_DIRECTORY_DIGEST
+    input_files: Digest = EMPTY_DIGEST
     run_in_workspace: bool = False
 
     def __post_init__(self):
-        if self.input_files != EMPTY_DIRECTORY_DIGEST and self.run_in_workspace:
+        if self.input_files != EMPTY_DIGEST and self.run_in_workspace:
             raise ValueError(
                 "InteractiveProessRequest should use the Workspace API to materialize any needed files when it runs in the workspace"
             )

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -51,7 +51,7 @@ async def evalute_preludes(address_mapper: AddressMapper) -> BuildFilePreludeSym
             glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
         )
     )
-    prelude_files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
+    prelude_files_content = await Get[FilesContent](Digest, snapshot.digest)
     values: Dict[str, Any] = {}
     for file_content in prelude_files_content:
         try:
@@ -86,7 +86,7 @@ async def parse_address_family(
         )
     )
     snapshot = await Get[Snapshot](PathGlobs, path_globs)
-    files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
+    files_content = await Get[FilesContent](Digest, snapshot.digest)
 
     if not files_content:
         raise ResolveError(

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -617,16 +617,16 @@ class SchedulerSession:
         )
         return self._scheduler._raise_or_return(result)
 
-    def merge_directories(self, directory_digests):
+    def merge_directories(self, digests):
         """Merges any number of directories.
 
-        :param directory_digests: Tuple of DirectoryDigests.
+        :param digests: Tuple of directory digests.
         :return: A Digest.
         """
         result = self._scheduler._native.lib.merge_directories(
             self._scheduler._scheduler,
             self._session,
-            self._scheduler._to_value(_DirectoryDigests(directory_digests)),
+            self._scheduler._to_value(_DirectoryDigests(digests)),
         )
         return self._scheduler._raise_or_return(result)
 

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
+from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResultWithPlatform, Process
 from pants.testutil.test_base import TestBase
@@ -14,7 +14,7 @@ class PlatformTest(TestBase):
 
         req = Process(
             argv=("/bin/echo", "test"),
-            input_files=EMPTY_DIRECTORY_DIGEST,
+            input_files=EMPTY_DIGEST,
             description="Run some program that will exit cleanly.",
         )
         result = self.request_single_product(FallibleProcessResultWithPlatform, req)

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Union
 
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
+from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import RootRule, rule
 from pants.util.meta import frozen_after_init
@@ -49,7 +49,7 @@ class Process:
         output_files: Optional[Tuple[str, ...]] = None,
         output_directories: Optional[Tuple[str, ...]] = None,
         timeout_seconds: Optional[Union[int, float]] = None,
-        unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: Digest = EMPTY_DIRECTORY_DIGEST,
+        unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: Digest = EMPTY_DIGEST,
         jdk_home: Optional[str] = None,
         is_nailgunnable: bool = False,
     ) -> None:
@@ -113,7 +113,7 @@ class ProcessResult:
 
     stdout: bytes
     stderr: bytes
-    output_directory_digest: Digest
+    output_digest: Digest
 
 
 @dataclass(frozen=True)
@@ -126,7 +126,7 @@ class FallibleProcessResult:
     stdout: bytes
     stderr: bytes
     exit_code: int
-    output_directory_digest: Digest
+    output_digest: Digest
 
 
 @dataclass(frozen=True)
@@ -139,7 +139,7 @@ class FallibleProcessResultWithPlatform:
     stdout: bytes
     stderr: bytes
     exit_code: int
-    output_directory_digest: Digest
+    output_digest: Digest
     platform: Platform
 
 
@@ -188,7 +188,7 @@ def fallible_to_exec_result_or_raise(
 
     if fallible_result.exit_code == 0:
         return ProcessResult(
-            fallible_result.stdout, fallible_result.stderr, fallible_result.output_directory_digest,
+            fallible_result.stdout, fallible_result.stderr, fallible_result.output_digest,
         )
     else:
         raise ProcessExecutionFailure(
@@ -205,7 +205,7 @@ def remove_platform_information(res: FallibleProcessResultWithPlatform,) -> Fall
         exit_code=res.exit_code,
         stdout=res.stdout,
         stderr=res.stderr,
-        output_directory_digest=res.output_directory_digest,
+        output_digest=res.output_digest,
     )
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -11,13 +11,7 @@ from typing_extensions import final
 
 from pants.base.specs import FilesystemLiteralSpec
 from pants.engine.addresses import Address
-from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
-    FileContent,
-    InputFilesContent,
-    PathGlobs,
-    Snapshot,
-)
+from pants.engine.fs import EMPTY_DIGEST, FileContent, InputFilesContent, PathGlobs, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Params
@@ -246,11 +240,7 @@ def test_async_field() -> None:
                 MockGet(
                     product_type=Snapshot,
                     subject_type=PathGlobs,
-                    mock=lambda _: Snapshot(
-                        directory_digest=EMPTY_DIRECTORY_DIGEST,
-                        files=hydrated_source_files,
-                        dirs=(),
-                    ),
+                    mock=lambda _: Snapshot(EMPTY_DIGEST, files=hydrated_source_files, dirs=()),
                 )
             ],
         )

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pants.engine.console import Console
 from pants.engine.fs import (
-    EMPTY_DIRECTORY_DIGEST,
+    EMPTY_DIGEST,
     Digest,
     DirectoryToMaterialize,
     FileContent,
@@ -134,7 +134,7 @@ class SingleFileExecutableTest(TestBase):
             SingleFileExecutable(snapshot)
 
     def test_raises_empty_digest(self):
-        snapshot = Snapshot(EMPTY_DIRECTORY_DIGEST, files=("a.txt",), dirs=())
+        snapshot = Snapshot(EMPTY_DIGEST, files=("a.txt",), dirs=())
 
         with self.assertRaisesWithMessage(
             SingleFileExecutable.ValidationError,

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -115,7 +115,7 @@ class SchedulerService(PantsService):
         new_snapshot = self._get_snapshot()
         if (
             self._invalidating_snapshot
-            and new_snapshot.directory_digest != self._invalidating_snapshot.directory_digest
+            and new_snapshot.digest != self._invalidating_snapshot.digest
         ):
             self._logger.critical(
                 "saw file events covered by invalidation globs [{}], terminating the daemon.".format(

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -119,7 +119,7 @@ class EagerFilesetWithSpec(FilesetWithSpec):
 
     @property
     def files_hash(self) -> bytes:
-        return self._snapshot.directory_digest.fingerprint.encode()
+        return self._snapshot.digest.fingerprint.encode()
 
     @property
     def snapshot(self) -> Snapshot:

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -310,7 +310,7 @@ class SimpleCodegenTask(Task):
         snapshots = self.context._scheduler.capture_snapshots(tuple(to_capture))
 
         for snapshot, vt in zip(snapshots, vts):
-            snapshot.directory_digest.dump(vt.current_results_dir)
+            snapshot.digest.dump(vt.current_results_dir)
 
         return tuple(
             EagerFilesetWithSpec(results_dir_relpath, filespec, snapshot,)

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1113,8 +1113,7 @@ pub extern "C" fn materialize_directories(
     values
       .iter()
       .map(|value| {
-        let dir_digest =
-          nodes::lift_digest(&externs::project_ignoring_type(&value, "directory_digest"));
+        let dir_digest = nodes::lift_digest(&externs::project_ignoring_type(&value, "digest"));
         let path_prefix = PathBuf::from(externs::project_str(&value, "path_prefix"));
         dir_digest.map(|dir_digest| (dir_digest, path_prefix))
       })

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -275,10 +275,7 @@ fn snapshot_subset_to_snapshot(context: Context, args: Vec<Value>) -> NodeFuture
 
   Box::pin(async move {
     let path_globs = Snapshot::lift_path_globs(&globs)?;
-    let original_digest = lift_digest(&externs::project_ignoring_type(
-      &args[0],
-      "directory_digest",
-    ))?;
+    let original_digest = lift_digest(&externs::project_ignoring_type(&args[0], "digest"))?;
 
     let snapshot = store::Snapshot::get_snapshot_subset(store, original_digest, path_globs).await?;
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
@@ -19,7 +19,7 @@ class ResourcesTaskTestBase(TaskTestBase):
         def __init__(self, contents, **kwargs):
             payload = Payload()
             payload.add_field("contents", PrimitiveField(contents))
-            super(MinimalImplResourcesTaskTest.TestTarget, self).__init__(payload=payload, **kwargs)
+            super().__init__(payload=payload, **kwargs)
 
     class MinimalImplResourcesTask(ResourcesTask):
         @staticmethod

--- a/tests/python/pants_test/binaries/test_binary_tool.py
+++ b/tests/python/pants_test/binaries/test_binary_tool.py
@@ -162,5 +162,5 @@ class BinaryToolBaseTest(TestBase):
             _, snapshot = default_version_tool.hackily_snapshot(context)
             self.assertEqual(
                 "51a98706ab7458069aabe01856cb352ca97686e3edd3bf9ebd3205c2b38b2974",
-                snapshot.directory_digest.fingerprint,
+                snapshot.digest.fingerprint,
             )


### PR DESCRIPTION
A `Digest` can be either "an opaque handle to a set of files" or it can refer to a string/bytes. To disambiguate, in the early days of V2, we used the variable name `directory_digest` to refer to when the digest is referring to the filesystem.

It turns out, we use `Digest` extremely frequently for the FS use. Because of this, we've over time shifted from `directory_digest` to the more ergonomic `digest`.

But, we're now inconsistent that we still sometimes use `directory_digest` and sometimes `digest`. This inconsistency results in wasted cognitive load.

Instead of fixing `digest` to say `directory_digest`, this PR converges around `digest`, given the overwhelming amount of use cases for the FS. If we ever need to use a `Digest` object to refer to a string/bytes, then we can rename that variable to `str_digest`.

This does not touch Rust, which does want the extra verbosity to disambiguate.

Closes https://github.com/pantsbuild/pants/issues/9129.

[ci skip-jvm-tests]