### PR TITLE
Fix crash when V2 goals like `repl` have no specified targets

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -82,6 +82,8 @@ class PexInterpreterConstraints(DeduplicatedCollection[str]):
         """
         # Each element (a Set[ParsedConstraint]) will get ANDed. We use sets to deduplicate
         # identical top-level parsed constraint sets.
+        if not constraint_sets:
+            return []
         parsed_constraint_sets: Set[FrozenSet[ParsedConstraint]] = set()
         for constraint_set in constraint_sets:
             # Each element (a ParsedConstraint) will get ORed.

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -125,6 +125,9 @@ def test_merge_interpreter_constraints() -> None:
         input=[["CPython==3.7.*", "PyPy==43.0"]], expected=["CPython==3.7.*", "PyPy==43.0"]
     )
 
+    # Ensure we can handle empty input.
+    assert_merged(input=[], expected=[])
+
 
 @dataclass(frozen=True)
 class ExactRequirement:


### PR DESCRIPTION
`./v2 repl` with no arguments was crashing with:

```
IndexError: tuple index out of range
```

[ci skip-rust-tests]
[ci skip-jvm-tests]