### PR TITLE
Rename --v2-ui to --dynamic-ui

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -84,8 +84,11 @@ class LocalPantsRunner:
             native, options_bootstrapper, build_config
         )
 
-        v2_ui = options.for_global_scope().get("v2_ui", False)
-        use_colors = options.for_global_scope().get("colors", True)
+        global_scope = options.for_global_scope()
+
+        dynamic_ui = global_scope.dynamic_ui
+        use_colors = global_scope.get("colors", True)
+
         zipkin_trace_v2 = options.for_scope("reporting").zipkin_trace_v2
         # TODO(#8658) This should_report_workunits flag must be set to True for
         # StreamingWorkunitHandler to receive WorkUnits. It should eventually
@@ -96,7 +99,7 @@ class LocalPantsRunner:
         return graph_scheduler_helper.new_session(
             zipkin_trace_v2,
             RunTracker.global_instance().run_id,
-            v2_ui=v2_ui,
+            dynamic_ui=dynamic_ui,
             use_colors=use_colors,
             should_report_workunits=stream_workunits,
         )

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -55,7 +55,7 @@ class Console:
         the system stdout/stderr. If they are not defined, the effective stdout/stderr are proxied
         to Rust engine intrinsic code if there is a scheduler session provided, or just written to
         the standard Python-provided stdout/stderr if it is None. A scheduler session is provided if
-        --v2-ui is set.
+        --dynamic-ui is set.
         """
 
         has_scheduler = session is not None

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -940,7 +940,7 @@ class Native(metaclass=SingletonMetaclass):
         self,
         scheduler,
         should_record_zipkin_spans,
-        should_render_ui,
+        dynamic_ui: bool,
         build_id,
         should_report_workunits: bool,
     ):
@@ -948,7 +948,7 @@ class Native(metaclass=SingletonMetaclass):
             self.lib.session_create(
                 scheduler,
                 should_record_zipkin_spans,
-                should_render_ui,
+                dynamic_ui,
                 self.context.utf8_buf(build_id),
                 should_report_workunits,
             ),

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -386,13 +386,17 @@ class Scheduler:
         return self._native.new_nailgun_server(self._scheduler, port_requested, runner)
 
     def new_session(
-        self, zipkin_trace_v2, build_id, v2_ui=False, should_report_workunits=False
+        self,
+        zipkin_trace_v2: bool,
+        build_id,
+        dynamic_ui: bool = False,
+        should_report_workunits: bool = False,
     ) -> "SchedulerSession":
         """Creates a new SchedulerSession for this Scheduler."""
         return SchedulerSession(
             self,
             self._native.new_session(
-                self._scheduler, zipkin_trace_v2, v2_ui, build_id, should_report_workunits,
+                self._scheduler, zipkin_trace_v2, dynamic_ui, build_id, should_report_workunits,
             ),
         )
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -181,14 +181,14 @@ class LegacyGraphScheduler:
         self,
         zipkin_trace_v2,
         build_id,
-        v2_ui=False,
+        dynamic_ui: bool = False,
         use_colors=True,
         should_report_workunits=False,
     ) -> "LegacyGraphSession":
         session = self.scheduler.new_session(
-            zipkin_trace_v2, build_id, v2_ui, should_report_workunits
+            zipkin_trace_v2, build_id, dynamic_ui, should_report_workunits
         )
-        console = Console(use_colors=use_colors, session=session if v2_ui else None,)
+        console = Console(use_colors=use_colors, session=session if dynamic_ui else None,)
         return LegacyGraphSession(session, console, self.build_file_aliases, self.goal_map)
 
 

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -50,7 +50,7 @@ def load_backends_and_plugins(
                 "1) Avoids unnecessary prework. This new implementation should be faster to run.",
                 (
                     "2) Has less verbose output. Pants will now only show what isort itself outputs. "
-                    "(Use `--v2-ui` if you want to see the work Pants is doing behind-the-scenes.)"
+                    "(Use `--dyanmic-ui` if you want to see the work Pants is doing behind-the-scenes.)"
                 ),
                 (
                     "3) Works with `./pants lint` automatically. When you run `./pants lint`, Pants "

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -50,7 +50,7 @@ def load_backends_and_plugins(
                 "1) Avoids unnecessary prework. This new implementation should be faster to run.",
                 (
                     "2) Has less verbose output. Pants will now only show what isort itself outputs. "
-                    "(Use `--dyanmic-ui` if you want to see the work Pants is doing behind-the-scenes.)"
+                    "(Use `--dynamic-ui` if you want to see the work Pants is doing behind-the-scenes.)"
                 ),
                 (
                     "3) Works with `./pants lint` automatically. When you run `./pants lint`, Pants "

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -930,7 +930,7 @@ class GlobalOptions(Subsystem):
             type=bool,
             daemon=False,
             passive=not register.bootstrap.v2,
-            removal_version="1.30.0.dev0",
+            removal_version="1.31.0.dev0",
             removal_hint="Use --dynamic-ui instead.",
             help="Whether to show v2 engine execution progress.",
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -915,13 +915,23 @@ class GlobalOptions(Subsystem):
             "tags ('-' prefix).  Useful with ::, to find subsets of targets "
             "(e.g., integration tests.)",
         )
+        register(
+            "--dynamic-ui",
+            type=bool,
+            default=sys.stderr.isatty(),
+            daemon=False,
+            help="Display a dynamically-updating console UI as pants runs.",
+        )
 
         register(
             "--v2-ui",
             default=False,
+            dest="dynamic_ui",
             type=bool,
             daemon=False,
             passive=not register.bootstrap.v2,
+            removal_version="1.30.0.dev0",
+            removal_hint="Use --dynamic-ui instead.",
             help="Whether to show v2 engine execution progress.",
         )
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -44,7 +44,7 @@ struct InnerSession {
   // times if they were polled.
   roots: Mutex<HashMap<Root, Option<LastObserved>>>,
   // If enabled, the display that will render the progress of the V2 engine. This is only
-  // Some(_) if the --v2-ui option is enabled.
+  // Some(_) if the --dynamic-ui option is enabled.
   display: Option<Mutex<ConsoleUI>>,
   // If enabled, Zipkin spans for v2 engine will be collected.
   should_record_zipkin_spans: bool,

--- a/v2
+++ b/v2
@@ -2,4 +2,4 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-./pants --no-v1 --v2 --v2-ui "$@"
+./pants --no-v1 --v2 "$@"


### PR DESCRIPTION
### Problem

`--v2-ui` is a poor name for the flag that controls the presence/absence of the dynamically-updating swimlanes UI, since it mentions "v2" explicitly.

### Solution

Rename this option to `--dynamic-ui`, and deprecate the old `--v2-ui` option.