### PR TITLE
Remove unused `@addressable_dict` mechanism

### DIFF
--- a/src/python/pants/engine/internals/addressable.py
+++ b/src/python/pants/engine/internals/addressable.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import inspect
-from collections.abc import Mapping
 from functools import update_wrapper
 from typing import Any, Set, Tuple, Type
 
@@ -273,40 +272,3 @@ def addressable_sequence(type_constraint):
     :type type_constraint: :class:`TypeConstraint`
     """
     return _addressable_wrapper(AddressableSequence, type_constraint)
-
-
-class AddressableDict(AddressableDescriptor):
-    def _checked_value(self, instance, value):
-        if value is None:
-            return None
-
-        if not isinstance(value, Mapping):
-            raise TypeError(
-                "The {} property of {} must be a dict, given {} of type {}".format(
-                    self._name, instance, value, type(value).__name__
-                )
-            )
-        return {
-            k: super(AddressableDict, self)._checked_value(instance, v) for k, v in value.items()
-        }
-
-    def _resolve_value(self, instance, value):
-        return (
-            {k: super(AddressableDict, self)._resolve_value(instance, v) for k, v in value.items()}
-            if value
-            else {}
-        )
-
-
-def addressable_dict(type_constraint):
-    """Marks a dicts's values as satisfying a given type constraint.
-
-    Some (or all) values in the dict may be :class:`pants.engine.objects.Resolvable` values to
-    resolve later.
-
-    See :class:`AddressableDescriptor` for more details.
-
-    :param type_constraint: The type constraint the dict's values must all satisfy.
-    :type type_constraint: :class:`TypeConstraint`
-    """
-    return _addressable_wrapper(AddressableDict, type_constraint)

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -13,7 +13,7 @@ from pants.base.project_tree import Dir
 from pants.base.specs import AddressSpecs, SiblingAddresses, SingleAddress
 from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
-from pants.engine.internals.addressable import addressable, addressable_dict
+from pants.engine.internals.addressable import addressable
 from pants.engine.internals.build_files import (
     ResolvedTypeMismatchError,
     addresses_with_origins_from_address_families,
@@ -197,17 +197,12 @@ class ApacheThriftConfiguration(StructWithDeps):
 class PublishConfiguration(Struct):
     # An example of addressable and addressable_mapping field wrappers.
 
-    def __init__(self, default_repo, repos, name=None, **kwargs):
+    def __init__(self, default_repo, name=None, **kwargs):
         super().__init__(name=name, **kwargs)
         self.default_repo = default_repo
-        self.repos = repos
 
     @addressable(Exactly(Struct))
     def default_repo(self):
-        """"""
-
-    @addressable_dict(Exactly(Struct))
-    def repos(self):
         """"""
 
 
@@ -286,16 +281,7 @@ class InlinedGraphTest(GraphTestBase):
         expected_java1 = Target(
             address=address("java1"),
             configurations=[
-                PublishConfiguration(
-                    type_alias="PublishConfig",
-                    default_repo=public,
-                    repos={
-                        "jake": Struct(
-                            type_alias="Struct", url="https://dl.bintray.com/pantsbuild/maven"
-                        ),
-                        "jane": public,
-                    },
-                ),
+                PublishConfiguration(type_alias="PublishConfig", default_repo=public),
                 nonstrict,
                 ApacheThriftConfiguration(
                     type_alias="ApacheThriftConfig",

--- a/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD
+++ b/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD
@@ -21,12 +21,6 @@ Target(
   configurations=[
     PublishConfig(
       default_repo=':public',
-      repos={
-        'jake': Struct(
-          url='https://dl.bintray.com/pantsbuild/maven'
-        ),
-        'jane': ':public'
-      }
     )
   ]
 )

--- a/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD.json
+++ b/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD.json
@@ -22,14 +22,7 @@
   "configurations": [
     {
       "type_alias": "PublishConfig",
-      "default_repo": ":public",
-      "repos": {
-        "jake": {
-          "type_alias": "Struct",
-          "url": "https://dl.bintray.com/pantsbuild/maven"
-        },
-        "jane": ":public"
-      }
+      "default_repo": ":public"
     },
     # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
     # off / prove the capabilities of the new BUILD graph parser.

--- a/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD.python
+++ b/src/python/pants/engine/internals/examples/graph_test/self_contained.BUILD.python
@@ -16,12 +16,6 @@ java1 = Target(
   configurations=[
     PublishConfig(
       default_repo=':public',
-      repos={
-        'jake': Struct(
-          url='https://dl.bintray.com/pantsbuild/maven'
-        ),
-        'jane': ':public'
-      }
     ),
     # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
     # off / prove the capabilities of the new BUILD graph parser.


### PR DESCRIPTION
This isn't used in production. We can always add it back if we need it later.

[ci skip-rust-tests]
[ci skip-jvm-tests]
