### PR TITLE
Rename `Process.input_files` to `Process.input_digest`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -81,7 +81,7 @@ async def create_python_awslambda(
     )
 
     pex_result = await Get[TwoStepPex](TwoStepPexFromTargetsRequest, pex_request)
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests((pex_result.pex.digest, lambdex_setup.requirements_pex.digest))
     )
 
@@ -92,7 +92,7 @@ async def create_python_awslambda(
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./lambdex.pex",
         pex_args=lambdex_args,
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_files=(pex_filename,),
         description=f"Setting up handler in {pex_filename}",
     )

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.addresses import Addresses
-from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule
@@ -37,7 +37,6 @@ async def generate_python_from_protobuf(
         Process(
             (f"/bin/mkdir", output_dir),
             description=f"Create the directory {output_dir}",
-            input_files=EMPTY_DIGEST,
             output_directories=(output_dir,),
         )
     )
@@ -96,7 +95,7 @@ async def generate_python_from_protobuf(
                 output_dir,
                 *stripped_target_sources.snapshot.files,
             ),
-            input_files=input_digest,
+            input_digest=input_digest,
             description=f"Generating Python sources from {request.protocol_target.address}.",
             output_directories=(output_dir,),
         )

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -83,7 +83,7 @@ class CountLinesOfCode(ConsoleTask):
         # The cloc script reaches into $PATH to look up perl. Let's assume it's in /usr/bin.
         req = Process(
             argv=cmd,
-            input_files=input_digest,
+            input_digest=input_digest,
             output_files=("ignored", "report"),
             description="cloc",
         )

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -354,7 +354,7 @@ class Zinc:
         )
         req = Process(
             argv=argv,
-            input_files=inputs_digest,
+            input_digest=inputs_digest,
             output_files=(self._relative_to_buildroot(bridge_jar),),
             description="bootstrap compiler bridge.",
             # Since this is always hermetic, we need to use `underlying_dist`

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -243,7 +243,7 @@ class JavacCompile(JvmCompile):
 
         process = Process(
             argv=tuple(cmd),
-            input_files=input_snapshot.digest,
+            input_digest=input_snapshot.digest,
             output_files=output_files,
             description=f"Compiling {ctx.target.address.spec} with javac",
         )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -897,7 +897,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
         epr = Process(
             argv=tuple(cmd),
-            input_files=epr_input_files,
+            input_digest=epr_input_files,
             output_files=(fast_relpath(ctx.rsc_jar_file.path, get_buildroot()),),
             output_directories=tuple(),
             timeout_seconds=15 * 60,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -749,7 +749,7 @@ class BaseZincCompile(JvmCompile):
 
         req = Process(
             argv=tuple(argv),
-            input_files=merged_input_digest,
+            input_digest=merged_input_digest,
             output_files=(jar_file, relpath_to_analysis),
             output_directories=output_directories,
             description=f"zinc compile for {ctx.target.address.spec}",

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -93,10 +93,10 @@ async def bandit_lint(
         SpecifiedSourceFilesRequest((config.sources, config.origin) for config in configs)
     )
 
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (all_source_files.snapshot.digest, requirements_pex.digest, config_snapshot.digest)
-        ),
+        )
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in configs))
@@ -106,7 +106,7 @@ async def bandit_lint(
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path=f"./bandit.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, bandit=bandit),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         description=f"Run Bandit on {pluralize(len(configs), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -118,10 +118,10 @@ async def setup(
         SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
     )
 
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (all_source_files_snapshot.digest, requirements_pex.digest, config_snapshot.digest)
-        ),
+        )
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
@@ -135,7 +135,7 @@ async def setup(
             black=black,
             check_only=request.check_only,
         ),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_files=all_source_files_snapshot.files,
         description=(
             f"Run Black on {pluralize(len(request.configs), 'target')}: {address_references}."

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -96,8 +96,8 @@ async def setup(
         SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
     )
 
-    merged_input_files = await Get[Digest](
-        MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest)),
+    input_digest = await Get[Digest](
+        MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest))
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
@@ -111,7 +111,7 @@ async def setup(
             docformatter=docformatter,
             check_only=request.check_only,
         ),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_files=all_source_files_snapshot.files,
         description=(
             f"Run Docformatter on {pluralize(len(request.configs), 'target')}: "

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -94,10 +94,10 @@ async def flake8_lint(
         SpecifiedSourceFilesRequest((config.sources, config.origin) for config in configs)
     )
 
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (all_source_files.snapshot.digest, requirements_pex.digest, config_snapshot.digest)
-        ),
+        )
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in configs))
@@ -107,7 +107,7 @@ async def flake8_lint(
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path=f"./flake8.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, flake8=flake8),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         description=f"Run Flake8 on {pluralize(len(configs), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -111,10 +111,10 @@ async def setup(
         SpecifiedSourceFilesRequest((config.sources, config.origin) for config in request.configs)
     )
 
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (all_source_files_snapshot.digest, requirements_pex.digest, config_snapshot.digest)
-        ),
+        )
     )
 
     address_references = ", ".join(sorted(config.address.reference() for config in request.configs))
