### PR TITLE
Stop using `Collection.dependencies` in most places internally

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -19,7 +19,7 @@ class ListAndDieForTesting(Goal):
 
 @goal_rule
 def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> ListAndDieForTesting:
-    for address in addresses.dependencies:
+    for address in addresses:
         console.print_stdout(address.spec)
     return ListAndDieForTesting(exit_code=42)
 

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -48,7 +48,7 @@ class List(Goal):
 
 @goal_rule
 async def list_targets(addresses: Addresses, options: ListOptions, console: Console) -> List:
-    if not addresses.dependencies:
+    if not addresses:
         console.print_stderr(f"WARNING: No targets were matched in goal `{options.name}`.")
         return List(exit_code=0)
 

--- a/src/python/pants/backend/project_info/list_targets_old.py
+++ b/src/python/pants/backend/project_info/list_targets_old.py
@@ -91,7 +91,7 @@ async def list_targets(console: Console, list_options: ListOptions, addresses: A
         print_fn = lambda address: address.spec
 
     with list_options.line_oriented(console) as print_stdout:
-        if not collection.dependencies:
+        if not collection:
             console.print_stderr("WARNING: No targets were matched in goal `{}`.".format("list"))
 
         for item in collection:

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -62,7 +62,7 @@ class GoalRunnerFactory:
         self._kill_nailguns = self._global_options.kill_nailguns
 
         # V1 tasks do not understand FilesystemSpecs, so we eagerly convert them into AddressSpecs.
-        if self._specs.filesystem_specs.dependencies:
+        if self._specs.filesystem_specs:
             (owned_addresses,) = self._graph_session.scheduler_session.product_request(
                 Addresses, [Params(self._specs.filesystem_specs, self._options_bootstrapper)]
             )

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -25,8 +25,8 @@ def assert_single_address(addresses: Sequence[Address]) -> None:
 
 class Addresses(Collection[Address]):
     def expect_single(self) -> Address:
-        assert_single_address(self.dependencies)
-        return self.dependencies[0]
+        assert_single_address(self)
+        return self[0]
 
 
 @dataclass(frozen=True)
@@ -39,10 +39,8 @@ class AddressWithOrigin:
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):
     def expect_single(self) -> AddressWithOrigin:
-        assert_single_address(
-            [address_with_origin.address for address_with_origin in self.dependencies]
-        )
-        return self.dependencies[0]
+        assert_single_address([address_with_origin.address for address_with_origin in self])
+        return self[0]
 
 
 class BuildFileAddresses(Collection[BuildFileAddress]):

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -68,7 +68,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             scheduler, Snapshot, self.path_globs(filespecs_or_globs)
         ).value
         result = self.execute_expecting_one_result(scheduler, FilesContent, snapshot.digest).value
-        return {f.path: f.content for f in result.dependencies}
+        return {f.path: f.content for f in result}
 
     def assert_walk_dirs(self, filespecs_or_globs, paths, **kwargs):
         self.assert_walk_snapshot("dirs", filespecs_or_globs, paths, **kwargs)

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -99,9 +99,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         addresses = self._resolve_addresses(
             address_specs, address_family, snapshot, self._address_mapper()
         )
-
-        self.assertEqual(len(addresses.dependencies), 1)
-        self.assertEqual(addresses.dependencies[0].spec, "a:a")
+        assert len(addresses) == 1
+        assert addresses[0].spec == "a:a"
 
     def test_tag_filter(self) -> None:
         """Test that targets are filtered based on `tags`."""
@@ -118,9 +117,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         targets = self._resolve_addresses(
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
-
-        self.assertEqual(len(targets.dependencies), 1)
-        self.assertEqual(targets.dependencies[0].spec, "root:b")
+        assert len(targets) == 1
+        assert targets[0].spec == "root:b"
 
     def test_fails_on_nonexistent_specs(self) -> None:
         """Test that address specs referring to nonexistent targets raise a ResolveError."""
@@ -159,9 +157,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         targets = self._resolve_addresses(
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
-
-        self.assertEqual(len(targets.dependencies), 1)
-        self.assertEqual(targets.dependencies[0].spec, "root:not_me")
+        assert len(targets) == 1
+        assert targets[0].spec == "root:not_me"
 
     def test_exclude_pattern_with_single_address(self) -> None:
         """Test that single address targets are filtered based on exclude patterns."""
@@ -173,8 +170,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         targets = self._resolve_addresses(
             address_specs, address_family, self._snapshot(), self._address_mapper()
         )
-
-        self.assertEqual(len(targets.dependencies), 0)
+        assert len(targets.dependencies) == 0
 
 
 class ApacheThriftConfiguration(StructWithDeps):

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -335,8 +335,8 @@ class ProcessTest(TestBase):
             FilesContent, process_result.output_digest,
         )
 
-        self.assertEqual(
-            files_content_result.dependencies, (FileContent("roland", b"European Burmese", False),)
+        assert files_content_result == FilesContent(
+            [FileContent("roland", b"European Burmese", False)]
         )
 
     def test_timeout(self):
@@ -364,16 +364,12 @@ class Simple {
         request = JavacCompileRequest(
             BinaryLocation("/usr/bin/javac"), JavacSources(("simple/Simple.java",)),
         )
-
         result = self.request_single_product(JavacCompileResult, request)
-        files_content = self.request_single_product(FilesContent, result.digest).dependencies
-
-        self.assertEqual(
-            tuple(sorted(("simple/Simple.java", "simple/Simple.class",))),
-            tuple(sorted(file.path for file in files_content)),
+        files_content = self.request_single_product(FilesContent, result.digest)
+        assert sorted(["simple/Simple.java", "simple/Simple.class"]) == sorted(
+            file.path for file in files_content
         )
-
-        self.assertGreater(len(files_content[0].content), 0)
+        assert len(files_content[0].content) > 0
 
     def test_javac_compilation_example_failure(self):
         self.create_dir("simple")

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -515,8 +515,8 @@ class Targets(Collection[Target]):
     """
 
     def expect_single(self) -> Target:
-        assert_single_address([tgt.address for tgt in self.dependencies])
-        return self.dependencies[0]
+        assert_single_address([tgt.address for tgt in self])
+        return self[0]
 
 
 class TargetsWithOrigins(Collection[TargetWithOrigin]):
@@ -528,10 +528,8 @@ class TargetsWithOrigins(Collection[TargetWithOrigin]):
     """
 
     def expect_single(self) -> TargetWithOrigin:
-        assert_single_address(
-            [tgt_with_origin.target.address for tgt_with_origin in self.dependencies]
-        )
-        return self.dependencies[0]
+        assert_single_address([tgt_with_origin.target.address for tgt_with_origin in self])
+        return self[0]
 
     @memoized_property
     def targets(self) -> Tuple[Target, ...]:

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -94,7 +94,7 @@ class FileSystemTest(TestBase):
         output = workspace.materialize_directories((DirectoryToMaterialize(digest),))
 
         assert type(output) == MaterializeDirectoriesResult
-        materialize_result = output.dependencies[0]
+        materialize_result = output[0]
         assert type(materialize_result) == MaterializeDirectoryResult
         assert materialize_result.output_paths == tuple(
             str(Path(self.build_root, p)) for p in [path1, path2]


### PR DESCRIPTION
Instead, we can treat `Collection`s like first class `Sequence` types now. For example, we can directly index into them.

[ci skip-rust-tests]
[ci skip-jvm-tests]