### PR TITLE
Fix up dependency features

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1223,7 +1223,6 @@ dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3126,6 +3125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -9,6 +9,5 @@ publish = false
 digest = "0.8"
 hex = "0.3.1"
 sha2 = "0.8"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_test = "1.0"


### PR DESCRIPTION
As per https://github.com/rust-lang/cargo/issues/4463 if this package
happens to be built via the `engine/Cargo.toml` it will succeed (because
the `derive` feature will be enabled), if built separately it will fail.

This enables the feature explicitly in the crate's `Cargo.toml`,
reflecting that the code accesses the re-exported version of the trait.
[ci skip-jvm-tests]