### PR TITLE
remote execution: sort platform properties

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -869,12 +869,13 @@ pub fn make_execute_request(
   //   is done by code point, equivalently, by the UTF-8 bytes.
   //
   // Note: BuildBarn enforces this requirement.
-  command.mut_platform().mut_properties().sort_by(|x, y| {
-    match x.name.cmp(&y.name) {
+  command
+    .mut_platform()
+    .mut_properties()
+    .sort_by(|x, y| match x.name.cmp(&y.name) {
       Ordering::Equal => x.value.cmp(&y.value),
       v => v,
-    }
-  });
+    });
 
   let mut action = bazel_protos::remote_execution::Action::new();
   action.set_command_digest((&digest(&command)?).into());

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::mem::drop;
 use std::path::PathBuf;
@@ -858,6 +859,22 @@ pub fn make_execute_request(
       property
     });
   }
+
+  // Sort the platform properties.
+  //
+  // From the remote execution spec:
+  //   The properties that make up this platform. In order to ensure that
+  //   equivalent `Platform`s always hash to the same value, the properties MUST
+  //   be lexicographically sorted by name, and then by value. Sorting of strings
+  //   is done by code point, equivalently, by the UTF-8 bytes.
+  //
+  // Note: BuildBarn enforces this requirement.
+  command.mut_platform().mut_properties().sort_by(|x, y| {
+    match x.name.cmp(&y.name) {
+      Ordering::Equal => x.value.cmp(&y.value),
+      v => v,
+    }
+  });
 
   let mut action = bazel_protos::remote_execution::Action::new();
   action.set_command_digest((&digest(&command)?).into());

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -408,14 +408,8 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   });
   want_command.mut_platform().mut_properties().push({
     let mut property = bazel_protos::remote_execution::Platform_Property::new();
-    property.set_name("Multi".to_owned());
-    property.set_value("uno".to_owned());
-    property
-  });
-  want_command.mut_platform().mut_properties().push({
-    let mut property = bazel_protos::remote_execution::Platform_Property::new();
-    property.set_name("last".to_owned());
-    property.set_value("bar".to_owned());
+    property.set_name("JDK_SYMLINK".to_owned());
+    property.set_value(".jdk".to_owned());
     property
   });
   want_command.mut_platform().mut_properties().push({
@@ -426,8 +420,14 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   });
   want_command.mut_platform().mut_properties().push({
     let mut property = bazel_protos::remote_execution::Platform_Property::new();
-    property.set_name("JDK_SYMLINK".to_owned());
-    property.set_value(".jdk".to_owned());
+    property.set_name("Multi".to_owned());
+    property.set_value("uno".to_owned());
+    property
+  });
+  want_command.mut_platform().mut_properties().push({
+    let mut property = bazel_protos::remote_execution::Platform_Property::new();
+    property.set_name("last".to_owned());
+    property.set_value("bar".to_owned());
     property
   });
   want_command.mut_platform().mut_properties().push({
@@ -441,7 +441,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   want_action.set_command_digest(
     (&Digest(
       Fingerprint::from_hex_string(
-        "6c63c44ac364729d371931a091cc8379e32d021e06df52ab5f8461118d837e78",
+        "741a33b863aaa595e2be6a316f9ae187e3c0d8cf8a8054261417eebbede0cefe",
       )
       .unwrap(),
       118,
@@ -454,7 +454,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   want_execute_request.set_action_digest(
     (&Digest(
       Fingerprint::from_hex_string(
-        "5246770d23d09dc7d145e19d3a7b8233fc42316115fbc5420dfe501fb684e5e9",
+        "c3dc9c1e73f5cdfbf7e3b55dd6dead4f6fe03323dc19db87b27617fede27e9b4",
       )
       .unwrap(),
       140,


### PR DESCRIPTION
### Problem

The Remote Execution specifications [requires platform properties to be sorted so that the `Command` protobuf hashes consistently](https://github.com/bazelbuild/remote-apis/blob/7802003e00901b4e740fe0ebec1243c221e02ae2/build/bazel/remote/execution/v2/remote_execution.proto#L603):

>The properties that make up this platform. In order to ensure that
>equivalent `Platform`s always hash to the same value, the properties MUST
>be lexicographically sorted by name, and then by value. Sorting of strings
>is done by code point, equivalently, by the UTF-8 bytes.

I encountered this issue when pointing Pants at a BuildBarn cluster. BuildBarn enforces the sorting requirement and so execution requests fail if the platform properties are not sorted.

### Solution

Sort the platform properties submitted for remote execution requests.

### Result

Requests submitted to BuildBarn no longer fail because platform properties were not sorted.
