### PR TITLE
Always register `engine.target.rules()` via `engine_initializer.py`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -17,7 +17,6 @@ from pants.engine.target import (
     HydrateSourcesRequest,
     WrappedTarget,
 )
-from pants.engine.target import rules as target_rules
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
@@ -35,7 +34,6 @@ class ProtobufPythonIntegrationTest(TestBase):
             *archive.rules(),
             *determine_source_files.rules(),
             *external_tool.rules(),
-            *target_rules(),
             RootRule(GeneratePythonFromProtobufRequest),
         )
 

--- a/src/python/pants/core/project_info/filedeps_test.py
+++ b/src/python/pants/core/project_info/filedeps_test.py
@@ -18,7 +18,6 @@ from pants.build_graph.resources import Resources as ResourcesV1
 from pants.build_graph.target import Target as TargetV1
 from pants.core.project_info import filedeps
 from pants.core.target_types import GenericTarget, Resources
-from pants.engine.target import rules as target_rules
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
 
@@ -28,7 +27,7 @@ class FileDepsTest(GoalRuleTestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *filedeps.rules(), *target_rules())
+        return (*super().rules(), *filedeps.rules())
 
     @classmethod
     def target_types(cls):

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -31,7 +31,6 @@ from pants.core.util_rules import (
     filter_empty_sources,
     strip_source_roots,
 )
-from pants.engine.target import rules as target_rules
 
 
 def rules():
@@ -57,8 +56,6 @@ def rules():
         *strip_source_roots.rules(),
         *archive.rules(),
         *external_tool.rules(),
-        # other
-        *target_rules(),
     ]
 
 

--- a/src/python/pants/core/util_rules/determine_source_files_test.py
+++ b/src/python/pants/core/util_rules/determine_source_files_test.py
@@ -24,7 +24,6 @@ from pants.core.util_rules.strip_source_roots import rules as strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.selectors import Params
 from pants.engine.target import Sources as SourcesField
-from pants.engine.target import rules as target_rules
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
@@ -50,7 +49,6 @@ class DetermineSourceFilesTest(TestBase):
             *super().rules(),
             *determine_source_files_rules(),
             *strip_source_roots_rules(),
-            *target_rules(),
         )
 
     def mock_sources_field_with_origin(

--- a/src/python/pants/core/util_rules/filter_empty_sources.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources.py
@@ -11,7 +11,6 @@ from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
 from pants.engine.target import Target
-from pants.engine.target import rules as target_rules
 
 
 # This protocol allows us to work with any arbitrary Configuration. See
@@ -72,5 +71,4 @@ def rules():
         determine_targets_with_sources,
         RootRule(ConfigurationsWithSourcesRequest),
         RootRule(TargetsWithSourcesRequest),
-        *target_rules(),
     ]

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -21,7 +21,6 @@ from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
-from pants.engine.target import rules as target_rules
 from pants.source.source_root import NoSourceRootError, SourceRootConfig
 from pants.util.meta import frozen_after_init
 
@@ -175,5 +174,4 @@ def rules():
         subsystem_rule(SourceRootConfig),
         RootRule(StripSnapshotRequest),
         RootRule(StripSourcesFieldRequest),
-        *target_rules(),
     ]

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -43,5 +43,5 @@ class InteractiveRunner:
         return self._scheduler.run_local_interactive_process(request)
 
 
-def create_interactive_runner_rules():
+def rules():
     return [RootRule(InteractiveRunner)]

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -209,7 +209,7 @@ def remove_platform_information(res: FallibleProcessResultWithPlatform,) -> Fall
     )
 
 
-def create_process_rules():
+def rules():
     """Creates rules that consume the intrinsic filesystem types."""
     return [
         RootRule(Process),

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -54,7 +54,6 @@ from pants.engine.target import (
     TooManyTargetsException,
     WrappedTarget,
 )
-from pants.engine.target import rules as target_rules
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.testutil.engine.util import MockGet, run_rule
 from pants.testutil.test_base import TestBase
@@ -525,7 +524,6 @@ class TestFindValidConfigurations(TestBase):
     def rules(cls):
         return (
             *super().rules(),
-            *target_rules(),
             RootRule(TargetsWithOrigins),
             UnionRule(cls.ConfigSuperclass, cls.ConfigSubclass1),
             UnionRule(cls.ConfigSuperclass, cls.ConfigSubclass2),
@@ -768,7 +766,7 @@ def test_dict_string_to_string_sequence_field() -> None:
 class TestSources(TestBase):
     @classmethod
     def rules(cls):
-        return (*super().rules(), *target_rules(), RootRule(HydrateSourcesRequest))
+        return (*super().rules(), RootRule(HydrateSourcesRequest))
 
     def test_raw_value_sanitation(self) -> None:
         addr = Address.parse(":test")
@@ -938,7 +936,6 @@ class TestCodegen(TestBase):
     def rules(cls):
         return (
             *super().rules(),
-            *target_rules(),
             generate_fortran_from_avro,
             RootRule(GenerateFortranFromAvroRequest),
             RootRule(HydrateSourcesRequest),

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -22,10 +22,11 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.remote_sources import RemoteSources
 from pants.build_graph.target import Target as TargetV1
+from pants.engine import interactive_runner, process, target
 from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
 from pants.engine.goal import Goal
-from pants.engine.interactive_runner import InteractiveRunner, create_interactive_runner_rules
+from pants.engine.interactive_runner import InteractiveRunner
 from pants.engine.internals import graph, options_parsing
 from pants.engine.internals.build_files import create_graph_rules
 from pants.engine.internals.mapper import AddressMapper
@@ -49,7 +50,6 @@ from pants.engine.legacy.structs import (
 )
 from pants.engine.legacy.structs import rules as structs_rules
 from pants.engine.platform import create_platform_rules
-from pants.engine.process import create_process_rules
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Params
 from pants.engine.target import RegisteredTargetTypes
@@ -425,12 +425,13 @@ class EngineInitializer:
             registered_target_types_singleton,
             union_membership_singleton,
             build_root_singleton,
+            *interactive_runner.rules(),
             *graph.rules(),
             *options_parsing.rules(),
+            *process.rules(),
+            *target.rules(),
             *create_legacy_graph_tasks(),
             *create_fs_rules(),
-            *create_interactive_runner_rules(),
-            *create_process_rules(),
             *create_platform_rules(),
             *create_graph_rules(address_mapper),
             *structs_rules(),


### PR DESCRIPTION
Certain rules get initialized in `engine_initializer.py` so that they are always registered, no matter what, such as in tests. We do this for the most fundamental rules, like the `fs.py` rules.

We originally didn't do this for `engine.target.rules()` because those rules were experimental, but they're now widely used. 

[ci skip-rust-tests]
[ci skip-jvm-tests]