### PR TITLE
Fix deprecated use of `Thread.isAlive()`

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -212,7 +212,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
                     stdout_pipe.stop_writing()
                     stderr_pipe.stop_writing()
                     writer.join(timeout=60)
-                    if writer.isAlive():
+                    if writer.is_alive():
                         raise NailgunStreamWriterError(
                             "pantsd timed out while waiting for the stdout/err to finish writing to the socket."
                         )

--- a/tests/python/pants_test/pantsd/service/test_pants_service.py
+++ b/tests/python/pants_test/pantsd/service/test_pants_service.py
@@ -46,8 +46,8 @@ class TestPantsService(TestBase):
         # there without exiting.
         self.assertTrue(self.service._state.await_paused(timeout=5))
         t.join(timeout=0.5)
-        self.assertTrue(t.isAlive())
+        self.assertTrue(t.is_alive())
         # Resume the service, and confirm that the child thread exits.
         self.service.resume()
         t.join(timeout=5)
-        self.assertFalse(t.isAlive())
+        self.assertFalse(t.is_alive())


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/9687.

[ci skip-rust-tests]
[ci skip-jvm-tests]
