### PR TITLE
Improve concurrency of V2 formatter and linter setup

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -4,7 +4,7 @@
 import re
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union, cast
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
@@ -29,7 +29,7 @@ from pants.core.util_rules.determine_source_files import (
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
@@ -86,7 +86,7 @@ async def setup(
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> Setup:
-    requirements_pex = await Get[Pex](
+    requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="black.pex",
             requirements=PexRequirements(black.get_requirement_specs()),
@@ -98,7 +98,7 @@ async def setup(
     )
 
     config_path: Optional[str] = black.options.config
-    config_snapshot = await Get[Snapshot](
+    config_snapshot_request = Get[Snapshot](
         PathGlobs(
             globs=tuple([config_path] if config_path else []),
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
@@ -106,18 +106,31 @@ async def setup(
         )
     )
 
-    if request.field_sets.prior_formatter_result is None:
-        all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
-        )
-        all_source_files_snapshot = all_source_files.snapshot
-    else:
-        all_source_files_snapshot = request.field_sets.prior_formatter_result
-
-    specified_source_files = await Get[SourceFiles](
+    all_source_files_request = Get[SourceFiles](
+        AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
+    )
+    specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
             (field_set.sources, field_set.origin) for field_set in request.field_sets
         )
+    )
+
+    requests: List[Get] = [
+        requirements_pex_request,
+        config_snapshot_request,
+        specified_source_files_request,
+    ]
+    if request.field_sets.prior_formatter_result is None:
+        requests.append(all_source_files_request)
+    requirements_pex, config_snapshot, specified_source_files, *rest = cast(
+        Union[Tuple[Pex, Snapshot, SourceFiles], Tuple[Pex, Snapshot, SourceFiles, SourceFiles]],
+        await MultiGet(requests),
+    )
+
+    all_source_files_snapshot = (
+        request.field_sets.prior_formatter_result
+        if request.field_sets.prior_formatter_result
+        else rest[0].snapshot
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import List, Tuple, Union, cast
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
@@ -27,7 +27,7 @@ from pants.core.util_rules.determine_source_files import (
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
@@ -73,7 +73,7 @@ async def setup(
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> Setup:
-    requirements_pex = await Get[Pex](
+    requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="docformatter.pex",
             requirements=PexRequirements(docformatter.get_requirement_specs()),
@@ -84,18 +84,27 @@ async def setup(
         )
     )
 
-    if request.field_sets.prior_formatter_result is None:
-        all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
-        )
-        all_source_files_snapshot = all_source_files.snapshot
-    else:
-        all_source_files_snapshot = request.field_sets.prior_formatter_result
-
-    specified_source_files = await Get[SourceFiles](
+    all_source_files_request = Get[SourceFiles](
+        AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
+    )
+    specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
             (field_set.sources, field_set.origin) for field_set in request.field_sets
         )
+    )
+
+    requests: List[Get] = [requirements_pex_request, specified_source_files_request]
+    if request.field_sets.prior_formatter_result is None:
+        requests.append(all_source_files_request)
+    requirements_pex, specified_source_files, *rest = cast(
+        Union[Tuple[Pex, SourceFiles], Tuple[Pex, SourceFiles, SourceFiles]],
+        await MultiGet(requests),
+    )
+
+    all_source_files_snapshot = (
+        request.field_sets.prior_formatter_result
+        if request.field_sets.prior_formatter_result
+        else rest[0].snapshot
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.rules import download_pex_bin, pex
@@ -25,7 +25,7 @@ from pants.core.util_rules.determine_source_files import (
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, named_rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
@@ -69,7 +69,7 @@ async def flake8_lint(
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (field_set.compatibility for field_set in field_sets), python_setup
     )
-    requirements_pex = await Get[Pex](
+    requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="flake8.pex",
             requirements=PexRequirements(flake8.get_requirement_specs()),
@@ -79,21 +79,33 @@ async def flake8_lint(
     )
 
     config_path: Optional[str] = flake8.options.config
-    config_snapshot = await Get[Snapshot](
+    config_snapshot_request = Get[Snapshot](
         PathGlobs(
-            globs=tuple([config_path] if config_path else []),
+            globs=[config_path] if config_path else [],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin="the option `--flake8-config`",
         )
     )
 
-    all_source_files = await Get[SourceFiles](
+    all_source_files_request = Get[SourceFiles](
         AllSourceFilesRequest(field_set.sources for field_set in field_sets)
     )
-    specified_source_files = await Get[SourceFiles](
+    specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
             (field_set.sources, field_set.origin) for field_set in field_sets
         )
+    )
+
+    requirements_pex, config_snapshot, all_source_files, specified_source_files = cast(
+        Tuple[Pex, Snapshot, SourceFiles, SourceFiles],
+        await MultiGet(
+            [
+                requirements_pex_request,
+                config_snapshot_request,
+                all_source_files_request,
+                specified_source_files_request,
+            ]
+        ),
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union, cast
 
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.lint.python_fmt import PythonFmtFieldSets
@@ -27,7 +27,7 @@ from pants.core.util_rules.determine_source_files import (
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -78,7 +78,7 @@ async def setup(
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> Setup:
-    requirements_pex = await Get[Pex](
+    requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="isort.pex",
             requirements=PexRequirements(isort.get_requirement_specs()),
@@ -90,7 +90,7 @@ async def setup(
     )
 
     config_path: Optional[List[str]] = isort.options.config
-    config_snapshot = await Get[Snapshot](
+    config_snapshot_request = Get[Snapshot](
         PathGlobs(
             globs=config_path or (),
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
@@ -99,18 +99,31 @@ async def setup(
         )
     )
 
-    if request.field_sets.prior_formatter_result is None:
-        all_source_files = await Get[SourceFiles](
-            AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
-        )
-        all_source_files_snapshot = all_source_files.snapshot
-    else:
-        all_source_files_snapshot = request.field_sets.prior_formatter_result
-
-    specified_source_files = await Get[SourceFiles](
+    all_source_files_request = Get[SourceFiles](
+        AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
+    )
+    specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
             (field_set.sources, field_set.origin) for field_set in request.field_sets
         )
+    )
+
+    requests: List[Get] = [
+        requirements_pex_request,
+        config_snapshot_request,
+        specified_source_files_request,
+    ]
+    if request.field_sets.prior_formatter_result is None:
+        requests.append(all_source_files_request)
+    requirements_pex, config_snapshot, specified_source_files, *rest = cast(
+        Union[Tuple[Pex, Snapshot, SourceFiles], Tuple[Pex, Snapshot, SourceFiles, SourceFiles]],
+        await MultiGet(requests),
+    )
+
+    all_source_files_snapshot = (
+        request.field_sets.prior_formatter_result
+        if request.field_sets.prior_formatter_result
+        else rest[0].snapshot
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.rules import download_pex_bin, importable_python_sources, pex
@@ -23,7 +23,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, named_rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies, Targets
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -70,7 +70,6 @@ async def pylint_lint(
         addresses.append(field_set.address)
         addresses.extend(field_set.dependencies.value or ())
     targets = await Get[Targets](Addresses(addresses))
-    prepared_python_sources = await Get[ImportablePythonSources](Targets, targets)
 
     # NB: Pylint output depends upon which Python interpreter version it's run with. We ensure that
     # each target runs with its own interpreter constraints. See
@@ -78,7 +77,7 @@ async def pylint_lint(
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (field_set.compatibility for field_set in field_sets), python_setup
     )
-    requirements_pex = await Get[Pex](
+    requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="pylint.pex",
             requirements=PexRequirements(pylint.get_requirement_specs()),
@@ -88,12 +87,32 @@ async def pylint_lint(
     )
 
     config_path: Optional[str] = pylint.options.config
-    config_snapshot = await Get[Snapshot](
+    config_snapshot_request = Get[Snapshot](
         PathGlobs(
             globs=tuple([config_path] if config_path else []),
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin="the option `--pylint-config`",
         )
+    )
+
+    prepare_python_sources_request = Get[ImportablePythonSources](Targets, targets)
+    specified_source_files_request = Get[SourceFiles](
+        SpecifiedSourceFilesRequest(
+            ((field_set.sources, field_set.origin) for field_set in field_sets),
+            strip_source_roots=True,
+        )
+    )
+
+    requirements_pex, config_snapshot, prepared_python_sources, specified_source_files = cast(
+        Tuple[Pex, Snapshot, ImportablePythonSources, SourceFiles],
+        await MultiGet(
+            [
+                requirements_pex_request,
+                config_snapshot_request,
+                prepare_python_sources_request,
+                specified_source_files_request,
+            ]
+        ),
     )
 
     input_digest = await Get[Digest](
@@ -104,13 +123,6 @@ async def pylint_lint(
                 prepared_python_sources.snapshot.digest,
             )
         ),
-    )
-
-    specified_source_files = await Get[SourceFiles](
-        SpecifiedSourceFilesRequest(
-            ((field_set.sources, field_set.origin) for field_set in field_sets),
-            strip_source_roots=True,
-        )
     )
 
     address_references = ", ".join(

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -3,7 +3,7 @@
 
 import functools
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 from pants.backend.python.rules.importable_python_sources import ImportablePythonSources
 from pants.backend.python.rules.pex import (
@@ -155,7 +155,7 @@ async def setup_pytest_for_target(
     #   https://github.com/pantsbuild/pants/issues/9294
     # Some awkward code follows in order to execute 5-6 items concurrently given the current state
     # of MultiGet typing / API. Improve this since we should encourage full concurrency in general.
-    requests: List[Get[Any]] = [
+    requests: List[Get] = [
         Get[Pex](PexRequest, pytest_pex_request),
         Get[Pex](PexFromTargetsRequest, requirements_pex_request),
         Get[Pex](PexRequest, test_runner_pex_request),


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/9283, we were using many serial `await Get`s in the linter/formatter setup, even when there were no data dependencies. This unnecessarily restricts concurrency.

See https://github.com/pantsbuild/pants/issues/9294 to track making this more ergonomic.
 
[ci skip-rust-tests]
[ci skip-jvm-tests]