### PR TITLE
Rename `subsystem_rule` to `SubsystemRule`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -36,7 +36,7 @@ from pants.core.util_rules import strip_source_roots
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -127,7 +127,7 @@ def rules():
         create_python_awslambda,
         setup_lambdex,
         UnionRule(AWSLambdaConfiguration, PythonAwsLambdaConfiguration),
-        subsystem_rule(Lambdex),
+        SubsystemRule(Lambdex),
         *download_pex_bin.rules(),
         *importable_python_sources.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -12,7 +12,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -109,5 +109,5 @@ def rules():
     return [
         generate_python_from_protobuf,
         UnionRule(GenerateSourcesRequest, GeneratePythonFromProtobufRequest),
-        subsystem_rule(Protoc),
+        SubsystemRule(Protoc),
     ]

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -12,7 +12,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.fs import Digest, FilesContent, SourcesSnapshot, SourcesSnapshots
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -299,5 +299,5 @@ def rules():
     return [
         validate,
         match_regexes_for_one_snapshot,
-        subsystem_rule(SourceFileValidation),
+        SubsystemRule(SourceFileValidation),
     ]

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -116,7 +116,7 @@ async def bandit_lint(
 def rules():
     return [
         bandit_lint,
-        subsystem_rule(Bandit),
+        SubsystemRule(Bandit),
         UnionRule(LinterConfigurations, BanditConfigurations),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import named_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -167,7 +167,7 @@ def rules():
         setup,
         black_fmt,
         black_lint,
-        subsystem_rule(Black),
+        SubsystemRule(Black),
         UnionRule(PythonFmtConfigurations, BlackConfigurations),
         UnionRule(LinterConfigurations, BlackConfigurations),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import named_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -148,7 +148,7 @@ def rules():
         setup,
         docformatter_fmt,
         docformatter_lint,
-        subsystem_rule(Docformatter),
+        SubsystemRule(Docformatter),
         UnionRule(PythonFmtConfigurations, DocformatterConfigurations),
         UnionRule(LinterConfigurations, DocformatterConfigurations),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -117,7 +117,7 @@ async def flake8_lint(
 def rules():
     return [
         flake8_lint,
-        subsystem_rule(Flake8),
+        SubsystemRule(Flake8),
         UnionRule(LinterConfigurations, Flake8Configurations),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import named_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import GlobExpansionConjunction
@@ -160,7 +160,7 @@ def rules():
         setup,
         isort_fmt,
         isort_lint,
-        subsystem_rule(Isort),
+        SubsystemRule(Isort),
         UnionRule(PythonFmtConfigurations, IsortConfigurations),
         UnionRule(LinterConfigurations, IsortConfigurations),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -22,7 +22,7 @@ from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedS
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import named_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule
 from pants.engine.selectors import Get
 from pants.engine.target import Dependencies, Targets
 from pants.engine.unions import UnionRule
@@ -129,7 +129,7 @@ async def pylint_lint(
 def rules():
     return [
         pylint_lint,
-        subsystem_rule(Pylint),
+        SubsystemRule(Pylint),
         UnionRule(LinterConfigurations, PylintConfigurations),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -12,7 +12,7 @@ from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.fs import Digest, SingleFileExecutable, Snapshot
 from pants.engine.platform import PlatformConstraint
 from pants.engine.process import Process
-from pants.engine.rules import rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
 
@@ -105,4 +105,4 @@ async def download_pex_bin(pex_binary_tool: DownloadedPexBin.Factory) -> Downloa
 
 
 def rules():
-    return [download_pex_bin, subsystem_rule(DownloadedPexBin.Factory)]
+    return [download_pex_bin, SubsystemRule(DownloadedPexBin.Factory)]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -29,7 +29,7 @@ from pants.engine.fs import (
 )
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.process import MultiPlatformProcess, ProcessResult
-from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -439,6 +439,6 @@ def rules():
         two_step_create_pex,
         RootRule(PexRequest),
         RootRule(TwoStepPexRequest),
-        subsystem_rule(PythonSetup),
-        subsystem_rule(PythonRepos),
+        SubsystemRule(PythonSetup),
+        SubsystemRule(PythonRepos),
     ]

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     MergeDigests,
 )
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, named_rule, rule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Sources, Targets, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -390,7 +390,7 @@ def rules():
         generate_coverage_report,
         merge_coverage_data,
         setup_coverage,
-        subsystem_rule(PytestCoverage),
+        SubsystemRule(PytestCoverage),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
         RootRule(CoverageConfigRequest),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -42,7 +42,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import named_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Targets, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -291,6 +291,6 @@ def rules():
         debug_python_test,
         setup_pytest_for_target,
         UnionRule(TestConfiguration, PythonTestConfiguration),
-        subsystem_rule(PyTest),
-        subsystem_rule(PythonSetup),
+        SubsystemRule(PyTest),
+        SubsystemRule(PythonSetup),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -29,7 +29,7 @@ from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
-from pants.engine.rules import RootRule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule
 from pants.engine.selectors import Params
 from pants.engine.target import TargetWithOrigin
 from pants.python.python_requirement import PythonRequirement
@@ -126,7 +126,7 @@ class PytestRunnerIntegrationTest(TestBase):
             *python_native_code.rules(),
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
-            subsystem_rule(TestOptions),
+            SubsystemRule(TestOptions),
             RootRule(CoverageConfigRequest),
             RootRule(PythonTestConfiguration),
         )

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -10,7 +10,7 @@ from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.repl import ReplBinary, ReplImplementation
 from pants.engine.addresses import Addresses
-from pants.engine.rules import rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 
@@ -56,7 +56,7 @@ async def run_ipython_repl(repl: IPythonRepl, ipython: IPython) -> ReplBinary:
 
 def rules():
     return [
-        subsystem_rule(IPython),
+        SubsystemRule(IPython),
         UnionRule(ReplImplementation, PythonRepl),
         UnionRule(ReplImplementation, IPythonRepl),
         run_python_repl,

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -58,7 +58,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import goal_rule, named_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, goal_rule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -717,5 +717,5 @@ def rules():
         get_owned_dependencies,
         get_exporting_owner,
         setup_setuptools,
-        subsystem_rule(Setuptools),
+        SubsystemRule(Setuptools),
     ]

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -11,7 +11,7 @@ from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.base.exceptions import IncompatiblePlatformsError
-from pants.engine.rules import rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.python import pex_build_util
 from pants.python.python_setup import PythonSetup
 from pants.subsystem.subsystem import Subsystem
@@ -162,6 +162,6 @@ def create_pex_native_build_environment(
 
 def rules():
     return [
-        subsystem_rule(PythonNativeCode),
+        SubsystemRule(PythonNativeCode),
         create_pex_native_build_environment,
     ]

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from pants.engine.rules import rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -58,6 +58,6 @@ def create_subprocess_encoding_environment(
 
 def rules():
     return [
-        subsystem_rule(SubprocessEnvironment),
+        SubsystemRule(SubprocessEnvironment),
         create_subprocess_encoding_environment,
     ]

--- a/src/python/pants/core/project_info/cloc.py
+++ b/src/python/pants/core/project_info/cloc.py
@@ -19,7 +19,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import goal_rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, goal_rule
 from pants.engine.selectors import Get
 
 
@@ -128,5 +128,5 @@ async def run_cloc(
 def rules():
     return [
         run_cloc,
-        subsystem_rule(ClocBinary),
+        SubsystemRule(ClocBinary),
     ]

--- a/src/python/pants/core/project_info/list_roots.py
+++ b/src/python/pants/core/project_info/list_roots.py
@@ -6,7 +6,7 @@ from typing import Set
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, rule, subsystem_rule
+from pants.engine.rules import SubsystemRule, goal_rule, rule
 from pants.engine.selectors import Get
 from pants.source.source_root import AllSourceRoots, SourceRoot, SourceRootConfig
 
@@ -61,4 +61,4 @@ async def list_roots(console: Console, options: RootsOptions, all_roots: AllSour
 
 
 def rules():
-    return [all_roots, list_roots, subsystem_rule(SourceRootConfig)]
+    return [all_roots, list_roots, SubsystemRule(SourceRootConfig)]

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -69,7 +69,7 @@ class ExternalTool(Subsystem):
 
     ...
     def rules():
-      return [my_rule, subsystem_rule(MyExternalTool)]
+      return [my_rule, SubsystemRule(MyExternalTool)]
 
 
     A lightweight replacement for the code in binary_tool.py and binary_util.py,

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -17,7 +17,7 @@ from pants.engine.fs import (
     Snapshot,
     SnapshotSubset,
 )
-from pants.engine.rules import RootRule, rule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -166,7 +166,7 @@ def rules():
     return [
         strip_source_roots_from_snapshot,
         strip_source_roots_from_sources_field,
-        subsystem_rule(SourceRootConfig),
+        SubsystemRule(SourceRootConfig),
         RootRule(StripSnapshotRequest),
         RootRule(StripSourcesFieldRequest),
     ]

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.engine.rules import RootRule, rule, subsystem_rule
+from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
@@ -45,7 +45,7 @@ def rules():
     return [
         scope_options,
         parse_options,
-        subsystem_rule(GlobalOptions),
+        SubsystemRule(GlobalOptions),
         log_level,
         RootRule(Scope),
         RootRule(OptionsBootstrapper),

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -68,16 +68,15 @@ class _RuleVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+# NB: This violates Python naming conventions of using snake_case for functions. This is because
+# SubsystemRule behaves very similarly to UnionRule and RootRule, and we want to use the same
+# naming scheme.
+#
+# We could refactor this to be a class with __call__() defined, but we would lose the `@memoized`
+# decorator.
 @memoized
 def SubsystemRule(optionable_factory: Type[OptionableFactory]) -> "TaskRule":
-    """Returns a TaskRule that constructs an instance of the subsystem.
-
-    TODO: This API is slightly awkward for two reasons:
-      1) We should consider whether Subsystems/Optionables should be constructed explicitly using
-        `@rule`s, which would allow them to have non-option dependencies that would be explicit in
-        their constructors (which would avoid the need for the `Subsystem.Factory` pattern).
-      2) Optionable depending on TaskRule would create a cycle in the Python package graph.
-    """
+    """Returns a TaskRule that constructs an instance of the subsystem."""
     return TaskRule(**optionable_factory.signature())
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -69,7 +69,7 @@ class _RuleVisitor(ast.NodeVisitor):
 
 
 @memoized
-def subsystem_rule(optionable_factory: Type[OptionableFactory]) -> "TaskRule":
+def SubsystemRule(optionable_factory: Type[OptionableFactory]) -> "TaskRule":
     """Returns a TaskRule that constructs an instance of the subsystem.
 
     TODO: This API is slightly awkward for two reasons:
@@ -164,7 +164,7 @@ def _make_rule(
         )
 
         # Register dependencies for @goal_rule/Goal.
-        dependency_rules = (subsystem_rule(return_type.subsystem_cls),) if is_goal_cls else None
+        dependency_rules = (SubsystemRule(return_type.subsystem_cls),) if is_goal_cls else None
 
         # Set a default canonical name if one is not explicitly provided. For Goal classes
         # this is the name of the Goal; for other named ruled this is the __name__ of the function

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -71,7 +71,7 @@ class ChangedOptions:
     """A wrapper for the options from the `Changed` Subsystem.
 
     This is necessary because parsing of these options happens before conventional subsystems are
-    configured, so the normal mechanisms like `subsystem_rule` would not work properly.
+    configured, so the normal mechanisms like `SubsystemRule` would not work properly.
     """
 
     changes_since: Optional[str]


### PR DESCRIPTION
We expose 6 public ways to register a rule:
* `@rule`
* `@named_rule`
* `@goal_rule`
* `subsystem_rule(S)`
* `RootRule(R)`
* `UnionRule(A, B)`

The first 3 are decorators, whereas the last 3 we expect to define directly in the `rules()` entry point and to pass a `Type` as the parameter.

It's confusing that `subsystem_rule` looks like it should be a decorator, when really it behaves like `RootRule` and `UnionRule`. This PR changes the name to be less surprising.

[ci skip-rust-tests]
[ci skip-jvm-tests]