### PR TITLE
Filter streaming workunits by LogLevel

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -51,7 +51,7 @@ class Fib:
     val: int
 
 
-@named_rule
+@named_rule(desc="Fibonacci")
 async def fib(n: int) -> Fib:
     if n < 2:
         return Fib(n)
@@ -98,7 +98,11 @@ class Omega:
     pass
 
 
-@named_rule(canonical_name="rule_one")
+class Epsilon:
+    pass
+
+
+@named_rule(canonical_name="rule_one", desc="Rule number 1")
 async def rule_one_function(i: Input) -> Beta:
     """This rule should be the first one executed by the engine, and thus have no parent."""
     a = Alpha()
@@ -108,7 +112,7 @@ async def rule_one_function(i: Input) -> Beta:
     return b
 
 
-@named_rule
+@named_rule(desc="Rule number 2")
 async def rule_two(a: Alpha) -> Omega:
     """This rule should be invoked in the body of `rule_one` and therefore its workunit should be a
     child of `rule_one`'s workunit."""
@@ -128,6 +132,25 @@ def rule_four(a: Alpha) -> Gamma:
     """This rule should be invoked in the body of `rule_two` and therefore its workunit should be a
     child of `rule_two`'s workunit."""
     return Gamma()
+
+
+@named_rule(desc="Rule A")
+async def rule_A(i: Input) -> Alpha:
+    o = Omega()
+    a = await Get[Alpha](Omega, o)
+    return a
+
+
+@rule
+async def rule_B(o: Omega) -> Alpha:
+    e = Epsilon()
+    a = await Get[Alpha](Epsilon, e)
+    return a
+
+
+@named_rule(desc="Rule C")
+def rule_C(e: Epsilon) -> Alpha:
+    return Alpha()
 
 
 class EngineTest(unittest.TestCase, SchedulerTestBase):
@@ -435,3 +458,53 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
         r1 = next(item for item in finished if item["name"] == "rule_one")
         assert r1["parent_id"] == select["span_id"]
+
+    def test_streaming_workunit_log_level_parent_rewrite(self) -> None:
+        rules = [RootRule(Input), rule_A, rule_B, rule_C]
+        scheduler = self.mk_scheduler(
+            rules, include_trace_on_error=False, should_report_workunits=True
+        )
+        tracker = self.WorkunitTracker()
+        info_level_handler = StreamingWorkunitHandler(
+            scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
+        )
+
+        with info_level_handler.session():
+            i = Input()
+            scheduler.product_request(Alpha, subjects=[i])
+
+        assert tracker.finished
+        finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
+
+        assert len(finished) == 2
+        r_A = next(item for item in finished if item["name"] == "rule_A")
+        r_C = next(item for item in finished if item["name"] == "rule_C")
+        assert "parent_id" not in r_A
+        assert r_C["parent_id"] == r_A["span_id"]
+
+        scheduler = self.mk_scheduler(
+            rules, include_trace_on_error=False, should_report_workunits=True
+        )
+        tracker = self.WorkunitTracker()
+        debug_level_handler = StreamingWorkunitHandler(
+            scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.DEBUG,
+        )
+
+        with debug_level_handler.session():
+            i = Input()
+            scheduler.product_request(Alpha, subjects=[i])
+
+        assert tracker.finished
+        finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
+
+        r_A = next(item for item in finished if item["name"] == "rule_A")
+        r_B = next(item for item in finished if item["name"] == "rule_B")
+        r_C = next(item for item in finished if item["name"] == "rule_C")
+        assert r_B["parent_id"] == r_A["span_id"]
+        assert r_C["parent_id"] == r_B["span_id"]

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -395,7 +395,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
         # rule_one should have a parent ID that is not emitted because of its low log level
         r1_parent_id = r1["parent_id"]
-        assert r1_parent_id not in set(item["span_id"] for item in (r1, r2, r3, r4))
+        assert r1_parent_id not in {item["span_id"] for item in (r1, r2, r3, r4)}
 
         assert r2["parent_id"] == r1["span_id"]
         assert r3["parent_id"] == r1["span_id"]
@@ -403,8 +403,9 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
         assert r3["description"] == "Rule number 3"
         assert r4["description"] == "Rule number 4"
+        assert r4["level"] == "INFO"
 
-    def test_streaming_workunit_log_levels(self):
+    def test_streaming_workunit_log_levels(self) -> None:
         rules = [RootRule(Input), rule_one_function, rule_two, rule_three, rule_four]
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
@@ -431,3 +432,4 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             if item["name"] not in {"rule_one", "rule_two", "rule_three", "rule_four"}
         )
         assert select["name"] == "select"
+        assert select["level"] == "DEBUG"

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -393,9 +393,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         r3 = next(item for item in finished if item["name"] == "rule_three")
         r4 = next(item for item in finished if item["name"] == "rule_four")
 
-        # rule_one should have a parent ID that is not emitted because of its low log level
-        r1_parent_id = r1["parent_id"]
-        assert r1_parent_id not in {item["span_id"] for item in (r1, r2, r3, r4)}
+        # rule_one should have no parent_id because its actual parent workunit was filted based on level
+        assert r1.get("parent_id", None) is None
 
         assert r2["parent_id"] == r1["span_id"]
         assert r3["parent_id"] == r1["span_id"]
