### PR TITLE
WIP: Don't register RootRule when not necessary

### DIFF
--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -8,7 +8,7 @@ from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFil
 from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.platform import Platform
-from pants.engine.rules import rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.util.dirutil import is_readable_dir
 from pants.util.enums import match
 from pants.util.memo import memoized_method, memoized_property
@@ -138,4 +138,4 @@ def get_clang_plusplus(llvm: LLVM) -> CppCompiler:
 
 
 def create_llvm_rules():
-    return [get_lld, get_clang, get_clang_plusplus, subsystem_rule(LLVM)]
+    return [get_lld, get_clang, get_clang_plusplus, SubsystemRule(LLVM)]

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -8,7 +8,7 @@ from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFil
 from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.platform import Platform
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule, subsystem_rule
 from pants.util.dirutil import is_readable_dir
 from pants.util.enums import match
 from pants.util.memo import memoized_method, memoized_property
@@ -138,9 +138,4 @@ def get_clang_plusplus(llvm: LLVM) -> CppCompiler:
 
 
 def create_llvm_rules():
-    return [
-        get_lld,
-        get_clang,
-        get_clang_plusplus,
-        RootRule(LLVM),
-    ]
+    return [get_lld, get_clang, get_clang_plusplus, subsystem_rule(LLVM)]

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -19,7 +19,7 @@ from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.native.subsystems.xcode_cli_tools import XCodeCLITools
 from pants.engine.platform import Platform
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, rule, subsystem_rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.enums import match
@@ -398,6 +398,6 @@ def create_native_toolchain_rules():
         select_gcc_cpp_toolchain,
         select_c_toolchain,
         select_cpp_toolchain,
-        RootRule(NativeToolchain),
+        subsystem_rule(NativeToolchain),
         RootRule(ToolchainVariantRequest),
     ]

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -19,7 +19,7 @@ from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.native.subsystems.xcode_cli_tools import XCodeCLITools
 from pants.engine.platform import Platform
-from pants.engine.rules import RootRule, rule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.enums import match
@@ -398,6 +398,6 @@ def create_native_toolchain_rules():
         select_gcc_cpp_toolchain,
         select_c_toolchain,
         select_cpp_toolchain,
-        subsystem_rule(NativeToolchain),
+        SubsystemRule(NativeToolchain),
         RootRule(ToolchainVariantRequest),
     ]

--- a/src/python/pants/backend/python/rules/importable_python_sources.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources.py
@@ -10,7 +10,7 @@ from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Snapshot
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.engine.target import Sources, Targets
 
@@ -46,9 +46,4 @@ async def prepare_python_sources(targets: Targets) -> ImportablePythonSources:
 
 
 def rules():
-    return [
-        prepare_python_sources,
-        *determine_source_files.rules(),
-        *inject_init_rules(),
-        RootRule(Targets),
-    ]
+    return [prepare_python_sources, *determine_source_files.rules(), *inject_init_rules()]

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 
 from pants.engine.fs import Digest, FileContent, InputFilesContent, MergeDigests, Snapshot
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.python.pex_build_util import identify_missing_init_files
 
@@ -38,4 +38,4 @@ async def inject_missing_init_files(request: InjectInitRequest) -> InitInjectedS
 
 
 def rules():
-    return [inject_missing_init_files, RootRule(InjectInitRequest)]
+    return [inject_missing_init_files]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -29,7 +29,7 @@ from pants.engine.fs import (
 )
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.process import MultiPlatformProcess, ProcessResult
-from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -439,8 +439,6 @@ def rules():
     return [
         create_pex,
         two_step_create_pex,
-        RootRule(PexRequest),
-        RootRule(TwoStepPexRequest),
         SubsystemRule(PythonSetup),
         SubsystemRule(PythonRepos),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -19,7 +19,7 @@ from pants.backend.python.target_types import (
 )
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import RootRule, named_rule, rule
+from pants.engine.rules import named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Targets, TransitiveTargets
 from pants.python.python_setup import PythonSetup
@@ -136,9 +136,4 @@ async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoSte
 
 
 def rules():
-    return [
-        pex_from_targets,
-        two_step_pex_from_targets,
-        RootRule(PexFromTargetsRequest),
-        RootRule(TwoStepPexFromTargetsRequest),
-    ]
+    return [pex_from_targets, two_step_pex_from_targets]

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     MergeDigests,
 )
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Sources, Targets, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -392,5 +392,4 @@ def rules():
         setup_coverage,
         SubsystemRule(PytestCoverage),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
