### PR TITLE
Make the `Dependencies` field an AsyncField

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -58,7 +58,7 @@ class PylintSourcePlugin(Target):
 
     alias = "pylint_source_plugin"
     core_fields = (
-        *(FrozenOrderedSet(COMMON_PYTHON_FIELDS) - {Dependencies}),
+        *(FrozenOrderedSet(COMMON_PYTHON_FIELDS) - {Dependencies}),  # type: ignore[misc]
         PylintPluginDependencies,
         PylintPluginSources,
     )

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -7,6 +7,7 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.rules import RootRule
 from pants.engine.target import (
     Dependencies,
+    DependenciesRequest,
     Target,
     Targets,
     TransitiveTarget,
@@ -42,8 +43,6 @@ class GraphTest(TestBase):
             address=Address.parse(":root"),
         )
 
-        # TODO: possibly figure out how to deduplicate this when developing utilities for testing
-        #  with the Target API.
         self.add_to_build_file(
             "",
             dedent(
@@ -58,9 +57,7 @@ class GraphTest(TestBase):
             ),
         )
 
-        direct_deps = self.request_single_product(
-            Targets, Addresses(root[Dependencies].value)  # type: ignore[arg-type]
-        )
+        direct_deps = self.request_single_product(Targets, DependenciesRequest(root[Dependencies]))
         assert direct_deps == Targets([d1, d2, d3])
 
         transitive_target = self.request_single_product(TransitiveTarget, WrappedTarget(root))

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1053,7 +1053,7 @@ class TestDependencies(TestBase):
         assert self.request_single_product(Addresses, DependenciesRequest(deps_field)) == deps
 
         # Also test that we handle no dependencies.
-        empty_deps_field = Dependencies(deps, address=addr)
+        empty_deps_field = Dependencies(None, address=addr)
         assert self.request_single_product(
             Addresses, DependenciesRequest(empty_deps_field)
         ) == Addresses([])


### PR DESCRIPTION
Soon, we will add two new features:

1) Dependency injection for codegen runtime platforms, e.g. `protobuf_library`'s automatically getting injected with the Python runtime wheel, if configured by the user to do so.
2) Dependency inference, meaning that users can leave off `dependencies` from BUILD files and Pants will figure out the appropriate values from their import statements.

Both of these mechanisms will require the engine to work. So, we can no longer get away with `Dependencies` being a `PrimitiveField` and we instead make it an `AsyncField`.

For now, the rule is extremely simple. The key change is to call sites - this should be the only change necessary for those call sites to automatically work with both features.

### Importance of one rule

Like we do with `sources`, we have only one rule to hydrate dependencies, rather than having a distinct rule for each possible subclass of the `Dependencies` field. 

This is essential to allow us to centralize the implementation of both features to one single place. While we could create helper rules and have us expect subclasses to call those helper rules in their own rules, it would be very error-prone and easy to forgot to do.

Similar to `Sources`, we will add "hooks" to the superclass to allow subclasses to customize functionality. For example, we could add a hook to ban certain addresses. Or, we could add a hook to inject dependencies.

[ci skip-rust-tests]
[ci skip-jvm-tests]
