### PR TITLE
pin AR=/usr/bin/ar on osx when building native_engine.so

### DIFF
--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -40,9 +40,18 @@ export PROTOC="${protoc}"
 # then becomes:
 # "Symbol not found: _wrapped_PyInit_native_engine"
 # when attempting to import the native engine library in native.py.
-if [[ "$(uname)" == 'Darwin' ]]; then
-  export AR='/usr/bin/ar'
-fi
+case "$(uname)" in
+  "Darwin")
+    export AR='/usr/bin/ar'
+    ;;
+  "Linux")
+    binutils="$("${download_binary}" "binutils" "2.30" "binutils.tar.gz")"
+    export AR="${binutils}/bin/ar"
+    ;;
+  *)
+    die "Unknown platform: uname was $(uname)"
+    ;;
+esac
 
 cargo_bin="${CARGO_HOME}/bin/cargo"
 

--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -34,17 +34,20 @@ export PROTOC="${protoc}"
 
 # We implicitly pull in `ar` to create libnative_engine_ffi.a from native_engine.o via the `cc`
 # crate in engine_cffi/build.rs.
-# The homebrew version of the `ar` tool appears to "sometimes" create libnative_engine_ffi.a
-# instances which aren't recognized as Mach-O x86-64 binaries when first on the PATH. This causes a
-# silent linking error at build time due to the use of the `-undefined dynamic_lookup` flag, which
-# then becomes:
-# "Symbol not found: _wrapped_PyInit_native_engine"
-# when attempting to import the native engine library in native.py.
 case "$(uname)" in
   "Darwin")
+    # The homebrew version of the `ar` tool appears to "sometimes" create libnative_engine_ffi.a
+    # instances which aren't recognized as Mach-O x86-64 binaries when first on the PATH. This
+    # causes a silent linking error at build time due to the use of the `-undefined dynamic_lookup`
+    # flag, which then becomes:
+    # "Symbol not found: _wrapped_PyInit_native_engine"
+    # when attempting to import the native engine library in native.py.
+    # NB: This line uses the version of `ar` provided by OSX itself, which avoids the linking error.
     export AR='/usr/bin/ar'
     ;;
   "Linux")
+    # While the linking error when consuming libnative_engine_ffi.a does not repro on Linux, since
+    # we have a reliable version of `ar` available from the pantsbuild s3, we might as well use it.
     binutils="$("${download_binary}" "binutils" "2.30" "binutils.tar.gz")"
     export AR="${binutils}/bin/ar"
     ;;


### PR DESCRIPTION
### Problem
*(from the `#engine` channel on slack)*

Without this change, I get this error message when pants imports the native engine module in `native.py`:
```
Exception message: dlopen(/Users/dmcclanahan/tools/p1/native_engine.so, 2): Symbol not found: _wrapped_PyInit_native_engine
  Referenced from: /Users/dmcclanahan/tools/p1/native_engine.so
  Expected in: flat namespace
 in /Users/dmcclanahan/tools/p1/native_engine.so
```
This goes away when I ensure `/usr/bin` is before `/usr/local/bin` on my PATH, which I traced down specifically to the `ar` tool by removing `-undefined dynamic_lookup` from `engine_cffi/build.rs`, getting this error message:
```
 = note: ld: warning: ignoring file /Users/dmcclanahan/tools/p1/src/rust/engine/target/debug/build/engine_cffi-0cfc0b2057922e53/out/libnative_engine_ffi.a, building for macOS-x86_64 but attempting to link with file built for unknown-unsupported file format ( 0x21 0x3C 0x61 0x72 0x63 0x68 0x3E 0x0A 0x2F 0x20 0x20 0x20 0x20 0x20 0x20 0x20 )
          Undefined symbols for architecture x86_64:
            "_wrapped_PyInit_native_engine", referenced from:
                _PyInit_native_engine in engine_cffi.2e9skz2skowhnlv2.rcgu.o
            "_wrapped_initnative_engine", referenced from:
                _initnative_engine in engine_cffi.2e9skz2skowhnlv2.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see **invocation)**
```
I was able to make the above command succeed by replacing `libnative_engine_ffi.a` with the path to `native_engine.o`, which the `.a` file is created from. This made me realize that the homebrew `ar` was for some reason producing bad binaries.

**I've had this occur off and on for the past two years, so this isn't a one-time fluke.** I'm relatively confident this change will not break on anyone else's machine, and it is conclusively resolving the issue on mine.

### Solution

- Pin `AR=/usr/bin/ar` in `cargo.sh` on OSX.
- On Linux, use the `ar` from the `binutils` archive on the pantsbuild s3.

### Result

I can work in the pants repo again!

[ci skip-jvm-tests]