### PR TITLE
Implement `load` in pants for easier macros

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/BUILD
@@ -4,6 +4,7 @@
 target(
   name = 'all_directories',
   dependencies = [
+    ':build_file_macros_directory',
     ':fact_directory',
     ':hello_directory',
     ':jvm_run_directory',
@@ -12,6 +13,11 @@ target(
     ':several_scala_targets_directory',
     ':styleissue_directory',
   ],
+)
+
+files(
+  name = 'build_file_macros_directory',
+  sources = ['build_file_macros/**/*'],
 )
 
 page(

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
@@ -1,13 +1,8 @@
-load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "my_func")
-#def my_func():
-#    return ['examples/src/scala/org/pantsbuild/example/hello/welcome:welcome']
-
-
-def my_source():
-  return 'Exe.scala'
+load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "dep_on_welcome")
+load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2", "source_exe_scala")
 
 jvm_binary(
   main="org.pantsbuild.example.build_file_macros.Exe",
-  source=my_source(),
-  dependencies=my_func()
+  source=source_exe_scala(),
+  dependencies=dep_on_welcome()
 )

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
@@ -1,0 +1,13 @@
+load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "my_func")
+#def my_func():
+#    return ['examples/src/scala/org/pantsbuild/example/hello/welcome:welcome']
+
+
+def my_source():
+  return 'Exe.scala'
+
+jvm_binary(
+  main="org.pantsbuild.example.build_file_macros.Exe",
+  source=my_source(),
+  dependencies=my_func()
+)

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
@@ -3,6 +3,6 @@ load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2
 
 jvm_binary(
   main="org.pantsbuild.example.build_file_macros.Exe",
-  source=source_exe_scala(),
+  sources=source_exe_scala(),
   dependencies=dep_on_welcome()
 )

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
@@ -1,0 +1,2 @@
+def my_func():
+    return ['examples/src/scala/org/pantsbuild/example/hello/welcome:welcome']

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
@@ -1,2 +1,4 @@
-def my_func():
+def dep_on_welcome():
+
     return ['examples/src/scala/org/pantsbuild/example/hello/welcome:welcome']
