### PR TITLE
Use V2 `setup-py` to build Pants wheels

### DIFF
--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -86,10 +86,10 @@ def core_packages() -> Set[Package]:
     return {
         Package(
             "pantsbuild.pants",
-            "//src/python/pants:pants-packaged",
+            "src/python/pants:pants-packaged",
             bdist_wheel_flags=("--py-limited-api", "cp36"),
         ),
-        Package("pantsbuild.pants.testutil", "//src/python/pants/testutil:testutil_wheel"),
+        Package("pantsbuild.pants.testutil", "src/python/pants/testutil:testutil_wheel"),
     }
 
 
@@ -97,35 +97,35 @@ def contrib_packages() -> Set[Package]:
     return {
         Package(
             "pantsbuild.pants.contrib.scrooge",
-            "//contrib/scrooge/src/python/pants/contrib/scrooge:plugin",
+            "contrib/scrooge/src/python/pants/contrib/scrooge:plugin",
         ),
-        Package("pantsbuild.pants.contrib.go", "//contrib/go/src/python/pants/contrib/go:plugin",),
+        Package("pantsbuild.pants.contrib.go", "contrib/go/src/python/pants/contrib/go:plugin"),
         Package(
-            "pantsbuild.pants.contrib.node", "//contrib/node/src/python/pants/contrib/node:plugin",
+            "pantsbuild.pants.contrib.node", "contrib/node/src/python/pants/contrib/node:plugin",
         ),
         Package(
             "pantsbuild.pants.contrib.python.checks",
-            "//contrib/python/src/python/pants/contrib/python/checks:plugin",
+            "contrib/python/src/python/pants/contrib/python/checks:plugin",
         ),
         Package(
             "pantsbuild.pants.contrib.python.checks.checker",
-            "//contrib/python/src/python/pants/contrib/python/checks/checker",
+            "contrib/python/src/python/pants/contrib/python/checks/checker",
             bdist_wheel_flags=("--universal",),
         ),
         Package(
             "pantsbuild.pants.contrib.confluence",
-            "//contrib/confluence/src/python/pants/contrib/confluence:plugin",
+            "contrib/confluence/src/python/pants/contrib/confluence:plugin",
         ),
         Package(
             "pantsbuild.pants.contrib.codeanalysis",
-            "//contrib/codeanalysis/src/python/pants/contrib/codeanalysis:plugin",
+            "contrib/codeanalysis/src/python/pants/contrib/codeanalysis:plugin",
         ),
         Package(
-            "pantsbuild.pants.contrib.mypy", "//contrib/mypy/src/python/pants/contrib/mypy:plugin",
+            "pantsbuild.pants.contrib.mypy", "contrib/mypy/src/python/pants/contrib/mypy:plugin",
         ),
         Package(
             "pantsbuild.pants.contrib.awslambda_python",
-            "//contrib/awslambda/python/src/python/pants/contrib/awslambda/python:plugin",
+            "contrib/awslambda/python/src/python/pants/contrib/awslambda/python:plugin",
         ),
     }
 
@@ -218,9 +218,9 @@ def build_and_print_packages(version: str) -> None:
     for flags, packages in packages_by_flags.items():
         bdist_flags = " ".join(flags)
         args = (
-            "./pants",
-            "setup-py",
-            f"--run=bdist_wheel {bdist_flags}",
+            "./v2",
+            "setup-py2",
+            f"--args=bdist_wheel {bdist_flags}",
             *(package.target for package in packages),
         )
         try:

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -33,6 +33,7 @@ def run_shellcheck() -> None:
     }
     targets -= set(glob("./build-support/bin/native/src/**/*.sh", recursive=True))
     targets -= set(glob("./build-support/virtualenv.dist/**/*.sh", recursive=True))
+    targets -= set(glob("./build-support/twine-deps.venv/**/*.sh", recursive=True))
     command = ["shellcheck", "--shell=bash", "--external-sources"] + sorted(targets)
     try:
         subprocess.run(command, check=True)


### PR DESCRIPTION
Beyond more dogfooding, we expect this to improve performance for the wheel building shards thanks to better caching and parallelism.

[ci skip-rust-tests]
[ci skip-jvm-tests]