### PR TITLE
Run `packages.py` through Pants

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -11,7 +11,7 @@ files(
 # stripping the source root from the files.
 files(
   name = 'python_scripts',
-  sources = ['*.py'],
+  sources = ['common.py', 'check_header.py'],
 )
 
 python_binary(
@@ -109,4 +109,15 @@ python_binary(
     ':common',
   ],
   tags = {'type_checked'},
+)
+
+# TODO: rename this to `release.py` once done porting Bash to Python.
+python_binary(
+  name = "packages",
+  sources = ["packages.py"],
+  dependencies = [
+    ':common',
+    '3rdparty/python:beautifulsoup4',
+  ],
+  tags = {"type_checked"},
 )

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -118,6 +118,7 @@ python_binary(
   dependencies = [
     ':common',
     '3rdparty/python:beautifulsoup4',
+    '3rdparty/python:requests',
   ],
   tags = {"type_checked"},
 )

--- a/build-support/bin/bootstrap_and_deploy_ci_pants_pex.py
+++ b/build-support/bin/bootstrap_and_deploy_ci_pants_pex.py
@@ -23,7 +23,7 @@ def main() -> None:
         )
     args = create_parser().parse_args()
     pex_url = f"s3://{args.aws_bucket}/{args.pex_key}"
-    native_engine_so_local_path = f"./src/python/pants/engine/internals/native_engine.so"
+    native_engine_so_local_path = "./src/python/pants/engine/internals/native_engine.so"
 
     # NB: we must set `$PY` before calling `bootstrap()` to ensure that we use the exact same
     # Python interpreter when calculating the hash of `native_engine.so` as the one we use when
@@ -169,7 +169,7 @@ def deploy_native_engine_so(
 
 
 def deploy_pants_pex(pex_url: str) -> None:
-    _deploy(f"./pants.pex", pex_url)
+    _deploy("./pants.pex", pex_url)
 
 
 if __name__ == "__main__":

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -295,16 +295,8 @@ def check_release_prereqs() -> None:
     check_ownership({me})
 
 
-def list_packages(*, with_packages: bool) -> None:
-    entries = [
-        (
-            f"{package.name} {package.target} {' '.join(package.bdist_wheel_flags)}"
-            if with_packages
-            else package.name
-        )
-        for package in sorted(all_packages())
-    ]
-    print("\n".join(entries))
+def list_packages() -> None:
+    print("\n".join(package.name for package in sorted(all_packages())))
 
 
 def list_owners() -> None:
@@ -315,7 +307,7 @@ def list_owners() -> None:
             )
             continue
         formatted_owners = "\n".join(sorted(package.owners()))
-        print(f"Owners of {package.name}:{formatted_owners}")
+        print(f"Owners of {package.name}:\n{formatted_owners}\n")
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -323,10 +315,8 @@ def create_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("list-owners")
+    subparsers.add_parser("list-packages")
     subparsers.add_parser("check-release-prereqs")
-
-    parser_list = subparsers.add_parser("list")
-    parser_list.add_argument("--with-packages", action="store_true")
 
     parser_build_and_print = subparsers.add_parser("build-and-print")
     parser_build_and_print.add_argument("version")
@@ -335,10 +325,10 @@ def create_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = create_parser().parse_args()
-    if args.command == "list":
-        list_packages(with_packages=args.with_packages)
     if args.command == "list-owners":
         list_owners()
+    if args.command == "list-packages":
+        list_packages()
     if args.command == "check-release-prereqs":
         check_release_prereqs()
     if args.command == "build-and-print":

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -10,26 +10,12 @@ import sys
 from collections import defaultdict
 from configparser import ConfigParser
 from functools import total_ordering
