### PR TITLE
Filter thrift java away for modulizable targets calculation

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -1008,7 +1008,11 @@ class ZincCompile(BaseZincCompile):
             filter(is_jvm_or_resource_target, self.context.target_roots)
         )
         jvm_and_resources_target_roots_minus_synthetic_addresses = set(
-            t.address for t in filter(lambda x: not is_synthetic_or_can_derive_synthetic(x), jvm_and_resources_target_roots)
+            t.address
+            for t in filter(
+                lambda x: not is_synthetic_or_can_derive_synthetic(x),
+                jvm_and_resources_target_roots,
+            )
         )
         all_targets = set(self.context.targets())
         modulizable_targets = set(
@@ -1021,7 +1025,9 @@ class ZincCompile(BaseZincCompile):
             )
             if is_jvm_or_resource_target(t)
         )
-        synthetic_modulizable_targets = set(filter(lambda x: is_synthetic_or_can_derive_synthetic(x), modulizable_targets))
+        synthetic_modulizable_targets = set(
+            filter(lambda x: is_synthetic_or_can_derive_synthetic(x), modulizable_targets)
+        )
         if len(synthetic_modulizable_targets) > 0:
             # TODO(yic): improve the error message to show the dependency chain that caused
             # a synthetic target depending on a non-synthetic one.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -1046,7 +1046,7 @@ class ZincCompile(BaseZincCompile):
             msg = (
                 f"Modulizable targets must not contain any synthetic target, but in this "
                 f"case the "
-                f"following synthetic targets depend on other non-synthetformatted_targetsic modules:\n"
+                f"following synthetic targets depend on other non-synthetic modules:\n"
                 f"{formatted_targets}\n"
                 f"One approach that may help is to reduce the scope of the import to "
                 f"further avoid synthetic targets."

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -1007,7 +1007,10 @@ class ZincCompile(BaseZincCompile):
             return set()
 
         def is_jvm_or_resource_target(t):
-            return isinstance(t, (JvmTarget, JvmApp, JarLibrary, Resources))
+            return (
+                isinstance(t, (JvmTarget, JvmApp, JarLibrary, Resources))
+                or t.type_alias == "target"
+            )
 
         def is_synthetic_or_can_derive_synthetic(t):
             return t.is_synthetic or isinstance(t, JavaThriftLibrary)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -61,6 +61,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         # We need an initialized ScalaPlatform in order to make ScalaLibrary targets below.
         scala_options = {ScalaPlatform.options_scope: {"version": "custom"}}
         init_subsystems([JUnit, ScalaPlatform, ScoveragePlatform], scala_options)
+        self.set_options_for_scope("compile.rsc", error_on_synthetic_modulizable_targets=True)
 
         self.make_target(
             ":jar-tool", JarLibrary, jars=[JarDependency("org.pantsbuild", "jar-tool", "0.0.10")]


### PR DESCRIPTION
### Problem

`JavaThriftLibrary` isn't synthetic, but still derive synthetic target.

Whereas the intention of code below is to filter out the thrift related targets.
```
        jvm_and_resources_target_roots_minus_synthetic_addresses = set(
            t.address for t in filter(lambda x: not x.is_synthetic, jvm_and_resources_target_roots)
        )
```
Not filtering it out would inadvertently cause other thrift targets to be included in the modulizable targets.

### Solution

Adding `JavaThriftLibrary` into the filter, and make sure `target` is not filtered away.
