### PR TITLE
MyPy now checks partially_type_checked targets.

### DIFF
--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -19,7 +19,8 @@ def main() -> None:
                 # still want to run MyPy against it so that we can enforce the type hints that may be there
                 # already and we can make sure that we don't revert in adding code that MyPy flags as an
                 # error.
-                "--tag=+type_checked,+partially_type_checked,-nolint",
+                "--tag=+type_checked,partially_type_checked",
+                "--tag=-nolint",
                 "--backend-packages=pants.contrib.mypy",
                 "--mypy-config=build-support/mypy/mypy.ini",
                 "lint.mypy",

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -19,7 +19,7 @@ class GoLocalSourceTestBase(ABC):
     def setUpClass(cls):
         if not issubclass(cls, TestBase):
             raise TypeError("Subclasses must mix in TestBase")
-        super().setUpClass()  # type: ignore[misc]  # MyPy does not understand this mixin
+        super().setUpClass()
 
     def setUp(self):
         super().setUp()

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -63,7 +63,7 @@ class BlackIntegrationTest(TestBase):
         lint_result = self.request_single_product(
             LintResult, Params(BlackFieldSets(field_sets), options_bootstrapper)
         )
-        input_snapshot = self.request_single_product(
+        input_sources = self.request_single_product(
             SourceFiles,
             Params(
                 AllSourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -73,7 +73,7 @@ class BlackIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                BlackFieldSets(field_sets, prior_formatter_result=input_snapshot),
+                BlackFieldSets(field_sets, prior_formatter_result=input_sources.snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -56,7 +56,7 @@ class DocformatterIntegrationTest(TestBase):
         lint_result = self.request_single_product(
             LintResult, Params(DocformatterFieldSets(field_sets), options_bootstrapper)
         )
-        input_snapshot = self.request_single_product(
+        input_sources = self.request_single_product(
             SourceFiles,
             Params(
                 AllSourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -66,7 +66,7 @@ class DocformatterIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                DocformatterFieldSets(field_sets, prior_formatter_result=input_snapshot),
+                DocformatterFieldSets(field_sets, prior_formatter_result=input_sources.snapshot),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -70,7 +70,7 @@ class IsortIntegrationTest(TestBase):
         lint_result = self.request_single_product(
             LintResult, Params(IsortFieldSets(field_sets), options_bootstrapper)
         )
-        input_snapshot = self.request_single_product(
+        input_sources = self.request_single_product(
             SourceFiles,
             Params(
                 AllSourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -80,7 +80,7 @@ class IsortIntegrationTest(TestBase):
         fmt_result = self.request_single_product(
             FmtResult,
             Params(
-                IsortFieldSets(field_sets, prior_formatter_result=input_snapshot),
+                IsortFieldSets(field_sets, prior_formatter_result=input_sources.snapshot),
                 options_bootstrapper,
             ),
         )

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -208,11 +208,8 @@ class BuildGraphTest(TestBase):
 
         self.assertEqual(OrderedSet([d, a, c, b]), BuildGraph.closure(d_gen()))
 
-        def empty_gen():
-            return
-            yield  # type: ignore[misc] # MyPy complains that this is not reachable
-
-        self.assertEqual(OrderedSet([]), BuildGraph.closure(empty_gen()))
+        empty_gen = iter(())
+        self.assertEqual(OrderedSet([]), BuildGraph.closure(empty_gen))
 
     def test_closure_bfs(self):
         root = self.inject_graph(

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -3,6 +3,7 @@
 
 import os
 from contextlib import contextmanager
+from typing import Iterator
 
 from pants.fs.fs import safe_filename_from_path
 from pants.init.util import init_workdir
@@ -13,7 +14,7 @@ from pants.util.contextutil import temporary_dir
 
 class UtilTest(TestBase):
     @contextmanager
-    def physical_workdir_base(self) -> OptionValueContainer:
+    def physical_workdir_base(self) -> Iterator[OptionValueContainer]:
         with temporary_dir(cleanup=False) as physical_workdir_base:
             bootstrap_options = self.get_bootstrap_options(
                 [f"--pants-physical-workdir-base={physical_workdir_base}"]


### PR DESCRIPTION
The script was using bad `--tag` syntax. The `--tag` values are expected
to conform to `^[+-]?[^,]+(,[^,]+)*$`. In other words, a single leading
optional +/- operator and then a list of tag names to apply that single
operator to. As such, previously we were passing a `+` tag list
comprised of tag-litrals `type_checked`, `+partially_type_checked` and
`-nolint`. Of these we only ever matched the `type-checked` tag literal.

Also fix up the type checking failures that this fix exposed.

[ci skip-rust-tests]
[ci skip-jvm-tests]