### PR TITLE
Port the bulk of the process_execution crate to async/await

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2136,6 +2136,7 @@ dependencies = [
 name = "process_execution"
 version = "0.0.1"
 dependencies = [
+ "async-trait 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "async_semaphore 0.0.1",
  "bazel_protos 0.0.1",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+async-trait = "0.1"
 copy_dir = "0.1.2"
 walkdir = "2"
 async_semaphore = { path = "../async_semaphore" }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -4,17 +4,17 @@ use crate::{
 };
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use bincode;
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
-use futures::future::{self as future03, TryFutureExt};
-use futures01::{future, Future};
+use futures::future;
+use futures01::Future;
 use log::{debug, warn};
 use protobuf::Message;
-
-use boxfuture::{BoxFuture, Boxable};
-use hashing::Fingerprint;
 use serde::{Deserialize, Serialize};
+
+use hashing::Fingerprint;
 use sharded_lmdb::ShardedLmdb;
 use store::Store;
 
@@ -49,107 +49,93 @@ impl CommandRunner {
   }
 }
 
+#[async_trait]
 impl crate::CommandRunner for CommandRunner {
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     self.underlying.extract_compatible_request(req)
   }
 
   // TODO: Maybe record WorkUnits for local cache checks.
-  fn run(
+  async fn run(
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, String> {
     let digest = crate::digest(req.clone(), &self.metadata);
     let key = digest.0;
 
     let command_runner = self.clone();
-    self
-      .lookup(key)
-      .then(move |maybe_result| {
-        match maybe_result {
-          Ok(Some(result)) => return future::ok(result).to_boxed(),
-          Err(err) => {
-            warn!("Error loading process execution result from local cache: {} - continuing to execute", err);
-            // Falling through to re-execute.
-          },
-          Ok(None) => {
-            // Falling through to execute.
-          },
-        }
-        command_runner
-          .underlying
-          .run(req, context)
-          .and_then(move |result| {
-            if result.exit_code == 0 {
-              command_runner
-                .store(key, &result)
-                .then(|store_result| {
-                  if let Err(err) = store_result {
-                    debug!("Error storing process execution result to local cache: {} - ignoring and continuing", err);
-                  }
-                  Ok(result)
-                }).to_boxed()
-            } else {
-              future::ok(result).to_boxed()
-            }
-          })
-          .to_boxed()
+    match self.lookup(key).await {
+      Ok(Some(result)) => return Ok(result),
+      Err(err) => {
+        warn!(
+          "Error loading process execution result from local cache: {} - continuing to execute",
+          err
+        );
+        // Falling through to re-execute.
+      }
+      Ok(None) => {
+        // Falling through to execute.
+      }
+    }
 
-      })
-      .to_boxed()
+    let result = command_runner.underlying.run(req, context).await?;
+    if result.exit_code == 0 {
+      if let Err(err) = command_runner.store(key, &result).await {
+        debug!(
+          "Error storing process execution result to local cache: {} - ignoring and continuing",
+          err
+        );
+      }
+    }
+    Ok(result)
   }
 }
 
 impl CommandRunner {
-  fn lookup(
+  async fn lookup(
     &self,
     fingerprint: Fingerprint,
-  ) -> impl Future<Item = Option<FallibleProcessResultWithPlatform>, Error = String> {
+  ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
     use bazel_protos::remote_execution::ExecuteResponse;
-    let file_store = self.file_store.clone();
 
-    let command_runner = self.clone();
-    Box::pin(async move {
-      let maybe_execute_response: Option<(ExecuteResponse, Platform)> = command_runner
-        .process_execution_store
-        .load_bytes_with(fingerprint.clone(), move |bytes| {
-          let decoded: PlatformAndResponseBytes = bincode::deserialize(&bytes[..])
-            .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
+    let maybe_execute_response: Option<(ExecuteResponse, Platform)> = self
+      .process_execution_store
+      .load_bytes_with(fingerprint.clone(), move |bytes| {
+        let decoded: PlatformAndResponseBytes = bincode::deserialize(&bytes[..])
+          .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
 
-          let platform = decoded.platform;
+        let platform = decoded.platform;
 
-          let mut execute_response = ExecuteResponse::new();
-          execute_response
-            .merge_from_bytes(&decoded.response_bytes)
-            .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
+        let mut execute_response = ExecuteResponse::new();
+        execute_response
+          .merge_from_bytes(&decoded.response_bytes)
+          .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
 
-          Ok((execute_response, platform))
-        })
-        .await?;
+        Ok((execute_response, platform))
+      })
+      .await?;
 
-      if let Some((execute_response, platform)) = maybe_execute_response {
-        crate::remote::populate_fallible_execution_result(
-          file_store,
-          execute_response,
-          vec![],
-          platform,
-        )
-        .map(Some)
-        .compat()
-        .await
-      } else {
-        Ok(None)
-      }
-    })
-    .compat()
+    if let Some((execute_response, platform)) = maybe_execute_response {
+      crate::remote::populate_fallible_execution_result(
+        self.file_store.clone(),
+        execute_response,
+        vec![],
+        platform,
+      )
+      .map(Some)
+      .compat()
+      .await
+    } else {
+      Ok(None)
+    }
   }
 
-  fn store(
+  async fn store(
     &self,
     fingerprint: Fingerprint,
     result: &FallibleProcessResultWithPlatform,
-  ) -> impl Future<Item = (), Error = String> {
+  ) -> Result<(), String> {
     let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
     execute_response.set_cached_result(true);
     let action_result = execute_response.mut_result();
@@ -160,46 +146,42 @@ impl CommandRunner {
       directory.set_tree_digest((&result.output_directory).into());
       directory
     });
-    let process_execution_store = self.process_execution_store.clone();
     // TODO: Should probably have a configurable lease time which is larger than default.
     // (This isn't super urgent because we don't ever actually GC this store. So also...)
     // TODO: GC the local process execution cache.
-    //
 
-    let platform = result.platform;
+    let (stdout_digest, stderr_digest) = future::try_join(
+      self
+        .file_store
+        .store_file_bytes(result.stdout.clone(), true),
+      self
+        .file_store
+        .store_file_bytes(result.stderr.clone(), true),
+    )
+    .await?;
 
-    let command_runner = self.clone();
-    let stdout = result.stdout.clone();
-    let stderr = result.stderr.clone();
-    Box::pin(async move {
-      let (stdout_digest, stderr_digest) = future03::try_join(
-        command_runner.file_store.store_file_bytes(stdout, true),
-        command_runner.file_store.store_file_bytes(stderr, true),
-      )
-      .await?;
-      let action_result = execute_response.mut_result();
-      action_result.set_stdout_digest((&stdout_digest).into());
-      action_result.set_stderr_digest((&stderr_digest).into());
-      let response_bytes = execute_response
-        .write_to_bytes()
-        .map_err(|err| format!("Error serializing execute process result to cache: {}", err))?;
+    let action_result = execute_response.mut_result();
+    action_result.set_stdout_digest((&stdout_digest).into());
+    action_result.set_stderr_digest((&stderr_digest).into());
+    let response_bytes = execute_response
+      .write_to_bytes()
+      .map_err(|err| format!("Error serializing execute process result to cache: {}", err))?;
 
-      let bytes_to_store = bincode::serialize(&PlatformAndResponseBytes {
-        platform,
-        response_bytes,
-      })
-      .map(Bytes::from)
-      .map_err(|err| {
-        format!(
-          "Error serializing platform and execute process result: {}",
-          err
-        )
-      })?;
-
-      process_execution_store
-        .store_bytes(fingerprint, bytes_to_store, false)
-        .await
+    let bytes_to_store = bincode::serialize(&PlatformAndResponseBytes {
+      platform: result.platform,
+      response_bytes,
     })
-    .compat()
+    .map(Bytes::from)
+    .map_err(|err| {
+      format!(
+        "Error serializing platform and execute process result: {}",
+        err
+      )
+    })?;
+
+    self
+      .process_execution_store
+      .store_bytes(fingerprint, bytes_to_store, false)
+      .await
   }
 }

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -2,7 +2,6 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
   PlatformConstraint, Process, ProcessMetadata,
 };
-use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use sharded_lmdb::ShardedLmdb;
 use std::collections::{BTreeMap, BTreeSet};
@@ -64,10 +63,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     is_nailgunnable: false,
   };
 
-  let local_result = local
-    .run(request.clone().into(), Context::default())
-    .compat()
-    .await;
+  let local_result = local.run(request.clone().into(), Context::default()).await;
 
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
@@ -90,7 +86,6 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
 
   let uncached_result = caching
     .run(request.clone().into(), Context::default())
-    .compat()
     .await;
 
   assert_eq!(local_result, uncached_result);
@@ -99,10 +94,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   // fail due to a FileNotFound error. So, If the second run succeeds, that implies that the
   // cache was successfully used.
   std::fs::remove_file(&script_path).unwrap();
-  let maybe_cached_result = caching
-    .run(request.into(), Context::default())
-    .compat()
-    .await;
+  let maybe_cached_result = caching.run(request.into(), Context::default()).await;
 
   RoundtripResults {
     uncached: uncached_result,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -7,7 +7,6 @@ use fs::{self, GlobExpansionConjunction, GlobMatching, PathGlobs, StrictGlobMatc
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
-use futures01::{future, Future};
 use log::{debug, info};
 use nails::execution::{ChildOutput, ExitCode};
 
@@ -267,7 +266,6 @@ impl super::CommandRunner for CommandRunner {
         &self.work_dir_base,
         self.platform(),
       )
-      .compat()
       .await
   }
 }
@@ -291,8 +289,9 @@ impl CapturedWorkdir for CommandRunner {
   }
 }
 
+#[async_trait]
 pub trait CapturedWorkdir {
-  fn run_and_capture_workdir(
+  async fn run_and_capture_workdir(
     &self,
     req: Process,
     context: Context,
@@ -301,67 +300,75 @@ pub trait CapturedWorkdir {
     cleanup_local_dirs: bool,
     workdir_base: &Path,
     platform: Platform,
-  ) -> BoxFuture<FallibleProcessResultWithPlatform, String>
+  ) -> Result<FallibleProcessResultWithPlatform, String>
   where
     Self: Send + Sync + Clone + 'static,
   {
-    let workdir = try_future!(tempfile::Builder::new()
-      .prefix("process-execution")
-      .tempdir_in(workdir_base)
-      .map_err(|err| format!(
-        "Error making tempdir for local process execution: {:?}",
-        err
-      )));
-
-    let workdir_path = workdir.path().to_owned();
-    let workdir_path2 = workdir_path.clone();
-    let workdir_path3 = workdir_path.clone();
-    let workdir_path4 = workdir_path.clone();
-
-    let store2 = store.clone();
-
-    let command_runner = self.clone();
-    let req2 = req.clone();
-    let output_file_paths = req.output_files;
-    let output_file_paths2 = output_file_paths.clone();
-    let output_dir_paths = req.output_directories;
-    let output_dir_paths2 = output_dir_paths.clone();
-
-    let req_description = req.description;
-    let req_timeout = req.timeout;
-    let maybe_jdk_home = req.jdk_home;
-    let unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule =
-      req.unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule;
-
-    store
-      .materialize_directory(workdir_path.clone(), req.input_files)
-      .and_then({
-        move |_metadata| {
-          store2.materialize_directory(
-            workdir_path4,
-            unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
+    // Set up a temporary workdir, which will optionally be preserved.
+    let (workdir_path, maybe_workdir) = {
+      let workdir = tempfile::Builder::new()
+        .prefix("process-execution")
+        .tempdir_in(workdir_base)
+        .map_err(|err| {
+          format!(
+            "Error making tempdir for local process execution: {:?}",
+            err
           )
-        }
-      })
-      .and_then(move |_metadata| {
-        maybe_jdk_home.map_or(Ok(()), |jdk_home| {
-          symlink(jdk_home, workdir_path3.clone().join(".jdk"))
-            .map_err(|err| format!("Error making symlink for local execution: {:?}", err))
         })?;
+      if cleanup_local_dirs {
+        // Hold on to the workdir so that we can drop it explicitly after we've finished using it.
+        (workdir.path().to_owned(), Some(workdir))
+      } else {
+        // This consumes the `TempDir` without deleting directory on the filesystem, meaning
+        // that the temporary directory will no longer be automatically deleted when dropped.
+        let preserved_path = workdir.into_path();
+        info!(
+          "preserving local process execution dir `{:?}` for {:?}",
+          preserved_path, req.description
+        );
+        (preserved_path, None)
+      }
+    };
+
+    // Start with async materialization of input snapshots, followed by synchronous materialization
+    // of other configured inputs. Note that we don't do this in parallel, as that might cause
+    // non-determinism when paths overlap.
+    let _metadata = store
+      .materialize_directory(workdir_path.clone(), req.input_files)
+      .compat()
+      .await?;
+    let _metadata = store
+      .materialize_directory(
+        workdir_path.clone(),
+        req.unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
+      )
+      .compat()
+      .await?;
+    let workdir_path2 = workdir_path.clone();
+    let output_file_paths = req.output_files.clone();
+    let output_dir_paths = req.output_directories.clone();
+    let maybe_jdk_home = req.jdk_home.clone();
+    executor
+      .spawn_blocking(move || {
+        if let Some(jdk_home) = maybe_jdk_home {
+          symlink(jdk_home, workdir_path2.clone().join(".jdk"))
+            .map_err(|err| format!("Error making symlink for local execution: {:?}", err))?
+        }
+
         // The bazel remote execution API specifies that the parent directories for output files and
         // output directories should be created before execution completes: see
         //   https://github.com/pantsbuild/pants/issues/7084.
-        let parent_paths_to_create: HashSet<_> = output_file_paths2
-          .iter()
-          .chain(output_dir_paths2.iter())
-          .filter_map(|rel_path| rel_path.parent())
-          .map(|parent_relpath| workdir_path3.join(parent_relpath))
-          .collect();
         // TODO: we use a HashSet to deduplicate directory paths to create, but it would probably be
         // even more efficient to only retain the directories at greatest nesting depth, as
         // create_dir_all() will ensure all parents are created. At that point, we might consider
         // explicitly enumerating all the directories to be created and just using create_dir(),
         // unless there is some optimization in create_dir_all() that makes that less efficient.
+        let parent_paths_to_create: HashSet<_> = output_file_paths
+          .iter()
+          .chain(output_dir_paths.iter())
+          .filter_map(|rel_path| rel_path.parent())
+          .map(|parent_relpath| workdir_path2.join(parent_relpath))
+          .collect();
         for path in parent_paths_to_create {
           create_dir_all(path.clone()).map_err(|err| {
             format!(
@@ -370,96 +377,89 @@ pub trait CapturedWorkdir {
             )
           })?;
         }
-        Ok(())
+        let res: Result<_, String> = Ok(());
+        res
       })
-      .and_then(move |()| command_runner.run_in_workdir(&workdir_path, req2, context))
-      // NB: We fully buffer up the `Stream` above into final `ChildResults` below and so could
-      // instead be using `CommandExt::output_async` above to avoid the `ChildResults::collect_from`
-      // code. The idea going forward though is we eventually want to pass incremental results on
-      // down the line for streaming process results to console logs, etc. as tracked by:
-      //   https://github.com/pantsbuild/pants/issues/6089
-      .map(ChildResults::collect_from)
-      .and_then(move |child_results_future| {
-        let maybe_timed_out_child_results = Box::pin(async move {
-          if let Some(req_timeout) = req_timeout {
-            timeout(req_timeout, child_results_future)
-              .await
-              .map_err(|e| e.to_string())?
-          } else {
-            child_results_future.await
-          }
-        });
-        maybe_timed_out_child_results.compat()
-      })
-      .and_then(move |child_results| {
-        let output_snapshot = if output_file_paths.is_empty() && output_dir_paths.is_empty() {
-          future::ok(store::Snapshot::empty()).to_boxed()
-        } else {
-          // Use no ignore patterns, because we are looking for explicitly listed paths.
-          future::done(fs::GitignoreStyleExcludes::create(vec![]))
-            .and_then(|ignorer| future::done(fs::PosixFS::new(workdir_path2, ignorer, executor)))
-            .map_err(|err| {
-              format!(
-                "Error making posix_fs to fetch local process execution output files: {}",
-                err
-              )
-            })
-            .map(Arc::new)
-            .and_then(|posix_fs| {
-              CommandRunner::construct_output_snapshot(
-                store,
-                posix_fs,
-                output_file_paths,
-                output_dir_paths,
-              )
-            })
-            .to_boxed()
-        };
+      .await?;
 
-        output_snapshot
-          .map(move |snapshot| FallibleProcessResultWithPlatform {
-            stdout: child_results.stdout,
-            stderr: child_results.stderr,
-            exit_code: child_results.exit_code,
-            output_directory: snapshot.digest,
+    // Spawn the process.
+    // NB: We fully buffer up the `Stream` above into final `ChildResults` below and so could
+    // instead be using `CommandExt::output_async` above to avoid the `ChildResults::collect_from`
+    // code. The idea going forward though is we eventually want to pass incremental results on
+    // down the line for streaming process results to console logs, etc. as tracked by:
+    //   https://github.com/pantsbuild/pants/issues/6089
+    let child_results_result = {
+      let child_results_future =
+        ChildResults::collect_from(self.run_in_workdir(&workdir_path, req.clone(), context)?);
+      if let Some(req_timeout) = req.timeout {
+        timeout(req_timeout, child_results_future)
+          .await
+          .map_err(|e| e.to_string())
+          .and_then(|r| r)
+      } else {
+        child_results_future.await
+      }
+    };
+
+    // Capture the process outputs, and optionally clean up the workdir.
+    let output_snapshot = if req.output_files.is_empty() && req.output_directories.is_empty() {
+      store::Snapshot::empty()
+    } else {
+      // Use no ignore patterns, because we are looking for explicitly listed paths.
+      let posix_fs = Arc::new(
+        fs::PosixFS::new(
+          workdir_path,
+          fs::GitignoreStyleExcludes::empty(),
+          executor.clone(),
+        )
+        .map_err(|err| {
+          format!(
+            "Error making posix_fs to fetch local process execution output files: {}",
+            err
+          )
+        })?,
+      );
+      CommandRunner::construct_output_snapshot(
+        store,
+        posix_fs,
+        req.output_files,
+        req.output_directories,
+      )
+      .compat()
+      .await?
+    };
+    if let Some(workdir) = maybe_workdir {
+      // Dropping the temporary directory will likely involve a lot of IO: do it in the background.
+      let _background_cleanup = executor.spawn_blocking(|| std::mem::drop(workdir));
+    }
+
+    match child_results_result {
+      Ok(child_results) => Ok(FallibleProcessResultWithPlatform {
+        stdout: child_results.stdout,
+        stderr: child_results.stderr,
+        exit_code: child_results.exit_code,
+        output_directory: output_snapshot.digest,
+        execution_attempts: vec![],
+        platform,
+      }),
+      Err(msg) => {
+        if msg == "deadline has elapsed" {
+          Ok(FallibleProcessResultWithPlatform {
+            stdout: Bytes::from(format!(
+              "Exceeded timeout of {:?} for local process execution, {}",
+              req.timeout, req.description
+            )),
+            stderr: Bytes::new(),
+            exit_code: -libc::SIGTERM,
+            output_directory: hashing::EMPTY_DIGEST,
             execution_attempts: vec![],
             platform,
           })
-          .to_boxed()
-      })
-      .then(move |result| {
-        // Force workdir not to get dropped until after we've ingested the outputs
-        if !cleanup_local_dirs {
-          // This consumes the `TempDir` without deleting directory on the filesystem, meaning
-          // that the temporary directory will no longer be automatically deleted when dropped.
-          let preserved_path = workdir.into_path();
-          info!(
-            "preserved local process execution dir `{:?}` for {:?}",
-            preserved_path, req_description
-          );
-        } // Else, workdir gets dropped here
-        match result {
-          Ok(fallible_process_result) => Ok(fallible_process_result),
-          Err(msg) => {
-            if msg == "deadline has elapsed" {
-              Ok(FallibleProcessResultWithPlatform {
-                stdout: Bytes::from(format!(
-                  "Exceeded timeout of {:?} for local process execution, {}",
-                  req_timeout, req_description
-                )),
-                stderr: Bytes::new(),
-                exit_code: -libc::SIGTERM,
-                output_directory: hashing::EMPTY_DIGEST,
-                execution_attempts: vec![],
-                platform,
-              })
-            } else {
-              Err(msg)
-            }
-          }
+        } else {
+          Err(msg)
         }
-      })
-      .to_boxed()
+      }
+    }
   }
 
   ///

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -5,7 +5,6 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, Platform,
   PlatformConstraint, Process, RelativePath,
 };
-use futures::compat::Future01CompatExt;
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
 use std;
@@ -819,7 +818,7 @@ async fn run_command_locally_in_dir(
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
   let runner = crate::local::CommandRunner::new(store, executor.clone(), dir, cleanup);
-  runner.run(req.into(), Context::default()).compat().await
+  runner.run(req.into(), Context::default()).await
 }
 
 fn one_second() -> Option<Duration> {

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -195,7 +195,6 @@ impl super::CommandRunner for CommandRunner {
         &workdir_for_this_nailgun,
         Platform::current().unwrap(),
       )
-      .compat()
       .await
   }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use boxfuture::{try_future, BoxFuture, Boxable};
+use async_trait::async_trait;
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt};
@@ -162,17 +162,18 @@ impl CommandRunner {
   }
 }
 
+#[async_trait]
 impl super::CommandRunner for CommandRunner {
-  fn run(
+  async fn run(
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, String> {
     let original_request = self.extract_compatible_request(&req).unwrap();
 
     if !original_request.is_nailgunnable {
       trace!("The request is not nailgunnable! Short-circuiting to regular process execution");
-      return self.inner.run(req, context);
+      return self.inner.run(req, context).await;
     }
     debug!("Running request under nailgun:\n {:#?}", &original_request);
 
@@ -180,21 +181,22 @@ impl super::CommandRunner for CommandRunner {
     let store = self.inner.store.clone();
     let ParsedJVMCommandLines {
       client_main_class, ..
-    } = try_future!(ParsedJVMCommandLines::parse_command_lines(
-      &original_request.argv
-    ));
+    } = ParsedJVMCommandLines::parse_command_lines(&original_request.argv)?;
     let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
-    let workdir_for_this_nailgun = try_future!(self.get_nailgun_workdir(&nailgun_name));
+    let workdir_for_this_nailgun = self.get_nailgun_workdir(&nailgun_name)?;
 
-    self.run_and_capture_workdir(
-      original_request,
-      context,
-      store,
-      executor,
-      true,
-      &workdir_for_this_nailgun,
-      Platform::current().unwrap(),
-    )
+    self
+      .run_and_capture_workdir(
+        original_request,
+        context,
+        store,
+        executor,
+        true,
+        &workdir_for_this_nailgun,
+        Platform::current().unwrap(),
+      )
+      .compat()
+      .await
   }
 
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use bazel_protos::{self, call_option};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
@@ -11,7 +12,7 @@ use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat};
 use futures::compat::Future01CompatExt;
-use futures::future::{self as future03, FutureExt, TryFutureExt};
+use futures::future::{self as future03, TryFutureExt};
 use futures01::{future, Future, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
@@ -38,7 +39,7 @@ pub const CACHE_KEY_GEN_VERSION_ENV_VAR_NAME: &str = "PANTS_CACHE_KEY_GEN_VERSIO
 #[derive(Derivative)]
 #[derivative(Debug)]
 struct CancelRemoteExecutionToken {
-  //  CancelRemoteExecutionToken is used to cancel remote execution process
+  // CancelRemoteExecutionToken is used to cancel remote execution process
   // if we no longer care about the result, but we think it's still running.
   // Remote execution process can be cancelled by sending CancelOperationRequest.
   #[derivative(Debug = "ignore")]
@@ -141,6 +142,12 @@ impl ExecutionHistory {
   fn total_attempt_count(&self) -> usize {
     self.attempts.len() + 1
   }
+
+  /// Completes the current attempt and places it in the attempts list.
+  fn complete_attempt(&mut self) {
+    let current_attempt = std::mem::take(&mut self.current_attempt);
+    self.attempts.push(current_attempt);
+  }
 }
 
 impl CommandRunner {
@@ -156,19 +163,20 @@ impl CommandRunner {
     self.platform
   }
 
-  fn oneshot_execute(
+  async fn oneshot_execute(
     &self,
-    execute_request: &Arc<bazel_protos::remote_execution::ExecuteRequest>,
+    execute_request: &bazel_protos::remote_execution::ExecuteRequest,
     build_id: String,
-  ) -> BoxFuture<OperationOrStatus, String> {
-    let stream = try_future!(self
+  ) -> Result<OperationOrStatus, String> {
+    let stream = self
       .execution_client
       .execute_opt(
         &execute_request,
-        try_future!(call_option(&self.headers, Some(build_id),))
+        call_option(&self.headers, Some(build_id))?,
       )
-      .map_err(rpcerror_to_string));
-    stream
+      .map_err(rpcerror_to_string)?;
+
+    let maybe_operation_result = stream
       .take(1)
       .into_future()
       // If there was a response, drop the _stream to disconnect so that the server doesn't keep
@@ -183,20 +191,20 @@ impl CommandRunner {
         drop(stream);
         error
       })
-      .then(move |maybe_operation_result| match maybe_operation_result {
-        Ok(Some(operation)) => Ok(OperationOrStatus::Operation(operation)),
-        Ok(None) => {
-          Err("Didn't get proper stream response from server during remote execution".to_owned())
-        }
-        Err(err) => rpcerror_to_status_or_string(err).map(OperationOrStatus::Status),
-      })
-      .to_boxed()
+      .compat()
+      .await;
+
+    match maybe_operation_result {
+      Ok(Some(operation)) => Ok(OperationOrStatus::Operation(operation)),
+      Ok(None) => {
+        Err("Didn't get proper stream response from server during remote execution".to_owned())
+      }
+      Err(err) => rpcerror_to_status_or_string(err).map(OperationOrStatus::Status),
+    }
   }
 }
 
-// TODO(pantsbuild/pants#8039) Need to impl Drop on command runner  so that when the BoxFuture goes out of scope
-// we cancel a potential RPC. So we need to distinguish local vs. remote
-// requests and save enough state to BoxFuture or another abstraction around our execution results
+#[async_trait]
 impl super::CommandRunner for CommandRunner {
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
     for compatible_constraint in vec![
@@ -233,19 +241,16 @@ impl super::CommandRunner for CommandRunner {
   /// Loops until the server gives a response, either successful or error. Does not have any
   /// timeout: polls in a tight loop.
   ///
-  /// TODO: Request jdk_home be created if set.
-  ///
-  fn run(
+  async fn run(
     &self,
     req: MultiPlatformProcess,
     context: Context,
-  ) -> BoxFuture<FallibleProcessResultWithPlatform, String> {
+  ) -> Result<FallibleProcessResultWithPlatform, String> {
     let platform = self.platform();
     let compatible_underlying_request = self.extract_compatible_request(&req).unwrap();
-    let operations_client = self.operations_client.clone();
     let store = self.store.clone();
-    let execute_request_result =
-      make_execute_request(&compatible_underlying_request, self.metadata.clone());
+    let (action, command, execute_request) =
+      make_execute_request(&compatible_underlying_request, self.metadata.clone())?;
 
     let Process {
       description,
@@ -254,215 +259,174 @@ impl super::CommandRunner for CommandRunner {
       ..
     } = compatible_underlying_request;
 
-    let description2 = description.clone();
+    let mut history = ExecutionHistory::default();
 
-    match execute_request_result {
-      Ok((action, command, execute_request)) => {
-        let command_runner = self.clone();
-        let execute_request = Arc::new(execute_request);
+    // Upload inputs.
+    {
+      let (command_digest, action_digest) = future03::try_join(
+        self.store_proto_locally(&command),
+        self.store_proto_locally(&action),
+      )
+      .await?;
 
-        let mut history = ExecutionHistory::default();
-
-        self
-          .store_proto_locally(&command)
-          .join(self.store_proto_locally(&action))
-          .and_then({
-            let store = store.clone();
-            move |(command_digest, action_digest)| {
-              store.ensure_remote_has_recursive(
-                vec![command_digest, action_digest, input_files],
-              )
-            }
-          })
-          .and_then({
-            let execute_request = execute_request.clone();
-            let command_runner = command_runner.clone();
-            let build_id = context.build_id.to_owned();
-            move |summary| {
-              history.current_attempt += summary;
-              trace!(
-                "Executing remotely request: {:?} (command: {:?})",
-                execute_request,
-                command
-              );
-              command_runner
-                .oneshot_execute(&execute_request, build_id)
-                .join(future::ok(history))
-            }
-          })
-          .map({
-            let operations_client = operations_client.clone();
-            let executor = command_runner.executor.clone();
-            move |(operation, history)| {
-              let maybe_cancel_remote_exec_token = match operation {
-                OperationOrStatus::Operation(ref operation) => Some(
-                  CancelRemoteExecutionToken::new(operations_client, operation.name.clone(), executor),
-                ),
-                _ => None,
-              };
-              (operation, history, maybe_cancel_remote_exec_token)
-            }
-          })
-          .and_then(
-            move |(operation, history, maybe_cancel_remote_exec_token)| {
-              let start_time = Instant::now();
-
-              future::loop_fn(
-                (history, operation, maybe_cancel_remote_exec_token, 0),
-                move |(mut history, operation, maybe_cancel_remote_exec_token, iter_num)| {
-                  let description = description.clone();
-
-                  let execute_request = execute_request.clone();
-                  let store = store.clone();
-                  let operations_client = operations_client.clone();
-                  let command_runner = command_runner.clone();
-                  let build_id = context.build_id.to_string();
-
-                  let f = command_runner
-                    .extract_execute_response(operation, &mut history);
-                  f.then(move |value| {
-                    match value {
-                      Ok(result) => {
-                        if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
-                          cancel_remote_exec_token.do_not_send_cancellation_on_drop();
-                        }
-                        future::ok(future::Loop::Break(result)).to_boxed()
-                      },
-                      Err(err) => {
-                        match err {
-                          ExecutionError::Fatal(err) => {
-                            // In case of receiving  Fatal error from the server it is assumed that
-                            // remote execution is no longer running
-                            if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
-                              cancel_remote_exec_token.do_not_send_cancellation_on_drop();
-                            }
-                            future::err(err).to_boxed()
-                          }
-                          ExecutionError::Retryable(message) => {
-                            command_runner.retry_execution(
-                              execute_request,
-                              future::done({
-                                if history.total_attempt_count() >= 5 {
-                                  Err(format!("Gave up retrying remote execution after {} retriable attempts; last failure: {}", history.total_attempt_count(), message))
-                                } else {
-                                  trace!("Got retryable error from server; retrying. Error: {}", message);
-                                  Ok(())
-                                }
-                              }).to_boxed(),
-                              build_id,
-                              history,
-                              maybe_cancel_remote_exec_token,
-                            )
-                          },
-                          ExecutionError::MissingDigests(missing_digests) => {
-                            trace!(
-                              "Server reported missing digests ({:?}); trying to upload: {:?}",
-                              history.current_attempt,
-                              missing_digests,
-                            );
-
-                            command_runner.retry_execution(
-                              execute_request,
-                              store.ensure_remote_has_recursive(missing_digests).map(|_| ()).to_boxed(),
-                              build_id,
-                              history,
-                              maybe_cancel_remote_exec_token,
-                            )
-                          },
-                          ExecutionError::NotFinished(operation_name) => {
-                            let mut operation_request =
-                                bazel_protos::operations::GetOperationRequest::new();
-                            operation_request.set_name(operation_name.clone());
-
-                            let backoff_period = min(
-                              command_runner.backoff_max_wait,
-                              (1 + iter_num) * command_runner.backoff_incremental_wait,
-                            );
-
-                            // Take the grpc result and cancel the op if too much time has passed.
-                            // This timeout is here to make sure that if something goes wrong, e.g.
-                            // the connection hangs, we don't poll forever.
-                            let elapsed = start_time.elapsed();
-                            let total_timeout = timeout.map(|t| t + command_runner.queue_buffer_time);
-
-                            if total_timeout.map(|t| elapsed > t).unwrap_or(false) {
-                              let ExecutionHistory {
-                                mut attempts,
-                                mut current_attempt,
-                              } = history;
-                              current_attempt.remote_execution = Some(elapsed);
-                              attempts.push(current_attempt);
-                              future::ok(future::Loop::Break(FallibleProcessResultWithPlatform {
-                                stdout: Bytes::from(format!(
-                                  "Exceeded timeout of {:?} ({:?} for the process and {:?} for remoting buffer time) with {:?} for operation {}, {}",
-                                  total_timeout, timeout, command_runner.queue_buffer_time, elapsed, operation_name, description
-                                )),
-                                stderr: Bytes::new(),
-                                exit_code: -libc::SIGTERM,
-                                output_directory: hashing::EMPTY_DIGEST,
-                                execution_attempts: attempts,
-                                platform,
-                              }))
-                                  .to_boxed()
-                            } else {
-                              // maybe the delay here should be the min of remaining time and the backoff period
-                              delay_for(backoff_period)
-                                  .unit_error()
-                                  .boxed()
-                                  .compat()
-                                  .map_err(move |()| {
-                                    format!(
-                                      "Future-Delay errored at operation result polling for {}, {}",
-                                      operation_name, description
-                                    )
-                                  })
-                                  .and_then(move |_| {
-                              operations_client
-                                  .get_operation_opt(
-                                    &operation_request,
-                                    call_option(&command_runner.headers, Some(build_id))?,
-                                  )
-                                  .or_else(move |err| {
-                                    rpcerror_recover_cancelled(operation_request.take_name(), err)
-                                  }).map_err(rpcerror_to_string)
-                                  .map(OperationOrStatus::Operation)
-                            })
-                                    .map(move |operation| {
-                                      future::Loop::Continue((
-                                        history,
-                                        operation,
-                                        maybe_cancel_remote_exec_token,
-                                        iter_num + 1,
-                                      ))
-                                    })
-                                  .to_boxed()
-                            }
-                          }
-                        }
-                      }
-                    }
-                  })
-                },
-              )
-            },
-          )
-          .map(move |resp| {
-            let mut attempts = String::new();
-            for (i, attempt) in resp.execution_attempts.iter().enumerate() {
-              attempts += &format!("\nAttempt {}: {:?}", i, attempt);
-            }
-            debug!(
-              "Finished remote exceution of {} after {} attempts: Stats: {}",
-              description2,
-              resp.execution_attempts.len(),
-              attempts
-            );
-            resp
-          })
-          .to_boxed()
-      }
-      Err(err) => future::err(err).to_boxed(),
+      let summary = store
+        .ensure_remote_has_recursive(vec![command_digest, action_digest, input_files])
+        .compat()
+        .await?;
+      history.current_attempt += summary;
     }
+
+    trace!(
+      "Executing request remotely: {:?} (command: {:?})",
+      execute_request,
+      command
+    );
+    let start_time = Instant::now();
+    let mut operation = self
+      .oneshot_execute(&execute_request, context.build_id.clone())
+      .await?;
+    let mut iter_num = 0;
+    let mut maybe_cancel_remote_exec_token = match operation {
+      OperationOrStatus::Operation(ref operation) => Some(CancelRemoteExecutionToken::new(
+        self.operations_client.clone(),
+        operation.name.clone(),
+        self.executor.clone(),
+      )),
+      _ => None,
+    };
+
+    let response = loop {
+      match self
+        .extract_execute_response(operation, &mut history)
+        .compat()
+        .await
+      {
+        Ok(result) => {
+          if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
+            cancel_remote_exec_token.do_not_send_cancellation_on_drop();
+          }
+          break result;
+        }
+        Err(err) => {
+          match err {
+            ExecutionError::Fatal(err) => {
+              // In case of receiving Fatal error from the server it is assumed that remote
+              // execution is no longer running.
+              if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
+                cancel_remote_exec_token.do_not_send_cancellation_on_drop();
+              }
+              return Err(err);
+            }
+            ExecutionError::Retryable(message) => {
+              if history.total_attempt_count() >= 5 {
+                if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
+                  cancel_remote_exec_token.do_not_send_cancellation_on_drop();
+                }
+                return Err(format!(
+                  "Gave up retrying remote execution after {} retriable attempts; last failure: {}",
+                  history.total_attempt_count(),
+                  message
+                ));
+              } else {
+                trace!(
+                  "Got retryable error from server; retrying. Error: {}",
+                  message
+                );
+              }
+
+              // Kick off a new operation to retry.
+              operation = self
+                .retry_execution(
+                  &execute_request,
+                  context.build_id.clone(),
+                  &mut history,
+                  &mut maybe_cancel_remote_exec_token,
+                  &mut iter_num,
+                )
+                .await?;
+            }
+            ExecutionError::MissingDigests(missing_digests) => {
+              trace!(
+                "Server reported missing digests ({:?}); trying to upload: {:?}",
+                history.current_attempt,
+                missing_digests,
+              );
+              let summary = store
+                .ensure_remote_has_recursive(missing_digests)
+                .compat()
+                .await?;
+              operation = self
+                .retry_execution(
+                  &execute_request,
+                  context.build_id.clone(),
+                  &mut history,
+                  &mut maybe_cancel_remote_exec_token,
+                  &mut iter_num,
+                )
+                .await?;
+              history.current_attempt += summary;
+            }
+            ExecutionError::NotFinished(operation_name) => {
+              let mut operation_request = bazel_protos::operations::GetOperationRequest::new();
+              operation_request.set_name(operation_name.clone());
+
+              let backoff_period = min(
+                self.backoff_max_wait,
+                (1 + iter_num) * self.backoff_incremental_wait,
+              );
+
+              // Take the grpc result and cancel the op if too much time has passed.
+              // This timeout is here to make sure that if something goes wrong, e.g.
+              // the connection hangs, we don't poll forever.
+              let elapsed = start_time.elapsed();
+              let total_timeout = timeout.map(|t| t + self.queue_buffer_time);
+              if total_timeout.map(|t| elapsed > t).unwrap_or(false) {
+                history.current_attempt.remote_execution = Some(elapsed);
+                history.complete_attempt();
+
+                break FallibleProcessResultWithPlatform {
+                  stdout: Bytes::from(format!(
+                    "Exceeded timeout of {:?} ({:?} for the process and {:?} for remoting buffer time) with {:?} for operation {}, {}",
+                    total_timeout, timeout, self.queue_buffer_time, elapsed, operation_name, description
+                  )),
+                  stderr: Bytes::new(),
+                  exit_code: -libc::SIGTERM,
+                  output_directory: hashing::EMPTY_DIGEST,
+                  execution_attempts: history.attempts,
+                  platform,
+                };
+              }
+
+              // Wait before retrying, and then create a new operation.
+              // TODO: maybe the delay here should be the min of remaining time and the backoff period
+              delay_for(backoff_period).await;
+              iter_num += 1;
+              operation = self
+                .operations_client
+                .get_operation_opt(
+                  &operation_request,
+                  call_option(&self.headers, Some(context.build_id.clone()))?,
+                )
+                .or_else(move |err| rpcerror_recover_cancelled(operation_request.take_name(), err))
+                .map_err(rpcerror_to_string)
+                .map(OperationOrStatus::Operation)?;
+            }
+          }
+        }
+      }
+    };
+
+    let mut attempts = String::new();
+    for (i, attempt) in response.execution_attempts.iter().enumerate() {
+      attempts += &format!("\nAttempt {}: {:?}", i, attempt);
+    }
+    debug!(
+      "Finished remote exceution of {} after {} attempts: Stats: {}",
+      description,
+      response.execution_attempts.len(),
+      attempts
+    );
+    Ok(response)
   }
 }
 
@@ -528,24 +492,15 @@ impl CommandRunner {
     Ok(command_runner)
   }
 
-  fn store_proto_locally<P: protobuf::Message>(
-    &self,
-    proto: &P,
-  ) -> impl Future<Item = Digest, Error = String> {
-    let store = self.store.clone();
-    let maybe_command_bytes = proto
+  async fn store_proto_locally<P: protobuf::Message>(&self, proto: &P) -> Result<Digest, String> {
+    let command_bytes = proto
       .write_to_bytes()
-      .map_err(|e| format!("Error serializing proto {:?}", e));
-
-    // Box and pin a stdlib future, and then convert it to a futures01 future via `compat()`.
-    Box::pin(async move {
-      let command_bytes = maybe_command_bytes?;
-      store
-        .store_file_bytes(Bytes::from(command_bytes), true)
-        .await
-        .map_err(|e| format!("Error saving proto to local store: {:?}", e))
-    })
-    .compat()
+      .map_err(|e| format!("Error serializing proto {:?}", e))?;
+    self
+      .store
+      .store_file_bytes(Bytes::from(command_bytes), true)
+      .await
+      .map_err(|e| format!("Error saving proto to local store: {:?}", e))
   }
 
   // Only public for tests
@@ -660,7 +615,7 @@ impl CommandRunner {
 
         let status = execute_response.take_status();
         if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::OK {
-          let mut execution_attempts = std::mem::replace(&mut attempts.attempts, vec![]);
+          let mut execution_attempts = std::mem::take(&mut attempts.attempts);
           execution_attempts.push(attempts.current_attempt);
           return populate_fallible_execution_result(
             self.store.clone(),
@@ -767,65 +722,34 @@ impl CommandRunner {
     .to_boxed()
   }
 
-  #[allow(clippy::type_complexity)]
-  fn retry_execution(
+  async fn retry_execution(
     &self,
-    execute_request: Arc<bazel_protos::remote_execution::ExecuteRequest>,
-    prefix_future: BoxFuture<(), String>,
+    execute_request: &bazel_protos::remote_execution::ExecuteRequest,
     build_id: String,
-    history: ExecutionHistory,
-    maybe_cancel_remote_exec_token: Option<CancelRemoteExecutionToken>,
-  ) -> BoxFuture<
-    future::Loop<
-      FallibleProcessResultWithPlatform,
-      (
-        ExecutionHistory,
-        OperationOrStatus,
-        Option<CancelRemoteExecutionToken>,
-        u32,
-      ),
-    >,
-    String,
-  > {
-    if let Some(mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
+    history: &mut ExecutionHistory,
+    maybe_cancel_remote_exec_token: &mut Option<CancelRemoteExecutionToken>,
+    iter_num: &mut u32,
+  ) -> Result<OperationOrStatus, String> {
+    if let Some(ref mut cancel_remote_exec_token) = maybe_cancel_remote_exec_token {
+      // This request already failed: no need to cancel it.
       cancel_remote_exec_token.do_not_send_cancellation_on_drop();
     }
 
-    let ExecutionHistory {
-      mut attempts,
-      current_attempt,
-    } = history;
-    attempts.push(current_attempt);
-    let history = ExecutionHistory {
-      attempts,
-      current_attempt: ExecutionStats::default(),
-    };
+    history.complete_attempt();
 
-    let command_runner = self.clone();
-    prefix_future
-      .and_then(move |()| command_runner.oneshot_execute(&execute_request, build_id))
-      .map({
-        let operations_client = self.operations_client.clone();
-        let executor = self.executor.clone();
-        move |operation| {
-          let maybe_cancel_remote_exec_token = match operation {
-            OperationOrStatus::Operation(ref operation) => Some(CancelRemoteExecutionToken::new(
-              operations_client,
-              operation.name.clone(),
-              executor,
-            )),
-            _ => None,
-          };
-          future::Loop::Continue((
-            history,
-            operation,
-            maybe_cancel_remote_exec_token,
-            // Reset `iter_num` for a new Execute attempt:
-            0,
-          ))
-        }
-      })
-      .to_boxed()
+    let operation = self.oneshot_execute(&execute_request, build_id).await?;
+    *maybe_cancel_remote_exec_token = match operation {
+      OperationOrStatus::Operation(ref operation) => Some(CancelRemoteExecutionToken::new(
+        self.operations_client.clone(),
+        operation.name.clone(),
+        self.executor.clone(),
+      )),
+      _ => None,
+    };
+    // NB: Reset `iter_num` for a new Execute attempt.
+    *iter_num = 0;
+
+    Ok(operation)
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -3,8 +3,6 @@ use bazel_protos::operations::Operation;
 use bazel_protos::remote_execution::ExecutedActionMetadata;
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
-use futures::future::{FutureExt, TryFutureExt};
-use futures01::{future, Future};
 use grpcio;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use mock;
@@ -31,7 +29,7 @@ use std::ops::Sub;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::runtime::Handle;
-use tokio::time::delay_for;
+use tokio::time::{delay_for, timeout};
 use workunit_store::{WorkUnit, WorkUnitStore, WorkunitMetadata};
 
 #[derive(Debug, PartialEq)]
@@ -800,7 +798,6 @@ async fn sends_headers() {
   };
   command_runner
     .run(execute_request, context)
-    .compat()
     .await
     .expect("Execution failed");
 
@@ -999,7 +996,6 @@ async fn ensure_inline_stdio_is_stored() {
   .unwrap();
   let result = cmd_runner
     .run(echo_roland_request(), Context::default())
-    .compat()
     .await
     .unwrap();
   assert_eq!(
@@ -1194,34 +1190,16 @@ async fn dropped_request_cancels() {
     Platform::Linux,
   );
 
-  let successful_mock_result = FallibleProcessResultWithPlatform {
-    stdout: as_bytes("foo-fast"),
-    stderr: as_bytes(""),
-    exit_code: 0,
-    output_directory: EMPTY_DIGEST,
-    execution_attempts: vec![],
-    platform: Platform::Linux,
-  };
-
+  // Give the command only 100 ms to run (although it needs a lot more than that).
   let run_future = command_runner.run(execute_request.into(), Context::default());
-  let faster_future = delay_for(Duration::from_secs(1))
-    .unit_error()
-    .compat()
-    .map_err(|()| "Error from timer.".to_string())
-    .map({
-      let successful_mock_result = successful_mock_result.clone();
-      |_| successful_mock_result
-    });
+  if let Ok(_) = timeout(Duration::from_millis(100), run_future).await {
+    panic!("Should have timed out.");
+  }
 
-  let result = run_future
-    .select(faster_future)
-    .map(|(result, _future)| result)
-    .map_err(|(err, _future)| err)
-    .compat()
-    .await
-    .unwrap();
-
-  assert_eq!(result.without_execution_attempts(), successful_mock_result);
+  // Wait a bit longer for the cancellation to have been sent to the server.
+  // TODO: Would be better to be able to await a notification from the server that "something"
+  // had happened.
+  delay_for(Duration::from_secs(3)).await;
 
   assert_cancellation_requests(&mock_server, vec![op_name.to_owned()]);
 }
@@ -1556,7 +1534,6 @@ async fn execute_missing_file_uploads_if_known() {
 
   let result = command_runner
     .run(cat_roland_request(), Context::default())
-    .compat()
     .await
     .unwrap();
   assert_eq!(
@@ -1664,7 +1641,7 @@ async fn execute_missing_file_uploads_if_known_status() {
   )
   .unwrap()
   .run(cat_roland_request(), Context::default())
-  .wait();
+  .await;
   assert_eq!(
     result,
     Ok(FallibleProcessResultWithPlatform {
@@ -1747,7 +1724,6 @@ async fn execute_missing_file_errors_if_unknown() {
 
   let error = runner
     .run(cat_roland_request(), Context::default())
-    .compat()
     .await
     .expect_err("Want error");
   assert_contains(&error, &format!("{}", missing_digest.0));
@@ -1996,7 +1972,6 @@ async fn wait_between_request_1_retry() {
     );
     command_runner
       .run(execute_request, Context::default())
-      .compat()
       .await
       .unwrap();
 
@@ -2054,7 +2029,6 @@ async fn wait_between_request_3_retry() {
     );
     command_runner
       .run(execute_request, Context::default())
-      .compat()
       .await
       .unwrap();
 
@@ -2297,7 +2271,7 @@ async fn remote_workunits_are_stored() {
     Platform::Linux,
   );
 
-  future::lazy(move || {
+  futures01::future::lazy(move || {
     command_runner.extract_execute_response(
       OperationOrStatus::Operation(operation),
       &mut ExecutionHistory::default(),
@@ -2556,10 +2530,7 @@ async fn run_command_remote(
     Duration::from_secs(0),
     Platform::Linux,
   );
-  command_runner
-    .run(request, Context::default())
-    .compat()
-    .await
+  command_runner.run(request, Context::default()).await
 }
 
 fn create_command_runner(

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -391,7 +391,6 @@ async fn main() {
 
   let result = runner
     .run(request.into(), Context::default())
-    .compat()
     .await
     .expect("Error executing");
 


### PR DESCRIPTION
### Problem

We're planning to instrument process execution with additional workunits, but it can be challenging to identify critical sections in the presence of combinators.

### Solution

async/await for the bulk of the process_execution crate.