### PR TITLE
Add toml-suffixed default rc-file locations

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -17,6 +17,7 @@ from pants.base.build_environment import (
     pants_version,
 )
 from pants.base.deprecated import deprecated_conditional
+from pants.option.config import DEPRECATED_RC_LOCATIONS, RC_LOCATIONS
 from pants.option.custom_types import dir_option
 from pants.option.errors import OptionsError
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
@@ -381,9 +382,11 @@ class GlobalOptions(Subsystem):
             type=list,
             metavar="<path>",
             daemon=False,
-            default=["/etc/pantsrc", "~/.pants.rc"],
-            help="Override config with values from these files. "
-            "Later files override earlier ones.",
+            default=[*DEPRECATED_RC_LOCATIONS, *RC_LOCATIONS],
+            help=(
+                "Override config with values from these files. Later files override earlier ones. "
+                f"NB: Use of the following default locations is deprecated: {DEPRECATED_RC_LOCATIONS}"
+            ),
         )
         register(
             "--pythonpath",


### PR DESCRIPTION
### Problem

The use of the `toml` config parser is (quite reasonably) triggered by the extension of the parsed file, which means that neither of our existing default `rc` file locations are parsed as `toml` today.

### Solution

Piggyback on the deprecation of non-toml-suffixed config by adding toml-suffixed default rc-file locations. The previous locations are implicitly deprecated via those paths already being identified as ini files. Add some help for the rc-file case in the deprecation.

[ci skip-rust-tests]
[ci skip-jvm-tests]