### PR TITLE
Fix Target API bindings not loading for plugins

### DIFF
--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
@@ -15,6 +15,7 @@ contrib_plugin(
   description='Pants plugin for creating deployable AWS Lambdas out of python code.',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
 )
 
 python_library(

--- a/contrib/go/src/python/pants/contrib/go/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/BUILD
@@ -15,6 +15,7 @@ contrib_plugin(
   description='Go language support for pants.',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
 )
 
 python_library(

--- a/contrib/node/src/python/pants/contrib/node/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/BUILD
@@ -17,7 +17,8 @@ contrib_plugin(
   description='Node.js support for pants.',
   build_file_aliases=True,
   register_goals=True,
-  global_subsystems=True
+  global_subsystems=True,
+  target_types=True,
 )
 
 python_library(

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -175,6 +175,7 @@ class PantsPluginV1(PythonLibraryV1):
         global_subsystems=False,
         register_goals=False,
         rules=False,
+        target_types=False,
         **kwargs,
     ):
         """
@@ -192,6 +193,8 @@ class PantsPluginV1(PythonLibraryV1):
                                     registers the 'register_goals' 'pantsbuild.plugin' entrypoint.
         :param bool rules: If `True`, register.py:rules must be defined and registers the 'rules'
                            'pantsbuild.plugin' entrypoint.
+        :param bool target_types: If `True`, register.py:target_types must be defined and registers
+                                  the 'target_types' 'pantsbuild.plugin' entrypoint.
         """
         if not distribution_name.startswith("pantsbuild.pants."):
             raise ValueError(
@@ -211,20 +214,21 @@ class PantsPluginV1(PythonLibraryV1):
 
         super().__init__(address, payload, provides=setup_py, **kwargs)
 
-        if build_file_aliases or register_goals or global_subsystems or rules:
+        if build_file_aliases or register_goals or global_subsystems or rules or target_types:
             module = os.path.relpath(address.spec_path, self.target_base).replace(os.sep, ".")
-            entrypoints = []
+            entry_points = []
             if build_file_aliases:
-                entrypoints.append(f"build_file_aliases = {module}.register:build_file_aliases")
+                entry_points.append(f"build_file_aliases = {module}.register:build_file_aliases")
             if register_goals:
-                entrypoints.append(f"register_goals = {module}.register:register_goals")
+                entry_points.append(f"register_goals = {module}.register:register_goals")
             if global_subsystems:
-                entrypoints.append(f"global_subsystems = {module}.register:global_subsystems")
+                entry_points.append(f"global_subsystems = {module}.register:global_subsystems")
             if rules:
-                entrypoints.append(f"rules = {module}.register:rules")
-            entry_points = {"pantsbuild.plugin": entrypoints}
+                entry_points.append(f"rules = {module}.register:rules")
+            if target_types:
+                entry_points.append(f"target_types = {module}.register:target_types")
 
-            setup_py.setup_py_keywords["entry_points"] = entry_points
+            setup_py.setup_py_keywords["entry_points"] = {"pantsbuild.plugin": entry_points}
             self.mark_invalidation_hash_dirty()  # To pickup the PythonArtifact (setup_py) changes.
 
 
@@ -306,12 +310,20 @@ class PantsRulesToggle(BoolField):
     default = False
 
 
+class PantsTargetTypesToggle(BoolField):
+    """If `True`, register.py:target_types must be defined and registers the 'target_types'
+    'pantsbuild.plugin' entrypoint."""
+
+    alias = "target_types"
+    default = False
+
+
 class PantsPlugin(Target):
     """A Pants plugin published by pantsbuild."""
 
     alias = "pants_plugin"
     core_fields = (
-        *FrozenOrderedSet(PythonLibrary.core_fields) - {DescriptionField},  # type: ignore[misc]
+        *(FrozenOrderedSet(PythonLibrary.core_fields) - {DescriptionField}),  # type: ignore[misc]
         PantsPluginDistributionName,
         PantsPluginDescription,
         PantsPluginAdditionalClassifiers,
@@ -319,6 +331,7 @@ class PantsPlugin(Target):
         PantsGlobalSubsystemsToggle,
         PantsRegisterGoalsToggle,
         PantsRulesToggle,
+        PantsTargetTypesToggle,
     )
 
 

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -21,8 +21,9 @@ from pkg_resources import (
 from pants.base.exceptions import BuildConfigurationError
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.build_graph.target import Target
+from pants.build_graph.target import Target as TargetV1
 from pants.engine.rules import RootRule, rule
+from pants.engine.target import COMMON_TARGET_FIELDS, Target
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar
 from pants.init.extension_loader import (
@@ -59,24 +60,34 @@ class DummySubsystem2(Subsystem):
     options_scope = "dummy-subsystem2"
 
 
-class DummyTarget(Target):
+class DummyV1Target(TargetV1):
     @classmethod
     def subsystems(cls):
         return (DummySubsystem1,)
 
 
-class DummyTarget2(Target):
+class DummyV1Target2(TargetV1):
     @classmethod
     def subsystems(cls):
         return (DummySubsystem2,)
 
 
-class DummyObject1(object):
+class DummyTarget(Target):
+    alias = "dummy_tgt"
+    core_fields = COMMON_TARGET_FIELDS
+
+
+class DummyTarget2(Target):
+    alias = "dummy_tgt2"
+    core_fields = ()
+
+
+class DummyObject1:
     # Test that registering an object with no subsystems() method succeeds.
     pass
 
 
-class DummyObject2(object):
+class DummyObject2:
     @classmethod
     def subsystems(cls):
         return (DummySubsystem2,)
@@ -128,6 +139,7 @@ class LoaderTest(unittest.TestCase):
         register_goals=None,
         global_subsystems=None,
         rules=None,
+        target_types=None,
         module_name="register",
     ):
 
@@ -150,12 +162,13 @@ class LoaderTest(unittest.TestCase):
             register_entrypoint("global_subsystems", global_subsystems)
             register_entrypoint("register_goals", register_goals)
             register_entrypoint("rules", rules)
+            register_entrypoint("target_types", target_types)
 
             yield package_name
         finally:
             del sys.modules[package_name]
 
-    def assert_empty_aliases(self):
+    def assert_empty(self):
         registered_aliases = self.build_configuration.registered_aliases()
         self.assertEqual(0, len(registered_aliases.target_types))
         self.assertEqual(0, len(registered_aliases.target_macro_factories))
@@ -163,20 +176,21 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
         self.assertEqual(self.build_configuration.optionables(), OrderedSet())
         self.assertEqual(0, len(self.build_configuration.rules()))
+        self.assertEqual(0, len(self.build_configuration.target_types()))
 
     def test_load_valid_empty(self):
         with self.create_register() as backend_package:
             load_backend(self.build_configuration, backend_package, is_v1_backend=True)
-            self.assert_empty_aliases()
+            self.assert_empty()
 
     def test_load_valid_partial_aliases(self):
         aliases = BuildFileAliases(
-            targets={"bob": DummyTarget}, objects={"obj1": DummyObject1, "obj2": DummyObject2}
+            targets={"bob": DummyV1Target}, objects={"obj1": DummyObject1, "obj2": DummyObject2}
         )
         with self.create_register(build_file_aliases=lambda: aliases) as backend_package:
             load_backend(self.build_configuration, backend_package, is_v1_backend=True)
             registered_aliases = self.build_configuration.registered_aliases()
-            self.assertEqual(DummyTarget, registered_aliases.target_types["bob"])
+            self.assertEqual(DummyV1Target, registered_aliases.target_types["bob"])
             self.assertEqual(DummyObject1, registered_aliases.objects["obj1"])
             self.assertEqual(DummyObject2, registered_aliases.objects["obj2"])
             self.assertEqual(
@@ -196,7 +210,7 @@ class LoaderTest(unittest.TestCase):
             self.assertEqual(0, len(Goal.all()))
 
             load_backend(self.build_configuration, backend_package, is_v1_backend=True)
-            self.assert_empty_aliases()
+            self.assert_empty()
             self.assertEqual(1, len(Goal.all()))
 
             task_names = Goal.by_name("jack").ordered_task_names()
@@ -229,7 +243,9 @@ class LoaderTest(unittest.TestCase):
             self.load_plugins(["Foobar"], is_v1_plugin=False)
 
     @staticmethod
-    def get_mock_plugin(name, version, reg=None, alias=None, after=None, rules=None):
+    def get_mock_plugin(
+        name, version, reg=None, alias=None, after=None, rules=None, target_types=None
+    ):
         """Make a fake Distribution (optionally with entry points)
 
         Note the entry points do not actually point to code in the returned distribution --
@@ -246,6 +262,7 @@ class LoaderTest(unittest.TestCase):
         :param callable alias: Optional callable for build_file_aliases entry point
         :param callable after: Optional callable for load_after list entry point
         :param callable rules: Optional callable for rules entry point
+        :param callable target_types: Optional callable for target_types entry point
         """
 
         plugin_pkg = f"demoplugin{uuid.uuid4().hex}"
@@ -274,6 +291,10 @@ class LoaderTest(unittest.TestCase):
         if rules is not None:
             setattr(plugin, "qux", rules)
             entry_lines.append(f"rules = {module_name}:qux\n")
+
+        if target_types is not None:
+            setattr(plugin, "tofu", target_types)
+            entry_lines.append(f"target_types = {module_name}:tofu\n")
 
         if entry_lines:
             entry_data = "[pantsbuild.plugin]\n{}\n".format("\n".join(entry_lines))
@@ -335,21 +356,21 @@ class LoaderTest(unittest.TestCase):
     def test_plugin_installs_alias(self):
         def reg_alias():
             return BuildFileAliases(
-                targets={"pluginalias": DummyTarget},
+                targets={"pluginalias": DummyV1Target},
                 objects={"FROMPLUGIN1": DummyObject1, "FROMPLUGIN2": DummyObject2},
             )
 
         self.working_set.add(self.get_mock_plugin("aliasdemo", "0.0.1", alias=reg_alias))
 
         # Start with no aliases.
-        self.assert_empty_aliases()
+        self.assert_empty()
 
         # Now load the plugin which defines aliases.
         self.load_plugins(["aliasdemo"], is_v1_plugin=True)
 
         # Aliases now exist.
         registered_aliases = self.build_configuration.registered_aliases()
-        self.assertEqual(DummyTarget, registered_aliases.target_types["pluginalias"])
+        self.assertEqual(DummyV1Target, registered_aliases.target_types["pluginalias"])
         self.assertEqual(DummyObject1, registered_aliases.objects["FROMPLUGIN1"])
         self.assertEqual(DummyObject2, registered_aliases.objects["FROMPLUGIN2"])
         self.assertEqual(
@@ -396,13 +417,47 @@ class LoaderTest(unittest.TestCase):
             [example_rule.rule, RootRule(RootType), example_plugin_rule.rule],
         )
 
+    def test_target_types(self):
+        def target_types():
+            return [DummyTarget, DummyTarget2]
+
+        with self.create_register(target_types=target_types) as backend_package:
+            load_backend(self.build_configuration, backend_package, is_v1_backend=True)
+            assert self.build_configuration.target_types() == OrderedSet(
+                [DummyTarget, DummyTarget2]
+            )
+
+            load_backend(self.build_configuration, backend_package, is_v1_backend=False)
+            assert self.build_configuration.target_types() == OrderedSet(
+                [DummyTarget, DummyTarget2]
+            )
+
+        class PluginTarget(Target):
+            alias = "plugin_tgt"
+            core_fields = ()
+
+        def plugin_targets():
+            return [PluginTarget]
+
+        self.working_set.add(
+            self.get_mock_plugin("new-targets", "0.0.1", target_types=plugin_targets)
+        )
+        self.load_plugins(["new-targets"], is_v1_plugin=True)
+        assert self.build_configuration.target_types() == OrderedSet(
+            [DummyTarget, DummyTarget2, PluginTarget]
+        )
+        self.load_plugins(["new-targets"], is_v1_plugin=False)
+        assert self.build_configuration.target_types() == OrderedSet(
+            [DummyTarget, DummyTarget2, PluginTarget]
+        )
+
     def test_backend_plugin_ordering(self):
         def reg_alias():
-            return BuildFileAliases(targets={"override-alias": DummyTarget2})
+            return BuildFileAliases(targets={"override-alias": DummyV1Target2})
 
         self.working_set.add(self.get_mock_plugin("pluginalias", "0.0.1", alias=reg_alias))
         plugins = ["pluginalias==0.0.1"]
-        aliases = BuildFileAliases(targets={"override-alias": DummyTarget})
+        aliases = BuildFileAliases(targets={"override-alias": DummyV1Target})
         with self.create_register(build_file_aliases=lambda: aliases) as backend_module:
             backends = [backend_module]
             load_backends_and_plugins(
@@ -416,4 +471,4 @@ class LoaderTest(unittest.TestCase):
         # The backend should load first, then the plugins, therefore the alias registered in
         # the plugin will override the alias registered by the backend
         registered_aliases = self.build_configuration.registered_aliases()
-        self.assertEqual(DummyTarget2, registered_aliases.target_types["override-alias"])
+        self.assertEqual(DummyV1Target2, registered_aliases.target_types["override-alias"])


### PR DESCRIPTION
With a plugin, we must explicitly set the `entry_point` in the distribution's metadata.

[ci skip-rust-tests]
[ci skip-jvm-tests]