### PR TITLE
Upgrade pathspec from 0.5.9 to 0.8.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -22,7 +22,7 @@ mypy==0.770
 Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
-pathspec==0.5.9
+pathspec==0.8.0
 pex==2.1.9
 psutil==5.6.3
 Pygments==2.3.1


### PR DESCRIPTION
https://github.com/cpburnz/python-path-specification/blob/master/CHANGES.rst

Expose what patterns matched paths. Added util.detailed_match_files().
match_tree() doesn't return symlinks.
Support pathlib.Paths.
Add PathSpec.match_tree_entries and util.iter_tree_entries() to support directories and symlinks.
API change: match_tree() has been renamed to match_tree_files(). The old name match_tree() is still available as an alias.
API change: match_tree_files() now returns symlinks. This is a bug fix but it will change the returned results.
Add support for Python 3.8, and drop Python 3.4,  2.6, 3.2, and 3.3.
Publish bdist wheel.
Update README.rst.
Method to escape gitwildmatch.