### PR TITLE
Remove deprecated `--fast` option for tests.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
-from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
+from pants.task.testrunner_task_mixin import ChrootedTestRunnerTaskMixin, TestResult
 from pants.util.memo import memoized_property
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.strutil import create_path_env_var, safe_shlex_join, safe_shlex_split
@@ -14,7 +14,7 @@ from pants.util.strutil import create_path_env_var, safe_shlex_join, safe_shlex_
 from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 
 
-class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
+class GoTest(ChrootedTestRunnerTaskMixin, GoWorkspaceTask):
     """Runs `go test` on Go packages.
 
     To run a library's tests, GoTest only requires a Go workspace to be initialized (see

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -63,24 +63,13 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
         }
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
+    def tests(self, all_targets, test_targets):
+        def iter_tests():
+            for test_target in test_targets:
+                args = (self._generate_args_for_targets([test_target]),)
+                yield test_target, args
 
-            def iter_partitions():
-                for test_target in test_targets:
-                    partition = (test_target,)
-                    args = (self._generate_args_for_targets([test_target]),)
-                    yield partition, args
-
-        else:
-
-            def iter_partitions():
-                if test_targets:
-                    partition = tuple(test_targets)
-                    args = (self._generate_args_for_targets(test_targets),)
-                    yield partition, args
-
-        yield iter_partitions
+        yield iter_tests
 
     def collect_files(self, *args):
         """This task currently doesn't have any output that it would store in an artifact cache."""

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -44,14 +44,6 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
         self.assertIn("=== RUN   TestAdd", pants_run.stdout_data)
         self.assertIn("PASS", pants_run.stdout_data)
 
-    def test_no_fast(self):
-        args = ["test.go", "--no-fast", "contrib/go/examples/src/go/libA"]
-        pants_run = self.run_pants(args)
-        self.assert_success(pants_run)
-        # libA depends on libB, so both tests should be run.
-        self.assertRegex(pants_run.stdout_data, r"ok\s+libA")
-        self.assertRegex(pants_run.stdout_data, r"ok\s+libB")
-
     def test_go_test_unstyle(self):
         with self.temporary_sourcedir() as srcdir:
             lib_unstyle_relpath = "src/go/libUnstyle"

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -23,7 +23,7 @@ from pants.build_graph.target_scopes import Scopes
 from pants.java.executor import SubprocessExecutor
 from pants.java.junit.junit_xml_parser import RegistryOfTests, Test, parse_failed_targets
 from pants.process.lock import OwnerPrintingInterProcessFileLock
-from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
+from pants.task.testrunner_task_mixin import ChrootedTestRunnerTaskMixin, TestResult
 from pants.util import desktop
 from pants.util.argutil import ensure_arg, remove_arg
 from pants.util.contextutil import environment_as
