### PR TITLE
`BoolField` can leave off a default to represent tri-states

### DIFF
--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import cast
 
 from pex.pex_info import PexInfo
 
@@ -34,7 +35,7 @@ class PythonBinary(PythonTarget):
 
         @classmethod
         def register_options(cls, register):
-            super(PythonBinary.Defaults, cls).register_options(register)
+            super().register_options(register)
             register(
                 "--pex-emit-warnings",
                 advanced=True,
@@ -45,6 +46,10 @@ class PythonBinary(PythonTarget):
                 "Can be over-ridden by specifying the `emit_warnings` parameter of individual "
                 "`{}` targets".format(PythonBinary.alias()),
             )
+
+        @property
+        def pex_emit_warnings(self) -> bool:
+            return cast(bool, self.options.pex_emit_warnings)
 
         @classmethod
         def should_emit_warnings(cls, override=None):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1033,20 +1033,21 @@ class ScalarField(Generic[T], PrimitiveField, metaclass=ABCMeta):
 class BoolField(PrimitiveField, metaclass=ABCMeta):
     """A field whose value is a boolean.
 
-    Subclasses must define the class property `default`.
+    If subclasses do not set the class property `required = True` or `default`, the value will
+    default to None. This can be useful to represent three states: unspecified, False, and True.
 
         class ZipSafe(BoolField):
             alias = "zip_safe"
             default = True
     """
 
-    value: bool
-    default: ClassVar[bool]
+    value: Optional[bool]
+    default: ClassVar[Optional[bool]] = None
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[bool], *, address: Address) -> bool:
+    def compute_value(cls, raw_value: Optional[bool], *, address: Address) -> Optional[bool]:
         value_or_default = super().compute_value(raw_value, address=address)
-        if not isinstance(value_or_default, bool):
+        if value_or_default is not None and not isinstance(value_or_default, bool):
             raise InvalidFieldTypeException(
                 address, cls.alias, raw_value, expected_type="a boolean",
             )

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 import pytest
 from typing_extensions import final
@@ -77,9 +77,9 @@ from pants.util.ordered_set import OrderedSet
 
 
 class FortranExtensions(PrimitiveField):
-    alias: ClassVar = "fortran_extensions"
+    alias = "fortran_extensions"
     value: Tuple[str, ...]
-    default: ClassVar[Tuple[str, ...]] = ()
+    default = ()
 
     def compute_value(
         self, raw_value: Optional[Iterable[str]], *, address: Address
@@ -98,12 +98,12 @@ class FortranExtensions(PrimitiveField):
 
 
 class UnrelatedField(BoolField):
-    alias: ClassVar = "unrelated"
-    default: ClassVar = False
+    alias = "unrelated"
+    default = False
 
 
 class FortranSources(AsyncField):
-    alias: ClassVar = "sources"
+    alias = "sources"
     sanitized_raw_value: Optional[Tuple[str, ...]]
     default = None
 
@@ -144,8 +144,8 @@ async def hydrate_fortran_sources(request: FortranSourcesRequest) -> FortranSour
 
 
 class FortranTarget(Target):
-    alias: ClassVar = "fortran"
-    core_fields: ClassVar = (FortranExtensions, FortranSources)
+    alias = "fortran"
+    core_fields = (FortranExtensions, FortranSources)
 
 
 def test_invalid_fields_rejected() -> None:
@@ -284,8 +284,8 @@ def test_async_field() -> None:
 
 def test_add_custom_fields() -> None:
     class CustomField(BoolField):
-        alias: ClassVar = "custom_field"
-        default: ClassVar = False
+        alias = "custom_field"
+        default = False
 
     union_membership = UnionMembership({FortranTarget.PluginField: [CustomField]})
     tgt_values = {CustomField.alias: True}
@@ -325,8 +325,8 @@ def test_override_preexisting_field_via_new_target() -> None:
     # with subclasses of the original `Field`s.
 
     class CustomFortranExtensions(FortranExtensions):
-        banned_extensions: ClassVar = ("FortranBannedExt",)
-        default_extensions: ClassVar = ("FortranCustomExt",)
+        banned_extensions = ("FortranBannedExt",)
+        default_extensions = ("FortranCustomExt",)
 
         def compute_value(
             self, raw_value: Optional[Iterable[str]], *, address: Address
@@ -346,8 +346,8 @@ def test_override_preexisting_field_via_new_target() -> None:
             return (*specified_extensions, *self.default_extensions)
 
     class CustomFortranTarget(Target):
-        alias: ClassVar = "custom_fortran"
-        core_fields: ClassVar = tuple(
+        alias = "custom_fortran"
+        core_fields = tuple(
             {*FortranTarget.core_fields, CustomFortranExtensions} - {FortranExtensions}
         )
 


### PR DESCRIPTION
Stu pointed out that it can be valuable to know when a `BoolField` was left undefined. For example, this can be used to know to use a global default value.

Indeed, we had one `python_binary` field that uses this exact pattern and I didn't know how to port. We can now support this use case.

[ci skip-rust-tests]
[ci skip-jvm-tests]
