### PR TITLE
Add support for optimized fork of ANTLR4 for Java

### DIFF
--- a/examples/src/antlr/org/pantsbuild/example/exp/BUILD
+++ b/examples/src/antlr/org/pantsbuild/example/exp/BUILD
@@ -5,6 +5,7 @@ target(
   dependencies=[
     ':exp_antlr3',
     ':exp_antlr4',
+    ':exp_antlr4_fork'
   ]
 )
 
@@ -16,4 +17,9 @@ java_antlr_library(name='exp_antlr3',
 java_antlr_library(name='exp_antlr4',
   sources=['ExpAntlr4.g'],
   compiler='antlr4',
+)
+
+java_antlr_library(name='exp_antlr4_fork',
+  sources=['ExpAntlr4.g'],
+  compiler='antlr4_fork',
 )

--- a/examples/src/java/org/pantsbuild/example/antlr4/BUILD
+++ b/examples/src/java/org/pantsbuild/example/antlr4/BUILD
@@ -9,3 +9,13 @@ jvm_binary(
   ],
   strict_deps=False,
 )
+
+jvm_binary(
+  name="antlr4_fork",
+  sources=['ExampleAntlr4.java'],
+  main='org.pantsbuild.example.antlr4.ExampleAntlr4',
+  dependencies=[
+    'examples/src/antlr/org/pantsbuild/example/exp:exp_antlr4_fork',
+  ],
+  strict_deps=False,
+)

--- a/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
+++ b/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
@@ -21,9 +21,17 @@ def antlr4_jar(name):
     return JarDependency(org="org.antlr", name=name, rev="4.1")
 
 
+def antlr4_fork_jar(name):
+    return JarDependency(org="com.tunnelvisionlabs", name=name, rev="4.7.4")
+
+
 _DEFAULT_ANTLR_DEPS = {
     "antlr3": ("//:antlr-3.4", [JarDependency(org="org.antlr", name="antlr", rev="3.4")]),
     "antlr4": ("//:antlr-4", [antlr4_jar(name="antlr4"), antlr4_jar(name="antlr4-runtime")]),
+    "antlr4_fork": (
+        "//:antlr-4",
+        [antlr4_fork_jar(name="antlr4"), antlr4_fork_jar(name="antlr4-runtime")],
+    ),
 }
 
 
@@ -70,7 +78,7 @@ class AntlrJavaGen(SimpleCodegenTask, NailgunTask):
                     "The 'package' attribute is not supported for antlr3 and will be ignored."
                 )
             java_main = "org.antlr.Tool"
-        elif compiler == "antlr4":
+        elif compiler == "antlr4" or compiler == "antlr4_fork":
             args.append("-visitor")  # Generate Parse Tree Visitor As Well
             # Note that this assumes that there is no package set in the antlr file itself,
             # which is considered an ANTLR best practice.

