### PR TITLE
Always activate V2 `pants.backend.pants_info` and `pants.backend.project_info`

### DIFF
--- a/src/python/pants/backend/pants_info/list_backends.py
+++ b/src/python/pants/backend/pants_info/list_backends.py
@@ -94,7 +94,12 @@ class BackendInfo:
             "pants.core_tasks",
             *global_options.options.backend_packages,
         }
-        activated_v2_backends = {"pants.core", *global_options.options.backend_packages2}
+        activated_v2_backends = {
+            "pants.core",
+            "pants.backend.pants_info",
+            "pants.backend.project_info",
+            *global_options.options.backend_packages2,
+        }
 
         return cls(
             name=module_name,

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -255,7 +255,9 @@ def load_build_configuration_from_source(
     for backend_package in backend_packages1:
         load_backend(build_configuration, backend_package, is_v1_backend=True)
 
-    backend_packages2 = FrozenOrderedSet(["pants.core", *backends2])
+    backend_packages2 = FrozenOrderedSet(
+        ["pants.core", "pants.backend.pants_info", "pants.backend.project_info", *backends2]
+    )
     for backend_package in backend_packages2:
         load_backend(build_configuration, backend_package, is_v1_backend=False)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -314,7 +314,7 @@ class GlobalOptions(Subsystem):
             "--backend-packages2",
             advanced=True,
             type=list,
-            default=["pants.backend.pants_info", "pants.backend.project_info"],
+            default=[],
             help=(
                 "Register v2 rules from these backends. The backend packages must be present on "
                 "the PYTHONPATH, typically because they are in the Pants core dist, in a "


### PR DESCRIPTION
As pointed out in https://pantsbuild.slack.com/archives/C18RRR4JK/p1589044649085000?thread_ts=1588982378.078400&cid=C18RRR4JK, it is not very useful for end-users to be opt-out of end goals like `list` and `target-types`. 

While it would be consistent with all other backends, we never want a situation, for example, where we can't ask users to run `list` to debug something.

Further, we expect some users to accidentally set `backend_packages2 = [..]` instead of `backend_packages2.add = []`, which will confuse them why no goals are showing up.

[ci skip-rust-tests]
[ci skip-jvm-tests]