### PR TITLE
Standardized workunit names

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -48,7 +48,9 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
     None
   }
 
-  fn canonical_name(&self) -> String;
+  /// Provides the `name` field in workunits associated with this node. These names
+  /// should be friendly to machine-parsing (i.e. "my_node" rather than "My awesome node!").
+  fn workunit_name(&self) -> String;
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -649,7 +649,7 @@ impl Node for TNode {
     self.1
   }
 
-  fn canonical_name(&self) -> String {
+  fn workunit_name(&self) -> String {
     format!("{}", self)
   }
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -277,7 +277,7 @@ impl MultiPlatformProcess {
   }
 
   pub fn workunit_name(&self) -> String {
-    "MultiPlatformProcess".to_string()
+    "multi_platform_process".to_string()
   }
 }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -276,7 +276,7 @@ impl MultiPlatformProcess {
       .map(|(_platforms, epr)| epr.description.clone())
   }
 
-  pub fn canonical_name(&self) -> String {
+  pub fn workunit_name(&self) -> String {
     "MultiPlatformProcess".to_string()
   }
 }
@@ -435,7 +435,7 @@ impl CommandRunner for BoundedCommandRunner {
     req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    let name = format!("{}-waiting", req.canonical_name());
+    let name = format!("{}-waiting", req.workunit_name());
     let desc = req
       .user_facing_name()
       .unwrap_or_else(|| "<Unnamed process>".to_string());
@@ -448,7 +448,7 @@ impl CommandRunner for BoundedCommandRunner {
       let inner = self.inner.clone();
       let semaphore = self.inner.1.clone();
       let context = context.clone();
-      let name = format!("{}-running", req.canonical_name());
+      let name = format!("{}-running", req.workunit_name());
 
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1065,7 +1065,7 @@ impl Node for NodeKey {
     let started_workunit_id = {
       let display = context.session.should_handle_workunits()
         && (self.user_facing_name().is_some() || self.display_info().is_some());
-      let name = self.canonical_name();
+      let name = self.workunit_name();
       let span_id = new_span_id();
 
       // We're starting a new workunit: record our parent, and set the current parent to our span.
@@ -1156,14 +1156,14 @@ impl Node for NodeKey {
     }
   }
 
-  fn canonical_name(&self) -> String {
+  fn workunit_name(&self) -> String {
     match self {
       NodeKey::Task(_) => self
         .display_info()
         .and_then(|di| di.name.as_ref())
         .map(|s| s.to_owned())
         .unwrap_or_else(|| format!("{}", self)),
-      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.canonical_name(),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.workunit_name(),
       _ => format!("{}", self),
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1162,9 +1162,14 @@ impl Node for NodeKey {
         .display_info()
         .and_then(|di| di.name.as_ref())
         .map(|s| s.to_owned())
-        .unwrap_or_else(|| format!("{}", self)),
+        .unwrap_or_else(|| "<unnamed_rule>".to_string()),
       NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.workunit_name(),
-      _ => format!("{}", self),
+      NodeKey::Snapshot(..) => "snapshot".to_string(),
+      NodeKey::DigestFile(..) => "digest_file".to_string(),
+      NodeKey::DownloadedFile(..) => "downloaded_file".to_string(),
+      NodeKey::ReadLink(..) => "read_link".to_string(),
+      NodeKey::Scandir(_) => "scandir".to_string(),
+      NodeKey::Select(..) => "select".to_string(),
     }
   }
 }

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -317,7 +317,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
             trace = assert_single_element(ZipkinHandler.traces.values())
 
-            v2_span_name_part = "Snapshot"
+            v2_span_name_part = "snapshot"
             self.assertTrue(
                 any(v2_span_name_part in span["name"] for span in trace),
                 "There is no span that contains '{}' in it's name. The trace:{}".format(
@@ -349,7 +349,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
             trace = assert_single_element(ZipkinHandler.traces.values())
 
-            v2_span_name_part = "Snapshot"
+            v2_span_name_part = "snapshot"
             self.assertTrue(
                 any(v2_span_name_part in span["name"] for span in trace),
                 "There is no span that contains '{}' in it's name. The trace:{}".format(


### PR DESCRIPTION
### Problem

We want to give workunits standardized names so that they can be identified by clients of streaming workunits.

### Solution

Rename the method that provides this from `canonical_name` to `workunit_name` to remove the suggestion that these names have any kind of canonical or public status, and ensure that all node types have a meaningful string value.