### PR TITLE
Support V2 linters running on Python 2 and Python 3 targets at the same time

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -142,7 +142,7 @@ async def bandit_lint(
 
     # NB: Bandit output depends upon which Python interpreter version it's run with
     # ( https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit). We
-    # batch targets by their constraints to ensure, for example that all Python 2 targets run
+    # batch targets by their constraints to ensure, for example, that all Python 2 targets run
     # together and all Python 3 targets run together.
     constraints_to_field_sets = PexInterpreterConstraints.group_field_sets_by_constraints(
         request.field_sets, python_setup

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -15,7 +15,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
-from pants.core.goals.lint import LintRequest, LintResult
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -60,9 +60,9 @@ async def bandit_lint(
     bandit: Bandit,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> LintResult:
+) -> LintResults:
     if bandit.options.skip:
-        return LintResult.noop()
+        return LintResults()
 
     # NB: Bandit output depends upon which Python interpreter version it's run with. See
     # https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit.
@@ -127,7 +127,7 @@ async def bandit_lint(
         description=f"Run Bandit on {pluralize(len(request.field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result, linter_name="Bandit")
+    return LintResults([LintResult.from_fallible_process_result(result, linter_name="Bandit")])
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -7,7 +7,7 @@ from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
-from pants.core.goals.lint import LintResult
+from pants.core.goals.lint import LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import RootRule
@@ -54,7 +54,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResult:
+    ) -> LintResults:
         args = ["--backend-packages2=pants.backend.python.lint.bandit"]
         if config:
             self.create_file(relpath=".bandit", contents=config)
@@ -66,7 +66,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(
-            LintResult,
+            LintResults,
             Params(
                 BanditRequest(BanditFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
@@ -76,21 +76,24 @@ class BanditIntegrationTest(ExternalToolTestBase):
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
         result = self.run_bandit([target])
-        assert result.exit_code == 0
-        assert "No issues identified." in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "No issues identified." in result[0].stdout.strip()
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_bandit([target])
-        assert result.exit_code == 1
-        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
         result = self.run_bandit([target])
-        assert result.exit_code == 1
-        assert "good.py" not in result.stdout
-        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "good.py" not in result[0].stdout
+        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -98,9 +101,10 @@ class BanditIntegrationTest(ExternalToolTestBase):
             self.make_target_with_origin([self.bad_source]),
         ]
         result = self.run_bandit(targets)
-        assert result.exit_code == 1
-        assert "good.py" not in result.stdout
-        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "good.py" not in result[0].stdout
+        assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
@@ -108,8 +112,9 @@ class BanditIntegrationTest(ExternalToolTestBase):
             origin=FilesystemLiteralSpec(self.good_source.path),
         )
         result = self.run_bandit([target])
-        assert result.exit_code == 0
-        assert "No issues identified." in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "No issues identified." in result[0].stdout
 
     @skip_unless_python27_and_python3_present
     def test_uses_correct_python_version(self) -> None:
@@ -117,31 +122,36 @@ class BanditIntegrationTest(ExternalToolTestBase):
             [self.py3_only_source], interpreter_constraints="CPython==2.7.*"
         )
         py2_result = self.run_bandit([py2_target])
-        assert py2_result.exit_code == 0
-        assert "py3.py (syntax error while parsing AST from file)" in py2_result.stdout
+        assert len(py2_result) == 1
+        assert py2_result[0].exit_code == 0
+        assert "py3.py (syntax error while parsing AST from file)" in py2_result[0].stdout
+
         py3_target = self.make_target_with_origin(
             [self.py3_only_source], interpreter_constraints="CPython>=3.6"
         )
         py3_result = self.run_bandit([py3_target])
-        assert py3_result.exit_code == 0
-        assert "No issues identified." in py3_result.stdout.strip()
+        assert len(py3_result) == 1
+        assert py3_result[0].exit_code == 0
+        assert "No issues identified." in py3_result[0].stdout.strip()
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_bandit([target], config="skips: ['B303']\n")
-        assert result.exit_code == 0
-        assert "No issues identified." in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "No issues identified." in result[0].stdout.strip()
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_bandit([target], passthrough_args="--skip B303")
-        assert result.exit_code == 0
-        assert "No issues identified." in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "No issues identified." in result[0].stdout.strip()
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_bandit([target], skip=True)
-        assert result == LintResult.noop()
+        assert not result
 
     def test_3rdparty_plugin(self) -> None:
         target = self.make_target_with_origin(
@@ -150,5 +160,6 @@ class BanditIntegrationTest(ExternalToolTestBase):
         result = self.run_bandit(
             [target], additional_args=["--bandit-extra-requirements=bandit-aws"]
         )
-        assert result.exit_code == 1
-        assert "Issue: [C100:hardcoded_aws_key]" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "Issue: [C100:hardcoded_aws_key]" in result[0].stdout

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -8,7 +8,7 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResult
+from pants.core.goals.lint import LintResults
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent
@@ -49,7 +49,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
-    ) -> Tuple[LintResult, FmtResult]:
+    ) -> Tuple[LintResults, FmtResult]:
         args = ["--backend-packages2=pants.backend.python.lint.black"]
         if config is not None:
             self.create_file(relpath="pyproject.toml", contents=config)
@@ -60,8 +60,8 @@ class BlackIntegrationTest(ExternalToolTestBase):
             args.append("--black-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
-        lint_result = self.request_single_product(
-            LintResult, Params(BlackRequest(field_sets), options_bootstrapper)
+        lint_results = self.request_single_product(
+            LintResults, Params(BlackRequest(field_sets), options_bootstrapper)
         )
         input_sources = self.request_single_product(
             SourceFiles,
@@ -77,34 +77,39 @@ class BlackIntegrationTest(ExternalToolTestBase):
                 options_bootstrapper,
             ),
         )
-        return lint_result, fmt_result
+        return lint_results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
         return self.request_single_product(Digest, InputFilesContent(source_files))
 
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
-        lint_result, fmt_result = self.run_black([target])
-        assert lint_result.exit_code == 0
-        assert "1 file would be left unchanged" in lint_result.stderr
+        lint_results, fmt_result = self.run_black([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert "1 file would be left unchanged" in lint_results[0].stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
-        lint_result, fmt_result = self.run_black([target])
-        assert lint_result.exit_code == 1
-        assert "1 file would be reformatted" in lint_result.stderr
+        lint_results, fmt_result = self.run_black([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 1
+        assert "1 file would be reformatted" in lint_results[0].stderr
         assert "1 file reformatted" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
-        lint_result, fmt_result = self.run_black([target])
-        assert lint_result.exit_code == 1
-        assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
+        lint_results, fmt_result = self.run_black([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 1
+        assert (
+            "1 file would be reformatted, 1 file would be left unchanged" in lint_results[0].stderr
+        )
         assert "1 file reformatted, 1 file left unchanged", fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
@@ -114,9 +119,12 @@ class BlackIntegrationTest(ExternalToolTestBase):
             self.make_target_with_origin([self.good_source]),
             self.make_target_with_origin([self.bad_source]),
         ]
-        lint_result, fmt_result = self.run_black(targets)
-        assert lint_result.exit_code == 1
-        assert "1 file would be reformatted, 1 file would be left unchanged" in lint_result.stderr
+        lint_results, fmt_result = self.run_black(targets)
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 1
+        assert (
+            "1 file would be reformatted, 1 file would be left unchanged" in lint_results[0].stderr
+        )
         assert "1 file reformatted, 1 file left unchanged" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
@@ -125,38 +133,41 @@ class BlackIntegrationTest(ExternalToolTestBase):
         target = self.make_target_with_origin(
             [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
         )
-        lint_result, fmt_result = self.run_black([target])
-        assert lint_result.exit_code == 0
-        assert "1 file would be left unchanged" in lint_result.stderr
+        lint_results, fmt_result = self.run_black([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert "1 file would be left unchanged" in lint_results[0].stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
-        lint_result, fmt_result = self.run_black(
+        lint_results, fmt_result = self.run_black(
             [target], config="[tool.black]\nskip-string-normalization = 'true'\n"
         )
-        assert lint_result.exit_code == 0
-        assert "1 file would be left unchanged" in lint_result.stderr
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert "1 file would be left unchanged" in lint_results[0].stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.needs_config_source])
         assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.needs_config_source])
-        lint_result, fmt_result = self.run_black(
+        lint_results, fmt_result = self.run_black(
             [target], passthrough_args="--skip-string-normalization",
         )
-        assert lint_result.exit_code == 0
-        assert "1 file would be left unchanged" in lint_result.stderr
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert "1 file would be left unchanged" in lint_results[0].stderr
         assert "1 file left unchanged" in fmt_result.stderr
         assert fmt_result.output == self.get_digest([self.needs_config_source])
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
-        lint_result, fmt_result = self.run_black([target], skip=True)
-        assert lint_result == LintResult.noop()
+        lint_results, fmt_result = self.run_black([target], skip=True)
+        assert not lint_results
         assert fmt_result == FmtResult.noop()
         assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -69,7 +69,7 @@ def generate_args(
 
 @rule
 async def setup(
-    request: SetupRequest,
+    setup_request: SetupRequest,
     docformatter: Docformatter,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -86,16 +86,16 @@ async def setup(
     )
 
     all_source_files_request = Get[SourceFiles](
-        AllSourceFilesRequest(field_set.sources for field_set in request.request.field_sets)
+        AllSourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets)
     )
     specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in request.request.field_sets
+            (field_set.sources, field_set.origin) for field_set in setup_request.request.field_sets
         )
     )
 
     requests: List[Get] = [requirements_pex_request, specified_source_files_request]
-    if request.request.prior_formatter_result is None:
+    if setup_request.request.prior_formatter_result is None:
         requests.append(all_source_files_request)
     requirements_pex, specified_source_files, *rest = cast(
         Union[Tuple[Pex, SourceFiles], Tuple[Pex, SourceFiles, SourceFiles]],
@@ -103,8 +103,8 @@ async def setup(
     )
 
     all_source_files_snapshot = (
-        request.request.prior_formatter_result
-        if request.request.prior_formatter_result
+        setup_request.request.prior_formatter_result
+        if setup_request.request.prior_formatter_result
         else rest[0].snapshot
     )
 
@@ -113,7 +113,7 @@ async def setup(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in request.request.field_sets)
+        sorted(field_set.address.reference() for field_set in setup_request.request.field_sets)
     )
 
     process = requirements_pex.create_process(
@@ -123,12 +123,12 @@ async def setup(
         pex_args=generate_args(
             specified_source_files=specified_source_files,
             docformatter=docformatter,
-            check_only=request.check_only,
+            check_only=setup_request.check_only,
         ),
         input_digest=input_digest,
         output_files=all_source_files_snapshot.files,
         description=(
-            f"Run Docformatter on {pluralize(len(request.request.field_sets), 'target')}: "
+            f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'target')}: "
             f"{address_references}."
         ),
     )
@@ -147,12 +147,16 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
 
 
 @named_rule(desc="Lint Python docstrings with docformatter")
-async def docformatter_lint(request: DocformatterRequest, docformatter: Docformatter) -> LintResult:
+async def docformatter_lint(
+    request: DocformatterRequest, docformatter: Docformatter
+) -> LintResults:
     if docformatter.options.skip:
-        return LintResult.noop()
+        return LintResults()
     setup = await Get[Setup](SetupRequest(request, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(result, linter_name="Docformatter")
+    return LintResults(
+        [LintResult.from_fallible_process_result(result, linter_name="Docformatter")]
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -8,7 +8,7 @@ from pants.backend.python.lint.docformatter.rules import rules as docformatter_r
 from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResult
+from pants.core.goals.lint import LintResults
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, FileContent, InputFilesContent
@@ -45,7 +45,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         *,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
-    ) -> Tuple[LintResult, FmtResult]:
+    ) -> Tuple[LintResults, FmtResult]:
         args = ["--backend-packages2=pants.backend.python.lint.docformatter"]
         if passthrough_args:
             args.append(f"--docformatter-args='{passthrough_args}'")
@@ -53,8 +53,8 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
             args.append("--docformatter-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [DocformatterFieldSet.create(tgt) for tgt in targets]
-        lint_result = self.request_single_product(
-            LintResult, Params(DocformatterRequest(field_sets), options_bootstrapper)
+        lint_results = self.request_single_product(
+            LintResults, Params(DocformatterRequest(field_sets), options_bootstrapper)
         )
         input_sources = self.request_single_product(
             SourceFiles,
@@ -70,32 +70,35 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
                 options_bootstrapper,
             ),
         )
-        return lint_result, fmt_result
+        return lint_results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
         return self.request_single_product(Digest, InputFilesContent(source_files))
 
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
-        lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result.exit_code == 0
-        assert lint_result.stderr == ""
+        lint_results, fmt_result = self.run_docformatter([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert lint_results[0].stderr == ""
         assert fmt_result.output == self.get_digest([self.good_source])
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
-        lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result.exit_code == 3
-        assert lint_result.stderr.strip() == self.bad_source.path
+        lint_results, fmt_result = self.run_docformatter([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 3
+        assert lint_results[0].stderr.strip() == self.bad_source.path
         assert fmt_result.output == self.get_digest([self.fixed_bad_source])
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
-        lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result.exit_code == 3
-        assert lint_result.stderr.strip() == self.bad_source.path
+        lint_results, fmt_result = self.run_docformatter([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 3
+        assert lint_results[0].stderr.strip() == self.bad_source.path
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
@@ -104,9 +107,10 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
             self.make_target_with_origin([self.good_source]),
             self.make_target_with_origin([self.bad_source]),
         ]
-        lint_result, fmt_result = self.run_docformatter(targets)
-        assert lint_result.exit_code == 3
-        assert lint_result.stderr.strip() == self.bad_source.path
+        lint_results, fmt_result = self.run_docformatter(targets)
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 3
+        assert lint_results[0].stderr.strip() == self.bad_source.path
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
@@ -114,9 +118,10 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         target = self.make_target_with_origin(
             [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
         )
-        lint_result, fmt_result = self.run_docformatter([target])
-        assert lint_result.exit_code == 0
-        assert lint_result.stderr == ""
+        lint_results, fmt_result = self.run_docformatter([target])
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert lint_results[0].stderr == ""
         assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
         assert fmt_result.did_change is False
 
@@ -126,17 +131,18 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
             content=b'"""\nOne line docstring acting like it\'s multiline.\n"""\n',
         )
         target = self.make_target_with_origin([needs_config])
-        lint_result, fmt_result = self.run_docformatter(
+        lint_results, fmt_result = self.run_docformatter(
             [target], passthrough_args="--make-summary-multi-line"
         )
-        assert lint_result.exit_code == 0
-        assert lint_result.stderr == ""
+        assert len(lint_results) == 1
+        assert lint_results[0].exit_code == 0
+        assert lint_results[0].stderr == ""
         assert fmt_result.output == self.get_digest([needs_config])
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
-        lint_result, fmt_result = self.run_docformatter([target], skip=True)
-        assert lint_result == LintResult.noop()
+        lint_results, fmt_result = self.run_docformatter([target], skip=True)
+        assert not lint_results
         assert fmt_result == FmtResult.noop()
         assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -142,7 +142,7 @@ async def flake8_lint(
 
     # NB: Flake8 output depends upon which Python interpreter version it's run with
     # (http://flake8.pycqa.org/en/latest/user/invocation.html). We batch targets by their
-    # constraints to ensure, for example that all Python 2 targets run together and all Python 3
+    # constraints to ensure, for example, that all Python 2 targets run together and all Python 3
     # targets run together.
     constraints_to_field_sets = PexInterpreterConstraints.group_field_sets_by_constraints(
         request.field_sets, python_setup

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -45,6 +45,12 @@ class Flake8Request(LintRequest):
     field_set_type = Flake8FieldSet
 
 
+@dataclass(frozen=True)
+class Flake8Partition:
+    field_sets: Tuple[Flake8FieldSet, ...]
+    interpreter_constraints: PexInterpreterConstraints
+
+
 def generate_args(*, specified_source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:
     args = []
     if flake8.options.config is not None:
@@ -54,27 +60,21 @@ def generate_args(*, specified_source_files: SourceFiles, flake8: Flake8) -> Tup
     return tuple(args)
 
 
-@named_rule(desc="Lint using Flake8")
-async def flake8_lint(
-    request: Flake8Request,
+@rule
+async def flake8_lint_partition(
+    partition: Flake8Partition,
     flake8: Flake8,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> LintResults:
-    if flake8.options.skip:
-        return LintResults()
-
-    # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
-    # each target runs with its own interpreter constraints. See
-    # http://flake8.pycqa.org/en/latest/user/invocation.html.
-    interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (field_set.compatibility for field_set in request.field_sets), python_setup
-    ) or PexInterpreterConstraints(flake8.default_interpreter_constraints)
+) -> LintResult:
     requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="flake8.pex",
             requirements=PexRequirements(flake8.get_requirement_specs()),
-            interpreter_constraints=interpreter_constraints,
+            interpreter_constraints=(
+                partition.interpreter_constraints
+                or PexInterpreterConstraints(flake8.default_interpreter_constraints)
+            ),
             entry_point=flake8.get_entry_point(),
         )
     )
@@ -89,11 +89,11 @@ async def flake8_lint(
     )
 
     all_source_files_request = Get[SourceFiles](
-        AllSourceFilesRequest(field_set.sources for field_set in request.field_sets)
+        AllSourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
     specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in request.field_sets
+            (field_set.sources, field_set.origin) for field_set in partition.field_sets
         )
     )
 
@@ -116,7 +116,7 @@ async def flake8_lint(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in request.field_sets)
+        sorted(field_set.address.reference() for field_set in partition.field_sets)
     )
 
     process = requirements_pex.create_process(
@@ -126,16 +126,38 @@ async def flake8_lint(
         pex_args=generate_args(specified_source_files=specified_source_files, flake8=flake8),
         input_digest=input_digest,
         description=(
-            f"Run Flake8 on {pluralize(len(request.field_sets), 'target')}: {address_references}."
+            f"Run Flake8 on {pluralize(len(partition.field_sets), 'target')}: {address_references}."
         ),
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResults([LintResult.from_fallible_process_result(result, linter_name="Flake8")])
+    return LintResult.from_fallible_process_result(result, linter_name="Flake8")
+
+
+@named_rule(desc="Lint using Flake8")
+async def flake8_lint(
+    request: Flake8Request, flake8: Flake8, python_setup: PythonSetup
+) -> LintResults:
+    if flake8.options.skip:
+        return LintResults()
+
+    # NB: Flake8 output depends upon which Python interpreter version it's run with
+    # (http://flake8.pycqa.org/en/latest/user/invocation.html). We batch targets by their
+    # constraints to ensure, for example that all Python 2 targets run together and all Python 3
+    # targets run together.
+    constraints_to_field_sets = PexInterpreterConstraints.group_field_sets_by_constraints(
+        request.field_sets, python_setup
+    )
+    partitioned_results = await MultiGet(
+        Get[LintResult](Flake8Partition(partition_field_sets, partition_compatibility))
+        for partition_compatibility, partition_field_sets in constraints_to_field_sets.items()
+    )
+    return LintResults(partitioned_results)
 
 
 def rules():
     return [
         flake8_lint,
+        flake8_lint_partition,
         SubsystemRule(Flake8),
         UnionRule(LintRequest, Flake8Request),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -7,7 +7,7 @@ from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
-from pants.core.goals.lint import LintResult
+from pants.core.goals.lint import LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import RootRule
@@ -53,7 +53,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResult:
+    ) -> LintResults:
         args = ["--backend-packages2=pants.backend.python.lint.flake8"]
         if config:
             self.create_file(relpath=".flake8", contents=config)
@@ -65,7 +65,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(
-            LintResult,
+            LintResults,
             Params(
                 Flake8Request(Flake8FieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
@@ -75,21 +75,24 @@ class Flake8IntegrationTest(ExternalToolTestBase):
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
         result = self.run_flake8([target])
-        assert result.exit_code == 0
-        assert result.stdout.strip() == ""
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert result[0].stdout.strip() == ""
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_flake8([target])
-        assert result.exit_code == 1
-        assert "bad.py:1:1: F401" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "bad.py:1:1: F401" in result[0].stdout
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
         result = self.run_flake8([target])
-        assert result.exit_code == 1
-        assert "good.py" not in result.stdout
-        assert "bad.py:1:1: F401" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "good.py" not in result[0].stdout
+        assert "bad.py:1:1: F401" in result[0].stdout
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -97,17 +100,19 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             self.make_target_with_origin([self.bad_source]),
         ]
         result = self.run_flake8(targets)
-        assert result.exit_code == 1
-        assert "good.py" not in result.stdout
-        assert "bad.py:1:1: F401" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "good.py" not in result[0].stdout
+        assert "bad.py:1:1: F401" in result[0].stdout
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
             [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
         )
         result = self.run_flake8([target])
-        assert result.exit_code == 0
-        assert result.stdout.strip() == ""
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert result[0].stdout.strip() == ""
 
     @skip_unless_python27_and_python3_present
     def test_uses_correct_python_version(self) -> None:
@@ -115,31 +120,35 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             [self.py3_only_source], interpreter_constraints="CPython==2.7.*"
         )
         py2_result = self.run_flake8([py2_target])
-        assert py2_result.exit_code == 1
-        assert "py3.py:1:8: E999 SyntaxError" in py2_result.stdout
+        assert len(py2_result) == 1
+        assert py2_result[0].exit_code == 1
+        assert "py3.py:1:8: E999 SyntaxError" in py2_result[0].stdout
         py3_target = self.make_target_with_origin(
             [self.py3_only_source], interpreter_constraints="CPython>=3.6"
         )
         py3_result = self.run_flake8([py3_target])
-        assert py3_result.exit_code == 0
-        assert py3_result.stdout.strip() == ""
+        assert len(py3_result) == 1
+        assert py3_result[0].exit_code == 0
+        assert py3_result[0].stdout.strip() == ""
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_flake8([target], config="[flake8]\nignore = F401\n")
-        assert result.exit_code == 0
-        assert result.stdout.strip() == ""
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert result[0].stdout.strip() == ""
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_flake8([target], passthrough_args="--ignore=F401")
-        assert result.exit_code == 0
-        assert result.stdout.strip() == ""
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert result[0].stdout.strip() == ""
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_flake8([target], skip=True)
-        assert result == LintResult.noop()
+        assert not result
 
     def test_3rdparty_plugin(self) -> None:
         target = self.make_target_with_origin(
@@ -148,5 +157,6 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         result = self.run_flake8(
             [target], additional_args=["--flake8-extra-requirements=flake8-pantsbuild>=2.0,<3"]
         )
-        assert result.exit_code == 1
-        assert "bad.py:1:1: PB11" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert "bad.py:1:1: PB11" in result[0].stdout

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -17,7 +17,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtRequest, FmtResult
-from pants.core.goals.lint import LintRequest, LintResult
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -74,7 +74,7 @@ def generate_args(
 
 @rule
 async def setup(
-    request: SetupRequest,
+    setup_request: SetupRequest,
     isort: Isort,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
@@ -101,11 +101,11 @@ async def setup(
     )
 
     all_source_files_request = Get[SourceFiles](
-        AllSourceFilesRequest(field_set.sources for field_set in request.request.field_sets)
+        AllSourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets)
     )
     specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in request.request.field_sets
+            (field_set.sources, field_set.origin) for field_set in setup_request.request.field_sets
         )
     )
 
@@ -114,7 +114,7 @@ async def setup(
         config_snapshot_request,
         specified_source_files_request,
     ]
-    if request.request.prior_formatter_result is None:
+    if setup_request.request.prior_formatter_result is None:
         requests.append(all_source_files_request)
     requirements_pex, config_snapshot, specified_source_files, *rest = cast(
         Union[Tuple[Pex, Snapshot, SourceFiles], Tuple[Pex, Snapshot, SourceFiles, SourceFiles]],
@@ -122,8 +122,8 @@ async def setup(
     )
 
     all_source_files_snapshot = (
-        request.request.prior_formatter_result
-        if request.request.prior_formatter_result
+        setup_request.request.prior_formatter_result
+        if setup_request.request.prior_formatter_result
         else rest[0].snapshot
     )
 
@@ -134,7 +134,7 @@ async def setup(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in request.request.field_sets)
+        sorted(field_set.address.reference() for field_set in setup_request.request.field_sets)
     )
 
     process = requirements_pex.create_process(
@@ -144,12 +144,12 @@ async def setup(
         pex_args=generate_args(
             specified_source_files=specified_source_files,
             isort=isort,
-            check_only=request.check_only,
+            check_only=setup_request.check_only,
         ),
         input_digest=input_digest,
         output_files=all_source_files_snapshot.files,
         description=(
-            f"Run isort on {pluralize(len(request.request.field_sets), 'target')}: {address_references}."
+            f"Run isort on {pluralize(len(setup_request.request.field_sets), 'target')}: {address_references}."
         ),
     )
     return Setup(process, original_digest=all_source_files_snapshot.digest)
@@ -170,13 +170,17 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
 
 
 @named_rule(desc="Lint using isort")
-async def isort_lint(request: IsortRequest, isort: Isort) -> LintResult:
+async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
     if isort.options.skip:
-        return LintResult.noop()
+        return LintResults()
     setup = await Get[Setup](SetupRequest(request, check_only=True))
     result = await Get[FallibleProcessResult](Process, setup.process)
-    return LintResult.from_fallible_process_result(
-        result, linter_name="isort", strip_chroot_path=True
+    return LintResults(
+        [
+            LintResult.from_fallible_process_result(
+                result, linter_name="isort", strip_chroot_path=True
+            )
+        ]
     )
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -21,7 +21,7 @@ from pants.backend.python.target_types import (
     PythonRequirementsField,
     PythonSources,
 )
-from pants.core.goals.lint import LintRequest, LintResult
+from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.engine.addresses import Address, Addresses
@@ -69,9 +69,9 @@ async def pylint_lint(
     pylint: Pylint,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> LintResult:
+) -> LintResults:
     if pylint.skip:
-        return LintResult.noop()
+        return LintResults()
 
     # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
     # doesn't lint those direct dependencies nor does it care about transitive dependencies.
@@ -239,7 +239,7 @@ async def pylint_lint(
         description=f"Run Pylint on {pluralize(len(request.field_sets), 'target')}: {address_references}.",
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResult.from_fallible_process_result(result, linter_name="Pylint")
+    return LintResults([LintResult.from_fallible_process_result(result, linter_name="Pylint")])
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -266,6 +266,8 @@ async def pylint_lint(
         for field_set in request.field_sets
     )
 
+    # We batch targets by their interpreter constraints to ensure, for example, that all Python 2
+    # targets run together and all Python 3 targets run together.
     interpreter_constraints_to_target_setup = defaultdict(set)
     for field_set, tgt, dependencies in zip(
         request.field_sets, linted_targets, per_target_dependencies

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Tuple, cast
+from typing import Iterable, Tuple, cast
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.rules import download_pex_bin, importable_python_sources, pex
@@ -27,18 +28,20 @@ from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedS
 from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule
+from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     FieldSetWithOrigin,
+    Target,
     Targets,
     TransitiveTargets,
 )
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
+from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize
 
 
@@ -48,6 +51,36 @@ class PylintFieldSet(FieldSetWithOrigin):
 
     sources: PythonSources
     dependencies: Dependencies
+
+
+@dataclass(frozen=True)
+class PylintTargetSetup:
+    field_set: PylintFieldSet
+    target_with_dependencies: Targets
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class PylintPartition:
+    field_sets: Tuple[PylintFieldSet, ...]
+    targets_with_dependencies: Targets
+    interpreter_constraints: PexInterpreterConstraints
+    plugin_targets: Targets
+
+    def __init__(
+        self,
+        target_setups: Iterable[PylintTargetSetup],
+        interpreter_constraints: PexInterpreterConstraints,
+        plugin_targets: Iterable[Target],
+    ) -> None:
+        self.field_sets = tuple(target_setup.field_set for target_setup in target_setups)
+        self.targets_with_dependencies = Targets(
+            itertools.chain.from_iterable(
+                target_setup.target_with_dependencies for target_setup in target_setups
+            )
+        )
+        self.interpreter_constraints = interpreter_constraints
+        self.plugin_targets = Targets(plugin_targets)
 
 
 class PylintRequest(LintRequest):
@@ -63,80 +96,38 @@ def generate_args(*, specified_source_files: SourceFiles, pylint: Pylint) -> Tup
     return tuple(args)
 
 
-@named_rule(desc="Lint using Pylint")
-async def pylint_lint(
-    request: PylintRequest,
+@rule
+async def pylint_lint_partition(
+    partition: PylintPartition,
     pylint: Pylint,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> LintResults:
-    if pylint.skip:
-        return LintResults()
-
-    # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
-    # doesn't lint those direct dependencies nor does it care about transitive dependencies.
-    per_target_dependencies = await MultiGet(
-        Get[Targets](DependenciesRequest(field_set.dependencies))
-        for field_set in request.field_sets
-    )
-
-    plugin_targets_request = Get[TransitiveTargets](
-        Addresses(Address.parse(plugin_addr) for plugin_addr in pylint.source_plugins)
-    )
-    linted_targets_request = Get[Targets](
-        Addresses(field_set.address for field_set in request.field_sets)
-    )
-    plugin_targets, linted_targets = cast(
-        Tuple[TransitiveTargets, Targets],
-        await MultiGet([plugin_targets_request, linted_targets_request]),
-    )
-
-    targets_with_dependencies = Targets(
-        [*linted_targets, *itertools.chain.from_iterable(per_target_dependencies)]
-    )
-
-    # NB: Pylint output depends upon which Python interpreter version it's run with. See
-    # http://pylint.pycqa.org/en/latest/faq.html#what-versions-of-python-is-pylint-supporting.
-    interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
-        (
-            *(tgt.get(PythonInterpreterCompatibility) for tgt in targets_with_dependencies),
-            *(
-                plugin_tgt[PythonInterpreterCompatibility]
-                for plugin_tgt in plugin_targets.closure
-                if plugin_tgt.has_field(PythonInterpreterCompatibility)
-            ),
-        ),
-        python_setup,
-    ) or PexInterpreterConstraints(pylint.default_interpreter_constraints)
-
+) -> LintResult:
     # We build one PEX with Pylint requirements and another with all direct 3rd-party dependencies.
     # Splitting this into two PEXes gives us finer-grained caching. We then merge via `--pex-path`.
+    plugin_requirements = PexRequirements.create_from_requirement_fields(
+        plugin_tgt[PythonRequirementsField]
+        for plugin_tgt in partition.plugin_targets
+        if plugin_tgt.has_field(PythonRequirementsField)
+    )
+    target_requirements = PexRequirements.create_from_requirement_fields(
+        tgt[PythonRequirementsField]
+        for tgt in partition.targets_with_dependencies
+        if tgt.has_field(PythonRequirementsField)
+    )
     pylint_pex_request = Get[Pex](
         PexRequest(
             output_filename="pylint.pex",
-            requirements=PexRequirements(
-                [
-                    *pylint.get_requirement_specs(),
-                    *PexRequirements.create_from_requirement_fields(
-                        plugin_tgt[PythonRequirementsField]
-                        for plugin_tgt in plugin_targets.closure
-                        if plugin_tgt.has_field(PythonRequirementsField)
-                    ),
-                ]
-            ),
-            interpreter_constraints=interpreter_constraints,
+            requirements=PexRequirements([*pylint.get_requirement_specs(), *plugin_requirements]),
+            interpreter_constraints=partition.interpreter_constraints,
             entry_point=pylint.get_entry_point(),
         )
     )
     requirements_pex_request = Get[Pex](
         PexRequest(
             output_filename="requirements.pex",
-            requirements=PexRequirements.create_from_requirement_fields(
-                tgt[PythonRequirementsField]
-                for tgt in targets_with_dependencies
-                if tgt.has_field(PythonRequirementsField)
-            ),
-            interpreter_constraints=interpreter_constraints,
+            requirements=target_requirements,
+            interpreter_constraints=partition.interpreter_constraints,
         )
     )
     # TODO(John Sirois): Support shading python binaries:
@@ -152,7 +143,7 @@ async def pylint_lint(
         PexRequest(
             output_filename="pylint_runner.pex",
             entry_point=pylint.get_entry_point(),
-            interpreter_constraints=interpreter_constraints,
+            interpreter_constraints=partition.interpreter_constraints,
             additional_args=pylint_runner_pex_args,
         )
     )
@@ -165,13 +156,13 @@ async def pylint_lint(
         )
     )
 
-    prepare_plugin_sources_request = Get[ImportablePythonSources](Targets(plugin_targets.closure))
+    prepare_plugin_sources_request = Get[ImportablePythonSources](Targets, partition.plugin_targets)
     prepare_python_sources_request = Get[ImportablePythonSources](
-        Targets, targets_with_dependencies
+        Targets, partition.targets_with_dependencies
     )
     specified_source_files_request = Get[SourceFiles](
         SpecifiedSourceFilesRequest(
-            ((field_set.sources, field_set.origin) for field_set in request.field_sets),
+            ((field_set.sources, field_set.origin) for field_set in partition.field_sets),
             strip_source_roots=True,
         )
     )
@@ -221,7 +212,7 @@ async def pylint_lint(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in request.field_sets)
+        sorted(field_set.address.reference() for field_set in partition.field_sets)
     )
 
     process = pylint_runner_pex.create_process(
@@ -236,15 +227,79 @@ async def pylint_lint(
         env={"PYTHONPATH": "./__plugins"} if pylint.source_plugins else None,
         pex_args=generate_args(specified_source_files=specified_source_files, pylint=pylint),
         input_digest=input_digest,
-        description=f"Run Pylint on {pluralize(len(request.field_sets), 'target')}: {address_references}.",
+        description=(
+            f"Run Pylint on {pluralize(len(partition.field_sets), 'target')}: {address_references}."
+        ),
     )
     result = await Get[FallibleProcessResult](Process, process)
-    return LintResults([LintResult.from_fallible_process_result(result, linter_name="Pylint")])
+    return LintResult.from_fallible_process_result(result, linter_name="Pylint")
+
+
+@named_rule(desc="Lint using Pylint")
+async def pylint_lint(
+    request: PylintRequest, pylint: Pylint, python_setup: PythonSetup
+) -> LintResults:
+    if pylint.skip:
+        return LintResults()
+
+    plugin_targets_request = Get[TransitiveTargets](
+        Addresses(Address.parse(plugin_addr) for plugin_addr in pylint.source_plugins)
+    )
+    linted_targets_request = Get[Targets](
+        Addresses(field_set.address for field_set in request.field_sets)
+    )
+    plugin_targets, linted_targets = cast(
+        Tuple[TransitiveTargets, Targets],
+        await MultiGet([plugin_targets_request, linted_targets_request]),
+    )
+
+    plugin_targets_compatibility_fields = tuple(
+        plugin_tgt[PythonInterpreterCompatibility]
+        for plugin_tgt in plugin_targets.closure
+        if plugin_tgt.has_field(PythonInterpreterCompatibility)
+    )
+
+    # Pylint needs direct dependencies in the chroot to ensure that imports are valid. However, it
+    # doesn't lint those direct dependencies nor does it care about transitive dependencies.
+    per_target_dependencies = await MultiGet(
+        Get[Targets](DependenciesRequest(field_set.dependencies))
+        for field_set in request.field_sets
+    )
+
+    interpreter_constraints_to_target_setup = defaultdict(set)
+    for field_set, tgt, dependencies in zip(
+        request.field_sets, linted_targets, per_target_dependencies
+    ):
+        target_setup = PylintTargetSetup(field_set, Targets([tgt, *dependencies]))
+        interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
+            (
+                *(tgt.get(PythonInterpreterCompatibility) for tgt in [tgt, *dependencies]),
+                *plugin_targets_compatibility_fields,
+            ),
+            python_setup,
+        ) or PexInterpreterConstraints(pylint.default_interpreter_constraints)
+        interpreter_constraints_to_target_setup[interpreter_constraints].add(target_setup)
+
+    partitions = (
+        PylintPartition(
+            tuple(sorted(target_setups, key=lambda target_setup: target_setup.field_set.address)),
+            interpreter_constraints,
+            Targets(plugin_targets.closure),
+        )
+        for interpreter_constraints, target_setups in sorted(
+            interpreter_constraints_to_target_setup.items()
+        )
+    )
+    partitioned_results = await MultiGet(
+        Get[LintResult](PylintPartition, partition) for partition in partitions
+    )
+    return LintResults(partitioned_results)
 
 
 def rules():
     return [
         pylint_lint,
+        pylint_lint_partition,
         SubsystemRule(Pylint),
         UnionRule(LintRequest, PylintRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -11,7 +11,7 @@ from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.goals.lint import LintResult
+from pants.core.goals.lint import LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.legacy.graph import HydratedTargets
@@ -94,7 +94,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResult:
+    ) -> LintResults:
         args = ["--backend-packages2=pants.backend.python.lint.pylint"]
         if config:
             self.create_file(relpath="pylintrc", contents=config)
@@ -106,7 +106,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
         if additional_args:
             args.extend(additional_args)
         return self.request_single_product(
-            LintResult,
+            LintResults,
             Params(
                 PylintRequest(PylintFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
@@ -116,21 +116,24 @@ class PylintIntegrationTest(ExternalToolTestBase):
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])
         result = self.run_pylint([target])
-        assert result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in result[0].stdout.strip()
 
     def test_failing_source(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_pylint([target])
-        assert result.exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "bad.py:2:0: C0103" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
+        assert "bad.py:2:0: C0103" in result[0].stdout
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
         result = self.run_pylint([target])
-        assert result.exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "good.py" not in result.stdout
-        assert "bad.py:2:0: C0103" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
+        assert "good.py" not in result[0].stdout
+        assert "bad.py:2:0: C0103" in result[0].stdout
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -138,17 +141,19 @@ class PylintIntegrationTest(ExternalToolTestBase):
             self.make_target_with_origin([self.bad_source], name="t2"),
         ]
         result = self.run_pylint(targets)
-        assert result.exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "good.py" not in result.stdout
-        assert "bad.py:2:0: C0103" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
+        assert "good.py" not in result[0].stdout
+        assert "bad.py:2:0: C0103" in result[0].stdout
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
             [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
         )
         result = self.run_pylint([target])
-        assert result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in result[0].stdout.strip()
 
     @skip_unless_python27_and_python3_present
     def test_uses_correct_python_version(self) -> None:
@@ -162,26 +167,31 @@ class PylintIntegrationTest(ExternalToolTestBase):
                 "--pylint-extra-requirements=setuptools<45",
             ],
         )
-        assert py2_result.exit_code == 2
-        assert "invalid syntax (<string>, line 2) (syntax-error)" in py2_result.stdout
+        assert len(py2_result) == 1
+        assert py2_result[0].exit_code == 2
+        assert "invalid syntax (<string>, line 2) (syntax-error)" in py2_result[0].stdout
+
         py3_target = self.make_target_with_origin(
             [self.py3_only_source], name="py3", interpreter_constraints="CPython>=3.6"
         )
         py3_result = self.run_pylint([py3_target])
-        assert py3_result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in py3_result.stdout.strip()
+        assert len(py3_result) == 1
+        assert py3_result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in py3_result[0].stdout.strip()
 
     def test_respects_config_file(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_pylint([target], config="[pylint]\ndisable = C0103\n")
-        assert result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in result[0].stdout.strip()
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_pylint([target], passthrough_args="--disable=C0103")
-        assert result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in result[0].stdout.strip()
 
     def test_includes_direct_dependencies(self) -> None:
         self.add_to_build_file(
@@ -243,13 +253,14 @@ class PylintIntegrationTest(ExternalToolTestBase):
         )
 
         result = self.run_pylint([target])
-        assert result.exit_code == 0
-        assert "Your code has been rated at 10.00/10" in result.stdout.strip()
+        assert len(result) == 1
+        assert result[0].exit_code == 0
+        assert "Your code has been rated at 10.00/10" in result[0].stdout.strip()
 
     def test_skip(self) -> None:
         target = self.make_target_with_origin([self.bad_source])
         result = self.run_pylint([target], skip=True)
-        assert result == LintResult.noop()
+        assert not result
 
     def test_3rdparty_plugin(self) -> None:
         source_content = dedent(
@@ -274,8 +285,9 @@ class PylintIntegrationTest(ExternalToolTestBase):
             additional_args=["--pylint-extra-requirements=pylint-unittest>=0.1.3,<0.2"],
             passthrough_args="--load-plugins=pylint_unittest",
         )
-        assert result.exit_code == 4
-        assert "thirdparty_plugin.py:10:8: W5301" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == 4
+        assert "thirdparty_plugin.py:10:8: W5301" in result[0].stdout
 
     def test_source_plugin(self) -> None:
         # NB: We make this source plugin fairly complex by having it use transitive dependencies.
@@ -365,5 +377,6 @@ class PylintIntegrationTest(ExternalToolTestBase):
             ],
             config=config_content,
         )
-        assert result.exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "source_plugin.py:2:0: C9871" in result.stdout
+        assert len(result) == 1
+        assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
+        assert "source_plugin.py:2:0: C9871" in result[0].stdout

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -9,6 +10,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
 )
+from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
@@ -27,10 +29,6 @@ class LintResult:
     linter_name: str
 
     @staticmethod
-    def noop() -> "LintResult":
-        return LintResult(exit_code=0, stdout="", stderr="", linter_name="")
-
-    @staticmethod
     def from_fallible_process_result(
         process_result: FallibleProcessResult, *, linter_name: str, strip_chroot_path: bool = False
     ) -> "LintResult":
@@ -43,6 +41,16 @@ class LintResult:
             stderr=prep_output(process_result.stderr),
             linter_name=linter_name,
         )
+
+
+class LintResults(Collection[LintResult]):
+    """Zero or more LintResult objects for a single linter.
+
+    Typically, linters will return one result. If they no-oped, they will return zero results.
+    However, some linters may need to partition their batch of LinterFieldSets and thus may need to
+    return multiple results. For example, many Python linters will need to group by interpreter
+    compatibility.
+    """
 
 
 @union
@@ -116,20 +124,20 @@ async def lint(
 
     if options.values.per_target_caching:
         results = await MultiGet(
-            Get[LintResult](LintRequest, lint_request.__class__([field_set]))
+            Get[LintResults](LintRequest, lint_request.__class__([field_set]))
             for lint_request in valid_lint_requests
             for field_set in lint_request.field_sets
         )
     else:
         results = await MultiGet(
-            Get[LintResult](LintRequest, lint_request) for lint_request in valid_lint_requests
+            Get[LintResults](LintRequest, lint_request) for lint_request in valid_lint_requests
         )
 
     if not results:
         return Lint(exit_code=0)
 
     exit_code = 0
-    sorted_results = sorted(results, key=lambda res: res.linter_name)
+    sorted_results = sorted(itertools.chain.from_iterable(results), key=lambda res: res.linter_name)
     for result in sorted_results:
         console.print_stderr(
             f"{console.green('✓')} {result.linter_name} succeeded."

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -78,15 +78,11 @@ class LintOptions(GoalSubsystem):
             default=False,
             help=(
                 "Rather than running all targets in a single batch, run each target as a "
-                "separate process. Why do this? You'll get many more cache hits. Additionally, for "
-                "Python users, if you have some targets that only work with Python 2 and some that "
-                "only work with Python 3, `--per-target-caching` will allow you to use the right "
-                "interpreter for each target. Why not do this? Linters both have substantial "
-                "startup overhead and are cheap to add one additional file to the run. On a cold "
-                "cache, it is much faster to use `--no-per-target-caching`. We only recommend "
-                "using `--per-target-caching` if you "
-                "are using a remote cache, or if you have some Python 2-only targets and "
-                "some Python 3-only targets, or if you have benchmarked that this option will be "
+                "separate process. Why do this? You'll get many more cache hits. Why not do this? "
+                "Linters both have substantial startup overhead and are cheap to add one "
+                "additional file to the run. On a cold cache, it is much faster to use "
+                "`--no-per-target-caching`. We only recommend using `--per-target-caching` if you "
+                "are using a remote cache or if you have benchmarked that this option will be "
                 "faster than `--no-per-target-caching` for your use case."
             ),
         )


### PR DESCRIPTION
### Problem

When using the default `--no-per-target-caching`, `./v2 lint ::` will fail if you have any targets with conflicting Python interpreter constraints, e.g. Python 2-only targets mixed with Python 3-only targets. This is a common problem due to Python 3 migrations.


It is not acceptable to say "just use `--per-target-caching`" because we want `./pants lint ::` to work regardless of this setting.

### Solution

The main change is for linter rules to now return `LintResults`, rather than a single `LintResult`. Typically, this will only have one element, but it can include more, such as partitioning by interpreter constraints. In JVM land, we might partition by JVM compatibility, for example.

Then, Pylint, Bandit, and Flake8 are rewritten to have new rules that take a `Partition` of the original input targets and return a single `LintResult`. Another rule does the partitioning and aggregates these results.

### Result

`./v2 lint ::` works on any Python codebase, regardless of interpreter constraints.
