### PR TITLE
Upgrade docutils from 0.14 to 0.16

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4>=4.6.0,<4.7
 cffi==1.13.2
 coverage>=4.5,<4.6
 dataclasses==0.6
-docutils==0.14
+docutils==0.16
 fasteners==0.15.0
 
 # The MyPy requirement should be maintained in lockstep with the requirement the Pants repo uses


### PR DESCRIPTION
https://docutils.sourceforge.io/RELEASE-NOTES.html

reStructuredText:
Keep backslash escapes in the document tree. This allows, e.g., escaping of author-separators in bibliographic fields.
LaTeX writer:
Informal titles of type "rubric" default to bold-italic and left aligned.
Deprecate \docutilsrole prefix for styling commands: use \DUrole instead.
Fix topic subtitle.
Add "latex writers" to the config_section_dependencies.
Ignore classes for rubric elements (class wrapper interferes with LaTeX formatting).
tools/buildhtml.py
New option "--html-writer" allows to select "html" (default), "html4" or "html5".
docutils/io.py
Remove the handle_io_errors option from io.FileInput/Output.
docutils/nodes.py
If auto_id_prefix ends with "%", this is replaced with the tag name.
Various bugfixes and improvements (see HISTORY).

reStructuredText:
Allow embedded colons in field list field names (before, tokens like :this:example: were considered ordinary text).
Fixed a bug with the "trim" options of the "unicode" directive.
languages: Added Korean localisation (ko).
Bugfixes (see HISTORY).