### PR TITLE
Modernize `fs_test.py` to use type hints and `assert` statements

### DIFF
--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -12,7 +12,7 @@ from abc import ABCMeta
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
-from typing import Callable
+from typing import Callable, List
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.fs import (
@@ -84,23 +84,23 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             if prepare:
                 prepare(project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
-            self.assertEqual(sorted(getattr(result, field)), sorted(paths))
+            assert sorted(getattr(result, field)) == sorted(paths)
 
     def assert_content(self, filespecs_or_globs, expected_content):
         with self.mk_project_tree() as project_tree:
             scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
             actual_content = self.read_file_content(scheduler, filespecs_or_globs)
-            self.assertEqual(expected_content, actual_content)
+            assert expected_content == actual_content
 
     def assert_digest(self, filespecs_or_globs, expected_files):
         with self.mk_project_tree() as project_tree:
             scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
             # Confirm all expected files were digested.
-            self.assertEqual(set(expected_files), set(result.files))
-            self.assertTrue(result.digest.fingerprint is not None)
+            assert set(expected_files) == set(result.files)
+            assert result.digest.fingerprint is not None
 
-    def test_walk_literal(self):
+    def test_walk_literal(self) -> None:
         self.assert_walk_files(["4.txt"], ["4.txt"])
         self.assert_walk_files(["a/b/1.txt", "a/b/2"], ["a/b/1.txt", "a/b/2"])
         self.assert_walk_files(["c.ln/2"], ["c.ln/2"])
@@ -108,21 +108,21 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         self.assert_walk_files(["a/3.txt"], ["a/3.txt"])
         self.assert_walk_files(["z.txt"], [])
 
-    def test_walk_literal_directory(self):
+    def test_walk_literal_directory(self) -> None:
         self.assert_walk_dirs(["c.ln"], ["c.ln"])
         self.assert_walk_dirs(["a"], ["a"])
         self.assert_walk_dirs(["a/b"], ["a/b"])
         self.assert_walk_dirs(["z"], [])
         self.assert_walk_dirs(["4.txt", "a/3.txt"], [])
 
-    def test_walk_siblings(self):
+    def test_walk_siblings(self) -> None:
         self.assert_walk_files(["*.txt"], ["4.txt"])
         self.assert_walk_files(["a/b/*.txt"], ["a/b/1.txt"])
         self.assert_walk_files(["c.ln/*.txt"], ["c.ln/1.txt"])
         self.assert_walk_files(["a/b/*"], ["a/b/1.txt", "a/b/2"])
         self.assert_walk_files(["*/0.txt"], [])
 
-    def test_walk_recursive(self):
+    def test_walk_recursive(self) -> None:
         self.assert_walk_files(["**/*.txt.ln"], ["a/4.txt.ln", "d.ln/4.txt.ln"])
         self.assert_walk_files(
             ["**/*.txt"],
@@ -135,13 +135,13 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         self.assert_walk_files(["**/3.t*t"], ["a/3.txt", "d.ln/3.txt"])
         self.assert_walk_files(["**/*.zzz"], [])
 
-    def test_walk_single_star(self):
+    def test_walk_single_star(self) -> None:
         self.assert_walk_files(["*"], ["4.txt"])
 
-    def test_walk_parent_link(self):
+    def test_walk_parent_link(self) -> None:
         self.assert_walk_files(["c.ln/../3.txt"], ["c.ln/../3.txt"])
 
-    def test_walk_escaping_symlink(self):
+    def test_walk_escaping_symlink(self) -> None:
         link = "subdir/escaping"
         dest = "../../"
 
@@ -156,7 +156,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         with self.assertRaisesRegex(Exception, exc_reg):
             self.assert_walk_files([link], [], prepare=prepare)
 
-    def test_walk_recursive_all(self):
+    def test_walk_recursive_all(self) -> None:
         self.assert_walk_files(
             ["**"],
             [
@@ -174,7 +174,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             ],
         )
 
-    def test_walk_ignore(self):
+    def test_walk_ignore(self) -> None:
         # Ignore '*.ln' suffixed items at the root.
         self.assert_walk_files(
             ["**"],
@@ -188,25 +188,25 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             ignore_patterns=["/*.ln", "!c.ln"],
         )
 
-    def test_walk_recursive_trailing_doublestar(self):
+    def test_walk_recursive_trailing_doublestar(self) -> None:
         self.assert_walk_files(["a/**"], ["a/3.txt", "a/4.txt.ln", "a/b/1.txt", "a/b/2"])
         self.assert_walk_files(
             ["d.ln/**"], ["d.ln/3.txt", "d.ln/4.txt.ln", "d.ln/b/1.txt", "d.ln/b/2"]
         )
         self.assert_walk_dirs(["a/**"], ["a/b"])
 
-    def test_walk_recursive_slash_doublestar_slash(self):
+    def test_walk_recursive_slash_doublestar_slash(self) -> None:
         self.assert_walk_files(["a/**/3.txt"], ["a/3.txt"])
         self.assert_walk_files(["a/**/b/1.txt"], ["a/b/1.txt"])
         self.assert_walk_files(["a/**/2"], ["a/b/2"])
 
-    def test_walk_recursive_directory(self):
+    def test_walk_recursive_directory(self) -> None:
         self.assert_walk_dirs(["*"], ["a", "c.ln", "d.ln"])
         self.assert_walk_dirs(["*/*"], ["a/b", "d.ln/b"])
         self.assert_walk_dirs(["**/*"], ["a", "c.ln", "d.ln", "a/b", "d.ln/b"])
         self.assert_walk_dirs(["*/*/*"], [])
 
-    def test_remove_duplicates(self):
+    def test_remove_duplicates(self) -> None:
         self.assert_walk_files(
             ["*", "**"],
             [
@@ -229,40 +229,37 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         )
         self.assert_walk_dirs(["*", "**"], ["a", "c.ln", "d.ln", "a/b", "d.ln/b"])
 
-    def test_files_content_literal(self):
+    def test_files_content_literal(self) -> None:
         self.assert_content(["4.txt", "a/4.txt.ln"], {"4.txt": b"four\n", "a/4.txt.ln": b"four\n"})
 
-    def test_files_content_directory(self):
+    def test_files_content_directory(self) -> None:
         with self.assertRaises(Exception):
             self.assert_content(["a/b/"], {"a/b/": "nope\n"})
         with self.assertRaises(Exception):
             self.assert_content(["a/b"], {"a/b": "nope\n"})
 
-    def test_files_content_symlink(self):
+    def test_files_content_symlink(self) -> None:
         self.assert_content(["c.ln/../3.txt"], {"c.ln/../3.txt": b"three\n"})
 
-    def test_files_digest_literal(self):
+    def test_files_digest_literal(self) -> None:
         self.assert_digest(["a/3.txt", "4.txt"], ["a/3.txt", "4.txt"])
 
-    def test_snapshot_from_outside_buildroot(self):
+    def test_snapshot_from_outside_buildroot(self) -> None:
         with temporary_dir() as temp_dir:
-            with open(os.path.join(temp_dir, "roland"), "w") as f:
-                f.write("European Burmese")
-            scheduler = self.mk_scheduler(rules=create_fs_rules())
-            globs = PathGlobs(["*"])
-            snapshot = scheduler.capture_snapshots((PathGlobsAndRoot(globs, temp_dir),))[0]
+            Path(temp_dir, "roland").write_text("European Burmese")
+            snapshot = self.scheduler.capture_snapshots(
+                (PathGlobsAndRoot(PathGlobs(["*"]), temp_dir),)
+            )[0]
             self.assert_snapshot_equals(
                 snapshot,
                 ["roland"],
                 Digest("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80),
             )
 
-    def test_multiple_snapshots_from_outside_buildroot(self):
+    def test_multiple_snapshots_from_outside_buildroot(self) -> None:
         with temporary_dir() as temp_dir:
-            with open(os.path.join(temp_dir, "roland"), "w") as f:
-                f.write("European Burmese")
-            with open(os.path.join(temp_dir, "susannah"), "w") as f:
-                f.write("I don't know")
+            Path(temp_dir, "roland").write_text("European Burmese")
+            Path(temp_dir, "susannah").write_text("I don't know")
             scheduler = self.mk_scheduler(rules=create_fs_rules())
             snapshots = scheduler.capture_snapshots(
                 (
@@ -271,7 +268,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                     PathGlobsAndRoot(PathGlobs(["doesnotexist"]), temp_dir),
                 )
             )
-            self.assertEqual(3, len(snapshots))
+            assert 3 == len(snapshots)
             self.assert_snapshot_equals(
                 snapshots[0],
                 ["roland"],
@@ -284,31 +281,26 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
             self.assert_snapshot_equals(snapshots[2], [], EMPTY_DIGEST)
 
-    def test_snapshot_from_outside_buildroot_failure(self):
+    def test_snapshot_from_outside_buildroot_failure(self) -> None:
         with temporary_dir() as temp_dir:
-            scheduler = self.mk_scheduler(rules=create_fs_rules())
-            globs = PathGlobs(["*"])
             with self.assertRaises(Exception) as cm:
-                scheduler.capture_snapshots(
-                    (PathGlobsAndRoot(globs, os.path.join(temp_dir, "doesnotexist")),)
+                self.scheduler.capture_snapshots(
+                    (PathGlobsAndRoot(PathGlobs(["*"]), os.path.join(temp_dir, "doesnotexist")),)
                 )
-            self.assertIn("doesnotexist", str(cm.exception))
+            assert "doesnotexist" in str(cm.exception)
 
-    def assert_snapshot_equals(self, snapshot, files, digest):
-        self.assertEqual(list(snapshot.files), files)
-        self.assertEqual(snapshot.digest, digest)
+    @staticmethod
+    def assert_snapshot_equals(snapshot: Snapshot, files: List[str], digest: Digest) -> None:
+        assert list(snapshot.files) == files
+        assert snapshot.digest == digest
 
-    def test_merge_zero_directories(self):
-        scheduler = self.mk_scheduler(rules=create_fs_rules())
-        dir = scheduler.merge_directories(())
-        self.assertEqual(EMPTY_DIGEST, dir)
+    def test_merge_zero_directories(self) -> None:
+        assert self.scheduler.merge_directories(()) == EMPTY_DIGEST
 
-    def test_synchronously_merge_directories(self):
+    def test_synchronously_merge_directories(self) -> None:
         with temporary_dir() as temp_dir:
-            with open(os.path.join(temp_dir, "roland"), "w") as f:
-                f.write("European Burmese")
-            with open(os.path.join(temp_dir, "susannah"), "w") as f:
-                f.write("Not sure actually")
+            Path(temp_dir, "roland").write_text("European Burmese")
+            Path(temp_dir, "susannah").write_text("Not sure actually")
             (
                 empty_snapshot,
                 roland_snapshot,
@@ -324,27 +316,22 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
 
             empty_merged = self.scheduler.merge_directories((empty_snapshot.digest,))
-            self.assertEqual(
-                empty_snapshot.digest, empty_merged,
-            )
+            assert empty_snapshot.digest == empty_merged
 
             roland_merged = self.scheduler.merge_directories(
                 (roland_snapshot.digest, empty_snapshot.digest)
             )
-            self.assertEqual(roland_snapshot.digest, roland_merged)
+            assert roland_snapshot.digest == roland_merged
 
             both_merged = self.scheduler.merge_directories(
                 (roland_snapshot.digest, susannah_snapshot.digest)
             )
+            assert both_snapshot.digest == both_merged
 
-            self.assertEqual(both_snapshot.digest, both_merged)
-
-    def test_asynchronously_merge_digests(self):
+    def test_asynchronously_merge_digests(self) -> None:
         with temporary_dir() as temp_dir:
-            with open(os.path.join(temp_dir, "roland"), "w") as f:
-                f.write("European Burmese")
-            with open(os.path.join(temp_dir, "susannah"), "w") as f:
-                f.write("Not sure actually")
+            Path(temp_dir, "roland").write_text("European Burmese")
+            Path(temp_dir, "susannah").write_text("Not sure actually")
             (
                 empty_snapshot,
                 roland_snapshot,
@@ -362,55 +349,48 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             empty_merged = self.request_single_product(
                 Digest, MergeDigests((empty_snapshot.digest,)),
             )
-            self.assertEqual(empty_snapshot.digest, empty_merged)
+            assert empty_snapshot.digest == empty_merged
 
             roland_merged = self.request_single_product(
                 Digest, MergeDigests((roland_snapshot.digest, empty_snapshot.digest)),
             )
-            self.assertEqual(
-                roland_snapshot.digest, roland_merged,
-            )
+            assert roland_snapshot.digest == roland_merged
 
             both_merged = self.request_single_product(
                 Digest, MergeDigests((roland_snapshot.digest, susannah_snapshot.digest)),
             )
+            assert both_snapshot.digest == both_merged
 
-            self.assertEqual(both_snapshot.digest, both_merged)
-
-    def test_materialize_directories(self):
+    def test_materialize_directories(self) -> None:
         self.prime_store_with_roland_digest()
         digest = Digest("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80)
         self.scheduler.materialize_directory(DirectoryToMaterialize(digest, path_prefix="test/"))
         assert Path(self.build_root, "test/roland").read_text() == "European Burmese"
 
-    def test_add_prefix(self):
+    def test_add_prefix(self) -> None:
         input_files_content = InputFilesContent(
             (
                 FileContent(path="main.py", content=b'print("from main")'),
                 FileContent(path="subdir/sub.py", content=b'print("from sub")'),
             )
         )
-
         digest = self.request_single_product(Digest, input_files_content)
-
-        dpa = AddPrefix(digest, "outer_dir")
-        output_digest = self.request_single_product(Digest, dpa)
+        output_digest = self.request_single_product(Digest, AddPrefix(digest, "outer_dir"))
         snapshot = self.request_single_product(Snapshot, output_digest)
+        assert sorted(snapshot.files) == ["outer_dir/main.py", "outer_dir/subdir/sub.py"]
+        assert sorted(snapshot.dirs) == ["outer_dir", "outer_dir/subdir"]
 
-        self.assertEqual(sorted(snapshot.files), ["outer_dir/main.py", "outer_dir/subdir/sub.py"])
-        self.assertEqual(sorted(snapshot.dirs), ["outer_dir", "outer_dir/subdir"])
-
-    def test_remove_prefix(self):
+    def test_remove_prefix(self) -> None:
         # Set up files:
-
         relevant_files = (
             "characters/dark_tower/roland",
             "characters/dark_tower/susannah",
         )
         all_files = (
-            ("books/dark_tower/gunslinger", "characters/altered_carbon/kovacs",)
-            + relevant_files
-            + ("index",)
+            "books/dark_tower/gunslinger",
+            "characters/altered_carbon/kovacs",
+            *relevant_files,
+            "index",
         )
 
         with temporary_dir() as temp_dir:
@@ -436,31 +416,29 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 )
             )
             # Check that we got the full snapshots that we expect
-            self.assertEqual(snapshot.files, relevant_files)
-            self.assertEqual(snapshot_with_extra_files.files, all_files)
+            assert snapshot.files == relevant_files
+            assert snapshot_with_extra_files.files == all_files
 
             # Strip empty prefix:
             zero_prefix_stripped_digest = self.request_single_product(
                 Digest, RemovePrefix(snapshot.digest, ""),
             )
-            self.assertEqual(snapshot.digest, zero_prefix_stripped_digest)
+            assert snapshot.digest == zero_prefix_stripped_digest
 
             # Strip a non-empty prefix shared by all files:
             stripped_digest = self.request_single_product(
                 Digest, RemovePrefix(snapshot.digest, "characters/dark_tower"),
             )
-            self.assertEqual(
-                stripped_digest,
-                Digest(
-                    fingerprint="71e788fc25783c424db555477071f5e476d942fc958a5d06ffc1ed223f779a8c",
-                    serialized_bytes_length=162,
-                ),
+            assert stripped_digest == Digest(
+                fingerprint="71e788fc25783c424db555477071f5e476d942fc958a5d06ffc1ed223f779a8c",
+                serialized_bytes_length=162,
             )
+
             expected_snapshot = assert_single_element(
                 self.scheduler.capture_snapshots((PathGlobsAndRoot(PathGlobs(["*"]), tower_dir),))
             )
-            self.assertEqual(expected_snapshot.files, ("roland", "susannah"))
-            self.assertEqual(stripped_digest, expected_snapshot.digest)
+            assert expected_snapshot.files == ("roland", "susannah")
+            assert stripped_digest == expected_snapshot.digest
 
             # Try to strip a prefix which isn't shared by all files:
             with self.assertRaisesWithMessageContaining(
@@ -473,13 +451,13 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                     Digest, RemovePrefix(snapshot_with_extra_files.digest, "characters/dark_tower"),
                 )
 
-    def test_lift_digest_to_snapshot(self):
+    def test_lift_digest_to_snapshot(self) -> None:
         digest = self.prime_store_with_roland_digest()
         snapshot = self.request_single_product(Snapshot, digest)
-        self.assertEqual(snapshot.files, ("roland",))
-        self.assertEqual(snapshot.digest, digest)
+        assert snapshot.files == ("roland",)
+        assert snapshot.digest == digest
 
-    def test_error_lifting_file_digest_to_snapshot(self):
+    def test_error_lifting_file_digest_to_snapshot(self) -> None:
         self.prime_store_with_roland_digest()
 
         # A file digest is not a directory digest! Hash the file that was primed as part of that
@@ -492,7 +470,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         with self.assertRaisesWithMessageContaining(ExecutionError, "unknown directory"):
             self.request_single_product(Snapshot, digest)
 
-    def test_glob_match_error(self):
+    def test_glob_match_error(self) -> None:
         test_name = f"{__name__}.{self.test_glob_match_error.__name__}()"
         with self.assertRaises(ValueError) as cm:
             self.assert_walk_files(
@@ -505,7 +483,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
         assert f'Unmatched glob from {test_name}: "not-a-file.txt"' in str(cm.exception)
 
-    def test_glob_match_error_with_exclude(self):
+    def test_glob_match_error_with_exclude(self) -> None:
         test_name = f"{__name__}.{self.test_glob_match_error_with_exclude.__name__}()"
         with self.assertRaises(ValueError) as cm:
             self.assert_walk_files(
@@ -519,7 +497,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         assert f'Unmatched glob from {test_name}: "*.txt", exclude: "4.txt"' in str(cm.exception)
 
     @unittest.skip("Skipped to expedite landing #5769: see #5863")
-    def test_glob_match_warn_logging(self):
+    def test_glob_match_warn_logging(self) -> None:
         test_name = f"{__name__}.{self.test_glob_match_warn_logging.__name__}()"
         with self.captured_logging(logging.WARNING) as captured:
             self.assert_walk_files(
@@ -534,7 +512,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             assert len(all_warnings) == 1
             assert f'Unmatched glob from {test_name}: "not-a-file.txt"' == str(all_warnings[0])
 
-    def test_glob_match_ignore_logging(self):
+    def test_glob_match_ignore_logging(self) -> None:
         with self.captured_logging(logging.WARNING) as captured:
             self.assert_walk_files(
                 PathGlobs(
@@ -545,7 +523,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             )
             assert len(captured.warnings()) == 0
 
-    def prime_store_with_roland_digest(self):
+    def prime_store_with_roland_digest(self) -> Digest:
         """This method primes the store with a directory of a file named 'roland' and contents
         'European Burmese'."""
         with temporary_dir() as temp_dir:
@@ -564,7 +542,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         "63652768bd65af8a4938c415bdc25e446e97c473308d26b3da65890aebacf63f", 18
     )
 
-    def test_download(self):
+    def test_download(self) -> None:
         with self.isolated_local_store():
             with http_server(StubHandler) as port:
                 url = UrlToFetch(f"http://localhost:{port}/CNAME", self.pantsbuild_digest)
@@ -575,15 +553,15 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                     Digest("16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf", 81),
                 )
 
-    def test_download_missing_file(self):
+    def test_download_missing_file(self) -> None:
         with self.isolated_local_store():
             with http_server(StubHandler) as port:
                 url = UrlToFetch(f"http://localhost:{port}/notfound", self.pantsbuild_digest)
                 with self.assertRaises(ExecutionError) as cm:
                     self.request_single_product(Snapshot, url)
-                self.assertIn("404", str(cm.exception))
+                assert "404" in str(cm.exception)
 
-    def test_download_wrong_digest(self):
+    def test_download_wrong_digest(self) -> None:
         with self.isolated_local_store():
             with http_server(StubHandler) as port:
                 url = UrlToFetch(
@@ -595,10 +573,10 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 )
                 with self.assertRaises(ExecutionError) as cm:
                     self.request_single_product(Snapshot, url)
-                self.assertIn("wrong digest", str(cm.exception).lower())
+                assert "wrong digest" in str(cm.exception).lower()
 
     # It's a shame that this isn't hermetic, but setting up valid local HTTPS certificates is a pain.
-    def test_download_https(self):
+    def test_download_https(self) -> None:
         with self.isolated_local_store():
             url = UrlToFetch(
                 "https://www.pantsbuild.org/CNAME",
@@ -611,7 +589,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 Digest("16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf", 81),
             )
 
-    def test_caches_downloads(self):
+    def test_caches_downloads(self) -> None:
         with self.isolated_local_store():
             with http_server(StubHandler) as port:
                 self.prime_store_with_roland_digest()
@@ -716,9 +694,9 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
             with open(path_to_fname, "w") as f:
                 f.write(new_data)
 
-            def assertion_fn():
+            def assertion_fn() -> bool:
                 new_content = self.read_file_content(scheduler, [fname])
-                if new_content[fname].decode("utf-8") == new_data:
+                if new_content[fname].decode() == new_data:
                     # successfully read new data
                     return True
                 return False
@@ -754,20 +732,20 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
     def assert_mutated_digest(
         self, mutation_function: Callable[[FileSystemProjectTree, str], Exception]
-    ):
+    ) -> None:
         with self.mk_project_tree() as project_tree:
             scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
             dir_path = "a/"
-            dir_glob = dir_path + "*"
+            dir_glob = f"{dir_path}/*"
             initial_snapshot = self.execute_expecting_one_result(
-                scheduler, Snapshot, self.path_globs([dir_glob])
+                scheduler, Snapshot, PathGlobs([dir_glob])
             ).value
             assert not initial_snapshot.is_empty
             assertion_error = mutation_function(project_tree, dir_path)
 
-            def assertion_fn():
+            def assertion_fn() -> bool:
                 new_snapshot = self.execute_expecting_one_result(
-                    scheduler, Snapshot, self.path_globs([dir_glob])
+                    scheduler, Snapshot, PathGlobs([dir_glob])
                 ).value
                 assert not new_snapshot.is_empty
                 if initial_snapshot.digest != new_snapshot.digest:
@@ -786,7 +764,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
                 return True
         return False
 
-    def test_digest_invalidated_by_child_removal(self):
+    def test_digest_invalidated_by_child_removal(self) -> None:
         def mutation_function(project_tree, dir_path):
             removed_path = os.path.join(project_tree.build_root, dir_path, "3.txt")
             os.remove(removed_path)
@@ -796,7 +774,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
         self.assert_mutated_digest(mutation_function)
 
-    def test_digest_invalidated_by_child_change(self):
+    def test_digest_invalidated_by_child_change(self) -> None:
         def mutation_function(project_tree, dir_path):
             new_file_path = os.path.join(project_tree.build_root, dir_path, "new_file.txt")
             with open(new_file_path, "w") as f:


### PR DESCRIPTION
The real goal is to get rid of `FileSystemProjectTree`. This is prework to make the tests easier to work with and to follow our style guide.

[ci skip-rust-tests]
[ci skip-jvm-tests]