### PR TITLE
Provide more useful and consistent console UI messages

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -47,6 +47,8 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   fn user_facing_name(&self) -> Option<String> {
     None
   }
+
+  fn canonical_name(&self) -> String;
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -43,7 +43,7 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   /// implementations). This user-facing name is intended to provide high-level information
   /// to end users of pants about what computation pants is currently doing. Not all
   /// `Node`s need a user-facing name. For `Node`s derived from Python `@rule`s, the
-  /// user-facing name should be the same as the `name` annotation on the rule decorator.
+  /// user-facing name should be the same as the `desc` annotation on the rule decorator.
   fn user_facing_name(&self) -> Option<String> {
     None
   }

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -648,6 +648,10 @@ impl Node for TNode {
   fn cacheable(&self) -> bool {
     self.1
   }
+
+  fn canonical_name(&self) -> String {
+    format!("{}", self)
+  }
 }
 
 impl std::fmt::Display for TNode {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -24,7 +24,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-#![type_length_limit = "32185118"]
+#![type_length_limit = "32187898"]
 #[macro_use]
 extern crate derivative;
 
@@ -431,11 +431,12 @@ impl CommandRunner for BoundedCommandRunner {
     req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    let name = req
+    let name = "multi_platform_process - waiting".to_string();
+    let desc = req
       .user_facing_name()
-      .unwrap_or_else(|| "Unnamed node".to_string());
+      .unwrap_or_else(|| "<Unnamed process>".to_string());
     let outer_metadata = WorkunitMetadata {
-      desc: Some("Workunit waiting for opportunity to run".to_string()),
+      desc: Some(desc.clone()),
       display: false,
       blocked: true,
     };
@@ -443,11 +444,11 @@ impl CommandRunner for BoundedCommandRunner {
       let inner = self.inner.clone();
       let semaphore = self.inner.1.clone();
       let context = context.clone();
-      let name = name.clone();
+      let name = "multi_platform_process - running".to_string();
 
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {
-          desc: Some("Workunit executing currently".to_string()),
+          desc: Some(desc),
           display: false,
           blocked: false,
         };

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -275,6 +275,10 @@ impl MultiPlatformProcess {
       .next()
       .map(|(_platforms, epr)| epr.description.clone())
   }
+
+  pub fn canonical_name(&self) -> String {
+    "MultiPlatformProcess".to_string()
+  }
 }
 
 impl From<Process> for MultiPlatformProcess {
@@ -431,7 +435,7 @@ impl CommandRunner for BoundedCommandRunner {
     req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    let name = "multi_platform_process - waiting".to_string();
+    let name = format!("{}-waiting", req.canonical_name());
     let desc = req
       .user_facing_name()
       .unwrap_or_else(|| "<Unnamed process>".to_string());
@@ -444,7 +448,7 @@ impl CommandRunner for BoundedCommandRunner {
       let inner = self.inner.clone();
       let semaphore = self.inner.1.clone();
       let context = context.clone();
-      let name = "multi_platform_process - running".to_string();
+      let name = format!("{}-running", req.canonical_name());
 
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -28,6 +28,7 @@
 // just the one minor call as unsafe, than to mark the whole function as unsafe which may hide
 // other unsafeness.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![type_length_limit = "42187898"]
 
 mod context;
 mod core;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1162,6 +1162,7 @@ impl Node for NodeKey {
         .and_then(|di| di.name.as_ref())
         .map(|s| s.to_owned())
         .unwrap_or_else(|| format!("{}", self)),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.canonical_name(),
       _ => format!("{}", self),
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1064,7 +1064,7 @@ impl Node for NodeKey {
 
     let started_workunit_id = {
       let display = context.session.should_handle_workunits() && self.user_facing_name().is_some();
-      let name = self.display_info().and_then(|di| di.name.as_ref().cloned()).unwrap_or(format!("{}", self));
+      let name = self.canonical_name();
       let span_id = new_span_id();
 
       // We're starting a new workunit: record our parent, and set the current parent to our span.
@@ -1150,6 +1150,17 @@ impl Node for NodeKey {
       NodeKey::ReadLink(..) => None,
       NodeKey::Scandir(..) => None,
       NodeKey::Select(..) => None,
+    }
+  }
+
+  fn canonical_name(&self) -> String {
+    match self {
+      NodeKey::Task(_) => self
+        .display_info()
+        .and_then(|di| di.name.as_ref())
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| format!("{}", self)),
+      _ => format!("{}", self),
     }
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1063,7 +1063,8 @@ impl Node for NodeKey {
     let mut workunit_state = workunit_store::expect_workunit_state();
 
     let started_workunit_id = {
-      let display = context.session.should_handle_workunits() && self.user_facing_name().is_some();
+      let display = context.session.should_handle_workunits()
+        && (self.user_facing_name().is_some() || self.display_info().is_some());
       let name = self.canonical_name();
       let span_id = new_span_id();
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1145,10 +1145,12 @@ impl Node for NodeKey {
       NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
       NodeKey::Snapshot(_) => Some(format!("{}", self)),
       NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.user_facing_name(),
-      NodeKey::DigestFile(..) => None,
+      NodeKey::DigestFile(DigestFile(File { path, .. })) => {
+        Some(format!("Fingerprinting: {}", path.display()))
+      }
       NodeKey::DownloadedFile(..) => None,
       NodeKey::ReadLink(..) => None,
-      NodeKey::Scandir(..) => None,
+      NodeKey::Scandir(Scandir(Dir(path))) => Some(format!("Reading {}", path.display())),
       NodeKey::Select(..) => None,
     }
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -311,7 +311,7 @@ impl Tasks {
       .expect("Must `begin()` a task creation before adding display info!");
     task.display_info = DisplayInfo {
       name: Some(name),
-      desc: Some(desc),
+      desc: if desc.is_empty() { None } else { Some(desc) },
     };
   }
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -200,25 +200,21 @@ impl WorkUnitStore {
     let mut res = HashMap::new();
     while let Some((dur, span_id)) = queue.pop() {
       let record = inner.workunit_records.get(&span_id).unwrap();
-      let (name, desc, blocked) = match record {
+      let (desc, blocked) = match record {
         WorkunitRecord::Started(StartedWorkUnit {
-          name,
           metadata: WorkunitMetadata { blocked, desc, .. },
           ..
-        }) => (name, desc, *blocked),
+        }) => (desc, *blocked),
         WorkunitRecord::Completed(WorkUnit {
-          name,
           metadata: WorkunitMetadata { blocked, desc, .. },
           ..
-        }) => (name, desc, *blocked),
+        }) => (desc, *blocked),
       };
       let maybe_duration = if blocked { None } else { Some(dur) };
-      let effective_name = match desc {
-        Some(text) => text.to_string(),
-        None => name.to_string(),
-      };
+      if let Some(effective_name) = desc {
+        res.insert(effective_name.to_string(), maybe_duration);
+      }
 
-      res.insert(effective_name, maybe_duration);
       if res.len() >= k {
         break;
       }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -200,20 +200,25 @@ impl WorkUnitStore {
     let mut res = HashMap::new();
     while let Some((dur, span_id)) = queue.pop() {
       let record = inner.workunit_records.get(&span_id).unwrap();
-      let (name, blocked) = match record {
+      let (name, desc, blocked) = match record {
         WorkunitRecord::Started(StartedWorkUnit {
           name,
-          metadata: WorkunitMetadata { blocked, .. },
+          metadata: WorkunitMetadata { blocked, desc, .. },
           ..
-        }) => (name.clone(), *blocked),
+        }) => (name, desc, *blocked),
         WorkunitRecord::Completed(WorkUnit {
           name,
-          metadata: WorkunitMetadata { blocked, .. },
+          metadata: WorkunitMetadata { blocked, desc, .. },
           ..
-        }) => (name.clone(), *blocked),
+        }) => (name, desc, *blocked),
       };
       let maybe_duration = if blocked { None } else { Some(dur) };
-      res.insert(name, maybe_duration);
+      let effective_name = match desc {
+        Some(text) => text.to_string(),
+        None => name.to_string(),
+      };
+
+      res.insert(effective_name, maybe_duration);
       if res.len() >= k {
         break;
       }


### PR DESCRIPTION
### Problem

We currently have a few inconsistent ways of displaying a representation of a chunk of work in pants - we can use the `fmt::Display` implementation of a `Node` rust type, or the `user_facing_name` method defined for a `Node`, or use the `name` or `description. We sometimes show human-friendly names of pants work items in the console UI, and other times show debug representations.

### Solution

This commit makes a few separate changes with the aim of providing a more consistent and useful user experience:
- `Node`s now have a `canonical_name` method in addition to `user_facing_name`
- `canonical_name` should consistently map to the `name` key on a workunit, and is intended to be used as a machine-friendly key for code that needs to manipulate workunits. There is a little bit of special casing around blocked and currently-executing workunits associated with the BoundedCommandRunner lock.
- `user_facing_name` consistently maps to the `description` key on a workunit, which is also what gets displayed in the console UI swimlanes
- workunits are not displayed in the console UI unless they have a description. This mostly prevents bare `@rule` function names, which come from `@rule`s defined in Python with no explicit `desc` annotation, from appearing in the console UI
- finally, this commit adds friendly `user_facing_name`s for the `ScanDir` and `DigestFile` nodes, in lieu of the Rust debug representation of these types

### Result

https://asciinema.org/a/327779 is an asciinema recording of a `pants test` run with these changes.