### PR TITLE
Deprecate the `codeanalysis` plugin due to low usage

### DIFF
--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
@@ -10,7 +10,7 @@ contrib_plugin(
   ],
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.codeanalysis',
-    description='Support for various code analysis tools in Pants.',
+    description='Support for various code analysis tools in Pants. (Deprecated)',
     register_goals=True,
   ),
   tags = {"partially_type_checked"},

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/register.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/register.py
@@ -6,11 +6,22 @@
 See https://www.kythe.io.
 """
 
+from pants.base.deprecated import warn_or_error
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.codeanalysis.tasks.bundle_entries import BundleEntries
 from pants.contrib.codeanalysis.tasks.extract_java import ExtractJava
 from pants.contrib.codeanalysis.tasks.index_java import IndexJava
+
+warn_or_error(
+    removal_version="1.30.0.dev0",
+    deprecated_entity_description="The `pants.contrib.codeanalysis` plugin",
+    hint=(
+        "The `pants.contrib.codeanalysis` plugin is being removed due to low usage.\n\nIf you "
+        "still need this plugin, please message us on Slack (see "
+        "https://pants.readme.io/docs/community)."
+    ),
+)
 
 
 def register_goals():

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
@@ -11,7 +11,11 @@ class TestIndexJavaIntegration(PantsRunIntegrationTest):
     def test_index_simple_java_code(self):
         # Very simple test that we can run the extractor and indexer on some
         # fairly trivial code without crashing, and that we produce something.
-        args = ["index", "examples/src/java/org/pantsbuild/example/hello::"]
+        args = [
+            "--backend-packages=pants.contrib.codeanalysis",
+            "index",
+            "examples/src/java/org/pantsbuild/example/hello::",
+        ]
         with self.temporary_workdir(cleanup=False) as workdir:
             pants_run = self.run_pants_with_workdir(args, workdir)
             self.assert_success(pants_run)

--- a/pants.toml
+++ b/pants.toml
@@ -26,7 +26,6 @@ enable_pantsd = true
 pythonpath = [
   "%(buildroot)s/contrib/awslambda/python/src/python",
   "%(buildroot)s/contrib/buildrefactor/src/python",
-  "%(buildroot)s/contrib/codeanalysis/src/python",
   "%(buildroot)s/contrib/confluence/src/python",
   "%(buildroot)s/contrib/go/src/python",
   "%(buildroot)s/contrib/mypy/src/python",
@@ -37,7 +36,6 @@ pythonpath = [
 backend_packages.add = [
   "pants.backend.docgen",
   "pants.contrib.buildrefactor",
-  "pants.contrib.codeanalysis",
   "pants.contrib.confluence",
   "pants.contrib.go",
   "pants.contrib.node",

--- a/pants.toml
+++ b/pants.toml
@@ -26,6 +26,7 @@ enable_pantsd = true
 pythonpath = [
   "%(buildroot)s/contrib/awslambda/python/src/python",
   "%(buildroot)s/contrib/buildrefactor/src/python",
+  "%(buildroot)s/contrib/codeanalysis/src/python",
   "%(buildroot)s/contrib/confluence/src/python",
   "%(buildroot)s/contrib/go/src/python",
   "%(buildroot)s/contrib/mypy/src/python",


### PR DESCRIPTION
[ci skip-rust-tests]
[ci skip-jvm-tests]
