### PR TITLE
Deprecate `pants.ini` in favor of `pants.toml`

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -7,6 +7,7 @@ import io
 import itertools
 import os
 import re
+import textwrap
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ import toml
 from typing_extensions import Literal
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
+from pants.base.deprecated import warn_or_error
 from pants.option.ranked_value import Value
 from pants.util.eval import parse_expression
 from pants.util.ordered_set import OrderedSet
@@ -105,6 +107,43 @@ class Config(ABC):
                 }
                 config_values = _TomlValues(toml_values)
             else:
+                script_instructions = (
+                    "curl -L -o migrate_to_toml_config.py 'https://git.io/Jv02R' && chmod +x "
+                    f"migrate_to_toml_config.py && ./migrate_to_toml_config.py {config_path}"
+                )
+                msg = [
+                    textwrap.fill(
+                        "Pants now supports TOML config files. TOML is inspired by the INI "
+                        "file format, and makes several improvements and removes many gotchas. For "
+                        "example, you no longer need to worry about indentation for "
+                        "list and dict options.",
+                        88,
+                    ),
+                    "\n",
+                    textwrap.fill(
+                        "To migrate, we recommend using our migration "
+                        f"script by running `{script_instructions}`.",
+                        88,
+                    ),
+                    "\n",
+                    textwrap.fill(
+                        "You must also upgrade your `./pants` script to understand pants.toml by "
+                        "running `curl -L -o ./pants https://pantsbuild.github.io/setup/pants`.",
+                        88,
+                    ),
+                    "\n",
+                    textwrap.fill(
+                        "See https://pants.readme.io/docs/options for more information on how to "
+                        "set each option type, including adding and removing from a list option "
+                        "and using dict options.",
+                        88,
+                    ),
+                ]
+                warn_or_error(
+                    removal_version="1.31.0.dev0",
+                    deprecated_entity_description="INI config files (`pants.ini`)",
+                    hint="\n".join(msg),
+                )
                 ini_parser = configparser.ConfigParser(defaults=normalized_seed_values)
                 ini_parser.read_string(content.decode())
                 config_values = _IniValues(ini_parser)

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -5,12 +5,12 @@ import json
 import os
 import shlex
 import unittest.mock
-from contextlib import contextmanager
 from enum import Enum
 from functools import partial
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Union, cast
 
+import toml
 import yaml
 from packaging.version import Version
 
@@ -69,16 +69,10 @@ def subsystem(scope: str) -> ScopeInfo:
 
 
 class OptionsTest(TestBase):
-    @contextmanager
-    def _write_config_to_file(self, fp, config):
-        for section, options in config.items():
-            fp.write(f"[{section}]\n")
-            for key, value in options.items():
-                fp.write(f"{key}: {value}\n")
-
-    def _create_config(self, config: Optional[Dict[str, Dict[str, str]]] = None) -> Config:
-        with open(os.path.join(safe_mkdtemp(), "test_config.ini"), "w") as fp:
-            self._write_config_to_file(fp, config or {})
+    @staticmethod
+    def _create_config(config: Optional[Dict[str, Dict[str, str]]] = None) -> Config:
+        with open(os.path.join(safe_mkdtemp(), "test_config.toml"), "w") as fp:
+            toml.dump(config or {}, fp)
         return Config.load(config_paths=[fp.name])
 
     def _parse(


### PR DESCRIPTION
We originally did not deprecate `pants.ini` per a request from Twitter, as they have dozens of scripts that read from the INI file and it would have taken substantial time to fix.

However, Twitter will no longer be upgrading to the latest version of Pants. Further, according to users on Slack, the vast majority of users have upgraded to pants.toml without much issue.

We want to get rid of `pants.ini` because it presents some maintenance cost. For example, we're exploring moving part of options parsing to Rust. It will be much easier to do if we only ever have TOML config files, and don't need to support INI.

[ci skip-rust-tests]
[ci skip-jvm-tests]