### PR TITLE
Remove forced copying in local load_bytes_with

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2986,8 +2986,6 @@ dependencies = [
 name = "serverset"
 version = "0.0.1"
 dependencies = [
- "boxfuture 0.0.1",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -580,7 +580,7 @@ impl fuse::Filesystem for BuildResultFS {
                   let begin = std::cmp::min(offset as usize, bytes.len());
                   let end = std::cmp::min(offset as usize + size as usize, bytes.len());
                   let mut reply = reply.lock();
-                  reply.take().unwrap().data(&bytes.slice(begin, end));
+                  reply.take().unwrap().data(&bytes[begin..end]);
                 })
                 .await
             })

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -541,7 +541,10 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         .parse::<usize>()
         .expect("size_bytes must be a non-negative number");
       let digest = Digest(fingerprint, size_bytes);
-      let v = match store.load_file_bytes_with(digest, |bytes| bytes).await? {
+      let v = match store
+        .load_file_bytes_with(digest, |bytes| bytes.into())
+        .await?
+      {
         None => {
           let maybe_dir = store.load_directory(digest).await?;
           maybe_dir.map(|(dir, _metadata)| {

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -289,17 +289,26 @@ impl ByteStore {
     Ok(digest)
   }
 
-  pub async fn load_bytes_with<T: Send + 'static, F: Fn(Bytes) -> T + Send + Sync + 'static>(
+  ///
+  /// Loads bytes from the underlying LMDB store using the given function. Because the database is
+  /// blocking, this accepts a function that views a slice rather than returning a clone of the
+  /// data. The upshot is that the database is able to provide slices directly into shared memory.
+  ///
+  /// The provided function is guaranteed to be called in a context where it is safe to block.
+  ///
+  pub async fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
     &self,
     entry_type: EntryType,
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {
     if digest == EMPTY_DIGEST {
-      // Avoid expensive I/O for this super common case.
-      // Also, this allows some client-provided operations (like merging snapshots) to work
-      // without needing to first store the empty snapshot.
-      return Ok(Some(f(Bytes::new())));
+      // Avoid I/O for this case. This allows some client-provided operations (like merging
+      // snapshots) to work without needing to first store the empty snapshot.
+      //
+      // To maintain the guarantee that the given function is called in a blocking context, we
+      // spawn the task..
+      return Ok(Some(self.executor().spawn_blocking(move || f(&[])).await));
     }
 
     let dbs = match entry_type {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -486,7 +486,7 @@ async fn empty_file_is_known() {
   let empty_file = TestData::empty();
   assert_eq!(
     store
-      .load_bytes_with(EntryType::File, empty_file.digest(), |b| b)
+      .load_bytes_with(EntryType::File, empty_file.digest(), |b| Bytes::from(b))
       .await,
     Ok(Some(empty_file.bytes())),
   )
@@ -499,7 +499,7 @@ async fn empty_directory_is_known() {
   let empty_dir = TestDirectory::empty();
   assert_eq!(
     store
-      .load_bytes_with(EntryType::Directory, empty_dir.digest(), |b| b)
+      .load_bytes_with(EntryType::Directory, empty_dir.digest(), |b| Bytes::from(b))
       .await,
     Ok(Some(empty_dir.bytes())),
   )
@@ -533,7 +533,9 @@ pub async fn load_bytes(
   entry_type: EntryType,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(entry_type, digest, |b| b).await
+  store
+    .load_bytes_with(entry_type, digest, |b| Bytes::from(b))
+    .await
 }
 
 async fn prime_store_with_file_bytes(store: &ByteStore, bytes: Bytes) -> Digest {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -1,15 +1,15 @@
 use super::{BackoffConfig, EntryType};
 
 use bazel_protos::{self, call_option};
-use boxfuture::{try_future, Boxable};
 use bytes::{Bytes, BytesMut};
 use concrete_time::TimeSpan;
 use digest::{Digest as DigestTrait, FixedOutput};
 use futures::compat::Future01CompatExt;
-use futures01::{future, Future, IntoFuture, Sink, Stream};
+use futures::future::{FutureExt, TryFutureExt};
+use futures01::{future, Future, Sink, Stream};
 use grpcio;
 use hashing::{Digest, Fingerprint};
-use serverset::{Retry, Serverset};
+use serverset::{retry, Serverset};
 use sha2::Sha256;
 use std::cmp::min;
 use std::collections::{BTreeMap, HashSet};
@@ -72,44 +72,34 @@ impl ByteStore {
     })
   }
 
-  fn with_byte_stream_client<
-    Value: Send + 'static,
-    Fut: Future<Item = Value, Error = String>,
-    IntoFut: IntoFuture<Future = Fut, Item = Value, Error = String>,
-    F: Fn(bazel_protos::bytestream_grpc::ByteStreamClient) -> IntoFut + Send + Sync + Clone + 'static,
+  async fn with_byte_stream_client<
+    Value: Send,
+    Fut: std::future::Future<Output = Result<Value, String>>,
+    F: Fn(bazel_protos::bytestream_grpc::ByteStreamClient) -> Fut,
   >(
     &self,
     f: F,
-  ) -> impl Future<Item = Value, Error = String> {
-    Retry(self.serverset.clone()).all_errors_immediately(
-      move |channel| {
-        f(bazel_protos::bytestream_grpc::ByteStreamClient::new(
-          channel,
-        ))
-      },
-      self.rpc_attempts,
-    )
+  ) -> Result<Value, String> {
+    retry::all_errors_immediately(&self.serverset, self.rpc_attempts, move |channel| {
+      f(bazel_protos::bytestream_grpc::ByteStreamClient::new(
+        channel,
+      ))
+    })
+    .await
   }
 
-  fn with_cas_client<
-    Value: Send + 'static,
-    Fut: Future<Item = Value, Error = String>,
-    IntoFut: IntoFuture<Future = Fut, Item = Value, Error = String>,
-    F: Fn(bazel_protos::remote_execution_grpc::ContentAddressableStorageClient) -> IntoFut
-      + Send
-      + Sync
-      + Clone
-      + 'static,
+  async fn with_cas_client<
+    Value: Send,
+    Fut: std::future::Future<Output = Result<Value, String>>,
+    F: Fn(bazel_protos::remote_execution_grpc::ContentAddressableStorageClient) -> Fut,
   >(
     &self,
     f: F,
-  ) -> impl Future<Item = Value, Error = String> {
-    Retry(self.serverset.clone()).all_errors_immediately(
-      move |channel| {
-        f(bazel_protos::remote_execution_grpc::ContentAddressableStorageClient::new(channel))
-      },
-      self.rpc_attempts,
-    )
+  ) -> Result<Value, String> {
+    retry::all_errors_immediately(&self.serverset, self.rpc_attempts, move |channel| {
+      f(bazel_protos::remote_execution_grpc::ContentAddressableStorageClient::new(channel))
+    })
+    .await
   }
 
   pub async fn store_bytes(&self, bytes: Bytes) -> Result<Digest, String> {
@@ -130,92 +120,93 @@ impl ByteStore {
     let workunit_name = format!("store_bytes({})", resource_name.clone());
     let store = self.clone();
 
-    let result =
-      self
-        .with_byte_stream_client(move |client| {
-          match client
-            .write_opt(try_future!(call_option(&store.headers, None)).timeout(store.upload_timeout))
-            .map(|v| (v, client))
-          {
-            Err(err) => future::err(format!(
-              "Error attempting to connect to upload digest {:?}: {:?}",
-              digest, err
-            ))
-            .to_boxed(),
-            Ok(((sender, receiver), _client)) => {
-              let chunk_size_bytes = store.chunk_size_bytes;
-              let resource_name = resource_name.clone();
-              let bytes = bytes.clone();
-              let stream =
-                futures01::stream::unfold::<_, _, future::FutureResult<_, grpcio::Error>, _>(
-                  (0, false),
-                  move |(offset, has_sent_any)| {
-                    if offset >= bytes.len() && has_sent_any {
-                      None
-                    } else {
-                      let mut req = bazel_protos::bytestream::WriteRequest::new();
-                      req.set_resource_name(resource_name.clone());
-                      req.set_write_offset(offset as i64);
-                      let next_offset = min(offset + chunk_size_bytes, bytes.len());
-                      req.set_finish_write(next_offset == bytes.len());
-                      req.set_data(bytes.slice(offset, next_offset));
-                      Some(future::ok((
-                        (req, grpcio::WriteFlags::default()),
-                        (next_offset, true),
-                      )))
-                    }
-                  },
-                );
+    let result = self
+      .with_byte_stream_client(move |client| {
+        let resource_name = resource_name.clone();
+        let store = store.clone();
+        let bytes = bytes.clone();
+        async move {
+          let (sender, receiver) = client
+            .write_opt(call_option(&store.headers, None)?.timeout(store.upload_timeout))
+            .map_err(|err| {
+              format!(
+                "Error attempting to connect to upload digest {:?}: {:?}",
+                digest, err
+              )
+            })?;
 
-              sender
-                .send_all(stream)
-                .map(|_| ())
-                .or_else(move |e| {
-                  match e {
-                    // Some implementations of the remote execution API early-return if the blob has
-                    // been concurrently uploaded by another client. In this case, they return a
-                    // WriteResponse with a committed_size equal to the digest's entire size before
-                    // closing the stream.
-                    // Because the server then closes the stream, the client gets an RpcFinished
-                    // error in this case. We ignore this, and will later on verify that the
-                    // committed_size we received from the server is equal to the expected one. If
-                    // these are not equal, the upload will be considered a failure at that point.
-                    // Whether this type of response will become part of the official API is up for
-                    // discussion: see
-                    // https://groups.google.com/d/topic/remote-execution-apis/NXUe3ItCw68/discussion.
-                    grpcio::Error::RpcFinished(None) => Ok(()),
-                    e => Err(format!(
-                      "Error attempting to upload digest {:?}: {:?}",
-                      digest, e
-                    )),
-                  }
-                })
-                .and_then(move |()| {
-                  receiver.map_err(move |e| {
-                    format!(
-                      "Error from server when uploading digest {:?}: {:?}",
-                      digest, e
-                    )
-                  })
-                })
-                .and_then(move |received| {
-                  if received.get_committed_size() == len as i64 {
-                    Ok(digest)
-                  } else {
-                    Err(format!(
-                      "Uploading file with digest {:?}: want commited size {} but got {}",
-                      digest,
-                      len,
-                      received.get_committed_size()
-                    ))
-                  }
-                })
-                .to_boxed()
-            }
+          let chunk_size_bytes = store.chunk_size_bytes;
+          let resource_name = resource_name.clone();
+          let bytes = bytes.clone();
+          let stream = futures01::stream::unfold::<_, _, future::FutureResult<_, grpcio::Error>, _>(
+            (0, false),
+            move |(offset, has_sent_any)| {
+              if offset >= bytes.len() && has_sent_any {
+                None
+              } else {
+                let mut req = bazel_protos::bytestream::WriteRequest::new();
+                req.set_resource_name(resource_name.clone());
+                req.set_write_offset(offset as i64);
+                let next_offset = min(offset + chunk_size_bytes, bytes.len());
+                req.set_finish_write(next_offset == bytes.len());
+                req.set_data(bytes.slice(offset, next_offset));
+                Some(future::ok((
+                  (req, grpcio::WriteFlags::default()),
+                  (next_offset, true),
+                )))
+              }
+            },
+          );
+
+          sender
+            .send_all(stream)
+            .map(|_| ())
+            .or_else(move |e| {
+              match e {
+                // Some implementations of the remote execution API early-return if the blob has
+                // been concurrently uploaded by another client. In this case, they return a
+                // WriteResponse with a committed_size equal to the digest's entire size before
+                // closing the stream.
+                // Because the server then closes the stream, the client gets an RpcFinished
+                // error in this case. We ignore this, and will later on verify that the
+                // committed_size we received from the server is equal to the expected one. If
+                // these are not equal, the upload will be considered a failure at that point.
+                // Whether this type of response will become part of the official API is up for
+                // discussion: see
+                // https://groups.google.com/d/topic/remote-execution-apis/NXUe3ItCw68/discussion.
+                grpcio::Error::RpcFinished(None) => Ok(()),
+                e => Err(format!(
+                  "Error attempting to upload digest {:?}: {:?}",
+                  digest, e
+                )),
+              }
+            })
+            .compat()
+            .await?;
+
+          let received = receiver
+            .map_err(move |e| {
+              format!(
+                "Error from server when uploading digest {:?}: {:?}",
+                digest, e
+              )
+            })
+            .compat()
+            .await?;
+
+          if received.get_committed_size() == len as i64 {
+            Ok(digest)
+          } else {
+            Err(format!(
+              "Uploading file with digest {:?}: want commited size {} but got {}",
+              digest,
+              len,
+              received.get_committed_size()
+            ))
           }
-        })
-        .compat()
-        .await;
+        }
+      })
+      .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
       let parent_id = workunit_state.parent_id;
@@ -253,53 +244,53 @@ impl ByteStore {
 
     let result = self
       .with_byte_stream_client(move |client| {
-        match client
-          .read_opt(
-            &{
-              let mut req = bazel_protos::bytestream::ReadRequest::new();
-              req.set_resource_name(resource_name.clone());
-              req.set_read_offset(0);
-              // 0 means no limit.
-              req.set_read_limit(0);
-              req
-            },
-            try_future!(call_option(&store.headers, None)),
-          )
-          .map(|stream| (stream, client))
-        {
-          Ok((stream, client)) => {
-            let f = f.clone();
-            // We shouldn't have to pass around the client here, it's a workaround for
-            // https://github.com/pingcap/grpc-rs/issues/123
-            future::ok(client)
-              .join(
-                stream.fold(BytesMut::with_capacity(digest.1), move |mut bytes, r| {
-                  bytes.extend_from_slice(&r.data);
-                  future::ok::<_, grpcio::Error>(bytes)
-                }),
-              )
-              .map(|(_client, bytes)| Some(bytes.freeze()))
-              .or_else(|e| match e {
-                grpcio::Error::RpcFailure(grpcio::RpcStatus {
-                  status: grpcio::RpcStatusCode::NOT_FOUND,
-                  ..
-                }) => Ok(None),
-                _ => Err(format!(
-                  "Error from server in response to CAS read request: {:?}",
-                  e
-                )),
-              })
-              .map(move |maybe_bytes| maybe_bytes.map(f))
-              .to_boxed()
-          }
-          Err(err) => future::err(format!(
-            "Error making CAS read request for {:?}: {:?}",
-            digest, err
-          ))
-          .to_boxed(),
+        let resource_name = resource_name.clone();
+        let store = store.clone();
+        let f = f.clone();
+        async move {
+          let stream = client
+            .read_opt(
+              &{
+                let mut req = bazel_protos::bytestream::ReadRequest::new();
+                req.set_resource_name(resource_name.clone());
+                req.set_read_offset(0);
+                // 0 means no limit.
+                req.set_read_limit(0);
+                req
+              },
+              call_option(&store.headers, None)?,
+            )
+            .map_err(|err| format!("Error making CAS read request for {:?}: {:?}", digest, err))?;
+
+          let bytes_res = stream
+            .fold(BytesMut::with_capacity(digest.1), move |mut bytes, r| {
+              bytes.extend_from_slice(&r.data);
+              future::ok::<_, grpcio::Error>(bytes)
+            })
+            .compat()
+            .await;
+
+          // We ensure that we hold onto the client until after we've consumed the stream as a
+          // workaround for https://github.com/pingcap/grpc-rs/issues/123
+          std::mem::drop(client);
+
+          let maybe_bytes = match bytes_res {
+            Ok(bytes) => Some(bytes.freeze()),
+            Err(grpcio::Error::RpcFailure(grpcio::RpcStatus {
+              status: grpcio::RpcStatusCode::NOT_FOUND,
+              ..
+            })) => None,
+            Err(e) => {
+              return Err(format!(
+                "Error from server in response to CAS read request: {:?}",
+                e
+              ))
+            }
+          };
+
+          Ok(maybe_bytes.map(f))
         }
       })
-      .compat()
       .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
@@ -330,36 +321,42 @@ impl ByteStore {
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
-    self
-      .with_cas_client(move |client| {
-        client
-          .find_missing_blobs_opt(&request, call_option(&store.headers, None)?)
-          .map_err(|err| {
-            format!(
-              "Error from server in response to find_missing_blobs_request: {:?}",
-              err
-            )
-          })
-          .and_then(|response| {
+    async move {
+      let store2 = store.clone();
+      let res = store2
+        .with_cas_client(move |client| {
+          let request = request.clone();
+          let store = store.clone();
+          async move {
+            let response = client
+              .find_missing_blobs_opt(&request, call_option(&store.headers, None)?)
+              .map_err(|err| {
+                format!(
+                  "Error from server in response to find_missing_blobs_request: {:?}",
+                  err
+                )
+              })?;
             response
               .get_missing_blob_digests()
               .iter()
               .map(|digest| digest.into())
-              .collect()
-          })
-      })
-      .then(move |future| {
-        if let Some(workunit_state) = workunit_store::get_workunit_state() {
-          let name = workunit_name.clone();
-          let time_span = TimeSpan::since(&start_time);
-          let parent_id = workunit_state.parent_id;
-          let metadata = workunit_store::WorkunitMetadata::new();
-          workunit_state
-            .store
-            .add_completed_workunit(name, time_span, parent_id, metadata);
-        }
-        future
-      })
+              .collect::<Result<HashSet<_>, _>>()
+          }
+        })
+        .await;
+      if let Some(workunit_state) = workunit_store::get_workunit_state() {
+        let name = workunit_name.clone();
+        let time_span = TimeSpan::since(&start_time);
+        let parent_id = workunit_state.parent_id;
+        let metadata = workunit_store::WorkunitMetadata::new();
+        workunit_state
+          .store
+          .add_completed_workunit(name, time_span, parent_id, metadata);
+      }
+      res
+    }
+    .boxed()
+    .compat()
   }
 
   pub(super) fn find_missing_blobs_request<'a, Digests: Iterator<Item = &'a Digest>>(

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -139,7 +139,7 @@ async fn write_file_one_chunk() {
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    store.store_bytes(testdata.bytes()).await,
+    store.store_bytes(&testdata.bytes()).await,
     Ok(testdata.digest())
   );
 
@@ -170,7 +170,7 @@ async fn write_file_multiple_chunks() {
   let fingerprint = big_file_fingerprint();
 
   assert_eq!(
-    store.store_bytes(all_the_henries.clone()).await,
+    store.store_bytes(&all_the_henries).await,
     Ok(big_file_digest())
   );
 
@@ -198,7 +198,7 @@ async fn write_empty_file() {
 
   let store = new_byte_store(&cas);
   assert_eq!(
-    store.store_bytes(empty_file.bytes()).await,
+    store.store_bytes(&empty_file.bytes()).await,
     Ok(empty_file.digest())
   );
 
@@ -215,7 +215,7 @@ async fn write_file_errors() {
 
   let store = new_byte_store(&cas);
   let error = store
-    .store_bytes(TestData::roland().bytes())
+    .store_bytes(&TestData::roland().bytes())
     .await
     .expect_err("Want error");
   assert!(
@@ -244,7 +244,7 @@ async fn write_connection_error() {
   )
   .unwrap();
   let error = store
-    .store_bytes(TestData::roland().bytes())
+    .store_bytes(&TestData::roland().bytes())
     .await
     .expect_err("Want error");
   assert!(

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -71,7 +71,9 @@ pub fn extra_big_file_bytes() -> Bytes {
 }
 
 pub async fn load_file_bytes(store: &Store, digest: Digest) -> Result<Option<Bytes>, String> {
-  let option = store.load_file_bytes_with(digest, |bytes| bytes).await?;
+  let option = store
+    .load_file_bytes_with(digest, |bytes| Bytes::from(bytes))
+    .await?;
   Ok(option.map(|(bytes, _metadata)| bytes))
 }
 
@@ -916,7 +918,7 @@ async fn instance_name_download() {
 
   assert_eq!(
     store_with_remote
-      .load_file_bytes_with(TestData::roland().digest(), |b| b,)
+      .load_file_bytes_with(TestData::roland().digest(), |b| Bytes::from(b))
       .await
       .unwrap()
       .unwrap()
@@ -997,7 +999,7 @@ async fn auth_download() {
 
   assert_eq!(
     store_with_remote
-      .load_file_bytes_with(TestData::roland().digest(), |b| b,)
+      .load_file_bytes_with(TestData::roland().digest(), |b| Bytes::from(b))
       .await
       .unwrap()
       .unwrap()

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -905,7 +905,7 @@ fn extract_stdout(
       try_future!(stdout_digest_result.map_err(|err| format!("Error extracting stdout: {}", err)));
     Box::pin(async move {
       let (bytes, _metadata) = store
-        .load_file_bytes_with(stdout_digest, |v| v)
+        .load_file_bytes_with(stdout_digest, |v| v.into())
         .map_err(move |error| {
           format!(
             "Error fetching stdout digest ({:?}): {:?}",
@@ -952,7 +952,7 @@ fn extract_stderr(
 
     Box::pin(async move {
       let (bytes, _metadata) = store
-        .load_file_bytes_with(stderr_digest, |v| v)
+        .load_file_bytes_with(stderr_digest, |v| v.into())
         .map_err(move |error| {
           format!(
             "Error fetching stderr digest ({:?}): {:?}",

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1015,7 +1015,7 @@ async fn ensure_inline_stdio_is_stored() {
   {
     assert_eq!(
       local_store
-        .load_file_bytes_with(test_stdout.digest(), |v| v,)
+        .load_file_bytes_with(test_stdout.digest(), |v| Bytes::from(v))
         .await
         .unwrap()
         .unwrap()
@@ -1024,7 +1024,7 @@ async fn ensure_inline_stdio_is_stored() {
     );
     assert_eq!(
       local_store
-        .load_file_bytes_with(test_stderr.digest(), |v| v,)
+        .load_file_bytes_with(test_stderr.digest(), |v| Bytes::from(v))
         .await
         .unwrap()
         .unwrap()

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -6,9 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-boxfuture = { path = "../boxfuture" }
-futures01 = { package = "futures", version = "0.1" }
-futures = { version = "0.3", features = ["compat"] }
+futures = "0.3"
 parking_lot = "0.6"
 tokio = { version = "0.2", features = ["time"] }
 

--- a/src/rust/engine/serverset/src/retry.rs
+++ b/src/rust/engine/serverset/src/retry.rs
@@ -1,49 +1,41 @@
 use crate::{Health, Serverset};
-use futures01::{future, Future, IntoFuture};
 
-pub struct Retry<T: Clone>(pub Serverset<T>);
+use std::future::Future;
 
-impl<T: Clone + Send + Sync + 'static> Retry<T> {
-  ///
-  /// Runs `f` up to `times` times, taking servers from the underlying serverset.
-  ///
-  /// Will retry any time `f` produces an error. The underlying serverset may lead to backoff
-  /// between attempts, but the Retry implementation itself will not.
-  ///
-  pub fn all_errors_immediately<
-    Value: Send + 'static,
-    Fut: Future<Item = Value, Error = String>,
-    IntoFut: IntoFuture<Future = Fut, Item = Value, Error = String>,
-    F: FnMut(T) -> IntoFut + Send + Sync + Clone + 'static,
-  >(
-    &self,
-    f: F,
-    times: usize,
-  ) -> impl Future<Item = Value, Error = String> {
-    let serverset = self.0.clone();
-    future::loop_fn(0_usize, move |i| {
-      let serverset = serverset.clone();
-      let f = f.clone();
-      serverset
-        .next()
-        .and_then(move |(server, token)| {
-          future::ok(server).and_then(f).then(move |result| {
-            let health = match &result {
-              &Ok(_) => Health::Healthy,
-              &Err(_) => Health::Unhealthy,
-            };
-            serverset.report_health(token, health);
-            result
-          })
-        })
-        .map(future::Loop::Break)
-        .or_else(move |err| {
-          if i >= times {
-            Err(format!("Failed after {} retries; last failure: {}", i, err))
-          } else {
-            Ok(future::Loop::Continue(i + 1))
-          }
-        })
-    })
+///
+/// Runs `f` up to `times` times, taking servers from the given serverset.
+///
+/// Will retry any time `f` produces an error. The underlying serverset may lead to backoff
+/// between attempts, but the Retry implementation itself will not.
+///
+pub async fn all_errors_immediately<
+  T: Clone + Send + Sync + 'static,
+  Value: Send,
+  Fut: Future<Output = Result<Value, String>>,
+  F: Fn(T) -> Fut,
+>(
+  serverset: &Serverset<T>,
+  times: usize,
+  f: F,
+) -> Result<Value, String> {
+  let mut i = 0;
+  loop {
+    // Request a server, and run the function.
+    let (server, token) = serverset.next().await?;
+    let result = f(server).await;
+
+    // If the function failed, report the server unhealthy and try again.
+    if let Err(e) = result {
+      serverset.report_health(token, Health::Unhealthy);
+      if i >= times {
+        return Err(format!("Failed after {} retries; last failure: {}", i, e));
+      }
+      i += 1;
+      continue;
+    }
+
+    // Otherwise, we're done!
+    serverset.report_health(token, Health::Healthy);
+    return result;
   }
 }

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -289,7 +289,7 @@ impl ShardedLmdb {
 
   pub async fn load_bytes_with<
     T: Send + 'static,
-    F: Fn(Bytes) -> Result<T, String> + Send + Sync + 'static,
+    F: Fn(&[u8]) -> Result<T, String> + Send + Sync + 'static,
   >(
     &self,
     fingerprint: Fingerprint,
@@ -305,7 +305,7 @@ impl ShardedLmdb {
           .begin_ro_txn()
           .map_err(|err| format!("Failed to begin read transaction: {}", err));
         ro_txn.and_then(|txn| match txn.get(db, &effective_key) {
-          Ok(bytes) => f(Bytes::from(bytes)).map(Some),
+          Ok(bytes) => f(bytes).map(Some),
           Err(lmdb::Error::NotFound) => Ok(None),
           Err(err) => Err(format!(
             "Error loading versioned key {:?}: {}",


### PR DESCRIPTION
### Problem

The LMDB API allows for direct references into its storage, which will always be MMAP'ed. But because it has a blocking API, we interact with it on threads that have been spawned for that purpose.

To allow for interacting with the database in a way that avoids copying data into userspace, the `load_bytes_with` method takes a function that will be called on the blocking thread with a reference directly to that memory. This allows for minimizing copies of data, and avoiding holding full copies of database entries in memory.

But at some point a while back (before async/await made dealing with references easy again), `load_bytes_with` started passing a `Bytes` instance to its callback. And constructing a `Bytes` instance with anything other than a static memory reference (which this isn't) requires copying into the `Bytes` instance to give it ownership. This meant that we weren't actually taking advantage of the odd shape of `load_bytes_with`.

### Solution

Switch the local `load_bytes_with` back to providing a reference into the database's owned memory, and document the reason for its shape. In separate commits, port the `serverset` crate and code that touches it to async/await. Finally, adjust the remote `store_bytes` to accept a reference to avoid potential copies there as well.

### Result

Less memory usage, and less copying of data. In particular: cases that read from the local database in order to copy elsewhere (such as `materialize_directory`, `ensure_remote_has_recursive`, and BRFS `read`) will now copy data directly out of the database and into the destination.

`ensure_remote_has_recursive` should now hold onto only [one chunk's worth](https://github.com/pantsbuild/pants/blob/4f45871814c15c0f41b335fc80f98780b9b38d92/src/python/pants/option/global_options.py#L752-L758) of data at a time per file it is uploading, which might be sufficient to fix #9395 (although the other changes mentioned there will likely still be useful).