### PR TITLE
Refine the workaround that allows pantsd to watch its pid file

### DIFF
--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -118,9 +118,12 @@ class OptionsInitializer:
 
         add(global_options.pants_workdir)
         add(global_options.pants_distdir)
-        # NB: We punch a hole in the ignore patterns to allow pants to directly watch process
-        # metadata that is written to disk.
+        # TODO: We punch a hole in the ignore patterns to allow pantsd to directly watch process
+        # metadata that is written to disk, but we re-ignore the watchman directory (which
+        # contains a named pipe). Over time, as more of the pantsd server components are ported to
+        # rust, we will be able to remove this special case.
         add(global_options.pants_subprocessdir, include=True)
+        add(os.path.join(global_options.pants_subprocessdir, "watchman"))
 
         return pants_ignore
 


### PR DESCRIPTION
### Problem

As described in #9758, there is a workaround in place to allow `pantsd` to watch its pid file in a way that is easily exposed to the Python `pantsd` services. But users who used `pantsd` before we disabled `watchman` will have a socket file at `.pids/watchman/watchman.sock` which needs to continue to be ignored.

### Solution

Refine the workaround to ensure that that subdirectory continues to be hidden. Once less `pantsd` code is on the python side of the FFI boundary we'll have more flexibility to fix this.

### Result

Fixes #9758.

[ci skip-rust-tests]
[ci skip-jvm-tests]