### PR TITLE
Test that Pylint and Bandit correctly set interpreter constraints

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -67,7 +67,7 @@ async def bandit_lint(
     # https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit.
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (field_set.compatibility for field_set in field_sets), python_setup=python_setup
-    )
+    ) or PexInterpreterConstraints(bandit.default_interpreter_constraints)
     requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="bandit.pex",

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -49,7 +49,7 @@ def generate_args(*, specified_source_files: SourceFiles, bandit: Bandit) -> Tup
     if bandit.options.config is not None:
         args.append(f"--config={bandit.options.config}")
     args.extend(bandit.options.args)
-    args.extend(sorted(specified_source_files.snapshot.files))
+    args.extend(specified_source_files.files)
     return tuple(args)
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -73,9 +73,8 @@ def generate_args(
     # Black to run over everything recursively under the directory of our target, as Black should
     # only touch files directly specified. We can use `--include` to ensure that Black only
     # operates on the files we actually care about.
-    files = sorted(specified_source_files.snapshot.files)
-    args.extend(["--include", "|".join(re.escape(f) for f in files)])
-    args.extend(PurePath(f).parent.as_posix() for f in files)
+    args.extend(["--include", "|".join(re.escape(f) for f in specified_source_files.files)])
+    args.extend(PurePath(f).parent.as_posix() for f in specified_source_files.files)
     return tuple(args)
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -62,7 +62,7 @@ def generate_args(
     return (
         "--check" if check_only else "--in-place",
         *docformatter.options.args,
-        *sorted(specified_source_files.snapshot.files),
+        *specified_source_files.files,
     )
 
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -68,7 +68,7 @@ async def flake8_lint(
     # http://flake8.pycqa.org/en/latest/user/invocation.html.
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (field_set.compatibility for field_set in field_sets), python_setup
-    )
+    ) or PexInterpreterConstraints(flake8.default_interpreter_constraints)
     requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="flake8.pex",

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -49,7 +49,7 @@ def generate_args(*, specified_source_files: SourceFiles, flake8: Flake8) -> Tup
     if flake8.options.config is not None:
         args.append(f"--config={flake8.options.config}")
     args.extend(flake8.options.args)
-    args.extend(sorted(specified_source_files.snapshot.files))
+    args.extend(specified_source_files.files)
     return tuple(args)
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -67,7 +67,7 @@ def generate_args(
     if check_only:
         args.append("--check-only")
     args.extend(isort.options.args)
-    args.extend(sorted(specified_source_files.snapshot.files))
+    args.extend(specified_source_files.files)
     return tuple(args)
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -99,7 +99,7 @@ async def pylint_lint(
             ),
         ),
         python_setup,
-    )
+    ) or PexInterpreterConstraints(pylint.default_interpreter_constraints)
 
     # We build one PEX with Pylint requirements and another with all direct 3rd-party dependencies.
     # Splitting this into two PEXes gives us finer-grained caching. We then merge via `--pex-path`.

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -40,9 +40,7 @@ from pants.util.strutil import pluralize
 class PylintFieldSet(LinterFieldSet):
     required_fields = (PythonSources,)
 
-    sources: PythonSources
     dependencies: Dependencies
-    compatibility: PythonInterpreterCompatibility
 
 
 class PylintFieldSets(LinterFieldSets):
@@ -91,7 +89,7 @@ async def pylint_lint(
     # http://pylint.pycqa.org/en/latest/faq.html#what-versions-of-python-is-pylint-supporting.
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (
-            *(field_set.compatibility for field_set in field_sets),
+            *(tgt.get(PythonInterpreterCompatibility) for tgt in targets_with_dependencies),
             *(
                 plugin_tgt[PythonInterpreterCompatibility]
                 for plugin_tgt in plugin_targets.closure

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -40,6 +40,7 @@ from pants.util.strutil import pluralize
 class PylintFieldSet(LinterFieldSet):
     required_fields = (PythonSources,)
 
+    sources: PythonSources
     dependencies: Dependencies
 
 

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -21,7 +21,7 @@ class Collection(Sequence[T]):
             pass
     """
 
-    def __init__(self, dependencies: Iterable[T]) -> None:
+    def __init__(self, dependencies: Iterable[T] = ()) -> None:
         # TODO: rename to `items`, `elements`, or even make this private. Python consumers should
         #  not directly access this.
         self.dependencies = tuple(dependencies)


### PR DESCRIPTION
Soon, we will improve Bandit, Flake8, and Pylint to partition targets based on interpreter constraints so that you can run `./pants lint ::` on a mixed Python 2/3 codebase, whereas right now it would fail to resolve a Python interpreter.

Before doing this, we need to test that we even use targets to determine interpreter constraints in the first place.

This also fixes two small issues:
* If the targets and `python-setup` have no constraints, use the subsystem defaults.
* Pylint should include direct dependencies in the interpreter constraints, not just target roots.

[ci skip-rust-tests]
[ci skip-jvm-tests]