### PR TITLE
Refactor Workunit types

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -38,7 +38,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use store::UploadSummary;
-use workunit_store::{with_workunit, WorkUnitStore, WorkunitMetadata};
+use workunit_store::{with_workunit, WorkunitMetadata, WorkunitStore};
 
 use async_semaphore::AsyncSemaphore;
 use hashing::Digest;
@@ -350,12 +350,12 @@ impl AddAssign<UploadSummary> for ExecutionStats {
 
 #[derive(Clone, Default)]
 pub struct Context {
-  workunit_store: WorkUnitStore,
+  workunit_store: WorkunitStore,
   build_id: String,
 }
 
 impl Context {
-  pub fn new(workunit_store: WorkUnitStore, build_id: String) -> Context {
+  pub fn new(workunit_store: WorkunitStore, build_id: String) -> Context {
     Context {
       workunit_store,
       build_id,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use std;
 use std::cmp::min;
-use workunit_store::WorkUnitStore;
+use workunit_store::WorkunitStore;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the
@@ -758,7 +758,7 @@ fn maybe_add_workunit(
   name: &str,
   time_span: concrete_time::TimeSpan,
   parent_id: Option<String>,
-  workunit_store: &WorkUnitStore,
+  workunit_store: &WorkunitStore,
 ) {
   //  TODO: workunits for scheduling, fetching, executing and uploading should be recorded
   //   only if '--reporting-zipkin-trace-v2' is set

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::time::{delay_for, timeout};
-use workunit_store::{WorkUnit, WorkUnitStore, WorkunitMetadata};
+use workunit_store::{Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[derive(Debug, PartialEq)]
 enum StdoutType {
@@ -793,7 +793,7 @@ async fn sends_headers() {
   )
   .unwrap();
   let context = Context {
-    workunit_store: WorkUnitStore::default(),
+    workunit_store: WorkunitStore::default(),
     build_id: String::from("marmosets"),
   };
   command_runner
@@ -2234,11 +2234,11 @@ async fn extract_output_files_from_response_no_prefix() {
   )
 }
 
-fn workunits_with_constant_span_id(workunit_store: &mut WorkUnitStore) -> HashSet<WorkUnit> {
+fn workunits_with_constant_span_id(workunit_store: &mut WorkunitStore) -> HashSet<Workunit> {
   workunit_store.with_latest_workunits(|_, completed_workunits| {
     completed_workunits
       .iter()
-      .map(|workunit| WorkUnit {
+      .map(|workunit| Workunit {
         span_id: String::from("ignore"),
         ..workunit.clone()
       })
@@ -2248,7 +2248,7 @@ fn workunits_with_constant_span_id(workunit_store: &mut WorkUnitStore) -> HashSe
 
 #[tokio::test]
 async fn remote_workunits_are_stored() {
-  let mut workunit_store = WorkUnitStore::new();
+  let mut workunit_store = WorkunitStore::new();
   workunit_store.init_thread_state(None);
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
@@ -2287,41 +2287,49 @@ async fn remote_workunits_are_stored() {
   use concrete_time::TimeSpan;
 
   let want_workunits = hashset! {
-    WorkUnit {
+    Workunit {
       name: String::from("remote execution action scheduling"),
-      time_span: TimeSpan {
+      state: WorkunitState::Completed {
+        time_span: TimeSpan {
           start: Duration::new(0, 0),
           duration: Duration::new(1, 0),
+        }
       },
       span_id: String::from("ignore"),
       parent_id: None,
       metadata: WorkunitMetadata::new(),
     },
-    WorkUnit {
+    Workunit {
       name: String::from("remote execution worker input fetching"),
-      time_span: TimeSpan {
+      state: WorkunitState::Completed {
+        time_span: TimeSpan {
           start: Duration::new(2, 0),
           duration: Duration::new(1, 0),
+        }
       },
       span_id: String::from("ignore"),
       parent_id: None,
       metadata: WorkunitMetadata::new(),
     },
-    WorkUnit {
+    Workunit {
       name: String::from("remote execution worker command executing"),
-      time_span: TimeSpan {
+      state: WorkunitState::Completed {
+        time_span: TimeSpan {
           start: Duration::new(4, 0),
           duration: Duration::new(1, 0),
+        }
       },
       span_id: String::from("ignore"),
       parent_id: None,
       metadata: WorkunitMetadata::new(),
     },
-    WorkUnit {
+    Workunit {
       name: String::from("remote execution worker output uploading"),
-      time_span: TimeSpan {
+      state: WorkunitState::Completed {
+        time_span: TimeSpan {
           start: Duration::new(6, 0),
           duration: Duration::new(1, 0),
+        }
       },
       span_id: String::from("ignore"),
       parent_id: None,

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -23,7 +23,7 @@ use task_executor::Executor;
 use ui::ConsoleUI;
 use uuid::Uuid;
 use watch::Invalidatable;
-use workunit_store::WorkUnitStore;
+use workunit_store::WorkunitStore;
 
 pub enum ExecutionTermination {
   KeyboardInterrupt,
@@ -49,7 +49,7 @@ struct InnerSession {
   // If enabled, Zipkin spans for v2 engine will be collected.
   should_record_zipkin_spans: bool,
   // A place to store info about workunits in rust part
-  workunit_store: WorkUnitStore,
+  workunit_store: WorkunitStore,
   // The unique id for this Session: used for metrics gathering purposes.
   build_id: String,
   // An id used to control the visibility of uncacheable rules. Generally this is identical for an
@@ -74,7 +74,7 @@ impl Session {
     build_id: String,
     should_report_workunits: bool,
   ) -> Session {
-    let workunit_store = WorkUnitStore::new();
+    let workunit_store = WorkunitStore::new();
     let display = if should_render_ui {
       Some(Mutex::new(ConsoleUI::new(workunit_store.clone())))
     } else {
@@ -127,7 +127,7 @@ impl Session {
     self.0.should_report_workunits
   }
 
-  pub fn workunit_store(&self) -> WorkUnitStore {
+  pub fn workunit_store(&self) -> WorkunitStore {
     self.0.workunit_store.clone()
   }
 

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -37,16 +37,16 @@ use uuid::Uuid;
 
 use logging::logger::{StdioHandler, LOGGER};
 use task_executor::Executor;
-use workunit_store::WorkUnitStore;
+use workunit_store::WorkunitStore;
 
 pub struct ConsoleUI {
-  workunit_store: WorkUnitStore,
+  workunit_store: WorkunitStore,
   // While the UI is running, there will be an Instance present.
   instance: Option<Instance>,
 }
 
 impl ConsoleUI {
-  pub fn new(workunit_store: WorkUnitStore) -> ConsoleUI {
+  pub fn new(workunit_store: WorkunitStore) -> ConsoleUI {
     ConsoleUI {
       workunit_store,
       instance: None,
@@ -124,7 +124,7 @@ impl ConsoleUI {
   }
 
   ///
-  /// Updates all of the swimlane ProgressBars with new data from the WorkUnitStore. For this
+  /// Updates all of the swimlane ProgressBars with new data from the WorkunitStore. For this
   /// method to have any effect, the `initialize` method must have been called first.
   ///
   /// *Technically this method does not do the "render"ing: rather, the `MultiProgress` instance

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -43,21 +43,18 @@ pub type SpanId = String;
 type WorkunitGraph = DiGraph<SpanId, (), u32>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct WorkUnit {
+pub struct Workunit {
   pub name: String,
-  pub time_span: TimeSpan,
   pub span_id: SpanId,
   pub parent_id: Option<String>,
+  pub state: WorkunitState,
   pub metadata: WorkunitMetadata,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct StartedWorkUnit {
-  pub name: String,
-  pub start_time: SystemTime,
-  pub span_id: SpanId,
-  pub parent_id: Option<String>,
-  pub metadata: WorkunitMetadata,
+pub enum WorkunitState {
+  Started { start_time: SystemTime },
+  Completed { time_span: TimeSpan },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -77,39 +74,8 @@ impl WorkunitMetadata {
   }
 }
 
-impl StartedWorkUnit {
-  fn finish(self) -> WorkUnit {
-    WorkUnit {
-      name: self.name,
-      time_span: TimeSpan::since(&self.start_time),
-      span_id: self.span_id,
-      parent_id: self.parent_id,
-      metadata: self.metadata,
-    }
-  }
-}
-
-impl WorkUnit {
-  pub fn new(name: String, time_span: TimeSpan, parent_id: Option<String>) -> WorkUnit {
-    let span_id = new_span_id();
-    WorkUnit {
-      name,
-      time_span,
-      span_id,
-      parent_id,
-      metadata: WorkunitMetadata::new(),
-    }
-  }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-enum WorkunitRecord {
-  Started(StartedWorkUnit),
-  Completed(WorkUnit),
-}
-
 #[derive(Clone, Default)]
-pub struct WorkUnitStore {
+pub struct WorkunitStore {
   inner: Arc<Mutex<WorkUnitInnerStore>>,
 }
 
@@ -117,28 +83,23 @@ pub struct WorkUnitStore {
 pub struct WorkUnitInnerStore {
   graph: WorkunitGraph,
   span_id_to_graph: HashMap<SpanId, NodeIndex<u32>>,
-  workunit_records: HashMap<SpanId, WorkunitRecord>,
+  workunit_records: HashMap<SpanId, Workunit>,
   started_ids: Vec<SpanId>,
   completed_ids: Vec<SpanId>,
   last_seen_started_idx: usize,
   last_seen_completed_idx: usize,
 }
 
-fn should_display_workunit(workunit_records: &HashMap<SpanId, WorkunitRecord>, id: &str) -> bool {
-  let record = match workunit_records.get(id) {
-    None => return false,
-    Some(record) => record,
-  };
-  let metadata = match record {
-    WorkunitRecord::Started(StartedWorkUnit { metadata, .. }) => metadata,
-    WorkunitRecord::Completed(WorkUnit { metadata, .. }) => metadata,
-  };
-  metadata.display
+fn should_display_workunit(workunit_records: &HashMap<SpanId, Workunit>, id: &str) -> bool {
+  match workunit_records.get(id) {
+    None => false,
+    Some(record) => record.metadata.display,
+  }
 }
 
-impl WorkUnitStore {
-  pub fn new() -> WorkUnitStore {
-    WorkUnitStore {
+impl WorkunitStore {
+  pub fn new() -> WorkunitStore {
+    WorkunitStore {
       inner: Arc::new(Mutex::new(WorkUnitInnerStore {
         graph: DiGraph::new(),
         span_id_to_graph: HashMap::new(),
@@ -158,7 +119,7 @@ impl WorkUnitStore {
     }))
   }
 
-  pub fn get_workunits(&self) -> Vec<WorkUnit> {
+  pub fn get_workunits(&self) -> Vec<Workunit> {
     let mut inner_guard = (*self.inner).lock();
     let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
     let workunit_records = &inner_store.workunit_records;
@@ -166,9 +127,9 @@ impl WorkUnitStore {
       .completed_ids
       .iter()
       .flat_map(|id| workunit_records.get(id))
-      .flat_map(|record| match record {
-        WorkunitRecord::Started(_) => None,
-        WorkunitRecord::Completed(c) => Some(c.clone()),
+      .flat_map(|workunit| match workunit.state {
+        WorkunitState::Started { .. } => None,
+        WorkunitState::Completed { .. } => Some(workunit.clone()),
       })
       .collect()
   }
@@ -186,12 +147,16 @@ impl WorkUnitStore {
       edge_workunits
         .map(|entry| workunit_graph[entry].clone())
         .flat_map(|span_id: SpanId| {
-          let record = inner.workunit_records.get(&span_id);
-          match record {
-            Some(WorkunitRecord::Started(StartedWorkUnit { start_time, .. })) => now
+          let workunit: Option<&Workunit> = inner.workunit_records.get(&span_id);
+          match workunit {
+            Some(Workunit {
+              span_id,
+              state: WorkunitState::Started { start_time, .. },
+              ..
+            }) => now
               .duration_since(*start_time)
               .ok()
-              .map(|duration| (duration, span_id)),
+              .map(|duration| (duration, span_id.clone())),
             _ => None,
           }
         }),
@@ -199,17 +164,9 @@ impl WorkUnitStore {
 
     let mut res = HashMap::new();
     while let Some((dur, span_id)) = queue.pop() {
-      let record = inner.workunit_records.get(&span_id).unwrap();
-      let (desc, blocked) = match record {
-        WorkunitRecord::Started(StartedWorkUnit {
-          metadata: WorkunitMetadata { blocked, desc, .. },
-          ..
-        }) => (desc, *blocked),
-        WorkunitRecord::Completed(WorkUnit {
-          metadata: WorkunitMetadata { blocked, desc, .. },
-          ..
-        }) => (desc, *blocked),
-      };
+      let workunit = inner.workunit_records.get(&span_id).unwrap();
+      let desc = workunit.metadata.desc.as_ref();
+      let blocked = workunit.metadata.blocked;
       let maybe_duration = if blocked { None } else { Some(dur) };
       if let Some(effective_name) = desc {
         res.insert(effective_name.to_string(), maybe_duration);
@@ -229,17 +186,17 @@ impl WorkUnitStore {
     parent_id: Option<SpanId>,
     metadata: WorkunitMetadata,
   ) -> SpanId {
-    let started = StartedWorkUnit {
+    let started = Workunit {
       name,
       span_id: span_id.clone(),
       parent_id: parent_id.clone(),
-      start_time: std::time::SystemTime::now(),
+      state: WorkunitState::Started {
+        start_time: std::time::SystemTime::now(),
+      },
       metadata,
     };
     let mut inner = self.inner.lock();
-    inner
-      .workunit_records
-      .insert(span_id.clone(), WorkunitRecord::Started(started));
+    inner.workunit_records.insert(span_id.clone(), started);
     inner.started_ids.push(span_id.clone());
     let child = inner.graph.add_node(span_id.clone());
     inner
@@ -262,19 +219,20 @@ impl WorkUnitStore {
         "No previously-started workunit found for id: {}",
         span_id
       )),
-      Entry::Occupied(o) => match o.remove_entry() {
-        (span_id, WorkunitRecord::Started(started)) => {
-          let finished = started.finish();
-          inner
-            .workunit_records
-            .insert(span_id.clone(), WorkunitRecord::Completed(finished));
-          inner.completed_ids.push(span_id);
-          Ok(())
-        }
-        (span_id, WorkunitRecord::Completed(_)) => {
-          Err(format!("Workunit {} was already completed.", span_id))
-        }
-      },
+      Entry::Occupied(o) => {
+        let (span_id, mut workunit) = o.remove_entry();
+        let time_span = match workunit.state {
+          WorkunitState::Completed { .. } => {
+            return Err(format!("Workunit {} was already completed", span_id))
+          }
+          WorkunitState::Started { start_time } => TimeSpan::since(&start_time),
+        };
+        let new_state = WorkunitState::Completed { time_span };
+        workunit.state = new_state;
+        inner.workunit_records.insert(span_id.clone(), workunit);
+        inner.completed_ids.push(span_id);
+        Ok(())
+      }
     }
   }
 
@@ -287,13 +245,13 @@ impl WorkUnitStore {
   ) {
     let inner = &mut self.inner.lock();
     let span_id = new_span_id();
-    let workunit = WorkunitRecord::Completed(WorkUnit {
+    let workunit = Workunit {
       name,
-      time_span,
       span_id: span_id.clone(),
       parent_id,
+      state: WorkunitState::Completed { time_span },
       metadata,
-    });
+    };
 
     inner.workunit_records.insert(span_id.clone(), workunit);
     inner.completed_ids.push(span_id);
@@ -301,103 +259,65 @@ impl WorkUnitStore {
 
   pub fn with_latest_workunits<F, T>(&mut self, f: F) -> T
   where
-    F: FnOnce(&[StartedWorkUnit], &[WorkUnit]) -> T,
+    F: FnOnce(&[Workunit], &[Workunit]) -> T,
   {
     let mut inner_guard = (*self.inner).lock();
     let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
-
     let workunit_records = &inner_store.workunit_records;
+
+    let compute_should_display = |workunit: Workunit| -> Workunit {
+      let mut parent_id: Option<SpanId> = workunit.parent_id;
+      loop {
+        if let Some(current_parent_id) = parent_id {
+          if should_display_workunit(workunit_records, &current_parent_id) {
+            return Workunit {
+              parent_id: Some(current_parent_id),
+              ..workunit
+            };
+          } else {
+            let new_parent_id: Option<SpanId> = workunit_records
+              .get(&current_parent_id.clone())
+              .and_then(|workunit| match &workunit.parent_id {
+                Some(id) => Some(id.clone()),
+                None => None,
+              });
+            parent_id = new_parent_id;
+          }
+        } else {
+          return Workunit {
+            parent_id: None,
+            ..workunit
+          };
+        }
+      }
+    };
 
     let cur_len = inner_store.started_ids.len();
     let latest: usize = inner_store.last_seen_started_idx;
-    let started_workunits: Vec<StartedWorkUnit> = inner_store.started_ids[latest..cur_len]
+    let started_workunits: Vec<Workunit> = inner_store.started_ids[latest..cur_len]
       .iter()
       .flat_map(|id| workunit_records.get(id))
-      .flat_map(|record| match record {
-        WorkunitRecord::Completed(_) => None,
-        WorkunitRecord::Started(StartedWorkUnit { metadata, .. }) if !metadata.display => None,
-        WorkunitRecord::Started(c) => Some(c.clone()),
+      .flat_map(|workunit| match workunit.state {
+        WorkunitState::Started { .. } if workunit.metadata.display => Some(workunit.clone()),
+        WorkunitState::Started { .. } => None,
+        WorkunitState::Completed { .. } => None,
       })
-      .map(|started: StartedWorkUnit| {
-        let mut parent_id: Option<SpanId> = started.parent_id;
-        loop {
-          if let Some(current_parent_id) = parent_id {
-            if should_display_workunit(workunit_records, &current_parent_id) {
-              return StartedWorkUnit {
-                parent_id: Some(current_parent_id),
-                ..started
-              };
-            } else {
-              let new_parent_id: Option<SpanId> = workunit_records
-                .get(&current_parent_id.clone())
-                .and_then(|record| match record {
-                  WorkunitRecord::Started(StartedWorkUnit {
-                    parent_id: Some(id),
-                    ..
-                  }) => Some(id.clone()),
-                  WorkunitRecord::Completed(WorkUnit {
-                    parent_id: Some(id),
-                    ..
-                  }) => Some(id.clone()),
-                  _ => None,
-                });
-              parent_id = new_parent_id;
-            }
-          } else {
-            return StartedWorkUnit {
-              parent_id: None,
-              ..started
-            };
-          }
-        }
-      })
+      .map(compute_should_display)
       .collect();
     inner_store.last_seen_started_idx = cur_len;
 
     let completed_ids = &inner_store.completed_ids;
     let cur_len = completed_ids.len();
     let latest: usize = inner_store.last_seen_completed_idx;
-    let completed_workunits: Vec<WorkUnit> = inner_store.completed_ids[latest..cur_len]
+    let completed_workunits: Vec<Workunit> = inner_store.completed_ids[latest..cur_len]
       .iter()
       .flat_map(|id| workunit_records.get(id))
-      .flat_map(|record| match record {
-        WorkunitRecord::Started(_) => None,
-        WorkunitRecord::Completed(WorkUnit { metadata, .. }) if !metadata.display => None,
-        WorkunitRecord::Completed(c) => Some(c.clone()),
+      .flat_map(|workunit| match workunit.state {
+        WorkunitState::Completed { .. } if workunit.metadata.display => Some(workunit.clone()),
+        WorkunitState::Completed { .. } => None,
+        WorkunitState::Started { .. } => None,
       })
-      .map(|workunit: WorkUnit| {
-        let mut parent_id: Option<SpanId> = workunit.parent_id;
-        loop {
-          if let Some(current_parent_id) = parent_id {
-            if should_display_workunit(workunit_records, &current_parent_id) {
-              return WorkUnit {
-                parent_id: Some(current_parent_id),
-                ..workunit
-              };
-            } else {
-              let new_parent_id: Option<SpanId> = workunit_records
-                .get(&current_parent_id.clone())
-                .and_then(|record| match record {
-                  WorkunitRecord::Started(StartedWorkUnit {
-                    parent_id: Some(id),
-                    ..
-                  }) => Some(id.clone()),
-                  WorkunitRecord::Completed(WorkUnit {
-                    parent_id: Some(id),
-                    ..
-                  }) => Some(id.clone()),
-                  _ => None,
-                });
-              parent_id = new_parent_id;
-            }
-          } else {
-            return WorkUnit {
-              parent_id: None,
-              ..workunit
-            };
-          }
-        }
-      })
+      .map(compute_should_display)
       .collect();
     inner_store.last_seen_completed_idx = cur_len;
 
@@ -420,7 +340,7 @@ fn hex_16_digit_string(number: u64) -> String {
 ///
 #[derive(Clone)]
 pub struct WorkUnitState {
-  pub store: WorkUnitStore,
+  pub store: WorkunitStore,
   pub parent_id: Option<String>,
 }
 
@@ -453,11 +373,11 @@ pub fn get_workunit_state() -> Option<WorkUnitState> {
 }
 
 pub fn expect_workunit_state() -> WorkUnitState {
-  get_workunit_state().expect("A WorkUnitStore has not been set for this thread.")
+  get_workunit_state().expect("A WorkunitStore has not been set for this thread.")
 }
 
 pub async fn with_workunit<F>(
-  workunit_store: WorkUnitStore,
+  workunit_store: WorkunitStore,
   name: String,
   metadata: WorkunitMetadata,
   f: F,


### PR DESCRIPTION
### Problem

In the process of making workunits more sophisticated, it's become clear that the distinction between a `StartedWorkunit` and a `Workunit` no longer makes sense, and leads to a lot of code duplication in trying to handle the mostly-identical `StartedWorkunit` and `WorkUnit` types.

### Solution

This commit unifies workunits into a single type named `Workunit`, and adds a new member `state` of a new type `WorkunitState` to distinguish between started and completed workunits. Also the `WorkUnitStore` type is renamed to `WorkunitStore` to be consistent about the camel-casing of the type.
