### PR TITLE
Improve output of V2 `fmt` and `lint` goals

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -126,7 +126,7 @@ async def bandit_lint(
         description=f"Run Bandit on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, linter_name="Bandit")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -168,7 +168,10 @@ async def black_fmt(field_sets: BlackFieldSets, black: Black) -> FmtResult:
     setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, strip_chroot_path=True
+        result,
+        original_digest=setup.original_digest,
+        formatter_name="Black",
+        strip_chroot_path=True,
     )
 
 
@@ -178,7 +181,9 @@ async def black_lint(field_sets: BlackFieldSets, black: Black) -> LintResult:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result, strip_chroot_path=True)
+    return LintResult.from_fallible_process_result(
+        result, linter_name="Black", strip_chroot_path=True
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -142,7 +142,9 @@ async def docformatter_fmt(
         return FmtResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
-    return FmtResult.from_process_result(result, original_digest=setup.original_digest)
+    return FmtResult.from_process_result(
+        result, original_digest=setup.original_digest, formatter_name="Docformatter"
+    )
 
 
 @named_rule(desc="Lint Python docstrings with docformatter")
@@ -153,7 +155,7 @@ async def docformatter_lint(
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, linter_name="Docformatter")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -78,7 +78,8 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
         lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result == LintResult.noop()
+        assert lint_result.exit_code == 0
+        assert lint_result.stderr == ""
         assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
@@ -114,7 +115,8 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
             [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
         )
         lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result == LintResult.noop()
+        assert lint_result.exit_code == 0
+        assert lint_result.stderr == ""
         assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
@@ -127,7 +129,8 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         lint_result, fmt_result = self.run_docformatter(
             [target], passthrough_args="--make-summary-multi-line"
         )
-        assert lint_result == LintResult.noop()
+        assert lint_result.exit_code == 0
+        assert lint_result.stderr == ""
         assert fmt_result.output == self.get_digest([needs_config])
         assert fmt_result.did_change is False
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -127,7 +127,7 @@ async def flake8_lint(
         description=f"Run Flake8 on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, linter_name="Flake8")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -161,7 +161,10 @@ async def isort_fmt(field_sets: IsortFieldSets, isort: Isort) -> FmtResult:
     setup = await Get[Setup](SetupRequest(field_sets, check_only=False))
     result = await Get[ProcessResult](Process, setup.process)
     return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, strip_chroot_path=True
+        result,
+        original_digest=setup.original_digest,
+        formatter_name="isort",
+        strip_chroot_path=True,
     )
 
 
@@ -171,7 +174,9 @@ async def isort_lint(field_sets: IsortFieldSets, isort: Isort) -> LintResult:
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result, strip_chroot_path=True)
+    return LintResult.from_fallible_process_result(
+        result, linter_name="isort", strip_chroot_path=True
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -138,7 +138,7 @@ async def pylint_lint(
         description=f"Run Pylint on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(result, linter_name="Pylint")
 
 
 def rules():

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -249,17 +249,19 @@ async def fmt(
         merged_formatted_digest = await Get[Digest](MergeDigests(changed_digests))
         workspace.materialize_directory(DirectoryToMaterialize(merged_formatted_digest))
 
-    for result in sorted(individual_results, key=lambda res: res.formatter_name):
+    sorted_results = sorted(individual_results, key=lambda res: res.formatter_name)
+    for result in sorted_results:
         console.print_stderr(
             f"{console.green('✓')} {result.formatter_name} made no changes."
             if not result.did_change
             else f"{console.red('𐄂')} {result.formatter_name} made changes."
         )
         if result.stdout:
-            console.print_stdout(result.stdout)
+            console.print_stderr(result.stdout)
         if result.stderr:
             console.print_stderr(result.stderr)
-        console.print_stderr("")
+        if result != sorted_results[-1]:
+            console.print_stderr("")
 
     # Since the rules to produce FmtResult should use ExecuteRequest, rather than
     # FallibleProcess, we assume that there were no failures.

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -64,6 +64,7 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
                     output=EMPTY_DIGEST,
                     stdout=self.stdout(addresses),
                     stderr="",
+                    formatter_name="MockFormatter",
                 ),
             ),
             input=EMPTY_DIGEST,

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -3,7 +3,8 @@
 
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Iterable, List, Optional, Type, cast
+from textwrap import dedent
+from typing import ClassVar, Iterable, List, Optional, Type, cast
 
 from pants.base.specs import SingleAddress
 from pants.core.goals.fmt import (
@@ -46,6 +47,8 @@ class InvalidSources(Sources):
 
 
 class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
+    formatter_name: ClassVar[str]
+
     @staticmethod
     @abstractmethod
     def stdout(_: Iterable[Address]) -> str:
@@ -55,16 +58,14 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
         addresses = [
             target_with_origin.target.address for target_with_origin in self.targets_with_origins
         ]
-        # NB: For these tests, we only care that
-        # LanguageFmtResults.input != LanguageFmtResults.output so that we write to the build root.
         return LanguageFmtResults(
             (
                 FmtResult(
                     input=EMPTY_DIGEST,
-                    output=EMPTY_DIGEST,
+                    output=result_digest,
                     stdout=self.stdout(addresses),
                     stderr="",
-                    formatter_name="MockFormatter",
+                    formatter_name=self.formatter_name,
                 ),
             ),
             input=EMPTY_DIGEST,
@@ -74,26 +75,29 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
 
 class FortranTargets(MockLanguageTargets):
     required_fields = (FortranSources,)
+    formatter_name = "FortranFormatter"
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Fortran targets: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class SmalltalkTargets(MockLanguageTargets):
     required_fields = (SmalltalkSources,)
+    formatter_name = "SmalltalkFormatter"
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Smalltalk targets: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class InvalidTargets(MockLanguageTargets):
     required_fields = (InvalidSources,)
+    formatter_name = "InvalidFormatter"
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Invalid targets: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class FmtTest(TestBase):
@@ -159,7 +163,8 @@ class FmtTest(TestBase):
             union_membership=union_membership,
         )
         assert result.exit_code == 0
-        return cast(str, console.stdout.getvalue())
+        assert not console.stdout.getvalue()
+        return cast(str, console.stderr.getvalue())
 
     def assert_workspace_modified(
         self, *, fortran_formatted: bool, smalltalk_formatted: bool
@@ -175,14 +180,14 @@ class FmtTest(TestBase):
 
     def test_empty_target_noops(self) -> None:
         def assert_noops(*, per_target_caching: bool) -> None:
-            stdout = self.run_fmt_rule(
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets],
                 targets=[self.make_target_with_origin()],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
                 include_sources=False,
             )
-            assert stdout.strip() == ""
+            assert stderr.strip() == ""
             self.assert_workspace_modified(fortran_formatted=False, smalltalk_formatted=False)
 
         assert_noops(per_target_caching=False)
@@ -190,13 +195,13 @@ class FmtTest(TestBase):
 
     def test_invalid_target_noops(self) -> None:
         def assert_noops(*, per_target_caching: bool) -> None:
-            stdout = self.run_fmt_rule(
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[InvalidTargets],
                 targets=[self.make_target_with_origin()],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
             )
-            assert stdout.strip() == ""
+            assert stderr.strip() == ""
             self.assert_workspace_modified(fortran_formatted=False, smalltalk_formatted=False)
 
         assert_noops(per_target_caching=False)
@@ -207,14 +212,18 @@ class FmtTest(TestBase):
         target_with_origin = self.make_target_with_origin(address)
 
         def assert_expected(*, per_target_caching: bool) -> None:
-
-            stdout = self.run_fmt_rule(
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets],
                 targets=[target_with_origin],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
             )
-            assert stdout.strip() == FortranTargets.stdout([address])
+            assert stderr == dedent(
+                f"""\
+                𐄂 FortranFormatter made changes.
+                {FortranTargets.stdout([address])}
+                """
+            )
             self.assert_workspace_modified(fortran_formatted=True, smalltalk_formatted=False)
 
         assert_expected(per_target_caching=False)
@@ -223,27 +232,38 @@ class FmtTest(TestBase):
     def test_single_language_with_multiple_targets(self) -> None:
         addresses = [Address.parse(":t1"), Address.parse(":t2")]
 
-        def get_stdout(*, per_target_caching: bool) -> str:
-            stdout = self.run_fmt_rule(
+        def get_stderr(*, per_target_caching: bool) -> str:
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets],
                 targets=[self.make_target_with_origin(addr) for addr in addresses],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
             )
             self.assert_workspace_modified(fortran_formatted=True, smalltalk_formatted=False)
-            return stdout
+            return stderr
 
-        assert get_stdout(per_target_caching=False).strip() == FortranTargets.stdout(addresses)
-        assert get_stdout(per_target_caching=True).splitlines() == [
-            FortranTargets.stdout([address]) for address in addresses
-        ]
+        assert get_stderr(per_target_caching=False) == dedent(
+            f"""\
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout(addresses)}
+            """
+        )
+        assert get_stderr(per_target_caching=True) == dedent(
+            f"""\
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout([addresses[0]])}
+
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout([addresses[1]])}
+            """
+        )
 
     def test_multiple_languages_with_single_targets(self) -> None:
         fortran_address = Address.parse(":fortran")
         smalltalk_address = Address.parse(":smalltalk")
 
         def assert_expected(*, per_target_caching: bool) -> None:
-            stdout = self.run_fmt_rule(
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets, SmalltalkTargets],
                 targets=[
                     self.make_target_with_origin(fortran_address, target_cls=FortranTarget),
@@ -252,10 +272,15 @@ class FmtTest(TestBase):
                 result_digest=self.merged_digest,
                 per_target_caching=per_target_caching,
             )
-            assert stdout.splitlines() == [
-                FortranTargets.stdout([fortran_address]),
-                SmalltalkTargets.stdout([smalltalk_address]),
-            ]
+            assert stderr == dedent(
+                f"""\
+                𐄂 FortranFormatter made changes.
+                {FortranTargets.stdout([fortran_address])}
+    
+                𐄂 SmalltalkFormatter made changes.
+                {SmalltalkTargets.stdout([smalltalk_address])}
+                """
+            )
             self.assert_workspace_modified(fortran_formatted=True, smalltalk_formatted=True)
 
         assert_expected(per_target_caching=False)
@@ -274,21 +299,37 @@ class FmtTest(TestBase):
             for addr in smalltalk_addresses
         ]
 
