### PR TITLE
Fix harmless error rendered when stdin is closed under pantsd

### DIFF
--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -73,5 +73,5 @@ class TestNailgunStreamWriter(unittest.TestCase):
         mock_select.return_value = ([self.in_fd], [self.in_fd], [])
         mock_read.return_value = b""  # EOF.
         self.writer.run()
-        self.assertFalse(self.writer.is_alive())
-        self.assertEqual(mock_select.call_count, 1)
+        assert self.writer.is_alive() is False
+        assert mock_select.call_count == 1

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -64,3 +64,14 @@ class TestNailgunStreamWriter(unittest.TestCase):
                 unittest.mock.call(unittest.mock.ANY, ChunkType.STDIN_EOF),
             ]
         )
+
+    @unittest.mock.patch("os.close")
+    @unittest.mock.patch("os.read")
+    @unittest.mock.patch("select.select")
+    def test_run_exits_for_closed_and_errored_socket(self, mock_select, mock_read, mock_close):
+        # When stdin is closed, select can indicate that it is both empty and errored.
+        mock_select.return_value = ([self.in_fd], [self.in_fd], [])
+        mock_read.return_value = b""  # EOF.
+        self.writer.run()
+        self.assertFalse(self.writer.is_alive())
+        self.assertEqual(mock_select.call_count, 1)


### PR DESCRIPTION
### Problem

Closing `stdin` with the existing python client (such as occurs in script environments with explicitly empty stdin) currently triggers a harmless warning in the thread that manages stdin:
```
Exception in thread NailgunStreamWriter:
Traceback (most recent call last):
  File "/Users/stuhood/.pyenv/versions/3.7.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/Users/stuhood/src/pants/src/python/pants/java/nailgun_io.py", line 109, in run
    self.do_run(readable_fds, errored_fds)
  File "/Users/stuhood/src/pants/src/python/pants/java/nailgun_io.py", line 128, in do_run
    self.stop_reading_from_fd(fileno)
  File "/Users/stuhood/src/pants/src/python/pants/java/nailgun_io.py", line 97, in stop_reading_from_fd
    self._in_fds.remove(fileno)
ValueError: list.remove(x): x not in list
```
This occurs because `select` can return the fd as both readable-but-empty and error'ed when it is closed, which caused two attempts to `stop_reading_from_fd`.

### Solution

Allow for multiple calls to `_stop_reading_from_fd`.

[ci skip-rust-tests]
[ci skip-jvm-tests]