### PR TITLE
Deprecate `filedeps` defaulting to `--absolute`

### DIFF
--- a/src/python/pants/backend/project_info/BUILD
+++ b/src/python/pants/backend/project_info/BUILD
@@ -30,10 +30,7 @@ python_tests(
   sources=['*_test.py', '!*_integration_test.py'],
   dependencies = [
     ':project_info',
-    'src/python/pants/backend/codegen/thrift/java',
-    'src/python/pants/backend/jvm:artifact',
-    'src/python/pants/backend/jvm:repository',
-    'src/python/pants/backend/jvm/targets:all',
+    'src/python/pants/backend/codegen/protobuf',
     'src/python/pants/backend/python/rules',
     'src/python/pants/backend/python/targets',
     'src/python/pants/core/util_rules',

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -32,10 +32,10 @@ class FiledepsOptions(LineOriented, GoalSubsystem):
         register(
             "--absolute",
             type=bool,
-            default=True,
+            default=False,
             help=(
-                "If True, output with absolute path; else, output with path relative to the "
-                "build root."
+                "If True, output with absolute path. If unspecified, output with path relative to "
+                "the build root."
             ),
         )
         register(
@@ -51,8 +51,10 @@ class FiledepsOptions(LineOriented, GoalSubsystem):
             "--transitive",
             type=bool,
             default=False,
-            help="If True, list files from all transitive dependencies. If unspecified, list "
-            "files from direct dependencies only.",
+            help=(
+                "If True, list files from all dependencies, including transitive dependencies. If "
+                "unspecified, only list files from the target."
+            ),
         )
 
 

--- a/src/python/pants/backend/project_info/filedeps_integration_test.py
+++ b/src/python/pants/backend/project_info/filedeps_integration_test.py
@@ -12,7 +12,6 @@ class FiledepsIntegrationTest(PantsRunIntegrationTest):
     ) -> None:
         args = [
             "filedeps2",
-            "--no-absolute",
             "--transitive",
             *(filedeps_options or []),
             "examples/src/scala/org/pantsbuild/example/hello/exe:exe",

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -13,7 +13,7 @@ from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsyst
 
 
 class MockTarget(Target):
-    alias = "mock_target"
+    alias = "tgt"
     core_fields = (DescriptionField, ProvidesField)
 
 

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -6,6 +6,7 @@ import os
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.task.console_task import ConsoleTask
 
 
@@ -35,6 +36,16 @@ class FileDeps(ConsoleTask):
         return os.path.join(get_buildroot(), path) if self.get_options().absolute else path
 
     def console_output(self, targets):
+        deprecated_conditional(
+            lambda: self.get_options().is_default("absolute"),
+            entity_description="defaulting to `--filedeps-absolute`",
+            removal_version="1.30.0.dev0",
+            hint_message=(
+                "`filedeps` will soon default to `--no-filedeps-absolute`. If you want to "
+                "permanently configure absolute paths, set this in your `pants.toml`:\n\n"
+                "[filedeps]\nabsolute = true\n"
+            ),
+        )
         concrete_targets = set()
         for target in targets:
             concrete_target = target.concrete_derived_from


### PR DESCRIPTION
Relative paths rule in a V2 world. We want to keep `--absolute` path as an option so that Pants can talk to tools that need absolute paths, but we should default to relative paths.

Unlike V1 `filedeps`, `filedeps2` changes the option without a deprecation cycle.

This also updates the V2 tests to fully use the Target API.
 
[ci skip-rust-tests]
[ci skip-jvm-tests]