### PR TITLE
Avoid using bare 'except'

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -627,7 +627,7 @@ class SchedulerSession:
         raised_exception = None
         try:
             request = self.execution_request([product], subjects, poll=poll, timeout=timeout)
-        except:  # noqa: T803
+        except Exception:
             # If there are any exceptions during CFFI extern method calls, we want to return an error with
             # them and whatever failure results from it. This typically results from unhashable types.
             if self._scheduler._native._peek_cffi_extern_method_runtime_exceptions():

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -319,7 +319,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
         def create_cffi_exception():
             try:
                 raise Exception("test cffi exception")
-            except:  # noqa: T803
+            except Exception:
                 return Native.CFFIExternMethodRuntimeErrorInfo(*sys.exc_info()[0:3])
 
         # Test that CFFI extern method errors result in an ExecutionError, even if .execution_request()


### PR DESCRIPTION
Added here: https://github.com/pantsbuild/pants/pull/7532/files#diff-c7c549754b542689b556b0dc41c3b3a7R514


### Problem

Bare excepts are dangerous and can hide actual bugs.. syntax errors (for example)

### Solution

Just case base exception in lieu of catching specific exceptions