### PR TITLE
Optimize `strip_source_roots.py` when there is only 1 source root

### DIFF
--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -81,6 +81,9 @@ async def strip_source_roots_from_snapshot(
 ) -> SourceRootStrippedSources:
     """Removes source roots from a snapshot, e.g. `src/python/pants/util/strutil.py` ->
     `pants/util/strutil.py`."""
+    if not request.snapshot.files:
+        return SourceRootStrippedSources(request.snapshot)
+
     source_roots_object = source_root_config.get_source_roots()
 
     def determine_source_root(path: str) -> str:
@@ -93,13 +96,9 @@ async def strip_source_roots_from_snapshot(
         return PurePath(path).parent.as_posix()
 
     if request.representative_path is not None:
-        resulting_digest = await Get[Digest](
-            RemovePrefix(
-                request.snapshot.digest, determine_source_root(request.representative_path),
-            )
-        )
-        resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
-        return SourceRootStrippedSources(snapshot=resulting_snapshot)
+        source_root = determine_source_root(request.representative_path)
+        resulting_snapshot = await Get[Snapshot](RemovePrefix(request.snapshot.digest, source_root))
+        return SourceRootStrippedSources(resulting_snapshot)
 
     files_grouped_by_source_root = {
         source_root: tuple(files)
@@ -107,6 +106,12 @@ async def strip_source_roots_from_snapshot(
             request.snapshot.files, key=determine_source_root
         )
     }
+
+    if len(files_grouped_by_source_root) == 1:
+        source_root = next(iter(files_grouped_by_source_root.keys()))
+        resulting_snapshot = await Get[Snapshot](RemovePrefix(request.snapshot.digest, source_root))
+        return SourceRootStrippedSources(resulting_snapshot)
+
     snapshot_subsets = await MultiGet(
         Get[Snapshot](SnapshotSubset(request.snapshot.digest, PathGlobs(files)))
         for files in files_grouped_by_source_root.values()
@@ -116,8 +121,7 @@ async def strip_source_roots_from_snapshot(
         for snapshot, source_root in zip(snapshot_subsets, files_grouped_by_source_root.keys())
     )
 
-    merged_result = await Get[Digest](MergeDigests(resulting_digests))
-    resulting_snapshot = await Get[Snapshot](Digest, merged_result)
+    resulting_snapshot = await Get[Snapshot](MergeDigests(resulting_digests))
     return SourceRootStrippedSources(resulting_snapshot)
 
 

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -13,6 +13,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.core.util_rules.strip_source_roots import rules as strip_source_root_rules
 from pants.engine.addresses import Address
+from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.selectors import Params
 from pants.engine.target import Sources as SourcesField
@@ -34,7 +35,7 @@ class StripSourceRootsTest(TestBase):
         result = self.request_single_product(
             SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),
         )
-        return sorted(result.snapshot.files)
+        return list(result.snapshot.files)
 
     def test_strip_snapshot(self) -> None:
         def get_stripped_files_for_snapshot(
@@ -43,7 +44,7 @@ class StripSourceRootsTest(TestBase):
             use_representative_path: bool = True,
             args: Optional[List[str]] = None,
         ) -> List[str]:
-            input_snapshot = self.make_snapshot({fp: "" for fp in paths})
+            input_snapshot = self.make_snapshot_of_empty_files(paths)
             request = StripSnapshotRequest(
                 input_snapshot, representative_path=paths[0] if use_representative_path else None
             )
@@ -53,6 +54,9 @@ class StripSourceRootsTest(TestBase):
         assert get_stripped_files_for_snapshot(["src/python/project/example.py"]) == [
             "project/example.py"
         ]
+        assert get_stripped_files_for_snapshot(
+            ["src/python/project/example.py"], use_representative_path=False
+        ) == ["project/example.py"]
         assert get_stripped_files_for_snapshot(["src/java/com/project/example.java"]) == [
             "com/project/example.java"
         ]
@@ -80,6 +84,9 @@ class StripSourceRootsTest(TestBase):
         assert sorted(
             get_stripped_files_for_snapshot(file_names, use_representative_path=False)
         ) == sorted(["project/example.py", "com/project/example.java"])
+
+        # Gracefully handle an empty snapshot
+        assert self.get_stripped_files(StripSnapshotRequest(EMPTY_SNAPSHOT)) == []
 
     def test_strip_sources_field(self) -> None:
         source_root = "src/python/project"


### PR DESCRIPTION
As found in https://github.com/pantsbuild/pants/pull/9702#issuecomment-624740307, it is particularly expensive to run `SnapshotSubset`s (35.16 seconds for 10k files). There is also a small, but nontrivial cost to using `MergeDigests` (0.03 seconds for 10k files).

When we have only one single source root, there is no need for the extra work and extra complexity of trying to handle multiple source roots. Even if we optimize `SnapshotSubset`, we would still be doing unnecessary work.
 
Benchmark:

before | after | change
-- | -- | --
35.430 | 0.190 | -99%

(Running `strip_source_roots` on 10k files in a unit test.)

### Why still use `representative_path`?

We earlier added this as an optimization to only determine the source root for one single file in the snapshot, then use that result as the prefix for the whole snapshot. We use this when stripping a target's `sources`.

This optimization is still valuable. Benchmarking over 10k files:

* `representative_path`: 0.074
* no `representative_path`, after this PR: 0.190

After this PR, the `await Get[Digest](RemovePrefix)` ends up being identical to before. So, the cost comes from calling `itertools.groupby()` and calling `SourceRoots.find_by_path()` on every single file, instead of just one.

[ci skip-rust-tests]
[ci skip-jvm-tests]