### PR TITLE
Install Python 3.8 in centos7 docker image

### DIFF
--- a/build-support/docker/centos7/Dockerfile
+++ b/build-support/docker/centos7/Dockerfile
@@ -19,24 +19,28 @@ RUN yum install -y \
         unzip \
         zlib-devel
 
-ARG PYTHON_27_VERSION=2.7.13
-ARG PYTHON_36_VERSION=3.6.8
-ARG PYTHON_37_VERSION=3.7.3
+ARG PYTHON_27_VERSION=2.7.18
+ARG PYTHON_36_VERSION=3.6.10
+ARG PYTHON_37_VERSION=3.7.7
+ARG PYTHON_38_VERSION=3.8.2
 
 ENV PYENV_ROOT /pyenv-docker-build
 ENV PYENV_BIN "${PYENV_ROOT}/bin/pyenv"
 RUN git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
 
-# NB: We intentionally do not use `--enable-shared`, as it results in our shipped wheels for the PEX release using
-# `libpython.X.Y.so.1`, which means that the PEX will not work for any consumer interpreters that were statically
-# built, i.e. compiled without `--enable-shared`. See https://github.com/pantsbuild/pants/pull/7794.
+# NB: We intentionally do not use `--enable-shared`, as it results in our shipped wheels for the
+# PEX release using `libpython.X.Y.so.1`, which means that the PEX will not work for any consumer
+# interpreters that were statically built, i.e. compiled without `--enable-shared`. See
+# https://github.com/pantsbuild/pants/pull/7794.
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_27_VERSION}
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_36_VERSION}
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_37_VERSION}
+RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_38_VERSION}
 
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_36_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_37_VERSION}/bin:${PATH}"
+ENV PATH "${PYENV_ROOT}/versions/${PYTHON_38_VERSION}/bin:${PATH}"
 
 # We install the AWS CLI for use in CI to cache assets like pants.pex.
 ENV AWS_CLI_ROOT /aws-docker-build


### PR DESCRIPTION
This will allow us to add Python 3.8 to CI and to build a Python 3.8 wheel.

[ci skip-rust-tests]
[ci skip-jvm-tests]