-from typing import Dict, NoReturn, Optional, Set, Tuple, cast
+from typing import Dict, Optional, Set, Tuple, cast
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup
-
-# TODO: move this script to `build-support/bin` so that we can import `common.py`.
-
-COLOR_BLUE = "\x1b[34m"
-COLOR_RED = "\x1b[31m"
-COLOR_RESET = "\x1b[0m"
-
-
-def banner(message: str) -> None:
-    print(f"{COLOR_BLUE}[=== {message} ===]{COLOR_RESET}")
-
-
-def die(message: str) -> NoReturn:
-    raise SystemExit(f"{COLOR_RED}{message}{COLOR_RESET}")
-
+from common import banner, die
 
 # -----------------------------------------------------------------------------------------------
 # Pants package definitions

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -702,8 +702,7 @@ elif [[ "${test_release}" == "true" ]]; then
 else
   banner "Releasing packages to PyPI"
   (
-    check_release_prereqs && \
-#    check_release_prereqs && publish_packages && tag_release && publish_docs_if_master && \
+    check_release_prereqs && publish_packages && tag_release && publish_docs_if_master && \
       banner "Successfully released packages to PyPI"
   ) || die "Failed to release packages to PyPI."
 fi

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -319,7 +319,7 @@ function install_and_test_packages() {
   # WONTFIX: fixing the array expansion is too difficult to be worth it. See https://github.com/koalaman/shellcheck/wiki/SC2207.
   # shellcheck disable=SC2207
   packages=(
-    $(run_packages_script list | grep '.' | awk '{print $1}')
+    $(run_packages_script list-packages | grep '.' | awk '{print $1}')
   ) || die "Failed to list packages!"
 
   for package in "${packages[@]}"
@@ -462,7 +462,7 @@ function fetch_and_check_prebuilt_wheels() {
   # WONTFIX: fixing the array expansion is too difficult to be worth it. See https://github.com/koalaman/shellcheck/wiki/SC2207.
   # shellcheck disable=SC2207
   RELEASE_PACKAGES=(
-    $(run_packages_script list | grep '.' | awk '{print $1}')
+    $(run_packages_script list-packages | grep '.' | awk '{print $1}')
   ) || die "Failed to get a list of packages to release!"
   for PACKAGE in "${RELEASE_PACKAGES[@]}"; do
     # WONTFIX: fixing the array expansion is too difficult to be worth it. See https://github.com/koalaman/shellcheck/wiki/SC2207.

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -670,7 +670,7 @@ while getopts ":${_OPTS}" opt; do
     n) dry_run="true" ;;
     f) build_fs_util ; exit $? ;;
     t) test_release="true" ;;
-    l) run_packages_script list ; exit $? ;;
+    l) run_packages_script list-packages ; exit $? ;;
     o) run_packages_script list-owners ; exit $? ;;
     w) list_prebuilt_wheels ; exit $? ;;
     e) fetch_and_check_prebuilt_wheels ; exit $? ;;

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -87,7 +87,8 @@ function run_pex() {
 function run_packages_script() {
   (
     cd "${ROOT}"
-    run_pex "$(requirement beautifulsoup4)" -- "${ROOT}/src/python/pants/releases/packages.py" "$@"
+    # TODO: use V2 once we either figure out how to safely expand $@ to --run-args or we land 9835.
+    ./pants --quiet run "${ROOT}/build-support/bin/packages.py" -- "$@"
   )
 }
 
@@ -701,7 +702,8 @@ elif [[ "${test_release}" == "true" ]]; then
 else
   banner "Releasing packages to PyPI"
   (
-    check_release_prereqs && publish_packages && tag_release && publish_docs_if_master && \
+    check_release_prereqs && \
+#    check_release_prereqs && publish_packages && tag_release && publish_docs_if_master && \
       banner "Successfully released packages to PyPI"
   ) || die "Failed to release packages to PyPI."
 fi

--- a/src/python/pants/releases/BUILD
+++ b/src/python/pants/releases/BUILD
@@ -10,10 +10,3 @@ python_binary(
   ],
   tags = {"partially_type_checked"},
 )
-
-# While this is a target, it should be run with pex. See build-support/bin/release.sh.
-python_binary(
-  name = "packages",
-  sources = ["packages.py"],
-  tags = {"type_checked"},
-)


### PR DESCRIPTION
This makes it easier to iterate on the script, as we can now run it directly rather than needing `release.sh`.

We also use the `requests` library rather than `urlopen` for higher-level code.

[ci skip-rust-tests]
[ci skip-jvm-tests]