-        RootRule(CoverageConfigRequest),
     ]

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -382,7 +382,6 @@ async def fetch_binary_tool(req: BinaryToolFetchRequest, url_set: BinaryToolUrlS
 
 def rules():
     return [
-        RootRule(PlatformConstraint),
         translate_host_platform,
         get_binary_tool_urls,
         fetch_binary_tool,

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 from pants.engine.fs import Digest, RemovePrefix, Snapshot
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get
 
 
@@ -62,4 +62,4 @@ async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
 
 
 def rules():
-    return [maybe_extract, RootRule(MaybeExtractable)]
+    return [maybe_extract]

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -11,7 +11,7 @@ from pants.core.util_rules.strip_source_roots import (
     StripSourcesFieldRequest,
 )
 from pants.engine.fs import MergeDigests, PathGlobs, Snapshot, SnapshotSubset
-from pants.engine.rules import rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -182,4 +182,6 @@ def rules():
         determine_all_source_files,
         determine_specified_source_files,
         *strip_source_roots.rules(),
+        RootRule(AllSourceFilesRequest),
+        RootRule(SpecifiedSourceFilesRequest),
     ]

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -11,7 +11,7 @@ from pants.core.util_rules.strip_source_roots import (
     StripSourcesFieldRequest,
 )
 from pants.engine.fs import MergeDigests, PathGlobs, Snapshot, SnapshotSubset
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -181,7 +181,5 @@ def rules():
     return [
         determine_all_source_files,
         determine_specified_source_files,
-        RootRule(AllSourceFilesRequest),
-        RootRule(SpecifiedSourceFilesRequest),
         *strip_source_roots.rules(),
     ]

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -10,7 +10,7 @@ from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
 from pants.engine.fs import Digest, DirectoryToMaterialize, Snapshot, UrlToFetch
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -237,4 +237,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return [download_external_tool]
+    return [download_external_tool, RootRule(ExternalToolRequest)]

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -10,7 +10,7 @@ from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
 from pants.engine.fs import Digest, DirectoryToMaterialize, Snapshot, UrlToFetch
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -237,4 +237,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return [download_external_tool, RootRule(ExternalToolRequest)]
+    return [download_external_tool]

--- a/src/python/pants/core/util_rules/filter_empty_sources.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 from typing_extensions import Protocol
 
 from pants.engine.collection import Collection
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -66,9 +66,4 @@ async def determine_targets_with_sources(request: TargetsWithSourcesRequest) -> 
 
 
 def rules():
-    return [
-        determine_field_sets_with_sources,
-        determine_targets_with_sources,
-        RootRule(FieldSetsWithSourcesRequest),
-        RootRule(TargetsWithSourcesRequest),
-    ]
+    return [determine_field_sets_with_sources, determine_targets_with_sources]

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -17,7 +17,7 @@ from pants.engine.fs import (
     Snapshot,
     SnapshotSubset,
 )
-from pants.engine.rules import RootRule, SubsystemRule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -167,6 +167,4 @@ def rules():
         strip_source_roots_from_snapshot,
         strip_source_roots_from_sources_field,
         SubsystemRule(SourceRootConfig),
-        RootRule(StripSnapshotRequest),
-        RootRule(StripSourcesFieldRequest),
     ]

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -375,8 +375,5 @@ def create_graph_rules(address_mapper: AddressMapper):
         # AddressFamilies for each of them.
         addresses_with_origins_from_address_families,
         strip_address_origins,
-        # Root rules representing parameters that might be provided via root subjects.
-        RootRule(Address),
-        RootRule(AddressWithOrigin),
         RootRule(AddressSpecs),
     ]

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -338,5 +338,4 @@ def rules():
         sources_snapshots_from_address_specs,
         sources_snapshots_from_filesystem_specs,
         RootRule(FilesystemSpecs),
-        RootRule(OwnersRequest),
     ]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -36,7 +36,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.legacy.structs import BundleAdaptor
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionMembership, union
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper, Filespec
@@ -166,7 +166,7 @@ class AsyncField(Field, metaclass=ABCMeta):
 
     You should also create corresponding HydratedField and HydrateFieldRequest classes and define a
     rule to go from this HydrateFieldRequest to HydratedField. The HydrateFieldRequest type should
-    have an attribute storing the underlying AsyncField; it also must be registered as a RootRule.
+    have an attribute storing the underlying AsyncField.
 
     For example:
 
@@ -205,7 +205,7 @@ class AsyncField(Field, metaclass=ABCMeta):
 
 
         def rules():
-            return [hydrate_sources, RootRule(HydrateSourcesRequest)]
+            return [hydrate_sources]
 
     Then, call sites can `await Get` if they need to hydrate the field, even if they subclassed
     the original `AsyncField` to have custom behavior:
@@ -1653,9 +1653,4 @@ class BundlesField(AsyncField):
 
 
 def rules():
-    return [
-        find_valid_field_sets,
-        hydrate_sources,
-        RootRule(TargetsToValidFieldSetsRequest),
-        RootRule(HydrateSourcesRequest),
-    ]
+    return [find_valid_field_sets, hydrate_sources]

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -136,7 +136,4 @@ class Changed(Subsystem):
 
 
 def rules():
-    return [
-        find_owners,
-        RootRule(ChangedRequest),
-    ]
+    return [find_owners, RootRule(ChangedRequest)]


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/pull/9634#discussion_r415412400, we do not need to register something as a `RootRule` if either:

a) A rule returns that type, or
b) that type is injected as the subject in an `await Get[P](Subject)`

We only need `RootRule` when either of those conditions are not met. Generally, `RootRule` should be preserved for types that are "public".

--

This PR removes many unnecessary `RootRules`, resulting in a tigher rule graph.

We also had two `RootRule`s that should have been `subsystem_rule`s, but were not because that did not yet exist.

[ci skip-rust-tests]
[ci skip-jvm-tests]