### PR TITLE
Improve output of V2 `test` goal

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -135,7 +135,7 @@ class ConsoleCoverageReport(CoverageReport):
     report: str
 
     def materialize(self, console: Console, workspace: Workspace) -> Optional[PurePath]:
-        console.print_stdout(f"\n{self.report}")
+        console.print_stderr(f"\n{self.report}")
         return None
 
 
@@ -153,7 +153,7 @@ class FilesystemCoverageReport(CoverageReport):
                 self.result_digest, path_prefix=str(self.directory_to_materialize_to),
             )
         )
-        console.print_stdout(f"\nWrote coverage report to `{self.directory_to_materialize_to}`")
+        console.print_stderr(f"\nWrote coverage report to `{self.directory_to_materialize_to}`")
         return self.report_file
 
 
@@ -216,7 +216,6 @@ async def run_tests(
             )
         )
         field_set = targets_to_valid_field_sets.field_sets[0]
-        logger.info(f"Starting test in debug mode: {field_set.address.reference()}")
         request = await Get[TestDebugRequest](TestFieldSet, field_set)
         debug_result = interactive_runner.run_local_interactive_process(request.ipr)
         return Test(debug_result.process_exit_code)
@@ -237,33 +236,33 @@ async def run_tests(
         for field_set in field_sets_with_sources
     )
 
-    did_any_fail = False
+    exit_code = PANTS_SUCCEEDED_EXIT_CODE
     for result in results:
         if result.test_result.status == Status.FAILURE:
-            did_any_fail = True
+            exit_code = PANTS_FAILED_EXIT_CODE
+        has_output = result.test_result.stdout or result.test_result.stderr
+        if has_output:
+            status = (
+                console.green("✓")
+                if result.test_result.status == Status.SUCCESS
+                else console.red("𐄂")
+            )
+            console.print_stderr(f"{status} {result.address}")
         if result.test_result.stdout:
-            console.write_stdout(
-                f"{result.address.reference()} stdout:\n{result.test_result.stdout}\n"
-            )
+            console.print_stderr(result.test_result.stdout)
         if result.test_result.stderr:
-            # NB: we write to stdout, rather than to stderr, to avoid potential issues interleaving
-            # the two streams.
-            console.write_stdout(
-                f"{result.address.reference()} stderr:\n{result.test_result.stderr}\n"
+            console.print_stderr(result.test_result.stderr)
+        if has_output and result != results[-1]:
+            console.print_stderr("")
+
+    # Print summary
+    if len(results) > 1:
+        console.print_stderr("")
+        for result in results:
+            console.print_stderr(
+                f"{result.address.reference():80}.....{result.test_result.status.value:>10}"
             )
 
-    console.write_stdout("\n")
-
-    for result in results:
-        console.print_stdout(
-            f"{result.address.reference():80}.....{result.test_result.status.value:>10}"
-        )
-
-    if did_any_fail:
-        console.print_stderr(console.red("\nTests failed"))
-        exit_code = PANTS_FAILED_EXIT_CODE
-    else:
-        exit_code = PANTS_SUCCEEDED_EXIT_CODE
     for result in results:
         xml_results = result.test_result.xml_results
         if not xml_results:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -196,38 +196,38 @@ class TestTest(TestBase):
             ],
             union_membership=union_membership,
         )
-        return result.exit_code, console.stdout.getvalue()
+        assert not console.stdout.getvalue()
+        return result.exit_code, console.stderr.getvalue()
 
     def test_empty_target_noops(self) -> None:
-        exit_code, stdout = self.run_test_rule(
+        exit_code, stderr = self.run_test_rule(
             field_set=SuccessfulFieldSet,
             targets=[self.make_target_with_origin()],
             include_sources=False,
         )
         assert exit_code == 0
-        assert stdout.strip() == ""
+        assert stderr.strip() == ""
 
     def test_invalid_target_noops(self) -> None:
-        exit_code, stdout = self.run_test_rule(
+        exit_code, stderr = self.run_test_rule(
             field_set=SuccessfulFieldSet,
             targets=[self.make_target_with_origin()],
             valid_targets=False,
         )
         assert exit_code == 0
-        assert stdout.strip() == ""
+        assert stderr.strip() == ""
 
     def test_single_target(self) -> None:
         address = Address.parse(":tests")
-        exit_code, stdout = self.run_test_rule(
+        exit_code, stderr = self.run_test_rule(
             field_set=SuccessfulFieldSet, targets=[self.make_target_with_origin(address)]
         )
         assert exit_code == 0
-        assert stdout == dedent(
+        # NB: We don't render a summary when only running one target.
+        assert stderr == dedent(
             f"""\
-            {address} stdout:
+            ✓ {address}
             {SuccessfulFieldSet.stdout(address)}
-
-            {address}                                                                        .....   SUCCESS
             """
         )
 
@@ -235,7 +235,7 @@ class TestTest(TestBase):
         good_address = Address.parse(":good")
         bad_address = Address.parse(":bad")
 
-        exit_code, stdout = self.run_test_rule(
+        exit_code, stderr = self.run_test_rule(
             field_set=ConditionallySucceedsFieldSet,
             targets=[
                 self.make_target_with_origin(good_address),
@@ -243,11 +243,12 @@ class TestTest(TestBase):
             ],
         )
         assert exit_code == 1
-        assert stdout == dedent(
+        assert stderr == dedent(
             f"""\
-            {good_address} stdout:
+            ✓ {good_address}
             {ConditionallySucceedsFieldSet.stdout(good_address)}
-            {bad_address} stderr:
+
+            𐄂 {bad_address}
             {ConditionallySucceedsFieldSet.stderr(bad_address)}
 
             {good_address}                                                                         .....   SUCCESS

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3126,6 +3126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Changes:
* Don't log with `test --debug`.
* Stop explicitly separating `stdout` and `stderr` into distinct sections for the same result.
* Use `✓` and `𐄂` when outputting the test's output.
* Only render the summary if > 1 target.
* Don't output "Tests failed". The summary, return code, and individual results already express this.
* Always write to stderr. See https://github.com/pantsbuild/pants/pull/9710#issuecomment-624998470 for a justification.


![success](https://user-images.githubusercontent.com/14852634/81332659-448f8680-9058-11ea-9184-0bc729da8f19.png)

![failure](https://user-images.githubusercontent.com/14852634/81332671-48bba400-9058-11ea-9ee5-f0ccf544697e.png)

Once we have streaming workunits, we will replace the log statements with immediately writing the results to the console.

[ci skip-jvm-tests]
