### PR TITLE
Fix extraneous blank lines

### DIFF
--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -83,7 +83,7 @@ class Console:
         self.stderr.write(payload)
 
     def print_stdout(self, payload, end="\n"):
-        print(payload, file=self.stdout, end=end)
+        self.stdout.write(f"{payload}{end}")
 
     def print_stderr(self, payload, end="\n"):
         self.stderr.write(f"{payload}{end}")

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -86,7 +86,7 @@ class Console:
         print(payload, file=self.stdout, end=end)
 
     def print_stderr(self, payload, end="\n"):
-        print(payload, file=self.stderr, end=end)
+        self.stderr.write(f"{payload}{end}")
 
     def flush(self):
         self.stdout.flush()


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/9806

### Solution

The `print_stderr` method in `console.py` seemed to be making two separate calls to the underlying writer, one for the payload, and another for the ending. In the dynamic UI case, this was causing the `Bar::println` method provided by the `indicatif` library to be called twice to print stdout above the swim lanes, which entailed printing extraneous newlines. Rewriting `print_stderr` to avoid the call to `print` with a redirected `file` kwarg seems to have fixed it.

This commit also changes `print_stdout` to avoid calling the std library `print` function, even though stdout doesn't interact with the `indicatif` library in the same way, in order to reduce future developer confusion over why there are two separate and slightly-different ways to put some text on the screen.

### Result

The asciinema recording https://asciinema.org/a/334572 shows that the printed output with `--no-dynamic-ui` is identical to the default output where the dynamic UI is turned on.