@@ -433,3 +432,6 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         )
         assert select["name"] == "select"
         assert select["level"] == "DEBUG"
+
+        r1 = next(item for item in finished if item["name"] == "rule_one")
+        assert r1["parent_id"] == select["span_id"]

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -827,7 +827,6 @@ class Native(metaclass=SingletonMetaclass):
             none = self.ffi.from_handle(context._handle).to_value(None)
             self.lib.externs_set(
                 context._handle,
-                logger.getEffectiveLevel(),
                 none,
                 self.ffi_lib.extern_call,
                 self.ffi_lib.extern_generator_send,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -308,7 +308,8 @@ class Scheduler:
     def _metrics(self, session):
         return self._from_value(self._native.lib.scheduler_metrics(self._scheduler, session))
 
-    def poll_workunits(self, session, max_verbosity: int) -> PolledWorkunits:
+    def poll_workunits(self, session, max_log_verbosity: LogLevel) -> PolledWorkunits:
+        max_verbosity = max_log_verbosity.level
         result: Tuple[Tuple[Workunit], Tuple[Workunit]] = self._from_value(
             self._native.lib.poll_session_workunits(self._scheduler, session, max_verbosity)
         )
@@ -435,8 +436,7 @@ class SchedulerSession:
         return self._session
 
     def poll_workunits(self, max_log_verbosity: LogLevel) -> PolledWorkunits:
-        max_verbosity = max_log_verbosity.level
-        return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session, max_verbosity))
+        return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session, max_log_verbosity))
 
     def graph_len(self):
         return self._scheduler.graph_len()

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -436,7 +436,9 @@ class SchedulerSession:
         return self._session
 
     def poll_workunits(self, max_log_verbosity: LogLevel) -> PolledWorkunits:
-        return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session, max_log_verbosity))
+        return cast(
+            PolledWorkunits, self._scheduler.poll_workunits(self._session, max_log_verbosity)
+        )
 
     def graph_len(self):
         return self._scheduler.graph_len()

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -41,6 +41,7 @@ from pants.engine.unions import union
 from pants.option.global_options import ExecutionOptions
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import check_no_overlapping_paths
+from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 if TYPE_CHECKING:
@@ -307,9 +308,9 @@ class Scheduler:
     def _metrics(self, session):
         return self._from_value(self._native.lib.scheduler_metrics(self._scheduler, session))
 
-    def poll_workunits(self, session) -> PolledWorkunits:
+    def poll_workunits(self, session, max_verbosity: int) -> PolledWorkunits:
         result: Tuple[Tuple[Workunit], Tuple[Workunit]] = self._from_value(
-            self._native.lib.poll_session_workunits(self._scheduler, session)
+            self._native.lib.poll_session_workunits(self._scheduler, session, max_verbosity)
         )
         return {"started": result[0], "completed": result[1]}
 
@@ -433,8 +434,9 @@ class SchedulerSession:
     def session(self):
         return self._session
 
-    def poll_workunits(self) -> PolledWorkunits:
-        return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session))
+    def poll_workunits(self, max_log_verbosity: LogLevel) -> PolledWorkunits:
+        max_verbosity = max_log_verbosity.level
+        return cast(PolledWorkunits, self._scheduler.poll_workunits(self._session, max_verbosity))
 
     def graph_len(self):
         return self._scheduler.graph_len()

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -593,9 +593,7 @@ fn workunit_to_py_value(workunit: &Workunit) -> Option<Value> {
   Some(externs::store_dict(&dict_entries.as_slice()))
 }
 
