### PR TITLE
Remove unused variants experiment

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -9,7 +9,7 @@ from pants.base.build_file import BuildFile
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
-# @ is reserved for configuring variant, see `addressable.parse_variants`
+# @ is currently unused, but reserved for possible future needs.
 BANNED_CHARS_IN_TARGET_NAME = frozenset("@")
 
 


### PR DESCRIPTION
Variants were a way to express in a BUILD file which of several possible values a field should use, e.g. which Thrift config to use. We ended up not using this mechanism.

Here, we still reserve the `@` symbol in addresses for any possible future use, such as reviving this feature.

[ci skip-rust-tests]
[ci skip-jvm-tests]