### PR TITLE
Fix several typos in source code

### DIFF
--- a/build-support/bin/get_ci_bootstrapped_pants_pex.sh
+++ b/build-support/bin/get_ci_bootstrapped_pants_pex.sh
@@ -20,7 +20,7 @@ NUM_VERSIONS=$(aws --no-sign-request --region us-east-1 s3api list-object-versio
   --bucket "${AWS_BUCKET}" --prefix "${BOOTSTRAPPED_PEX_KEY}" --max-items 2 \
   | jq '.Versions | length')
 [ "${NUM_VERSIONS}" == "1" ] || die "Multiple copies of pants.pex found at" \
-   "${BOOTSTRAPPED_PEX_URL}. This is not allowed as a security precuation. This likely happened" \
+   "${BOOTSTRAPPED_PEX_URL}. This is not allowed as a security precaution. This likely happened" \
    "from restarting the bootstrap shards in the same Travis build. Instead, initiate a new build" \
    "by either pulling from master or pushing an empty commit (\`git commit --allow-empty\`)."
 

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -26,7 +26,7 @@ function calculate_current_hash() {
   #
   # Assumes we're in the venv that will be used to build the native engine.
   #
-  # NB: Ensure that this stays in sync wtih `githooks/prepare-commit-msg`.
+  # NB: Ensure that this stays in sync with `githooks/prepare-commit-msg`.
   (
    cd "${REPO_ROOT}" || exit 1
    (echo "${MODE_FLAG}"

--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher.py
@@ -106,7 +106,7 @@ class ArchiveFetcher(Fetcher):
                       remote import path\'s `rev`, `import_prefix`, and `pkg`.
         - default_rev: Fetch this rev if no other rev is specified.
         - strip_level: An integer indicating the number of leading path components to strip from
-                       files upacked from the archive.
+                       files unpacked from the archive.
         """
 
     def __init__(self, import_path, import_prefix, url_info, archive_retriever):

--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
@@ -72,7 +72,7 @@ class FetcherFactory(Subsystem):
             "1. The default revision string to use when no `rev` is supplied; ie 'HEAD' or "
             "'master' for git.\n"
             "2. An integer indicating the number of leading path components to strip from "
-            "files upacked from the archive.",
+            "files unpacked from the archive.",
         )
 
     def get_fetcher(self, import_path):

--- a/contrib/go/src/python/pants/contrib/go/targets/go_target.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_target.py
@@ -43,7 +43,7 @@ class GoTarget(Target):
         All other packages are of the form 'path' or 'path/subpath', etc.
 
         If the given path is either absolute or relative (includes the parent dir path signifier, '..'),
-        then an error is raised since the path cannot be noramlized.
+        then an error is raised since the path cannot be normalized.
 
         :param string package_path: The Go package path to normalize.
         :raises: `ValueError` if the package path cannot be normalized.

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -139,7 +139,7 @@ class TestNodeBuild(TaskTestBase):
 
     def test_run_non_existing_script(self):
         package_json_file = self.create_file("src/node/build_test/package.json", contents="{}")
-        build_script = "my_non_existing_build_scirpt"
+        build_script = "my_non_existing_build_script"
         target = self.make_target(
             spec="src/node/build_test",
             target_type=NodeModule,

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -137,9 +137,9 @@ class TestNodeBuild(TaskTestBase):
         with open(os.path.join(target_paths[0], "output_file"), "r") as f:
             self.assertEqual(f.read(), "Hello, world!\n")
 
-    def test_run_non_existing_script(self):
+    def test_run_nonexistent_script(self):
         package_json_file = self.create_file("src/node/build_test/package.json", contents="{}")
-        build_script = "my_non_existing_build_script"
+        build_script = "my_nonexistent_build_script"
         target = self.make_target(
             spec="src/node/build_test",
             target_type=NodeModule,

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -25,7 +25,7 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
-from pants.contrib.python.checks.tasks.python_eval_subsystem import PythonEval as PythonEvalSubystem
+from pants.contrib.python.checks.tasks.python_eval_subsystem import PythonEval as PythonEvalSubsystem
 
 
 class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
@@ -45,14 +45,14 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
     @classmethod
     def subsystem_dependencies(cls):
         return super().subsystem_dependencies() + (
-            PythonEvalSubystem,
+            PythonEvalSubsystem,
             PexBuilderWrapper.Factory,
             PythonInterpreterCache,
         )
 
     @property
     def skip_execution(self):
-        return PythonEvalSubystem.global_instance().options.skip
+        return PythonEvalSubsystem.global_instance().options.skip
 
     @classmethod
     def prepare(cls, options, round_manager):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -25,7 +25,9 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
-from pants.contrib.python.checks.tasks.python_eval_subsystem import PythonEval as PythonEvalSubsystem
+from pants.contrib.python.checks.tasks.python_eval_subsystem import (
+    PythonEval as PythonEvalSubsystem,
+)
 
 
 class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):

--- a/examples/src/java/org/pantsbuild/example/publish.md
+++ b/examples/src/java/org/pantsbuild/example/publish.md
@@ -110,7 +110,7 @@ with the additional information needed to publish artifacts. Here is an example 
              login <login>
              password <password>
 
-           The realm must match the kind of repository you are publishing to. For Sonotype Nexus, use:
+           The realm must match the kind of repository you are publishing to. For Sonatype Nexus, use:
 
            realm="Sonatype Nexus Repository Manager"
 

--- a/src/docs/architecture_pantsd.md
+++ b/src/docs/architecture_pantsd.md
@@ -22,7 +22,7 @@ The [`PantsDaemon`](https://github.com/pantsbuild/pants/blob/master/src/python/p
 Initialization is encapsulated in the `PantsDaemon.Factory.create()` method.
 `PantsDaemon` is a `ProcessManager`, which means one can know if it's alive, or if it needs to restart.
 
-`PantsDaemon`s can be `launch()`ed, which will terminate the process it was running, and call `daemon_spawn()` to fork a new process. This new process will run the code in `PantsDaemon.post_fork_child()`, which in short means it will run `os.spawnve` to execute the `pants_daemon.py:launch()` function, which will call `PantsDaemon.run_sync()`. `run_sync()` does a lot of things, but the vital things are calling `_setup_services()` to spin up services, and `_run_services()` to start an infinte loop polling them. More on services later.
+`PantsDaemon`s can be `launch()`ed, which will terminate the process it was running, and call `daemon_spawn()` to fork a new process. This new process will run the code in `PantsDaemon.post_fork_child()`, which in short means it will run `os.spawnve` to execute the `pants_daemon.py:launch()` function, which will call `PantsDaemon.run_sync()`. `run_sync()` does a lot of things, but the vital things are calling `_setup_services()` to spin up services, and `_run_services()` to start an infinite loop polling them. More on services later.
 
 Pailgun
 -------

--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -17,7 +17,7 @@ See the Changelog section below for differences between versions of the export f
   project.
   - "targets" : Dictionary of targets defined in BUILD files.
   - "distributions" : Information about JVM distributions.
-  - "jvm_platforms" : Information about JVM platforms(language level and additionals arguments).
+  - "jvm_platforms" : Information about JVM platforms(language level and additional arguments).
   - "python_setup" : Information about Python setup(interpreters and chroots for them).
 
 ## Version

--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -574,7 +574,7 @@ class AntJunitXmlReportListener extends RunListener {
    * actually gets run.
    *
    * Situations where this happens:
-   *   - testFailure() gets passed Desription.TEST_MECHANISM
+   *   - testFailure() gets passed Description.TEST_MECHANISM
    *   - Class initialization fails and the Description passed to testFailure() may only have a
    *   string description.
    *

--- a/src/java/org/pantsbuild/tools/junit/impl/CompositeRequestRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/CompositeRequestRunner.java
@@ -69,7 +69,7 @@ public class CompositeRequestRunner extends ParentRunner<Request> {
       eachNotifier.fireTestIgnored();
     } catch (StoppedByUserException e) {
       throw e;
-    // We wan't to fail the test no matter what here for an intelligible user message.
+    // We want to fail the test no matter what here for an intelligible user message.
     // SUPPRESS CHECKSTYLE RegexpSinglelineJava
     } catch (Throwable e) {
       eachNotifier.addFailure(e);

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -34,7 +34,7 @@ class Zinc:
     """Configuration for Pants' zinc wrapper tool."""
 
     ZINC_COMPILE_MAIN = "org.pantsbuild.zinc.compiler.Main"
-    ZINC_BOOTSTRAPER_MAIN = "org.pantsbuild.zinc.bootstrapper.Main"
+    ZINC_BOOTSTRAPPER_MAIN = "org.pantsbuild.zinc.bootstrapper.Main"
     DEFAULT_CONFS = ["default"]
 
     ZINC_COMPILER_TOOL_NAME = "zinc"
@@ -92,7 +92,7 @@ class Zinc:
                 register,
                 Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME,
                 classpath=[JarDependency("org.pantsbuild", "zinc-bootstrapper_2.12", "0.0.12")],
-                main=Zinc.ZINC_BOOTSTRAPER_MAIN,
+                main=Zinc.ZINC_BOOTSTRAPPER_MAIN,
                 custom_rules=shader_rules,
             )
 
@@ -349,7 +349,7 @@ class Zinc:
         )
         argv = tuple(
             [".jdk/bin/java"]
-            + ["-cp", bootstrapper, Zinc.ZINC_BOOTSTRAPER_MAIN]
+            + ["-cp", bootstrapper, Zinc.ZINC_BOOTSTRAPPER_MAIN]
             + bootstrapper_args
         )
         req = Process(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -1019,7 +1019,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             tool_classpath = self._scalac_classpath
             # In fact, nailgun should not be used for -Youtline
             # in case of self.ExecutionStrategy.nailgun,
-            # we will force the scalac -Youtline invokation to run via subprocess
+            # we will force the scalac -Youtline invocation to run via subprocess
             nailgun_classpath = self._scalac_classpath
         else:
             main = "rsc.cli.Main"

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -217,7 +217,7 @@ class IdeaPluginGen(ConsoleTask):
             return output.name
 
     def _write_to_tempfile(self, content):
-        """Writes coontent to a temp file and returns the path to that file."""
+        """Writes content to a temp file and returns the path to that file."""
         with temporary_file(cleanup=False, binary_mode=False) as output:
             output.write(content)
             return output.name

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -327,7 +327,7 @@ class PexTest(ExternalToolTestBase):
         assert pex_output["info"]["interpreter_constraints"] == []
 
     def test_additional_inputs(self) -> None:
-        # We use pex's --preamble-file option to set a custom premable from a file.
+        # We use pex's --preamble-file option to set a custom preamble from a file.
         # This verifies that the file was indeed provided as additional input to the pex call.
         preamble_file = "custom_preamble.txt"
         preamble = "#!CUSTOM PREAMBLE\n"

--- a/src/python/pants/backend/python/rules/util.py
+++ b/src/python/pants/backend/python/rules/util.py
@@ -142,7 +142,7 @@ def find_packages(
     # See which packages are pkg_resources-style namespace packages.
     # Note that implicit PEP 420 namespace packages and pkgutil-style namespace packages
     # should *not* be listed in the setup namespace_packages kwarg. That's for pkg_resources-style
-    # namespace pacakges only. See https://github.com/pypa/sample-namespace-packages/.
+    # namespace packages only. See https://github.com/pypa/sample-namespace-packages/.
     namespace_packages: Set[str] = set()
     init_py_by_path: Dict[str, bytes] = {ipc.path: ipc.content for ipc in init_py_contents}
     for pkg in packages:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -713,7 +713,7 @@ class PytestRun(ChrootedTestRunnerTaskMixin, Task):
 
             # NB: While passthrough args are not supported in v2 yet, as discussed on #9075, it seems
             # likely that we can find a way to preserve the ability to use passthrough args for
-            # umabiguous goals in v2.
+            # unambiguous goals in v2.
             args.extend([*self.get_passthru_args(), *PyTest.global_instance().options.args])
 
             args.extend(test_args)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -307,7 +307,7 @@ class LocalPantsRunner:
 
         if additional_messages:
             # NB: We do not log to the exceptions log in this case, because we expect that these are
-            # higher level unstructed errors: strutured versions will already have been written at
+            # higher level unstructed errors: structured versions will already have been written at
             # various places.
             logger.error("\n".join(additional_messages))
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -307,7 +307,7 @@ class LocalPantsRunner:
 
         if additional_messages:
             # NB: We do not log to the exceptions log in this case, because we expect that these are
-            # higher level unstructed errors: structured versions will already have been written at
+            # higher level unstructured errors: structured versions will already have been written at
             # various places.
             logger.error("\n".join(additional_messages))
 

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -57,7 +57,7 @@ class GoalSubsystem(SubsystemClientMixin, Optionable):
     @classmethod
     def conflict_free_name(cls):
         # v2 goal names ending in '2' are assumed to be so-named to avoid conflict with a v1 goal.
-        # If we're in v2-exclusivce mode, strip off the '2', so we can use the more natural name.
+        # If we're in v2-exclusive mode, strip off the '2', so we can use the more natural name.
         # Note that this implies a change of options scope when changing to v2-only mode: options
         # on the foo2 scope will need to be moved to the foo scope. But we already expect options
         # changes when switching to v2-exclusive mode (e.g., some v1 options aren't even registered

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -43,7 +43,7 @@ def _key_func(entry):
 
 
 @rule
-async def evalute_preludes(address_mapper: AddressMapper) -> BuildFilePreludeSymbols:
+async def evaluate_preludes(address_mapper: AddressMapper) -> BuildFilePreludeSymbols:
     snapshot = await Get[Snapshot](
         PathGlobs(
             address_mapper.prelude_glob_patterns,
@@ -357,7 +357,7 @@ def create_graph_rules(address_mapper: AddressMapper):
         parse_address_family,
         find_build_file,
         find_build_files,
-        evalute_preludes,
+        evaluate_preludes,
         # AddressSpec handling: locate directories that contain build files, and request
         # AddressFamilies for each of them.
         addresses_with_origins_from_address_families,

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -18,7 +18,7 @@ from pants.engine.internals.build_files import (
     ResolvedTypeMismatchError,
     addresses_with_origins_from_address_families,
     create_graph_rules,
-    evalute_preludes,
+    evaluate_preludes,
     parse_address_family,
     strip_address_origins,
 )
@@ -427,7 +427,7 @@ class PreludeParsingTest(unittest.TestCase):
         address_mapper.prelude_glob_patterns = ("prelude",)
 
         symbols = run_rule(
-            evalute_preludes,
+            evaluate_preludes,
             rule_args=[address_mapper,],
             mock_gets=[
                 MockGet(
@@ -454,7 +454,7 @@ class PreludeParsingTest(unittest.TestCase):
             Exception, "Error parsing prelude file /dev/null/prelude: name 'blah' is not defined"
         ):
             run_rule(
-                evalute_preludes,
+                evaluate_preludes,
                 rule_args=[address_mapper,],
                 mock_gets=[
                     MockGet(
@@ -488,7 +488,7 @@ class PreludeParsingTest(unittest.TestCase):
             Exception, "Import used in /dev/null/prelude at line 1\\. Import statements are banned"
         ):
             run_rule(
-                evalute_preludes,
+                evaluate_preludes,
                 rule_args=[address_mapper,],
                 mock_gets=[
                     MockGet(

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -292,7 +292,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             str(cm.exception),
         )
 
-    def test_non_existing_root_fails_differently(self):
+    def test_nonexistent_root_fails_differently(self):
         rules = [upcast]
 
         with self.assertRaises(Exception) as cm:

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -380,7 +380,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             "rule_four",
         }
 
-        # Because of the artifical delay in rule_one, it should have time to be reported as
+        # Because of the artificial delay in rule_one, it should have time to be reported as
         # started but not yet finished.
         started = list(itertools.chain.from_iterable(tracker.started_workunit_chunks))
         assert len(list(item for item in started if item["name"] == "rule_one")) > 0

--- a/src/python/pants/engine/legacy/round_engine_test.py
+++ b/src/python/pants/engine/legacy/round_engine_test.py
@@ -161,11 +161,11 @@ class RoundEngineTest(EngineTestBase, TestBase):
             expected_execute_actions.append(self.construct_action(action))
             expected_execute_actions.append(self.execute_action(action))
 
-        expeceted_execute_actions_length = len(expected_execute_ordering) * 2
+        expected_execute_actions_length = len(expected_execute_ordering) * 2
         self.assertEqual(
-            expected_pre_execute_actions, set(self.actions[:-expeceted_execute_actions_length])
+            expected_pre_execute_actions, set(self.actions[:-expected_execute_actions_length])
         )
-        self.assertEqual(expected_execute_actions, self.actions[-expeceted_execute_actions_length:])
+        self.assertEqual(expected_execute_actions, self.actions[-expected_execute_actions_length:])
 
     def test_lifecycle_ordering(self):
         task1 = self.install_task("task1", goal="goal1", product_types=["1"])

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -286,7 +286,7 @@ class RuleIndexTest(TestBase):
 
 
 class RuleArgumentAnnotationTest(unittest.TestCase):
-    def test_annoations_kwargs(self):
+    def test_annotations_kwargs(self):
         @named_rule
         def a_named_rule(a: int, b: str) -> bool:
             return False

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -430,7 +430,7 @@ class RunTracker(Subsystem):
         """
 
         def error(msg):
-            # Report aleady closed, so just print error.
+            # Report already closed, so just print error.
             print(f"WARNING: Failed to upload stats to {stats_url} due to {msg}", file=sys.stderr)
             return False
 

--- a/src/python/pants/notes/1.24.x.rst
+++ b/src/python/pants/notes/1.24.x.rst
@@ -248,7 +248,7 @@ API Changes
 New Features
 ~~~~~~~~~~~~
 
-* Add `fast-depedencies` V2 rule (#8759)
+* Add `fast-dependencies` V2 rule (#8759)
   `PR #8759 <https://github.com/pantsbuild/pants/pull/8759>`_
 
 Bugfixes

--- a/src/python/pants/notes/1.28.x.rst
+++ b/src/python/pants/notes/1.28.x.rst
@@ -143,7 +143,7 @@ Bugfixes
 * Remove deprecation warning from ivy_imports.py. (#9696)
   `PR #9696 <https://github.com/pantsbuild/pants/pull/9696>`_
 
-* Fix `PYTHONPATH` comingling in sitepackages. (#9690)
+* Fix `PYTHONPATH` commingling in sitepackages. (#9690)
   `PR #9690 <https://github.com/pantsbuild/pants/pull/9690>`_
 
 Refactoring, Improvements, and Tooling

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -261,8 +261,8 @@ class _IniValues(_ConfigValues):
         return self.parser.defaults()
 
 
-_TomlPrimitve = Union[bool, int, float, str]
-_TomlValue = Union[_TomlPrimitve, List[_TomlPrimitve]]
+_TomlPrimitive = Union[bool, int, float, str]
+_TomlValue = Union[_TomlPrimitive, List[_TomlPrimitive]]
 
 
 @dataclass(frozen=True)
@@ -384,7 +384,7 @@ class _TomlValues(_ConfigValues):
 
         if isinstance(raw_value, list):
 
-            def stringify_list_member(member: _TomlPrimitve) -> str:
+            def stringify_list_member(member: _TomlPrimitive) -> str:
                 if not isinstance(member, str):
                     return str(member)
                 interpolated_member = possibly_interpolate(member) if interpolate else member

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -120,7 +120,7 @@ class Config(ABC):
     def _determine_seed_values(*, seed_values: Optional[SeedValues] = None) -> Dict[str, str]:
         """We pre-populate several default values to allow %([key-name])s interpolation.
 
-        This sets up those defaults and checks if the user overrided any of the values.
+        This sets up those defaults and checks if the user overrode any of the values.
         """
         safe_seed_values = seed_values or {}
         buildroot = cast(str, safe_seed_values.get("buildroot", get_buildroot()))

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -367,7 +367,7 @@ class Options:
         """Returns a function for registering options on the given scope."""
         self._assert_not_frozen()
         # TODO(benjy): Make this an instance of a class that implements __call__, so we can
-        # docstring it, and so it's less weird than attatching properties to a function.
+        # docstring it, and so it's less weird than attaching properties to a function.
         def register(*args, **kwargs):
             kwargs["registering_class"] = optionable_class
             self.register(optionable_class.options_scope, *args, **kwargs)

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -231,7 +231,7 @@ class OptionsBootstrapper:
         """Get the full Options instance bootstrapped by this object for the given known scopes.
 
         :param known_scope_infos: ScopeInfos for all scopes that may be encountered.
-        :returns: A bootrapped Options instance that also carries options for all the supplied known
+        :returns: A bootstrapped Options instance that also carries options for all the supplied known
                   scopes.
         """
         return self._full_options(

--- a/src/python/pants/python/pex_build_util.py
+++ b/src/python/pants/python/pex_build_util.py
@@ -299,7 +299,7 @@ class PexBuilderWrapper:
         """Multi-platform dependency resolution for PEX files.
 
         Returns a tuple containing a list of distributions that must be included in order to satisfy a
-        set of requirements, and the transitive == requirements for thosee distributions. This may
+        set of requirements, and the transitive == requirements for those distributions. This may
         involve distributions for multiple platforms.
 
         :param interpreter: The :class:`PythonInterpreter` to resolve for.

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -438,7 +438,7 @@ class ChrootedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
 
     def check_artifact_cache_for(self, invalidation_check):
         # TODO(https://github.com/pantsbuild/pants/issues/9734): Remove this override and leverage
-        #  default target level caching suport now that the --fast option is removed.
+        #  default target level caching support now that the --fast option is removed.
         # Tests generate artifacts, namely junit.xml and coverage reports, that cover the full target
         # set whether that is all targets in the context (`--fast`) or each target individually
         # (`--no-fast`).

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -62,7 +62,7 @@ class TestContext(Context):
         def report_target_info(self, scope, target, keys, val):
             pass
 
-    class TestLogger(logging.getLoggerClass()):  # type: ignore[misc] # MyPy does't understand this dynamic base class
+    class TestLogger(logging.getLoggerClass()):  # type: ignore[misc] # MyPy doesn't understand this dynamic base class
         """A logger that converts our structured records into flat ones.
 
         This is so we can use a regular logger in tests instead of our reporting machinery.

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -291,7 +291,7 @@ async fn garbage_collect_remove_file_with_leased_directory() {
   let store = new_store(dir.path());
 
   let testdir = TestDirectory::containing_roland();
-  let testdata = TestData::fourty_chars();
+  let testdata = TestData::forty_chars();
 
   store
     .store_bytes(EntryType::Directory, testdir.bytes(), true)
@@ -330,9 +330,9 @@ async fn garbage_collect_remove_file_while_leased_file() {
     .store_bytes(EntryType::Directory, testdir.bytes(), false)
     .await
     .expect("Error storing");
-  let fourty_chars = TestData::fourty_chars();
+  let forty_chars = TestData::forty_chars();
   store
-    .store_bytes(EntryType::File, fourty_chars.bytes(), true)
+    .store_bytes(EntryType::File, forty_chars.bytes(), true)
     .await
     .expect("Error storing");
 
@@ -341,8 +341,8 @@ async fn garbage_collect_remove_file_while_leased_file() {
     .expect("Error shrinking");
 
   assert_eq!(
-    load_bytes(&store, EntryType::File, fourty_chars.digest()).await,
-    Ok(Some(fourty_chars.bytes())),
+    load_bytes(&store, EntryType::File, forty_chars.digest()).await,
+    Ok(Some(forty_chars.bytes())),
     "File was missing despite lease"
   );
   assert_eq!(
@@ -358,14 +358,14 @@ async fn garbage_collect_fail_because_too_many_leases() {
   let store = new_store(dir.path());
 
   let testdir = TestDirectory::containing_roland();
-  let fourty_chars = TestData::fourty_chars();
+  let forty_chars = TestData::forty_chars();
 
   store
     .store_bytes(EntryType::Directory, testdir.bytes(), true)
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::File, fourty_chars.bytes(), true)
+    .store_bytes(EntryType::File, forty_chars.bytes(), true)
     .await
     .expect("Error storing");
 
@@ -377,8 +377,8 @@ async fn garbage_collect_fail_because_too_many_leases() {
   assert_eq!(store.shrink(80, ShrinkBehavior::Fast), Ok(160));
 
   assert_eq!(
-    load_bytes(&store, EntryType::File, fourty_chars.digest()).await,
-    Ok(Some(fourty_chars.bytes())),
+    load_bytes(&store, EntryType::File, forty_chars.digest()).await,
+    Ok(Some(forty_chars.bytes())),
     "Leased file should still be present"
   );
   assert_eq!(

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -196,7 +196,7 @@ impl ByteStore {
             Ok(digest)
           } else {
             Err(format!(
-              "Uploading file with digest {:?}: want commited size {} but got {}",
+              "Uploading file with digest {:?}: want committed size {} but got {}",
               digest,
               len,
               received.get_committed_size()

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1059,7 +1059,7 @@ impl<'a, N: Node + 'a, F: Fn(&EntryId) -> bool> Iterator for Walk<'a, N, F> {
   fn next(&mut self) -> Option<Self::Item> {
     while let Some(id) = self.deque.pop_front() {
       // Visit this node and it neighbors if this node has not yet be visited and we aren't
-      // stopping our walk at this node, based on if it satifies the stop_walking_predicate.
+      // stopping our walk at this node, based on if it satisfies the stop_walking_predicate.
       // This mechanism gives us a way to selectively dirty parts of the graph respecting node boundaries
       // like uncacheable nodes, which sholdn't be dirtied.
       if !self.walked.insert(id) || (self.stop_walking_predicate)(&id) {

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -328,7 +328,7 @@ impl<N: Node> InnerGraph<N> {
       .filter_map(|(node, &entry_id)| {
         // A NotStarted entry does not need clearing, and we can assume that its dependencies are
         // either already dirtied, or have never observed a value for it. Filtering these redundant
-        // events helps to "debounce" invalidation (ie, avoid redundent re-dirtying of dependencies).
+        // events helps to "debounce" invalidation (ie, avoid redundant re-dirtying of dependencies).
         if predicate(node) && self.unsafe_entry_for_id(entry_id).is_started() {
           Some(entry_id)
         } else {

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -29,7 +29,7 @@ use hashing;
 
 use petgraph;
 
-// make the entry module public for testing purposes. We use it to contruct mock
+// make the entry module public for testing purposes. We use it to construct mock
 // graph entries in the notify watch tests.
 pub mod entry;
 mod node;

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1061,7 +1061,7 @@ impl<'a, N: Node + 'a, F: Fn(&EntryId) -> bool> Iterator for Walk<'a, N, F> {
       // Visit this node and it neighbors if this node has not yet be visited and we aren't
       // stopping our walk at this node, based on if it satisfies the stop_walking_predicate.
       // This mechanism gives us a way to selectively dirty parts of the graph respecting node boundaries
-      // like uncacheable nodes, which sholdn't be dirtied.
+      // like uncacheable nodes, which shouldn't be dirtied.
       if !self.walked.insert(id) || (self.stop_walking_predicate)(&id) {
         continue;
       }

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -54,7 +54,7 @@ async fn get_workdir_creates_directory_if_it_doesnt_exist() {
   let mock_workdir_base = unique_temp_dir(std::env::temp_dir(), None)
     .path()
     .to_owned();
-  let mock_nailgun_name = "mock_non_existing_workdir".to_string();
+  let mock_nailgun_name = "mock_nonexistent_workdir".to_string();
   let runner = mock_nailgun_runner(Some(mock_workdir_base.clone()));
 
   let target_workdir = mock_workdir_base.join(mock_nailgun_name.clone());

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -27,7 +27,7 @@ impl TestData {
     TestData::new("Pug")
   }
 
-  pub fn fourty_chars() -> TestData {
+  pub fn forty_chars() -> TestData {
     TestData::new(
       "0123456789012345678901234567890123456789\
        0123456789012345678901234567890123456789",

--- a/tests/java/org/pantsbuild/tools/junit/impl/UtilTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/UtilTest.java
@@ -77,7 +77,7 @@ public class UtilTest {
         Util.sanitizeSuiteName("Thequickbrownfoxjumpedoverthelazydog."));
     assertEquals("이것은-한국인", Util.sanitizeSuiteName("이것은 한국인..."));
     String sanitizedPunctuations = Util.sanitizeSuiteName("`~!@#$%^&*()+-=[]{}\\/<>|");
-    assertTrue("Sanitized punctuations were't converted to all hyphens: " + sanitizedPunctuations,
+    assertTrue("Sanitized punctuations weren't converted to all hyphens: " + sanitizedPunctuations,
         sanitizedPunctuations.matches("^[-]+$"));
   }
 

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -252,7 +252,7 @@ class BundleTest(TestBase):
         self.create_file(os.path.join(spec_path, "three.xml"))
         self.assertNotEqual(fingerprint_before, calc_fingerprint(include_three_xml=True))
 
-    def test_jvmapp_fingerprinting_with_non_existing_files(self):
+    def test_jvmapp_fingerprinting_with_nonexistent_files(self):
         spec_path = "y"
 
         def calc_fingerprint():
@@ -261,13 +261,13 @@ class BundleTest(TestBase):
                 "y:app", JvmApp, dependencies=[], bundles=[_bundle(spec_path)(fileset=["one.xml"])]
             ).payload.fingerprint()
 
-        fingerprint_non_existing_file = calc_fingerprint()
+        fingerprint_nonexistent_file = calc_fingerprint()
         self.create_file(os.path.join(spec_path, "one.xml"))
         fingerprint_empty_file = calc_fingerprint()
         self.create_file(os.path.join(spec_path, "one.xml"), contents="some content")
         fingerprint_file_with_content = calc_fingerprint()
 
-        self.assertNotEqual(fingerprint_empty_file, fingerprint_non_existing_file)
+        self.assertNotEqual(fingerprint_empty_file, fingerprint_nonexistent_file)
         self.assertNotEqual(fingerprint_empty_file, fingerprint_file_with_content)
         self.assertNotEqual(fingerprint_file_with_content, fingerprint_empty_file)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
@@ -72,7 +72,7 @@ class JvmCompileTest(NailgunTaskTestBase):
             "compile_classpath", ClasspathProducts.init_func(self.pants_workdir)
         )
         # This should cause the jvm compile execution to exclude target roots and their
-        # dependess from the set of relevant targets.
+        # dependees from the set of relevant targets.
         for rp in required_products:
             context.products.require_data(rp)
         self.execute(context)
@@ -98,7 +98,7 @@ class JvmCompileTest(NailgunTaskTestBase):
     def test_modulized_targets_are_compiled_when_runtime_classpath_is_requested(self):
         targets = self.make_linear_graph(["a", "b", "c", "d", "e"], target_type=JavaLibrary)
         # This should cause the jvm compile execution to exclude target roots and their
-        # dependess from the set of relevant targets.
+        # dependees from the set of relevant targets.
         runtime_classpath = self.create_and_return_classpath_products(
             targets, ["runtime_classpath"]
         )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile.py
@@ -24,7 +24,7 @@ class ZincCompileTest(JvmToolTaskTestBase):
         task = self.create_task(context)
         return task
 
-    def test_spaces_preservend_when_populating_zinc_args_product_from_argfile(self):
+    def test_spaces_preserved_when_populating_zinc_args_product_from_argfile(self):
         with temporary_file_path() as arg_file_path:
             compile_contexts = {
                 self.java_target: CompileContext(

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -158,7 +158,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
     def test_properties_file_names_does_not_invalidates_targets(self, cache_args):
         with self.temporary_workdir() as workdir:
             with temporary_dir(root_dir=get_buildroot()) as tmp:
-                suppression_names = ["one-supress.xml", "two-supress.xml"]
+                suppression_names = ["one-suppress.xml", "two-suppress.xml"]
                 suppression_data = dedent(
                     """
                     <?xml version="1.0"?>

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -616,7 +616,7 @@ class ClasspathProductsTest(TestBase):
         targets,
         libs_dir,
         expected_canonical_classpath,
-        expected_classspath_files,
+        expected_classpath_files,
         excludes=None,
     ):
         """Helper method to call `create_canonical_classpath` and verify generated canonical
@@ -626,7 +626,7 @@ class ClasspathProductsTest(TestBase):
         :param list targets: List of targets to generate canonical classpath from.
         :param string libs_dir: Directory where canonical classpath are to be generated.
         :param list expected_canonical_classpath: List of canonical classpath relative to a base directory.
-        :param dict expected_classspath_files: A dict of classpath.txt path to its expected content.
+        :param dict expected_classpath_files: A dict of classpath.txt path to its expected content.
         """
         canonical_classpath = ClasspathProducts.create_canonical_classpath(
             classpath_products,
@@ -644,16 +644,16 @@ class ClasspathProductsTest(TestBase):
         # check canonical path created contain the exact set of files, no more, no less
         self.assertTrue(
             contains_exact_files(
-                libs_dir, expected_canonical_classpath + list(expected_classspath_files.keys())
+                libs_dir, expected_canonical_classpath + list(expected_classpath_files.keys())
             )
         )
 
         # check the content of classpath.txt
-        for classpath_file in expected_classspath_files:
+        for classpath_file in expected_classpath_files:
             self.assertTrue(
                 check_file_content(
                     os.path.join(libs_dir, classpath_file),
-                    expected_classspath_files[classpath_file],
+                    expected_classpath_files[classpath_file],
                 )
             )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -205,7 +205,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
         self.assertIs(v2, IvyUtils._resolve_conflict(v1, v2))
         self.assertIs(v2, IvyUtils._resolve_conflict(v2, v1))
 
-    def test_resove_conflict_no_conflicts(self):
+    def test_resolve_conflict_no_conflicts(self):
         v1 = JarDependency("org.example", "foo", "1", force=False)
         v1_force = JarDependency("org.example", "foo", "1", force=True)
         v2 = JarDependency("org.example", "foo", "2", force=False)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar_integration.py
@@ -44,13 +44,13 @@ class ExportDepAsJarIntegrationTest(ScalacPluginIntegrationTestBase):
 
         for (key, expected_option_values) in expected_options_patterns.items():
             result_options = target_info[key]
-            strigified_result_options = " ".join(result_options)
+            stringified_result_options = " ".join(result_options)
 
             expected_option_values += self.commonly_expected_options[key]
 
             assert len(expected_option_values) == len(result_options)
             for pattern in expected_option_values:
-                assert (pattern in result_options) or re.match(pattern, strigified_result_options)
+                assert (pattern in result_options) or re.match(pattern, stringified_result_options)
 
     def test_compile_with_compiler_options(self):
         target_to_test = f"{self.scalac_test_targets_dir}/compiler_options:with_nonfatal_warnings"


### PR DESCRIPTION
### Problem

Spelling errors make codebases less friendly.

This is the follow-up to #9800

This is based on [GitHub Action](https://github.com/features/actions): [check-spelling](https://github.com/marketplace/actions/check-spelling)'s run: https://github.com/jsoref/pants/commit/fe18d254ee459587abf1a78c814a5a17fff0f99d#commitcomment-39270921

I'm hoping someone can help me wrap that into a pants plugin at some point...

### Solution

Generally replacing a misspelled word with the correctly spelled word.