### PR TITLE
Fix Pylint when a target has third-party dependencies

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -53,7 +53,7 @@ def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tup
     if pylint.config is not None:
         args.append(f"--rcfile={pylint.config}")
     args.extend(pylint.args)
-    args.extend(sorted(specified_source_files.files))
+    args.extend(specified_source_files.files)
     return tuple(args)
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -69,11 +69,11 @@ async def pylint_lint(
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
-    linted_addresses = []
+    addresses_with_dependencies = []
     for field_set in field_sets:
-        linted_addresses.append(field_set.address)
-        linted_addresses.extend(field_set.dependencies.value or ())
-    targets = await Get[Targets](Addresses(linted_addresses))
+        addresses_with_dependencies.append(field_set.address)
+        addresses_with_dependencies.extend(field_set.dependencies.value or ())
+    targets = await Get[Targets](Addresses(addresses_with_dependencies))
 
     # NB: Pylint output depends upon which Python interpreter version it's run with. We ensure that
     # each target runs with its own interpreter constraints. See

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import List, Optional, cast
+
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.option.custom_types import file_option, shell_str
 
@@ -31,3 +33,15 @@ class Pylint(PythonToolBase):
             advanced=True,
             help="Path to `pylintrc` or alternative Pylint config file",
         )
+
+    @property
+    def skip(self) -> bool:
+        return cast(bool, self.options.skip)
+
+    @property
+    def args(self) -> List[str]:
+        return cast(List[str], self.options.args)
+
+    @property
+    def config(self) -> Optional[str]:
+        return cast(Optional[str], self.options.config)


### PR DESCRIPTION
Pylint looks at direct dependencies to ensure that all import statements are valid. We knew this and were pulling in first-party dependencies, but we left off third-party dependencies.

To avoid too much of a performance hit, we use a pattern used in `pytest_runner.py` to resolve Pylint separately from resolving third-party dependencies. This avoids unnecessary re-resolution of Pylint.

This also does some prework for https://github.com/pantsbuild/pants/pull/9792:
1) Stop using `create_library()` in tests to avoid V1 code paths.
2) Add type hinted `@property`s to the `Pylint` subsystem to make for more ergonomic rules code.