### PR TITLE
Add a GH action to check for PR Labels.

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+   types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: Verify that the PR has a valid label
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verify PR label action
+        uses: ./
+        id: verify-pr-label
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: 'release:API-Changes, release:Testing, release:Documentation, release:Refactoring, release:Features, release:Bugfixes, release:Release, release:Documentation'

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -14,4 +14,4 @@ jobs:
         id: verify-pr-label
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: 'release:API-Changes, release:Testing, release:Documentation, release:Refactoring, release:Features, release:Bugfixes, release:Release, release:Documentation'
+          valid-labels: 'release:api-changes, releasex:testing, release:documentation, release:refactoring, release:features, release:bugfixes, release:release, release:documentation'

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -14,4 +14,4 @@ jobs:
         id: verify-pr-label
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: 'release:api-changes, releasex:testing, release:documentation, release:refactoring, release:features, release:bugfixes, release:release, release:documentation'
+          valid-labels: 'release:api-changes, release:testing, release:refactoring, release:features, release:bugfixes, release:documentation'


### PR DESCRIPTION
### Problem

The process of creating a changelog for a release involves running a script, however the script currently doesn't have an easy way to categorize PR into the difference sections.

### Solution

This GH action will require every PR to have one or more labels on it before merging, those labels in turn will allow the script to automatically categorize PRs in the changelog

### Result

More automation in the release process