### PR TITLE
Rework internal `contrib_plugin` to work with the Target API

### DIFF
--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/BUILD
@@ -11,11 +11,13 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   tags = {"partially_type_checked"},
-  distribution_name='pantsbuild.pants.contrib.awslambda_python',
-  description='Pants plugin for creating deployable AWS Lambdas out of python code.',
-  build_file_aliases=True,
-  register_goals=True,
-  target_types=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.awslambda_python',
+    description='Pants plugin for creating deployable AWS Lambdas out of python code.',
+    build_file_aliases=True,
+    register_goals=True,
+    target_types=True,
+  )
 )
 
 python_library(

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
@@ -7,9 +7,11 @@ contrib_plugin(
     ':buildrefactor'
   ],
   tags = {'partially_type_checked'},
-  distribution_name='pantsbuild.pants.contrib.buildrefactor',
-  description='Plugin to manipulate and refactor BUILD files and targets',
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.buildrefactor',
+    description='Plugin to manipulate and refactor BUILD files and targets',
+    register_goals=True,
+  )
 )
 
 python_library(

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
@@ -8,8 +8,10 @@ contrib_plugin(
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
   ],
-  distribution_name='pantsbuild.pants.contrib.codeanalysis',
-  description='Support for various code analysis tools in Pants.',
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.codeanalysis',
+    description='Support for various code analysis tools in Pants.',
+    register_goals=True,
+  ),
   tags = {"partially_type_checked"},
 )

--- a/contrib/confluence/src/python/pants/contrib/confluence/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/BUILD
@@ -8,8 +8,10 @@ contrib_plugin(
     'contrib/confluence/src/python/pants/contrib/confluence/util',
     'src/python/pants/build_graph',
   ],
-  distribution_name='pantsbuild.pants.contrib.confluence',
-  description='Confluence pants plugin',
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.confluence',
+    description='Confluence pants plugin',
+    register_goals=True,
+  ),
   tags = {"partially_type_checked"},
 )

--- a/contrib/go/src/python/pants/contrib/go/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/BUILD
@@ -11,11 +11,13 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   tags = {'partially_type_checked'},
-  distribution_name='pantsbuild.pants.contrib.go',
-  description='Go language support for pants.',
-  build_file_aliases=True,
-  register_goals=True,
-  target_types=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.go',
+    description='Go language support for pants.',
+    build_file_aliases=True,
+    register_goals=True,
+    target_types=True,
+  )
 )
 
 python_library(

--- a/contrib/mypy/src/python/pants/contrib/mypy/BUILD
+++ b/contrib/mypy/src/python/pants/contrib/mypy/BUILD
@@ -7,8 +7,10 @@ contrib_plugin(
     'contrib/mypy/src/python/pants/contrib/mypy/tasks',
     'src/python/pants/goal:task_registrar',
   ],
-  distribution_name='pantsbuild.pants.contrib.mypy',
-  description='MyPy static type analyzer',
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.mypy',
+    description='MyPy static type analyzer',
+    register_goals=True,
+  ),
   tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/BUILD
@@ -13,12 +13,14 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   tags = {'partially_type_checked'},
-  distribution_name='pantsbuild.pants.contrib.node',
-  description='Node.js support for pants.',
-  build_file_aliases=True,
-  register_goals=True,
-  global_subsystems=True,
-  target_types=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.node',
+    description='Node.js support for pants.',
+    build_file_aliases=True,
+    register_goals=True,
+    global_subsystems=True,
+    target_types=True,
+  ),
 )
 
 python_library(

--- a/contrib/python/src/python/pants/contrib/python/checks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/BUILD
@@ -9,7 +9,9 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   tags = {'partially_type_checked'},
-  distribution_name='pantsbuild.pants.contrib.python.checks',
-  description='Additional python lints and checks.',
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.python.checks',
+    description='Additional python lints and checks.',
+    register_goals=True,
+  ),
 )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -8,10 +8,12 @@ contrib_plugin(
     'src/python/pants/goal:task_registrar',
   ],
   tags = {"partially_type_checked"},
-  distribution_name='pantsbuild.pants.contrib.scrooge',
-  description='Scrooge thrift generator pants plugins.',
-  additional_classifiers=[
-    'Topic :: Software Development :: Code Generators'
-  ],
-  register_goals=True,
+  provides=contrib_setup_py(
+    name='pantsbuild.pants.contrib.scrooge',
+    description='Scrooge thrift generator pants plugins.',
+    additional_classifiers=[
+      'Topic :: Software Development :: Code Generators'
+    ],
+    register_goals=True,
+  ),
 )

