### PR TITLE
Fix F541 f-string is missing placeholders

### DIFF
--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/python_awslambda.py
@@ -42,12 +42,12 @@ class PythonAWSLambda(Target):
         dependencies = self.dependencies
         if len(dependencies) != 1:
             raise TargetDefinitionException(
-                self, f"An app must define exactly one binary " "dependency, have: {dependencies}"
+                self, f"An app must define exactly one binary dependency, have: {dependencies}"
             )
         binary = dependencies[0]
         if not isinstance(binary, PythonBinary):
             raise TargetDefinitionException(
-                self, f"Expected binary dependency to be a python_binary " "target, found {binary}"
+                self, f"Expected binary dependency to be a python_binary target, found {binary}"
             )
         return binary
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -35,7 +35,7 @@ async def generate_python_from_protobuf(
     # TODO(#9650): replace this with a proper intrinsic to create empty directories.
     create_output_dir_request = Get[ProcessResult](
         Process(
-            (f"/bin/mkdir", output_dir),
+            ("/bin/mkdir", output_dir),
             description=f"Create the directory {output_dir}",
             output_directories=(output_dir,),
         )

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -79,7 +79,7 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
     def injectables_address_spec_mapping(self):
         return {
             # Target spec for scoverage plugin.
-            "scoverage": [f"//:scoverage"],
+            "scoverage": ["//:scoverage"],
         }
 
     def is_blacklisted(self, target_address_spec) -> bool:

--- a/src/python/pants/backend/jvm/tasks/scalafix_task.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix_task.py
@@ -173,4 +173,4 @@ class ScalaFixCheck(LintTaskMixin, ScalafixTask):
 
     def process_result(self, result):
         if result != 0:
-            raise TaskError(f"Targets failed scalafix checks.")
+            raise TaskError("Targets failed scalafix checks.")

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -120,7 +120,7 @@ async def bandit_lint(
     process = requirements_pex.create_process(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path=f"./bandit.pex",
+        pex_path="./bandit.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, bandit=bandit),
         input_digest=input_digest,
         description=f"Run Bandit on {pluralize(len(field_sets), 'target')}: {address_references}.",

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -60,7 +60,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--bandit-args={passthrough_args}")
         if skip:
-            args.append(f"--bandit-skip")
+            args.append("--bandit-skip")
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -57,7 +57,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--black-args='{passthrough_args}'")
         if skip:
-            args.append(f"--black-skip")
+            args.append("--black-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
         lint_result = self.request_single_product(

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -50,7 +50,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--docformatter-args='{passthrough_args}'")
         if skip:
-            args.append(f"--docformatter-skip")
+            args.append("--docformatter-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [DocformatterFieldSet.create(tgt) for tgt in targets]
         lint_result = self.request_single_product(

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -121,7 +121,7 @@ async def flake8_lint(
     process = requirements_pex.create_process(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
-        pex_path=f"./flake8.pex",
+        pex_path="./flake8.pex",
         pex_args=generate_args(specified_source_files=specified_source_files, flake8=flake8),
         input_digest=input_digest,
         description=f"Run Flake8 on {pluralize(len(field_sets), 'target')}: {address_references}.",

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -61,7 +61,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--flake8-args='{passthrough_args}'")
         if skip:
-            args.append(f"--flake8-skip")
+            args.append("--flake8-skip")
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -64,7 +64,7 @@ class IsortIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--isort-args='{passthrough_args}'")
         if skip:
-            args.append(f"--isort-skip")
+            args.append("--isort-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [IsortFieldSet.create(tgt) for tgt in targets]
         lint_result = self.request_single_product(

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -99,7 +99,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--pylint-args='{passthrough_args}'")
         if skip:
-            args.append(f"--pylint-skip")
+            args.append("--pylint-skip")
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -360,7 +360,7 @@ async def generate_coverage_report(
         input_digest=input_digest,
         output_directories=("htmlcov",),
         output_files=("coverage.xml",),
-        description=f"Generate Pytest coverage report.",
+        description="Generate Pytest coverage report.",
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
     )

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -56,7 +56,7 @@ class PythonBinaryFieldSet(BinaryFieldSet):
         if self.shebang.value is not None:
             args.append(f"--python-shebang={self.shebang.value}")
         if self.zip_safe.value is False:
-            args.append(f"--not-zip-safe")
+            args.append("--not-zip-safe")
         return tuple(args)
 
 

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -121,8 +121,8 @@ class PythonBinaryCreate(Task):
             name = binary.name
             if name in names:
                 raise TaskError(
-                    f"Cannot build two binaries with the same name in a single invocation. "
-                    "{binary} and {names[name]} both have the name {name}."
+                    "Cannot build two binaries with the same name in a single invocation. "
+                    f"{binary} and {names[name]} both have the name {name}."
                 )
             names[name] = binary
 

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _is_build_file_name(name: str) -> bool:
-    return bool(re.match(rf"^BUILD(\.[a-zA-Z0-9_-]+)?$", name))
+    return bool(re.match(r"^BUILD(\.[a-zA-Z0-9_-]+)?$", name))
 
 
 # Note: Significant effort has been made to keep the types BuildFile, BuildGraph, Address, and

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -47,7 +47,7 @@ class Binary(Goal):
 async def create_binary(workspace: Workspace, dist_dir: DistDir, build_root: BuildRoot) -> Binary:
     targets_to_valid_field_sets = await Get[TargetsToValidFieldSets](
         TargetsToValidFieldSetsRequest(
-            BinaryFieldSet, goal_description=f"the `binary` goal", error_if_no_valid_targets=True
+            BinaryFieldSet, goal_description="the `binary` goal", error_if_no_valid_targets=True
         )
     )
     binaries = await MultiGet(

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -749,7 +749,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
             if not self.try_with_backoff(assertion_fn):
                 raise AssertionError(
-                    f"Deleting parent dir and could still read file from original snapshot."
+                    "Deleting parent dir and could still read file from original snapshot."
                 )
 
     def assert_mutated_digest(

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -197,7 +197,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
         self.assert_equal_with_printing(
             dedent(
-                f"""
+                """
                 1 Exception encountered:
 
                 Traceback (most recent call last):
@@ -206,7 +206,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
                   File LOCATION-INFO, in nested_raise
                     fn_raises(x)
                   File LOCATION-INFO, in fn_raises
-                    raise Exception(f"An exception for {{type(x).__name__}}")
+                    raise Exception(f"An exception for {type(x).__name__}")
                 Exception: An exception for B
                 """
             ).lstrip(),

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -363,7 +363,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
         assert_equal_with_printing(
             self,
             dedent(
-                f"""\
+                """\
                  1 Exception encountered:
 
                  Engine traceback:
@@ -374,7 +374,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
                    File LOCATION-INFO, in nested_raise
                      fn_raises(x)
                    File LOCATION-INFO, in fn_raises
-                     raise Exception(f"An exception for {{type(x).__name__}}")
+                     raise Exception(f"An exception for {type(x).__name__}")
                  Exception: An exception for B
                  """
             ),

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -248,7 +248,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
         annotations = DEFAULT_RULE_ANNOTATIONS
         if any(x is not None for x in (canonical_name, desc)):
             raise UnrecognizedRuleArgument(
-                f"@rules that are not @named_rules or @goal_rules do not accept keyword arguments"
+                "@rules that are not @named_rules or @goal_rules do not accept keyword arguments"
             )
 
     if (

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -134,7 +134,7 @@ class SchedulerService(PantsService):
             self._scheduler.check_invalidation_watcher_liveness()
         except Exception as e:
             # Watcher failed for some reason
-            self._logger.critical(f"The scheduler was invalidated: {e}")
+            self._logger.critical(f"The scheduler was invalidated: {e!r}")
             self.terminate()
 
     def prepare(self) -> LegacyGraphScheduler:
@@ -142,7 +142,7 @@ class SchedulerService(PantsService):
         # racing watchman startup vs invalidation events.
         if self._fs_event_service is not None and self._scheduler.graph_len() > 0:
             self._logger.debug(
-                f"fs event service is running and graph_len > 0: waiting for initial watchman event"
+                "fs event service is running and graph_len > 0: waiting for initial watchman event"
             )
             self._fs_event_service.await_started()
         return self._graph_helper

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -74,7 +74,7 @@ def linkify(buildroot, s, memoized_urls):
             if Path(buildroot, putative_dir).is_dir():
                 build_files = sorted(
                     build_file
-                    for build_file in Path(buildroot, putative_dir).glob(f"BUILD*")
+                    for build_file in Path(buildroot, putative_dir).glob("BUILD*")
                     if _is_build_file_name(build_file.name) and build_file.is_file()
                 )
                 if not build_files:

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -141,8 +141,8 @@ class Git(Scm):
         origins = list(origin_urls())
         if len(origins) != 1:
             raise Scm.LocalException(
-                f"Unable to find remote named 'origin' that accepts pushes "
-                "amongst:\n{git_output}"
+                "Unable to find remote named 'origin' that accepts pushes "
+                f"amongst:\n{git_output}"
             )
         return origins[0]
 

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -29,8 +29,8 @@ class FmtTaskMixin:
             )
         if is_scalafix and only == "scalafix" and skipped:
             raise ValueError(
-                f"Invalid flag combination. You cannot both set `--fmt-only=scalafix` and "
-                f"`--scalafix-skip`.",
+                "Invalid flag combination. You cannot both set `--fmt-only=scalafix` and "
+                "`--scalafix-skip`.",
             )
 
         if only == "scalafix" and not is_scalafix:

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -79,7 +79,7 @@ def get_docstring(
 def pretty_print_type_hint(hint: Any) -> str:
     if getattr(hint, "__origin__", None) == Union:
         union_members = hint.__args__
-        hint_str = f" | ".join(pretty_print_type_hint(member) for member in union_members)
+        hint_str = " | ".join(pretty_print_type_hint(member) for member in union_members)
     # NB: Checking for GenericMeta is only for Python 3.6 because some `typing` classes like
     # `typing.Iterable` have its type, whereas Python 3.7+ removes it. Remove this check
     # once we drop support for Python 3.6.

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_integration.py
@@ -223,7 +223,7 @@ class PythonBinaryIntegrationTest(PantsRunIntegrationTest):
                     f"--pants-distdir={tmp_distdir}",
                     # tensorflow==1.14.0 has a setuptools>=41.0.0 requirement, so the .ipex resolve fails
                     # without this override.
-                    f"--pex-builder-wrapper-setuptools-version=41.0.0",
+                    "--pex-builder-wrapper-setuptools-version=41.0.0",
                     "--binary-py-generate-ipex",
                     "binary",
                     "examples/src/python/example/tensorflow_custom_op:show-tf-version",

--- a/tests/python/pants_test/bin/test_runner_integration.py
+++ b/tests/python/pants_test/bin/test_runner_integration.py
@@ -17,7 +17,7 @@ class RunnerIntegrationTest(PantsRunIntegrationTest):
         cmdline = [
             "--no-enable-pantsd",
             f"--pythonpath=+['{Path(get_buildroot(), 'testprojects/pants-plugins/src/python')}']",
-            f"--backend-packages=+['test_pants_plugin']",
+            "--backend-packages=+['test_pants_plugin']",
             # This task will always emit a DeprecationWarning.
             "deprecation-warning-task",
         ]

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -75,7 +75,7 @@ def test_get_docstring() -> None:
 
     assert get_docstring_summary(MultilineSummaryWithDetails) == long_summary
     assert get_docstring(MultilineSummaryWithDetails) == dedent(
-        f"""\
+        """\
         This is all one sentence, it's just really really really long so it stretches to a whole
         new line.
 


### PR DESCRIPTION
### Problem

The new version of flake8 (3.8.0) adds a check for f-string w/ place holders. As you can see in this PR, this actually exposed a few bugs in the source code.

### Solution

Remove f-strings where they are not needed, fix f-strings where they are


### Result

The ability to upgade and use the new version of flake8 in the pants repo