### PR TITLE
Remove `build-setup-requires-pex` options scope.

### DIFF
--- a/src/python/pants/python/setup_py_runner.py
+++ b/src/python/pants/python/setup_py_runner.py
@@ -26,8 +26,6 @@ class SetupPyRunner:
 
     class Factory(ExecutablePexTool):
         options_scope = "setup-py-runner"
-        deprecated_options_scope = "build-setup-requires-pex"
-        deprecated_options_scope_removal_version = "1.28.0.dev2"
 
         @classmethod
         def register_options(cls, register: Callable[..., None]) -> None:


### PR DESCRIPTION
This has been moved to the `setup-py-runner` options scope.

[ci skip-rust-tests]
[ci skip-jvm-tests]
