### PR TITLE
Log workunit creation and completion

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -274,9 +274,11 @@ def _make_rule(
         effective_name = annotations.canonical_name
         if effective_name is None:
             effective_name = return_type.name if is_goal_cls else func.__name__
-        normalized_annotations = RuleAnnotations(
-            canonical_name=effective_name, desc=annotations.desc
-        )
+
+        effective_desc = annotations.desc
+        if effective_desc is None and is_goal_cls:
+            effective_desc = f"`{effective_name}` goal"
+        normalized_annotations = RuleAnnotations(canonical_name=effective_name, desc=effective_desc)
 
         # Set our own custom `__line_number__` dunder so that the engine may visualize the line number.
         func.__line_number__ = func.__code__.co_firstlineno

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -711,7 +711,7 @@ async fn sends_headers() {
   )
   .unwrap();
   let context = Context {
-    workunit_store: WorkunitStore::default(),
+    workunit_store: WorkunitStore::new(false),
     build_id: String::from("marmosets"),
   };
   command_runner

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2164,7 +2164,7 @@ fn workunits_with_constant_span_id(workunit_store: &mut WorkunitStore) -> HashSe
 
 #[tokio::test]
 async fn remote_workunits_are_stored() {
-  let mut workunit_store = WorkunitStore::new();
+  let mut workunit_store = WorkunitStore::new(false);
   workunit_store.init_thread_state(None);
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1020,7 +1020,6 @@ impl Node for NodeKey {
       let user_facing_name = self.user_facing_name();
       let level = match self {
         NodeKey::Task(_) if user_facing_name.is_some() => Level::Info,
-        NodeKey::MultiPlatformExecuteProcess(_) => Level::Info,
         NodeKey::Task(_) => Level::Debug,
         _ => Level::Debug,
       };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1018,11 +1018,11 @@ impl Node for NodeKey {
 
     let (started_workunit_id, user_facing_name) = {
       let user_facing_name = self.user_facing_name();
-      let higher_priority = context.session.should_handle_workunits() && user_facing_name.is_some();
-      let level = if higher_priority {
-        Level::Info
-      } else {
-        Level::Debug
+      let level = match self {
+        NodeKey::Task(_) if user_facing_name.is_some() => Level::Info,
+        NodeKey::MultiPlatformExecuteProcess(_) => Level::Info,
+        NodeKey::Task(_) => Level::Debug,
+        _ => Level::Debug,
       };
       let name = self.workunit_name();
       let span_id = new_span_id();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1005,6 +1005,14 @@ impl NodeKey {
       _ => None,
     }
   }
+
+  fn workunit_level(&self) -> Level {
+    match self {
+      NodeKey::Task(_) if self.user_facing_name().is_some() => Level::Info,
+      NodeKey::Task(_) => Level::Debug,
+      _ => Level::Debug,
+    }
+  }
 }
 
 impl Node for NodeKey {
@@ -1018,11 +1026,6 @@ impl Node for NodeKey {
 
     let (started_workunit_id, user_facing_name) = {
       let user_facing_name = self.user_facing_name();
-      let level = match self {
-        NodeKey::Task(_) if user_facing_name.is_some() => Level::Info,
-        NodeKey::Task(_) => Level::Debug,
-        _ => Level::Debug,
-      };
       let name = self.workunit_name();
       let span_id = new_span_id();
 
@@ -1030,7 +1033,7 @@ impl Node for NodeKey {
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
       let metadata = WorkunitMetadata {
         desc: user_facing_name.clone(),
-        level,
+        level: self.workunit_level(),
         blocked: false,
       };
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -73,7 +73,7 @@ impl Session {
     build_id: String,
     should_report_workunits: bool,
   ) -> Session {
-    let workunit_store = WorkunitStore::new();
+    let workunit_store = WorkunitStore::new(should_render_ui);
     let display = if should_render_ui {
       Some(Mutex::new(ConsoleUI::new(workunit_store.clone())))
     } else {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -228,7 +228,6 @@ impl WorkunitStore {
       metadata,
     };
     let mut inner = self.inner.lock();
-    started.log_workunit_state();
 
     inner.workunit_records.insert(span_id.clone(), started);
     inner.started_ids.push(span_id.clone());

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
+use log::log;
 pub use log::Level;
 use parking_lot::Mutex;
 use petgraph::graph::{DiGraph, NodeIndex};
@@ -50,6 +51,43 @@ pub struct Workunit {
   pub parent_id: Option<String>,
   pub state: WorkunitState,
   pub metadata: WorkunitMetadata,
+}
+
+impl Workunit {
+  fn log_workunit_state(&self) {
+    let state = match self.state {
+      WorkunitState::Started { .. } => "Starting",
+      WorkunitState::Completed { .. } => "Completing",
+    };
+
+    let level = self.metadata.level;
+    let identifier = if let Some(ref s) = self.metadata.desc {
+      s.as_str()
+    } else {
+      self.name.as_str()
+    };
+
+    /* This length calculation doesn't treat multi-byte unicode charcters identically
+     * to single-byte ones for the purpose of figuring out where to truncate the string. But that's
+     * ok, since we just want to truncate the log string if it's roughly "too long", we don't care
+     * exactly what the max_len is or whether it effectively changes slightly if there are
+     * multibyte unicode characters in the string
+     */
+    let max_len = 200;
+    if identifier.len() > max_len {
+      let truncated_identifier: String = identifier.chars().take(max_len).collect();
+      let trunc = identifier.len() - max_len;
+      log!(
+        level,
+        "{} {}... ({} characters truncated)",
+        state,
+        truncated_identifier,
+        trunc
+      );
+    } else {
+      log!(level, "{} {}", state, identifier);
+    }
+  }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -190,6 +228,8 @@ impl WorkunitStore {
       metadata,
     };
     let mut inner = self.inner.lock();
+    started.log_workunit_state();
+
     inner.workunit_records.insert(span_id.clone(), started);
     inner.started_ids.push(span_id.clone());
     let child = inner.graph.add_node(span_id.clone());
@@ -223,6 +263,8 @@ impl WorkunitStore {
         };
         let new_state = WorkunitState::Completed { time_span };
         workunit.state = new_state;
+        workunit.log_workunit_state();
+
         inner.workunit_records.insert(span_id.clone(), workunit);
         inner.completed_ids.push(span_id);
         Ok(())

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -56,8 +56,8 @@ pub struct Workunit {
 impl Workunit {
   fn log_workunit_state(&self) {
     let state = match self.state {
-      WorkunitState::Started { .. } => "Starting",
-      WorkunitState::Completed { .. } => "Completing",
+      WorkunitState::Started { .. } => "Starting:",
+      WorkunitState::Completed { .. } => "Completed:",
     };
 
     let level = self.metadata.level;

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -115,6 +115,7 @@ impl WorkunitMetadata {
 
 #[derive(Clone, Default)]
 pub struct WorkunitStore {
+  rendering_dynamic_ui: bool,
   inner: Arc<Mutex<WorkUnitInnerStore>>,
 }
 
@@ -130,8 +131,9 @@ pub struct WorkUnitInnerStore {
 }
 
 impl WorkunitStore {
-  pub fn new() -> WorkunitStore {
+  pub fn new(rendering_dynamic_ui: bool) -> WorkunitStore {
     WorkunitStore {
+      rendering_dynamic_ui,
       inner: Arc::new(Mutex::new(WorkUnitInnerStore {
         graph: DiGraph::new(),
         span_id_to_graph: HashMap::new(),
@@ -228,6 +230,9 @@ impl WorkunitStore {
       metadata,
     };
     let mut inner = self.inner.lock();
+    if !self.rendering_dynamic_ui {
+      started.log_workunit_state()
+    }
 
     inner.workunit_records.insert(span_id.clone(), started);
     inner.started_ids.push(span_id.clone());


### PR DESCRIPTION
### Problem

Now that we have workunits with levels, we want to provide more information about when a workunit starts and ends.

### Solution

Emit a normal log entry when a workunit is created and when one completes, whose level is the same as that of the associated workunit. This commit also ensured that `goal_rule`s were always created with a description, so that they would always have the `Info` log level be set and be visible with the default pants rule visibility. 

### Result

https://asciinema.org/a/ODfsUbEx8A8Vh24nONzEagcir is an asciinema recording of the behavior of a run with the `fmt` rule.