-fn workunits_to_py_tuple_value<'a>(
-  workunits: impl Iterator<Item = &'a Workunit>,
-) -> Value {
+fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a Workunit>) -> Value {
   let workunit_values = workunits
     .flat_map(|workunit: &Workunit| workunit_to_py_value(workunit))
     .collect::<Vec<_>>();
@@ -622,17 +620,18 @@ pub extern "C" fn poll_session_workunits(
 
   with_scheduler(scheduler_ptr, |_scheduler| {
     with_session(session_ptr, |session| {
-      let value = session
-        .workunit_store()
-        .with_latest_workunits(max_log_verbosity, |started, completed| {
-          let mut started_iter = started.iter();
-          let started = workunits_to_py_tuple_value(&mut started_iter);
+      let value =
+        session
+          .workunit_store()
+          .with_latest_workunits(max_log_verbosity, |started, completed| {
+            let mut started_iter = started.iter();
+            let started = workunits_to_py_tuple_value(&mut started_iter);
 
-          let mut completed_iter = completed.iter();
-          let completed = workunits_to_py_tuple_value(&mut completed_iter);
+            let mut completed_iter = completed.iter();
+            let completed = workunits_to_py_tuple_value(&mut completed_iter);
 
-          externs::store_tuple(&[started, completed])
-        });
+            externs::store_tuple(&[started, completed])
+          });
       value.into()
     })
   })

--- a/src/rust/engine/logging/src/lib.rs
+++ b/src/rust/engine/logging/src/lib.rs
@@ -56,7 +56,7 @@ use num_enum::TryFromPrimitive;
 // This is a hard-coding of constants in the standard logging python package.
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
 #[repr(u64)]
-enum PythonLogLevel {
+pub enum PythonLogLevel {
   NotSet = 0,
   // Trace doesn't exist in a Python world, so set it to "a bit lower than Debug".
   Trace = 5,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -442,7 +442,7 @@ impl CommandRunner for BoundedCommandRunner {
       .unwrap_or_else(|| "<Unnamed process>".to_string());
     let outer_metadata = WorkunitMetadata {
       desc: Some(desc.clone()),
-      level: Level::Trace,
+      level: Level::Debug,
       blocked: true,
     };
     let bounded_fut = {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -442,8 +442,7 @@ impl CommandRunner for BoundedCommandRunner {
       .unwrap_or_else(|| "<Unnamed process>".to_string());
     let outer_metadata = WorkunitMetadata {
       desc: Some(desc.clone()),
-      level: Level::Info,
-      display: false,
+      level: Level::Trace,
       blocked: true,
     };
     let bounded_fut = {
@@ -456,7 +455,6 @@ impl CommandRunner for BoundedCommandRunner {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
           level: Level::Info,
-          display: false,
           blocked: false,
         };
         with_workunit(context.workunit_store.clone(), name, metadata, async move {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2235,7 +2235,7 @@ async fn extract_output_files_from_response_no_prefix() {
 }
 
 fn workunits_with_constant_span_id(workunit_store: &mut WorkunitStore) -> HashSet<Workunit> {
-  workunit_store.with_latest_workunits(|_, completed_workunits| {
+  workunit_store.with_latest_workunits(log::Level::Trace, |_, completed_workunits| {
     completed_workunits
       .iter()
       .map(|workunit| Workunit {

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -344,7 +344,6 @@ pub type ExternContext = raw::c_void;
 
 pub struct Externs {
   pub context: *const ExternContext,
-  pub log_level: u8,
   pub none: Handle,
   pub call: CallExtern,
   pub generator_send: GeneratorSendExtern,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1025,7 +1025,7 @@ impl Node for NodeKey {
       let level = if higher_priority {
         Level::Info
       } else {
-        Level::Trace
+        Level::Debug
       };
       let name = self.workunit_name();
       let span_id = new_span_id();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1020,8 +1020,7 @@ impl Node for NodeKey {
 
     let (started_workunit_id, user_facing_name) = {
       let user_facing_name = self.user_facing_name();
-      let higher_priority = context.session.should_handle_workunits()
-        && (user_facing_name.is_some() || self.display_info().is_some());
+      let higher_priority = context.session.should_handle_workunits() && user_facing_name.is_some();
       let level = if higher_priority {
         Level::Info
       } else {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1020,8 +1020,13 @@ impl Node for NodeKey {
 
     let (started_workunit_id, user_facing_name) = {
       let user_facing_name = self.user_facing_name();
-      let display = context.session.should_handle_workunits()
+      let higher_priority = context.session.should_handle_workunits()
         && (user_facing_name.is_some() || self.display_info().is_some());
+      let level = if higher_priority {
+        Level::Info
+      } else {
+        Level::Trace
+      };
       let name = self.workunit_name();
       let span_id = new_span_id();
 
@@ -1029,8 +1034,7 @@ impl Node for NodeKey {
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
       let metadata = WorkunitMetadata {
         desc: user_facing_name.clone(),
-        level: Level::Info,
-        display,
+        level,
         blocked: false,
       };
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -255,7 +255,6 @@ impl WorkunitStore {
   where
     F: FnOnce(&[Workunit], &[Workunit]) -> T,
   {
-
     let mut inner_guard = (*self.inner).lock();
     let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
     let workunit_records = &inner_store.workunit_records;
@@ -267,8 +266,8 @@ impl WorkunitStore {
       loop {
         if let Some(current_parent_id) = parent_id {
           let should_emit = match workunit_records.get(&current_parent_id) {
-              None => false,
-              Some(workunit) => should_emit(&workunit)
+            None => false,
+            Some(workunit) => should_emit(&workunit),
           };
           if should_emit {
             return Workunit {
@@ -314,7 +313,7 @@ impl WorkunitStore {
       .iter()
       .flat_map(|id| workunit_records.get(id))
       .flat_map(|workunit| match workunit.state {
-        WorkunitState::Completed { .. } if  should_emit(&workunit) => Some(workunit.clone()),
+        WorkunitState::Completed { .. } if should_emit(&workunit) => Some(workunit.clone()),
         WorkunitState::Completed { .. } => None,
         WorkunitState::Started { .. } => None,
       })


### PR DESCRIPTION
### Problem

Now that we have the ability to assign a LogLevel to workunits, we want to use that log level to filter which workunits we stream to Python plugins.

### Solution

Remove the `display` bool on `WorkunitMetadata` and replace it with logic that accepts a maximum log verbosity `LogLevel` from Python code, and filters streaming workunits based on this maximum verbosity.

