### PR TITLE
Batch all fsync calls at the end of materialize_directory.

### DIFF
--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1014,7 +1014,7 @@ async fn materialize_missing_file() {
   let store_dir = TempDir::new().unwrap();
   let store = new_local_store(store_dir.path());
   store
-    .materialize_file(file.clone(), TestData::roland().digest(), false)
+    .materialize_file(file.clone(), TestData::roland().digest(), false, true)
     .compat()
     .await
     .expect_err("Want unknown digest error");
@@ -1034,7 +1034,7 @@ async fn materialize_file() {
     .await
     .expect("Error saving bytes");
   store
-    .materialize_file(file.clone(), testdata.digest(), false)
+    .materialize_file(file.clone(), testdata.digest(), false, true)
     .compat()
     .await
     .expect("Error materializing file");
@@ -1056,7 +1056,7 @@ async fn materialize_file_executable() {
     .await
     .expect("Error saving bytes");
   store
-    .materialize_file(file.clone(), testdata.digest(), true)
+    .materialize_file(file.clone(), testdata.digest(), true, true)
     .compat()
     .await
     .expect("Error materializing file");


### PR DESCRIPTION
### Problem

`fsync`'ing files is very slow, but `materialize_directory` needs to do so to ensure that their contents are visible outside of the current process, particularly when we are spawning child processes that execute or read those files.

### Solution

Assuming that the semantics are the same (and it seems like they should be), waiting to `fsync` any files until the entire directory structure is laid out significantly improves performance. 

### Result

`materialize_directory` is much faster:
```
change: [-87.925% -86.577% -84.838%] (p = 0.00 < 0.05)
Performance has improved.
```

[ci skip-jvm-tests]