### PR TITLE
Remove noisy Pants output with V2 `binary`, `run`, and `repl`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # GENERATED, DO NOT EDIT!
 # To change, edit `build-support/bin/generate_travis_yml.py` and run:
-# ./pants --quiet run build-support/bin:generate_travis_yml > .travis.yml
+#   ./v2 run build-support/bin:generate_travis_yml > .travis.yml
 
 
 conditions: v1

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -11,7 +11,7 @@ HEADER = dedent(
     """\
     # GENERATED, DO NOT EDIT!
     # To change, edit `build-support/bin/generate_travis_yml.py` and run:
-    # ./pants --quiet run build-support/bin:generate_travis_yml > .travis.yml
+    #   ./v2 run build-support/bin:generate_travis_yml > .travis.yml
     """
 )
 

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -61,9 +61,9 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   if git diff "${MERGE_BASE}" --name-only | grep build-support/bin/generate_travis_yml.py > /dev/null; then
     echo "* Checking .travis.yml generation"
     actual_travis_yml=$(<.travis.yml)
-    expected_travis_yml=$(./pants --quiet run build-support/bin:generate_travis_yml)
+    expected_travis_yml=$(./v2 run build-support/bin:generate_travis_yml)
     [ "${expected_travis_yml}" == "${actual_travis_yml}" ] || \
