### PR TITLE
Enable color output in travis

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -10,7 +10,7 @@ travis_parallelism = 4
 
 [GLOBAL]
 # Override color support detection - we want colors and Travis supports them.
-use_colors = true
+colors = true
 
 [black]
 args = ["--quiet"]

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,6 +8,7 @@ execution_strategy = "subprocess"
 # overhead or else just generally thrash the container and slow things down.
 travis_parallelism = 4
 
+[GLOBAL]
 # Override color support detection - we want colors and Travis supports them.
 use_colors = true
 

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -8,6 +8,9 @@ execution_strategy = "subprocess"
 # overhead or else just generally thrash the container and slow things down.
 travis_parallelism = 4
 
+# Override color support detection - we want colors and Travis supports them.
+use_colors = true
+
 [black]
 args = ["--quiet"]
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -319,7 +319,7 @@ class BaseZincCompileIntegrationTest:
         # Compile a target that we expect will raise an "Unused import" warning.
         with self.temporary_workdir() as workdir:
             with self.temporary_cachedir() as cachedir:
-                args = ['--compile-rsc-args=+["-S-Ywarn-unused:_"]', "-ldebug"] + (
+                args = ['--compile-rsc-args=+["-S-Ywarn-unused:_"]', "-ldebug", "--no-colors"] + (
                     ["--compile-rsc-use-barebones-logger"] if use_barebones_logger else []
                 )
                 pants_run = self.run_test_compile(

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -129,7 +129,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         self.assertTrue(self.DEBUG_LEVEL_COMPILE_MSG in pants_run.stdout_data)
 
     def test_default_console(self):
-        command = ["compile", "examples/src/java/org/pantsbuild/example/hello::"]
+        command = ["--no-colors", "compile", "examples/src/java/org/pantsbuild/example/hello::"]
         pants_run = self.run_pants(command)
         self.assert_success(pants_run)
         self.assertIn(


### PR DESCRIPTION
### Problem

pantsbuild output doesn't currently include colors even though travis portions of the same logs do

### Solution

try to turn on colors

### Result