### PR TITLE
Remove use of proctitle in the exception sink

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -68,7 +68,6 @@ python_library(
   name = 'exception_sink',
   sources = ['exception_sink.py'],
   dependencies = [
-    '3rdparty/python:setproctitle',
     'src/python/pants/util:dirutil',
     ':build_environment',
     ':exiter',

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -12,8 +12,6 @@ import traceback
 from contextlib import contextmanager
 from typing import Optional
 
-import setproctitle
-
 from pants.util.dirutil import safe_mkdir, safe_open
 from pants.util.meta import classproperty
 from pants.util.osutil import Pid
@@ -346,7 +344,6 @@ class ExceptionSink:
     # NB: This includes a trailing newline, but no leading newline.
     _EXCEPTION_LOG_FORMAT = """\
 timestamp: {timestamp}
-process title: {process_title}
 sys.argv: {args}
 pid: {pid}
 {message}
@@ -355,11 +352,7 @@ pid: {pid}
     @classmethod
     def _format_exception_message(cls, msg, pid):
         return cls._EXCEPTION_LOG_FORMAT.format(
-            timestamp=cls._iso_timestamp_for_now(),
-            process_title=setproctitle.getproctitle(),
-            args=sys.argv,
-            pid=pid,
-            message=msg,
+            timestamp=cls._iso_timestamp_for_now(), args=sys.argv, pid=pid, message=msg,
         )
 
     _traceback_omitted_default_text = "(backtrace omitted)"

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -56,7 +56,6 @@ class TestExceptionSink(TestBase):
             sink.reset_log_location("/")
 
     def test_log_exception(self):
-        fake_process_title = "fake_title"
         msg = "XXX"
         sink = self._gen_sink_subclass()
         pid = os.getpid()
@@ -65,12 +64,7 @@ class TestExceptionSink(TestBase):
             # Check that tmpdir exists, and log an exception into that directory.
             sink.reset_log_location(tmpdir)
 
-            with unittest.mock.patch(
-                "setproctitle.getproctitle", autospec=True, spec_set=True
-            ) as getproctitle_mock:
-                getproctitle_mock.return_value = fake_process_title
-                sink._log_exception(msg)
-                getproctitle_mock.assert_called_once()
+            sink._log_exception(msg)
 
             # This should have created two log files, one specific to the current pid.
             self.assertEqual(os.listdir(tmpdir), [".pids"])
@@ -88,12 +82,11 @@ class TestExceptionSink(TestBase):
             # We only logged a single error, so the files should both contain only that single log entry.
             err_rx = """\
 timestamp: ([^\n]+)
-process title: {fake_process_title}
 sys.argv: ([^\n]+)
 pid: {pid}
 {msg}
 """.format(
-                fake_process_title=re.escape(fake_process_title), pid=pid, msg=msg
+                pid=pid, msg=msg
             )
             with open(cur_process_error_log_path, "r") as cur_pid_file:
                 self.assertRegex(cur_pid_file.read(), err_rx)

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -19,7 +19,6 @@ class ExceptionSinkIntegrationTest(PantsDaemonIntegrationTestBase):
             file_contents,
             """\
 timestamp: ([^\n]+)
-process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
 pid: {pid}
 Exception caught: \\([^)]*\\)
@@ -132,7 +131,6 @@ Exception message:.* 1 Exception encountered:
             contents,
             """\
 timestamp: ([^\n]+)
-process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
 pid: {pid}
 Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.


### PR DESCRIPTION
### Problem

The `setproctitle` dependency for `ExceptionSink` can cause errors like:
```
 pants_test/base/test_exception_sink.py:9: in <module>
     from pants.base.exception_sink import ExceptionSink
 pants/base/exception_sink.py:15: in <module>
     import setproctitle
 E   ImportError: dlopen(/Users/stuhood/src/pants/.pants.d/pyprep/requirements/CPython-3.7.3/ed7a92c2155be22d4362d99c1893aff1683e105a/.deps/setproctitle-1.1.10-cp37-cp37m-macosx_10_14_x86_64.whl/setproctitle.cpython-37m-darwin.so, 2): Symbol not found: _Py_GetArgcArgv
 E     Referenced from: /Users/stuhood/src/pants/.pants.d/pyprep/requirements/CPython-3.7.3/ed7a92c2155be22d4362d99c1893aff1683e105a/.deps/setproctitle-1.1.10-cp37-cp37m-macosx_10_14_x86_64.whl/setproctitle.cpython-37m-darwin.so
 E     Expected in: flat namespace
 E    in /Users/stuhood/src/pants/.pants.d/pyprep/requirements/CPython-3.7.3/ed7a92c2155be22d4362d99c1893aff1683e105a/.deps/setproctitle-1.1.10-cp37-cp37m-macosx_10_14_x86_64.whl/setproctitle.cpython-37m-darwin.so
```

### Solution

I looked into porting our proctitle usage to rust, but the [relevant crate](https://crates.io/crates/proctitle), 1) doesn't have a `get` method, 2) doesn't support OSX. So that was right out. Instead, we remove the proctitle recording here, since it is not strictly necessary when compared to the args and stacktrace.

### Result

Stable-r `ExceptionSink` tests.

[ci skip-rust-tests]
[ci skip-jvm-tests]