### PR TITLE
Fix V2 isort and Black including the tmpdir in their output

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -154,7 +154,9 @@ async def black_fmt(field_sets: BlackFieldSets, black: Black) -> FmtResult:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
+    return FmtResult.from_process_result(
+        result, original_digest=setup.original_digest, strip_chroot_path=True
+    )
 
 
 @named_rule(desc="Lint using Black")
@@ -163,7 +165,7 @@ async def black_lint(field_sets: BlackFieldSets, black: Black) -> LintResult:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -147,7 +147,9 @@ async def isort_fmt(field_sets: IsortFieldSets, isort: Isort) -> FmtResult:
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
+    return FmtResult.from_process_result(
+        result, original_digest=setup.original_digest, strip_chroot_path=True
+    )
 
 
 @named_rule(desc="Lint using isort")
@@ -156,7 +158,7 @@ async def isort_lint(field_sets: IsortFieldSets, isort: Isort) -> LintResult:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -24,6 +24,7 @@ from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Field, Target, TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
+from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
@@ -39,13 +40,16 @@ class FmtResult:
 
     @staticmethod
     def from_process_result(
-        process_result: ProcessResult, *, original_digest: Digest
+        process_result: ProcessResult, *, original_digest: Digest, strip_chroot_path: bool = False
     ) -> "FmtResult":
+        def prep_output(s: bytes) -> str:
+            return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
+
         return FmtResult(
             input=original_digest,
             output=process_result.output_digest,
-            stdout=process_result.stdout.decode(),
-            stderr=process_result.stderr.decode(),
+            stdout=prep_output(process_result.stdout),
+            stderr=prep_output(process_result.stderr),
         )
 
     @property

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -17,6 +17,7 @@ from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin, Sources, TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
+from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
@@ -30,11 +31,16 @@ class LintResult:
         return LintResult(exit_code=0, stdout="", stderr="")
 
     @staticmethod
-    def from_fallible_process_result(process_result: FallibleProcessResult,) -> "LintResult":
+    def from_fallible_process_result(
+        process_result: FallibleProcessResult, *, strip_chroot_path: bool = False
+    ) -> "LintResult":
+        def prep_output(s: bytes) -> str:
+            return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
+
         return LintResult(
             exit_code=process_result.exit_code,
-            stdout=process_result.stdout.decode(),
-            stderr=process_result.stderr.decode(),
+            stdout=prep_output(process_result.stdout),
+            stderr=prep_output(process_result.stderr),
         )
 
 

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -137,6 +137,13 @@ def strip_prefix(string: str, prefix: str) -> str:
 
 # NB: We allow bytes because `ProcessResult.std{err,out}` uses bytes.
 def strip_v2_chroot_path(v: Union[bytes, str]) -> str:
+    """Remove all instances of the chroot tmpdir path from the str so that it only uses relative
+    paths.
+
+    This is useful when a tool that is run with the V2 engine outputs absolute paths. It is
+    confusing for the user to see the absolute path in the final output because it is an
+    implementation detail that Pants copies their source code into a chroot.
+    """
     if isinstance(v, bytes):
         v = v.decode()
     return re.sub(r"/.*/process-execution[a-zA-Z0-9]+/", "", v)

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -133,3 +133,10 @@ def strip_prefix(string: str, prefix: str) -> str:
         return string[len(prefix) :]
     else:
         return string
+
+
+# NB: We allow bytes because `ProcessResult.std{err,out}` uses bytes.
+def strip_v2_chroot_path(v: Union[bytes, str]) -> str:
+    if isinstance(v, bytes):
+        v = v.decode()
+    return re.sub(r"/.*/process-execution[a-zA-Z0-9]+/", "", v)

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -2,8 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from textwrap import dedent
 
-from pants.util.strutil import camelcase, ensure_binary, ensure_text, pluralize, strip_prefix
+from pants.util.strutil import (
+    camelcase,
+    ensure_binary,
+    ensure_text,
+    pluralize,
+    strip_prefix,
+    strip_v2_chroot_path,
+)
 
 
 # TODO(Eric Ayers): Backfill tests for other methods in strutil.py
@@ -35,12 +43,12 @@ class StrutilTest(unittest.TestCase):
 
     def test_ensure_text(self) -> None:
         bytes_val = bytes(bytearray([0xE5, 0xBF, 0xAB]))
-        self.assertEqual(u"快", ensure_text(bytes_val))
+        self.assertEqual("快", ensure_text(bytes_val))
         with self.assertRaises(TypeError):
             ensure_text(45)  # type: ignore[arg-type] # intended to fail type check
 
     def test_ensure_binary(self) -> None:
-        unicode_val = u"快"
+        unicode_val = "快"
         self.assertEqual(bytearray([0xE5, 0xBF, 0xAB]), ensure_binary(unicode_val))
         with self.assertRaises(TypeError):
             ensure_binary(45)  # type: ignore[arg-type] # intended to fail type check
@@ -53,3 +61,47 @@ class StrutilTest(unittest.TestCase):
         self.assertEqual("//testString", strip_prefix("////testString", "//"))
         self.assertEqual("test//String", strip_prefix("test//String", "//"))
         self.assertEqual("testString//", strip_prefix("testString//", "//"))
+
+
+def test_strip_chroot_path() -> None:
+    assert (
+        strip_v2_chroot_path(
+            dedent(
+                """\
+            Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-execution3zt5Ph/src/python/example.py
+            Would reformat /var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionOCnquv/test.py
+            Would reformat /custom-tmpdir/process-execution7zt4pH/custom_tmpdir.py
+
+            Some other output.
+            """
+            )
+        )
+        == dedent(
+            """\
+        Would reformat src/python/example.py
+        Would reformat test.py
+        Would reformat custom_tmpdir.py
+
+        Some other output.
+        """
+        )
+    )
+
+    # A subdir must be prefixed with `process-execution`, then some characters after it.
+    assert (
+        strip_v2_chroot_path("/var/process_executionOCnquv/test.py")
+        == "/var/process_executionOCnquv/test.py"
+    )
+    assert (
+        strip_v2_chroot_path("/var/process-execution/test.py") == "/var/process-execution/test.py"
+    )
+
+    # Our heuristic requires absolute paths.
+    assert (
+        strip_v2_chroot_path("var/process-executionOCnquv/test.py")
+        == "var/process-executionOCnquv/test.py"
+    )
+
+    # Confirm we can handle values with no chroot path.
+    assert strip_v2_chroot_path("") == ""
+    assert strip_v2_chroot_path("hello world") == "hello world"


### PR DESCRIPTION
Before:

```
▶ ./v2 --changed-since=HEAD lint


would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionnVN1WF/tests/python/pants_test/util/test_strutil.py
would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionnVN1WF/src/python/pants/util/strutil.py
Oh no! 💥 💔 💥
2 files would be reformatted.

ERROR: /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionymOGR9/src/python/pants/util/strutil.py Imports are incorrectly sorted.
ERROR: /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionymOGR9/tests/python/pants_test/util/test_strutil.py Imports are incorrectly sorted.
```

After:

```
▶ ./v2 --changed-since=HEAD lint


would reformat tests/python/pants_test/util/test_strutil.py
would reformat src/python/pants/util/strutil.py
Oh no! 💥 💔 💥
2 files would be reformatted.

ERROR: src/python/pants/util/strutil.py Imports are incorrectly sorted.
ERROR: tests/python/pants_test/util/test_strutil.py Imports are incorrectly sorted.
```

Closes https://github.com/pantsbuild/pants/issues/8670.

[ci skip-rust-tests]
[ci skip-jvm-tests]