### PR TITLE
Fix console UI redraw issues

### DIFF
--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -2,19 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
-from typing import Any, Callable, Optional
+from typing import Callable, Optional, cast
 
 from colors import blue, cyan, green, magenta, red
 
 from pants.engine.internals.native import Native
+from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.rules import side_effecting
 
 
 # TODO this needs to be a file-like object/stream
 class NativeWriter:
-    def __init__(self, session: Any):
+    def __init__(self, scheduler_session: SchedulerSession):
         self._native = Native()
-        self._session = session._session
+        self.session = scheduler_session.session
 
     def write(self, payload: str):
         raise NotImplementedError
@@ -27,12 +28,12 @@ class NativeWriter:
 
 class NativeStdOut(NativeWriter):
     def write(self, payload):
-        self._native.write_stdout(self._session, payload)
+        self._native.write_stdout(self.session, payload)
 
 
 class NativeStdErr(NativeWriter):
     def write(self, payload):
-        self._native.write_stderr(self._session, payload)
+        self._native.write_stderr(self.session, payload)
 
 
 @side_effecting
@@ -42,7 +43,11 @@ class Console:
     side_effecting = True
 
     def __init__(
-        self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None
+        self,
+        stdout=None,
+        stderr=None,
+        use_colors: bool = True,
+        session: Optional[SchedulerSession] = None,
     ):
         """`stdout` and `stderr` may be explicitly provided when Console is constructed.
 
@@ -55,8 +60,12 @@ class Console:
 
         has_scheduler = session is not None
 
-        self._stdout = stdout or (NativeStdOut(session) if has_scheduler else sys.stdout)
-        self._stderr = stderr or (NativeStdErr(session) if has_scheduler else sys.stderr)
+        self._stdout = stdout or (
+            NativeStdOut(cast(SchedulerSession, session)) if has_scheduler else sys.stdout
+        )
+        self._stderr = stderr or (
+            NativeStdErr(cast(SchedulerSession, session)) if has_scheduler else sys.stderr
+        )
         self._use_colors = use_colors
 
     @property

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -899,7 +899,8 @@ class Native(metaclass=SingletonMetaclass):
         return self.lib.write_log(msg.encode(), level, target.encode())
 
     def write_stdout(self, session, msg: str):
-        return self.lib.write_stdout(session, msg.encode())
+        res = self.lib.write_stdout(session, msg.encode())
+        self.context.raise_or_return(res)
 
     def write_stderr(self, session, msg: str):
         return self.lib.write_stderr(session, msg.encode())

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -385,7 +385,9 @@ class Scheduler:
         """
         return self._native.new_nailgun_server(self._scheduler, port_requested, runner)
 
-    def new_session(self, zipkin_trace_v2, build_id, v2_ui=False, should_report_workunits=False):
+    def new_session(
+        self, zipkin_trace_v2, build_id, v2_ui=False, should_report_workunits=False
+    ) -> "SchedulerSession":
         """Creates a new SchedulerSession for this Scheduler."""
         return SchedulerSession(
             self,
@@ -422,6 +424,10 @@ class SchedulerSession:
     @property
     def scheduler(self):
         return self._scheduler
+
+    @property
+    def session(self):
+        return self._session
 
     def poll_workunits(self) -> PolledWorkunits:
         return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session))

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -43,6 +43,8 @@ use engine::{
   externs, nodes, Core, ExecutionRequest, ExecutionTermination, Failure, Function, Handle,
   Intrinsics, Key, Params, Rule, Scheduler, Session, Tasks, TypeId, Types, Value,
 };
+
+use futures::future::FutureExt;
 use futures::future::{self as future03, TryFutureExt};
 use futures01::{future, Future};
 use hashing::{Digest, EMPTY_DIGEST};
@@ -1124,7 +1126,8 @@ pub extern "C" fn run_local_interactive_process(
 
   with_scheduler(scheduler_ptr, |scheduler| {
     with_session(session_ptr, |session| {
-      session.with_console_ui_disabled(|| {
+      let output: Result<Value, String> = block_in_place_and_wait(
+      session.with_console_ui_disabled(|| -> Result<Value, String> {
         let types = &scheduler.core.types;
         let construct_interactive_process_result = types.construct_interactive_process_result;
 
@@ -1197,9 +1200,12 @@ pub extern "C" fn run_local_interactive_process(
         ));
         output
       })
+      .boxed_local()
+      .compat()
+      );
+      output.into()
     })
   })
-  .into()
 }
 
 #[no_mangle]
@@ -1329,11 +1335,11 @@ pub extern "C" fn write_log(msg: *const raw::c_char, level: u64, target: *const 
 }
 
 #[no_mangle]
-pub extern "C" fn write_stdout(session_ptr: *mut Session, msg: *const raw::c_char) {
+pub extern "C" fn write_stdout(session_ptr: *mut Session, msg: *const raw::c_char) -> PyResult {
   with_session(session_ptr, |session| {
     let message_str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
-    session.write_stdout(&message_str);
-  });
+    block_in_place_and_wait(session.write_stdout(&message_str).boxed_local().compat()).into()
+  })
 }
 
 #[no_mangle]


### PR DESCRIPTION
### Problem

With the new console UI, there are a number of console glitches caused by the library that animates the swimlanes not correctly clearing them when some other pants component tries to write to stdout.

### Solution

Whenever we call `ConsoleUI::write_stdout` or `ConsoleUI::with_console_ui_disabled`, we need to de-initialize the screen entirely by calling `teardown`. This drops the data structures that the swimlane-drawing library makes use of causing the screen to be correctly cleared. Doing this in a futures-safe way required some modification to the CFFI functions that call `Scheduler::write_stdout` and `Scheduler::with_console_ui_disabled`.

An earlier version of this code required some additional modifications in `console.py`. We were able to architect this commit in such a way as to make those modifications unnecessary, but in the process we improved the type annotations in `console.py` and those are left in this commit.