### PR TITLE
Rename V2 `Configuration` to `FieldSet`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -7,7 +7,7 @@ from typing import Tuple
 from zipfile import ZipFile
 
 from pants.backend.awslambda.common.awslambda_common_rules import CreatedAWSLambda
-from pants.backend.awslambda.python.awslambda_python_rules import PythonAwsLambdaConfiguration
+from pants.backend.awslambda.python.awslambda_python_rules import PythonAwsLambdaFieldSet
 from pants.backend.awslambda.python.awslambda_python_rules import rules as awslambda_python_rules
 from pants.backend.awslambda.python.target_types import PythonAWSLambda
 from pants.backend.python.target_types import PythonLibrary
@@ -23,7 +23,7 @@ from pants.testutil.test_base import TestBase
 class TestPythonAWSLambdaCreation(TestBase):
     @classmethod
     def rules(cls):
-        return (*super().rules(), *awslambda_python_rules(), RootRule(PythonAwsLambdaConfiguration))
+        return (*super().rules(), *awslambda_python_rules(), RootRule(PythonAwsLambdaFieldSet))
 
     @classmethod
     def target_types(cls):
@@ -34,7 +34,7 @@ class TestPythonAWSLambdaCreation(TestBase):
         created_awslambda = self.request_single_product(
             CreatedAWSLambda,
             Params(
-                PythonAwsLambdaConfiguration.create(target),
+                PythonAwsLambdaFieldSet.create(target),
                 create_options_bootstrapper(
                     args=["--backend-packages2=pants.backend.awslambda.python"]
                 ),

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.bandit.rules import BanditConfiguration, BanditConfigurations
+from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditFieldSets
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -25,7 +25,7 @@ class BanditIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *bandit_rules(), RootRule(BanditConfigurations))
+        return (*super().rules(), *bandit_rules(), RootRule(BanditFieldSets))
 
     def make_target_with_origin(
         self,
@@ -63,7 +63,7 @@ class BanditIntegrationTest(TestBase):
         return self.request_single_product(
             LintResult,
             Params(
-                BanditConfigurations(BanditConfiguration.create(tgt) for tgt in targets),
+                BanditFieldSets(BanditFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
-from pants.backend.python.lint.python_fmt import PythonFmtConfigurations
+from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     Pex,
@@ -18,8 +18,8 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtConfiguration, FmtConfigurations, FmtResult
-from pants.core.goals.lint import LinterConfigurations, LintResult
+from pants.core.goals.fmt import FmtFieldSet, FmtFieldSets, FmtResult
+from pants.core.goals.lint import LinterFieldSets, LintResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -37,19 +37,19 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class BlackConfiguration(FmtConfiguration):
+class BlackFieldSet(FmtFieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
 
 
-class BlackConfigurations(FmtConfigurations):
-    config_type = BlackConfiguration
+class BlackFieldSets(FmtFieldSets):
+    field_set_type = BlackFieldSet
 
 
 @dataclass(frozen=True)
 class SetupRequest:
-    configs: BlackConfigurations
+    field_sets: BlackFieldSets
     check_only: bool
 
 
@@ -106,16 +106,18 @@ async def setup(
         )
     )
 
-    if request.configs.prior_formatter_result is None:
+    if request.field_sets.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(config.sources for config in request.configs)
+            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
         )
         all_source_files_snapshot = all_source_files.snapshot
     else:
-        all_source_files_snapshot = request.configs.prior_formatter_result
+        all_source_files_snapshot = request.field_sets.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
+        SpecifiedSourceFilesRequest(
+            (field_set.sources, field_set.origin) for field_set in request.field_sets
+        )
     )
 
     merged_input_files = await Get[Digest](
@@ -124,7 +126,9 @@ async def setup(
         ),
     )
 
-    address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
+    address_references = ", ".join(
+        sorted(field_set.address.reference() for field_set in request.field_sets)
+    )
 
     process = requirements_pex.create_process(
         python_setup=python_setup,
@@ -138,26 +142,26 @@ async def setup(
         input_files=merged_input_files,
         output_files=all_source_files_snapshot.files,
         description=(
-            f"Run Black on {pluralize(len(request.configs), 'target')}: {address_references}."
+            f"Run Black on {pluralize(len(request.field_sets), 'target')}: {address_references}."
         ),
     )
     return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
 @named_rule(desc="Format using Black")
-async def black_fmt(configs: BlackConfigurations, black: Black) -> FmtResult:
+async def black_fmt(field_sets: BlackFieldSets, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=False))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
     return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint using Black")
-async def black_lint(configs: BlackConfigurations, black: Black) -> LintResult:
+async def black_lint(field_sets: BlackFieldSets, black: Black) -> LintResult:
     if black.options.skip:
         return LintResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=True))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
     return LintResult.from_fallible_process_result(result)
 
@@ -168,8 +172,8 @@ def rules():
         black_fmt,
         black_lint,
         SubsystemRule(Black),
-        UnionRule(PythonFmtConfigurations, BlackConfigurations),
-        UnionRule(LinterConfigurations, BlackConfigurations),
+        UnionRule(PythonFmtFieldSets, BlackFieldSets),
+        UnionRule(LinterFieldSets, BlackFieldSets),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional, Tuple
 
-from pants.backend.python.lint.black.rules import BlackConfiguration, BlackConfigurations
+from pants.backend.python.lint.black.rules import BlackFieldSet, BlackFieldSets
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -30,7 +30,7 @@ class BlackIntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *black_rules(), RootRule(BlackConfigurations))
+        return (*super().rules(), *black_rules(), RootRule(BlackFieldSets))
 
     def make_target_with_origin(
         self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
@@ -59,20 +59,21 @@ class BlackIntegrationTest(TestBase):
         if skip:
             args.append(f"--black-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
-        configs = [BlackConfiguration.create(tgt) for tgt in targets]
+        field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
         lint_result = self.request_single_product(
-            LintResult, Params(BlackConfigurations(configs), options_bootstrapper)
+            LintResult, Params(BlackFieldSets(field_sets), options_bootstrapper)
         )
         input_snapshot = self.request_single_product(
             SourceFiles,
             Params(
-                AllSourceFilesRequest(config.sources for config in configs), options_bootstrapper
+                AllSourceFilesRequest(field_set.sources for field_set in field_sets),
+                options_bootstrapper,
             ),
         )
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                BlackConfigurations(configs, prior_formatter_result=input_snapshot),
+                BlackFieldSets(field_sets, prior_formatter_result=input_snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
-from pants.backend.python.lint.python_fmt import PythonFmtConfigurations
+from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     Pex,
@@ -16,8 +16,8 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtConfiguration, FmtConfigurations, FmtResult
-from pants.core.goals.lint import LinterConfigurations, LintResult
+from pants.core.goals.fmt import FmtFieldSet, FmtFieldSets, FmtResult
+from pants.core.goals.lint import LinterFieldSets, LintResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -34,19 +34,19 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class DocformatterConfiguration(FmtConfiguration):
+class DocformatterFieldSet(FmtFieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
 
 
-class DocformatterConfigurations(FmtConfigurations):
-    config_type = DocformatterConfiguration
+class DocformatterFieldSets(FmtFieldSets):
+    field_set_type = DocformatterFieldSet
 
 
 @dataclass(frozen=True)
 class SetupRequest:
-    configs: DocformatterConfigurations
+    field_sets: DocformatterFieldSets
     check_only: bool
 
 
@@ -84,23 +84,27 @@ async def setup(
         )
     )
 
-    if request.configs.prior_formatter_result is None:
+    if request.field_sets.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(config.sources for config in request.configs)
+            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
         )
         all_source_files_snapshot = all_source_files.snapshot
     else:
-        all_source_files_snapshot = request.configs.prior_formatter_result
+        all_source_files_snapshot = request.field_sets.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
+        SpecifiedSourceFilesRequest(
+            (field_set.sources, field_set.origin) for field_set in request.field_sets
+        )
     )
 
     merged_input_files = await Get[Digest](
         MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest)),
     )
 