-        def get_stdout(*, per_target_caching: bool) -> str:
-            stdout = self.run_fmt_rule(
+        def get_stderr(*, per_target_caching: bool) -> str:
+            stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets, SmalltalkTargets],
                 targets=[*fortran_targets, *smalltalk_targets],
                 result_digest=self.merged_digest,
                 per_target_caching=per_target_caching,
             )
             self.assert_workspace_modified(fortran_formatted=True, smalltalk_formatted=True)
-            return stdout
+            return stderr
 
-        assert get_stdout(per_target_caching=False).splitlines() == [
-            FortranTargets.stdout(fortran_addresses),
-            SmalltalkTargets.stdout(smalltalk_addresses),
-        ]
-        assert get_stdout(per_target_caching=True).splitlines() == [
-            *(FortranTargets.stdout([address]) for address in fortran_addresses),
-            *(SmalltalkTargets.stdout([address]) for address in smalltalk_addresses),
-        ]
+        assert get_stderr(per_target_caching=False) == dedent(
+            f"""\
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout(fortran_addresses)}
+
+            𐄂 SmalltalkFormatter made changes.
+            {SmalltalkTargets.stdout(smalltalk_addresses)}
+            """
+        )
+        assert get_stderr(per_target_caching=True) == dedent(
+            f"""\
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout([fortran_addresses[0]])}
+
+            𐄂 FortranFormatter made changes.
+            {FortranTargets.stdout([fortran_addresses[1]])}
+
+            𐄂 SmalltalkFormatter made changes.
+            {SmalltalkTargets.stdout([smalltalk_addresses[0]])}
+
+            𐄂 SmalltalkFormatter made changes.
+            {SmalltalkTargets.stdout([smalltalk_addresses[1]])}
+            """
+        )

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -25,14 +25,15 @@ class LintResult:
     exit_code: int
     stdout: str
     stderr: str
