### PR TITLE
Upgrade to pex 2.1.10.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -23,7 +23,7 @@ Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.8.0
-pex==2.1.9
+pex==2.1.10
 psutil==5.6.3
 Pygments==2.6.1
 pyopenssl==19.1.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -23,9 +23,9 @@ from pants.python.python_setup import PythonSetup
 class PexBin(ExternalTool):
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.9"
+    default_version = "v2.1.10"
     default_known_versions = [
-        f"v2.1.9|{plat}|4e2677ce7270dd04d767e93e1904c90aa8c7f4f53b76f3615215970b45d100d7|2624111"
+        f"v2.1.10|{plat}|a9b5eb55ec4d7babc11279fc070c066565915c8b8a7b009a4eaceb41149a5f03|2631051"
         for plat in ["darwin", "linux"]
     ]
 


### PR DESCRIPTION
There are new options to wire up to control network behavior but this
change sticks to a straight upgrade. With Pex now back to using a
default HTTP cache TTL of 2.5 days, this should immediately net
performance improvement in v1 tasks.

[ci skip-jvm-tests]