-    address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
+    address_references = ", ".join(
+        sorted(field_set.address.reference() for field_set in request.field_sets)
+    )
 
     process = requirements_pex.create_process(
         python_setup=python_setup,
@@ -114,7 +118,7 @@ async def setup(
         input_files=merged_input_files,
         output_files=all_source_files_snapshot.files,
         description=(
-            f"Run Docformatter on {pluralize(len(request.configs), 'target')}: "
+            f"Run Docformatter on {pluralize(len(request.field_sets), 'target')}: "
             f"{address_references}."
         ),
     )
@@ -123,22 +127,22 @@ async def setup(
 
 @named_rule(desc="Format Python docstrings with docformatter")
 async def docformatter_fmt(
-    configs: DocformatterConfigurations, docformatter: Docformatter
+    field_sets: DocformatterFieldSets, docformatter: Docformatter
 ) -> FmtResult:
     if docformatter.options.skip:
         return FmtResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=False))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
     return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint Python docstrings with docformatter")
 async def docformatter_lint(
-    configs: DocformatterConfigurations, docformatter: Docformatter
+    field_sets: DocformatterFieldSets, docformatter: Docformatter
 ) -> LintResult:
     if docformatter.options.skip:
         return LintResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=True))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
     return LintResult.from_fallible_process_result(result)
 
@@ -149,8 +153,8 @@ def rules():
         docformatter_fmt,
         docformatter_lint,
         SubsystemRule(Docformatter),
