### PR TITLE
Sort libraries for target in export-dep-as-jar

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -306,7 +306,7 @@ class ExportDepAsJar(ConsoleTask):
         if not current_target.is_synthetic:
             info["globs"] = current_target.globs_relative_to_buildroot()
 
-        libraries_for_target = set(
+        libraries_for_target = OrderedSet(
             [self._jar_id(jar) for jar in iter_transitive_jars(current_target)]
         )
         for dep in sorted(flat_non_modulizable_deps_for_modulizable_targets[current_target]):


### PR DESCRIPTION
[ci skip-rust-tests]

### Problem

Despite `flat_non_modulizable_deps_for_modulizable_targets` being an `OrderedSet`, `libraries_for_target` is not ordered. This causes problems in the classpath returned by `export-deps-as-jar`, specifically it is not the same as the classpath used by `compile`.

### Solution

Instantiate `libraries_for_target` as an `OrderedSet`.

### Result

`libraries_for_target` will now be ordered as expected, preserving the ordering from `flat_non_modulizable_deps_for_modulizable_targets`