### PR TITLE
Adapt to upstream scalatest change

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -155,7 +155,13 @@ jar_library(name='junit',
 
 jar_library(name='scalatest',
             jars=[
-              scala_jar('org.scalatest', 'scalatest', '3.0.0')
+              scala_jar('org.scalatest', 'scalatest', '3.1.1')
+            ],
+            dependencies = [':scalatestplus-junit4'])
+
+jar_library(name='scalatestplus-junit4',
+            jars=[
+              scala_jar('org.scalatestplus', 'junit-4-12', '3.1.1.0')
             ])
 
 jar_library(name='wire-runtime',

--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -155,13 +155,7 @@ jar_library(name='junit',
 
 jar_library(name='scalatest',
             jars=[
-              scala_jar('org.scalatest', 'scalatest', '3.1.1')
-            ],
-            dependencies = [':scalatestplus-junit4'])
-
-jar_library(name='scalatestplus-junit4',
-            jars=[
-              scala_jar('org.scalatestplus', 'junit-4-12', '3.1.1.0')
+              scala_jar('org.scalatest', 'scalatest', '3.0.8')
             ])
 
 jar_library(name='wire-runtime',

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -74,7 +74,7 @@ especially relevant.
 > Pants also includes support for using the ScalaTest framework.  The
 > testing framework automatically picks up scala tests that extend the
 > org.scalatest.Suite class and runs them
-> using org.scalatest.junit.JUnitRunner.
+> using org.scalatestplus.junit.JUnitRunner.
 >
 > Most other scala test frameworks support running with JUnit via a base
 > class/trait or via a `@RunWith` annotation; so you can use

--- a/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
@@ -17,7 +17,7 @@ public final class ScalaTestUtil {
   static {
     try {
       suiteClass = Class.forName("org.scalatest.Suite");
-      junitRunnerClass = Class.forName("org.scalatest.junit.JUnitRunner");
+      junitRunnerClass = Class.forName("org.scalatestplus.junit.JUnitRunner");
     } catch (ClassNotFoundException e) {
       // No scalatest tests on classpath
     }


### PR DESCRIPTION
# Delete this line to force CI to run Clippy and the Rust tests.
[ci skip-rust-tests]

### Problem

ScalaTestUtil tries to hydrate org.scalatest.junit.JUnitRunner. However, it turns out that class was moved to org.scalatestplus.junit.JUnitRunner, and we never caught up. Now that they've deleted the type alias for JUnitRunner, we can't upgrade our scalatest version to 3.1.x. 

### Solution

use `org.scalatestplus.junit.JUnitRunner` instead as the junitRunnerClass
