### PR TITLE
Upgrade responses.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -33,7 +33,7 @@ pywatchman==1.4.1
 PyYAML>=5.3.1,<5.4
 py_zipkin==0.18.4
 requests[security]>=2.20.1
-responses==0.10.4
+responses==0.10.14
 setproctitle==1.1.10
 setuptools==44.0.0
 toml==0.10.0


### PR DESCRIPTION
https://github.com/getsentry/responses/blob/master/CHANGES
- Improved README examples.
- Improved handling of unicode bodies. The inferred content-type for unicode
  bodies is now `text/plain; charset=utf-8`.
- Streamlined querysting matching code.
- Fixed incorrect content-type in `add_callback()` when headers are provided as a list of tuples.
- Fixed invalid README formatted.
- Fixed string formatting in error message.
- Added Python 3.8 support
- Remove Python 3.4 from test suite matrix.
- The `response.request` object now has a `params` attribute that contains the query string parameters from the request that was captured.
- `add_passthru` now supports `re` pattern objects to match URLs.
- ConnectionErrors raised by responses now include more details on the request that was attempted and the mocks registered.
- Fixed regression with `add_callback()` and content-type header.
- Fixed implicit dependency on urllib3>1.23.0
- Fixed cookie parsing and enabled multiple cookies to be set by using a list of
  tuple values.
- Added pypi badges to README.
- Fixed formatting issues in README.
- Quoted cookie values are returned correctly now.
- Improved compatibility for pytest 5
- Module level method names are no longer generated dynamically improving IDE navigation.
- Improved documentation.
- Improved installation requirements for py3
- ConnectionError's raised by responses now indicate which request
  path/method failed to match a mock.
- `test_responses.py` is no longer part of the installation targets.
- Improved support for raising exceptions from callback mocks. If a mock
  callback returns an exception object that exception will be raised.