### PR TITLE
strip trailing whitespace from some plugins

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -182,7 +182,7 @@ async def black_lint(field_sets: BlackFieldSets, black: Black) -> LintResult:
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
     return LintResult.from_fallible_process_result(
-        result, linter_name="Black", strip_chroot_path=True
+        result, linter_name="Black", strip_chroot_path=True, rstrip=True
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -155,7 +155,7 @@ async def docformatter_lint(
         return LintResult.noop()
     setup = await Get[Setup](SetupRequest(field_sets, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result, linter_name="Docformatter")
+    return LintResult.from_fallible_process_result(result, linter_name="Docformatter", rstrip=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -127,7 +127,7 @@ async def flake8_lint(
         description=f"Run Flake8 on {pluralize(len(field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result, linter_name="Flake8")
+    return LintResult.from_fallible_process_result(result, linter_name="Flake8", rstrip=True)
 
 
 def rules():

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -33,10 +33,20 @@ class LintResult:
 
     @staticmethod
     def from_fallible_process_result(
-        process_result: FallibleProcessResult, *, linter_name: str, strip_chroot_path: bool = False
+        process_result: FallibleProcessResult,
+        *,
+        linter_name: str,
+        strip_chroot_path: bool = False,
+        rstrip: bool = False
     ) -> "LintResult":
         def prep_output(s: bytes) -> str:
-            return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
+            if strip_chroot_path:
+                s = strip_v2_chroot_path(s)
+            else:
+                s.decode()
+            if rstrip:
+                s = s.rstrip()
+            return s
 
         return LintResult(
             exit_code=process_result.exit_code,


### PR DESCRIPTION
### Problem

https://travis-ci.com/github/pantsbuild/pants/jobs/335893658
```
271.22s$ travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py --remote-execution-enabled --lint --python-version 3.6
✓ Black succeeded.

✓ Black succeeded.

...

✓ Black succeeded.

✓ Black succeeded.

✓ Black succeeded.

✓ Docformatter succeeded.

✓ Docformatter succeeded.

✓ Docformatter succeeded.

...

✓ Docformatter succeeded.

✓ Docformatter succeeded.

✓ Docformatter succeeded.

✓ Flake8 succeeded.

✓ Flake8 succeeded.

✓ Flake8 succeeded.

...

✓ Flake8 succeeded.

✓ Flake8 succeeded.

✓ Flake8 succeeded.

✓ isort succeeded.
✓ isort succeeded.
✓ isort succeeded.
...
```

### Solution

I'm trying to add a flag and pass it around. But this isn't tested.

### Result

Hopefully the blank lines will disappear.