### PR TITLE
Add support for dependency injection and use it with V2 Protobuf

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -9,12 +9,13 @@ See https://pants.readme.io/docs/protobuf.
 from pants.backend.codegen.protobuf.python import additional_fields
 from pants.backend.codegen.protobuf.python.rules import rules as python_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.backend.codegen.protobuf.target_types import rules as target_rules
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target as TargetV1
 
 
 def rules():
-    return [*additional_fields.rules(), *python_rules()]
+    return [*additional_fields.rules(), *python_rules(), *target_rules()]
 
 
 def target_types():

--- a/src/python/pants/backend/codegen/protobuf/subsystems/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystems/protoc.py
@@ -1,8 +1,11 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import List, cast
+
 from pants.core.util_rules.external_tool import ExternalTool, ExternalToolError
 from pants.engine.platform import Platform
+from pants.option.custom_types import target_option
 
 
 class Protoc(ExternalTool):
@@ -14,6 +17,22 @@ class Protoc(ExternalTool):
         "3.11.4|darwin|8c6af11e1058efe953830ecb38324c0e0fd2fb67df3891896d138c535932e7db|2482119",
         "3.11.4|linux |6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be|1591191",
     ]
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--runtime-targets",
+            type=list,
+            member_type=target_option,
+            advanced=True,
+            help=(
+                "A list of addresses to targets for Protobuf runtime libraries. For example, a "
+                "`python_requirement_library` for the `protobuf` Python library. These targets "
+                "will be automatically injected into the `dependencies` field of every "
+                "`protobuf_library`."
+            ),
+        )
 
     def generate_url(self, plat: Platform) -> str:
         version = self.get_options().version
@@ -47,3 +66,7 @@ class Protoc(ExternalTool):
             return "protoc"
         else:
             return "bin/protoc"
+
+    @property
+    def runtime_targets(self) -> List[str]:
+        return cast(List[str], self.options.runtime_targets)

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -1,7 +1,28 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
+from pants.backend.codegen.protobuf.subsystems.protoc import Protoc
+from pants.engine.addresses import Address
+from pants.engine.rules import SubsystemRule, rule
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    Sources,
+    Target,
+)
+from pants.engine.unions import UnionRule
+
+
+class ProtobufDependencies(Dependencies):
+    """Addresses to other targets that this target depends on, e.g. `['protobuf/example:lib']`.
+
+    Pants will automatically inject any targets that you configure in the option `runtime_targets`
+    in the `[protoc]` scope. For example, if you set that option to include the Python runtime
+    library for Protobuf, every `protobuf_library` will automatically include that in its
+    `dependencies`.
+    """
 
 
 class ProtobufSources(Sources):
@@ -16,4 +37,21 @@ class ProtobufLibrary(Target):
     """
 
     alias = "protobuf_library"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ProtobufSources)
+    core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources)
+
+
+class InjectProtobufDependencies(InjectDependenciesRequest):
+    inject_for = ProtobufDependencies
+
+
+@rule
+def inject_dependencies(_: InjectProtobufDependencies, protoc: Protoc) -> InjectedDependencies:
+    return InjectedDependencies(Address.parse(addr) for addr in protoc.runtime_targets)
+
+
+def rules():
+    return [
+        inject_dependencies,
+        UnionRule(InjectDependenciesRequest, InjectProtobufDependencies),
+        SubsystemRule(Protoc),
+    ]

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -30,6 +30,8 @@ from pants.engine.target import (
     GenerateSourcesRequest,
     HydratedSources,
     HydrateSourcesRequest,
+    InjectDependenciesRequest,
+    InjectedDependencies,
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
@@ -1041,10 +1043,43 @@ class TestCodegen(TestBase):
 # -----------------------------------------------------------------------------------------------
 
 
+class FortranDependencies(Dependencies):
+    pass
+
+
+class CustomFortranDependencies(FortranDependencies):
+    pass
+
+
+class InjectFortranDependencies(InjectDependenciesRequest):
+    inject_for = FortranDependencies
+
+
+class InjectCustomFortranDependencies(InjectDependenciesRequest):
+    inject_for = CustomFortranDependencies
+
+
+@rule
+def inject_fortran_deps(_: InjectFortranDependencies) -> InjectedDependencies:
+    return InjectedDependencies([Address.parse("//:injected")])
+
+
+@rule
+def inject_custom_fortran_deps(_: InjectCustomFortranDependencies) -> InjectedDependencies:
+    return InjectedDependencies([Address.parse("//:custom_injected")])
+
+
 class TestDependencies(TestBase):
     @classmethod
     def rules(cls):
-        return (*super().rules(), RootRule(DependenciesRequest))
+        return (
+            *super().rules(),
+            RootRule(DependenciesRequest),
+            inject_fortran_deps,
+            inject_custom_fortran_deps,
+            UnionRule(InjectDependenciesRequest, InjectFortranDependencies),
+            UnionRule(InjectDependenciesRequest, InjectCustomFortranDependencies),
+        )
 
     def test_normal_resolution(self) -> None:
         addr = Address.parse("src/fortran:lib")
@@ -1057,3 +1092,16 @@ class TestDependencies(TestBase):
         assert self.request_single_product(
             Addresses, DependenciesRequest(empty_deps_field)
         ) == Addresses([])
+
+    def test_dependency_injection(self) -> None:
+        def assert_injected(deps_cls: Type[Dependencies], *, injected: List[str]) -> None:
+            provided_addr = Address.parse("//:provided")
+            deps_field = deps_cls([provided_addr], address=Address.parse("//:target"))
+            result = self.request_single_product(Addresses, DependenciesRequest(deps_field))
+            assert result == Addresses(
+                sorted([provided_addr, *(Address.parse(addr) for addr in injected)])
+            )
+
+        assert_injected(Dependencies, injected=[])
+        assert_injected(FortranDependencies, injected=["//:injected"])
+        assert_injected(CustomFortranDependencies, injected=["//:custom_injected", "//:injected"])


### PR DESCRIPTION
We want to allow rule authors to create rules that will automatically inject dependencies for certain target types. For example, we want to use this with codegen to automatically inject the runtime libraries needed for the generated code to work properly.

Thanks to the Target API + unions, we can do this easily and also have the following features:

1) A dependency injection rule can ask for any additional params, such as asking for a subsystem.
     * We use this with the protobuf rule to read from a new `--protoc-runtime-targets` option. 
2)  You can have multiple distinct dependency injection rules in use at the same time.
     * For example, we may provide a rule to inject `ProtobufDependencies`. A plugin author could also write a rule to inject all `Dependencies` fields and subclasses. Both will get used together.

### Does not use "precise" dependency injection for codegen

In V2, we have one single `protobuf_library`, rather than `python_protobuf_library` etc. When hydrating `Sources`, we require the call site to disambiguate which of the N languages should be generated by specifying, for example, `PythonSources`.

Here, we do not use this precision. For a `protobuf_library`, we will inject all dependencies specified in `--protoc-runtime-targets`, regardless of the target type.

We do this in part because we cannot know the type of an `Address` until we have converted it into a `Target`. The scope for `resolve_dependencies` is to simply give back the `Addresses` specified in the `dependencies` field, not to filter out irrelevant target types. For example, there is nothing stopping a user from having a `python_library` explicitly depend on a `java_library`.

Instead, that filtering has been happening at the call sites, such as in the file `importable_python_sources.py`. It works well to filter there because the filtering can be arbitrary and complex, such as "get me all targets with PythonBinarySources _and_ EntryPoint". Often, we don't want to filter, like `dependencies.py`.

[ci skip-jvm-tests]
[ci skip-rust-tests]