### PR TITLE
Port release.sh's fetching of pre-built wheels to Python

### DIFF
--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -141,14 +141,13 @@ def all_packages() -> Set[Package]:
 
 class _Constants:
     def __init__(self) -> None:
-        # self._head_sha = (
-        #     subprocess.run(
-        #         ["git", "rev-parse", "--verify", "HEAD"], stdout=subprocess.PIPE, check=True
-        #     )
-        #     .stdout.decode()
-        #     .strip()
-        # )
-        self._head_sha = "f2521cab6fb8bed3b8b12b479369280b2dee2c9f"
+        self._head_sha = (
+            subprocess.run(
+                ["git", "rev-parse", "--verify", "HEAD"], stdout=subprocess.PIPE, check=True
+            )
+            .stdout.decode()
+            .strip()
+        )
         self.pants_stable_version = Path("src/python/pants/VERSION").read_text().strip()
 
     @property

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -353,8 +353,6 @@ class PrebuiltWheel(NamedTuple):
 
 
 def determine_prebuilt_wheels() -> List[PrebuiltWheel]:
-    """List wheels as tab-separated tuples of filename and URL-encoded name."""
-
     def determine_wheels(wheel_path: str) -> List[PrebuiltWheel]:
         response = requests.get(f"{CONSTANTS.binary_base_url}/?prefix={wheel_path}")
         xml_root = ElementTree.fromstring(response.text)

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -351,9 +351,6 @@ class PrebuiltWheel(NamedTuple):
     def create(cls, path: str) -> "PrebuiltWheel":
         return cls(path, quote_plus(path))
 
-    def format(self) -> str:
-        return f"{self.path}\t{self.url}"
-
 
 def determine_prebuilt_wheels() -> List[PrebuiltWheel]:
     """List wheels as tab-separated tuples of filename and URL-encoded name."""
@@ -376,7 +373,11 @@ def determine_prebuilt_wheels() -> List[PrebuiltWheel]:
 
 
 def list_prebuilt_wheels() -> None:
-    print("\n".join(wheel.format() for wheel in determine_prebuilt_wheels()))
+    print(
+        "\n".join(
+            f"{CONSTANTS.binary_base_url}/{wheel.url}" for wheel in determine_prebuilt_wheels()
+        )
+    )
 
 
 # TODO: possibly parallelize through httpx and asyncio.

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -544,7 +544,7 @@ function usage() {
   echo "       and can be installed in an ephemeral virtualenv."
   echo " -l  Lists all pantsbuild packages that this script releases."
   echo " -o  Lists all pantsbuild package owners."
-  echo " -w  List pre-built wheels for this release."
+  echo " -w  List pre-built wheels for this release (specifically the URLs to download)."
   echo " -e  Check that wheels are prebuilt for this release."
   echo " -p  Build a pex from prebuilt wheels for this release."
   echo " -q  Build a pex which only works on the host platform, using the code as exists on disk."

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -397,39 +397,13 @@ function reversion_whls() {
 
 readonly BINARY_BASE_URL=https://binaries.pantsbuild.org
 
-function list_prebuilt_wheels() {
-  # List prebuilt wheels as tab-separated tuples of filename and URL-encoded name.
-  wheel_listing="$(mktemp -t pants.wheels.XXXXX)"
-  trap 'rm -f "${wheel_listing}"' RETURN
-
-  for wheels_path in "${DEPLOY_PANTS_WHEELS_PATH}" "${DEPLOY_3RDPARTY_WHEELS_PATH}"; do
-    safe_curl -s "${BINARY_BASE_URL}/?prefix=${wheels_path}" > "${wheel_listing}"
-    "${PY}" << EOF
-from __future__ import print_function
-import sys
-import urllib
-import xml.etree.ElementTree as ET
-try:
-  from urllib.parse import quote_plus
-except ImportError:
-  from urllib import quote_plus
-root = ET.parse("${wheel_listing}")
-ns = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
-for key in root.findall('s3:Contents/s3:Key', ns):
-  # Because filenames may contain characters that have different meanings
-  # in URLs (namely '+'), # print the key both as url-encoded and as a file path.
-  print('{}\t{}'.format(key.text, quote_plus(key.text)))
-EOF
- done
-}
-
 function fetch_prebuilt_wheels() {
   local -r to_dir="$1"
 
   banner "Fetching prebuilt wheels for ${PANTS_UNSTABLE_VERSION}"
   (
     cd "${to_dir}"
-    list_prebuilt_wheels | {
+    run_packages_script list-prebuilt-wheels | {
       while read -r path_tuple
       do
         local file_path
@@ -672,7 +646,7 @@ while getopts ":${_OPTS}" opt; do
     t) test_release="true" ;;
     l) run_packages_script list-packages ; exit $? ;;
     o) run_packages_script list-owners ; exit $? ;;
-    w) list_prebuilt_wheels ; exit $? ;;
+    w) run_packages_script list-prebuilt-wheels ; exit $? ;;
     e) fetch_and_check_prebuilt_wheels ; exit $? ;;
     p) build_pex fetch ; exit $? ;;
     q) build_pex build ; exit $? ;;


### PR DESCRIPTION
This changes the output of `release.sh -w` to only be the URL, and for the URL to be fully formed, i.e. include the domain prefix.

[ci skip-rust-tests]
[ci skip-jvm-tests]