### PR TITLE
Upgrade py_zipkin from 0.18.4 to 0.20.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -31,7 +31,7 @@ pystache==0.5.3
 python-Levenshtein==0.12.0
 pywatchman==1.4.1
 PyYAML>=5.3.1,<5.4
-py_zipkin==0.18.4
+py_zipkin==0.20.0
 requests[security]>=2.20.1
 responses==0.10.14
 setproctitle==1.1.10


### PR DESCRIPTION
https://github.com/Yelp/py_zipkin/blob/master/CHANGELOG.rst

Add create_http_headers helper
Add zipkin_span.add_annotation() method
Add autoinstrumentation for python Threads
Allow creating a copy of Tracer
Add extract_zipkin_attrs_from_headers() helper
Expose encoding.create_endpoint helper
Ensure tags are strings when using V2_JSON encoding
Add testing.MockTransportHandler module