### PR TITLE
Calculate `SourcesSnapshot` using the Target API

### DIFF
--- a/src/python/pants/core/project_info/cloc_test.py
+++ b/src/python/pants/core/project_info/cloc_test.py
@@ -1,8 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.target_types import PythonLibrary
 from pants.backend.jvm.target_types import JavaLibrary
+from pants.backend.python.target_types import PythonLibrary
 from pants.core.project_info import cloc
 from pants.core.util_rules import archive, external_tool
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase

--- a/src/python/pants/core/project_info/cloc_test.py
+++ b/src/python/pants/core/project_info/cloc_test.py
@@ -1,8 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.backend.python.target_types import PythonLibrary
+from pants.backend.jvm.target_types import JavaLibrary
 from pants.core.project_info import cloc
 from pants.core.util_rules import archive, external_tool
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
@@ -12,12 +12,12 @@ class ClocTest(GoalRuleTestBase):
     goal_cls = cloc.CountLinesOfCode
 
     @classmethod
-    def rules(cls):
-        return [*super().rules(), *cloc.rules(), *archive.rules(), *external_tool.rules()]
+    def target_types(cls):
+        return [JavaLibrary, PythonLibrary]
 
     @classmethod
-    def alias_groups(cls):
-        return BuildFileAliases(targets={"java_library": JavaLibrary})
+    def rules(cls):
+        return [*super().rules(), *cloc.rules(), *archive.rules(), *external_tool.rules()]
 
     def assert_counts(
         self,

--- a/src/python/pants/engine/internals/BUILD
+++ b/src/python/pants/engine/internals/BUILD
@@ -96,8 +96,6 @@ python_library(
     '3rdparty/python:dataclasses',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:specs',
-    'src/python/pants/engine/legacy:graph',
-    'src/python/pants/engine/legacy:structs',
     'src/python/pants/engine:addresses',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:rules',


### PR DESCRIPTION
This means that `engine/internals` no longer has any dependency on `engine/legacy` (outside of some tests).

Running `./v2 cloc2` with address specs will also result in Target API validation, now, if there are any invalid fields.

[ci skip-rust-tests]
[ci skip-jvm-tests]