@@ -33,7 +33,7 @@ from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import pluralize
 
 
-class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
+class JUnitRun(ChrootedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     """
     :API: public
     """

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -571,31 +571,21 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         return list(files_iter())
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
+    def tests(self, all_targets, test_targets):
         complete_test_registry = self._collect_test_targets(test_targets)
-        with self._isolation(per_target, all_targets) as (output_dir, reports, coverage):
-            if per_target:
+        with self._isolation(all_targets) as (output_dir, reports, coverage):
 
-                def iter_partitions():
-                    for test_target in test_targets:
-                        partition = (test_target,)
-                        args = (
-                            os.path.join(output_dir, test_target.id),
-                            coverage,
-                            complete_test_registry,
-                        )
-                        yield partition, args
-
-            else:
-
-                def iter_partitions():
-                    if test_targets:
-                        partition = tuple(test_targets)
-                        args = (output_dir, coverage, complete_test_registry)
-                        yield partition, args
+            def iter_tests():
+                for test_target in test_targets:
+                    args = (
+                        os.path.join(output_dir, test_target.id),
+                        coverage,
+                        complete_test_registry,
+                    )
+                    yield test_target, args
 
             try:
-                yield iter_partitions
+                yield iter_tests
             finally:
                 _, error, _ = sys.exc_info()
                 reports.generate(output_dir, exc=error)
@@ -620,12 +610,11 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                     raise TaskError(e)
 
     @contextmanager
-    def _isolation(self, per_target, all_targets):
+    def _isolation(self, all_targets):
         run_dir = "_runs"
-        mode_dir = "isolated" if per_target else "combined"
         batch_dir = str(self._batch_size) if self._batched else "all"
         output_dir = os.path.join(
-            self.workdir, run_dir, Target.identify(all_targets), mode_dir, batch_dir
+            self.workdir, run_dir, Target.identify(all_targets), "isolated", batch_dir
         )
         safe_mkdir(output_dir, clean=False)
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -28,7 +28,7 @@ from pants.base.hash_utils import Sharder
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.task.task import Task
-from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
+from pants.task.testrunner_task_mixin import ChrootedTestRunnerTaskMixin, TestResult
 from pants.util.contextutil import environment_as, pushd, temporary_dir, temporary_file
 from pants.util.dirutil import mergetree, safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
@@ -91,7 +91,7 @@ class PytestResult(TestResult):
         return 0 if value in cls._SUCCESS_EXIT_CODES else value
 
 
-class PytestRun(PartitionedTestRunnerTaskMixin, Task):
+class PytestRun(ChrootedTestRunnerTaskMixin, Task):
     @classmethod
     def implementation_version(cls):
         return super().implementation_version() + [("PytestRun", 3)]

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -50,7 +50,7 @@ class _Workdirs:
 
     @memoized_method
     def target_set_id(self, *targets):
-        return Target.maybe_readable_identify(targets or self.target)
+        return Target.maybe_readable_identify(targets) if targets else self.target.id
 
     @memoized_method
     def junitxml_path(self, *targets):

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -40,17 +40,17 @@ from pants.util.xml_parser import XmlParser
 @dataclass(frozen=True)
 class _Workdirs:
     root_dir: Any
-    partition: Any
+    target: Any
 
     @classmethod
-    def for_partition(cls, work_dir, partition):
-        root_dir = os.path.join(work_dir, Target.maybe_readable_identify(partition))
+    def for_target(cls, work_dir, target):
+        root_dir = os.path.join(work_dir, target.id)
         safe_mkdir(root_dir, clean=False)
-        return cls(root_dir=root_dir, partition=partition)
+        return cls(root_dir=root_dir, target=target)
 
     @memoized_method
     def target_set_id(self, *targets):
-        return Target.maybe_readable_identify(targets or self.partition)
+        return Target.maybe_readable_identify(targets or self.target)
 
     @memoized_method
     def junitxml_path(self, *targets):
@@ -601,27 +601,16 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         return relsrc_to_target.get(relsrc)
 
     @contextmanager
-    def partitions(self, per_target, all_targets, test_targets):
-        if per_target:
-
-            def iter_partitions():
-                for test_target in test_targets:
-                    yield (test_target,)
-
-        else:
-
-            def iter_partitions():
-                yield tuple(test_targets)
-
+    def tests(self, all_targets, test_targets):
         workdir = self.workdir
 
-        def iter_partitions_with_args():
-            for partition in iter_partitions():
-                workdirs = _Workdirs.for_partition(workdir, partition)
+        def iter_tests():
+            for test_target in test_targets:
+                workdirs = _Workdirs.for_target(workdir, test_target)
                 args = (workdirs,)
-                yield partition, args
+                yield test_target, args
 
-        yield iter_partitions_with_args
+        yield iter_tests
 
     # TODO(John Sirois): Its probably worth generalizing a means to mark certain options or target
     # attributes as making results un-cacheable. See: https://github.com/pantsbuild/pants/issues/4748

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -406,11 +406,10 @@ class TestRunnerTaskMixin:
         raise NotImplementedError
 
 
-class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
-    """A mixin for test tasks that support running tests over both individual targets and batches.
+class ChrootedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
+    """A mixin for test tasks that support running tests in chroots.
 
-    Provides support for partitioning via `--fast` (batches) and `--no-fast` (per target) options and
-    helps ensure correct caching behavior in either mode.
+    Provides support for testing (per target) options and helps ensure correct caching behavior.
 
     It's expected that mixees implement proper chrooting (see `run_tests_in_chroot`) to support
     correct successful test result caching.
@@ -438,6 +437,8 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         return VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
 
     def check_artifact_cache_for(self, invalidation_check):
+        # TODO(https://github.com/pantsbuild/pants/issues/9734): Remove this override and leverage
+        #  default target level caching suport now that the --fast option is removed.
         # Tests generate artifacts, namely junit.xml and coverage reports, that cover the full target
         # set whether that is all targets in the context (`--fast`) or each target individually
         # (`--no-fast`).
@@ -531,6 +532,9 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
                 # A low-level test execution failure occurred before tests were run.
                 raise TaskError()
 
+    # TODO(https://github.com/pantsbuild/pants/issues/9734): Simplify this method and mixin as a
+    #  whole now that targets are always tested individually and there are no longer ever
+    #  multi-target partitions now that the --fast option is removed.
     # Some notes on invalidation vs caching as used in `run_partition` below. Here invalidation
     # refers to executing task work in `Task.invalidated` blocks against invalid targets. Caching
     # refers to storing the results of that work in the artifact cache using

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -111,7 +111,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
             self.assertIn("Welcome.scala", html_report_string)
 
     def test_junit_run_with_coverage_succeeds_scoverage(self):
-        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot", "--fast"])
+        self.do_test_junit_run_with_coverage_succeeds_scoverage(args=["--no-chroot"])
 
     def do_test_junit_run_with_coverage_succeeds_cobertura(self, tests=(), args=()):
         html_path = (
@@ -214,11 +214,10 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
         self.assert_failure(pants_run)
         self.assertIn("No target found for test specifier", pants_run.stdout_data)
 
-    def test_junit_run_no_fast_multi(self):
+    def test_junit_run_multi(self):
         pants_run = self.run_pants(
             [
                 "test.junit",
-                "--no-fast",
                 "--test=PassingTest",
                 "testprojects/tests/java/org/pantsbuild/testproject/dummies:passing_target",
                 "testprojects/tests/java/org/pantsbuild/testproject/matcher",

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -514,10 +514,6 @@ python_tests(
     def test_green(self):
         self.run_tests(targets=[self.green])
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_caches_greens_fast(self):
-        self.run_tests(targets=[self.green, self.green2, self.green3], fast=True)
-
     @ensure_cached(PytestRun, expected_num_artifacts=3)
     def test_cache_greens(self):
         self.run_tests(targets=[self.green, self.green2, self.green3])
@@ -529,10 +525,6 @@ python_tests(
             timeout_default=3,
         )
 
-    @ensure_cached(PytestRun, expected_num_artifacts=1)
-    def test_out_of_band_deselect_fast_success(self):
-        self.run_tests([self.green, self.red], "-kno_tests_should_match_at_all", fast=True)
-
     # NB: Both red and green are cached. Red because its skipped via deselect and so runs (noops)
     # successfully. This is OK since the -k passthru is part of the task fingerprinting.
     @ensure_cached(PytestRun, expected_num_artifacts=2)
@@ -542,15 +534,6 @@ python_tests(
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_red(self):
         self.run_failing_tests(targets=[self.red], failed_targets=[self.red])
-
-    @ensure_cached(PytestRun, expected_num_artifacts=0)
-    def test_fail_fast_skips_second_red_test_with_single_chroot(self):
-        self.run_failing_tests(
-            targets=[self.red, self.red_in_class],
-            failed_targets=[self.red],
-            fail_fast=True,
-            fast=True,
-        )
 
     @ensure_cached(PytestRun, expected_num_artifacts=0)
     def test_fail_fast_skips_second_red_test(self):


### PR DESCRIPTION
This change removes support for the option but does not fully simplify
the code in `TestRunnerTaskMixin` and mixees as a matter of expedience.
That work is deferred to #9734.

[ci skip-rust-tests]
[ci skip-jvm-tests]
