### PR TITLE
Rename V2's `--test-run-coverage` to `--test-use-coverage`

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -237,8 +237,8 @@ async def run_python_test(
         )
     env = {"PYTEST_ADDOPTS": " ".join(add_opts)}
 
-    run_coverage = test_options.values.run_coverage
-    output_dirs = [".coverage"] if run_coverage else []
+    use_coverage = test_options.values.use_coverage
+    output_dirs = [".coverage"] if use_coverage else []
     if test_setup.xml_dir:
         output_dirs.append(test_results_file)
     process = test_setup.test_runner_pex.create_process(
@@ -255,7 +255,7 @@ async def run_python_test(
     result = await Get[FallibleProcessResult](Process, process)
 
     coverage_data = None
-    if run_coverage:
+    if use_coverage:
         coverage_snapshot = await Get[Snapshot](
             SnapshotSubset(result.output_digest, PathGlobs([".coverage"]))
         )

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -109,9 +109,9 @@ async def setup_pytest_for_target(
     # and then by Pytest). See https://github.com/jaraco/zipp/pull/26.
     additional_args_for_pytest = ("--not-zip-safe",)
 
-    run_coverage = test_options.values.run_coverage
+    use_coverage = test_options.values.use_coverage
     plugin_file_digest: Optional[Digest] = (
-        await Get[Digest](InputFilesContent, COVERAGE_PLUGIN_INPUT) if run_coverage else None
+        await Get[Digest](InputFilesContent, COVERAGE_PLUGIN_INPUT) if use_coverage else None
     )
 
     pytest_pex_request = pex_request(
@@ -162,7 +162,7 @@ async def setup_pytest_for_target(
         Get[ImportablePythonSources](Targets(all_targets)),
         Get[SourceFiles](SpecifiedSourceFilesRequest, specified_source_files_request),
     ]
-    if run_coverage:
+    if use_coverage:
         requests.append(
             Get[CoverageConfig](
                 CoverageConfigRequest(
@@ -193,13 +193,13 @@ async def setup_pytest_for_target(
         pytest_pex.digest,
         test_runner_pex.digest,
     ]
-    if run_coverage:
+    if use_coverage:
         coverage_config = rest[0]
         digests_to_merge.append(coverage_config.digest)
     input_digest = await Get[Digest](MergeDigests(digests_to_merge))
 
     coverage_args = []
-    if run_coverage:
+    if use_coverage:
         coverage_args = [
             "--cov-report=",  # To not generate any output. https://pytest-cov.readthedocs.io/en/latest/config.html
         ]

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -134,7 +134,7 @@ class ConsoleCoverageReport(CoverageReport):
 
     report: str
 
-    def materialize(self, console: Console, workspace: Workspace) -> Optional[PurePath]:
+    def materialize(self, console: Console, workspace: Workspace) -> None:
         console.print_stderr(f"\n{self.report}")
         return None
 
@@ -174,21 +174,25 @@ class TestOptions(GoalSubsystem):
             "--debug",
             type=bool,
             default=False,
-            help="Run a single test target in an interactive process. This is necessary, for "
-            "example, when you add breakpoints in your code.",
+            help=(
+                "Run a single test target in an interactive process. This is necessary, for "
+                "example, when you add breakpoints to your code."
+            ),
         )
         register(
-            "--run-coverage",
+            "--use-coverage",
             type=bool,
             default=False,
-            help="Generate a coverage report for this test run.",
+            help="Generate a coverage report if the test runner supports it.",
         )
         register(
             "--open-coverage",
             type=bool,
             default=False,
-            help="If a coverage report file is generated, open it on the local system if the "
-            "system supports this.",
+            help=(
+                "If a coverage report file is generated, open it on the local system if the "
+                "system supports this."
+            ),
         )
 
 
@@ -269,7 +273,7 @@ async def run_tests(
             continue
         workspace.materialize_directory(DirectoryToMaterialize(xml_results))
 
-    if options.values.run_coverage:
+    if options.values.use_coverage:
         all_coverage_data: Iterable[CoverageData] = [
             result.test_result.coverage_data
             for result in results


### PR DESCRIPTION
`--run-coverage` isn't ergonomic because Pants thinks the `run` corresponds to the `run` option scope, so you can't type `./pants test --run-coverage` and must use the more verbose `./pants --test-run-coverage test`.

We can't use `--test-coverage` because it's claimed by `test.junit`.

--

This also adds basic testing for `test.py`'s coverage logic.

[ci skip-rust-tests]
[ci skip-jvm-tests]