### PR TITLE
improve jvm-platform version parsing assumptions around later jvm versions

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -313,7 +313,7 @@ class JvmPlatform(Subsystem):
         elif version.components[0] in cls.SUPPORTED_CONVERSION_VERSIONS:
             return Revision(1, version.components[0])
         elif version.components[0] > 8:
-            return Revision(*version.components)
+            return Revision(version.components[0])
         else:
             raise ValueError(f"Unsupported Java version {version}")
 

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jvm_platform.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jvm_platform.py
@@ -19,6 +19,27 @@ class HasRuntimePlatform(RuntimePlatformMixin, JvmTarget):
 
 
 class JvmPlatformTest(TestBase):
+    def test_parse_java_version(self):
+        def parse(v):
+            return JvmPlatform.parse_java_version(v)
+
+        def rev(v):
+            return Revision.lenient(v)
+
+        assert parse("1.8") == rev("1.8")
+        assert parse("1.8.2") == rev("1.8")
+        assert parse("1.9") == rev("9")
+        assert parse("6") == rev("1.6")
+        assert parse("7") == rev("1.7")
+        assert parse("8") == rev("1.8")
+        assert parse("8.0") == rev("1.8")
+        assert parse("9") == rev("9")
+        assert parse("10") == rev("10")
+        assert parse("11") == rev("11")
+        assert parse("11.0") == rev("11")
+        with self.assertRaisesWithMessage(ValueError, "Unsupported Java version 5"):
+            parse("5")
+
     def test_runtime_lookup_both_defaults(self):
         init_subsystem(
             JvmPlatform,

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jvm_platform.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jvm_platform.py
@@ -26,6 +26,7 @@ class JvmPlatformTest(TestBase):
         def rev(v):
             return Revision.lenient(v)
 
+        assert parse("1.6.2") == rev("1.6")
         assert parse("1.8") == rev("1.8")
         assert parse("1.8.2") == rev("1.8")
         assert parse("1.9") == rev("9")
@@ -37,6 +38,7 @@ class JvmPlatformTest(TestBase):
         assert parse("10") == rev("10")
         assert parse("11") == rev("11")
         assert parse("11.0") == rev("11")
+        assert parse("99.0") == rev("99")
         with self.assertRaisesWithMessage(ValueError, "Unsupported Java version 5"):
             parse("5")
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -225,8 +225,8 @@ class JavaCompileSettingsPartitioningTest(NailgunTaskTestBase):
 
     def test_java_home_extraction_missing_distributions(self):
         # This will need to be bumped if java ever gets to major version one million.
-        far_future_version = "999999.1"
-        farer_future_version = "999999.2"
+        far_future_version = "999998"
+        farer_future_version = "999999"
 
         os_name = normalize_os_name(get_os_name())
 


### PR DESCRIPTION
[ci skip-rust-tests]
[ci skip-jvm-tests]

### Problem

When passed eg `11.0`, it didn't truncate the `.0` from the version, confusing javac.

### Solution

rewrite the truncation to cover more cases.

### Result

Better version support.