### PR TITLE
Improve the `repr` for V2 `Target`

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -318,14 +318,12 @@ class Target(ABC):
         """
 
     def __repr__(self) -> str:
+        fields = ", ".join(str(field) for field in self.field_values.values())
         return (
             f"{self.__class__}("
             f"address={self.address}, "
             f"alias={repr(self.alias)}, "
-            f"core_fields={list(self.core_fields)}, "
-            f"plugin_fields={list(self.plugin_fields)}, "
-            f"field_values={list(self.field_values.values())}"
-            f")"
+            f"{fields})"
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
The original was unusable. It had far too much information. 

Before:

> <class 'pants.backend.python.target_types.PythonLibrary'>(address=src/python/pants/util:strutil, alias='python_library', core_fields=[pants.engine.target.Tags, pants.engine.target.DescriptionField, <class 'pants.engine.target.NoCacheField'>, pants.engine.target.ScopeField, <class 'pants.engine.target.IntransitiveField'>, <class 'pants.engine.target.Dependencies'>, pants.backend.python.target_types.PythonProvidesField, pants.backend.python.target_types.PythonInterpreterCompatibility, <class 'pants.backend.python.target_types.PythonLibrarySources'>], plugin_fields=[], field_values=[<class 'pants.backend.python.target_types.PythonLibrarySources'>(alias='sources', sanitized_raw_value=('strutil.py',), default=('*.py', '!test_*.py', '!*_test.py', '!conftest.py')), pants.engine.target.Tags(alias='tags', value=('type_checked',), default=None), <class 'pants.engine.target.Dependencies'>(alias='dependencies', value=None, default=None), <class 'pants.engine.target.IntransitiveField'>(alias='_transitive', value=False, default=False), pants.backend.python.target_types.PythonProvidesField(alias='provides', value=None, default=None), pants.engine.target.ScopeField(alias='scope', value=None, default=None), <class 'pants.engine.target.NoCacheField'>(alias='no_cache', value=False, default=False), pants.engine.target.DescriptionField(alias='description', value=None, default=None), pants.backend.python.target_types.PythonInterpreterCompatibility(alias='compatibility', value=None, default=None)])


After:

> <class 'pants.backend.python.target_types.PythonLibrary'>(address=src/python/pants/util:strutil, alias='python_library', sources=('strutil.py',), tags=('type_checked',), dependencies=None, compatibility=None, _transitive=False, scope=None, no_cache=False, description=None, provides=None)


`str()` (same as before):

> python_library(address="src/python/pants/util:strutil", sources=(\'strutil.py\',), tags=(\'type_checked\',), dependencies=None, compatibility=None, _transitive=False, scope=None, no_cache=False, description=None, provides=None)


[ci skip-rust-tests]
[ci skip-jvm-tests]