### PR TITLE
Fix Target API bindings not loading for plugins

### DIFF
--- a/contrib/avro/src/python/pants/contrib/avro/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/BUILD
@@ -14,5 +14,6 @@ contrib_plugin(
   description='Avro Java code generation support for pants (deprecated)',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
   tags = {"partially_type_checked"},
 )

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
@@ -15,4 +15,5 @@ contrib_plugin(
   description='Pants plugin for creating deployable AWS Lambdas out of python code.',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -15,5 +15,6 @@ contrib_plugin(
   description='C++ pants plugin (deprecated).',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
   tags = {"partially_type_checked"},
 )

--- a/contrib/go/src/python/pants/contrib/go/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/BUILD
@@ -15,4 +15,5 @@ contrib_plugin(
   description='Go language support for pants.',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
 )

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
@@ -14,5 +14,6 @@ contrib_plugin(
   description='JAX-WS Pants plugin (deprecated)',
   build_file_aliases=True,
   register_goals=True,
+  target_types=True,
   tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/BUILD
@@ -17,5 +17,6 @@ contrib_plugin(
   description='Node.js support for pants.',
   build_file_aliases=True,
   register_goals=True,
-  global_subsystems=True
+  global_subsystems=True,
+  target_types=True,
 )

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/BUILD
@@ -17,5 +17,6 @@ contrib_plugin(
   description='scala.js support for pants (deprecated).',
   build_file_aliases=True,
   register_goals=True,
-  global_subsystems=True
+  global_subsystems=True,
+  target_types=True,
 )

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
@@ -24,4 +24,5 @@ contrib_plugin(
   ],
   register_goals=True,
   build_file_aliases=True,
+  target_types=True,
 )

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -238,9 +238,6 @@ def load_plugins(
             if "build_file_aliases2" in entries:
                 build_file_aliases2 = entries["build_file_aliases2"].load()()
                 build_configuration.register_aliases(build_file_aliases2)
-            if "targets2" in entries:
-                targets = entries["targets2"].load()()
-                build_configuration.register_targets(targets)
         loaded[dist.as_requirement().key] = dist
 
 


### PR DESCRIPTION
With a plugin, we must explicitly set the `entry_point` in the distribution's metadata.

[ci skip-rust-tests]
[ci skip-jvm-tests]