### PR TITLE
Explicitly handle conflict between --v2-ui and --dynamic-ui

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -316,7 +316,8 @@ def resolve_conflicting_options(
     if old_configured and new_configured:
 
         def format_option(*, scope: str, option: str) -> str:
-            return f"`--{scope}-{option}`".replace("_", "-")
+            scope_preamble = "--" if scope == "" else f"--{scope}-"
+            return f"`{scope_preamble}{option}`".replace("_", "-")
 
         old_display = format_option(scope=old_scope, option=old_option)
         new_display = format_option(scope=new_scope, option=new_option)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -8,6 +8,7 @@ from typing import Mapping, Optional, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode
 from pants.base.specs import Specs
@@ -30,6 +31,7 @@ from pants.init.specs_calculator import SpecsCalculator
 from pants.option.arg_splitter import UnknownGoalHelp
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.scope import GLOBAL_SCOPE
 from pants.reporting.reporting import Reporting
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.subsystem.subsystem import Subsystem
@@ -86,7 +88,17 @@ class LocalPantsRunner:
 
         global_scope = options.for_global_scope()
 
-        dynamic_ui = global_scope.dynamic_ui
+        if global_scope.v2:
+            dynamic_ui = resolve_conflicting_options(
+                old_option="v2_ui",
+                new_option="dynamic_ui",
+                old_scope=GLOBAL_SCOPE,
+                new_scope=GLOBAL_SCOPE,
+                old_container=global_scope,
+                new_container=global_scope,
+            )
+        else:
+            dynamic_ui = False
         use_colors = global_scope.get("colors", True)
 
         zipkin_trace_v2 = options.for_scope("reporting").zipkin_trace_v2

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -926,10 +926,8 @@ class GlobalOptions(Subsystem):
         register(
             "--v2-ui",
             default=False,
-            dest="dynamic_ui",
             type=bool,
             daemon=False,
-            passive=not register.bootstrap.v2,
             removal_version="1.31.0.dev0",
             removal_hint="Use --dynamic-ui instead.",
             help="Whether to show v2 engine execution progress.",


### PR DESCRIPTION
### Problem

Now that --v2-ui is deprecated and its value is redirected to that of --dynamic-ui, we are effectively treating this boolean as false by default unless one of those two flags is explicitly set, which we don't want. This seems to be a weird edge case of the `dest` faculty on the option-specification framework.

### Solution

Use the `resolve_conflicting_options` helper function to explicitly handle conflicts between the two flags and remove the `dest`. Also remove the `passive` option since we will never try to use this flag if v2 isn't set. And explicitly set --no-dynamic-ui on the invocation of pants in the bootstrapper so that that invocation of pants doesn't itself spawn a dynamic UI.