### PR TITLE
Upgrade pyopenssl.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -26,7 +26,7 @@ pathspec==0.5.9
 pex==2.1.9
 psutil==5.6.3
 Pygments==2.3.1
-pyopenssl==17.3.0
+pyopenssl==19.1.0
 pystache==0.5.3
 python-Levenshtein==0.12.0
 pywatchman==1.4.1


### PR DESCRIPTION
[Changelog](https://www.pyopenssl.org/en/stable/changelog.html):
```

Backward-incompatible changes:
  Removed deprecated ContextType, ConnectionType, PKeyType, X509NameType, X509ReqType, X509Type, X509StoreType, CRLType, PKCS7Type, PKCS12Type, and NetscapeSPKIType aliases. Use the classes without the Type suffix instead. #814
  The minimum cryptography version is now 2.8 due to issues on macOS with a transitive dependency. #875
  Support for Python 2.6 has been dropped.
  X509Store.add_cert no longer raises an error if you add a duplicate cert. #787

Deprecations:
  Deprecated OpenSSL.SSL.Context.set_npn_advertise_callback, OpenSSL.SSL.Context.set_npn_select_callback, and OpenSSL.SSL.Connection.get_next_proto_negotiated. ALPN should be used instead. #820

Changes:
  Support bytearray in SSL.Connection.send() by using cffi’s from_buffer. #852
  The OpenSSL.SSL.Context.set_alpn_select_callback can return a new NO_OVERLAPPING_PROTOCOLS sentinel value to allow a TLS handshake to complete without an application protocol.
  pyOpenSSL now works with OpenSSL 1.1.1. #805
  pyOpenSSL now handles NUL bytes in X509Name.get_components() #804
  Added Connection.get_certificate to retrieve the local certificate. #733
  OpenSSL.SSL.Connection now sets SSL_MODE_AUTO_RETRY by default. #753
  Added Context.set_tlsext_use_srtp to enable negotiation of SRTP keying material. #734
  Fixed a potential use-after-free in the verify callback and resolved a memory leak when loading PKCS12 files with cacerts. #723
  Added Connection.export_keying_material for RFC 5705 compatible export of keying material. #725
  Re-added a subset of the OpenSSL.rand module. This subset allows conscientious users to reseed the OpenSSL CSPRNG after fork. #708
  Corrected a use-after-free when reusing an issuer or subject from an X509 object after the underlying object has been mutated. #709
```