### PR TITLE
Do not memoize failures in the Graph

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -459,7 +459,7 @@ impl<N: Node> InnerGraph<N> {
       .into_iter()
       .filter_map(move |eid| self.entry_for_id(eid))
       .filter_map(move |entry| match entry.peek(&context) {
-        Some(Ok(item)) => N::digest(item),
+        Some(item) => N::digest(item),
         _ => None,
       })
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -942,9 +942,7 @@ impl NodeVisualizer<NodeKey> for Visualizer {
     let max_colors = 12;
     match entry.peek(context) {
       None => "white".to_string(),
-      Some(Err(Failure::Throw { .. })) => "4".to_string(),
-      Some(Err(Failure::Invalidated)) => "12".to_string(),
-      Some(Ok(_)) => {
+      Some(_) => {
         let viz_colors_len = self.viz_colors.len();
         self
           .viz_colors


### PR DESCRIPTION
### Problem

We've always memoized failures in the `Graph`, but when using `pantsd` with `v2` the fact that "everything" happens within the `Graph` makes it more likely that we will memoize an infrastructure error. Memoized failures are frustrating.

### Solution

Remove storage of failures from the `Graph`. Instead, send the failure to all waiters, and move a `Node` back to `NotStarted`.