### PR TITLE
Add log levels to workunit

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3873,6 +3873,7 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time 0.0.1",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -30,6 +30,7 @@ extern crate derivative;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+pub use log::Level;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
@@ -441,6 +442,7 @@ impl CommandRunner for BoundedCommandRunner {
       .unwrap_or_else(|| "<Unnamed process>".to_string());
     let outer_metadata = WorkunitMetadata {
       desc: Some(desc.clone()),
+      level: Level::Info,
       display: false,
       blocked: true,
     };
@@ -453,6 +455,7 @@ impl CommandRunner for BoundedCommandRunner {
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
+          level: Level::Info,
           display: false,
           blocked: false,
         };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -34,7 +34,7 @@ use rule_graph;
 
 use graph::{Entry, Node, NodeError, NodeVisualizer};
 use store::{self, StoreFileByDigest};
-use workunit_store::{new_span_id, scope_task_workunit_state, WorkunitMetadata};
+use workunit_store::{new_span_id, scope_task_workunit_state, Level, WorkunitMetadata};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 
@@ -1029,6 +1029,7 @@ impl Node for NodeKey {
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
       let metadata = WorkunitMetadata {
         desc: user_facing_name.clone(),
+        level: Level::Info,
         display,
         blocked: false,
       };

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -11,3 +11,4 @@ parking_lot = "0.6"
 rand = "0.6"
 tokio = { version = "0.2", features = ["rt-util"] }
 petgraph = "0.4.5"
+log = "0.4"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
+pub use log::Level;
 use parking_lot::Mutex;
 use petgraph::graph::{DiGraph, NodeIndex};
 use rand::thread_rng;
@@ -60,6 +61,7 @@ pub enum WorkunitState {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
+  pub level: Level,
   pub display: bool,
   pub blocked: bool,
 }
@@ -68,6 +70,7 @@ impl WorkunitMetadata {
   pub fn new() -> WorkunitMetadata {
     WorkunitMetadata {
       display: true,
+      level: Level::Info,
       desc: None,
       blocked: false,
     }


### PR DESCRIPTION
This commit is pre-work for a more sophisticated notion of logging in pants that takes into account the current workunit. In order to carry this out, we will need to tag workunits with a log level. This commit adds that field to the `WorkunitMetadata` struct, setting it to `LogLevel::Info` in all cases - eventually this should be configurable.