### PR TITLE
Fix write_stderr in native.py

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -877,7 +877,7 @@ class Native(metaclass=SingletonMetaclass):
         return self.lib.write_stdout(session, msg.encode())
 
     def write_stderr(self, session, msg: str):
-        return self.lib.write_stdout(session, msg.encode())
+        return self.lib.write_stderr(session, msg.encode())
 
     def flush_log(self):
         return self.lib.flush_log()


### PR DESCRIPTION
### Problem

The `write_stderr` function in `native.py` was mistakenly calling the Rust FFI function to write to stdout rather than to write to stderr. This was causing problems with redrawing swim lanes in the new terminal UI, and is in general incorrect.

### Solution

Have the `native.py` function invoke the correct Rust FFI function.