+    linter_name: str
 
     @staticmethod
     def noop() -> "LintResult":
-        return LintResult(exit_code=0, stdout="", stderr="")
+        return LintResult(exit_code=0, stdout="", stderr="", linter_name="")
 
     @staticmethod
     def from_fallible_process_result(
-        process_result: FallibleProcessResult, *, strip_chroot_path: bool = False
+        process_result: FallibleProcessResult, *, linter_name: str, strip_chroot_path: bool = False
     ) -> "LintResult":
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
@@ -41,6 +42,7 @@ class LintResult:
             exit_code=process_result.exit_code,
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
+            linter_name=linter_name,
         )
 
 
@@ -146,11 +148,17 @@ async def lint(
         return Lint(exit_code=0)
 
     exit_code = 0
-    for result in results:
+    for result in sorted(results, key=lambda res: res.linter_name):
+        console.print_stderr(
+            f"{console.green('✓')} {result.linter_name} succeeded."
+            if result.exit_code == 0
+            else f"{console.red('𐄂')} {result.linter_name} failed."
+        )
         if result.stdout:
             console.print_stdout(result.stdout)
         if result.stderr:
             console.print_stderr(result.stderr)
+        console.print_stderr("")
         if result.exit_code != 0:
             exit_code = result.exit_code
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -148,17 +148,19 @@ async def lint(
         return Lint(exit_code=0)
 
     exit_code = 0
-    for result in sorted(results, key=lambda res: res.linter_name):
+    sorted_results = sorted(results, key=lambda res: res.linter_name)
+    for result in sorted_results:
         console.print_stderr(
             f"{console.green('✓')} {result.linter_name} succeeded."
             if result.exit_code == 0
             else f"{console.red('𐄂')} {result.linter_name} failed."
         )
         if result.stdout:
-            console.print_stdout(result.stdout)
+            console.print_stderr(result.stdout)
         if result.stderr:
             console.print_stderr(result.stderr)
-        console.print_stderr("")
+        if result != sorted_results[-1]:
+            console.print_stderr("")
         if result.exit_code != 0:
             exit_code = result.exit_code
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -49,7 +49,9 @@ class MockLinterFieldSets(LinterFieldSets, metaclass=ABCMeta):
     @property
     def lint_result(self) -> LintResult:
         addresses = [config.address for config in self]
-        return LintResult(self.exit_code(addresses), self.stdout(addresses), "")
+        return LintResult(
+            self.exit_code(addresses), self.stdout(addresses), "", linter_name="MockLinter"
+        )
 
 
 class SuccessfulFieldSets(MockLinterFieldSets):

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABCMeta, abstractmethod
-from typing import Iterable, List, Optional, Tuple, Type
+from textwrap import dedent
+from typing import ClassVar, Iterable, List, Optional, Tuple, Type
 
 from pants.base.specs import SingleAddress
 from pants.core.goals.lint import (
@@ -35,6 +36,7 @@ class MockLinterFieldSet(LinterFieldSet):
 
 class MockLinterFieldSets(LinterFieldSets, metaclass=ABCMeta):
     field_set_type = MockLinterFieldSet
+    linter_name: ClassVar[str]
 
     @staticmethod
     @abstractmethod
@@ -50,31 +52,37 @@ class MockLinterFieldSets(LinterFieldSets, metaclass=ABCMeta):
     def lint_result(self) -> LintResult:
         addresses = [config.address for config in self]
         return LintResult(
-            self.exit_code(addresses), self.stdout(addresses), "", linter_name="MockLinter"
+            self.exit_code(addresses), self.stdout(addresses), "", linter_name=self.linter_name
         )
 
 
 class SuccessfulFieldSets(MockLinterFieldSets):
+    linter_name = "SuccessfulLinter"
+
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
         return 0
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Successful linter: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class FailingFieldSets(MockLinterFieldSets):
+    linter_name = "FailingLinter"
+
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
         return 1
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Failing linter: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class ConditionallySucceedsFieldSets(MockLinterFieldSets):
+    linter_name = "ConditionallySucceedsLinter"
+
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
         if any(address.target_name == "bad" for address in addresses):
@@ -83,7 +91,7 @@ class ConditionallySucceedsFieldSets(MockLinterFieldSets):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Conditionally succeeds linter: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class InvalidField(Sources):
@@ -96,6 +104,7 @@ class InvalidFieldSet(MockLinterFieldSet):
 
 class InvalidFieldSets(MockLinterFieldSets):
     field_set_type = InvalidFieldSet
+    linter_name = "InvalidLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -103,7 +112,7 @@ class InvalidFieldSets(MockLinterFieldSets):
 
     @staticmethod
     def stdout(addresses: Iterable[Address]) -> str:
-        return f"Invalid target linter: {', '.join(str(address) for address in addresses)}"
+        return ", ".join(str(address) for address in addresses)
 
 
 class LintTest(TestBase):
@@ -150,31 +159,32 @@ class LintTest(TestBase):
             ],
             union_membership=union_membership,
         )
-        return result.exit_code, console.stdout.getvalue()
+        assert not console.stdout.getvalue()
+        return result.exit_code, console.stderr.getvalue()
 
     def test_empty_target_noops(self) -> None:
         def assert_noops(per_target_caching: bool) -> None:
-            exit_code, stdout = self.run_lint_rule(
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[FailingFieldSets],
                 targets=[self.make_target_with_origin()],
                 per_target_caching=per_target_caching,
                 include_sources=False,
             )
             assert exit_code == 0
-            assert stdout == ""
+            assert stderr == ""
 
         assert_noops(per_target_caching=False)
         assert_noops(per_target_caching=True)
 
     def test_invalid_target_noops(self) -> None:
         def assert_noops(per_target_caching: bool) -> None:
-            exit_code, stdout = self.run_lint_rule(
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[InvalidFieldSets],
                 targets=[self.make_target_with_origin()],
                 per_target_caching=per_target_caching,
             )
             assert exit_code == 0
-            assert stdout == ""
+            assert stderr == ""
 
         assert_noops(per_target_caching=False)
         assert_noops(per_target_caching=True)
@@ -184,13 +194,18 @@ class LintTest(TestBase):
         target_with_origin = self.make_target_with_origin(address)
 
         def assert_expected(per_target_caching: bool) -> None:
-            exit_code, stdout = self.run_lint_rule(
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[FailingFieldSets],
                 targets=[target_with_origin],
                 per_target_caching=per_target_caching,
             )
             assert exit_code == FailingFieldSets.exit_code([address])
-            assert stdout.strip() == FailingFieldSets.stdout([address])
+            assert stderr == dedent(
+                f"""\
+                𐄂 FailingLinter failed.
+                {FailingFieldSets.stdout([address])}
+                """
+            )
 
         assert_expected(per_target_caching=False)
         assert_expected(per_target_caching=True)
@@ -200,16 +215,21 @@ class LintTest(TestBase):
         target_with_origin = self.make_target_with_origin(address)
 
         def assert_expected(per_target_caching: bool) -> None:
-            exit_code, stdout = self.run_lint_rule(
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[SuccessfulFieldSets, FailingFieldSets],
                 targets=[target_with_origin],
                 per_target_caching=per_target_caching,
             )
             assert exit_code == FailingFieldSets.exit_code([address])
-            assert stdout.splitlines() == [
-                SuccessfulFieldSets.stdout([address]),
-                FailingFieldSets.stdout([address]),
-            ]
+            assert stderr == dedent(
+                f"""\
+                𐄂 FailingLinter failed.
+                {FailingFieldSets.stdout([address])}
+
+                ✓ SuccessfulLinter succeeded.
+                {SuccessfulFieldSets.stdout([address])}
+                """
+            )
 
         assert_expected(per_target_caching=False)
         assert_expected(per_target_caching=True)
@@ -218,8 +238,8 @@ class LintTest(TestBase):
         good_address = Address.parse(":good")
         bad_address = Address.parse(":bad")
 
-        def get_stdout(*, per_target_caching: bool) -> str:
-            exit_code, stdout = self.run_lint_rule(
+        def get_stderr(*, per_target_caching: bool) -> str:
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[ConditionallySucceedsFieldSets],
                 targets=[
                     self.make_target_with_origin(good_address),
@@ -228,23 +248,31 @@ class LintTest(TestBase):
                 per_target_caching=per_target_caching,
             )
             assert exit_code == ConditionallySucceedsFieldSets.exit_code([bad_address])
-            return stdout
+            return stderr
 
-        stdout = get_stdout(per_target_caching=False)
-        assert stdout.strip() == ConditionallySucceedsFieldSets.stdout([good_address, bad_address])
+        assert get_stderr(per_target_caching=False) == dedent(
+            f"""\
+            𐄂 ConditionallySucceedsLinter failed.
+            {ConditionallySucceedsFieldSets.stdout([good_address, bad_address])}
+            """
+        )
 
-        stdout = get_stdout(per_target_caching=True)
-        assert stdout.splitlines() == [
-            ConditionallySucceedsFieldSets.stdout([address])
-            for address in [good_address, bad_address]
-        ]
+        assert get_stderr(per_target_caching=True) == dedent(
+            f"""\
+            ✓ ConditionallySucceedsLinter succeeded.
+            {ConditionallySucceedsFieldSets.stdout([good_address])}
+
+            𐄂 ConditionallySucceedsLinter failed.
+            {ConditionallySucceedsFieldSets.stdout([bad_address])}
+            """
+        )
 
     def test_multiple_targets_with_multiple_linters(self) -> None:
         good_address = Address.parse(":good")
         bad_address = Address.parse(":bad")
 
-        def get_stdout(*, per_target_caching: bool) -> str:
-            exit_code, stdout = self.run_lint_rule(
+        def get_stderr(*, per_target_caching: bool) -> str:
+            exit_code, stderr = self.run_lint_rule(
                 field_set_collection_types=[ConditionallySucceedsFieldSets, SuccessfulFieldSets,],
                 targets=[
                     self.make_target_with_origin(good_address),
@@ -253,17 +281,30 @@ class LintTest(TestBase):
                 per_target_caching=per_target_caching,
             )
             assert exit_code == ConditionallySucceedsFieldSets.exit_code([bad_address])
-            return stdout
+            return stderr
 
-        stdout = get_stdout(per_target_caching=False)
-        assert stdout.splitlines() == [
-            field_set_collection.stdout([good_address, bad_address])
-            for field_set_collection in [ConditionallySucceedsFieldSets, SuccessfulFieldSets]
-        ]
+        assert get_stderr(per_target_caching=False) == dedent(
+            f"""\
+            𐄂 ConditionallySucceedsLinter failed.
+            {ConditionallySucceedsFieldSets.stdout([good_address, bad_address])}
 
-        stdout = get_stdout(per_target_caching=True)
-        assert stdout.splitlines() == [
-            field_set_collection.stdout([address])
-            for field_set_collection in [ConditionallySucceedsFieldSets, SuccessfulFieldSets]
-            for address in [good_address, bad_address]
-        ]
+            ✓ SuccessfulLinter succeeded.
+            {SuccessfulFieldSets.stdout([good_address, bad_address])}
+            """
+        )
+
+        assert get_stderr(per_target_caching=True) == dedent(
+            f"""\
+            ✓ ConditionallySucceedsLinter succeeded.
+            {ConditionallySucceedsFieldSets.stdout([good_address])}
+
+            𐄂 ConditionallySucceedsLinter failed.
+            {ConditionallySucceedsFieldSets.stdout([bad_address])}
+
+            ✓ SuccessfulLinter succeeded.
+            {SuccessfulFieldSets.stdout([good_address])}
+
+            ✓ SuccessfulLinter succeeded.
+            {SuccessfulFieldSets.stdout([bad_address])}
+            """
+        )


### PR DESCRIPTION
### Problem

It's confusing which linters and formatters have run. For example, docformatter will simply put the file name with no context when there is a lint failure, like this:

```bash
$ ./v2 lint src/python::

src/python/pants/util/strutil.py
```

Goals of the design:
1. Disambiguate which linters were run.
2. Preserve the original output.
3. Be minimally intrusive to the user.

### Result

![fmt example](https://user-images.githubusercontent.com/14852634/81235842-c035f880-8fb0-11ea-92c5-6e2952b17f37.png)

![lint example](https://user-images.githubusercontent.com/14852634/81236042-30447e80-8fb1-11ea-92f8-ec4e30b86ff6.png)

We always write to stderr for consistency and to follow the Unix philosophy. Because the output mangles multiple tools into one stream, the output cannot be safely piped to other tools. (Instead, we should add support for writing tool output to specific files, like we allow with Pytest.)

[ci skip-rust-tests]
[ci skip-jvm-tests]
