### PR TITLE
Render failures via explicit traceback construction rather than graph walks

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -30,7 +30,7 @@ from pants.engine.internals.examples.parsers import (
 from pants.engine.internals.mapper import AddressFamily, AddressMapper
 from pants.engine.internals.nodes import Return, State, Throw
 from pants.engine.internals.parser import BuildFilePreludeSymbols, HydratedStruct, SymbolTable
-from pants.engine.internals.scheduler import ExecutionRequest, SchedulerSession
+from pants.engine.internals.scheduler import ExecutionError, ExecutionRequest, SchedulerSession
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.internals.struct import Struct, StructWithDeps
 from pants.engine.legacy.structs import TargetAdaptor
@@ -349,9 +349,10 @@ class InlinedGraphTest(GraphTestBase):
         # Confirm that the root failed, and that a cycle occurred deeper in the graph.
         request, state = self._populate(scheduler, parsed_address)
         self.assertEqual(type(state), Throw)
-        trace_message = "\n".join(scheduler.trace(request))
+        with self.assertRaises(ExecutionError) as cm:
+            scheduler._raise_on_error([state])
+        trace_message = str(cm.exception)
 
-        self.assert_throws_are_leaves(trace_message, Throw.__name__)
         if expected_regex:
             print(trace_message)
             self.assertRegex(trace_message, expected_regex)
@@ -364,28 +365,6 @@ class InlinedGraphTest(GraphTestBase):
             parsed_address,
             f"(?ms)Dep graph contained a cycle:.*{cyclic_address_str}.* <-.*{cyclic_address_str}.* <-",
         )
-
-    def assert_throws_are_leaves(self, error_msg, throw_name) -> None:
-        def indent_of(s: str) -> int:
-            return len(s) - len(s.lstrip())
-
-        def assert_equal_or_more_indentation(
-            more_indented_line: str, less_indented_line: str
-        ) -> None:
-            self.assertTrue(
-                indent_of(more_indented_line) >= indent_of(less_indented_line),
-                '\n"{}"\nshould have more equal or more indentation than\n"{}"\n{}'.format(
-                    more_indented_line, less_indented_line, error_msg
-                ),
-            )
-
-        lines = error_msg.splitlines()
-        line_indices_of_throws = [i for i, v in enumerate(lines) if throw_name in v]
-        for idx in line_indices_of_throws:
-            # Make sure lines with Throw have more or equal indentation than its neighbors.
-            current_line = lines[idx]
-            line_above = lines[max(0, idx - 1)]
-            assert_equal_or_more_indentation(current_line, line_above)
 
     def test_cycle_self(self) -> None:
         self.do_test_cycle("graph_test:self_cycle", "graph_test:self_cycle")

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -16,7 +16,6 @@ from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.testutil.engine.util import (
     assert_equal_with_printing,
     fmt_rule,
-    fmt_rust_function,
     remove_locations_from_traceback,
 )
 
@@ -160,7 +159,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             list(scheduler.product_request(A, subjects=[(B())]))
 
         self.assert_equal_with_printing(
-            "1 Exception encountered:\n  Exception: An exception for B", str(cm.exception)
+            "1 Exception encountered:\n\n  Exception: An exception for B\n", str(cm.exception)
         )
 
     def test_no_include_trace_error_multiple_paths_raises_executionerror(self):
