### PR TITLE
Disable capturing core dumps in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ jobs:
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ulimit -c unlimited
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -108,8 +106,6 @@ jobs:
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ulimit -c unlimited
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -154,7 +150,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     cache:
       directories:
@@ -194,7 +189,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     cache:
       directories:
@@ -359,7 +353,6 @@ jobs:
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     cache:
       directories:
@@ -1314,7 +1307,6 @@ jobs:
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     cache:
       directories:
@@ -1348,7 +1340,6 @@ jobs:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
     - brew cask install osxfuse
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     cache:
       directories:
@@ -1404,7 +1395,6 @@ jobs:
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    - ulimit -c unlimited
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1445,7 +1435,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1474,7 +1463,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1498,7 +1486,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1522,7 +1509,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1547,7 +1533,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1572,7 +1557,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:
@@ -1597,7 +1581,6 @@ jobs:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
     before_script:
-    - ulimit -c unlimited
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     env:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -351,7 +351,6 @@ def linux_shard(
             )
     if use_docker:
         setup["services"] = ["docker"]
-        safe_append(setup, "before_script", "ulimit -c unlimited")
     return setup
 
 
@@ -396,7 +395,7 @@ def osx_shard(
     setup = {
         "os": "osx",
         "language": "generic",
-        "before_script": ["ulimit -c unlimited", "ulimit -n 8192"],
+        "before_script": ["ulimit -n 8192"],
         "before_install": [
             "curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq",
             "chmod 755 /usr/local/bin/jq",
@@ -510,7 +509,7 @@ def clippy() -> Dict:
         **linux_fuse_shard(),
         "name": "Clippy (Rust linter)",
         "stage": Stage.test.value,
-        "before_script": ["ulimit -c unlimited", "ulimit -n 8192"],
+        "before_script": ["ulimit -n 8192"],
         "script": ["./build-support/bin/ci.py --clippy"],
         "env": ["CACHE_NAME=clippy"],
         "if": SKIP_RUST_CONDITION,
@@ -644,7 +643,7 @@ def integration_tests_v2(python_version: PythonVersion) -> Dict:
 _RUST_TESTS_BASE: Dict = {
     **CACHE_NATIVE_ENGINE,
     "stage": Stage.test.value,
-    "before_script": ["ulimit -c unlimited", "ulimit -n 8192"],
+    "before_script": ["ulimit -n 8192"],
     # NB: We also build `fs_util` in this shard to leverage having had compiled the engine. This
     # requires setting PREPARE_DEPLOY=1.
     "script": ["./build-support/bin/ci.py --rust-tests", "./build-support/bin/release.sh -f"],


### PR DESCRIPTION
### Problem

A while back we started capturing core dumps "globally" in travis. But in practice we have never consumed them, and I'm fairly certain that they are causing the OSX shards that test sending `SIGABRT` (which, if core dumps are enabled, will trigger a core dump) to `pantsd` to:
1. be racey, because while the core is dumping, the process is non-responsive and can't be killed, leading to errors like:
```FAILURE: failure while terminating pantsd: failed to kill pid 28775 with signals (<Signals.SIGTERM: 15>, <Signals.SIGKILL: 9>)```
2. run out of disk space: we've seen mysterious "out of disk" errors on the OSX shards... and core dumps are large.

### Solution

Disable core dumps everywhere. If we end up needing them in the future, we can enable them on a case-by-case basis.

### Result

Fixes #8127.

[ci skip-rust-tests]
[ci skip-jvm-tests]