### PR TITLE
Simplify Scheduler::execute and unify Graph retry

### DIFF
--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -38,8 +38,6 @@ MERGE_BASE="$(git_merge_base)"
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
-    echo "* Checking formatting of Rust files"
-    ./build-support/bin/check_rust_formatting.sh || exit 1
     # Clippy happens on a different Travis CI shard because of separate caching concerns.
     # The TRAVIS env var is documented here:
     #   https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
@@ -47,6 +45,8 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
       echo "* Running cargo clippy"
       ./build-support/bin/check_clippy.sh || exit 1
     fi
+    echo "* Checking formatting of Rust files"
+    ./build-support/bin/check_rust_formatting.sh || exit 1
     echo "* Checking Rust target headers"
     build-support/bin/check_rust_target_headers.sh || exit 1
   fi

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -350,12 +350,10 @@ impl Context {
   pub fn get<N: WrappedNode>(&self, node: N) -> BoxFuture<N::Item, Failure> {
     // TODO: Odd place for this... could do it periodically in the background?
     maybe_drop_handles();
-    let result = if let Some(entry_id) = self.entry_id {
-      self.core.graph.get(entry_id, self, node.into()).to_boxed()
-    } else {
-      self.core.graph.create(node.into(), self).to_boxed()
-    };
-    result
+    self
+      .core
+      .graph
+      .get(self.entry_id, self, node.into())
       .map(|node_result| {
         node_result
           .try_into()

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -9,7 +9,8 @@ use std::sync::{mpsc, Arc};
 use std::time::Duration;
 
 use futures::compat::Future01CompatExt;
-use futures01::future::{self, Future};
+use futures::future::{self as future03};
+use futures01::future::Future;
 
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
@@ -22,6 +23,7 @@ use log::{debug, info, warn};
 use logging::logger::LOGGER;
 use parking_lot::Mutex;
 use ui::{EngineDisplay, KeyboardCommand};
+use uuid::Uuid;
 use watch::Invalidatable;
 use workunit_store::WorkUnitStore;
 
@@ -277,64 +279,35 @@ impl Scheduler {
   }
 
   ///
-  /// Attempts to complete all of the given roots, retrying the entire set (up to `count`
-  /// times) if any of them fail with `Failure::Invalidated`. Sends the result on the given
-  /// mpsc Sender, which allows the caller to poll a channel for the result without blocking
-  /// uninterruptibly on a Future.
-  ///
-  /// In common usage, graph entries won't be repeatedly invalidated, but in a case where they
-  /// were (say by an automated process changing files under pants), we'd want to eventually
-  /// give up.
+  /// Attempts to complete all of the given roots, and send the result on the given mpsc Sender,
+  /// which allows the caller to poll a channel for the result without blocking uninterruptibly
+  /// on a Future.
   ///
   fn execute_helper(
     context: Context,
     sender: mpsc::Sender<Vec<Result<Value, Failure>>>,
     roots: Vec<Root>,
-    count: usize,
   ) {
     let core = context.core.clone();
-    // Attempt all roots in parallel, failing fast to retry for `Invalidated`.
-    let roots_res = future::join_all(
-      roots
-        .clone()
-        .into_iter()
-        .map(|root| {
-          context
-            .core
-            .graph
-            .create(root.clone().into(), &context)
-            .then::<_, Result<Result<Value, Failure>, Failure>>(move |r| {
-              match r {
-                Err(Failure::Invalidated) if count > 0 => {
-                  // A node was invalidated: fail quickly so that all roots can be retried.
-                  Err(Failure::Invalidated)
-                }
-                other => {
-                  // Otherwise (if it is a success, some other type of Failure, or if we've run
-                  // out of retries) recover to complete the join, which will cause the results to
-                  // propagate to the user.
-                  debug!("Root {} completed.", NodeKey::Select(Box::new(root)));
-                  Ok(other.map(|res| {
-                    res
-                      .try_into()
-                      .unwrap_or_else(|_| panic!("A Node implementation was ambiguous."))
-                  }))
-                }
-              }
-            })
-        })
-        .collect::<Vec<_>>(),
-    );
-
-    // If the join failed (due to `Invalidated`, since that is the only error we propagate), retry
-    // the entire set of roots.
     core.executor.spawn_and_ignore(async move {
-      let res = roots_res.compat().await;
-      if let Ok(res) = res {
-        let _ = sender.send(res);
-      } else {
-        Scheduler::execute_helper(context, sender, roots, count - 1);
-      }
+      let res = future03::join_all(
+        roots
+          .into_iter()
+          .map(|root| {
+            context
+              .core
+              .graph
+              .create(root.into(), &context)
+              .map(|nr| {
+                nr.try_into()
+                  .unwrap_or_else(|e| panic!("A Node implementation was ambiguous: {:?}", e))
+              })
+              .compat()
+          })
+          .collect::<Vec<_>>(),
+      )
+      .await;
+      let _ = sender.send(res);
     });
   }
 
@@ -356,62 +329,59 @@ impl Scheduler {
     let context = Context::new(self.core.clone(), session.clone());
     let (sender, receiver) = mpsc::channel();
 
-    Scheduler::execute_helper(context, sender, request.roots.clone(), 8);
+    Scheduler::execute_helper(context, sender, request.roots.clone());
 
     // This map keeps the k most relevant jobs in assigned possitions.
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.
-    let mut tasks_to_display = IndexMap::new();
+    let mut tasks = IndexMap::new();
     let refresh_interval = Duration::from_millis(100);
 
-    Ok(match session.maybe_display() {
-      Some(display) => {
-        {
-          let mut display = display.lock();
-          display.start();
-        }
-        let unique_handle = LOGGER.register_engine_display(display.clone());
-
-        let results = loop {
-          if let Ok(res) = receiver.recv_timeout(refresh_interval) {
-            break res;
-          } else {
-            let workunit_store = session.workunit_store().clone();
-            let render_result =
-              Scheduler::display_ongoing_tasks(workunit_store, display, &mut tasks_to_display);
-            match render_result {
-              Err(e) => warn!("{}", e),
-              Ok(KeyboardCommand::CtrlC) => {
-                info!("Exiting early in response to Ctrl-C");
-                {
-                  let mut display = display.lock();
-                  display.finish();
-                }
-                return Err(ExecutionTermination::KeyboardInterrupt);
-              }
-              Ok(KeyboardCommand::None) => (),
-            };
-          }
-        };
-        LOGGER.deregister_engine_display(unique_handle);
-        {
-          let mut display = display.lock();
-          display.finish();
-        }
-        results
+    let maybe_display_handle = Self::maybe_display_initialize(&session);
+    let result = loop {
+      if let Ok(res) = receiver.recv_timeout(refresh_interval) {
+        break Ok(res);
+      } else if let Err(e) = Self::maybe_display_render(&session, &mut tasks) {
+        break Err(e);
       }
-      None => loop {
-        if let Ok(res) = receiver.recv_timeout(refresh_interval) {
-          break res;
-        }
-      },
-    })
+    };
+    Self::maybe_display_teardown(session, maybe_display_handle);
+
+    result
   }
 
-  fn display_ongoing_tasks(
-    workunit_store: WorkUnitStore,
-    display: &Mutex<EngineDisplay>,
+  fn maybe_display_initialize(session: &Session) -> Option<Uuid> {
+    if let Some(display) = session.maybe_display() {
+      {
+        let mut display = display.lock();
+        display.start();
+      }
+      Some(LOGGER.register_engine_display(display.clone()))
+    } else {
+      None
+    }
+  }
+
+  fn maybe_display_teardown(session: &Session, handle: Option<Uuid>) {
+    if let Some(handle) = handle {
+      LOGGER.deregister_engine_display(handle);
+    }
+    if let Some(display) = session.maybe_display() {
+      let mut display = display.lock();
+      display.finish();
+    }
+  }
+
+  fn maybe_display_render(
+    session: &Session,
     tasks_to_display: &mut IndexMap<String, Option<Duration>>,
-  ) -> Result<KeyboardCommand, String> {
+  ) -> Result<(), ExecutionTermination> {
+    let display = if let Some(display) = session.maybe_display() {
+      display
+    } else {
+      return Ok(());
+    };
+    let workunit_store = session.workunit_store();
+
     // Update the graph. To do that, we iterate over heavy hitters.
 
     let worker_count = {
@@ -457,7 +427,22 @@ impl Scheduler {
     for i in tasks_to_display.len()..worker_count {
       d.update(i.to_string(), "".to_string());
     }
-    d.render()
+
+    match d.render() {
+      Err(e) => {
+        warn!("{}", e);
+        Ok(())
+      }
+      Ok(KeyboardCommand::CtrlC) => {
+        info!("Exiting early in response to Ctrl-C");
+        {
+          let mut display = display.lock();
+          display.finish();
+        }
+        Err(ExecutionTermination::KeyboardInterrupt)
+      }
+      Ok(KeyboardCommand::None) => Ok(()),
+    }
   }
 }
 


### PR DESCRIPTION
### Problem

Both the `Graph` and the `Scheduler` implemented retry for requested Nodes, but the `Scheduler` implementation was pre-async-await and much more complicated.

### Solution

Unify the retry implementations into `Graph::get` (either roots or uncacheable nodes are retried), and simplify the `Scheduler`'s loop down to:
```
let maybe_display_handle = Self::maybe_display_initialize(&session);
let result = loop {
  if let Ok(res) = receiver.recv_timeout(refresh_interval) {
    break Ok(res);
  } else if let Err(e) = Self::maybe_display_render(&session, &mut tasks) {
    break Err(e);
  }
};
Self::maybe_display_teardown(session, maybe_display_handle);
result
```

### Result

A single, more modern retry implementation (thanks @hrfuller!), and a cleaner `Scheduler::execute` loop.