### PR TITLE
Fix Shellcheck lint.

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -68,9 +68,11 @@ function activate_pants_venv() {
 
   if ! [ -f "${BOOTSTRAPPED_FILE}" ]; then
     log "Bootstrapping pants_deps with requirements:"
-    # Use -f ${REPO_ROOT}/third_party if patching in local dependencies like so
-    # pip_extra="-f ${REPO_ROOT}/third_party"
-    pip_extra=""
+    # Use -f ${REPO_ROOT}/third_party if patching in local dependencies like so:
+    #
+    #   pip_extra=(-f "${REPO_ROOT}/third_party")
+    #
+    pip_extra=()
 
     for req in "${REQUIREMENTS[@]}"; do
       log "  ${req}"
@@ -83,7 +85,7 @@ function activate_pants_venv() {
     ensure_gcc
 
     for req in "${REQUIREMENTS[@]}"; do
-      pip install "${pip_extra}" -r "${req}" || \
+      pip install "${pip_extra[@]}" -r "${req}" || \
         die "Failed to install requirements from ${req}."
     done
     touch "${BOOTSTRAPPED_FILE}"

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -83,7 +83,7 @@ function activate_pants_venv() {
     ensure_gcc
 
     for req in "${REQUIREMENTS[@]}"; do
-      pip install ${pip_extra} -r "${req}" || \
+      pip install "${pip_extra}" -r "${req}" || \
         die "Failed to install requirements from ${req}."
     done
     touch "${BOOTSTRAPPED_FILE}"


### PR DESCRIPTION
On master we had the following error previously:
```
$ ./build-support/bin/shellcheck.py

In ./build-support/pants_venv line 86:
      pip install ${pip_extra} -r "${req}" || \
                  ^----------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
      pip install "${pip_extra}" -r "${req}" || \

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
Please fix the above errors and run again.
```

[ci skip-rust-tests]
[ci skip-jvm-tests]