--- a/pants-plugins/src/python/internal_backend/utilities/BUILD
+++ b/pants-plugins/src/python/internal_backend/utilities/BUILD
@@ -17,6 +17,7 @@ python_library(
 )
 
 python_tests(
+  name="tests",
   dependencies=[
     ':plugin',
     'src/python/pants/base:revision',

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -12,6 +12,7 @@ from pants.backend.python.target_types import (
     PythonLibrary,
     PythonLibrarySources,
     PythonProvidesField,
+    PythonSources,
 )
 from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -185,7 +186,7 @@ class ContribPluginV1(PythonLibraryV1):
     pass
 
 
-class ContribPluginSources(PythonLibrarySources):
+class ContribPluginSources(PythonSources):
     default = ("register.py",)
 
 
@@ -197,7 +198,7 @@ class ContribPlugin(Target):
     alias = "contrib_plugin"
     core_fields = (
         *(
-            FrozenOrderedSet(PythonLibrary.core_fields)
+            FrozenOrderedSet(PythonLibrary.core_fields)  # type: ignore[misc]
             - {PythonLibrarySources, PythonProvidesField}
         ),
         ContribPluginSources,

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -3,7 +3,9 @@
 
 import os
 from pathlib import Path
-from typing import Optional, cast
+from typing import Dict, List, Optional, cast
+
+from packaging.version import Version
 
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.target_types import PythonLibrary
@@ -25,16 +27,18 @@ from pants.util.ordered_set import FrozenOrderedSet
 from pants.version import PANTS_SEMVER, VERSION
 
 
-def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
-    """Creates the setup_py for a pants artifact.
+def pants_setup_py(
+    name: str, description: str, additional_classifiers: Optional[List[str]] = None, **kwargs
+) -> PythonArtifact:
+    """Creates the setup_py for a Pants artifact.
 
-    :param str name: The name of the package.
-    :param str description: A brief description of what the package provides.
-    :param list additional_classifiers: Any additional trove classifiers that apply to the package,
+    :param name: The name of the package.
+    :param description: A brief description of what the package provides.
+    :param additional_classifiers: Any additional trove classifiers that apply to the package,
                                         see: https://pypi.org/pypi?%3Aaction=list_classifiers
     :param kwargs: Any additional keyword arguments to be passed to `setuptools.setup
                    <https://pythonhosted.org/setuptools/setuptools.html>`_.
-    :returns: A setup_py suitable for building and publishing pants components.
+    :returns: A setup_py suitable for building and publishing Pants components.
     """
     if not name.startswith("pantsbuild.pants"):
         raise ValueError(
@@ -75,7 +79,9 @@ def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
     )
 
 
-def contrib_setup_py(name, description, additional_classifiers=None, **kwargs):
+def contrib_setup_py(
+    name: str, description: str, additional_classifiers: Optional[List[str]] = None, **kwargs
+) -> PythonArtifact:
     """Creates the setup_py for a pants contrib plugin artifact.
 
     :param str name: The name of the package; must start with 'pantsbuild.pants.contrib.'.
@@ -115,11 +121,11 @@ class PantsReleases(Subsystem):
         )
 
     @property
-    def _branch_notes(self):
-        return self.get_options().branch_notes
+    def _branch_notes(self) -> Dict[str, str]:
+        return cast(Dict[str, str], self.options.branch_notes)
 
     @classmethod
-    def _branch_name(cls, version) -> str:
+    def _branch_name(cls, version: Version) -> str:
         """Defines a mapping between versions and branches.
 
         All releases, including dev releases, map to a particular branch page.
@@ -130,12 +136,8 @@ class PantsReleases(Subsystem):
             raise ValueError(f"Unparseable pants version number: {version}")
         return "{}.{}.x".format(*components[:2])
 
-    def notes_for_version(self, version) -> str:
-        """Given the parsed Version of pants, return its release notes.
-
-        TODO: This method should parse out the specific version from the resulting file:
-          see https://github.com/pantsbuild/pants/issues/1708
-        """
+    def notes_for_version(self, version: Version) -> str:
+        """Given the parsed Version of pants, return its release notes."""
         branch_name = self._branch_name(version)
         branch_notes_file = self._branch_notes.get(branch_name, None)
         if branch_notes_file is None:

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -3,25 +3,19 @@
 
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, cast
+from typing import Callable, Dict, List, Optional, cast
 
 from packaging.version import Version
 
 from pants.backend.python.python_artifact import PythonArtifact
-from pants.backend.python.target_types import PythonLibrary
-from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
-from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TargetDefinitionException
-from pants.build_graph.address import Address
-from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.target import (
-    BoolField,
-    DescriptionField,
-    InvalidFieldException,
-    StringField,
-    StringSequenceField,
-    Target,
+from pants.backend.python.target_types import (
+    PythonLibrary,
+    PythonLibrarySources,
+    PythonProvidesField,
 )
+from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.target import Target
 from pants.subsystem.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.version import PANTS_SEMVER, VERSION
@@ -79,31 +73,70 @@ def pants_setup_py(
     )
 
 
-def contrib_setup_py(
-    name: str, description: str, additional_classifiers: Optional[List[str]] = None, **kwargs
-) -> PythonArtifact:
-    """Creates the setup_py for a pants contrib plugin artifact.
+def contrib_setup_py_context_aware_object_factory(parse_context) -> Callable:
+    def contrib_setup_py(
+        name: str,
+        description: str,
+        build_file_aliases: bool = False,
+        global_subsystems: bool = False,
+        register_goals: bool = False,
+        rules: bool = False,
+        target_types: bool = False,
+        additional_classifiers: Optional[List[str]] = None,
+        **kwargs,
+    ) -> PythonArtifact:
+        """Creates the setup_py for a pants contrib plugin artifact.
 
-    :param str name: The name of the package; must start with 'pantsbuild.pants.contrib.'.
-    :param str description: A brief description of what the plugin provides.
-    :param list additional_classifiers: Any additional trove classifiers that apply to the plugin,
-                                        see: https://pypi.org/pypi?%3Aaction=list_classifiers
-    :param kwargs: Any additional keyword arguments to be passed to `setuptools.setup
-                   <https://pythonhosted.org/setuptools/setuptools.html>`_.
-    :returns: A setup_py suitable for building and publishing pants components.
-    """
-    if not name.startswith("pantsbuild.pants.contrib."):
-        raise ValueError(
-            f"Contrib plugin package names must start with 'pantsbuild.pants.contrib.', given {name}"
+        :param name: The name of the package; must start with 'pantsbuild.pants.contrib.'.
+        :param description: A brief description of what the plugin provides.
+        :param additional_classifiers: Any additional trove classifiers that apply to the plugin,
+                                       see: https://pypi.org/pypi?%3Aaction=list_classifiers
+        :param build_file_aliases: If `True`, register.py:build_file_aliases must be defined and
+                                   registers the 'build_file_aliases' 'pantsbuild.plugin' entrypoint.
+        :param global_subsystems: If `True`, register.py:global_subsystems must be defined and
+                                  registers the 'global_subsystems' 'pantsbuild.plugin' entrypoint.
+        :param register_goals: If `True`, register.py:register_goals must be defined and
+                               registers the 'register_goals' 'pantsbuild.plugin' entrypoint.
+        :param rules: If `True`, register.py:rules must be defined and registers the 'rules'
+                      'pantsbuild.plugin' entrypoint.
+        :param target_types: If `True`, register.py:target_types must be defined and registers
+                             the 'target_types' 'pantsbuild.plugin' entrypoint.
+        :param kwargs: Any additional keyword arguments to be passed to `setuptools.setup
+                       <https://pythonhosted.org/setuptools/setuptools.html>`_.
+        :returns: A setup_py suitable for building and publishing Pants components.
+        """
+        if not name.startswith("pantsbuild.pants.contrib."):
+            raise ValueError(
+                f"Contrib plugin package names must start with 'pantsbuild.pants.contrib.', given {name}"
+            )
+
+        setup_py = pants_setup_py(
+            name,
+            description,
+            additional_classifiers=additional_classifiers,
+            namespace_packages=["pants", "pants.contrib"],
+            **kwargs,
         )
 
-    return pants_setup_py(
-        name,
-        description,
-        additional_classifiers=additional_classifiers,
-        namespace_packages=["pants", "pants.contrib"],
-        **kwargs,
-    )
+        if build_file_aliases or register_goals or global_subsystems or rules or target_types:
+            module = parse_context.rel_path.replace(os.path.sep, ".")
+            entry_points = []
+            if build_file_aliases:
+                entry_points.append(f"build_file_aliases = {module}.register:build_file_aliases")
+            if register_goals:
+                entry_points.append(f"register_goals = {module}.register:register_goals")
+            if global_subsystems:
+                entry_points.append(f"global_subsystems = {module}.register:global_subsystems")
+            if rules:
+                entry_points.append(f"rules = {module}.register:rules")
+            if target_types:
+                entry_points.append(f"target_types = {module}.register:target_types")
+
+            setup_py.setup_py_keywords["entry_points"] = {"pantsbuild.plugin": entry_points}
+
+        return setup_py
+
+    return contrib_setup_py
 
 
 class PantsReleases(Subsystem):
@@ -148,194 +181,28 @@ class PantsReleases(Subsystem):
         return Path(branch_notes_file).read_text()
 
 
-class PantsPluginV1(PythonLibraryV1):
-    """A pants plugin published by pantsbuild."""
-
-    @classmethod
-    def create_setup_py(cls, name, description, additional_classifiers=None):
-        return pants_setup_py(
-            name,
-            description,
-            additional_classifiers=additional_classifiers,
-            namespace_packages=["pants", "pants.backend"],
-        )
-
-    def __init__(
-        self,
-        address=None,
-        payload=None,
-        distribution_name=None,
-        description=None,
-        additional_classifiers=None,
-        build_file_aliases=False,
-        global_subsystems=False,
-        register_goals=False,
-        rules=False,
-        target_types=False,
-        **kwargs,
-    ):
-        """
-        :param str distribution_name: The name of the plugin package; must start with
-                                      'pantsbuild.pants.'.
-        :param str description: A brief description of what the plugin provides.
-        :param list additional_classifiers: Any additional trove classifiers that apply to the plugin,
-                                            see: https://pypi.org/pypi?%3Aaction=list_classifiers
-        :param bool build_file_aliases: If `True`, register.py:build_file_aliases must be defined and
-                                        registers the 'build_file_aliases' 'pantsbuild.plugin'
-                                        entrypoint.
-        :param bool global_subsystems: If `True`, register.py:global_subsystems must be defined and
-                                       registers the 'global_subsystems' 'pantsbuild.plugin' entrypoint.
-        :param bool register_goals: If `True`, register.py:register_goals must be defined and
-                                    registers the 'register_goals' 'pantsbuild.plugin' entrypoint.
-        :param bool rules: If `True`, register.py:rules must be defined and registers the 'rules'
-                           'pantsbuild.plugin' entrypoint.
-        :param bool target_types: If `True`, register.py:target_types must be defined and registers
-                                  the 'target_types' 'pantsbuild.plugin' entrypoint.
-        """
-        if not distribution_name.startswith("pantsbuild.pants."):
-            raise ValueError(
-                "Pants plugin package distribution names must start with 'pantsbuild.pants.', given "
-                f"{distribution_name}"
-            )
-
-        if not os.path.exists(os.path.join(get_buildroot(), address.spec_path, "register.py")):
-            raise TargetDefinitionException(
-                address.spec_path,
-                "A PantsPlugin target must have a register.py file in the same directory.",
-            )
-
-        setup_py = self.create_setup_py(
-            distribution_name, description, additional_classifiers=additional_classifiers
-        )
-
-        super().__init__(address, payload, provides=setup_py, **kwargs)
-
-        if build_file_aliases or register_goals or global_subsystems or rules or target_types:
-            module = os.path.relpath(address.spec_path, self.target_base).replace(os.sep, ".")
-            entry_points = []
-            if build_file_aliases:
-                entry_points.append(f"build_file_aliases = {module}.register:build_file_aliases")
-            if register_goals:
-                entry_points.append(f"register_goals = {module}.register:register_goals")
-            if global_subsystems:
-                entry_points.append(f"global_subsystems = {module}.register:global_subsystems")
-            if rules:
-                entry_points.append(f"rules = {module}.register:rules")
-            if target_types:
-                entry_points.append(f"target_types = {module}.register:target_types")
-
-            setup_py.setup_py_keywords["entry_points"] = {"pantsbuild.plugin": entry_points}
-            self.mark_invalidation_hash_dirty()  # To pickup the PythonArtifact (setup_py) changes.
+class ContribPluginV1(PythonLibraryV1):
+    pass
 
 
-class ContribPluginV1(PantsPluginV1):
-    """A contributed pants plugin published by pantsbuild."""
-
-    @classmethod
-    def create_setup_py(cls, name, description, additional_classifiers=None):
-        return contrib_setup_py(name, description, additional_classifiers=additional_classifiers)
+class ContribPluginSources(PythonLibrarySources):
+    default = ("register.py",)
 
 
-class PantsPluginDistributionName(StringField):
-    """The name of the plugin package.
-
-    This must start with 'pantsbuild.pants.'.
-    """
-
-    alias = "distribution_name"
+class ContribPluginProvidesField(PythonProvidesField):
     required = True
-    value: str
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address=address))
-        if not value.startswith("pantsbuild.pants."):
-            raise InvalidFieldException(
-                f"The {repr(cls.alias)} in target {address} must start with `pantsbuild.pants`, "
-                f"but was {value}."
-            )
-        return value
-
-
-class PantsPluginDescription(DescriptionField):
-    """A brief description of what the plugin provides."""
-
-    alias = "description"
-    required = True
-    value: str
-
-
-class PantsPluginAdditionalClassifiers(StringSequenceField):
-    """Any additional trove classifiers that apply to the plugin.
-
-    See: https://pypi.org/pypi?%3Aaction=list_classifiers.
-    """
-
-    alias = "additional_classifiers"
-
-
-class PantsPluginBuildFileAliasesToggle(BoolField):
-    """If `True`, register.py:build_file_aliases must be defined and registers the
-    'build_file_aliases' 'pantsbuild.plugin' entrypoint."""
-
-    alias = "build_file_aliases"
-    default = False
-
-
-class PantsGlobalSubsystemsToggle(BoolField):
-    """If `True`, register.py:global_subsystems must be defined and registers the
-    'global_subsystems' 'pantsbuild.plugin' entrypoint."""
-
-    alias = "global_subsystems"
-    default = False
-
-
-class PantsRegisterGoalsToggle(BoolField):
-    """If `True`, register.py:register_goals must be defined and registers the 'register_goals'
-    'pantsbuild.plugin' entrypoint."""
-
-    alias = "register_goals"
-    default = False
-
-
-class PantsRulesToggle(BoolField):
-    """If `True`, register.py:rules must be defined and registers the 'rules' 'pantsbuild.plugin'
-    entrypoint."""
-
-    alias = "rules"
-    default = False
-
-
-class PantsTargetTypesToggle(BoolField):
-    """If `True`, register.py:target_types must be defined and registers the 'target_types'
-    'pantsbuild.plugin' entrypoint."""
-
-    alias = "target_types"
-    default = False
-
-
-class PantsPlugin(Target):
-    """A Pants plugin published by pantsbuild."""
-
-    alias = "pants_plugin"
-    core_fields = (
-        *(FrozenOrderedSet(PythonLibrary.core_fields) - {DescriptionField}),  # type: ignore[misc]
-        PantsPluginDistributionName,
-        PantsPluginDescription,
-        PantsPluginAdditionalClassifiers,
-        PantsPluginBuildFileAliasesToggle,
-        PantsGlobalSubsystemsToggle,
-        PantsRegisterGoalsToggle,
-        PantsRulesToggle,
-        PantsTargetTypesToggle,
-    )
 
 
 class ContribPlugin(Target):
-    """A contributed Pants plugin published by pantsbuild."""
-
     alias = "contrib_plugin"
-    core_fields = PantsPlugin.core_fields
+    core_fields = (
+        *(
+            FrozenOrderedSet(PythonLibrary.core_fields)
+            - {PythonLibrarySources, PythonProvidesField}
+        ),
+        ContribPluginSources,
+        ContribPluginProvidesField,
+    )
 
 
 def global_subsystems():
@@ -344,10 +211,13 @@ def global_subsystems():
 
 def build_file_aliases():
     return BuildFileAliases(
-        objects={"pants_setup_py": pants_setup_py, "contrib_setup_py": contrib_setup_py},
-        targets={"pants_plugin": PantsPluginV1, "contrib_plugin": ContribPluginV1},
+        context_aware_object_factories={
+            "contrib_setup_py": contrib_setup_py_context_aware_object_factory
+        },
+        objects={"pants_setup_py": pants_setup_py},
+        targets={"contrib_plugin": ContribPluginV1},
     )
 
 
 def target_types():
-    return [PantsPlugin, ContribPlugin]
+    return [ContribPlugin]


### PR DESCRIPTION
### Problem

V2 `setup-py` doesn't understand `contrib_plugin` because it relies on mutating the V1 target to have a `provides` field. This doesn't fit in with the V2 target model, where target declarations are no more than 3 lines and should not be mutating their fields.

### Solution

Instead of dynamically adding a `provides` field, have the user explicitly give a `provides` value. Augment the `contrib_setup_py` object so that it can behave the same as before.

Also, remove the unused `PantsPlugin` target type.

### Result

We can now use V2 `setup-py` to build Pants and its plugins.