### PR TITLE
Add tests for using plugins with Bandit, Flake8, and Pylint

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -80,7 +80,7 @@ async def bandit_lint(
     config_path: Optional[str] = bandit.options.config
     config_snapshot_request = Get[Snapshot](
         PathGlobs(
-            globs=tuple([config_path] if config_path else []),
+            globs=[config_path] if config_path else [],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin="the option `--bandit-config`",
         )

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -51,6 +51,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
+        additional_args: Optional[List[str]] = None,
     ) -> LintResult:
         args = ["--backend-packages2=pants.backend.python.lint.bandit"]
         if config:
@@ -60,6 +61,8 @@ class BanditIntegrationTest(ExternalToolTestBase):
             args.append(f"--bandit-args={passthrough_args}")
         if skip:
             args.append(f"--bandit-skip")
+        if additional_args:
+            args.extend(additional_args)
         return self.request_single_product(
             LintResult,
             Params(
@@ -122,3 +125,13 @@ class BanditIntegrationTest(ExternalToolTestBase):
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_bandit([target], skip=True)
         assert result == LintResult.noop()
+
+    def test_3rdparty_plugin(self) -> None:
+        target = self.make_target_with_origin(
+            [FileContent("bad.py", b"aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n")]
+        )
+        result = self.run_bandit(
+            [target], additional_args=["--bandit-extra-requirements=bandit-aws>0.0.1,<0.0.3"]
+        )
+        assert result.exit_code == 1
+        assert "Issue: [C100:hardcoded_aws_key]" in result.stdout

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -131,7 +131,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
             [FileContent("bad.py", b"aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n")]
         )
         result = self.run_bandit(
-            [target], additional_args=["--bandit-extra-requirements=bandit-aws>0.0.1,<0.0.3"]
+            [target], additional_args=["--bandit-extra-requirements=bandit-aws"]
         )
         assert result.exit_code == 1
         assert "Issue: [C100:hardcoded_aws_key]" in result.stdout

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -100,7 +100,7 @@ async def setup(
     config_path: Optional[str] = black.options.config
     config_snapshot_request = Get[Snapshot](
         PathGlobs(
-            globs=tuple([config_path] if config_path else []),
+            globs=[config_path] if config_path else [],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin="the option `--black-config`",
         )

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -52,6 +52,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
+        additional_args: Optional[List[str]] = None,
     ) -> LintResult:
         args = ["--backend-packages2=pants.backend.python.lint.flake8"]
         if config:
@@ -61,6 +62,8 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             args.append(f"--flake8-args='{passthrough_args}'")
         if skip:
             args.append(f"--flake8-skip")
+        if additional_args:
+            args.extend(additional_args)
         return self.request_single_product(
             LintResult,
             Params(
@@ -137,3 +140,13 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_flake8([target], skip=True)
         assert result == LintResult.noop()
+
+    def test_3rdparty_plugin(self) -> None:
+        target = self.make_target_with_origin(
+            [FileContent("bad.py", b"'constant' and 'constant2'\n")]
+        )
+        result = self.run_flake8(
+            [target], additional_args=["--flake8-extra-requirements=flake8-pantsbuild>=2.0,<3"]
+        )
+        assert result.exit_code == 1
+        assert "bad.py:1:1: PB11" in result.stdout

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -89,7 +89,7 @@ async def pylint_lint(
     config_path: Optional[str] = pylint.options.config
     config_snapshot_request = Get[Snapshot](
         PathGlobs(
-            globs=tuple([config_path] if config_path else []),
+            globs=[config_path] if config_path else [],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin="the option `--pylint-config`",
         )


### PR DESCRIPTION
We now advertise this in the docs at https://pants.readme.io/docs/python-linters-and-formatters#configuring-the-tools-and-adding-plugins, so we should be testing it.

[ci skip-rust-tests]
[ci skip-jvm-tests]