### PR TITLE
Default to compiling Rust in debug mode when running locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
   - AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS=AKIAV6A6G7RQWPRUWIXR
   - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   - RUST_BACKTRACE="all"
+  - MODE=release
 jobs:
   include:
   - addons:
@@ -1542,7 +1543,7 @@ jobs:
     os: osx
     osx_image: xcode9.2
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
+    - ./build-support/bin/ci.py --sanity-checks --python-version 3.6
     stage: Test Pants
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1568,7 +1569,7 @@ jobs:
     os: osx
     osx_image: xcode9.2
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.7
+    - ./build-support/bin/ci.py --sanity-checks --python-version 3.7
     stage: Test Pants (Cron)
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1594,7 +1595,7 @@ jobs:
     os: osx
     osx_image: xcode10.1
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
+    - ./build-support/bin/ci.py --sanity-checks --python-version 3.6
     stage: Test Pants
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1620,7 +1621,7 @@ jobs:
     os: osx
     osx_image: xcode10.1
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.7
+    - ./build-support/bin/ci.py --sanity-checks --python-version 3.7
     stage: Test Pants (Cron)
   - addons:
       apt:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -100,6 +100,8 @@ GLOBAL_ENV_VARS = [
         )
     },
     'RUST_BACKTRACE="all"',
+    # We optimize for faster Pants runs at the expense of slower compiles.
+    "MODE=release",
 ]
 
 # ----------------------------------------------------------------------
@@ -739,7 +741,7 @@ def _osx_sanity_check(
         **osx_shard(python_version=python_version, osx_image=osx_image),
         "name": f"OSX 10.{os_version_number} sanity check (Python {python_version.decimal})",
         "script": [
-            f"MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version {python_version.decimal}"
+            f"./build-support/bin/ci.py --sanity-checks --python-version {python_version.decimal}"
         ],
     }
     safe_append(

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -10,11 +10,14 @@ source "${REPO_ROOT}/build-support/common.sh"
 
 readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 
-# N.B. Set $MODE to "debug" for faster builds.
-readonly MODE="${MODE:-release}"
+# N.B. Set $MODE to "release" for much faster Pants runs, but slower compiles.
+# We optimize for faster compiles to reduce the barrier to entry for new contributors
+# (https://github.com/pantsbuild/pants/issues/9822). Most core Pants devs will want to permanently
+# configure MODE=release.
+readonly MODE="${MODE:-debug}"
 case "$MODE" in
-  debug) MODE_FLAG="" ;;
-  *) MODE_FLAG="--release" ;;
+  release) MODE_FLAG="--release" ;;
+  *) MODE_FLAG="" ;;
 esac
 
 RUST_TOOLCHAIN="$(cat "${REPO_ROOT}/rust-toolchain")"

--- a/build-support/bin/native/calculate_engine_hash.sh
+++ b/build-support/bin/native/calculate_engine_hash.sh
@@ -12,8 +12,8 @@ readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 
 # N.B. Set $MODE to "release" for much faster Pants runs, but slower compiles.
 # We optimize for faster compiles to reduce the barrier to entry for new contributors
-# (https://github.com/pantsbuild/pants/issues/9822). Most core Pants devs will want to permanently
-# configure MODE=release.
+# (https://github.com/pantsbuild/pants/issues/9822). Most core Pants devs will want to configure
+# MODE=release when working on Python, but keep the default when developing on Rust.
 readonly MODE="${MODE:-debug}"
 case "$MODE" in
   release) MODE_FLAG="--release" ;;

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -210,6 +210,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
             # Ensure that the underlying ./pants invocation doesn't run from sources
             # (and therefore bootstrap) if we don't want it to.
             "RUN_PANTS_FROM_PEX",
+            # Whether to compile Rust in debug or release mode.
+            "MODE",
         ]
 
     def setUp(self):

--- a/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
+++ b/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
@@ -25,6 +25,9 @@ class PantsRequirementIntegrationTestBase(PantsRunIntegrationTest):
         with environment_as(
             _PANTS_VERSION_OVERRIDE=unstable_version,
             PANTS_PANTS_RELEASES_BRANCH_NOTES="{'0.0.x': 'pants.toml'}",
+            # We propagate whether to compile Rust in debug or release mode to avoid having to
+            # recompile the engine.
+            MODE=os.environ.get("MODE", ""),
         ):
             pants_run = self.run_pants(["--version"])
             self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
@@ -10,7 +10,7 @@ from pants_test.backend.python.pants_requirement_integration_test_base import (
 
 
 class PantsRequirementIntegrationTest(PantsRequirementIntegrationTestBase):
-    """A pants plugin should be able to depend on a pants_requirement() alone to declare its
+    """A Pants plugin should be able to depend on a pants_requirement() alone to declare its
     dependencies on pants modules.
 
     This plugin, when added to the pythonpath and backend_packages, should be able to declare new


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/9823. 

A first-time contributor reported it taking 1.5 hours to bootstrap Rust the first time! While we're fortunate they didn't give up—and we expect it to be faster for most contributors—we still have a substantial barrier to entry.

By changing the default from release to debug mode, we make it much easier for new contributors to onboard. (It doesn't matter if Pants runs slower if they give up before even getting to that part.)

We add a tool tip in https://pants.readme.io/docs/contributor-setup#step-3-bootstrap-the-rust-engine to explain how they can set `MODE=release`. Core devs will likely always want to set this value.

[ci skip-jvm-tests]
