### PR TITLE
Change `GoalRuleTestBase.execute_rule` to return the captured stderr

### DIFF
--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -63,29 +63,29 @@ class ReplTest(GoalRuleTestBase):
 
     def test_repl_with_targets(self) -> None:
         self.setup_python_library()
-        output = self.execute_rule(
+        result = self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
             args=["src/python:some_lib"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
-        assert output == "REPL exited successfully."
+        assert result.stdout == "REPL exited successfully."
 
     def test_repl_ipython(self) -> None:
         self.setup_python_library()
-        output = self.execute_rule(
+        result = self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
             args=["--shell=ipython", "src/python:some_lib"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
-        assert output == "REPL exited successfully."
+        assert result.stdout == "REPL exited successfully."
 
     def test_repl_bogus_repl_name(self) -> None:
         self.setup_python_library()
-        output = self.execute_rule(
+        result = self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
             args=["--shell=bogus-repl", "src/python:some_lib"],
             additional_params=[InteractiveRunner(self.scheduler)],
             exit_code=-1,
         )
 
-        assert "bogus-repl is not an installed REPL program. Available REPLs:" in output
+        assert "bogus-repl is not an installed REPL program. Available REPLs:" in result.stdout

--- a/src/python/pants/core/project_info/cloc_test.py
+++ b/src/python/pants/core/project_info/cloc_test.py
@@ -5,7 +5,26 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.project_info import cloc
 from pants.core.util_rules import archive, external_tool
-from pants.testutil.goal_rule_test_base import GoalRuleTestBase
+from pants.testutil.goal_rule_test_base import GoalRuleResult, GoalRuleTestBase
+
+
+def assert_counts(
+    stdout: str, lang: str, *, num_files: int = 1, blank: int = 0, comment: int = 0, code: int = 0
+) -> None:
+    summary_line = next(
+        (
+            line
+            for line in stdout.splitlines()
+            if len(line.split()) == 5 and line.split()[0] == lang
+        ),
+        None,
+    )
+    assert summary_line is not None, f"Found no output line for {lang}"
+    fields = summary_line.split()
+    assert num_files == int(fields[1])
+    assert blank == int(fields[2])
+    assert comment == int(fields[3])
+    assert code == int(fields[4])
 
 
 class ClocTest(GoalRuleTestBase):
@@ -18,27 +37,6 @@ class ClocTest(GoalRuleTestBase):
     @classmethod
     def alias_groups(cls):
         return BuildFileAliases(targets={"java_library": JavaLibrary})
-
-    def assert_counts(
-        self,
-        stdout: str,
-        lang: str,
-        *,
-        num_files: int = 1,
-        blank: int = 0,
-        comment: int = 0,
-        code: int = 0,
-    ) -> None:
-        for line in stdout.splitlines():
-            fields = line.split()
-            if len(fields) < 5 or fields[0] != lang:
-                continue
-            self.assertEqual(num_files, int(fields[1]))
-            self.assertEqual(blank, int(fields[2]))
-            self.assertEqual(comment, int(fields[3]))
-            self.assertEqual(code, int(fields[4]))
-            return
-        self.fail(f"Found no output line for {lang}")
 
     def test_cloc(self) -> None:
         py_dir = "src/py/foo"
@@ -55,9 +53,9 @@ class ClocTest(GoalRuleTestBase):
         )
         self.add_to_build_file(java_dir, "java_library(source='Foo.java')")
 
-        output = self.execute_rule(args=[py_dir, java_dir])
-        self.assert_counts(output, "Python", num_files=2, blank=2, comment=3, code=2)
-        self.assert_counts(output, "Java", comment=1, code=1)
+        result = self.execute_rule(args=[py_dir, java_dir])
+        assert_counts(result.stdout, "Python", num_files=2, blank=2, comment=3, code=2)
+        assert_counts(result.stdout, "Java", comment=1, code=1)
 
     def test_ignored(self) -> None:
         py_dir = "src/py/foo"
@@ -65,9 +63,9 @@ class ClocTest(GoalRuleTestBase):
         self.create_file(f"{py_dir}/empty.py", "")
         self.add_to_build_file(py_dir, "python_library()")
 
-        output = self.execute_rule(args=[py_dir, "--cloc2-ignored"])
-        assert "Ignored the following files:" in output
-        assert "empty.py: zero sized file" in output
+        result = self.execute_rule(args=[py_dir, "--cloc2-ignored"])
+        assert "Ignored the following files:" in result.stdout
+        assert "empty.py: zero sized file" in result.stdout
 
     def test_filesystem_specs_with_owners(self) -> None:
         """Even if a file belongs to a target which has multiple sources, we should only run over
@@ -76,20 +74,20 @@ class ClocTest(GoalRuleTestBase):
         self.create_file(f"{py_dir}/foo.py", "print('some code')")
         self.create_file(f"{py_dir}/bar.py", "print('some code')\nprint('more code')")
         self.add_to_build_file(py_dir, "python_library()")
-        output = self.execute_rule(args=[f"{py_dir}/foo.py"])
-        self.assert_counts(output, "Python", num_files=1, code=1)
+        result = self.execute_rule(args=[f"{py_dir}/foo.py"])
+        assert_counts(result.stdout, "Python", num_files=1, code=1)
 
     def test_filesystem_specs_without_owners(self) -> None:
         """Unlike most goals, cloc works on any readable file in the build root, regardless of
         whether it's declared in a BUILD file."""
         self.create_file("test/foo.ex", 'IO.puts("im a free thinker!")')
         self.create_file("test/foo.hs", 'main = putStrLn "Whats Pants, precious?"')
-        output = self.execute_rule(args=["test/foo.*"])
-        self.assert_counts(output, "Elixir", code=1)
-        self.assert_counts(output, "Haskell", code=1)
+        result = self.execute_rule(args=["test/foo.*"])
+        assert_counts(result.stdout, "Elixir", code=1)
+        assert_counts(result.stdout, "Haskell", code=1)
 
     def test_no_sources_exits_gracefully(self) -> None:
         py_dir = "src/py/foo"
         self.add_to_build_file(py_dir, "python_library(sources=[])")
-        output = self.execute_rule(args=[py_dir])
-        assert output.strip() == ""
+        result = self.execute_rule(args=[py_dir])
+        assert result == GoalRuleResult(return_code=0, stdout="", stderr="")

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -95,6 +95,7 @@ python_library(
   sources = ['goal_rule_test_base.py'],
   dependencies = [
     ':test_base',
+    '3rdparty/python:dataclasses',
     'src/python/pants/init',
     'src/python/pants/testutil/option',
     'src/python/pants/util:meta',

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -27,17 +27,11 @@ class GoalRuleResult:
 
 
 class GoalRuleTestBase(TestBase):
-    """A baseclass useful for testing a Goal defined as a @goal_rule.
-
-    :API: public
-    """
+    """A baseclass useful for testing a Goal defined as a @goal_rule."""
 
     @classproperty
     def goal_cls(cls):
-        """Subclasses must return the Goal type to test.
-
-        :API: public
-        """
+        """Subclasses must return the Goal type to test."""
         raise NotImplementedError()
 
     def setUp(self):
@@ -55,8 +49,6 @@ class GoalRuleTestBase(TestBase):
         additional_params: Optional[Iterable[Any]] = None,
     ) -> GoalRuleResult:
         """Executes the @goal_rule for this test class.
-
-        :API: public
 
         Returns the return code, stdout, and stderr of the goal.
         """
@@ -93,12 +85,10 @@ class GoalRuleTestBase(TestBase):
 
         return GoalRuleResult(actual_exit_code, stdout_val, stderr_val)
 
-    def assert_entries(self, sep, *output, **kwargs) -> None:
+    def assert_entries(self, sep: str, *output, **kwargs) -> None:
         """Verifies the expected output text is flushed by goal rule.
 
         NB: order of entries is not tested, just presence.
-
-        :API: public
 
         sep:      the expected output separator.
         *output:  the output entries expected between the separators
@@ -116,8 +106,6 @@ class GoalRuleTestBase(TestBase):
 
         NB: order of entries is not tested, just presence.
 
-        :API: public
-
         *output:  the expected output entries
         **kwargs: additional kwargs passed to execute_rule.
         """
@@ -126,8 +114,6 @@ class GoalRuleTestBase(TestBase):
 
     def assert_console_output_contains(self, output, **kwargs) -> None:
         """Verifies the expected output string is emitted by the goal rule.
-
-        :API: public
 
         output:  the expected output entry(ies)
         **kwargs: additional kwargs passed to execute_rule.
@@ -140,8 +126,6 @@ class GoalRuleTestBase(TestBase):
 
         NB: order of entries is tested.
 
-        :API: public
-
         *output:  the expected output entries in expected order
         **kwargs: additional kwargs passed to execute_rule.
         """
@@ -150,8 +134,6 @@ class GoalRuleTestBase(TestBase):
 
     def assert_console_raises(self, exception: Type[Exception], **kwargs) -> None:
         """Verifies the expected exception is raised by the goal rule.
-
-        :API: public
 
         **kwargs: additional kwargs are passed to execute_rule.
         """

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -1,8 +1,11 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
 from io import StringIO
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Type
+
+import pytest
 
 from pants.engine.console import Console
 from pants.engine.fs import Workspace
@@ -14,6 +17,13 @@ from pants.option.global_options import GlobalOptions
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 from pants.util.meta import classproperty
+
+
+@dataclass(frozen=True)
+class GoalRuleResult:
+    return_code: int
+    stdout: str
+    stderr: str
 
 
 class GoalRuleTestBase(TestBase):
@@ -32,23 +42,23 @@ class GoalRuleTestBase(TestBase):
 
     def setUp(self):
         super().setUp()
-
         if not issubclass(self.goal_cls, Goal):
             raise AssertionError(f"goal_cls() must return a Goal subclass, got {self.goal_cls}")
 
     def execute_rule(
         self,
+        *,
         args: Optional[Iterable[str]] = None,
         global_args: Optional[Iterable[str]] = None,
         env: Optional[Dict[str, str]] = None,
         exit_code: int = 0,
         additional_params: Optional[Iterable[Any]] = None,
-    ) -> str:
+    ) -> GoalRuleResult:
         """Executes the @goal_rule for this test class.
 
         :API: public
 
-        Returns the text output of the task.
+        Returns the return code, stdout, and stderr of the goal.
         """
         # Create an OptionsBootstrapper for these args/env, and a captured Console instance.
         options_bootstrapper = create_options_bootstrapper(
@@ -60,16 +70,14 @@ class GoalRuleTestBase(TestBase):
         )
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr)
-        scheduler = self.scheduler
-        workspace = Workspace(scheduler)
 
-        # Run for the target specs parsed from the args.
+        # Run for the specs parsed from the args.
         specs = SpecsCalculator.parse_specs(full_options.specs, self.build_root)
         params = Params(
             specs.provided_specs,
             console,
             options_bootstrapper,
-            workspace,
+            Workspace(self.scheduler),
             *(additional_params or []),
         )
         actual_exit_code = self.scheduler.run_goal_rule(self.goal_cls, params)
@@ -83,10 +91,10 @@ class GoalRuleTestBase(TestBase):
             exit_code == actual_exit_code
         ), f"Exited with {actual_exit_code} (expected {exit_code}):\nstdout:\n{stdout_val}\nstderr:\n{stderr_val}"
 
-        return stdout_val
+        return GoalRuleResult(actual_exit_code, stdout_val, stderr_val)
 
-    def assert_entries(self, sep, *output, **kwargs):
-        """Verifies the expected output text is flushed by the console task under test.
+    def assert_entries(self, sep, *output, **kwargs) -> None:
+        """Verifies the expected output text is flushed by goal rule.
 
         NB: order of entries is not tested, just presence.
 
@@ -96,16 +104,15 @@ class GoalRuleTestBase(TestBase):
         *output:  the output entries expected between the separators
         **kwargs: additional kwargs passed to execute_rule.
         """
-        # We expect each output line to be suffixed with the separator, so for , and [1,2,3] we expect:
-        # '1,2,3,' - splitting this by the separator we should get ['1', '2', '3', ''] - always an extra
-        # empty string if the separator is properly always a suffix and not applied just between
-        # entries.
-        self.assertEqual(
-            sorted(list(output) + [""]), sorted((self.execute_rule(**kwargs)).split(sep))
-        )
+        # We expect each output line to be suffixed with the separator, so for `,` and [1, 2, 3] we
+        # expect: '1,2,3,' - splitting this by the separator we should get
+        # ['1', '2', '3', ''] - always an extra empty string if the separator is properly always
+        # a suffix and not applied just between entries.
+        result = self.execute_rule(**kwargs)
+        assert sorted([*output, ""]) == sorted(result.stdout.split(sep))
 
-    def assert_console_output(self, *output, **kwargs):
-        """Verifies the expected output entries are emitted by the console task under test.
+    def assert_console_output(self, *output, **kwargs) -> None:
+        """Verifies the expected output entries are emitted by the goal rule.
 
         NB: order of entries is not tested, just presence.
 
@@ -114,20 +121,22 @@ class GoalRuleTestBase(TestBase):
         *output:  the expected output entries
         **kwargs: additional kwargs passed to execute_rule.
         """
-        self.assertEqual(sorted(output), sorted(self.execute_rule(**kwargs).splitlines()))
+        result = self.execute_rule(**kwargs)
+        assert sorted(output) == sorted(result.stdout.splitlines())
 
-    def assert_console_output_contains(self, output, **kwargs):
-        """Verifies the expected output string is emitted by the console task under test.
+    def assert_console_output_contains(self, output, **kwargs) -> None:
+        """Verifies the expected output string is emitted by the goal rule.
 
         :API: public
 
         output:  the expected output entry(ies)
         **kwargs: additional kwargs passed to execute_rule.
         """
-        self.assertIn(output, self.execute_rule(**kwargs))
+        result = self.execute_rule(**kwargs)
+        assert output in result.stdout
 
-    def assert_console_output_ordered(self, *output, **kwargs):
-        """Verifies the expected output entries are emitted by the console task under test.
+    def assert_console_output_ordered(self, *output, **kwargs) -> None:
+        """Verifies the expected output entries are emitted by the goal rule.
 
         NB: order of entries is tested.
 
@@ -136,14 +145,15 @@ class GoalRuleTestBase(TestBase):
         *output:  the expected output entries in expected order
         **kwargs: additional kwargs passed to execute_rule.
         """
-        self.assertEqual(list(output), self.execute_rule(**kwargs).splitlines())
+        result = self.execute_rule(**kwargs)
+        assert list(output) == result.stdout.splitlines()
 
-    def assert_console_raises(self, exception, **kwargs):
-        """Verifies the expected exception is raised by the console task under test.
+    def assert_console_raises(self, exception: Type[Exception], **kwargs) -> None:
+        """Verifies the expected exception is raised by the goal rule.
 
         :API: public
 
         **kwargs: additional kwargs are passed to execute_rule.
         """
-        with self.assertRaises(exception):
+        with pytest.raises(exception):
             self.execute_rule(**kwargs)


### PR DESCRIPTION
In an upcoming change, `repl` will write to stderr, rather than stdout. So, we need `GoalRuleTestBase` to allow returning both the stdout and stderr.

We use a dataclass to keep things organized.

Technically, `GoalRuleTestBase` was marked a public API, but this doesn't make much sense because the V2 API is nowhere near stable. We end up breaking V2 tests almost every single weekly release through changes to the engine. So, this removes that premature indicator that we weren't respecting in the first place.

[ci skip-rust-tests]
[ci skip-jvm-tests]