@@ -178,8 +177,10 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             dedent(
                 """
                 2 Exceptions encountered:
+
                   Exception: An exception for B
-                  Exception: An exception for B"""
+                  Exception: An exception for B
+                """
             ).lstrip(),
             str(cm.exception),
         )
@@ -198,20 +199,17 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             dedent(
                 f"""
                 1 Exception encountered:
-                Computing Select(<{__name__}.B object at 0xEEEEEEEEE>, A)
-                  Computing Task({fmt_rust_function(nested_raise)}(), <{__name__}.B object at 0xEEEEEEEEE>, A, true)
-                    Throw(An exception for B)
-                      Traceback (most recent call last):
-                        File LOCATION-INFO, in call
-                          val = func(*args)
-                        File LOCATION-INFO, in nested_raise
-                          fn_raises(x)
-                        File LOCATION-INFO, in fn_raises
-                          raise Exception(f"An exception for {{type(x).__name__}}")
-                      Exception: An exception for B
+
+                Traceback (most recent call last):
+                  File LOCATION-INFO, in call
+                    val = func(*args)
+                  File LOCATION-INFO, in nested_raise
+                    fn_raises(x)
+                  File LOCATION-INFO, in fn_raises
+                    raise Exception(f"An exception for {{type(x).__name__}}")
+                Exception: An exception for B
                 """
-            ).lstrip()
-            + "\n",
+            ).lstrip(),
             remove_locations_from_traceback(str(cm.exception)),
         )
 

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -685,8 +685,8 @@ class ExternContext:
 
     def raise_or_return(self, pyresult):
         """Consumes the given PyResult to raise/return the exception/value it represents."""
-        value = self.from_value(pyresult.handle)
-        self._handles.remove(pyresult.handle)
+        value = self.from_value(pyresult.result)
+        self._handles.remove(pyresult.result)
         if pyresult.is_throw:
             raise value
         else:

--- a/src/python/pants/engine/internals/nodes.py
+++ b/src/python/pants/engine/internals/nodes.py
@@ -4,7 +4,7 @@
 import logging
 from abc import ABC
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -52,4 +52,6 @@ class Return(State):
 class Throw(State):
     """Indicates that a Node should have been able to return a value, but failed."""
 
-    exc: Any
+    exc: Exception
+    python_traceback: Optional[str] = None
+    engine_traceback: Tuple[str, ...] = tuple()

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1269,7 +1269,6 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
- "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -848,28 +848,6 @@ pub extern "C" fn graph_visualize(
 }
 
 #[no_mangle]
-pub extern "C" fn graph_trace(
-  scheduler_ptr: *mut Scheduler,
-  session_ptr: *mut Session,
-  execution_request_ptr: *mut ExecutionRequest,
-  path_ptr: *const raw::c_char,
-) {
-  let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
-  let path = PathBuf::from(path_str);
-  with_scheduler(scheduler_ptr, |scheduler| {
-    with_session(session_ptr, |session| {
-      with_execution_request(execution_request_ptr, |execution_request| {
-        scheduler
-          .trace(session, execution_request, path.as_path())
-          .unwrap_or_else(|e| {
-            println!("Failed to write trace to {}: {:?}", path.display(), e);
-          });
-      });
-    });
-  });
-}
-
-#[no_mangle]
 pub extern "C" fn nodes_destroy(raw_nodes_ptr: *mut RawNodes) {
   let _ = unsafe { Box::from_raw(raw_nodes_ptr) };
 }

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -11,7 +11,6 @@ fnv = "1.0.5"
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { package = "futures", version = "0.1" }
 hashing = { path = "../hashing" }
-indexmap = "1.0.2"
 log = "0.4"
 parking_lot = "0.6"
 petgraph = "0.4.5"

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::entry::{Entry, EntryState};
 use crate::entry::{Generation, RunToken};
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::hash::BuildHasherDefault;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
@@ -49,7 +49,6 @@ use fnv::FnvHasher;
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use futures01::future::{self, Future};
-use indexmap::IndexSet;
 use log::{debug, trace, warn};
 use parking_lot::Mutex;
 use petgraph::graph::DiGraph;
@@ -57,7 +56,7 @@ use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 use tokio::time::delay_for;
 
-pub use crate::node::{EntryId, Node, NodeContext, NodeError, NodeTracer, NodeVisualizer};
+pub use crate::node::{EntryId, Node, NodeContext, NodeError, NodeVisualizer};
 use boxfuture::{BoxFuture, Boxable};
 
 type FNV = BuildHasherDefault<FnvHasher>;
@@ -424,133 +423,6 @@ impl<N: Node> InnerGraph<N> {
     }
 
     f.write_all(b"}\n")?;
-    Ok(())
-  }
-
-  fn trace<T: NodeTracer<N>>(
-    &self,
-    roots: &[N],
-    file_path: &Path,
-    context: &N::Context,
-  ) -> Result<(), String> {
-    let root_ids: IndexSet<EntryId, FNV> = roots
-      .iter()
-      .filter_map(|nk| self.entry_id(nk))
-      .cloned()
-      .collect();
-
-    // Find all bottom Nodes for the trace by walking recursively under the roots.
-    let bottom_nodes = {
-      let mut queue: VecDeque<_> = root_ids.iter().cloned().collect();
-      let mut visited: HashSet<EntryId, FNV> = HashSet::default();
-      let mut bottom_nodes = Vec::new();
-      while let Some(id) = queue.pop_front() {
-        if !visited.insert(id) {
-          continue;
-        }
-
-        // If all dependencies are bottom nodes, then we represent a failure.
-        let mut non_bottom_deps = self
-          .pg
-          .neighbors_directed(id, Direction::Outgoing)
-          .filter(|dep_id| !T::is_bottom(self.unsafe_entry_for_id(*dep_id).peek(context)))
-          .peekable();
-
-        if non_bottom_deps.peek().is_none() {
-          bottom_nodes.push(id);
-        } else {
-          // Otherwise, continue recursing on `rest`.
-          queue.extend(non_bottom_deps);
-        }
-      }
-      bottom_nodes
-    };
-
-    // Invert the graph into a evenly-weighted dependent graph by cloning it and stripping out
-    // the Nodes (to avoid cloning them), adding equal edge weights, and then reversing it.
-    // Because we do not remove any Nodes or edges, all EntryIds remain stable.
-    let dependent_graph = {
-      let mut dg = self.pg.filter_map(|_, _| Some(()), |_, _| Some(1.0));
-      dg.reverse();
-      dg
-    };
-
-    // Render the shortest path through the dependent graph to any root for each bottom_node.
-    for bottom_node in bottom_nodes {
-      // We use Bellman Ford because it actually records paths, unlike Dijkstra's.
-      let (path_weights, paths) = petgraph::algo::bellman_ford(&dependent_graph, bottom_node)
-        .unwrap_or_else(|e| {
-          panic!(
-            "There should not be any negative edge weights. Got: {:?}",
-            e
-          )
-        });
-
-      // Find the root with the shortest path weight.
-      let minimum_path_id = root_ids
-        .iter()
-        .min_by_key(|root_id| path_weights[root_id.index()] as usize)
-        .ok_or_else(|| "Encountered a Node that was not reachable from any roots.".to_owned())?;
-
-      // Collect the path by walking through the `paths` Vec, which contains the indexes of
-      // predecessor Nodes along a path to the bottom Node.
-      let path = {
-        let mut next_id = *minimum_path_id;
-        let mut path = Vec::new();
-        path.push(next_id);
-        while let Some(current_id) = paths[next_id.index()] {
-          path.push(current_id);
-          if current_id == bottom_node {
-            break;
-          }
-          next_id = current_id;
-        }
-        path
-      };
-
-      // Render the path.
-      self
-        .trace_render_path_to_file::<T>(&path, file_path, context)
-        .map_err(|e| format!("Failed to render trace to {:?}: {}", file_path, e))?;
-    }
-
-    Ok(())
-  }
-
-  ///
-  /// Renders a Graph path to the given file path.
-  ///
-  fn trace_render_path_to_file<T: NodeTracer<N>>(
-    &self,
-    path: &[EntryId],
-    file_path: &Path,
-    context: &N::Context,
-  ) -> io::Result<()> {
-    let file = OpenOptions::new().append(true).open(file_path)?;
-    let mut f = BufWriter::new(file);
-
-    let format = |eid: EntryId, depth: usize, is_last: bool| -> String {
-      let entry = self.unsafe_entry_for_id(eid);
-      let indent = "  ".repeat(depth);
-      let output = format!("{}Computing {}", indent, entry.node());
-      if is_last {
-        format!(
-          "{}\n{}  {}",
-          output,
-          indent,
-          T::state_str(&indent, entry.peek(context))
-        )
-      } else {
-        output
-      }
-    };
-
-    let mut path_iter = path.iter().enumerate().peekable();
-    while let Some((depth, id)) = path_iter.next() {
-      writeln!(&mut f, "{}", format(*id, depth, path_iter.peek().is_none()))?;
-    }
-
-    f.write_all(b"\n")?;
     Ok(())
   }
 
@@ -967,16 +839,6 @@ impl<N: Node> Graph<N> {
   pub fn invalidate_from_roots<P: Fn(&N) -> bool>(&self, predicate: P) -> InvalidationResult {
     let mut inner = self.inner.lock();
     inner.invalidate_from_roots(predicate)
-  }
-
-  pub fn trace<T: NodeTracer<N>>(
-    &self,
-    roots: &[N],
-    path: &Path,
-    context: &N::Context,
-  ) -> Result<(), String> {
-    let inner = self.inner.lock();
-    inner.trace::<T>(roots, path, context)
   }
 
   pub fn visualize<V: NodeVisualizer<N>>(

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -88,26 +88,6 @@ pub trait NodeVisualizer<N: Node> {
 }
 
 ///
-/// A trait used to visualize Nodes for the purposes of CLI-output tracing.
-///
-pub trait NodeTracer<N: Node> {
-  ///
-  /// Returns true if the given Node Result represents the "bottom" of a trace.
-  ///
-  /// A trace represents a sub-dag of the entire Graph, and a "bottom" Node result represents
-  /// a boundary that the trace stops before (ie, a bottom Node will not be rendered in the trace,
-  /// but anything that depends on a bottom Node will be).
-  ///
-  fn is_bottom(result: Option<Result<N::Item, N::Error>>) -> bool;
-
-  ///
-  /// Renders the given result for a trace. The trace will already be indented by `indent`, but
-  /// an implementer creating a multi-line output would need to indent them as well.
-  ///
-  fn state_str(indent: &str, result: Option<Result<N::Item, N::Error>>) -> String;
-}
-
-///
 /// A context passed between Nodes that also stores an EntryId to uniquely identify them.
 ///
 pub trait NodeContext: Clone + Send + Sync + 'static {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -287,25 +287,33 @@ pub enum Failure {
   /// A Node failed because a filesystem change invalidated it or its inputs.
   /// A root requestor should usually immediately retry their request.
   Invalidated,
-  /// A rule raised an exception.
-  Throw(Value, String),
+  /// An error was thrown.
+  Throw {
+    // A python exception value, which might have a python-level stacktrace
+    val: Value,
+    // A pre-formatted python exception traceback.
+    python_traceback: String,
+    // A stack of engine-side "frame" information generated from Nodes.
+    engine_traceback: Vec<String>,
+  },
 }
 
 impl fmt::Display for Failure {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       Failure::Invalidated => write!(f, "Giving up on retrying due to changed files."),
-      Failure::Throw(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
+      Failure::Throw { val, .. } => write!(f, "{}", externs::val_to_str(val)),
     }
   }
 }
 
 pub fn throw(msg: &str) -> Failure {
-  Failure::Throw(
-    externs::create_exception(msg),
-    format!(
+  Failure::Throw {
+    val: externs::create_exception(msg),
+    python_traceback: format!(
       "Traceback (no traceback):\n  <pants native internals>\nException: {}",
       msg
     ),
-  )
+    engine_traceback: Vec::new(),
+  }
 }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -9,7 +9,7 @@ use std::os::raw;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::string::FromUtf8Error;
 
-use crate::core::{Failure, Function, Key, TypeId, Value};
+use crate::core::{native_python_traceback, Failure, Function, Key, TypeId, Value};
 use crate::handles::{DroppingHandle, Handle};
 use crate::interning::Interns;
 use itertools::Itertools;
@@ -413,7 +413,9 @@ pub type StoreBoolExtern = extern "C" fn(*const ExternContext, bool) -> Handle;
 #[repr(C)]
 pub struct PyResult {
   is_throw: bool,
-  handle: Handle,
+  result: Handle,
+  python_traceback: Handle,
+  engine_traceback: Handle,
 }
 
 impl PyResult {
@@ -431,7 +433,9 @@ impl From<Value> for PyResult {
   fn from(val: Value) -> Self {
     PyResult {
       is_throw: false,
-      handle: val.into(),
+      result: val.into(),
+      python_traceback: none(),
+      engine_traceback: store_tuple(&[]).into(),
     }
   }
 }
@@ -441,13 +445,36 @@ impl From<Result<Value, Failure>> for PyResult {
     match result {
       Ok(val) => val.into(),
       Err(f) => {
-        let val = match f {
-          f @ Failure::Invalidated => create_exception(&format!("{}", f)),
-          Failure::Throw { val, .. } => val,
+        let (val, python_traceback, engine_traceback) = match f {
+          f @ Failure::Invalidated => {
+            let msg = format!("{}", f);
+            (
+              create_exception(&msg),
+              native_python_traceback(&msg),
+              store_tuple(&[]).into(),
+            )
+          }
+          Failure::Throw {
+            val,
+            python_traceback,
+            engine_traceback,
+          } => (
+            val,
+            python_traceback,
+            store_tuple(
+              &engine_traceback
+                .into_iter()
+                .map(|s| store_utf8(&s))
+                .collect::<Vec<_>>(),
+            )
+            .into(),
+          ),
         };
         PyResult {
           is_throw: true,
-          handle: val.into(),
+          result: val.into(),
+          python_traceback: store_utf8(&python_traceback).into(),
+          engine_traceback,
         }
       }
     }
@@ -456,7 +483,7 @@ impl From<Result<Value, Failure>> for PyResult {
 
 impl From<PyResult> for Result<Value, Failure> {
   fn from(result: PyResult) -> Self {
-    let value = result.handle.into();
+    let value = result.result.into();
     if result.is_throw {
       Err(PyResult::failure_from(value))
     } else {
@@ -470,11 +497,15 @@ impl From<Result<Value, String>> for PyResult {
     match res {
       Ok(v) => PyResult {
         is_throw: false,
-        handle: v.into(),
+        result: v.into(),
+        python_traceback: none(),
+        engine_traceback: none(),
       },
       Err(msg) => PyResult {
         is_throw: true,
-        handle: create_exception(&msg).into(),
+        result: create_exception(&msg).into(),
+        python_traceback: store_utf8(&native_python_traceback(&msg)).into(),
+        engine_traceback: none(),
       },
     }
   }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -417,9 +417,13 @@ pub struct PyResult {
 }
 
 impl PyResult {
-  fn failure_from(v: Value) -> Failure {
-    let traceback = project_str(&v, "_formatted_exc");
-    Failure::Throw(v, traceback)
+  fn failure_from(val: Value) -> Failure {
+    let python_traceback = project_str(&val, "_formatted_exc");
+    Failure::Throw {
+      val,
+      python_traceback,
+      engine_traceback: Vec::new(),
+    }
   }
 }
 
@@ -439,7 +443,7 @@ impl From<Result<Value, Failure>> for PyResult {
       Err(f) => {
         let val = match f {
           f @ Failure::Invalidated => create_exception(&format!("{}", f)),
-          Failure::Throw(exc, _) => exc,
+          Failure::Throw { val, .. } => val,
         };
         PyResult {
           is_throw: true,

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -13,7 +13,7 @@ use futures::future;
 
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
-use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
+use crate::nodes::{NodeKey, Select, Visualizer};
 
 use graph::{InvalidationResult, LastObserved};
 use hashing;
@@ -242,14 +242,6 @@ impl ExecutionRequest {
       timeout: None,
     }
   }
-
-  ///
-  /// Roots are limited to `Select`, which is known to produce a Value. This method
-  /// exists to satisfy Graph APIs which need instances of the NodeKey enum.
-  ///
-  fn root_nodes(&self) -> Vec<NodeKey> {
-    self.roots.iter().map(|r| r.clone().into()).collect()
-  }
 }
 
 ///
@@ -272,20 +264,6 @@ impl Scheduler {
       .core
       .graph
       .visualize(Visualizer::default(), &session.root_nodes(), path, &context)
-  }
-
-  pub fn trace(
-    &self,
-    session: &Session,
-    request: &ExecutionRequest,
-    path: &Path,
-  ) -> Result<(), String> {
-    let context = Context::new(self.core.clone(), session.clone());
-    self
-      .core
-      .graph
-      .trace::<Tracer>(&request.root_nodes(), path, &context)?;
-    Ok(())
   }
 
   pub fn add_root_select(

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -26,6 +26,7 @@ Exception caught: \\([^)]*\\)
 (.|\n)*
 
 Exception message:.* 1 Exception encountered:
+
   ResolveError: "this-target-does-not-exist" was not found in namespace ""\\. Did you mean one of:
 """.format(
                 pid=pid


### PR DESCRIPTION
### Problem

In a near-future change, we would like to stop storing failures in the engine's `Graph` in order to improve the experience under `pantsd` (where memoized failures are more problematic than they are otherwise). But `Graph::trace` currently uses the failures stored in the graph to render traces: this "persist failures and then come back later to scrape them" approach is more complicated than it needs to be.

### Solution

Add traceback-like information to a `Failure` by calling a straightforward `Failure::with_pushed_frame` method generically at each `Node` as it fails. The method has one callsite in our `Node` wrapper, which should make it easy to adjust the "frame" information that we'd like to render here: for now, I went with the `user_facing_name` of the `Node` (which means that some Nodes will not be rendered).

### Result

The `Graph::trace` method is deleted, helping to unblock removing failures from the graph. Our rust/python tracebacks also become easier to manipulate in the python-side `Scheduler._raise_on_error` method.

See the changes to `scheduler_test.py` for an example of how the output with `--print-exception-stacktrace` changes.