### PR TITLE
Fix brfs to cleanly unmount.

### DIFF
--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -22,7 +22,7 @@ serverset = { path = "../../serverset" }
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.1.39"
-tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
+tokio = { version = "0.2", features = ["rt-threaded", "macros", "signal", "stream"] }
 workunit_store = { path = "../../workunit_store" }
 
 [dev-dependencies]


### PR DESCRIPTION
Previously a hack to unmount any dangling mount was in place. Now we set
up signal handlers to cleanly exit when killed or CTRL-C'd.

Additionally clean up lifecycle handling. Previously we slept and hoped
the filesystem was mounted. Now we leverage previously un-implemented
FUSE lifecycle methods `init` and `destroy` to synchronize on mount and
handle external unmounts (by umount or by fusermount -u) respectively.

Finally - wire up logging with env_logger.

[ci skip-jvm-tests]