-      die "Travis config generator changed but .travis.yml file not regenerated. See top of that file for instructions."
+      die "Travis config generator changed, but .travis.yml file was not regenerated. See the header of .travis.yml for instructions."
   fi
 else
   echo "* Skipping import/lint checks in partial working copy."

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -47,9 +47,7 @@ class Binary(Goal):
 async def create_binary(workspace: Workspace, dist_dir: DistDir, build_root: BuildRoot) -> Binary:
     targets_to_valid_field_sets = await Get[TargetsToValidFieldSets](
         TargetsToValidFieldSetsRequest(
-            BinaryFieldSet,
-            goal_description=f"the `binary` goal",
-            error_if_no_valid_targets=True,
+            BinaryFieldSet, goal_description=f"the `binary` goal", error_if_no_valid_targets=True
         )
     )
     binaries = await MultiGet(

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -89,8 +89,9 @@ async def run_repl(
     repl_implementation_cls = implementations.get(repl_shell_name)
     if repl_implementation_cls is None:
         available = sorted(set(implementations.keys()))
-        console.write_stdout(
-            f"{repl_shell_name} is not an installed REPL program. Available REPLs: {available}"
+        console.print_stderr(
+            f"{repr(repl_shell_name)} is not a registered REPL. Available REPLs (which may "
+            f"be specified through the option `--repl-shell`): {available}"
         )
         return Repl(-1)
 
@@ -111,14 +112,7 @@ async def run_repl(
         run_request = InteractiveProcessRequest(argv=(full_path,), run_in_workspace=True,)
 
     result = runner.run_local_interactive_process(run_request)
-    exit_code = result.process_exit_code
-
-    if exit_code == 0:
-        console.write_stdout("REPL exited successfully.")
-    else:
-        console.write_stdout(f"REPL exited with error: {exit_code}.")
-
-    return Repl(exit_code)
+    return Repl(result.process_exit_code)
 
 
 def rules():

--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -6,16 +6,14 @@ from pants.backend.python.rules import (
     importable_python_sources,
     pex,
     pex_from_targets,
-    repl,
 )
+from pants.backend.python.rules import repl as python_repl
 from pants.backend.python.rules.repl import PythonRepl
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.target_types import PythonLibrary
-from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
-from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.goals.repl import Repl, run_repl
+from pants.core.goals.repl import Repl
+from pants.core.goals.repl import rules as repl_rules
 from pants.core.util_rules import strip_source_roots
-from pants.engine.fs import FileContent
 from pants.engine.interactive_runner import InteractiveRunner
 from pants.engine.rules import RootRule
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
@@ -28,8 +26,8 @@ class ReplTest(GoalRuleTestBase):
     def rules(cls):
         return (
             *super().rules(),
-            *repl.rules(),
-            run_repl,
+            *repl_rules(),
+            *python_repl.rules(),
             *pex.rules(),
             *download_pex_bin.rules(),
             *importable_python_sources.rules(),
@@ -41,51 +39,35 @@ class ReplTest(GoalRuleTestBase):
         )
 
     @classmethod
-    def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(targets={"python_library": PythonLibraryV1})
-
-    @classmethod
     def target_types(cls):
         return [PythonLibrary]
 
     def setup_python_library(self) -> None:
-        library_source = FileContent(path="some_lib.py", content=b"class SomeClass:\n  pass\n")
-        self.create_library(
-            name="some_lib",
-            target_type="python_library",
-            path="src/python",
-            sources=["some_lib.py"],
-        )
-
-        self.create_file(
-            relpath="src/python/some_lib.py", contents=library_source.content.decode(),
-        )
+        self.add_to_build_file("src/python", "python_library()")
+        self.create_file("src/python/lib.py", "class SomeClass:\n  pass\n")
 
     def test_repl_with_targets(self) -> None:
         self.setup_python_library()
-        result = self.execute_rule(
+        self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
-            args=["src/python:some_lib"],
+            args=["src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
-        assert result.stdout == "REPL exited successfully."
 
     def test_repl_ipython(self) -> None:
         self.setup_python_library()
-        result = self.execute_rule(
+        self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
-            args=["--shell=ipython", "src/python:some_lib"],
+            args=["--shell=ipython", "src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
-        assert result.stdout == "REPL exited successfully."
 
     def test_repl_bogus_repl_name(self) -> None:
         self.setup_python_library()
         result = self.execute_rule(
             global_args=["--backend-packages2=pants.backend.python"],
-            args=["--shell=bogus-repl", "src/python:some_lib"],
+            args=["--shell=bogus-repl", "src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
             exit_code=-1,
         )
-
-        assert "bogus-repl is not an installed REPL program. Available REPLs:" in result.stdout
+        assert "'bogus-repl' is not a registered REPL. Available REPLs" in result.stderr

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -18,7 +18,11 @@ from pants.util.contextutil import temporary_dir
 
 
 class RunOptions(GoalSubsystem):
-    """Runs a runnable target."""
+    """Runs a binary target.
+
+    This goal propagates the return code of the underlying executable. Run `echo $?` to inspect the
+    resulting return code.
+    """
 
     name = "run"
 
@@ -44,12 +48,12 @@ class Run(Goal):
 
 @goal_rule
 async def run(
-    console: Console,
-    workspace: Workspace,
-    runner: InteractiveRunner,
-    build_root: BuildRoot,
     options: RunOptions,
     global_options: GlobalOptions,
+    console: Console,
+    runner: InteractiveRunner,
+    workspace: Workspace,
+    build_root: BuildRoot,
 ) -> Run:
     targets_to_valid_configs = await Get[TargetsToValidConfigurations](
         TargetsToValidConfigurationsRequest(
@@ -69,7 +73,6 @@ async def run(
             DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
         )
 
-        console.write_stdout(f"Running target: {config.address}\n")
         full_path = PurePath(tmpdir, binary.binary_name).as_posix()
         run_request = InteractiveProcessRequest(
             argv=(full_path, *options.values.args), run_in_workspace=True,
@@ -78,15 +81,8 @@ async def run(
         try:
             result = runner.run_local_interactive_process(run_request)
             exit_code = result.process_exit_code
-            if result.process_exit_code == 0:
-                console.write_stdout(f"{config.address} ran successfully.\n")
-            else:
-                console.write_stderr(
-                    f"{config.address} failed with code {result.process_exit_code}!\n"
-                )
-
         except Exception as e:
-            console.write_stderr(f"Exception when attempting to run {config.address}: {e!r}\n")
+            console.print_stderr(f"Exception when attempting to run {config.address}: {e!r}")
             exit_code = -1
 
     return Run(exit_code)

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -3,6 +3,8 @@
 
 from typing import cast
 
+import pytest
+
 from pants.base.build_root import BuildRoot
 from pants.base.specs import SingleAddress
 from pants.core.goals.binary import BinaryConfiguration, CreatedBinary
@@ -58,12 +60,12 @@ class RunTest(TestBase):
         res = run_rule(
             run,
             rule_args=[
-                console,
-                workspace,
-                interactive_runner,
-                BuildRoot(),
                 create_goal_subsystem(RunOptions, args=[]),
                 create_subsystem(GlobalOptions, pants_workdir=self.pants_workdir),
+                console,
+                interactive_runner,
+                workspace,
+                BuildRoot(),
             ],
             mock_gets=[
                 MockGet(
@@ -86,12 +88,7 @@ class RunTest(TestBase):
         res = self.single_target_run(
             console=console, program_text=program_text, address_spec="some/addr",
         )
-        self.assertEqual(res.exit_code, 0)
-        self.assertEqual(
-            console.stdout.getvalue(),
-            "Running target: some/addr:addr\nsome/addr:addr ran successfully.\n",
-        )
-        self.assertEqual(console.stderr.getvalue(), "")
+        assert res.exit_code == 0
 
     def test_materialize_input_files(self) -> None:
         program_text = b'#!/usr/bin/python\nprint("hello")'
@@ -101,12 +98,12 @@ class RunTest(TestBase):
             argv=("./program.py",), run_in_workspace=False, input_files=binary.digest,
         )
         result = interactive_runner.run_local_interactive_process(request)
-        self.assertEqual(result.process_exit_code, 0)
+        assert result.process_exit_code == 0
 
     def test_no_input_files_in_workspace(self) -> None:
         program_text = b'#!/usr/bin/python\nprint("hello")'
         binary = self.create_mock_binary(program_text)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             InteractiveProcessRequest(
                 argv=("/usr/bin/python",), run_in_workspace=True, input_files=binary.digest
             )
@@ -117,6 +114,4 @@ class RunTest(TestBase):
         res = self.single_target_run(
             console=console, program_text=program_text, address_spec="some/addr"
         )
-        self.assertEqual(res.exit_code, 1)
-        self.assertEqual(console.stdout.getvalue(), "Running target: some/addr:addr\n")
-        self.assertEqual(console.stderr.getvalue(), "some/addr:addr failed with code 1!\n")
+        assert res.exit_code == 1


### PR DESCRIPTION
For `run`, there is no need for output. We simply display what the executable would normally display, and then return the same error code.

For `repl`, it should be obvious that we're starting the REPL and whether it was successful or not. The messages didn't add much.

For `binary`, the messages are useful. But, users need some way to disable them. And, we should write to stderr, rather than stdout. We use `logger.info` to achieve both goals.

[ci skip-rust-tests]
[ci skip-jvm-tests]