--- a/src/python/pants/backend/codegen/antlr/java/java_antlr_library.py
+++ b/src/python/pants/backend/codegen/antlr/java/java_antlr_library.py
@@ -30,7 +30,7 @@ class JavaAntlrLibrary(JvmTarget):
             the sources are spread among different files, this must be set as the package cannot be
             inferred.
         """
-        if compiler not in ("antlr3", "antlr4"):
+        if compiler not in ("antlr3", "antlr4", "antlr4_fork"):
             raise TargetDefinitionException(
                 self, "Illegal value for 'compiler': {}.".format(compiler)
             )

--- a/src/python/pants/backend/codegen/antlr/java/target_types.py
+++ b/src/python/pants/backend/codegen/antlr/java/target_types.py
@@ -13,7 +13,7 @@ class AntlrCompiler(StringField):
     """The name of the compiler used to compile the ANTLR files."""
 
     alias = "compiler"
-    valid_choices = ("antlr3", "antlr4")
+    valid_choices = ("antlr3", "antlr4", "antlr4_fork")
     value: str
     default = "antlr3"
 

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -165,23 +165,26 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
         self.execute_antlr_test(expected_package)
 
     def test_derived_package_v3(self):
-        self._test_derived_package(None, "3")
+        self._test_derived_package(None, "3", "g3")
 
     def test_derived_package_v4(self):
-        self._test_derived_package(self.PARTS["dir"].replace("/", "."), "4")
+        self._test_derived_package(self.PARTS["dir"].replace("/", "."), "4", "g4")
 
-    def _test_derived_package(self, expected_package, version):
+    def test_derived_package_v4_fork(self):
+        self._test_derived_package(self.PARTS["dir"].replace("/", "."), "4_fork", "g4")
+
+    def _test_derived_package(self, expected_package, compiler_ver, ext):
         self.add_to_build_file(
             self.BUILDFILE,
             dedent(
                 """
                 java_antlr_library(
                   name='{name}',
-                  compiler='antlr{version}',
-                  sources=['{prefix}.g{version}'],
+                  compiler='antlr{compiler_ver}',
+                  sources=['{prefix}.{ext}'],
                 )
                 """.format(
-                    version=version, **self.PARTS
+                    compiler_ver=compiler_ver, ext=ext, **self.PARTS
                 )
             ),
         )
@@ -213,23 +216,30 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
             self.execute(self.create_context())
 
     def test_generated_target_fingerprint_stable_v3(self):
-        self._test_generated_target_fingerprint_stable("3", None)
+        self._test_generated_target_fingerprint_stable("3", "g3", None)
 
     def test_generated_target_fingerprint_stable_v4(self):
-        self._test_generated_target_fingerprint_stable("4", self.PARTS["dir"].replace("/", "."))
+        self._test_generated_target_fingerprint_stable(
+            "4", "g4", self.PARTS["dir"].replace("/", ".")
+        )
 
-    def _test_generated_target_fingerprint_stable(self, version, package):
+    def test_generated_target_fingerprint_stable_v4_fork(self):
+        self._test_generated_target_fingerprint_stable(
+            "4_fork", "g4", self.PARTS["dir"].replace("/", ".")
+        )
+
+    def _test_generated_target_fingerprint_stable(self, compiler_ver, ext, package):
         self.add_to_build_file(
             self.BUILDFILE,
             dedent(
                 """
                 java_antlr_library(
                   name='{name}',
-                  compiler='antlr{version}',
-                  sources=['{prefix}.g{version}'],
+                  compiler='antlr{compiler_ver}',
+                  sources=['{prefix}.{ext}'],
                 )
                 """.format(
-                    version=version, **self.PARTS
+                    compiler_ver=compiler_ver, ext=ext, **self.PARTS
                 )
             ),
         )

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
@@ -22,3 +22,12 @@ class AntlrJavaGenIntegrationTest(PantsRunIntegrationTest):
             args=["7*6"],
         )
         self.assertEqual("42.0", stdout_data.rstrip(), msg=f"got output:{stdout_data}")
+
+    def test_run_antlr4_fork(self):
+        stdout_data = self.bundle_and_run(
+            "examples/src/java/org/pantsbuild/example/antlr4:antlr4_fork",
+            "examples.src.java.org.pantsbuild.example.antlr4.antlr4_fork",
+            bundle_jar_name="antlr4_fork",
+            args=["7*6"],
+        )
+        self.assertEqual("42.0", stdout_data.rstrip(), msg=f"got output:{stdout_data}")


### PR DESCRIPTION
# Delete this line to force CI to run Clippy and the Rust tests.
[ci skip-rust-tests]

### Problem

Strato team wants to use https://github.com/tunnelvisionlabs/antlr4 instead of the original ANTLR4, but I don't think that's possible without switching everyone over too. 

### Solution

Add support for `java_antlr_library(..., compiler='antlr4_fork')` to use the fork version during code gen for `antlr-java`.

### Result

User has the option to use the optimized fork of ANTLR4 for Java. 