### PR TITLE
Simplify v1 Go buildgen's use of source roots.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -15,7 +15,6 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/option',
     'src/python/pants/process',
-    'src/python/pants/source',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
@@ -57,34 +57,17 @@ class GoBuildgenTest(TaskTestBase):
         task.execute()
         self.assertEqual(expected, context.targets())
 
-    def test_no_local_roots_failure(self):
-        context = self.context(target_roots=[self.make_target("src/go/src/fred", GoBinary)])
-        task = self.create_task(context)
-        with self.assertRaises(task.NoLocalRootsError):
-            task.execute()
-
     def test_multiple_local_roots_failure(self):
         self.create_dir("src/go/src")
         self.create_dir("src/main/go/src")
-        context = self.context(target_roots=[self.make_target("src/go/src/fred", GoBinary)])
+        context = self.context(
+            target_roots=[
+                self.make_target("src/go/src/fred", GoBinary),
+                self.make_target("src/main/go/src/barney", GoBinary),
+            ]
+        )
         task = self.create_task(context)
         with self.assertRaises(task.InvalidLocalRootsError):
-            task.execute()
-
-    def test_unrooted_failure(self):
-        self.create_dir("src/go/src")
-        context = self.context(target_roots=[self.make_target("src2/go/src/fred", GoBinary)])
-        task = self.create_task(context)
-        with self.assertRaises(task.UnrootedLocalSourceError):
-            task.execute()
-
-    def test_multiple_remote_roots_failure(self):
-        self.create_dir("3rdparty/go")
-        self.create_dir("src/go/src/fred")
-        self.create_dir("other/3rdparty/go")
-        context = self.context(target_roots=[self.make_target("src/go/src/fred", GoLibrary)])
-        task = self.create_task(context)
-        with self.assertRaises(task.InvalidRemoteRootsError):
             task.execute()
 
     def test_existing_targets_wrong_type(self):
@@ -285,6 +268,7 @@ class GoBuildgenTest(TaskTestBase):
             fred = self.make_target("src/go/src/fred", GoBinary)
             target_roots = [fred]
 
+        self.set_options(remote_root="3rdparty/go")
         context = self.context(target_roots=target_roots)
         pre_execute_files = self.buildroot_files()
         task = self.create_task(context)
@@ -349,42 +333,6 @@ class GoBuildgenTest(TaskTestBase):
     def test_fail_floating(self):
         with self.assertRaises(GoBuildgen.FloatingRemoteError):
             self.stitch_deps_remote(remote=True, materialize=True, fail_floating=True)
-
-    def test_issues_2395(self):
-        # Previously, when a remote was indirectly discovered via a scan of locals (no target roots
-        # presented on the CLI), the remote would be queried for from the build graph under the
-        # erroneous assumption it had been injected.  This would result in a graph miss (BUILD file was
-        # there on disk, but never loaded via injection) and lead to creation of a new synthetic remote
-        # target with no rev.  The end result was lossy go remote library rev values when using the
-        # newer, encouraged, target-less invocation of GoBuildgen.
-
-        self.set_options(remote=True, materialize=True, fail_floating=True)
-        self.add_to_build_file(
-            relpath="3rdparty/go/pantsbuild.org/fake", target='go_remote_library(rev="v4.5.6")'
-        )
-
-        self.create_file(
-            relpath="src/go/src/jane/bar.go",
-            contents=dedent(
-                """
-                package jane
-        
-                import "pantsbuild.org/fake"
-        
-                var PublicConstant = fake.DoesNotExistButWeShouldNotCareWhenCheckingDepsAndNotInstalling
-                """
-            ),
-        )
-        self.add_to_build_file(relpath="src/go/src/jane", target="go_library()")
-
-        context = self.context(target_roots=[])
-        pre_execute_files = self.buildroot_files()
-        task = self.create_task(context)
-        task.execute()
-
-        self.build_graph.reset()  # Force targets to be loaded off disk
-        self.assertEqual("v4.5.6", self.target("3rdparty/go/pantsbuild.org/fake").rev)
-        self.assertEqual(pre_execute_files, self.buildroot_files())
 
     def test_issues_2616(self):
         self.set_options(remote=False)


### PR DESCRIPTION
v1 Go buildgen is the only thing in the codebase that uses the fact that source roots know the language they are a root of, and the source/test/3rdparty distinction.

We'd like to greatly simplify source roots by getting rid of this extra data, which is not only not useful, but not always coherent (e.g., we can put multiple langs, and tests and sources, in the same source root). 

To facilitate this simplification we get rid of the one place we did use that data. Instead we infer the (single) local Go source root, and require the remote root to be provided explicitly as a flag, if needed. 

[ci skip-rust-tests]
[ci skip-jvm-tests]
