### PR TITLE
Reference the V2 docsite in the README and index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pants Build System
 
-Pants is a scalable build system for _monorepos_: codebases containing multiple projects, often using multiple programming languages and frameworks, in a single unified code repos
+Pants is a scalable build system for _monorepos_: codebases containing 
+multiple projects, often using multiple programming languages and frameworks, 
+in a single unified code repository.
 
 Some noteworthy features include:
 
@@ -30,6 +32,8 @@ To run Pants, you need:
 
 * Linux or macOS.
 * Python 3.6+ discoverable on your `PATH`.
+* A C compiler, system headers, Python headers (to compile native Python modules) and the `libffi`
+ library and headers (to compile and link modules that use CFFI to access native code).
 * Internet access (so that Pants can fully bootstrap itself).
 
 Additionally, if you use the JVM backend to work with Java or Scala code:

--- a/README.md
+++ b/README.md
@@ -1,32 +1,37 @@
 # Pants Build System
 
-Pants is a build system for software projects in a variety of languages.
-It works particularly well for a source code repository that contains
-many distinct projects.
+Pants is a scalable build system for _monorepos_: codebases containing multiple projects, often using multiple programming languages and frameworks, in a single unified code repos
 
-Friendly documentation: http://www.pantsbuild.org/
+Some noteworthy features include:
+
+* Explicit dependency modeling.
+* Fine-grained invalidation.
+* Shared result caching.
+* Concurrent execution.
+* Remote execution.
+* Unified interface for multiple tools and languages.
+* Extensibility and customizability via a plugin API.
+
+Documentation:
+
+ * V2 version of Pants (Python only, for now): https://pants.readme.io/docs/welcome-to-pants
+ * V1 version of Pants: http://www.pantsbuild.org/
 
 We release to [PyPI](https://pypi.org/pypi)
 [![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
 [![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
 
 We use [Travis CI](https://travis-ci.org) to verify the build
-[![Build Status](https://travis-ci.org/pantsbuild/pants.svg?branch=master)](https://travis-ci.org/pantsbuild/pants/branches).
-
-We use [Coveralls](https://coveralls.io) to monitor test coverage
-[![Coverage Status](https://coveralls.io/repos/pantsbuild/pants/badge.png?branch=master)](https://coveralls.io/r/pantsbuild/pants).
+[![Build Status](https://travis-ci.com/pantsbuild/pants.svg?branch=master)](https://travis-ci.com/pantsbuild/pants/branches).
 
 # Requirements
 
-At a minimum, Pants requires the following to run properly:
+To run Pants, you need:
 
 * Linux or macOS.
-* Python 3.6+.
-* A C compiler, system headers, Python headers (to compile native Python modules) and the libffi
-  library and headers (to compile and link modules that use CFFI to access native code).
-* Internet access (so that Pants can fully bootstrap itself)
+* Python 3.6+ discoverable on your `PATH`.
+* Internet access (so that Pants can fully bootstrap itself).
 
-Additionally, if you use the JVM backend to work with Java or Scala code (installed by default):
+Additionally, if you use the JVM backend to work with Java or Scala code:
 
 * OpenJDK or Oracle JDK version 8 or greater.
-

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -25,8 +25,12 @@ Adding support for other languages, frameworks and code generators is straightfo
 
 <p class="index-intro-text"></p>
 
-Pants is a collaborative open-source project, built and used by Twitter, Foursquare, Square,
+Pants is a collaborative open-source project, built and used by Twitter, Toolchain, Foursquare, Square,
 Medium and [[other companies|pants('src/docs:powered_by')]].
+
+<br/>
+
+If you are only using Python in your project, check out https://pants.readme.io/docs/welcome-to-pants for documentation using the improved V2 implementation.
 
 Getting Started
 ---------------

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -6,10 +6,11 @@ beginning, make sure your machine fits the requirements. At a minimum, Pants req
 
 * Linux or macOS.
 * Python 3.6+.
-* A C compiler, system headers, Python headers (to compile native Python modules) and the libffi
-  library and headers (to compile and link modules that use CFFI to access native code).
-* OpenJDK or Oracle JDK 7 or greater.
-* Internet access (so that Pants can fully bootstrap itself)
+* Internet access (so that Pants can fully bootstrap itself).
+
+Additionally, if you use the JVM backend to work with Java or Scala code:
+
+* OpenJDK or Oracle JDK version 8 or greater.
 
 After you have Pants installed, you'll need to
 [[Set up your code workspace to work with Pants|pants('src/docs:setup_repo')]].

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -6,6 +6,8 @@ beginning, make sure your machine fits the requirements. At a minimum, Pants req
 
 * Linux or macOS.
 * Python 3.6+.
+* A C compiler, system headers, Python headers (to compile native Python modules) and the `libffi`
+ library and headers (to compile and link modules that use CFFI to access native code).
 * Internet access (so that Pants can fully bootstrap itself).
 
 Additionally, if you use the JVM backend to work with Java or Scala code:


### PR DESCRIPTION
The docs rewrite at https://pants.readme.io/docs/welcome-to-pants describes how to use Pants V2. We've been linking to it liberally in Slack, but there's a discoverability issue that you can't find these docs anywhere else.

This adds light-weight references to the new site and clarifies that it should only be used for Python-only projects. Most people will still likely use the original V1 docs.

This also removes our claim for Coverage, which isn't properly configured.

[ci skip-rust-tests]
[ci skip-jvm-tests]