### PR TITLE
use @decorated_type_checkable for side-effecting rules!

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -16,7 +16,7 @@ from pants.engine.unions import UnionRule, union
 from pants.option.optionable import OptionableFactory
 from pants.util.collections import assert_single_element
 from pants.util.memo import memoized
-from pants.util.meta import frozen_after_init
+from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
@@ -29,11 +29,11 @@ class RuleAnnotations:
 DEFAULT_RULE_ANNOTATIONS = RuleAnnotations()
 
 
+@decorated_type_checkable
 def side_effecting(cls):
     """Annotates a class to indicate that it is a side-effecting type, which needs to be handled
     specially with respect to rule caching semantics."""
-    cls.__side_effecting = True
-    return cls
+    return side_effecting.define_instance_of(cls)
 
 
 class _RuleVisitor(ast.NodeVisitor):
@@ -293,9 +293,9 @@ def validate_parameter_types(
 ) -> None:
     if cacheable:
         for ty in parameter_types:
-            if getattr(ty, "__side_effecting", False):
+            if side_effecting.is_instance(ty):
                 raise ValueError(
-                    f"Non-console `@rule` {func_id} has a side-effecting parameter: {ty}"
+                    f"A `@rule` that was not a @goal_rule ({func_id}) has a side-effecting parameter: {ty}"
                 )
 
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -267,8 +267,11 @@ class RuleTest(TestBase):
                 return False
 
         error_str = str(cm.exception)
-        assert "invalid_rule has a side-effecting parameter" in error_str
-        assert "pants.engine.console.Console" in error_str
+        assert (
+            "(@rule pants.engine.rules_test:invalid_rule) has a side-effecting parameter"
+            in error_str
+        )
+        assert "pants.util.meta.Console" in error_str
 
 
 class RuleIndexTest(TestBase):


### PR DESCRIPTION
[ci skip-rust-tests]
[ci skip-jvm-tests]

### Problem

`@decorated_type_checkable` was added in #8496, and it makes checking for certain decorator types a little cleaner.

### Solution

- Use `@decorated_type_checkable` for `@side_effecting`.
- Update the error message to avoid referring to console rules.