### PR TITLE
Replace `list` with `list-v2` when in V2 exclusive mode

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -32,7 +32,7 @@ class BuildConfiguration:
     _optionables: OrderedSet = field(default_factory=OrderedSet)
     _rules: OrderedSet = field(default_factory=OrderedSet)
     _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
-    _targets: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
+    _target_types: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
 
     class ParseState(namedtuple("ParseState", ["parse_context", "parse_globals"])):
         @property
@@ -193,26 +193,28 @@ class BuildConfiguration:
     # because we pass whatever people put in their `register.py`s to this function; i.e., this is
     # an impure function that reads from the outside world. So, we use the type hint `Any` and
     # perform runtime type checking.
-    def register_targets(self, targets: Union[typing.Iterable[Type[Target]], Any]) -> None:
+    def register_target_types(
+        self, target_types: Union[typing.Iterable[Type[Target]], Any]
+    ) -> None:
         """Registers the given target types."""
-        if not isinstance(targets, Iterable):
+        if not isinstance(target_types, Iterable):
             raise TypeError(
-                f"The entrypoint `targets` must return an iterable. Given {repr(targets)}"
+                f"The entrypoint `target_types` must return an iterable. Given {repr(target_types)}"
             )
         bad_elements = [
             tgt_type
-            for tgt_type in targets
+            for tgt_type in target_types
             if not isinstance(tgt_type, type) or not issubclass(tgt_type, Target)
         ]
         if bad_elements:
             raise TypeError(
-                "Every element of the entrypoint `targets` must be a subclass of "
+                "Every element of the entrypoint `target_types` must be a subclass of "
                 f"{Target.__name__}. Bad elements: {bad_elements}."
             )
-        self._targets.update(targets)
+        self._target_types.update(target_types)
 
-    def targets(self) -> OrderedSet[Type[Target]]:
-        return self._targets
+    def target_types(self) -> OrderedSet[Type[Target]]:
+        return self._target_types
 
     @memoized_method
     def _get_addressable_factory(self, target_type, alias):

--- a/src/python/pants/core/project_info/list_targets.py
+++ b/src/python/pants/core/project_info/list_targets.py
@@ -12,7 +12,7 @@ from pants.engine.target import DescriptionField, ProvidesField, Targets
 
 
 class ListOptions(LineOriented, GoalSubsystem):
-    """Lists all targets."""
+    """Lists all targets matching the file or target arguments."""
 
     name = "list-v2"
 

--- a/src/python/pants/core/project_info/list_targets_old.py
+++ b/src/python/pants/core/project_info/list_targets_old.py
@@ -11,8 +11,10 @@ from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get
 
 
+# TODO: when deleting this, be sure to update engine/goal.py and core/register.py to no longer
+#  unregister this goal and rename `list-v2` to `list`.
 class ListOptions(LineOriented, GoalSubsystem):
-    """Lists all targets matching the target specs."""
+    """Lists all targets matching the file or target arguments."""
 
     name = "list"
 

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -31,6 +31,7 @@ from pants.core.util_rules import (
     filter_empty_sources,
     strip_source_roots,
 )
+from pants.option.options_bootstrapper import is_v2_exclusive
 
 
 def rules():
@@ -41,7 +42,7 @@ def rules():
         *list_roots.rules(),
         *list_target_types.rules(),
         *list_targets.rules(),
-        *list_targets_old.rules(),
+        *(list_targets_old.rules() if not is_v2_exclusive else ()),
         # goals
         *binary.rules(),
         *fmt.rules(),

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -63,8 +63,11 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
         # changes when switching to v2-exclusive mode (e.g., some v1 options aren't even registered
         # in that mode), so this is in keeping with existing expectations. And this provides
         # a much better experience to new users who never encountered v1 anyway.
-        if is_v2_exclusive and cls.name.endswith("2"):
-            return cls.name[:-1]
+        if is_v2_exclusive:
+            if cls.name == "list-v2":
+                return "list"
+            if cls.name.endswith("2"):
+                return cls.name[:-1]
         return cls.name
 
     @classproperty

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -372,7 +372,7 @@ class EngineInitializer:
         build_file_aliases = build_configuration.registered_aliases()
         rules = build_configuration.rules()
 
-        registered_target_types = RegisteredTargetTypes.create(build_configuration.targets())
+        registered_target_types = RegisteredTargetTypes.create(build_configuration.target_types())
 
         symbol_table = _legacy_symbol_table(build_file_aliases, registered_target_types)
 

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -220,8 +220,8 @@ def load_plugins(
         # bindings for targets to avoid breaking V1-only goals; and there is no V2 entry-point for
         # `objects` yet. Purely V2-repos can ignore `build_file_aliases`.
         if "target_types" in entries:
-            targets = entries["target_types"].load()()
-            build_configuration.register_targets(targets)
+            target_types = entries["target_types"].load()()
+            build_configuration.register_target_types(target_types)
         if "build_file_aliases" in entries:
             aliases = entries["build_file_aliases"].load()()
             build_configuration.register_aliases(aliases)
@@ -291,9 +291,9 @@ def load_backend(
 
     # See the comment in `load_plugins` for why we load both `target_types` and
     # `build_file_aliases` in both V1 and V2.
-    targets = invoke_entrypoint("target_types")
-    if targets:
-        build_configuration.register_targets(targets)
+    target_types = invoke_entrypoint("target_types")
+    if target_types:
+        build_configuration.register_target_types(target_types)
     build_file_aliases = invoke_entrypoint("build_file_aliases")
     if build_file_aliases:
         build_configuration.register_aliases(build_file_aliases)

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -303,7 +303,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         build_config = BuildConfiguration()
         build_config.register_aliases(cls.alias_groups())
         build_config.register_rules(cls.rules())
-        build_config.register_targets(cls.target_types())
+        build_config.register_target_types(cls.target_types())
         return build_config
 
     def setUp(self):


### PR DESCRIPTION
The only reason we still have `list` is that `list-v2` doesn't work with custom targets, unless they have Target API bindings.

Users using V2 exclusively by definition will not ever hit this problem, so we can use the newer `list-v2` instead.