### PR TITLE
Fix `protobuf_library` to be parsable by V1 tasks

### DIFF
--- a/src/python/pants/backend/awslambda/python/register.py
+++ b/src/python/pants/backend/awslambda/python/register.py
@@ -25,4 +25,4 @@ class LegacyPythonAWSLambda(Target):
 
 
 def build_file_aliases():
-    return BuildFileAliases(targets={"python_awslambda": LegacyPythonAWSLambda})
+    return BuildFileAliases(targets={PythonAWSLambda.alias: LegacyPythonAWSLambda})

--- a/src/python/pants/backend/codegen/protobuf/python/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/python/BUILD
@@ -6,6 +6,7 @@ python_library(
     'src/python/pants/backend/codegen/protobuf',
     'src/python/pants/backend/codegen/protobuf/subsystems',
     'src/python/pants/backend/python:target_types',
+    'src/python/pants/build_graph',
     'src/python/pants/core/util_rules',
     'src/python/pants/engine:addresses',
     'src/python/pants/engine:fs',

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -9,6 +9,8 @@ See https://developers.google.com/protocol-buffers/.
 from pants.backend.codegen.protobuf.python import additional_fields
 from pants.backend.codegen.protobuf.python.rules import rules as python_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target as TargetV1
 
 
 def rules():
@@ -17,3 +19,13 @@ def rules():
 
 def target_types():
     return [ProtobufLibrary]
+
+
+# Dummy v1 target to ensure that v1 tasks can still parse v2 BUILD files.
+class LegacyProtobufLibrary(TargetV1):
+    def __init__(self, sources=(), dependencies=(), python_compatibility=None, **kwargs):
+        super().__init__(**kwargs)
+
+
+def build_file_aliases():
+    return BuildFileAliases(targets={ProtobufLibrary.alias: LegacyProtobufLibrary})


### PR DESCRIPTION
Without this, whenever a V1 task like `filedeps` encounters a `protobuf_library`, Pants will crash.

[ci skip-rust-tests]
[ci skip-jvm-tests]