### PR TITLE
Stop using deprecated assertEquals()

### DIFF
--- a/src/python/pants/backend/project_info/rules/source_file_validator_test.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator_test.py
@@ -110,12 +110,12 @@ class MultiMatcherTest(unittest.TestCase):
             .lstrip()
             .encode("utf8")
         )
-        self.assertEquals(
+        self.assertEqual(
             (("python_header",), ("no_six",)),
             self._rm.check_content(("python_header", "no_six"), py_file_content, "utf8"),
         )
 
-        self.assertEquals(
+        self.assertEqual(
             RegexMatchResult("foo/bar/baz.py", ("python_header",), ("no_six",)),
             self._rm.check_source_file("foo/bar/baz.py", py_file_content),
         )

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -436,20 +436,20 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 )
             )
             # Check that we got the full snapshots that we expect
-            self.assertEquals(snapshot.files, relevant_files)
-            self.assertEquals(snapshot_with_extra_files.files, all_files)
+            self.assertEqual(snapshot.files, relevant_files)
+            self.assertEqual(snapshot_with_extra_files.files, all_files)
 
             # Strip empty prefix:
             zero_prefix_stripped_digest = self.request_single_product(
                 Digest, RemovePrefix(snapshot.digest, ""),
             )
-            self.assertEquals(snapshot.digest, zero_prefix_stripped_digest)
+            self.assertEqual(snapshot.digest, zero_prefix_stripped_digest)
 
             # Strip a non-empty prefix shared by all files:
             stripped_digest = self.request_single_product(
                 Digest, RemovePrefix(snapshot.digest, "characters/dark_tower"),
             )
-            self.assertEquals(
+            self.assertEqual(
                 stripped_digest,
                 Digest(
                     fingerprint="71e788fc25783c424db555477071f5e476d942fc958a5d06ffc1ed223f779a8c",
@@ -459,8 +459,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             expected_snapshot = assert_single_element(
                 self.scheduler.capture_snapshots((PathGlobsAndRoot(PathGlobs(["*"]), tower_dir),))
             )
-            self.assertEquals(expected_snapshot.files, ("roland", "susannah"))
-            self.assertEquals(stripped_digest, expected_snapshot.digest)
+            self.assertEqual(expected_snapshot.files, ("roland", "susannah"))
+            self.assertEqual(stripped_digest, expected_snapshot.digest)
 
             # Try to strip a prefix which isn't shared by all files:
             with self.assertRaisesWithMessageContaining(
@@ -476,8 +476,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     def test_lift_digest_to_snapshot(self):
         digest = self.prime_store_with_roland_digest()
         snapshot = self.request_single_product(Snapshot, digest)
-        self.assertEquals(snapshot.files, ("roland",))
-        self.assertEquals(snapshot.digest, digest)
+        self.assertEqual(snapshot.files, ("roland",))
+        self.assertEqual(snapshot.digest, digest)
 
     def test_error_lifting_file_digest_to_snapshot(self):
         self.prime_store_with_roland_digest()

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -348,7 +348,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
         flattened = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
         # The execution of the single named @rule "fib" should be providing this one workunit.
-        self.assertEquals(len(flattened), 1)
+        self.assertEqual(len(flattened), 1)
 
         tracker.finished_workunit_chunks = []
         with handler.session():

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -48,8 +48,8 @@ class TestEngineOptionsParsing(TestBase):
         # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
         one_opts = ob()
         two_opts = ob()
-        self.assertEquals(one_opts, two_opts)
-        self.assertEquals(hash(one_opts), hash(two_opts))
+        self.assertEqual(one_opts, two_opts)
+        self.assertEqual(hash(one_opts), hash(two_opts))
 
         # If they are equal, executing parsing on them should result in a memoized object.
         one = parse(one_opts)

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -193,11 +193,11 @@ class SchedulerTest(TestBase):
         # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
         a, b = A(), B()
         result_str = self.request_single_product(str, Params(a, b))
-        self.assertEquals(result_str, consumes_a_and_b(a, b))
+        self.assertEqual(result_str, consumes_a_and_b(a, b))
 
         # And confirm that a superset of Params is also accepted.
         result_str = self.request_single_product(str, Params(a, b, self))
-        self.assertEquals(result_str, consumes_a_and_b(a, b))
+        self.assertEqual(result_str, consumes_a_and_b(a, b))
 
         # But not a subset.
         expected_msg = "No installed @rules can compute {} given input Params(A), but".format(
@@ -211,7 +211,7 @@ class SchedulerTest(TestBase):
         # the selectors of consumes_a_and_b().
         a, c = A(), C()
         result_str = self.request_single_product(str, Params(a, c))
-        self.assertEquals(
+        self.assertEqual(
             remove_locations_from_traceback(result_str),
             remove_locations_from_traceback(consumes_a_and_b(a, transitive_b_c(c))),
         )

--- a/src/python/pants/source/test_filespec.py
+++ b/src/python/pants/source/test_filespec.py
@@ -34,9 +34,9 @@ class FilespecTest(TestBase):
         snapshot = self.request_single_product(Snapshot, PathGlobs([glob]))
         if negate:
             subset = set(expected_matches).intersection(set(snapshot.files))
-            self.assertEquals(subset, set(), f"{glob} {match_state} path(s) {subset}")
+            self.assertEqual(subset, set(), f"{glob} {match_state} path(s) {subset}")
         else:
-            self.assertEquals(sorted(expected_matches), sorted(snapshot.files))
+            self.assertEqual(sorted(expected_matches), sorted(snapshot.files))
 
     def test_matches_single_star_0(self) -> None:
         self.assert_rule_match("a/b/*/f.py", ("a/b/c/f.py", "a/b/q/f.py"))


### PR DESCRIPTION
A simple cleanup of deprecated python methods.