+

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2
@@ -1,0 +1,2 @@
+def source_exe_scala():
+  return ["Exe.scala"]

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_3
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_3
@@ -1,0 +1,2 @@
+def source_exe_scala():
+  return ["Exe.scala"]

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/Exe.scala
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/Exe.scala
@@ -1,0 +1,35 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.build_file_macros
+
+import java.io.{BufferedReader, InputStreamReader}
+
+import org.pantsbuild.example.hello.welcome
+
+// A simple jvm binary to illustrate Scala BUILD targets
+
+object Exe {
+  /** Test that resources are properly namespaced. */
+  def getWorld: String = {
+    val is =
+      this.getClass.getClassLoader.getResourceAsStream(
+        "org/pantsbuild/example/hello/world.txt"
+      )
+    try {
+      new BufferedReader(new InputStreamReader(is)).readLine()
+    } finally {
+      is.close()
+    }
+  }
+
+  def main(args: Array[String]) {
+    println("Num args passed: " + args.size + ". Stand by for welcome...")
+    if (args.size <= 0) {
+      println("Hello, " + getWorld + "!")
+    } else {
+      val w = welcome.WelcomeEverybody(args)
+      w.foreach(s => println(s))
+    }
+  }
+}

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -94,6 +94,7 @@ python_library(
     ':objects',
     ':selectors',
     ':struct',
+    ':load_statements',
     'src/python/pants/base:project_tree',
     'src/python/pants/build_graph',
     'src/python/pants/util:collections',
@@ -111,6 +112,7 @@ python_library(
     '3rdparty/python:dataclasses',
     ':objects',
     ':parser',
+    ':load_statements',
     'src/python/pants/build_graph',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
@@ -144,6 +146,16 @@ python_library(
 )
 
 python_library(
+    name='load_statements',
+    sources=['load_statements.py'],
+    dependencies=[
+        ':fs',
+        ':objects',
+        ':selectors',
+    ]
+)
+
+python_library(
   name='nodes',
   sources=['nodes.py'],
   dependencies=[
@@ -170,6 +182,7 @@ python_library(
   dependencies=[
     '3rdparty/python:dataclasses',
     ':struct',
+    ':load_statements',
   ],
   tags = {"partially_type_checked"},
 )

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -39,7 +39,8 @@ def _key_func(entry):
     return key
 
 class LoadedSymbolsToExpose(Collection[str]):
-    pass
+    def __str__(self):
+        return str([i for i in self])
 
 @dataclass(frozen=True)
 class LoadStatement:
@@ -119,7 +120,6 @@ async def load_symbols(build_file_contents: FilesContent) -> BuildFilesWithLoads
             Get[LoadStatementWithContent](LoadStatement, load_statement)
                 for load_statement in load_statements
         )
-        print(f"BL:load_statements_with_content {load_statements_with_content}")
 
         # At this point, I have a Map[build_file_path, List[LoadStatementWIthContent]]
         build_files_with_loads[build_file] = load_statements_with_content
@@ -143,13 +143,11 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
     files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
     build_files_with_loads = await Get[BuildFilesWithLoads](FilesContent, files_content)
 
-    print(f"BL: {build_files_with_loads}")
     if not files_content:
         raise ResolveError(
             'Directory "{}" does not contain any BUILD files.'.format(directory.path)
         )
     address_maps = []
-    print(f"BL: BUILDFILESWITHLOADS {build_files_with_loads}")
     for (filecontent_product, load_statements) in build_files_with_loads.map.items():
         address_maps.append(
             AddressMap.parse(

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -2,11 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-import ast
 import os.path
 from collections.abc import MutableMapping, MutableSequence
-from dataclasses import dataclass
-from typing import Dict, Iterable
+from typing import Dict
 
 from twitter.common.collections import OrderedSet
 
@@ -22,9 +20,15 @@ from pants.engine.addressable import (
     AddressWithOrigin,
     BuildFileAddresses,
 )
-from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot
+from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
+from pants.engine.load_statements import (
+    BuildFilesWithLoads,
+    load_symbols,
+    parse_build_file_for_load_statements,
+    snapshot_load_statement,
+)
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper
-from pants.engine.objects import Collection, Locatable, SerializableFactory, Validatable
+from pants.engine.objects import Locatable, SerializableFactory, Validatable
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -39,107 +43,6 @@ class ResolvedTypeMismatchError(ResolveError):
 def _key_func(entry):
     key, value = entry
     return key
-
-
-class LoadedSymbolsToExpose(Collection[str]):
-    def __str__(self):
-        return str([i for i in self])
-
-
-@dataclass(frozen=True)
-class LoadStatement:
-    """A load statement is of the form: load("path/to/a:file.py", "symbol1", "symbol2"...)
-
-    This will import "symbol1", "symbol2"... from file "path/to/a:file.py".
-
-    Note: The syntax is inspired by Bazel's load statements:
-        https://docs.bazel.build/versions/master/build-ref.html#load
-
-    Note: Load statements are always evaluated before anything else in the file,
-        so imported symbols can be reassigned.
-    """
-
-    path: str
-    symbols_to_expose: LoadedSymbolsToExpose
-
-
-class LoadStatements(Collection[LoadStatement]):
-    pass
-
-
-@dataclass(frozen=True)
-class LoadStatementWithContent:
-    path: str
-    content: FileContent
-    symbols_to_expose: LoadedSymbolsToExpose
-
-
-@dataclass(frozen=True)
-class BuildFilesWithLoads:
-    map: Dict[FileContent, Collection[LoadStatementWithContent]]
-
-
-@rule
-async def snapshot_load_statement(statement: LoadStatement) -> LoadStatementWithContent:
-    snapshot = await Get[Snapshot](PathGlobs(globs=(statement.path,)))
-    files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
-    file_content_list = [fc for fc in files_content]
-    if len(file_content_list) != 1:
-        raise ResolveError(f'Tried to load non existing file: "{statement.path}"')
-    file_content = file_content_list[0]
-    return LoadStatementWithContent(
-        path=statement.path, content=file_content, symbols_to_expose=statement.symbols_to_expose
-    )
-
-
-@rule
-async def parse_build_file_for_load_statements(content: FileContent) -> LoadStatements:
-    class LoadParser(ast.NodeVisitor):
-        """A utility class that parses load() calls in BUILD files."""
-
-        def __init__(self):
-            self.loads: list[LoadStatement] = []
-
-        def _path_from_label(self, label):
-            if label[0:2] == "//":
-                label = f"{label[2:]}"
-            label = label.replace(":", "/")
-            return label
-
-        def visit_Call(self, node):
-            if isinstance(node.func, ast.Name):
-                if node.func.id == "load":
-                    strargs = [arg.s for arg in node.args]
-                    source_file = self._path_from_label(strargs[0])
-                    exposed_symbols = strargs[1:]
-                    self.loads.append(
-                        LoadStatement(source_file, LoadedSymbolsToExpose(exposed_symbols))
-                    )
-
-        @staticmethod
-        def parse_loads(python_code: str) -> Iterable[LoadStatement]:
-            """Parse the python code searching for load statements."""
-            load_parser = LoadParser()
-            parsed = ast.parse(python_code)
-            load_parser.visit(parsed)
-            return load_parser.loads
-
-    return LoadStatements(LoadParser.parse_loads(content.content.decode()))
-
-
-@rule
-async def load_symbols(build_file_contents: FilesContent) -> BuildFilesWithLoads:
-    build_files_with_loads = {}
-    for build_file in build_file_contents:
-        load_statements = await Get[LoadStatements](FileContent, build_file)
-        load_statements_with_content = await MultiGet(
-            Get[LoadStatementWithContent](LoadStatement, load_statement)
-            for load_statement in load_statements
-        )
-
-        build_files_with_loads[build_file] = Collection(load_statements_with_content)
-
-    return BuildFilesWithLoads(build_files_with_loads)
 
 
 @rule

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -28,6 +28,7 @@ python_library(
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',
+    'src/python/pants/engine:build_files',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -14,8 +14,8 @@ from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import UnaddressableObjectError
 from pants.base.parse_context import ParseContext
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.build_files import LoadStatementWithContent
 from pants.engine.legacy.structs import BundleAdaptor, Globs, RGlobs, TargetAdaptor, ZGlobs
+from pants.engine.load_statements import LoadStatementWithContent
 from pants.engine.objects import Serializable
 from pants.engine.parser import ParseError, Parser, SymbolTable
 from pants.option.global_options import BuildFileImportsBehavior

--- a/src/python/pants/engine/load_statements.py
+++ b/src/python/pants/engine/load_statements.py
@@ -1,0 +1,114 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+import ast
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+from pants.base.exceptions import ResolveError
+from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot
+from pants.engine.objects import Collection
+from pants.engine.rules import rule
+from pants.engine.selectors import Get, MultiGet
+
+
+class LoadedSymbolsToExpose(Collection[str]):
+    def __str__(self):
+        return str([i for i in self])
+
+
+@dataclass(frozen=True)
+class LoadStatement:
+    """A load statement is of the form: load("path/to/a:file.py", "symbol1", "symbol2"...)
+
+    This will import "symbol1", "symbol2"... from file "path/to/a:file.py".
+
+    Note: The syntax is inspired by Bazel's load statements:
+        https://docs.bazel.build/versions/master/build-ref.html#load
+
+    Note: Load statements are always evaluated before anything else in the file,
+        so imported symbols can be reassigned.
+    """
+
+    path: str
+    symbols_to_expose: LoadedSymbolsToExpose
+
+
+class LoadStatements(Collection[LoadStatement]):
+    pass
+
+
+@dataclass(frozen=True)
+class LoadStatementWithContent:
+    path: str
+    content: FileContent
+    symbols_to_expose: LoadedSymbolsToExpose
+
+
+@dataclass(frozen=True)
+class BuildFilesWithLoads:
+    map: Dict[FileContent, Collection[LoadStatementWithContent]]
+
+
+@rule
+async def snapshot_load_statement(statement: LoadStatement) -> LoadStatementWithContent:
+    snapshot = await Get[Snapshot](PathGlobs(globs=(statement.path,)))
+    files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
+    file_content_list = [fc for fc in files_content]
+    if len(file_content_list) != 1:
+        raise ResolveError(f'Tried to load non existing file: "{statement.path}"')
+    file_content = file_content_list[0]
+    return LoadStatementWithContent(
+        path=statement.path, content=file_content, symbols_to_expose=statement.symbols_to_expose
+    )
+
+
+@rule
+async def parse_build_file_for_load_statements(content: FileContent) -> LoadStatements:
+    class LoadParser(ast.NodeVisitor):
+        """A utility class that parses load() calls in BUILD files."""
+
+        def __init__(self):
+            self.loads: list[LoadStatement] = []
+
+        def _path_from_label(self, label):
+            if label[0:2] == "//":
+                label = f"{label[2:]}"
+            label = label.replace(":", "/")
+            return label
+
+        def visit_Call(self, node):
+            if isinstance(node.func, ast.Name):
+                if node.func.id == "load":
+                    strargs = [arg.s for arg in node.args]
+                    source_file = self._path_from_label(strargs[0])
+                    exposed_symbols = strargs[1:]
+                    self.loads.append(
+                        LoadStatement(source_file, LoadedSymbolsToExpose(exposed_symbols))
+                    )
+
+        @staticmethod
+        def parse_loads(python_code: str) -> Iterable[LoadStatement]:
+            """Parse the python code searching for load statements."""
+            load_parser = LoadParser()
+            parsed = ast.parse(python_code)
+            load_parser.visit(parsed)
+            return load_parser.loads
+
+    return LoadStatements(LoadParser.parse_loads(content.content.decode()))
+
+
+@rule
+async def load_symbols(build_file_contents: FilesContent) -> BuildFilesWithLoads:
+    build_files_with_loads = {}
+    for build_file in build_file_contents:
+        load_statements = await Get[LoadStatements](FileContent, build_file)
+        load_statements_with_content = await MultiGet(
+            Get[LoadStatementWithContent](LoadStatement, load_statement)
+            for load_statement in load_statements
+        )
+
+        build_files_with_loads[build_file] = Collection(load_statements_with_content)
+
+    return BuildFilesWithLoads(build_files_with_loads)

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from pants.base.exceptions import DuplicateNameError, MappingError, UnaddressableObjectError
 from pants.build_graph.address import BuildFileAddress
+# from pants.engine.build_files import LoadStatementWithContent
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
 from pants.util.memo import memoized_property
@@ -29,7 +30,7 @@ class AddressMap:
     objects_by_name: Dict[str, ThinAddressableObject]
 
     @classmethod
-    def parse(cls, filepath: str, filecontent: bytes, parser: Parser) -> "AddressMap":
+    def parse(cls, filepath: str, filecontent: bytes, load_statements, parser: Parser) -> "AddressMap":
         """Parses a source for addressable Serializable objects.
 
         No matter the parser used, the parsed and mapped addressable objects are all 'thin'; ie: any
@@ -41,7 +42,7 @@ class AddressMap:
         :param parser: The parser cls to use.
         """
         try:
-            objects = parser.parse(filepath, filecontent)
+            objects = parser.parse(filepath, filecontent, load_statements)
         except Exception as e:
             raise MappingError(f"Failed to parse {filepath}:\n{e!r}")
         objects_by_name: Dict[str, ThinAddressableObject] = {}

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from pants.base.exceptions import DuplicateNameError, MappingError, UnaddressableObjectError
 from pants.build_graph.address import BuildFileAddress
-# from pants.engine.build_files import LoadStatementWithContent
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
 from pants.util.memo import memoized_property
@@ -30,7 +29,9 @@ class AddressMap:
     objects_by_name: Dict[str, ThinAddressableObject]
 
     @classmethod
-    def parse(cls, filepath: str, filecontent: bytes, load_statements, parser: Parser) -> "AddressMap":
+    def parse(
+        cls, filepath: str, filecontent: bytes, load_statements, parser: Parser
+    ) -> "AddressMap":
         """Parses a source for addressable Serializable objects.
 
         No matter the parser used, the parsed and mapped addressable objects are all 'thin'; ie: any

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from pants.base.exceptions import DuplicateNameError, MappingError, UnaddressableObjectError
 from pants.build_graph.address import BuildFileAddress
+from pants.engine.load_statements import LoadStatementWithContent
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
 from pants.util.memo import memoized_property
@@ -30,7 +31,11 @@ class AddressMap:
 
     @classmethod
     def parse(
-        cls, filepath: str, filecontent: bytes, load_statements, parser: Parser
+        cls,
+        filepath: str,
+        filecontent: bytes,
+        load_statements: Iterable[LoadStatementWithContent],
+        parser: Parser,
     ) -> "AddressMap":
         """Parses a source for addressable Serializable objects.
 

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -3,8 +3,9 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Type
+from typing import Dict, Iterable, Type
 
+from pants.engine.load_statements import LoadStatementWithContent
 from pants.engine.struct import Struct
 
 
@@ -33,7 +34,9 @@ class HydratedStruct:
 
 class Parser(ABC):
     @abstractmethod
-    def parse(self, filepath: str, filecontent: bytes, load_statements):
+    def parse(
+        self, filepath: str, filecontent: bytes, load_statements: Iterable[LoadStatementWithContent]
+    ):
         """
         :param filepath: The name of the file being parsed. The parser should not assume that the path
                          is accessible, and should consume the filecontent.

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -3,9 +3,8 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Type, Iterable
+from typing import Dict, Type
 
-# from pants.engine.build_files import LoadStatementWithContent
 from pants.engine.struct import Struct
 
 

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -3,8 +3,9 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Type
+from typing import Dict, Type, Iterable
 
+# from pants.engine.build_files import LoadStatementWithContent
 from pants.engine.struct import Struct
 
 
@@ -33,7 +34,7 @@ class HydratedStruct:
 
 class Parser(ABC):
     @abstractmethod
-    def parse(self, filepath: str, filecontent: bytes):
+    def parse(self, filepath: str, filecontent: bytes, load_statements):
         """
         :param filepath: The name of the file being parsed. The parser should not assume that the path
                          is accessible, and should consume the filecontent.

--- a/testprojects/src/scala/org/pantsbuild/testproject/build_file_macros/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/build_file_macros/BUILD
@@ -1,0 +1,9 @@
+load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "dep_on_welcome")
+# source_exe_scala should come from this file, but we don't expose it.
+load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2")
+
+jvm_binary(
+  main="org.pantsbuild.example.build_file_macros.Exe",
+  source=source_exe_scala(),
+  dependencies=dep_on_welcome()
+)

--- a/testprojects/src/scala/org/pantsbuild/testproject/build_file_macros/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/build_file_macros/BUILD
@@ -1,9 +1,0 @@
-load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "dep_on_welcome")
-# source_exe_scala should come from this file, but we don't expose it.
-load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2")
-
-jvm_binary(
-  main="org.pantsbuild.example.build_file_macros.Exe",
-  source=source_exe_scala(),
-  dependencies=dep_on_welcome()
-)

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -110,6 +110,7 @@ python_tests(
     ':scheduler_test_base',
     'src/python/pants/build_graph',
     'src/python/pants/engine:build_files',
+    'src/python/pants/engine:load_statements',
     'src/python/pants/engine/legacy:structs',
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:parser',

--- a/tests/python/pants_test/engine/examples/parsers.py
+++ b/tests/python/pants_test/engine/examples/parsers.py
@@ -62,7 +62,7 @@ class JsonParser(Parser):
         )
         return JSONDecoder(object_hook=decoder, strict=True)
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, load_statements=None):
         """Parse the given json encoded string into a list of top-level objects found.
 
         The parser accepts both blank lines and comment lines (those beginning with optional whitespace
@@ -71,6 +71,8 @@ class JsonParser(Parser):
         The parse also supports a simple protocol for serialized types that have an `_asdict` method.
         This includes `namedtuple` subtypes as well as any custom class with an `_asdict` method defined;
         see :class:`pants.engine.serializable.Serializable`.
+
+        Note: We ignore load statements in JSON Build files
         """
         json = ensure_text(filecontent)
 
@@ -225,7 +227,9 @@ class PythonAssignmentsParser(Parser):
             parse_globals[alias] = functools.partial(aliased, alias, symbol)
         return parse_globals
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, load_statements=None):
+        # Note: This parser is used for testing, we ignore load statements.
+
         parse_globals = self._globals
 
         python = filecontent
@@ -287,7 +291,9 @@ class PythonCallbacksParser(Parser):
             parse_globals[alias] = functools.partial(registered, alias, symbol)
         return objects, parse_globals
 
-    def parse(self, filepath, filecontent):
+    def parse(self, filepath, filecontent, load_statements=None):
+        # Note: This parser is used for testing, we ignore load statements.
+
         objects, parse_globals = self._globals
 
         python = filecontent

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -205,6 +205,18 @@ python_tests(
   tags = {"partially_type_checked"},
 )
 
+
+python_tests(
+    name = "parser_integration",
+    dependencies = [
+        'src/python/pants/testutil:int-test',
+        'tests/python/pants_test/pantsd:pantsd_integration_test_base',
+        'examples/src/scala/org/pantsbuild/example:build_file_macros_directory',
+    ],
+    tags = {"integration", "partially_type_checked"},
+    timeout = 180,
+)
+
 python_tests(
   name = 'structs',
   sources = ['test_structs.py'],

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -208,13 +208,14 @@ python_tests(
 
 python_tests(
     name = "parser_integration",
+    sources = ['test_parser_integration.py'],
     dependencies = [
         'src/python/pants/testutil:int-test',
         'tests/python/pants_test/pantsd:pantsd_integration_test_base',
         'examples/src/scala/org/pantsbuild/example:build_file_macros_directory',
     ],
     tags = {"integration", "partially_type_checked"},
-    timeout = 180,
+    timeout = 300,
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -18,7 +18,7 @@ class LegacyPythonCallbacksParserTest(unittest.TestCase):
             build_file_imports_behavior=BuildFileImportsBehavior.warn,
         )
         # Call to import a module should succeed.
-        parser.parse("/dev/null", b"""import os; os.path.join('x', 'y')""")
+        parser.parse("/dev/null", b"""import os; os.path.join('x', 'y')""", [])
         # But the imported module should not be visible as a symbol in further parses.
         with self.assertRaises(NameError):
-            parser.parse("/dev/null", b"""os.path.join('x', 'y')""")
+            parser.parse("/dev/null", b"""os.path.join('x', 'y')""", [])

--- a/tests/python/pants_test/engine/legacy/test_parser_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_parser_integration.py
@@ -1,0 +1,148 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.base.build_environment import get_buildroot
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_file_dump
+from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
+
+
+class LoadStatementsIntegrationTests(PantsDaemonIntegrationTestBase):
+    @contextmanager
+    def _mock_broken_project_dir(self, build_file_content):
+        with temporary_dir(root_dir=get_buildroot()) as tmpdir:
+            bad_build_file = os.path.join(tmpdir, "BUILD")
+            safe_file_dump(bad_build_file, build_file_content)
+            yield tmpdir
+
+    def test_files_with_load_statements_parse(self):
+        pants_run = self.do_command(
+            "list", "examples/src/scala/org/pantsbuild/example/build_file_macros", success=True
+        )
+        assert {
+            "examples/src/scala/org/pantsbuild/example/build_file_macros:build_file_macros"
+        } == set(pants_run.stdout_data.splitlines())
+
+    def test_only_load_specified_symbols(self):
+        fail_to_load_symbols_build_file = dedent(
+            """
+            # source_exe_scala should come from this file, but we don't expose it.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2")
+            
+            jvm_binary(
+              main="org.pantsbuild.example.build_file_macros.Exe",
+              sources=source_exe_scala(),
+            )
+            """
+        )
+
+        with self._mock_broken_project_dir(fail_to_load_symbols_build_file) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
+            assert "name 'source_exe_scala' is not defined" in pants_run.stderr_data
+
+    def test_cannot_load_symbol_twice(self):
+        load_symbol_from_multiple_files = dedent(
+            """
+            # We try to load the same symbol from two different files.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2", "source_exe_scala")
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_3", "source_exe_scala")
+
+            jvm_binary(
+              main="org.pantsbuild.example.build_file_macros.Exe",
+              sources=source_exe_scala(),
+            )
+            """
+        )
+
+        with self._mock_broken_project_dir(load_symbol_from_multiple_files) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
+            assert "Which has already been loaded from another file." in pants_run.stderr_data
+
+    def test_cannot_load_non_existing_symbol(self):
+        load_non_existing_symbol = dedent(
+            """
+            # We try to load the same symbol from two different files.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "bad_symbol")
+
+            jvm_binary(
+              main="org.pantsbuild.example.build_file_macros.Exe",
+              sources=bad_symbol(),
+            )
+            """
+        )
+
+        with self._mock_broken_project_dir(load_non_existing_symbol) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
+            assert "Symbol is not exported by loaded file." in pants_run.stderr_data
+
+    def test_cannot_load_non_existing_file(self):
+        load_non_existing_symbol = dedent(
+            """
+            # We try to load the same symbol from two different files.
+            load("non/existing/file", "mock_sources")
+
+            jvm_binary(
+              main="org.pantsbuild.example.build_file_macros.Exe",
+              source=mock_sources(),
+            )
+            """
+        )
+
+        with self._mock_broken_project_dir(load_non_existing_symbol) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
+            assert 'Tried to load non existing file: "non/existing/file"' in pants_run.stderr_data
+
+    def test_loads_dont_pollute_other_files(self):
+        fail_to_load_symbols_build_file = dedent(
+            """
+            # source_exe_scala should come from this file, but we don't expose it.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2")
+
+            jvm_binary(
+              main="org.pantsbuild.example.build_file_macros.Exe",
+              sources=source_exe_scala(),
+            )
+            """
+        )
+        with self._mock_broken_project_dir(fail_to_load_symbols_build_file) as tmpdir:
+            pants_run = self.do_command(
+                "list",
+                "examples/src/scala/org/pantsbuild/example/build_file_macros",
+                f"{tmpdir}",
+                success=False,
+            )
+            assert "name 'source_exe_scala' is not defined" in pants_run.stderr_data
+
+    def test_changing_macro_file_invalidates_build_parsing(self):
+        # Create a BUILD file in a nested temporary directory, and add additional targets to it.
+        with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _), temporary_dir(
+            root_dir=get_buildroot()
+        ) as tmpdir:
+
+            macro_file_path = os.path.join(tmpdir, "BUILD_MACRO")
+
+            safe_file_dump(
+                os.path.join(tmpdir, "BUILD"),
+                dedent(
+                    f"""
+                load("{macro_file_path}", "my_name")
+                target(name=my_name())
+                """
+                ),
+            )
+
+            def change_name_macro_and_run_list(name):
+                safe_file_dump(macro_file_path, f"def my_name(): return '{name}'")
+
+                daemon_run = pantsd_run(["list", f"{tmpdir}::"])
+                checker.assert_running()
+
+                assert f"{tmpdir}:{name}" in daemon_run.stdout_data
+
+            # Replace the BUILD file content twice.
+            change_name_macro_and_run_list("name_one")
+            change_name_macro_and_run_list("name_two")

--- a/tests/python/pants_test/engine/legacy/test_parser_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_parser_integration.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_dump
+from pants.util.dirutil import fast_relpath, safe_file_dump
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
@@ -125,11 +125,13 @@ class LoadStatementsIntegrationTests(PantsDaemonIntegrationTestBase):
 
             macro_file_path = os.path.join(tmpdir, "BUILD_MACRO")
 
+            rel_macro_file_path = fast_relpath(macro_file_path, get_buildroot())
+
             safe_file_dump(
                 os.path.join(tmpdir, "BUILD"),
                 dedent(
                     f"""
-                load("{macro_file_path}", "my_name")
+                load("{rel_macro_file_path}", "my_name")
                 target(name=my_name())
                 """
                 ),

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -20,8 +20,10 @@ from pants.engine.build_files import (
 )
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
+from pants.engine.load_statements import BuildFilesWithLoads
 from pants.engine.mapper import AddressFamily, AddressMapper
 from pants.engine.nodes import Return, State, Throw
+from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.scheduler import ExecutionRequest, SchedulerSession
@@ -40,6 +42,7 @@ class ParseAddressFamilyTest(unittest.TestCase):
     def test_empty(self) -> None:
         """Test that parsing an empty BUILD file results in an empty AddressFamily."""
         address_mapper = AddressMapper(JsonParser(TEST_TABLE))
+        build_file_content = FileContent(path="/dev/null/BUILD", content=b"")
         af = run_rule(
             parse_address_family,
             rule_args=[address_mapper, Dir("/dev/null")],
@@ -52,7 +55,12 @@ class ParseAddressFamilyTest(unittest.TestCase):
                 MockGet(
                     product_type=FilesContent,
                     subject_type=Digest,
-                    mock=lambda _: FilesContent([FileContent(path="/dev/null/BUILD", content=b"")]),
+                    mock=lambda _: FilesContent([build_file_content]),
+                ),
+                MockGet(
+                    product_type=BuildFilesWithLoads,
+                    subject_type=FilesContent,
+                    mock=lambda _: BuildFilesWithLoads({build_file_content: Collection([])}),
                 ),
             ],
         )

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -44,7 +44,7 @@ class AddressMapTest(unittest.TestCase):
     @contextmanager
     def parse_address_map(self, json):
         path = "/dev/null"
-        address_map = AddressMap.parse(path, json, self._parser)
+        address_map = AddressMap.parse(path, json, [], self._parser)
         self.assertEqual(path, address_map.path)
         yield address_map
 


### PR DESCRIPTION
Implement `load` according to https://docs.google.com/document/d/1mtkZGB6nZochxbbKx1zUzoJ1H3Jh_j4lEso586UPreE/edit#heading=h.2sobz45lj5sq

example:
```
load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "dep_on_welcome")
load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2", "source_exe_scala")

jvm_binary(
  main="org.pantsbuild.example.build_file_macros.Exe",
  sources=source_exe_scala(),
  dependencies=dep_on_welcome()
)
```

### Implementation:
The high level idea is:
- Before parsing a BUILD file, pants populates a symbol table with all the functions and aliases defined in backends and plugins.
- We pre-parse BUILD files using the `ast` module, looking for calls to `load("file", "symbol1", "symbol2"...)`. Before we parse BUILD files, we [`exec()`](https://www.programiz.com/python-programming/methods/built-in/exec) each file that it loads, which places all the defined symbols in [`locals()`](https://www.programiz.com/python-programming/methods/built-in/locals).
- We then take every symbol that the BUILD file imports, and we put it in the symbol table that will be passed to the BUILD file parser.

#### Invalidation
When using pantsd, we want a change in a file (e.g. `macros.py`) to invalidate the parsing of every BUILD file that loads that file. The v2 engine takes care of snapshotting and invalidating BUILD file parsing, in [build_files.py](https://github.com/blorente/pants/blob/master/src/python/pants/engine/build_files.py#L41). Therefore, we augment that codepath with the following changes:
- Make rules and types to make parsing the `load` statements from a BUILD file cached and parallel: [code](https://github.com/blorente/pants/blob/a7ba18ff69c94db79982eb0bd1657bce3874afcf/src/python/pants/engine/build_files.py#L76)
- Make rules and types to make snapshotting load statements cached and parallel: [code](https://github.com/blorente/pants/blob/a7ba18ff69c94db79982eb0bd1657bce3874afcf/src/python/pants/engine/build_files.py#L65)
- Make rules and types to hold information about what files a BUILD file loads, what their content is, and what symbols they want from those files: [code](https://github.com/blorente/pants/blob/a7ba18ff69c94db79982eb0bd1657bce3874afcf/src/python/pants/engine/build_files.py#L115)

We then pass that information to the legacy parser, so that it's easy to `exec` the files and import them in `parser.py`.

### Result

Users can use a new syntax `load("file", "symbol1", "symbol2"...)` to load files from arbitrary places in the repo. These loads are invalidated and cached properly in the presence of Pantsd, so there is very little performance overhead.

For BUILD files that do not import anything, there is zero performance cost.