### PR TITLE
Enforce that Python targets only have `.py` files in their `sources` field

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-from pathlib import PurePath
 from typing import Iterable, Optional, Sequence, Tuple, Union, cast
 
 from pants.backend.python.python_artifact import PythonArtifact

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -7,7 +7,6 @@ from typing import Iterable, Optional, Sequence, Tuple, Union, cast
 
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
-from pants.base.deprecated import deprecated_conditional
 from pants.core.util_rules.determine_source_files import SourceFiles
 from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot
@@ -37,22 +36,7 @@ from pants.python.python_setup import PythonSetup
 
 
 class PythonSources(Sources):
-    # TODO: uncomment this once done with the deprecation of using non-Python files.
-    # expected_file_extensions = (".py",)
-    def validate_snapshot(self, snapshot: Snapshot) -> None:
-        super().validate_snapshot(snapshot)
-        non_python_files = [fp for fp in snapshot.files if PurePath(fp).suffix != ".py"]
-        deprecated_conditional(
-            lambda: bool(non_python_files),
-            entity_description="Python targets including non-Python files",
-            removal_version="1.29.0.dev2",
-            hint_message=(
-                f"The {repr(self.alias)} field in target {self.address} should only contain "
-                f"files that end in '.py', but it had these files: {sorted(non_python_files)}.\n\n"
-                "Instead, put those files in another target, like a `resources` target, and add "
-                "that target to the `dependencies` field of this target."
-            ),
-        )
+    expected_file_extensions = (".py",)
 
 
 class PythonInterpreterCompatibility(StringOrStringSequenceField):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1290,6 +1290,8 @@ class Sources(AsyncField):
                 raise InvalidFieldException(
                     f"The {repr(self.alias)} field in target {self.address} must only contain "
                     f"files that end in {expected}, but it had these files: {sorted(bad_files)}."
+                    f"\n\nMaybe create a `resources()` or `files()` target and include it in the "
+                    f"`dependencies` field?"
                 )
         if self.expected_num_files is not None:
             num_files = len(snapshot.files)


### PR DESCRIPTION
This is an important assumption we rely on, such as when writing the Dependency Inference rule for PythonSources.

[ci skip-rust-tests]
[ci skip-jvm-tests]