-        UnionRule(PythonFmtConfigurations, DocformatterConfigurations),
-        UnionRule(LinterConfigurations, DocformatterConfigurations),
+        UnionRule(PythonFmtFieldSets, DocformatterFieldSets),
+        UnionRule(LinterFieldSets, DocformatterFieldSets),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -15,7 +15,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
-from pants.core.goals.lint import LinterConfiguration, LinterConfigurations, LintResult
+from pants.core.goals.lint import LinterFieldSet, LinterFieldSets, LintResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -33,15 +33,15 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class Flake8Configuration(LinterConfiguration):
+class Flake8FieldSet(LinterFieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
     compatibility: PythonInterpreterCompatibility
 
 
-class Flake8Configurations(LinterConfigurations):
-    config_type = Flake8Configuration
+class Flake8FieldSets(LinterFieldSets):
+    field_set_type = Flake8FieldSet
 
 
 def generate_args(*, specified_source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:
@@ -55,7 +55,7 @@ def generate_args(*, specified_source_files: SourceFiles, flake8: Flake8) -> Tup
 
 @named_rule(desc="Lint using Flake8")
 async def flake8_lint(
-    configs: Flake8Configurations,
+    field_sets: Flake8FieldSets,
     flake8: Flake8,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -67,7 +67,7 @@ async def flake8_lint(
     # each target runs with its own interpreter constraints. See
     # http://flake8.pycqa.org/en/latest/user/invocation.html.
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (config.compatibility for config in configs), python_setup
+        (field_set.compatibility for field_set in field_sets), python_setup
     )
     requirements_pex = await Get[Pex](
         PexRequest(
@@ -88,10 +88,12 @@ async def flake8_lint(
     )
 
     all_source_files = await Get[SourceFiles](
-        AllSourceFilesRequest(config.sources for config in configs)
+        AllSourceFilesRequest(field_set.sources for field_set in field_sets)
     )
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest((config.sources, config.origin) for config in configs)
+        SpecifiedSourceFilesRequest(
+            (field_set.sources, field_set.origin) for field_set in field_sets
+        )
     )
 
     merged_input_files = await Get[Digest](
@@ -100,7 +102,9 @@ async def flake8_lint(
         ),
     )
 
-    address_references = ", ".join(sorted(config.address.reference() for config in configs))
+    address_references = ", ".join(
+        sorted(field_set.address.reference() for field_set in field_sets)
+    )
 
     process = requirements_pex.create_process(
         python_setup=python_setup,
@@ -108,7 +112,7 @@ async def flake8_lint(
         pex_path=f"./flake8.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, flake8=flake8),
         input_files=merged_input_files,
-        description=f"Run Flake8 on {pluralize(len(configs), 'target')}: {address_references}.",
+        description=f"Run Flake8 on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
     return LintResult.from_fallible_process_result(result)
@@ -118,7 +122,7 @@ def rules():
     return [
         flake8_lint,
         SubsystemRule(Flake8),
-        UnionRule(LinterConfigurations, Flake8Configurations),
+        UnionRule(LinterFieldSets, Flake8FieldSets),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.flake8.rules import Flake8Configuration, Flake8Configurations
+from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8FieldSets
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
@@ -26,7 +26,7 @@ class Flake8IntegrationTest(TestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *flake8_rules(), RootRule(Flake8Configurations))
+        return (*super().rules(), *flake8_rules(), RootRule(Flake8FieldSets))
 
     def make_target_with_origin(
         self,
@@ -64,7 +64,7 @@ class Flake8IntegrationTest(TestBase):
         return self.request_single_product(
             LintResult,
             Params(
-                Flake8Configurations(Flake8Configuration.create(tgt) for tgt in targets),
+                Flake8FieldSets(Flake8FieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
-from pants.backend.python.lint.python_fmt import PythonFmtConfigurations
+from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
 from pants.backend.python.rules import download_pex_bin, pex
 from pants.backend.python.rules.pex import (
     Pex,
@@ -16,8 +16,8 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtConfiguration, FmtConfigurations, FmtResult
-from pants.core.goals.lint import LinterConfigurations, LintResult
+from pants.core.goals.fmt import FmtFieldSet, FmtFieldSets, FmtResult
+from pants.core.goals.lint import LinterFieldSets, LintResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -36,19 +36,19 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class IsortConfiguration(FmtConfiguration):
+class IsortFieldSet(FmtFieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
 
 
-class IsortConfigurations(FmtConfigurations):
-    config_type = IsortConfiguration
+class IsortFieldSets(FmtFieldSets):
+    field_set_type = IsortFieldSet
 
 
 @dataclass(frozen=True)
 class SetupRequest:
-    configs: IsortConfigurations
+    field_sets: IsortFieldSets
     check_only: bool
 
 
@@ -99,16 +99,18 @@ async def setup(
         )
     )
 
-    if request.configs.prior_formatter_result is None:
+    if request.field_sets.prior_formatter_result is None:
         all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(config.sources for config in request.configs)
+            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
         )
         all_source_files_snapshot = all_source_files.snapshot
     else:
-        all_source_files_snapshot = request.configs.prior_formatter_result
+        all_source_files_snapshot = request.field_sets.prior_formatter_result
 
     specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
+        SpecifiedSourceFilesRequest(
+            (field_set.sources, field_set.origin) for field_set in request.field_sets
+        )
     )
 
     merged_input_files = await Get[Digest](
@@ -117,7 +119,9 @@ async def setup(
         ),
     )
 
-    address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
+    address_references = ", ".join(
+        sorted(field_set.address.reference() for field_set in request.field_sets)
+    )
 
     process = requirements_pex.create_process(
         python_setup=python_setup,
@@ -131,26 +135,26 @@ async def setup(
         input_files=merged_input_files,
         output_files=all_source_files_snapshot.files,
         description=(
-            f"Run isort on {pluralize(len(request.configs), 'target')}: {address_references}."
+            f"Run isort on {pluralize(len(request.field_sets), 'target')}: {address_references}."
         ),
     )
     return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
 @named_rule(desc="Format using isort")
-async def isort_fmt(configs: IsortConfigurations, isort: Isort) -> FmtResult:
+async def isort_fmt(field_sets: IsortFieldSets, isort: Isort) -> FmtResult:
     if isort.options.skip:
         return FmtResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=False))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
     return FmtResult.from_process_result(result, original_digest=setup.original_digest)
 
 
 @named_rule(desc="Lint using isort")
-async def isort_lint(configs: IsortConfigurations, isort: Isort) -> LintResult:
+async def isort_lint(field_sets: IsortFieldSets, isort: Isort) -> LintResult:
     if isort.options.skip:
         return LintResult.noop()
-    setup = await Get[Setup](SetupRequest(configs, check_only=True))
+    setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
     return LintResult.from_fallible_process_result(result)
 
@@ -161,8 +165,8 @@ def rules():
         isort_fmt,
         isort_lint,
         SubsystemRule(Isort),
-        UnionRule(PythonFmtConfigurations, IsortConfigurations),
-        UnionRule(LinterConfigurations, IsortConfigurations),
+        UnionRule(PythonFmtFieldSets, IsortFieldSets),
+        UnionRule(LinterFieldSets, IsortFieldSets),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
-from pants.core.goals.lint import LinterConfiguration, LinterConfigurations, LintResult
+from pants.core.goals.lint import LinterFieldSet, LinterFieldSets, LintResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.engine.addresses import Addresses
@@ -32,7 +32,7 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class PylintConfiguration(LinterConfiguration):
+class PylintFieldSet(LinterFieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
@@ -40,8 +40,8 @@ class PylintConfiguration(LinterConfiguration):
     compatibility: PythonInterpreterCompatibility
 
 
-class PylintConfigurations(LinterConfigurations):
-    config_type = PylintConfiguration
+class PylintFieldSets(LinterFieldSets):
+    field_set_type = PylintFieldSet
 
 
 def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tuple[str, ...]:
@@ -55,7 +55,7 @@ def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tup
 
 @named_rule(desc="Lint using Pylint")
 async def pylint_lint(
-    configs: PylintConfigurations,
+    field_sets: PylintFieldSets,
     pylint: Pylint,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -66,9 +66,9 @@ async def pylint_lint(
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
     addresses = []
-    for config in configs:
-        addresses.append(config.address)
-        addresses.extend(config.dependencies.value or ())
+    for field_set in field_sets:
+        addresses.append(field_set.address)
+        addresses.extend(field_set.dependencies.value or ())
     targets = await Get[Targets](Addresses(addresses))
     prepared_python_sources = await Get[ImportablePythonSources](Targets, targets)
 
@@ -76,7 +76,7 @@ async def pylint_lint(
     # each target runs with its own interpreter constraints. See
     # http://pylint.pycqa.org/en/latest/faq.html#what-versions-of-python-is-pylint-supporting.
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (config.compatibility for config in configs), python_setup
+        (field_set.compatibility for field_set in field_sets), python_setup
     )
     requirements_pex = await Get[Pex](
         PexRequest(
@@ -108,11 +108,14 @@ async def pylint_lint(
 
     specified_source_files = await Get[SourceFiles](
         SpecifiedSourceFilesRequest(
-            ((config.sources, config.origin) for config in configs), strip_source_roots=True
+            ((field_set.sources, field_set.origin) for field_set in field_sets),
+            strip_source_roots=True,
         )
     )
 
-    address_references = ", ".join(sorted(config.address.reference() for config in configs))
+    address_references = ", ".join(
+        sorted(field_set.address.reference() for field_set in field_sets)
+    )
 
     process = requirements_pex.create_process(
         python_setup=python_setup,
@@ -120,7 +123,7 @@ async def pylint_lint(
         pex_path=f"./pylint.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, pylint=pylint),
         input_files=merged_input_files,
-        description=f"Run Pylint on {pluralize(len(configs), 'target')}: {address_references}.",
+        description=f"Run Pylint on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
     return LintResult.from_fallible_process_result(result)
@@ -130,7 +133,7 @@ def rules():
     return [
         pylint_lint,
         SubsystemRule(Pylint),
-        UnionRule(LinterConfigurations, PylintConfigurations),
+        UnionRule(LinterFieldSets, PylintFieldSets),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -5,7 +5,7 @@ from pathlib import PurePath
 from textwrap import dedent
 from typing import List, Optional
 
-from pants.backend.python.lint.pylint.rules import PylintConfiguration, PylintConfigurations
+from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintFieldSets
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
@@ -45,7 +45,7 @@ class PylintIntegrationTest(TestBase):
         return (
             *super().rules(),
             *pylint_rules(),
-            RootRule(PylintConfigurations),
+            RootRule(PylintFieldSets),
             RootRule(HydratedTargets),
         )
 
@@ -98,7 +98,7 @@ class PylintIntegrationTest(TestBase):
         return self.request_single_product(
             LintResult,
             Params(
-                PylintConfigurations(PylintConfiguration.create(tgt) for tgt in targets),
+                PylintFieldSets(PylintFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -5,12 +5,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Type
 
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import (
-    FmtConfigurations,
-    FmtResult,
-    LanguageFmtResults,
-    LanguageFmtTargets,
-)
+from pants.core.goals.fmt import FmtFieldSets, FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.rules import rule
@@ -24,7 +19,7 @@ class PythonFmtTargets(LanguageFmtTargets):
 
 
 @union
-class PythonFmtConfigurations:
+class PythonFmtFieldSets:
     pass
 
 
@@ -42,15 +37,15 @@ async def format_python_target(
     prior_formatter_result = original_sources.snapshot
 
     results: List[FmtResult] = []
-    config_collection_types: Iterable[Type[FmtConfigurations]] = union_membership.union_rules[
-        PythonFmtConfigurations
+    field_set_collection_types: Iterable[Type[FmtFieldSets]] = union_membership.union_rules[
+        PythonFmtFieldSets
     ]
-    for config_collection_type in config_collection_types:
+    for field_set_collection_type in field_set_collection_types:
         result = await Get[FmtResult](
-            PythonFmtConfigurations,
-            config_collection_type(
+            PythonFmtFieldSets,
+            field_set_collection_type(
                 (
-                    config_collection_type.config_type.create(target_with_origin)
+                    field_set_collection_type.field_set_type.create(target_with_origin)
                     for target_with_origin in targets_with_origins
                 ),
                 prior_formatter_result=prior_formatter_result,

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -3,9 +3,9 @@
 
 from typing import List, Optional
 
-from pants.backend.python.lint.black.rules import BlackConfigurations
+from pants.backend.python.lint.black.rules import BlackFieldSets
 from pants.backend.python.lint.black.rules import rules as black_rules
-from pants.backend.python.lint.isort.rules import IsortConfigurations
+from pants.backend.python.lint.isort.rules import IsortFieldSets
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
@@ -29,8 +29,8 @@ class PythonFmtIntegrationTest(TestBase):
             *black_rules(),
             *isort_rules(),
             RootRule(PythonFmtTargets),
-            RootRule(BlackConfigurations),
-            RootRule(IsortConfigurations),
+            RootRule(BlackFieldSets),
+            RootRule(IsortFieldSets),
         )
 
     def run_black_and_isort(

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -28,7 +28,7 @@ from pants.backend.python.target_types import (
     PythonTestsSources,
     PythonTestsTimeout,
 )
-from pants.core.goals.test import TestConfiguration, TestDebugRequest, TestOptions, TestResult
+from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestOptions, TestResult
 from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.fs import (
@@ -51,7 +51,7 @@ from pants.python.python_setup import PythonSetup
 
 
 @dataclass(frozen=True)
-class PythonTestConfiguration(TestConfiguration):
+class PythonTestFieldSet(TestFieldSet):
     required_fields = (PythonTestsSources,)
 
     sources: PythonTestsSources
@@ -74,7 +74,7 @@ class TestTargetSetup:
 
 @rule
 async def setup_pytest_for_target(
-    config: PythonTestConfiguration,
+    field_set: PythonTestFieldSet,
     pytest: PyTest,
     test_options: TestOptions,
     python_setup: PythonSetup,
@@ -82,7 +82,7 @@ async def setup_pytest_for_target(
     # TODO: Rather than consuming the TestOptions subsystem, the TestRunner should pass on coverage
     # configuration via #7490.
 
-    test_addresses = Addresses((config.address,))
+    test_addresses = Addresses((field_set.address,))
 
     transitive_targets = await Get[TransitiveTargets](Addresses, test_addresses)
     all_targets = transitive_targets.closure
@@ -148,7 +148,7 @@ async def setup_pytest_for_target(
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
     # to test, rather than using auto-discovery.
     specified_source_files_request = SpecifiedSourceFilesRequest(
-        [(config.sources, config.origin)], strip_source_roots=True
+        [(field_set.sources, field_set.origin)], strip_source_roots=True
     )
 
     # TODO(John Sirois): Support exploiting concurrency better:
@@ -203,7 +203,7 @@ async def setup_pytest_for_target(
         coverage_args = [
             "--cov-report=",  # To not generate any output. https://pytest-cov.readthedocs.io/en/latest/config.html
         ]
-        for package in config.coverage.determine_packages_to_cover(
+        for package in field_set.coverage.determine_packages_to_cover(
             specified_source_files=specified_source_files
         ):
             coverage_args.extend(["--cov", package])
@@ -213,7 +213,7 @@ async def setup_pytest_for_target(
         test_runner_pex=test_runner_pex,
         args=(*pytest.options.args, *coverage_args, *specified_source_file_names),
         input_files_digest=merged_input_files,
-        timeout_seconds=config.timeout.calculate_from_global_options(pytest),
+        timeout_seconds=field_set.timeout.calculate_from_global_options(pytest),
         xml_dir=pytest.options.junit_xml_dir,
         junit_family=pytest.options.junit_family,
     )
@@ -221,7 +221,7 @@ async def setup_pytest_for_target(
 
 @named_rule(desc="Run pytest")
 async def run_python_test(
-    config: PythonTestConfiguration,
+    field_set: PythonTestFieldSet,
     test_setup: TestTargetSetup,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -231,7 +231,7 @@ async def run_python_test(
     """Runs pytest for one target."""
     add_opts = [f"--color={'yes' if global_options.options.colors else 'no'}"]
     if test_setup.xml_dir:
-        test_results_file = f"{config.address.path_safe_spec}.xml"
+        test_results_file = f"{field_set.address.path_safe_spec}.xml"
         add_opts.extend(
             (f"--junitxml={test_results_file}", f"-o junit_family={test_setup.junit_family}",)
         )
@@ -248,7 +248,7 @@ async def run_python_test(
         pex_args=test_setup.args,
         input_files=test_setup.input_files_digest,
         output_directories=tuple(output_dirs) if output_dirs else None,
-        description=f"Run Pytest for {config.address.reference()}",
+        description=f"Run Pytest for {field_set.address.reference()}",
         timeout_seconds=test_setup.timeout_seconds,
         env=env,
     )
@@ -259,7 +259,7 @@ async def run_python_test(
         coverage_snapshot = await Get[Snapshot](
             SnapshotSubset(result.output_digest, PathGlobs([".coverage"]))
         )
-        coverage_data = PytestCoverageData(config.address, coverage_snapshot.digest)
+        coverage_data = PytestCoverageData(field_set.address, coverage_snapshot.digest)
 
     xml_results_digest = None
     if test_setup.xml_dir:
@@ -290,7 +290,7 @@ def rules():
         run_python_test,
         debug_python_test,
         setup_pytest_for_target,
-        UnionRule(TestConfiguration, PythonTestConfiguration),
+        UnionRule(TestFieldSet, PythonTestFieldSet),
         SubsystemRule(PyTest),
         SubsystemRule(PythonSetup),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -14,7 +14,7 @@ from pants.backend.python.rules import (
     pytest_runner,
 )
 from pants.backend.python.rules.pytest_coverage import CoverageConfigRequest, create_coverage_config
-from pants.backend.python.rules.pytest_runner import PythonTestConfiguration
+from pants.backend.python.rules.pytest_runner import PythonTestFieldSet
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
 from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
@@ -128,7 +128,7 @@ class PytestRunnerIntegrationTest(TestBase):
             *subprocess_environment.rules(),
             SubsystemRule(TestOptions),
             RootRule(CoverageConfigRequest),
-            RootRule(PythonTestConfiguration),
+            RootRule(PythonTestFieldSet),
         )
 
     def run_pytest(
@@ -148,7 +148,7 @@ class PytestRunnerIntegrationTest(TestBase):
             origin = SingleAddress(directory=address.spec_path, name=address.target_name)
         tgt = PythonTests({}, address=address)
         params = Params(
-            PythonTestConfiguration.create(TargetWithOrigin(tgt, origin)), options_bootstrapper
+            PythonTestFieldSet.create(TargetWithOrigin(tgt, origin)), options_bootstrapper
         )
         test_result = self.request_single_product(TestResult, params)
         debug_request = self.request_single_product(TestDebugRequest, params)

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -12,16 +12,12 @@ from pants.engine.fs import Digest, DirectoryToMaterialize, MergeDigests, Worksp
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
-from pants.engine.target import (
-    Configuration,
-    TargetsToValidConfigurations,
-    TargetsToValidConfigurationsRequest,
-)
+from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
 
 
 @union
-class BinaryConfiguration(Configuration, metaclass=ABCMeta):
+class BinaryFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary to create a binary from a target."""
 
 
@@ -37,7 +33,7 @@ class BinaryOptions(LineOriented, GoalSubsystem):
 
     name = "binary"
 
-    required_union_implementations = (BinaryConfiguration,)
+    required_union_implementations = (BinaryFieldSet,)
 
 
 class Binary(Goal):
@@ -52,16 +48,16 @@ async def create_binary(
     distdir: DistDir,
     buildroot: BuildRoot,
 ) -> Binary:
-    targets_to_valid_configs = await Get[TargetsToValidConfigurations](
-        TargetsToValidConfigurationsRequest(
-            BinaryConfiguration,
+    targets_to_valid_field_sets = await Get[TargetsToValidFieldSets](
+        TargetsToValidFieldSetsRequest(
+            BinaryFieldSet,
             goal_description=f"the `{options.name}` goal",
             error_if_no_valid_targets=True,
         )
     )
     binaries = await MultiGet(
-        Get[CreatedBinary](BinaryConfiguration, config)
-        for config in targets_to_valid_configs.configurations
+        Get[CreatedBinary](BinaryFieldSet, field_set)
+        for field_set in targets_to_valid_field_sets.field_sets
     )
     merged_digest = await Get[Digest](MergeDigests(binary.digest for binary in binaries))
     result = workspace.materialize_directory(

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -6,7 +6,7 @@ from abc import ABCMeta
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type
 
-from pants.core.goals.lint import LinterConfiguration
+from pants.core.goals.lint import LinterFieldSet
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.collection import Collection
 from pants.engine.console import Console
@@ -53,23 +53,23 @@ class FmtResult:
         return self.output != self.input
 
 
-class FmtConfiguration(LinterConfiguration, metaclass=ABCMeta):
+class FmtFieldSet(LinterFieldSet, metaclass=ABCMeta):
     """The fields necessary for a particular auto-formatter to work with a target."""
 
 
-class FmtConfigurations(Collection[FmtConfiguration]):
-    """A collection of Configurations for a particular formatter, e.g. a collection of
-    `IsortConfiguration`s."""
+class FmtFieldSets(Collection[FmtFieldSet]):
+    """A collection of `FieldSet`s for a particular formatter, e.g. a collection of
+    `IsortFieldSet`s."""
 
-    config_type: ClassVar[Type[FmtConfiguration]]
+    field_set_type: ClassVar[Type[FmtFieldSet]]
 
     def __init__(
         self,
-        configs: Iterable[FmtConfiguration],
+        field_sets: Iterable[FmtFieldSet],
         *,
         prior_formatter_result: Optional[Snapshot] = None
     ) -> None:
-        super().__init__(configs)
+        super().__init__(field_sets)
         self.prior_formatter_result = prior_formatter_result
 
 

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -4,14 +4,14 @@
 from pathlib import PurePath
 
 from pants.base.build_root import BuildRoot
-from pants.core.goals.binary import BinaryConfiguration, CreatedBinary
+from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
-from pants.engine.target import TargetsToValidConfigurations, TargetsToValidConfigurationsRequest
+from pants.engine.target import TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.option.custom_types import shell_str
 from pants.option.global_options import GlobalOptions
 from pants.util.contextutil import temporary_dir
@@ -22,8 +22,8 @@ class RunOptions(GoalSubsystem):
 
     name = "run"
 
-    # NB: To be runnable, there must be a BinaryConfiguration that works with the target.
-    required_union_implementations = (BinaryConfiguration,)
+    # NB: To be runnable, there must be a BinaryFieldSet that works with the target.
+    required_union_implementations = (BinaryFieldSet,)
 
     @classmethod
     def register_options(cls, register) -> None:
@@ -51,16 +51,16 @@ async def run(
     options: RunOptions,
     global_options: GlobalOptions,
 ) -> Run:
-    targets_to_valid_configs = await Get[TargetsToValidConfigurations](
-        TargetsToValidConfigurationsRequest(
-            BinaryConfiguration,
+    targets_to_valid_field_sets = await Get[TargetsToValidFieldSets](
+        TargetsToValidFieldSetsRequest(
+            BinaryFieldSet,
             goal_description=f"the `{options.name}` goal",
             error_if_no_valid_targets=True,
-            expect_single_config=True,
+            expect_single_field_set=True,
         )
     )
-    config = targets_to_valid_configs.configurations[0]
-    binary = await Get[CreatedBinary](BinaryConfiguration, config)
+    field_set = targets_to_valid_field_sets.field_sets[0]
+    binary = await Get[CreatedBinary](BinaryFieldSet, field_set)
 
     workdir = global_options.options.pants_workdir
     with temporary_dir(root_dir=workdir, cleanup=True) as tmpdir:
@@ -69,7 +69,7 @@ async def run(
             DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
         )
 
-        console.write_stdout(f"Running target: {config.address}\n")
+        console.write_stdout(f"Running target: {field_set.address}\n")
         full_path = PurePath(tmpdir, binary.binary_name).as_posix()
         run_request = InteractiveProcessRequest(
             argv=(full_path, *options.values.args), run_in_workspace=True,
@@ -79,14 +79,14 @@ async def run(
             result = runner.run_local_interactive_process(run_request)
             exit_code = result.process_exit_code
             if result.process_exit_code == 0:
-                console.write_stdout(f"{config.address} ran successfully.\n")
+                console.write_stdout(f"{field_set.address} ran successfully.\n")
             else:
                 console.write_stderr(
-                    f"{config.address} failed with code {result.process_exit_code}!\n"
+                    f"{field_set.address} failed with code {result.process_exit_code}!\n"
                 )
 
         except Exception as e:
-            console.write_stderr(f"Exception when attempting to run {config.address}: {e!r}\n")
+            console.write_stderr(f"Exception when attempting to run {field_set.address}: {e!r}\n")
             exit_code = -1
 
     return Run(exit_code)

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -5,15 +5,15 @@ from typing import cast
 
 from pants.base.build_root import BuildRoot
 from pants.base.specs import SingleAddress
-from pants.core.goals.binary import BinaryConfiguration, CreatedBinary
+from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.core.goals.run import Run, RunOptions, run
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveRunner
 from pants.engine.target import (
     Target,
-    TargetsToValidConfigurations,
-    TargetsToValidConfigurationsRequest,
+    TargetsToValidFieldSets,
+    TargetsToValidFieldSetsRequest,
     TargetWithOrigin,
 )
 from pants.option.global_options import GlobalOptions
@@ -41,7 +41,7 @@ class RunTest(TestBase):
         workspace = Workspace(self.scheduler)
         interactive_runner = InteractiveRunner(self.scheduler)
 
-        class TestBinaryConfiguration(BinaryConfiguration):
+        class TestBinaryFieldSet(BinaryFieldSet):
             required_fields = ()
 
         class TestBinaryTarget(Target):
@@ -53,7 +53,7 @@ class RunTest(TestBase):
         target_with_origin = TargetWithOrigin(
             target, SingleAddress(address.spec_path, address.target_name)
         )
-        config = TestBinaryConfiguration.create(target)
+        field_set = TestBinaryFieldSet.create(target)
 
         res = run_rule(
             run,
@@ -67,13 +67,13 @@ class RunTest(TestBase):
             ],
             mock_gets=[
                 MockGet(
-                    product_type=TargetsToValidConfigurations,
-                    subject_type=TargetsToValidConfigurationsRequest,
-                    mock=lambda _: TargetsToValidConfigurations({target_with_origin: [config]}),
+                    product_type=TargetsToValidFieldSets,
+                    subject_type=TargetsToValidFieldSetsRequest,
+                    mock=lambda _: TargetsToValidFieldSets({target_with_origin: [field_set]}),
                 ),
                 MockGet(
                     product_type=CreatedBinary,
-                    subject_type=TestBinaryConfiguration,
+                    subject_type=TestBinaryFieldSet,
                     mock=lambda _: self.create_mock_binary(program_text),
                 ),
             ],

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -14,16 +14,16 @@ from pants.core.goals.test import (
     FilesystemCoverageReport,
     Status,
     Test,
-    TestConfiguration,
     TestDebugRequest,
+    TestFieldSet,
     TestOptions,
     TestResult,
-    WrappedTestConfiguration,
+    WrappedTestFieldSet,
     run_tests,
 )
 from pants.core.util_rules.filter_empty_sources import (
-    ConfigurationsWithSources,
-    ConfigurationsWithSourcesRequest,
+    FieldSetsWithSources,
+    FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, Digest, FileContent, InputFilesContent, Workspace
@@ -31,8 +31,8 @@ from pants.engine.interactive_runner import InteractiveProcessRequest, Interacti
 from pants.engine.target import (
     Sources,
     Target,
-    TargetsToValidConfigurations,
-    TargetsToValidConfigurationsRequest,
+    TargetsToValidFieldSets,
+    TargetsToValidFieldSetsRequest,
     TargetWithOrigin,
 )
 from pants.engine.unions import UnionMembership
@@ -45,7 +45,7 @@ class MockTarget(Target):
     core_fields = (Sources,)
 
 
-class MockTestConfiguration(TestConfiguration, metaclass=ABCMeta):
+class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
     required_fields = (Sources,)
 
     @staticmethod
@@ -72,7 +72,7 @@ class MockTestConfiguration(TestConfiguration, metaclass=ABCMeta):
         )
 
 
-class SuccessfulConfiguration(MockTestConfiguration):
+class SuccessfulFieldSet(MockTestFieldSet):
     @staticmethod
     def status(_: Address) -> Status:
         return Status.SUCCESS
@@ -82,7 +82,7 @@ class SuccessfulConfiguration(MockTestConfiguration):
         return f"Successful test target: Passed for {address}!"
 
 
-class ConditionallySucceedsConfiguration(MockTestConfiguration):
+class ConditionallySucceedsFieldSet(MockTestFieldSet):
     @staticmethod
     def status(address: Address) -> Status:
         return Status.FAILURE if address.target_name == "bad" else Status.SUCCESS
@@ -126,7 +126,7 @@ class TestTest(TestBase):
     def run_test_rule(
         self,
         *,
-        config: Type[TestConfiguration],
+        field_set: Type[TestFieldSet],
         targets: List[TargetWithOrigin],
         debug: bool = False,
         include_sources: bool = True,
@@ -136,47 +136,52 @@ class TestTest(TestBase):
         options = create_goal_subsystem(TestOptions, debug=debug, run_coverage=False)
         interactive_runner = InteractiveRunner(self.scheduler)
         workspace = Workspace(self.scheduler)
-        union_membership = UnionMembership({TestConfiguration: [config]})
+        union_membership = UnionMembership({TestFieldSet: [field_set]})
 
-        def mock_find_valid_configs(
-            _: TargetsToValidConfigurationsRequest,
-        ) -> TargetsToValidConfigurations:
+        def mock_find_valid_field_sets(
+            _: TargetsToValidFieldSetsRequest,
+        ) -> TargetsToValidFieldSets:
             if not valid_targets:
-                return TargetsToValidConfigurations({})
-            return TargetsToValidConfigurations(
-                {tgt_with_origin: [config.create(tgt_with_origin)] for tgt_with_origin in targets}
+                return TargetsToValidFieldSets({})
+            return TargetsToValidFieldSets(
+                {
+                    tgt_with_origin: [field_set.create(tgt_with_origin)]
+                    for tgt_with_origin in targets
+                }
             )
 
         def mock_coordinator_of_tests(
-            wrapped_config: WrappedTestConfiguration,
+            wrapped_field_set: WrappedTestFieldSet,
         ) -> AddressAndTestResult:
-            config = cast(MockTestConfiguration, wrapped_config.config)
-            return AddressAndTestResult(address=config.address, test_result=config.test_result)
+            field_set = cast(MockTestFieldSet, wrapped_field_set.field_set)
+            return AddressAndTestResult(
+                address=field_set.address, test_result=field_set.test_result
+            )
 
         result: Test = run_rule(
             run_tests,
             rule_args=[console, options, interactive_runner, workspace, union_membership],
             mock_gets=[
                 MockGet(
-                    product_type=TargetsToValidConfigurations,
-                    subject_type=TargetsToValidConfigurationsRequest,
-                    mock=mock_find_valid_configs,
+                    product_type=TargetsToValidFieldSets,
+                    subject_type=TargetsToValidFieldSetsRequest,
+                    mock=mock_find_valid_field_sets,
                 ),
                 MockGet(
                     product_type=AddressAndTestResult,
-                    subject_type=WrappedTestConfiguration,
+                    subject_type=WrappedTestFieldSet,
                     mock=lambda wrapped_config: mock_coordinator_of_tests(wrapped_config),
                 ),
                 MockGet(
                     product_type=TestDebugRequest,
-                    subject_type=TestConfiguration,
+                    subject_type=TestFieldSet,
                     mock=lambda _: TestDebugRequest(self.make_ipr()),
                 ),
                 MockGet(
-                    product_type=ConfigurationsWithSources,
-                    subject_type=ConfigurationsWithSourcesRequest,
-                    mock=lambda configs: ConfigurationsWithSources(
-                        configs if include_sources else ()
+                    product_type=FieldSetsWithSources,
+                    subject_type=FieldSetsWithSourcesRequest,
+                    mock=lambda field_sets: FieldSetsWithSources(
+                        field_sets if include_sources else ()
                     ),
                 ),
                 MockGet(
@@ -195,7 +200,7 @@ class TestTest(TestBase):
 
     def test_empty_target_noops(self) -> None:
         exit_code, stdout = self.run_test_rule(
-            config=SuccessfulConfiguration,
+            field_set=SuccessfulFieldSet,
             targets=[self.make_target_with_origin()],
             include_sources=False,
         )
@@ -204,7 +209,7 @@ class TestTest(TestBase):
 
     def test_invalid_target_noops(self) -> None:
         exit_code, stdout = self.run_test_rule(
-            config=SuccessfulConfiguration,
+            field_set=SuccessfulFieldSet,
             targets=[self.make_target_with_origin()],
             valid_targets=False,
         )
@@ -214,13 +219,13 @@ class TestTest(TestBase):
     def test_single_target(self) -> None:
         address = Address.parse(":tests")
         exit_code, stdout = self.run_test_rule(
-            config=SuccessfulConfiguration, targets=[self.make_target_with_origin(address)]
+            field_set=SuccessfulFieldSet, targets=[self.make_target_with_origin(address)]
         )
         assert exit_code == 0
         assert stdout == dedent(
             f"""\
             {address} stdout:
-            {SuccessfulConfiguration.stdout(address)}
+            {SuccessfulFieldSet.stdout(address)}
 
             {address}                                                                        .....   SUCCESS
             """
@@ -231,7 +236,7 @@ class TestTest(TestBase):
         bad_address = Address.parse(":bad")
 
         exit_code, stdout = self.run_test_rule(
-            config=ConditionallySucceedsConfiguration,
+            field_set=ConditionallySucceedsFieldSet,
             targets=[
                 self.make_target_with_origin(good_address),
                 self.make_target_with_origin(bad_address),
@@ -241,9 +246,9 @@ class TestTest(TestBase):
         assert stdout == dedent(
             f"""\
             {good_address} stdout:
-            {ConditionallySucceedsConfiguration.stdout(good_address)}
+            {ConditionallySucceedsFieldSet.stdout(good_address)}
             {bad_address} stderr:
-            {ConditionallySucceedsConfiguration.stderr(bad_address)}
+            {ConditionallySucceedsFieldSet.stderr(bad_address)}
 
             {good_address}                                                                         .....   SUCCESS
             {bad_address}                                                                          .....   FAILURE
@@ -252,6 +257,6 @@ class TestTest(TestBase):
 
     def test_debug_target(self) -> None:
         exit_code, stdout = self.run_test_rule(
-            config=SuccessfulConfiguration, targets=[self.make_target_with_origin()], debug=True,
+            field_set=SuccessfulFieldSet, targets=[self.make_target_with_origin()], debug=True,
         )
         assert exit_code == 0

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -4,14 +4,14 @@
 from dataclasses import dataclass
 
 from pants.core.util_rules.filter_empty_sources import (
-    ConfigurationsWithSources,
-    ConfigurationsWithSourcesRequest,
+    FieldSetsWithSources,
+    FieldSetsWithSourcesRequest,
     TargetsWithSources,
     TargetsWithSourcesRequest,
 )
 from pants.core.util_rules.filter_empty_sources import rules as filter_empty_sources_rules
 from pants.engine.addresses import Address
-from pants.engine.target import Configuration, Sources, Tags, Target
+from pants.engine.target import FieldSet, Sources, Tags, Target
 from pants.testutil.test_base import TestBase
 
 
@@ -20,29 +20,28 @@ class FilterEmptySourcesTest(TestBase):
     def rules(cls):
         return (*super().rules(), *filter_empty_sources_rules())
 
-    def test_filter_configurations(self) -> None:
+    def test_filter_field_sets(self) -> None:
         @dataclass(frozen=True)
-        class MockConfiguration(Configuration):
+        class MockFieldSet(FieldSet):
             sources: Sources
-            # Another field to demo that we will preserve the whole Configuration data structure.
+            # Another field to demo that we will preserve the whole FieldSet data structure.
             tags: Tags
 
         self.create_file("f1.txt")
         valid_addr = Address.parse(":valid")
-        valid_config = MockConfiguration(
+        valid_field_set = MockFieldSet(
             valid_addr, Sources(["f1.txt"], address=valid_addr), Tags(None, address=valid_addr)
         )
 
         empty_addr = Address.parse(":empty")
-        empty_config = MockConfiguration(
+        empty_field_set = MockFieldSet(
             empty_addr, Sources(None, address=empty_addr), Tags(None, address=empty_addr)
         )
 
         result = self.request_single_product(
-            ConfigurationsWithSources,
-            ConfigurationsWithSourcesRequest([valid_config, empty_config]),
+            FieldSetsWithSources, FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
         )
-        assert tuple(result) == (valid_config,)
+        assert tuple(result) == (valid_field_set,)
 
     def test_filter_targets(self) -> None:
         class MockTarget(Target):

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -20,10 +20,10 @@ from pants.engine.target import (
     AmbiguousImplementationsException,
     AsyncField,
     BoolField,
-    Configuration,
-    ConfigurationWithOrigin,
     DictStringToStringField,
     DictStringToStringSequenceField,
+    FieldSet,
+    FieldSetWithOrigin,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -41,8 +41,8 @@ from pants.engine.target import (
     StringOrStringSequenceField,
     StringSequenceField,
     Target,
-    TargetsToValidConfigurations,
-    TargetsToValidConfigurationsRequest,
+    TargetsToValidFieldSets,
+    TargetsToValidFieldSetsRequest,
     TargetsWithOrigins,
     TargetWithOrigin,
     TooManyTargetsException,
@@ -407,11 +407,11 @@ def test_required_field() -> None:
 
 
 # -----------------------------------------------------------------------------------------------
-# Test Configuration
+# Test FieldSet
 # -----------------------------------------------------------------------------------------------
 
 
-def test_configuration() -> None:
+def test_field_set() -> None:
     class UnrelatedField(StringField):
         alias = "unrelated_field"
         default = "default"
@@ -426,14 +426,14 @@ def test_configuration() -> None:
         core_fields = ()
 
     @dataclass(frozen=True)
-    class FortranConfiguration(Configuration):
+    class FortranFieldSet(FieldSet):
         required_fields = (FortranSources,)
 
         sources: FortranSources
         unrelated_field: UnrelatedField
 
     @dataclass(frozen=True)
-    class UnrelatedFieldConfiguration(ConfigurationWithOrigin):
+    class UnrelatedFieldSet(FieldSetWithOrigin):
         required_fields = ()
 
         unrelated_field: UnrelatedField
@@ -445,38 +445,32 @@ def test_configuration() -> None:
     no_fields_addr = Address.parse(":no_fields")
     no_fields_tgt = NoFieldsTarget({}, address=no_fields_addr)
 
-    assert FortranConfiguration.is_valid(fortran_tgt) is True
-    assert FortranConfiguration.is_valid(unrelated_tgt) is False
-    assert FortranConfiguration.is_valid(no_fields_tgt) is False
+    assert FortranFieldSet.is_valid(fortran_tgt) is True
+    assert FortranFieldSet.is_valid(unrelated_tgt) is False
+    assert FortranFieldSet.is_valid(no_fields_tgt) is False
     # When no fields are required, every target is valid.
     for tgt in [fortran_tgt, unrelated_tgt, no_fields_tgt]:
-        assert UnrelatedFieldConfiguration.is_valid(tgt) is True
+        assert UnrelatedFieldSet.is_valid(tgt) is True
 
-    valid_fortran_config = FortranConfiguration.create(fortran_tgt)
-    assert valid_fortran_config.address == fortran_addr
-    assert valid_fortran_config.unrelated_field.value == UnrelatedField.default
+    valid_fortran_field_set = FortranFieldSet.create(fortran_tgt)
+    assert valid_fortran_field_set.address == fortran_addr
+    assert valid_fortran_field_set.unrelated_field.value == UnrelatedField.default
     with pytest.raises(KeyError):
-        FortranConfiguration.create(unrelated_tgt)
+        FortranFieldSet.create(unrelated_tgt)
 
     origin = FilesystemLiteralSpec("f.txt")
+    assert UnrelatedFieldSet.create(TargetWithOrigin(fortran_tgt, origin)).origin == origin
     assert (
-        UnrelatedFieldConfiguration.create(TargetWithOrigin(fortran_tgt, origin)).origin == origin
-    )
-    assert (
-        UnrelatedFieldConfiguration.create(
-            TargetWithOrigin(unrelated_tgt, origin)
-        ).unrelated_field.value
+        UnrelatedFieldSet.create(TargetWithOrigin(unrelated_tgt, origin)).unrelated_field.value
         == "configured"
     )
     assert (
-        UnrelatedFieldConfiguration.create(
-            TargetWithOrigin(no_fields_tgt, origin)
-        ).unrelated_field.value
+        UnrelatedFieldSet.create(TargetWithOrigin(no_fields_tgt, origin)).unrelated_field.value
         == UnrelatedField.default
     )
 
 
-class TestFindValidConfigurations(TestBase):
+class TestFindValidFieldSets(TestBase):
     class InvalidTarget(Target):
         alias = "invalid_target"
         core_fields = ()
@@ -486,26 +480,26 @@ class TestFindValidConfigurations(TestBase):
         return [FortranTarget, cls.InvalidTarget]
 
     @union
-    class ConfigSuperclass(Configuration):
+    class FieldSetSuperclass(FieldSet):
         pass
 
     @dataclass(frozen=True)
-    class ConfigSubclass1(ConfigSuperclass):
+    class FieldSetSubclass1(FieldSetSuperclass):
         required_fields = (FortranSources,)
 
         sources: FortranSources
 
     @dataclass(frozen=True)
-    class ConfigSubclass2(ConfigSuperclass):
+    class FieldSetSubclass2(FieldSetSuperclass):
         required_fields = (FortranSources,)
 
         sources: FortranSources
 
     @union
-    class ConfigSuperclassWithOrigin(ConfigurationWithOrigin):
+    class FieldSetSuperclassWithOrigin(FieldSetWithOrigin):
         pass
 
-    class ConfigSubclassWithOrigin(ConfigSuperclassWithOrigin):
+    class FieldSetSubclassWithOrigin(FieldSetSuperclassWithOrigin):
         required_fields = (FortranSources,)
 
         sources: FortranSources
@@ -515,55 +509,54 @@ class TestFindValidConfigurations(TestBase):
         return (
             *super().rules(),
             RootRule(TargetsWithOrigins),
-            UnionRule(cls.ConfigSuperclass, cls.ConfigSubclass1),
-            UnionRule(cls.ConfigSuperclass, cls.ConfigSubclass2),
-            UnionRule(cls.ConfigSuperclassWithOrigin, cls.ConfigSubclassWithOrigin),
+            UnionRule(cls.FieldSetSuperclass, cls.FieldSetSubclass1),
+            UnionRule(cls.FieldSetSuperclass, cls.FieldSetSubclass2),
+            UnionRule(cls.FieldSetSuperclassWithOrigin, cls.FieldSetSubclassWithOrigin),
         )
 
-    def test_find_valid_config_types(self) -> None:
+    def test_find_valid_field_sets(self) -> None:
         origin = FilesystemLiteralSpec("f.txt")
         valid_tgt = FortranTarget({}, address=Address.parse(":valid"))
         valid_tgt_with_origin = TargetWithOrigin(valid_tgt, origin)
         invalid_tgt = self.InvalidTarget({}, address=Address.parse(":invalid"))
         invalid_tgt_with_origin = TargetWithOrigin(invalid_tgt, origin)
 
-        def find_valid_configs(
+        def find_valid_field_sets(
             superclass: Type,
             targets_with_origins: Iterable[TargetWithOrigin],
             *,
             error_if_no_valid_targets: bool = False,
             expect_single_config: bool = False,
-        ) -> TargetsToValidConfigurations:
-            request = TargetsToValidConfigurationsRequest(
+        ) -> TargetsToValidFieldSets:
+            request = TargetsToValidFieldSetsRequest(
                 superclass,
                 goal_description="fake",
                 error_if_no_valid_targets=error_if_no_valid_targets,
-                expect_single_config=expect_single_config,
+                expect_single_field_set=expect_single_config,
             )
             return self.request_single_product(
-                TargetsToValidConfigurations,
-                Params(request, TargetsWithOrigins(targets_with_origins),),
+                TargetsToValidFieldSets, Params(request, TargetsWithOrigins(targets_with_origins),),
             )
 
-        valid = find_valid_configs(
-            self.ConfigSuperclass, [valid_tgt_with_origin, invalid_tgt_with_origin]
+        valid = find_valid_field_sets(
+            self.FieldSetSuperclass, [valid_tgt_with_origin, invalid_tgt_with_origin]
         )
         assert valid.targets == (valid_tgt,)
         assert valid.targets_with_origins == (valid_tgt_with_origin,)
-        assert valid.configurations == (
-            self.ConfigSubclass1.create(valid_tgt),
-            self.ConfigSubclass2.create(valid_tgt),
+        assert valid.field_sets == (
+            self.FieldSetSubclass1.create(valid_tgt),
+            self.FieldSetSubclass2.create(valid_tgt),
         )
 
         with pytest.raises(ExecutionError) as exc:
-            find_valid_configs(
-                self.ConfigSuperclass, [valid_tgt_with_origin], expect_single_config=True
+            find_valid_field_sets(
+                self.FieldSetSuperclass, [valid_tgt_with_origin], expect_single_config=True
             )
         assert AmbiguousImplementationsException.__name__ in str(exc.value)
 
         with pytest.raises(ExecutionError) as exc:
-            find_valid_configs(
-                self.ConfigSuperclass,
+            find_valid_field_sets(
+                self.FieldSetSuperclass,
                 [
                     valid_tgt_with_origin,
                     TargetWithOrigin(FortranTarget({}, address=Address.parse(":valid2")), origin),
@@ -572,24 +565,24 @@ class TestFindValidConfigurations(TestBase):
             )
         assert TooManyTargetsException.__name__ in str(exc.value)
 
-        no_valid_targets = find_valid_configs(self.ConfigSuperclass, [invalid_tgt_with_origin])
+        no_valid_targets = find_valid_field_sets(self.FieldSetSuperclass, [invalid_tgt_with_origin])
         assert no_valid_targets.targets == ()
         assert no_valid_targets.targets_with_origins == ()
-        assert no_valid_targets.configurations == ()
+        assert no_valid_targets.field_sets == ()
 
         with pytest.raises(ExecutionError) as exc:
-            find_valid_configs(
-                self.ConfigSuperclass, [invalid_tgt_with_origin], error_if_no_valid_targets=True
+            find_valid_field_sets(
+                self.FieldSetSuperclass, [invalid_tgt_with_origin], error_if_no_valid_targets=True
             )
         assert NoValidTargetsException.__name__ in str(exc.value)
 
-        valid_with_origin = find_valid_configs(
-            self.ConfigSuperclassWithOrigin, [valid_tgt_with_origin, invalid_tgt_with_origin]
+        valid_with_origin = find_valid_field_sets(
+            self.FieldSetSuperclassWithOrigin, [valid_tgt_with_origin, invalid_tgt_with_origin]
         )
         assert valid_with_origin.targets == (valid_tgt,)
         assert valid_with_origin.targets_with_origins == (valid_tgt_with_origin,)
-        assert valid_with_origin.configurations == (
-            self.ConfigSubclassWithOrigin.create(valid_tgt_with_origin),
+        assert valid_with_origin.field_sets == (
+            self.FieldSetSubclassWithOrigin.create(valid_tgt_with_origin),
         )
 
 


### PR DESCRIPTION
This name describes the ad hoc collection of Fields needed by some rules, such as the Fields needed to create an AWS Lambda.

"Configuration" is a very overloaded term and doesn't express its relationship to the Target API / Fields.

Rejected alternatives:

* Fields -> no way to make this plural.
* FieldCollection -> clunkier than FieldSet.
* AdHocTarget -> clunky and too close to `Target`.

[ci skip-rust-tests]
[ci skip-jvm-tests]