### PR TITLE
Remove deprecation warning from ivy_imports.py.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/java/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_import_products',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',

--- a/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
@@ -11,6 +11,7 @@ from pants.backend.codegen.protobuf.subsystems.protoc import Protoc
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.fs.archive import ZIP
@@ -174,6 +175,14 @@ class ProtobufGen(SimpleCodegenTask):
         imports = jar_import_products.imports(target)
         for coordinate, jar in imports:
             files.add(self._extract_jar(coordinate, jar))
+        if files:
+            deprecated_conditional(
+                lambda: True,
+                removal_version="1.30.0.dev0",
+                entity_description="Importing from .protos embedded in remote JAR files.",
+                hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
+                "if you need this functionality.",
+            )
         return files
 
     def _extract_jar(self, coordinate, jar_path):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -226,7 +226,6 @@ python_library(
     ':jar_import_products',
     ':nailgun_task',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/base:deprecated',
   ],
   tags = {'partially_type_checked'},
 )
@@ -727,6 +726,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_import_products',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/fs',
     'src/python/pants/task',

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -7,7 +7,6 @@ from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier_resolve import CoursierMixin
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-from pants.base.deprecated import deprecated_conditional
 
 
 class IvyImports(CoursierMixin, NailgunTask):
@@ -29,13 +28,6 @@ class IvyImports(CoursierMixin, NailgunTask):
         return isinstance(target, ImportJarsMixin) and target.imported_targets
 
     def execute(self):
-        deprecated_conditional(
-            lambda: True,
-            removal_version="1.30.0.dev0",
-            entity_description="The `imports` goal",
-            hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
-            "if you need this functionality.",
-        )
         jar_import_products = self.context.products.get_data(
             JarImportProducts, init_func=JarImportProducts
         )

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -5,6 +5,7 @@ from hashlib import sha1
 
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
+from pants.base.deprecated import deprecated_conditional
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
 from pants.fs.archive import ZIP
 from pants.task.unpack_remote_sources_base import UnpackRemoteSourcesBase
@@ -47,6 +48,14 @@ class UnpackJars(UnpackRemoteSourcesBase):
         return UnpackJarsFingerprintStrategy()
 
     def unpack_target(self, unpacked_jars, unpack_dir):
+        deprecated_conditional(
+            lambda: True,
+            removal_version="1.30.0.dev0",
+            entity_description="The `unpack-jars` goal",
+            hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
+            "if you need this functionality.",
+        )
+
         direct_coords = {jar.coordinate for jar in unpacked_jars.all_imported_jar_deps}
         unpack_filter = self.get_unpack_filter(unpacked_jars)
         jar_import_products = self.context.products.get_data(JarImportProducts)


### PR DESCRIPTION
It was displaying in every v1 run.

Instead deprecate the functionality that uses the
products it produces, and only if it's actually used.

[ci skip-rust-tests]
[ci skip-jvm-tests]
