### PR TITLE
Remove deprecated support for `within_data_subdir`.

### DIFF
--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -31,7 +31,7 @@ unpacked_whls(
     './*.so*',
     './*.dylib*',
   ],
-  within_data_subdir='purelib/tensorflow',
+  within_data_subdir=True,
 )
 
 files(

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -522,14 +522,6 @@ class UnpackedWheelsWithinDataSubdir(BoolField):
     alias = "within_data_subdir"
     default = False
 
-    @classmethod
-    def compute_value(  # type: ignore[override]
-        cls, raw_value: Optional[Union[bool, str]], *, address: Address
-    ) -> Union[bool, str]:
-        if isinstance(raw_value, str):
-            return raw_value
-        return super().compute_value(raw_value, address=address)
-
 
 class UnpackedWheels(Target):
     """A set of sources extracted from wheel files.

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -4,7 +4,6 @@
 import logging
 
 from pants.backend.python.targets.import_wheels_mixin import ImportWheelsMixin
-from pants.base.deprecated import deprecated_conditional
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
@@ -66,13 +65,6 @@ class UnpackedWheels(ImportWheelsMixin, Target):
                                         `include_patterns` matching exactly what is specified in the
                                         setup.py.
         """
-        # NB: Update python/rules/targets.py to no longer allow `str` when removing this deprecation.
-        deprecated_conditional(
-            lambda: type(within_data_subdir) not in (bool, type(None)),
-            removal_version="1.28.0.dev2",
-            entity_description="A non-boolean value for `within_data_subdir`",
-            hint_message="The location of the .data subdirectory will be inferred from the module name!",
-        )
         payload = payload or Payload()
         payload.add_fields(
             {


### PR DESCRIPTION
Previously the `UnpackedWheels` target allowed `within_data_subdir` to
be either a bool or a path. The deprecated path support is removed.

[ci skip-rust-tests]
[ci skip-jvm-tests]