### PR TITLE
Add support for passthrough options for v2

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_go.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_go.py
@@ -29,10 +29,11 @@ class GoInteropTask(QuietTaskMixin, GoWorkspaceTask):
         )
         args = self.get_passthru_args()
         if not go_targets or not args:
-            msg = yellow(
+            template = yellow(
                 "The pants `{goal}` goal expects at least one go target and at least one "
                 "pass-through argument to be specified, call with:\n"
-            ) + green("  ./pants {goal} {targets} -- {args}").format(
+            ) + green("  ./pants {goal} {targets} -- {args}")
+            msg = template.format(
                 goal=self.options_scope,
                 targets=(
                     green(" ".join(t.address.reference() for t in go_targets))

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -18,6 +18,7 @@ class PyTest(Subsystem):
             type=list,
             member_type=shell_str,
             fingerprint=True,
+            passthrough=True,
             help='Arguments to pass directly to Pytest, e.g. `--pytest-args="-k test_foo --quiet"`',
         )
         register(

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -76,14 +76,14 @@ class HelpFormatter:
         :return: Formatted help text for this option
         """
         indent = "      "
-        arg_line = f"  {self._maybe_magenta(', '.join(ohi.display_args))}"
+        arg_lines = [f"  {self._maybe_magenta(args)}" for args in ohi.display_args]
         choices = f"one of: [{ohi.choices}]; " if ohi.choices else ""
         default_lines = [
             f"{indent}{'  ' if i != 0 else ''}{self._maybe_cyan(s)}"
             for i, s in enumerate(wrap(f"{choices}default: {ohi.default}", 80))
         ]
         description_lines = [f"{indent}{s}" for s in wrap(ohi.help, 80)]
-        lines = [arg_line, *default_lines, *description_lines]
+        lines = [*arg_lines, *default_lines, *description_lines]
         if ohi.deprecated_message:
             lines.append(self._maybe_red(f"{indent}{ohi.deprecated_message}."))
             if ohi.removal_hint:

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -107,13 +107,16 @@ class HelpInfoExtracter:
         return default_str
 
     @staticmethod
+    def stringify_type(t: Type) -> str:
+        if t == dict:
+            return "{'key1': val1, 'key2': val2, ...}"
+        return f"<{t.__name__}>"
+
+    @staticmethod
     def compute_metavar(kwargs):
         """Compute the metavar to display in help for an option registered with these kwargs."""
 
-        def stringify(t: Type) -> str:
-            if t == dict:
-                return "{'key1': val1, 'key2': val2, ...}"
-            return f"<{t.__name__}>"
+        stringify = lambda t: HelpInfoExtracter.stringify_type(t)
 
         metavar = kwargs.get("metavar")
         if not metavar:
@@ -202,6 +205,9 @@ class HelpInfoExtracter:
             else:
                 metavar = self.compute_metavar(kwargs)
                 display_args.append(f"{scoped_arg}={metavar}")
+                if kwargs.get("passthrough"):
+                    type_str = self.stringify_type(kwargs.get("member_type", str))
+                    display_args.append(f"... -- [{type_str} [{type_str} [...]]]")
 
         typ = kwargs.get("type", str)
         default = self.compute_default(kwargs)

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -128,6 +128,13 @@ class HelpInfoExtracterTest(unittest.TestCase):
         self.assertEqual("do not use this", ohi.removal_hint)
         self.assertIsNotNone(ohi.deprecated_message)
 
+    def test_passthrough(self):
+        kwargs = {"passthrough": True, "type": list, "member_type": str}
+        ohi = HelpInfoExtracter("").get_option_help_info(["--thing"], kwargs)
+        assert 2 == len(ohi.display_args)
+        assert any(args.startswith("--thing") for args in ohi.display_args)
+        assert any(args.startswith("... -- ") for args in ohi.display_args)
+
     def test_choices(self) -> None:
         kwargs = {"choices": ["info", "debug"]}
         ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -214,15 +214,14 @@ class ArgSplitter:
         if not goals and not self._help_request:
             self._help_request = NoGoalHelp()
 
-        # When we remove this deprecation, we will remove passthru "owners" entirely: all scopes
-        # which have passthrough args will receive them.
+        # When we remove this deprecation, this case will turn into an error.
         deprecated_conditional(
             lambda: bool(passthru) and len(passthru_owners) > 1,
             removal_version="1.31.0.dev0",
             entity_description="Ambiguous scopes for passthrough args",
             hint_message="In future, all scopes which accept passthrough args (arguments after --) "
-            f"will receive them, so passing multiple scopes (in this case: {passthru_owners}) "
-            "while using passthrough args is no longer recommended.",
+            f"will receive them, and passing multiple scopes (in this case: {passthru_owners}) "
+            "while using passthrough args will no longer be allowed.",
         )
 
         return SplitArgs(

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -217,7 +217,7 @@ class ArgSplitter:
         # When we remove this deprecation, this case will turn into an error.
         deprecated_conditional(
             lambda: bool(passthru) and len(passthru_owners) > 1,
-            removal_version="1.31.0.dev0",
+            removal_version="1.30.0.dev0",
             entity_description="Ambiguous scopes for passthrough args",
             hint_message="In future, all scopes which accept passthrough args (arguments after --) "
             f"will receive them, and passing multiple scopes (in this case: {passthru_owners}) "

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from pants.base.deprecated import deprecated_conditional
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.ordered_set import OrderedSet
 
@@ -163,7 +164,7 @@ class ArgSplitter:
 
         specs = []
         passthru = []
-        passthru_owner = None
+        passthru_owners = []
 
         self._unconsumed_args = list(reversed(sys.argv if args is None else args))
         # In regular use the first token is the binary name, so skip it. However tests may
@@ -187,7 +188,7 @@ class ArgSplitter:
             if not self._check_for_help_request(scope.lower()):
                 add_scope(scope)
                 goals.add(scope.partition(".")[0])
-                passthru_owner = scope
+                passthru_owners.append(scope)
                 for flag in flags:
                     assign_flag_to_scope(flag, scope)
             scope, flags = self._consume_scope()
@@ -213,12 +214,23 @@ class ArgSplitter:
         if not goals and not self._help_request:
             self._help_request = NoGoalHelp()
 
+        # When we remove this deprecation, we will remove passthru "owners" entirely: all scopes
+        # which have passthrough args will receive them.
+        deprecated_conditional(
+            lambda: bool(passthru) and len(passthru_owners) > 1,
+            removal_version="1.31.0.dev0",
+            entity_description="Ambiguous scopes for passthrough args",
+            hint_message="In future, all scopes which accept passthrough args (arguments after --) "
+            f"will receive them, so passing multiple scopes (in this case: {passthru_owners}) "
+            "while using passthrough args is no longer recommended.",
+        )
+
         return SplitArgs(
             goals=list(goals),
             scope_to_flags=scope_to_flags,
             specs=specs,
             passthru=passthru,
-            passthru_owner=passthru_owner if passthru else None,
+            passthru_owner=passthru_owners.pop() if passthru else None,
             unknown_scopes=self._unknown_scopes,
         )
 

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -69,6 +69,10 @@ class OptionNameDoubleDash(RegistrationError):
     """Long option name must begin with a double-dash."""
 
 
+class PassthroughType(RegistrationError):
+    """Options marked passthrough must be typed as a string list."""
+
+
 class RecursiveSubsystemOption(RegistrationError):
     """Subsystem option cannot specify 'recursive'.
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -327,7 +327,7 @@ class Options:
         return scope in self._known_scope_to_info
 
     def passthru_args_for_scope(self, scope: str) -> List[str]:
-        # NB: The concept of passthru argument "ownership" will go away in 1.31.0.dev0, at which
+        # NB: The concept of passthru argument "ownership" will go away in 1.30.0.dev0, at which
         # point _all_ scopes which register passthrough args will receive them and this method can
         # go away. But because Subsystems have never been able to receive passthrough args before,
         # we can begin applying that behavior to them unambiguously before the deprecation. The

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -869,7 +869,7 @@ class OptionsTest(TestBase):
             self.assertEqual(["bar", "fleem:tgt", "foo", "morx:tgt"], sorted_specs)
 
     def test_passthru_args_ownership(self):
-        # TODO: Ownership of passthrough args will go away in 1.31.0.dev0, and all scopes that claim
+        # TODO: Ownership of passthrough args will go away in 1.30.0.dev0, and all scopes that claim
         # passthrough args will receive them, regardless of position. This test should then shrink
         # or be deleted.
         options = self._parse(flags="compile foo -- bar --baz")

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -131,6 +131,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
                 type=list,
                 advanced=True,
                 fingerprint=True,
+                passthrough=True,
                 help="Pass these options as pass-through args; ie: as if by appending "
                 "`-- <passthrough arg> ...` to the command line. Any passthrough args actually"
                 "supplied on the command line will be used as well.",
@@ -216,10 +217,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
         if not self.supports_passthru_args():
             raise TaskError("{} Does not support passthru args.".format(self.stable_name()))
 
-        passthru_args = []
-        passthru_args.extend(self.get_options().get("passthrough_args", default=()))
-        passthru_args.extend(self.context.options.passthru_args_for_scope(self.options_scope))
-        return passthru_args
+        return list(self.get_options().get("passthrough_args", default=()))
 
     @property
     def debug(self) -> bool:

--- a/src/python/pants/testutil/option/fakes.py
+++ b/src/python/pants/testutil/option/fakes.py
@@ -97,6 +97,12 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
             if isinstance(options_for_this_scope, _FakeOptionValues):
                 options_for_this_scope = options_for_this_scope.option_values
 
+            if passthru_args:
+                pa = options_for_this_scope.get("passthrough_args", [])
+                if isinstance(pa, RankedValue):
+                    pa = pa.value
+                options_for_this_scope["passthrough_args"] = [*pa, *passthru_args]
+
             scoped_options = {}
             if scope:
                 scoped_options.update(self.for_scope(enclosing_scope(scope)).option_values)


### PR DESCRIPTION
### Problem

Passthrough args have so far had positional ownership, and only been registrable by v1 `Task`s. This meant that we did not have support for using passthrough arguments with v2 `Goal`s.

### Solution

Add support for marking options as `passthrough=True` to have them filled from provided passthrough options, and deprecate the concept of positional ownership of passthrough args.

Because `Subsystem`s and v2 `Goal`s had not supported passthrough args previously, we can safely introduce this behavior before the deprecation. Nonetheless, we should be thoughtful while adding passthrough args to additional `Subsystem`s or `Goal`s to avoid overloading them in any particular context: similar to the current situation (where "all `Task`s in a `Goal` receive passthrough args"), it should be possible to unambiguously use passthrough args by either 1) running fewer goals at once, 2) passing a single type of target.

### Result

Passthrough args work for `pytest` in v2 (and other v2 `Goal`'s args can be marked in followup changes):
```
$ ./v2 test tests/python/pants_test/util/test_strutil.py -- -k test_ensure_binary
...

05:37:07:442 [INFO] Starting tests: tests/python/pants_test/util:strutil
05:37:07:463 [INFO] Tests succeeded: tests/python/pants_test/util:strutil
✓ tests/python/pants_test/util:strutil

============================= test session starts ==============================
...
======================= 1 passed, 5 deselected in 0.03s ========================
```

The help has also been updated to render that an option is passthrough:
<img width="615" alt="Screen Shot 2020-05-25 at 10 24 53 PM" src="https://user-images.githubusercontent.com/46740/82863316-a6fcd980-9ed6-11ea-9050-951ad0ba85fb.png">

[ci skip-rust-tests]
[ci skip-jvm-tests]