### PR TITLE
Avoid unnecessary `strip_source_roots.py` work when using a repo-level root

### DIFF
--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -81,6 +81,9 @@ async def strip_source_roots_from_snapshot(
 ) -> SourceRootStrippedSources:
     """Removes source roots from a snapshot, e.g. `src/python/pants/util/strutil.py` ->
     `pants/util/strutil.py`."""
+    if not request.snapshot.files:
+        return SourceRootStrippedSources(request.snapshot)
+
     source_roots_object = source_root_config.get_source_roots()
 
     def determine_source_root(path: str) -> str:
@@ -93,13 +96,12 @@ async def strip_source_roots_from_snapshot(
         return PurePath(path).parent.as_posix()
 
     if request.representative_path is not None:
-        resulting_digest = await Get[Digest](
-            RemovePrefix(
-                request.snapshot.digest, determine_source_root(request.representative_path),
-            )
-        )
-        resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
-        return SourceRootStrippedSources(snapshot=resulting_snapshot)
+        source_root = determine_source_root(request.representative_path)
+        is_repo_level_source_root = source_root == ""
+        if is_repo_level_source_root:
+            return SourceRootStrippedSources(request.snapshot)
+        resulting_snapshot = await Get[Snapshot](RemovePrefix(request.snapshot.digest, source_root))
+        return SourceRootStrippedSources(resulting_snapshot)
 
     files_grouped_by_source_root = {
         source_root: tuple(files)
@@ -107,6 +109,13 @@ async def strip_source_roots_from_snapshot(
             request.snapshot.files, key=determine_source_root
         )
     }
+
+    only_has_repo_level_source_root = (
+        len(files_grouped_by_source_root) == 1 and next(iter(files_grouped_by_source_root)) == ""
+    )
+    if only_has_repo_level_source_root:
+        return SourceRootStrippedSources(request.snapshot)
+
     snapshot_subsets = await MultiGet(
         Get[Snapshot](SnapshotSubset(request.snapshot.digest, PathGlobs(files)))
         for files in files_grouped_by_source_root.values()
@@ -116,8 +125,7 @@ async def strip_source_roots_from_snapshot(
         for snapshot, source_root in zip(snapshot_subsets, files_grouped_by_source_root.keys())
     )
 
-    merged_result = await Get[Digest](MergeDigests(resulting_digests))
-    resulting_snapshot = await Get[Snapshot](Digest, merged_result)
+    resulting_snapshot = await Get[Snapshot](MergeDigests(resulting_digests))
     return SourceRootStrippedSources(resulting_snapshot)
 
 

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -13,6 +13,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.core.util_rules.strip_source_roots import rules as strip_source_root_rules
 from pants.engine.addresses import Address
+from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.engine.target import Sources as SourcesField
@@ -80,6 +81,21 @@ class StripSourceRootsTest(TestBase):
         assert sorted(
             get_stripped_files_for_snapshot(file_names, use_representative_path=False)
         ) == sorted(["project/example.py", "com/project/example.java"])
+
+        # Test a source root at the repo root. We have performance optimizations for this case
+        # because there is nothing to strip.
+        source_root_config = ["--source-source-roots={'': ('python',)}"]
+        assert get_stripped_files_for_snapshot(
+            ["project/f1.py", "project/f2.py"],
+            args=source_root_config,
+            use_representative_path=True,
+        ) == ["project/f1.py", "project/f2.py"]
+        assert get_stripped_files_for_snapshot(
+            ["dir1/f.py", "dir2/f.py"], args=source_root_config, use_representative_path=False
+        ) == ["dir1/f.py", "dir2/f.py"]
+
+        # Gracefully handle an empty snapshot
+        assert self.get_stripped_files(StripSnapshotRequest(EMPTY_SNAPSHOT)) == []
 
     def test_strip_sources_field(self) -> None:
         source_root = "src/python/project"

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -54,6 +54,9 @@ class StripSourceRootsTest(TestBase):
         assert get_stripped_files_for_snapshot(["src/python/project/example.py"]) == [
             "project/example.py"
         ]
+        assert get_stripped_files_for_snapshot(
+            ["src/python/project/example.py"], use_representative_path=False
+        ) == ["project/example.py"]
         assert get_stripped_files_for_snapshot(["src/java/com/project/example.java"]) == [
             "com/project/example.java"
         ]


### PR DESCRIPTION
For monolingual repositories, we now recommend using a repo-level root, rather than something like `src/python`.

When using a repo-level root, there is no source root to strip. But, we kept running the same rule logic regardless.

### Benchmarks

before | after | change
-- | -- | --
2.02 | 1.98 | -2%

(This is from stripping 10k files in a unit test, and using Python's `time.time()` to calculate the elapsed time. It was run 3 times before and 3 times after, then averaged. See https://docs.google.com/spreadsheets/d/1_7wC0qYCrEYqVb0LKHfV8QreApoMRn2EpzF8ytneU-8/edit#gid=1193774959.)

[ci skip-rust-tests]
[ci skip-jvm-tests]