### PR TITLE
Improve `Snapshot::merge` errors.

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -25,6 +25,9 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+#[macro_use]
+extern crate log;
+
 mod snapshot;
 pub use crate::snapshot::{OneOffStoreFileByDigest, Snapshot, StoreFileByDigest};
 #[cfg(test)]


### PR DESCRIPTION
Previously just the basename of conflicting files was mentioned. Now
the full path of the conflicting file as well as the truncated contents
of each conflicting version of that file are included in the error
message. If Pants is run with debug logging enabled then full contents
of the conflicting files is included.

[ci skip-jvm-tests]