### PR TITLE
Fix pytest 2 by pinning configparser

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -28,7 +28,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     pytest_setup_for_python_2_tests = {
         "pytest": {
             "version": "pytest==4.6.6",  # so that we can run Python 2 tests
-            "pytest_plugins": ["zipp==1.0.0"],  # transitive dep of Pytest
+            "pytest_plugins": ["zipp==1.0.0", "configparser==4.0.2"],  # transitive dep of Pytest
         }
     }
 


### PR DESCRIPTION
https://pypi.org/project/configparser/5.0.0/ was rolled out recently, so the py2 related tests are affected. 

This change fixes:
```
pants_test/backend/python/tasks/test_pytest_run_integration.py:192: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pants/testutil/pants_run_integration_test.py:515: in assert_success
    self.assert_result(pants_run, PANTS_SUCCEEDED_EXIT_CODE, expected=True, msg=msg)
pants/testutil/pants_run_integration_test.py:536: in assert_result
    assertion(value, pants_run.returncode, error_msg)
E   AssertionError: 0 != 1 : /pyenv-docker-build/versions/3.6.8/bin/python3.6m -m pants --no-pantsrc --pants-workdir=/b/f/w/.pants.d/tmp/tmpombee8i4.pants.d --print-exception-stacktrace=True --kill-nailguns --pants-config-files=/b/f/w/.pants.d/tmp/tmpombee8i4.pants.d/pants.toml test testprojects/src/python/interpreter_selection/python_3_selection_testing:test_py2
E   returncode: 1
E   stdout:
E   	
E   	15:38:37 00:00 [main]
E   	               (To run a reporting server: ./pants server)
E   	15:38:40 00:03   [setup]
E   	15:38:40 00:03     [parse]
E   	               Executing tasks in goals: unpack-wheels -> bootstrap -> imports -> unpack-jars -> deferred-sources -> native-compile -> link -> jvm-platform-validate -> gen -> pyprep -> resolve -> resources -> compile -> test
E   	15:38:41 00:04   [unpack-wheels]
E   	15:38:41 00:04     [unpack-wheels]
E   	15:38:42 00:05   [bootstrap]
E   	15:38:42 00:05     [substitute-aliased-targets]
E   	15:38:42 00:05     [jar-dependency-management]
E   	15:38:42 00:05     [bootstrap-jvm-tools]
E   	15:38:42 00:05     [provide-tools-jar]
E   	15:38:42 00:05   [imports]
E   	15:38:42 00:05     [ivy-imports]
E   	15:38:42 00:05   [unpack-jars]
E   	15:38:42 00:05     [unpack-jars]
E   	15:38:42 00:05   [deferred-sources]
E   	15:38:42 00:05     [deferred-sources]
E   	15:38:42 00:05   [native-compile]
E   	15:38:42 00:05     [conan-prep]
E   	15:38:42 00:05     [conan-fetch]
E   	15:38:42 00:05     [c-for-ctypes]
E   	15:38:43 00:06     [cpp-for-ctypes]
E   	15:38:44 00:07   [link]
E   	15:38:44 00:07     [shared-libraries]
E   	15:38:44 00:07   [jvm-platform-validate]
E   	15:38:44 00:07     [jvm-platform-validate]
E   	15:38:45 00:08   [gen]
E   	15:38:45 00:08     [antlr-java]
E   	15:38:45 00:08     [antlr-py]
E   	15:38:45 00:08     [jaxb]
E   	15:38:45 00:08     [protoc]
E   	15:38:45 00:08     [ragel]
E   	15:38:45 00:08     [thrift-java]
E   	15:38:45 00:08     [thrift-py]
E   	15:38:45 00:08     [py-thrift-namespace-clash-check]
E   	15:38:45 00:08     [grpcio-prep]
E   	15:38:45 00:08     [grpcio-run]
E   	15:38:45 00:08     [wire]
E   	15:38:45 00:08     [avro-java]
E   	15:38:45 00:08     [go-thrift]
E   	15:38:45 00:08     [go-protobuf]
E   	15:38:45 00:08     [jax-ws]
E   	15:38:45 00:08     [scrooge]
E   	15:38:45 00:08     [thrifty]
E   	15:38:45 00:08   [pyprep]
E   	15:38:45 00:08     [interpreter]
E   	                   Invalidated 4 targets.
E   	15:38:45 00:08     [build-local-dists]
E   	15:38:45 00:08     [requirements]
E   	15:38:46 00:09     [sources]
E   	                   Invalidated 4 targets.
E   	15:38:47 00:10   [resolve]
E   	15:38:47 00:10     [ivy]
E   	15:38:47 00:10     [coursier]
E   	15:38:47 00:10     [go]
E   	15:38:47 00:10     [scala-js-compile]
E   	15:38:47 00:10     [scala-js-link]
E   	15:38:47 00:10     [node]
E   	15:38:47 00:10   [resources]
E   	15:38:47 00:10     [prepare]
E   	15:38:47 00:10     [services]
E   	15:38:47 00:10   [compile]
E   	15:38:47 00:10     [node]
E   	15:38:47 00:10     [compile-jvm-prep-command]
E   	15:38:47 00:10       [jvm_prep_command]
E   	15:38:47 00:10     [compile-prep-command]
E   	15:38:47 00:10     [compile]
E   	15:38:47 00:10     [rsc]
E   	15:38:47 00:10     [javac]
E   	15:38:47 00:10     [cpp]
E   	15:38:48 00:11     [errorprone]
E   	15:38:48 00:11     [findbugs]
E   	15:38:48 00:11     [go]
E   	15:38:48 00:11   [test]
E   	15:38:48 00:11     [test-jvm-prep-command]
E   	15:38:48 00:11       [jvm_prep_command]
E   	15:38:48 00:11     [test-prep-command]
E   	15:38:48 00:11     [legacy]
E   	15:38:48 00:11     [pytest-prep]
E   	                   Invalidated 4 targets.
E   	               Waiting for background workers to finish.
E   	15:38:52 00:15   [complete]
E   	               FAILURE
E   stderr:
E   	Scrubbed PYTHONPATH=/b/f/w:/b/f/w/pex_root/code/da39a3ee5e6b4b0d3255bfef95601890afd80709:/pyenv-docker-build/versions/3.6.8/lib/python36.zip:/pyenv-docker-build/versions/3.6.8/lib/python3.6:/pyenv-docker-build/versions/3.6.8/lib/python3.6/lib-dynload:/b/f/w/pex_root/install/coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl.12fa58619e224e74270381526b08ddf268a0c708/coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl:/b/f/w/pex_root/install/ipdb-0.13.2-py3-none-any.whl.675da26e6a721a2fdeb26bafa6d0736254d05f3a/ipdb-0.13.2-py3-none-any.whl:/b/f/w/pex_root/install/contextlib2-0.5.5-py2.py3-none-any.whl.edad6efe1aebf29bea2d8a9e8dab93fbbc2555bc/contextlib2-0.5.5-py2.py3-none-any.whl:/b/f/w/pex_root/install/certifi-2020.4.5.1-py2.py3-none-any.whl.887853a2207c4c68705492f1c8f4108f2ab24fe2/certifi-2020.4.5.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/traitlets-4.3.3-py2.py3-none-any.whl.b007b615e27d33531e49103457b52fa99e792ac2/traitlets-4.3.3-py2.py3-none-any.whl:/b/f/w/pex_root/install/pywatchman-1.4.1-cp36-cp36m-linux_x86_64.whl.48ea27189548683e7e895bef62ab2972d2d782b7/pywatchman-1.4.1-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/Pygments-2.3.1-py2.py3-none-any.whl.ee4bd72946de1ced4595abfa01a778b34f0cad86/Pygments-2.3.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/pathspec-0.5.9-py3-none-any.whl.8385d9631afea5f89b0b84977cd9d811d214d314/pathspec-0.5.9-py3-none-any.whl:/b/f/w/pex_root/install/chardet-3.0.4-py2.py3-none-any.whl.c4332e34e38b781695ce775973fe40663558a897/chardet-3.0.4-py2.py3-none-any.whl:/b/f/w/pex_root/install/PyYAML-5.1.2-cp36-cp36m-linux_x86_64.whl.9cf42c8cdcdf7383fe851f85465a864fa2f34348/PyYAML-5.1.2-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/ptyprocess-0.6.0-py2.py3-none-any.whl.77ec5a4b2dfe323172ab8fb799efcc4203596cdd/ptyprocess-0.6.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/beautifulsoup4-4.6.3-py3-none-any.whl.f69b3796d967a649e5bef9622259dadb21e19d59/beautifulsoup4-4.6.3-py3-none-any.whl:/b/f/w/pex_root/install/pytest_cov-2.8.1-py2.py3-none-any.whl.d8db070b6827e7734361dfe7ed2f3a4dd1ba76f1/pytest_cov-2.8.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.lang-0.3.11-py3-none-any.whl.753335ecc81fb9377df5ad090881a9a3cfaf6aa9/twitter.common.lang-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl:/b/f/w/pex_root/install/zipp-2.1.0-py3-none-any.whl.ee5d2212a71c1dca2ccc4d33a891d45625b178d8/zipp-2.1.0-py3-none-any.whl:/b/f/w/pex_root/install/Markdown-2.1.1-py3-none-any.whl.812da9d59dffb7923e6b68532609a332c25a274b/Markdown-2.1.1-py3-none-any.whl:/b/f/w/pex_root/install/pytest_timeout-1.3.4-py2.py3-none-any.whl.52b2a3a64bd0f0b0d8088b11e326e59951b45530/pytest_timeout-1.3.4-py2.py3-none-any.whl:/b/f/w/pex_root/install/parso-0.7.0-py2.py3-none-any.whl.a0603595a1ae1625a74897fe58f8313591baea83/parso-0.7.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.dirutil-0.3.11-py3-none-any.whl.27719e6d70e5792a4eaa4b057e7ad31a39bceddd/twitter.common.dirutil-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/cffi-1.13.2-cp36-cp36m-manylinux1_x86_64.whl.cba531143e909bfb619505b6c603167a81e1616f/cffi-1.13.2-cp36-cp36m-manylinux1_x86_64.whl:/b/f/w/pex_root/install/toml-0.10.0-py2.py3-none-any.whl.9301e7bc31e7a227b0325b1f18e6387d7888b90c/toml-0.10.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/attrs-19.3.0-py2.py3-none-any.whl.01c47aecb2cee3cc26140dc70eb5d5066d174785/attrs-19.3.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/pyflakes-2.1.1-py2.py3-none-any.whl.728507c2086c87982c8c1c24ff46b1c2e6c46574/pyflakes-2.1.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.collections-0.3.11-py3-none-any.whl.b3eeeb6a640fca93f1e271a2dd9a8a81fb47c030/twitter.common.collections-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/requests-2.23.0-py2.py3-none-any.whl.227781902c1191ba2e0c96e4589aebc430f58d77/requests-2.23.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/thriftpy2-0.4.11-cp36-cp36m-linux_x86_64.whl.68a912683473623639466d496b3f8a770f5c9f4d/thriftpy2-0.4.11-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/psutil-5.6.3-cp36-cp36m-linux_x86_64.whl.1b2203eb7a8e1c4548700c75899f405129ad9d6c/psutil-5.6.3-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/pytest-5.3.5-py3-none-any.whl.7067a5e6d5d446c348907383af489da5d7c805cb/pytest-5.3.5-py3-none-any.whl:/b/f/w/pex_root/install/pyOpenSSL-17.3.0-py2.py3-none-any.whl.f542e1c53dc88676d30ec1b1da93018ff42cb6a9/pyOpenSSL-17.3.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/pexpect-4.8.0-py2.py3-none-any.whl.cc14bf46a6d91e37d22e9f7974468acaa4d26f6e/pexpect-4.8.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/pytest_rerunfailures-9.0-py3-none-any.whl.76c1849ae7acb3841ff6a70600e569721a2ca975/pytest_rerunfailures-9.0-py3-none-any.whl:/b/f/w/pex_root/install/more_itertools-8.2.0-py3-none-any.whl.1604620d254e57887b546f857f4a6958acb6c245/more_itertools-8.2.0-py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.log-0.3.11-py3-none-any.whl.c920dbc14b8e880aec2bb78850d101855d756952/twitter.common.log-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/prompt_toolkit-3.0.5-py3-none-any.whl.84fbcc91e3a022733dd5d6280c5c4b151fe71e52/prompt_toolkit-3.0.5-py3-none-any.whl:/b/f/w/pex_root/install/pycodestyle-2.4.0-py2.py3-none-any.whl.0a958eee162effa42dbebab9ec410ad2e5c7fa7b/pycodestyle-2.4.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/monotonic-1.5-py2.py3-none-any.whl.e6c7e442a796dc3284dafc29d5bee78b3d3b527a/monotonic-1.5-py2.py3-none-any.whl:/b/f/w/pex_root/install/wcwidth-0.1.9-py2.py3-none-any.whl.92e579c160d4abd7fbcd54e88c859d26279f120e/wcwidth-0.1.9-py2.py3-none-any.whl:/b/f/w/pex_root/install/packaging-16.8-py2.py3-none-any.whl.e40536ef84ff020576b969f64434fa248c714237/packaging-16.8-py2.py3-none-any.whl:/b/f/w/pex_root/install/www_authenticate-0.9.2-py3-none-any.whl.a7cb2145b3e03bc83c68b6a3bd8f7d26627568b4/www_authenticate-0.9.2-py3-none-any.whl:/b/f/w/pex_root/install/six-1.14.0-py2.py3-none-any.whl.bfa7e0eb8c6e9f90040528481ecd1ad388555103/six-1.14.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.options-0.3.11-py3-none-any.whl.136eca7ec58c4a151b2d5b6a71d631ed1b3658b8/twitter.common.options-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/decorator-4.4.2-py2.py3-none-any.whl.87548ebd7fc04a440fa66eaf52a0ca587027ba49/decorator-4.4.2-py2.py3-none-any.whl:/b/f/w/pex_root/install/dataclasses-0.6-py3-none-any.whl.b0182a0043d72149b99128f2badc2b43ed38de40/dataclasses-0.6-py3-none-any.whl:/b/f/w/pex_root/install/setproctitle-1.1.10-cp36-cp36m-linux_x86_64.whl.c4d31bbee5397c4ab0ba20eef5d465ec42303a19/setproctitle-1.1.10-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/backcall-0.1.0-py3-none-any.whl.3da7821e2e50fee5311963c52153694a1c2d3b21/backcall-0.1.0-py3-none-any.whl:/b/f/w/pex_root/install/pluggy-0.13.1-py2.py3-none-any.whl.8a602208765d7d0d22fe72d28b5a19950463c4d5/pluggy-0.13.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/pyparsing-2.4.7-py2.py3-none-any.whl.60e23e442b06ef2f2466bd495be7c02afbba5657/pyparsing-2.4.7-py2.py3-none-any.whl:/b/f/w/pex_root/install/setuptools-40.6.3-py2.py3-none-any.whl.4a47c8d55bbea45ef1029b493d822f7c1d55a196/setuptools-40.6.3-py2.py3-none-any.whl:/b/f/w/pex_root/install/ansicolors-1.1.8-py2.py3-none-any.whl.a83d40427486b6f993a2513e5bb49647f8181005/ansicolors-1.1.8-py2.py3-none-any.whl:/b/f/w/pex_root/install/typing_extensions-3.7.4-py3-none-any.whl.1edcbe8619e77859668b3f056ad84bcfdf2e0fcd/typing_extensions-3.7.4-py3-none-any.whl:/b/f/w/pex_root/install/pystache-0.5.3-py3-none-any.whl.0a04214ba1f2c3adf1b0141fd1b4fabe4c16109b/pystache-0.5.3-py3-none-any.whl:/b/f/w/pex_root/install/ipython_genutils-0.2.0-py2.py3-none-any.whl.00e07f2b4c31aef83167d276553fac007e043d1b/ipython_genutils-0.2.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/python_Levenshtein-0.12.0-cp36-cp36m-linux_x86_64.whl.cab5b8daf3207dcf3a47ff5f7fa859062b3292bd/python_Levenshtein-0.12.0-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/jedi-0.17.0-py2.py3-none-any.whl.6d48332cd048addc727da1ff94730f5c71bb4a1c/jedi-0.17.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/py-1.8.1-py2.py3-none-any.whl.4f7451b21a46f2b588750be23eea1c4d28cfa076/py-1.8.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/importlib_metadata-1.6.0-py2.py3-none-any.whl.a7efd9420e4827caafadaa2f529db82d20798fac/importlib_metadata-1.6.0-py2.py3-none-any.whl:/b/f/w/pex_root/install/ply-3.11-py2.py3-none-any.whl.ced24d23e3ca145d26f6ac130df2de53c3e35188/ply-3.11-py2.py3-none-any.whl:/b/f/w/pex_root/install/urllib3-1.25.9-py2.py3-none-any.whl.214381b84eb5d245388770b6e435e5fbdd67d05b/urllib3-1.25.9-py2.py3-none-any.whl:/b/f/w/pex_root/install/cryptography-2.9.2-cp36-cp36m-linux_x86_64.whl.4595d26330515e51777f1c1d6e93bae4d3ea5be1/cryptography-2.9.2-cp36-cp36m-linux_x86_64.whl:/b/f/w/pex_root/install/fasteners-0.15-py2.py3-none-any.whl.f25f4ed0a5e75d8edca739c83a9c103c6a0dd9e7/fasteners-0.15-py2.py3-none-any.whl:/b/f/w/pex_root/install/idna-2.9-py2.py3-none-any.whl.d1fd8456c745d66a5033c3202c590880668262d3/idna-2.9-py2.py3-none-any.whl:/b/f/w/pex_root/install/py_zipkin-0.18.4-py2.py3-none-any.whl.cf7543ab85c6b8493274c465aa3e70d8bedd4118/py_zipkin-0.18.4-py2.py3-none-any.whl:/b/f/w/pex_root/install/twitter.common.confluence-0.3.11-py3-none-any.whl.db65f7c09e90802248102d3fe380f367d26b066e/twitter.common.confluence-0.3.11-py3-none-any.whl:/b/f/w/pex_root/install/pycparser-2.20-py2.py3-none-any.whl.43e6a45399261aa67b4bb76d2b3f987b88352754/pycparser-2.20-py2.py3-none-any.whl:/b/f/w/pex_root/install/wheel-0.31.1-py2.py3-none-any.whl.9162405b4c6d47ff554018389d29281b6e4854a6/wheel-0.31.1-py2.py3-none-any.whl:/b/f/w/pex_root/install/pickleshare-0.7.5-py2.py3-none-any.whl.ee5f8d8cd03b30c4e56a20e39a38433d48d39023/pickleshare-0.7.5-py2.py3-none-any.whl:/b/f/w/pex_root/install/docutils-0.14-py3-none-any.whl.199b17a7fbabc943293d072079258c1dd5c68e0a/docutils-0.14-py3-none-any.whl:/b/f/w/pex_root/install/ipython-7.14.0-py3-none-any.whl.c0b18c17b15c8c4333aba3ae831371ddfcbc713f/ipython-7.14.0-py3-none-any.whl:/b/f/w/pytest-with-requirements.pex/.bootstrap from the environment.
E   	15:38:46:552 [WARN] /b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl/pex/pep425tags.py:274: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
E   	  import imp
E   	
E   	15:38:47:473 [WARN] /b/f/w/pants/engine/round_engine.py:51: DeprecationWarning: DEPRECATED: Ivy Resolve will be removed in version 1.27.0.dev0.
E   	  resolve.ivy as well as --resolver-resolver=ivy will be removed.Please use --resolver-resolver=coursier instead and refer to https://www.pantsbuild.org/jvm_projects.html#coursier for setup.
E   	  task.execute()
E   	
E   	
E   	timestamp: 2020-05-19T15:38:52.889727
E   	Exception caught: (pex.resolver.Untranslateable)
E   	  File "/pyenv-docker-build/versions/3.6.8/lib/python3.6/runpy.py", line 193, in _run_module_as_main
E   	    "__main__", mod_spec)
E   	  File "/pyenv-docker-build/versions/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
E   	    exec(code, run_globals)
E   	  File "/b/f/w/pants/__main__.py", line 7, in <module>
E   	    pants_loader.main()
E   	  File "/b/f/w/pants/bin/pants_loader.py", line 94, in main
E   	    PantsLoader.run()
E   	  File "/b/f/w/pants/bin/pants_loader.py", line 90, in run
E   	    cls.load_and_execute(entrypoint)
E   	  File "/b/f/w/pants/bin/pants_loader.py", line 83, in load_and_execute
E   	    entrypoint_main()
E   	  File "/b/f/w/pants/bin/pants_exe.py", line 32, in main
E   	    PantsRunner(start_time=start_time).run()
E   	  File "/b/f/w/pants/bin/pants_runner.py", line 115, in run
E   	    return runner.run()
E   	  File "/b/f/w/pants/bin/local_pants_runner.py", line 295, in run
E   	    self._run()
E   	  File "/b/f/w/pants/bin/local_pants_runner.py", line 391, in _run
E   	    goal_runner_result = self._maybe_run_v1()
E   	  File "/b/f/w/pants/bin/local_pants_runner.py", line 332, in _maybe_run_v1
E   	    self._exiter,
E   	  File "/b/f/w/pants/bin/goal_runner.py", line 230, in run
E   	    return self._run_goals()
E   	  File "/b/f/w/pants/bin/goal_runner.py", line 201, in _run_goals
E   	    result = self._execute_engine()
E   	  File "/b/f/w/pants/bin/goal_runner.py", line 189, in _execute_engine
E   	    result = engine.execute(self._context, self._goals)
E   	  File "/b/f/w/pants/engine/legacy_engine.py", line 21, in execute
E   	    self.attempt(context, goals)
E   	  File "/b/f/w/pants/engine/round_engine.py", line 253, in attempt
E   	    goal_executor.attempt(explain)
E   	  File "/b/f/w/pants/engine/round_engine.py", line 51, in attempt
E   	    task.execute()
E   	  File "/b/f/w/pants/backend/python/tasks/pytest_prep.py", line 103, in execute
E   	    pytest_binary = self.create_pex(pex_info)
E   	  File "/b/f/w/pants/backend/python/tasks/python_execution_task_base.py", line 170, in create_pex
E   	    interpreter, self.extra_requirements()
E   	  File "/b/f/w/pants/backend/python/tasks/resolve_requirements_task_base.py", line 120, in resolve_requirement_strings
E   	    pex_builder.add_resolved_requirements(reqs)
E   	  File "/b/f/w/pants/python/pex_build_util.py", line 276, in add_resolved_requirements
E   	    distributions = self.resolve_distributions(reqs, platforms=platforms)
E   	  File "/b/f/w/pants/python/pex_build_util.py", line 252, in resolve_distributions
E   	    self._builder.interpreter, list(deduped_reqs), platforms, list(find_links),
E   	  File "/b/f/w/pants/python/pex_build_util.py", line 344, in _resolve_multi
E   	    use_manylinux=python_setup.use_manylinux,
E   	  File "/b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl/pex/resolver.py", line 515, in resolve
E   	    return resolver.resolve(resolvables_from_iterable(requirements, builder, interpreter=interpreter))
E   	  File "/b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl/pex/resolver.py", line 306, in resolve
E   	    dist = self.build(package, resolvable.options)
E   	  File "/b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl/pex/resolver.py", line 387, in build
E   	    dist = super(CachingResolver, self).build(package, options)
E   	  File "/b/f/w/pex_root/install/pex-1.6.12-py2.py3-none-any.whl.d8a368099663ef2d23c79e3403d86115039740d7/pex-1.6.12-py2.py3-none-any.whl/pex/resolver.py", line 264, in build
E   	    raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
E   	
E   	Exception message: Package SourcePackage('file:///home/nobody/.cache/pants/python_cache/requirements/CPython-2.7.12/configparser-5.0.0.tar.gz') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)
E   	
E   	
E   	**** Failed to install configparser-5.0.0 (caused by: NonZeroExit("received exit code 1 during execution of `['/usr/bin/python2.7', '-s', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpalfiaqz1']` while trying to execute `['/usr/bin/python2.7', '-s', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpalfiaqz1']`",)
E   	):
E   	stdout:
E   	running bdist_wheel
E   	running build
E   	running build_py
E   	creating build
E   	creating build/lib.linux-x86_64-2.7
E   	copying src/configparser.py -> build/lib.linux-x86_64-2.7
E   	creating build/lib.linux-x86_64-2.7/backports
E   	copying src/backports/__init__.py -> build/lib.linux-x86_64-2.7/backports
E   	creating build/lib.linux-x86_64-2.7/backports/configparser
E   	copying src/backports/configparser/helpers.py -> build/lib.linux-x86_64-2.7/backports/configparser
E   	copying src/backports/configparser/__init__.py -> build/lib.linux-x86_64-2.7/backports/configparser
E   	running egg_info
E   	
E   	stderr:
E   	error: 'egg_base' must be a directory name (got `src`)
```