@@ -128,7 +128,7 @@ async def setup(
             isort=isort,
             check_only=request.check_only,
         ),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_files=all_source_files_snapshot.files,
         description=(
             f"Run isort on {pluralize(len(request.configs), 'target')}: {address_references}."

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -96,7 +96,7 @@ async def pylint_lint(
         )
     )
 
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (
                 requirements_pex.digest,
@@ -119,7 +119,7 @@ async def pylint_lint(
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path=f"./pylint.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, pylint=pylint),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         description=f"Run Pylint on {pluralize(len(configs), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -62,7 +62,7 @@ class DownloadedPexBin(HermeticPex):
         *,
         pex_args: Iterable[str],
         description: str,
-        input_files: Optional[Digest] = None,
+        input_digest: Optional[Digest] = None,
         env: Optional[Mapping[str, str]] = None,
         **kwargs: Any,
     ) -> Process:
@@ -75,10 +75,10 @@ class DownloadedPexBin(HermeticPex):
         :param pex_build_environment: The build environment for the pex tool.
         :param pex_args: The arguments to pass to the pex CLI tool.
         :param description: A description of the process execution to be performed.
-        :param input_files: The files that contain the pex CLI tool itself and any input files it
-                            needs to run against. By default, this is just the files that contain
-                            the PEX CLI tool itself. To merge in additional files, include
-                            `self.digest` in a `MergeDigests` request.
+        :param input_digest: The directory digest that contain the PEX CLI tool itself and any
+                             input files it needs to run against. By default, this is just the
+                             files that contain the PEX CLI tool itself. To merge in additional
+                             files, include `self.digest` in a `MergeDigests` request.
         :param env: The environment to run the PEX in.
         :param kwargs: Any additional :class:`Process` kwargs to pass through.
         """
@@ -92,7 +92,7 @@ class DownloadedPexBin(HermeticPex):
             pex_path=self.executable,
             pex_args=pex_args,
             description=description,
-            input_files=input_files or self.digest,
+            input_digest=input_digest or self.digest,
             env=env,
             **kwargs,
         )

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -21,7 +21,7 @@ class HermeticPex:
         pex_path: str,
         pex_args: Iterable[str],
         description: str,
-        input_files: Digest,
+        input_digest: Digest,
         env: Optional[Mapping[str, str]] = None,
         **kwargs: Any
     ) -> Process:
@@ -34,8 +34,8 @@ class HermeticPex:
                          pex).
         :param pex_args: The arguments to pass to the PEX executable.
         :param description: A description of the process execution to be performed.
-        :param input_files: The files that contain the pex itself and any input files it needs to
-                            run against.
+        :param input_digest: The directory digest that contains the PEX itself and any input files
+                             it needs to run against.
         :param env: The environment to run the PEX in.
         :param **kwargs: Any additional :class:`Process` kwargs to pass through.
         """
@@ -60,5 +60,9 @@ class HermeticPex:
             hermetic_env.update(env)
 
         return Process(
-            argv=argv, input_files=input_files, description=description, env=hermetic_env, **kwargs
+            argv=argv,
+            input_digest=input_digest,
+            description=description,
+            env=hermetic_env,
+            **kwargs
         )

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -372,7 +372,7 @@ async def create_pex(
                 subprocess_encoding_environment=subprocess_encoding_environment,
                 pex_build_environment=pex_build_environment,
                 pex_args=argv,
-                input_files=merged_digest,
+                input_digest=merged_digest,
                 description=description,
                 output_files=(request.output_filename,),
             )

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -254,7 +254,7 @@ class PexTest(TestBase):
         process = Process(
             argv=("python", "test.pex"),
             env=env,
-            input_files=pex_output["pex"].digest,
+            input_digest=pex_output["pex"].digest,
             description="Run the pex and make sure it works",
         )
         result = self.request_single_product(ProcessResult, process)

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -287,7 +287,7 @@ async def merge_coverage_data(
     coverage_config = await Get[CoverageConfig](
         CoverageConfigRequest(Targets(transitive_targets.closure), is_test_time=True)
     )
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests(
             (
                 *coverage_digests,
@@ -303,7 +303,7 @@ async def merge_coverage_data(
     process = coverage_setup.requirements_pex.create_process(
         pex_path=f"./{coverage_setup.requirements_pex.output_filename}",
         pex_args=coverage_args,
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_files=(".coverage",),
         description=f"Merge {len(prefixes)} Pytest coverage reports.",
         python_setup=python_setup,
@@ -339,7 +339,7 @@ async def generate_coverage_report(
     sources_with_inits_snapshot = await Get[InitInjectedSnapshot](
         InjectInitRequest(sources.snapshot)
     )
-    merged_input_files: Digest = await Get(
+    input_digest: Digest = await Get(
         Digest,
         MergeDigests(
             (
@@ -357,7 +357,7 @@ async def generate_coverage_report(
     process = requirements_pex.create_process(
         pex_path=f"./{coverage_setup.requirements_pex.output_filename}",
         pex_args=coverage_args,
-        input_files=merged_input_files,
+        input_digest=input_digest,
         output_directories=("htmlcov",),
         output_files=("coverage.xml",),
         description=f"Generate Pytest coverage report.",

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -377,7 +377,7 @@ async def run_setup_py(
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> RunSetupPyResult:
     """Run a setup.py command on a single exported target."""
-    merged_input_files = await Get[Digest](
+    input_digest = await Get[Digest](
         MergeDigests((req.chroot.digest, setuptools_setup.requirements_pex.digest))
     )
     # The setuptools dist dir, created by it under the chroot (not to be confused with
@@ -388,7 +388,7 @@ async def run_setup_py(
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./setuptools.pex",
         pex_args=("setup.py", *req.args),
-        input_files=merged_input_files,
+        input_digest=input_digest,
         # setuptools commands that create dists write them to the distdir.
         # TODO: Could there be other useful files to capture?
         output_directories=(dist_dir,),

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -98,7 +98,7 @@ class RunTest(TestBase):
         binary = self.create_mock_binary(program_text)
         interactive_runner = InteractiveRunner(self.scheduler)
         request = InteractiveProcessRequest(
-            argv=("./program.py",), run_in_workspace=False, input_files=binary.digest,
+            argv=("./program.py",), run_in_workspace=False, input_digest=binary.digest,
         )
         result = interactive_runner.run_local_interactive_process(request)
         self.assertEqual(result.process_exit_code, 0)
@@ -108,7 +108,7 @@ class RunTest(TestBase):
         binary = self.create_mock_binary(program_text)
         with self.assertRaises(ValueError):
             InteractiveProcessRequest(
-                argv=("/usr/bin/python",), run_in_workspace=True, input_files=binary.digest
+                argv=("/usr/bin/python",), run_in_workspace=True, input_digest=binary.digest
             )
 
     def test_failed_run(self) -> None:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -111,7 +111,7 @@ class TestTest(TestBase):
         )
         digest = self.request_single_product(Digest, input_files_content)
         return InteractiveProcessRequest(
-            argv=("/usr/bin/python", "program.py",), run_in_workspace=False, input_files=digest,
+            argv=("/usr/bin/python", "program.py",), run_in_workspace=False, input_digest=digest,
         )
 
     @staticmethod

--- a/src/python/pants/core/project_info/cloc.py
+++ b/src/python/pants/core/project_info/cloc.py
@@ -21,6 +21,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import SubsystemRule, goal_rule
 from pants.engine.selectors import Get
+from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
@@ -65,11 +66,15 @@ async def run_cloc(
     cloc_binary: ClocBinary,
     sources_snapshots: SourcesSnapshots,
 ) -> CountLinesOfCode:
-    """Runs the cloc perl script in an isolated process."""
-    snapshots = [sources_snapshot.snapshot for sources_snapshot in sources_snapshots]
-    file_content = "\n".join(
-        sorted(set(itertools.chain.from_iterable(snapshot.files for snapshot in snapshots)))
-    ).encode()
+    """Runs the cloc Perl script."""
+    all_file_names = sorted(
+        set(
+            itertools.chain.from_iterable(
+                sources_snapshot.snapshot.files for sources_snapshot in sources_snapshots
+            )
+        )
+    )
+    file_content = "\n".join(all_file_names).encode()
 
     if not file_content:
         return CountLinesOfCode(exit_code=0)
@@ -86,7 +91,7 @@ async def run_cloc(
             (
                 input_file_digest,
                 downloaded_cloc_binary.digest,
-                *(snapshot.digest for snapshot in snapshots),
+                *(sources_snapshot.snapshot.digest for sources_snapshot in sources_snapshots),
             )
         )
     )
@@ -104,9 +109,9 @@ async def run_cloc(
     )
     req = Process(
         argv=cmd,
-        input_files=digest,
+        input_digest=digest,
         output_files=(report_filename, ignore_filename),
-        description="cloc",
+        description=f"Count lines of code for {pluralize(len(all_file_names), 'file')}",
     )
 
     exec_result = await Get[ProcessResult](Process, req)

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -50,7 +50,7 @@ async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
             extraction_cmd_str = " ".join(extraction_cmd)
             proc = Process(
                 argv=("/bin/bash", "-c", f"{extraction_cmd_str}"),
-                input_files=digest,
+                input_digest=digest,
                 description=f"Extract {snapshot.files[0]}",
                 env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
                 output_directories=(output_dir,),

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -21,13 +21,14 @@ class InteractiveProcessResult:
 class InteractiveProcessRequest:
     argv: Tuple[str, ...]
     env: Tuple[str, ...] = ()
-    input_files: Digest = EMPTY_DIGEST
+    input_digest: Digest = EMPTY_DIGEST
     run_in_workspace: bool = False
 
     def __post_init__(self):
-        if self.input_files != EMPTY_DIGEST and self.run_in_workspace:
+        if self.input_digest != EMPTY_DIGEST and self.run_in_workspace:
             raise ValueError(
-                "InteractiveProessRequest should use the Workspace API to materialize any needed files when it runs in the workspace"
+                "InteractiveProcessRequest should use the Workspace API to materialize any needed "
+                "files when it runs in the workspace"
             )
 
 

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResultWithPlatform, Process
 from pants.testutil.test_base import TestBase
@@ -12,11 +11,9 @@ class PlatformTest(TestBase):
 
         this_platform = Platform.current
 
-        req = Process(
-            argv=("/bin/echo", "test"),
-            input_files=EMPTY_DIGEST,
-            description="Run some program that will exit cleanly.",
+        process = Process(
+            argv=("/bin/echo", "test"), description="Run some program that will exit cleanly."
         )
-        result = self.request_single_product(FallibleProcessResultWithPlatform, req)
+        result = self.request_single_product(FallibleProcessResultWithPlatform, process)
         assert result.exit_code == 0
         assert result.platform == this_platform

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -419,4 +419,4 @@ class Broken {
 
         with self.assertRaises(ExecutionError) as cm:
             self.request_single_product(ProcessResult, request)
-        self.assertIn("process 'one-cat' failed with exit code 1.", str(cm.exception))
+        assert "Process 'one-cat' failed with exit code 1." in str(cm.exception)

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1041,8 +1041,8 @@ pub extern "C" fn run_local_interactive_process(
           Some(TempDir::new().map_err(|err| format!("Error creating tempdir: {}", err))?)
         };
 
-        let input_files_value = externs::project_ignoring_type(&value, "input_files");
-        let digest: Digest = nodes::lift_digest(&input_files_value)?;
+        let input_digest_value = externs::project_ignoring_type(&value, "input_digest");
+        let digest: Digest = nodes::lift_digest(&input_digest_value)?;
         if digest != EMPTY_DIGEST {
           if run_in_workspace {
             warn!("Local interactive process should not attempt to materialize files when run in workspace");

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -240,7 +240,7 @@ impl MultiPlatformExecuteProcess {
       }
     };
 
-    let digest = lift_digest(&externs::project_ignoring_type(&value, "input_files"))
+    let digest = lift_digest(&externs::project_ignoring_type(&value, "input_digest"))
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
     let output_files = externs::project_multi_strs(&value, "output_files")


### PR DESCRIPTION
Reasons:

1) `input_files` suggests you can only have files, when you can also have (empty) input directories.
2) `input_files` is vague. We should embrace the DSL's terms to be more precise. Anyone writing a rule will already know what a `Digest` is, so using `files` to refer to a `Digest` is unclear.
3) Parity with other attributes like `ProcessResult.output_digest`.

[ci skip-jvm-tests]