### PR TITLE
Prune the pantsd integration test target

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,3 +1,2 @@
 tests/python/pants_test/backend/python/tasks:setup_py_integration
 tests/python/pants_test/backend/python:integration
-tests/python/pants_test/pantsd:pantsd_integration

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -544,6 +544,8 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=False,
+            removal_version="1.29.0.dev2",
+            removal_hint="Not widely used, and will soon be rewritten to be inherent.",
             help="Create a new pantsd server, and use it, and shut it down immediately after. "
             "If pantsd is already running, it will shut it down and spawn a new instance (Beta)",
         )

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -151,6 +151,12 @@ python_library(
 )
 
 python_library(
+  name='retry',
+  sources=['retry.py'],
+  tags = {"partially_type_checked"},
+)
+
+python_library(
   name='pexrc_util',
   sources=['pexrc_util.py'],
   dependencies = [

--- a/src/python/pants/testutil/retry.py
+++ b/src/python/pants/testutil/retry.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import time
+from typing import Iterator
+
+
+def attempts(
+    msg: str, delay: float = 0.5, timeout: float = 30, backoff: float = 1.2,
+) -> Iterator[None]:
+    """A generator that yields a number of times before failing.
+
+    A caller should break out of a loop on the generator in order to succeed.
+    """
+    count = 0
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        count += 1
+        yield
+        time.sleep(delay)
+        delay *= backoff
+    raise AssertionError(f"After {count} attempts in {timeout} seconds: {msg}")

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -72,9 +72,10 @@ python_library(
   dependencies = [
     '3rdparty/python:ansicolors',
     'src/python/pants/pantsd:process_manager',
-    'src/python/pants/util:collections',
-    'src/python/pants/testutil:process_test_util',
     'src/python/pants/testutil:int-test',
+    'src/python/pants/testutil:process_test_util',
+    'src/python/pants/testutil:retry',
+    'src/python/pants/util:collections',
   ],
   tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -657,23 +657,6 @@ Interrupted by user over pailgun client!
             ctx.checker.assert_started()
             self.assert_success(result)
 
-    def test_daemon_auto_shutdown_after_first_run(self):
-        config = {"GLOBAL": {"shutdown_pantsd_after_run": True}}
-        with self.pantsd_test_context(extra_config=config) as (workdir, config, checker):
-            wait_handle = self.run_pants_with_workdir_without_waiting(["list"], workdir, config,)
-
-            # TODO(#6574, #7330): We might have a new default timeout after these are resolved.
-            checker.assert_started(timeout=16)
-            pantsd_processes = checker.runner_process_context.current_processes()
-            pants_run = wait_handle.join()
-            self.assert_success(pants_run)
-
-            # Permit enough time for the process to terminate in CI
-            time.sleep(5)
-
-            for process in pantsd_processes:
-                self.assertFalse(process.is_running())
-
     # This is a regression test for a bug where we would incorrectly detect a cycle if two targets swapped their
     # dependency relationship (#7404).
     def test_dependencies_swap(self):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -301,18 +301,16 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 return "\n".join(read_pantsd_log(ctx.workdir))
 
             # Check the logs.
+            ctx.checker.assert_running()
             self.assertRegex(
                 full_pantsd_log(), r"watching invalidating files:.*{}".format(test_dir)
             )
-
-            ctx.checker.assert_running()
 
             # Create a new file in test_dir
             with temporary_file(suffix=".py", binary_mode=False, root_dir=test_dir) as temp_f:
                 temp_f.write("import that\n")
                 temp_f.close()
 
-                time.sleep(10)
                 ctx.checker.assert_stopped()
 
             self.assertIn("saw file events covered by invalidation globs", full_pantsd_log())
@@ -332,7 +330,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
             # Delete tmp_pants_toml
             os.unlink(tmp_pants_toml)
-            time.sleep(10)
             ctx.checker.assert_stopped()
 
     def test_pantsd_pid_deleted(self):
@@ -347,8 +344,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             subprocess_dir = ctx.pantsd_config["GLOBAL"]["pants_subprocessdir"]
             os.unlink(os.path.join(subprocess_dir, "pantsd", "pid"))
 
-            # Permit ample time for the async file event propagate in CI.
-            time.sleep(10)
             ctx.checker.assert_stopped()
 
     def test_pantsd_pid_change(self):
@@ -365,8 +360,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             with open(pidpath, "w") as f:
                 f.write("9")
 
-            # Permit ample time for the async file event propagate in CI.
-            time.sleep(10)
             ctx.checker.assert_stopped()
 
             # Remove the pidfile so that the teardown script doesn't try to kill process 9.

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -44,12 +44,6 @@ def launch_file_toucher(f):
 
 
 class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
-    def test_pantsd_compile(self):
-        with self.pantsd_successful_run_context(log_level="debug") as ctx:
-            # This tests a deeper pantsd-based run by actually invoking a full compile.
-            ctx.runner(["compile", "examples/src/scala/org/pantsbuild/example/hello/welcome"])
-            ctx.checker.assert_started()
-
     @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/7573")
     def test_pantsd_run(self):
         with self.pantsd_successful_run_context(log_level="debug") as ctx:
@@ -656,21 +650,6 @@ Interrupted by user over pailgun client!
             result = first_run_handle.join(stdin_data="exit()")
             self.assert_success(result)
             checker.assert_running()
-
-    def test_pantsd_environment_scrubbing(self):
-        # This pair of JVM options causes the JVM to always crash, so the command will fail if the env
-        # isn't stripped.
-        with self.pantsd_successful_run_context(
-            extra_config={"compile.rsc": {"jvm_options": ["-Xmx1g"]}},
-            extra_env={"_JAVA_OPTIONS": "-Xms2g"},
-        ) as ctx:
-            ctx.runner(["help"])
-            ctx.checker.assert_started()
-
-            result = ctx.runner(
-                ["compile", "examples/src/java/org/pantsbuild/example/hello/simple"]
-            )
-            self.assert_success(result)
 
     def test_pantsd_unicode_environment(self):
         with self.pantsd_successful_run_context(extra_env={"XXX": "¡"},) as ctx:


### PR DESCRIPTION
### Problem

Local profiling showed that this test was spending up to 400 seconds bootstrapping/compiling JVM tools under `--v2`, but pantsd does not have any particular connection to the JVM, and so can stick to graph introspection goals.

### Solution

Remove JVM commands (and bootstrapping) from the pantsd integration test, and try moving it out of the `--chroot` blacklist. Additionally, the `--shutdown-pantsd-after-run` flag will soon be made inherent by the "pantsd by default" effort, so deprecate it and remove its test.