### PR TITLE
remoting: streaming remote execution client

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -297,6 +297,7 @@ class Native(metaclass=SingletonMetaclass):
             execution_options.process_execution_speculation_strategy,
             execution_options.process_execution_use_local_cache,
             tuple((k, v) for (k, v) in execution_options.remote_execution_headers.items()),
+            execution_options.remote_execution_enable_streaming,
             execution_options.process_execution_local_enable_nailgun,
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -97,6 +97,7 @@ class ExecutionOptions:
     remote_oauth_bearer_token_path: Any
     remote_execution_extra_platform_properties: Any
     remote_execution_headers: Any
+    remote_execution_enable_streaming: bool
     process_execution_local_enable_nailgun: bool
 
     @classmethod
@@ -122,6 +123,7 @@ class ExecutionOptions:
             remote_oauth_bearer_token_path=bootstrap_options.remote_oauth_bearer_token_path,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
             remote_execution_headers=bootstrap_options.remote_execution_headers,
+            remote_execution_enable_streaming=bootstrap_options.remote_execution_enable_streaming,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
         )
 
@@ -147,6 +149,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
+    remote_execution_enable_streaming=False,
     process_execution_local_enable_nailgun=False,
 )
 
@@ -838,6 +841,13 @@ class GlobalOptions(Subsystem):
             "Format: header=value. Pants itself may add additional headers.",
             type=dict,
             default={},
+        )
+        register(
+            "--remote-execution-enable-streaming",
+            type=bool,
+            default=False,
+            advanced=True,
+            help="Enable the streaming remote execution client (alpha quality).",
         )
         register(
             "--process-execution-local-parallelism",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -847,7 +847,7 @@ class GlobalOptions(Subsystem):
             type=bool,
             default=False,
             advanced=True,
-            help="Enable the streaming remote execution client (alpha quality).",
+            help="Enable the streaming remote execution client (experimental).",
         )
         register(
             "--process-execution-local-parallelism",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1861,13 +1861,16 @@ name = "mock"
 version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
+ "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=ed3afa3c24ddf1fdd86826e836f57c00757dfc00)",
  "hashing 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "testutil 0.0.1",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -29,6 +29,11 @@ use crate::{
 use std::cmp::min;
 use workunit_store::WorkunitStore;
 
+// Streaming client module. Intended as an eventual repalcement for the CommandRunner in this
+// module.
+mod streaming;
+pub use streaming::StreamingCommandRunner;
+
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the
 // CommandRunner.
@@ -260,6 +265,7 @@ impl super::CommandRunner for CommandRunner {
     let mut history = ExecutionHistory::default();
 
     // Upload inputs.
+    // REFACTOR: StreamingCommandRunner moves this to `ensure_action_uploaded`.
     {
       let (command_digest, action_digest) = future03::try_join(
         self.store_proto_locally(&command),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -202,7 +202,7 @@ impl CommandRunner {
       Ok(None) => {
         Err("Didn't get proper stream response from server during remote execution".to_owned())
       }
-      Err(err) => rpcerror_to_status_or_string(err).map(OperationOrStatus::Status),
+      Err(err) => rpcerror_to_status_or_string(&err).map(OperationOrStatus::Status),
     }
   }
 }
@@ -1157,7 +1157,7 @@ fn rpcerror_recover_cancelled(
 }
 
 fn rpcerror_to_status_or_string(
-  error: grpcio::Error,
+  error: &grpcio::Error,
 ) -> Result<bazel_protos::status::Status, String> {
   match error {
     grpcio::Error::RpcFailure(grpcio::RpcStatus {
@@ -1173,7 +1173,10 @@ fn rpcerror_to_status_or_string(
     }) => Err(format!(
       "{:?}: {:?}",
       status,
-      details.unwrap_or_else(|| "[no message]".to_string())
+      details
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or_else(|| "[no message]")
     )),
     err => Err(format!("{:?}", err)),
   }

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -385,8 +385,9 @@ impl StreamingCommandRunner {
           [details] => details,
           _ => {
             return Err(ExecutionError::Fatal(format!(
-            "Received multiple failure details in ExecuteResponse's status field: {:?}",
-            status.get_details())))
+              "Received multiple failure details in ExecuteResponse's status field: {:?}",
+              status.get_details()
+            )))
           }
         };
 

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -385,7 +385,7 @@ impl StreamingCommandRunner {
           [details] => details,
           _ => {
             return Err(ExecutionError::Fatal(format!(
-            "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
+            "Received multiple failure details in ExecuteResponse's status field: {:?}",
             status.get_details())))
           }
         };
@@ -408,7 +408,7 @@ impl StreamingCommandRunner {
           .merge_from_bytes(details.get_value())
           .map_err(|e| {
             ExecutionError::Fatal(format!(
-              "Error deserializing FailedPrecondition proto: {:?}",
+              "Error deserializing PreconditionFailure proto: {:?}",
               e
             ))
           })?;

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -1,0 +1,514 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+// use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use bazel_protos::remote_execution::{
+  Action, Command, ExecuteResponse, ExecutedActionMetadata, WaitExecutionRequest,
+};
+use bytes::Bytes;
+use futures::compat::{Future01CompatExt, Stream01CompatExt};
+use futures::future::{self as future03};
+use futures::{Stream, StreamExt};
+use hashing::{Digest, Fingerprint};
+use log::{debug, trace, warn};
+use protobuf::Message;
+use store::Store;
+
+use super::{
+  format_error, maybe_add_workunit, populate_fallible_execution_result, ExecutionError,
+  OperationOrStatus,
+};
+use crate::{
+  Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, PlatformConstraint,
+  Process, ProcessMetadata,
+};
+use bazel_protos::call_option;
+use bazel_protos::error_details::PreconditionFailure;
+use bazel_protos::status::Status;
+use concrete_time::TimeSpan;
+
+/// Implementation of CommandRunner that runs a command via the Bazel Remote Execution API
+/// (https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvroblTZ_6s/edit).
+///
+/// Results are streamed from the output stream of the Execute function (and possibly the
+/// WaitExecution function if `StreamingCommandRunner` needs to reconnect).
+///
+/// If the CommandRunner has a Store, files will be uploaded to the remote CAS as needed.
+/// Note that it does not proactively upload files to a remote CAS. This is because if we will
+/// get a cache hit, uploading the files was wasted time and bandwidth, and if the remote CAS
+/// already has some files, uploading them all is a waste. Instead, we look at the responses we
+/// get back from the server, and upload the files it says it's missing.
+///
+/// In the future, we may want to do some clever things like proactively upload files which the
+/// user has changed, or files which aren't known to the local git repository, but these are
+/// optimizations to shave off a round-trip in the future.
+#[derive(Clone)]
+pub struct StreamingCommandRunner {
+  metadata: ProcessMetadata,
+  platform: Platform,
+  store: Store,
+  headers: BTreeMap<String, String>,
+  channel: grpcio::Channel,
+  env: Arc<grpcio::Environment>,
+  execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
+}
+
+impl StreamingCommandRunner {
+  // /// Construct a new StreamingCommandRunner
+  // pub fn new() -> Self {
+  //
+  // }
+
+  pub fn platform(&self) -> Platform {
+    self.platform
+  }
+
+  async fn store_proto_locally<P: protobuf::Message>(&self, proto: &P) -> Result<Digest, String> {
+    let command_bytes = proto
+      .write_to_bytes()
+      .map_err(|e| format!("Error serializing proto {:?}", e))?;
+    self
+      .store
+      .store_file_bytes(Bytes::from(command_bytes), true)
+      .await
+      .map_err(|e| format!("Error saving proto to local store: {:?}", e))
+  }
+
+  async fn ensure_action_uploaded(
+    &self,
+    store: &Store,
+    command: &Command,
+    action: &Action,
+    input_files: Digest,
+  ) -> Result<(), String> {
+    let (command_digest, action_digest) = future03::try_join(
+      self.store_proto_locally(command),
+      self.store_proto_locally(action),
+    )
+    .await?;
+
+    let _ = store
+      .ensure_remote_has_recursive(vec![command_digest, action_digest, input_files])
+      .compat()
+      .await?;
+
+    Ok(())
+  }
+
+  // Monitors the operation stream returned by the REv2 Execute and WaitExecution methods.
+  // Outputs progress reported by the server and returns the next actionable operation
+  // or gRPC status back to the main loop (plus the operation name so the main loop can
+  // reconnect).
+  async fn wait_on_operation_stream<S>(&self, mut stream: S) -> (Option<String>, OperationOrStatus)
+  where
+    S: Stream<Item = Result<bazel_protos::operations::Operation, grpcio::Error>> + Unpin,
+  {
+    let mut operation_name_opt: Option<String> = None;
+
+    debug!("monitor_operation_stream: monitoring stream");
+
+    loop {
+      // TODO: Add deadline timeout.
+      match stream.next().await {
+        Some(Ok(operation)) => {
+          debug!("monitor_operation_stream: got operation: {:?}", &operation);
+          operation_name_opt = Some(operation.get_name().to_string());
+
+          // Continue monitoring if the operation is not complete.
+          if !operation.get_done() {
+            continue;
+          }
+
+          // Otherwise, return to the main loop with the operation as the result.
+          return (operation_name_opt, OperationOrStatus::Operation(operation));
+        }
+
+        Some(Err(_)) => {}
+
+        None => {
+          // Stream disconnected unexpectedly. Return UNAVAILABLE status so that the
+          // main loop will reconnect with the WaitExecution method.
+          debug!("Unexpected disconnect from RE server");
+          let mut status = bazel_protos::status::Status::new();
+          status.set_code(grpcio::RpcStatusCode::UNAVAILABLE.into());
+          status.set_message("stream disconnected unexpectedly".to_owned());
+          return (operation_name_opt, OperationOrStatus::Status(status));
+        }
+      }
+    }
+  }
+
+  // Store the remote timings into the workunit store.
+  fn save_workunit_timings(
+    &self,
+    execute_response: &ExecuteResponse,
+    metadata: &ExecutedActionMetadata,
+  ) {
+    let workunit_state = workunit_store::expect_workunit_state();
+    let workunit_store = workunit_state.store;
+    let parent_id = workunit_state.parent_id;
+    let result_cached = execute_response.get_cached_result();
+
+    match TimeSpan::from_start_and_end(
+      metadata.get_queued_timestamp(),
+      metadata.get_worker_start_timestamp(),
+      "remote queue",
+    ) {
+      Ok(time_span) => {
+        maybe_add_workunit(
+          result_cached,
+          "remote execution action scheduling",
+          time_span,
+          parent_id.clone(),
+          &workunit_store,
+        );
+      }
+      Err(s) => warn!("{}", s),
+    };
+
+    match TimeSpan::from_start_and_end(
+      metadata.get_input_fetch_start_timestamp(),
+      metadata.get_input_fetch_completed_timestamp(),
+      "remote input fetch",
+    ) {
+      Ok(time_span) => {
+        maybe_add_workunit(
+          result_cached,
+          "remote execution worker input fetching",
+          time_span,
+          parent_id.clone(),
+          &workunit_store,
+        );
+      }
+      Err(s) => warn!("{}", s),
+    }
+
+    match TimeSpan::from_start_and_end(
+      metadata.get_execution_start_timestamp(),
+      metadata.get_execution_completed_timestamp(),
+      "remote execution",
+    ) {
+      Ok(time_span) => {
+        maybe_add_workunit(
+          result_cached,
+          "remote execution worker command executing",
+          time_span,
+          parent_id.clone(),
+          &workunit_store,
+        );
+      }
+      Err(s) => warn!("{}", s),
+    }
+
+    match TimeSpan::from_start_and_end(
+      metadata.get_output_upload_start_timestamp(),
+      metadata.get_output_upload_completed_timestamp(),
+      "remote output store",
+    ) {
+      Ok(time_span) => {
+        maybe_add_workunit(
+          result_cached,
+          "remote execution worker output uploading",
+          time_span,
+          parent_id,
+          &workunit_store,
+        );
+      }
+      Err(s) => warn!("{}", s),
+    }
+  }
+
+  fn extract_missing_digests(&self, precondition_failure: &PreconditionFailure) -> ExecutionError {
+    let mut missing_digests = Vec::with_capacity(precondition_failure.get_violations().len());
+
+    for violation in precondition_failure.get_violations() {
+      if violation.get_field_type() != "MISSING" {
+        return ExecutionError::Fatal(format!(
+          "Unknown PreconditionFailure violation: {:?}",
+          violation
+        ));
+      }
+
+      let parts: Vec<_> = violation.get_subject().split('/').collect();
+      if parts.len() != 3 || parts[0] != "blobs" {
+        return ExecutionError::Fatal(format!(
+          "Received FailedPrecondition MISSING but didn't recognize subject {}",
+          violation.get_subject()
+        ));
+      }
+
+      let fingerprint = match Fingerprint::from_hex_string(parts[1]) {
+        Ok(f) => f,
+        Err(e) => {
+          return ExecutionError::Fatal(format!("Bad digest in missing blob: {}: {}", parts[1], e))
+        }
+      };
+
+      let size = match parts[2].parse::<usize>() {
+        Ok(s) => s,
+        Err(e) => {
+          return ExecutionError::Fatal(format!("Missing blob had bad size: {}: {}", parts[2], e))
+        }
+      };
+
+      missing_digests.push(Digest(fingerprint, size));
+    }
+
+    if missing_digests.is_empty() {
+      return ExecutionError::Fatal(
+        "Error from remote execution: FailedPrecondition, but no details".to_owned(),
+      );
+    }
+
+    ExecutionError::MissingDigests(missing_digests)
+  }
+
+  async fn extract_execute_response(
+    &self,
+    operation_or_status: OperationOrStatus,
+  ) -> Result<FallibleProcessResultWithPlatform, ExecutionError> {
+    trace!("Got operation response: {:?}", operation_or_status);
+
+    let status = match operation_or_status {
+      OperationOrStatus::Operation(operation) => {
+        assert!(operation.get_done(), "operation was not marked done");
+        if operation.has_error() {
+          warn!("protocol violation: REv2 prohibits setting Operation::error");
+          return Err(ExecutionError::Fatal(format_error(&operation.get_error())));
+        }
+
+        if !operation.has_response() {
+          return Err(ExecutionError::Fatal(
+            "Operation finished but no response supplied".to_string(),
+          ));
+        }
+
+        let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
+        execute_response
+          .merge_from_bytes(operation.get_response().get_value())
+          .map_err(|e| ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e)))?;
+
+        debug!("Got (nested) execute response: {:?}", execute_response);
+
+        if execute_response.get_result().has_execution_metadata() {
+          let metadata = execute_response.get_result().get_execution_metadata();
+          self.save_workunit_timings(&execute_response, &metadata);
+        }
+
+        let status = execute_response.take_status();
+        if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::OK {
+          return Ok(
+            populate_fallible_execution_result(
+              self.store.clone(),
+              execute_response,
+              vec![],
+              self.platform,
+            )
+            .compat()
+            .await
+            .map_err(ExecutionError::Fatal)?,
+          );
+        }
+
+        status
+      }
+      OperationOrStatus::Status(status) => status,
+    };
+
+    match grpcio::RpcStatusCode::from(status.get_code()) {
+      grpcio::RpcStatusCode::OK => unreachable!(),
+
+      grpcio::RpcStatusCode::FAILED_PRECONDITION => {
+        if status.get_details().len() != 1 {
+          return Err(ExecutionError::Fatal(format!(
+            "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
+            status.get_details()
+          )));
+        }
+        let details = status.get_details().get(0).unwrap();
+        let mut precondition_failure = PreconditionFailure::new();
+        let full_name = format!(
+          "type.googleapis.com/{}",
+          precondition_failure.descriptor().full_name()
+        );
+        if details.get_type_url() != full_name {
+          return Err(ExecutionError::Fatal(format!(
+            "Received PreconditionFailure, but didn't know how to resolve it: {}, protobuf type {}",
+            status.get_message(),
+            details.get_type_url()
+          )));
+        }
+
+        // Decode the precondition failure.
+        precondition_failure
+          .merge_from_bytes(details.get_value())
+          .map_err(|e| {
+            ExecutionError::Fatal(format!(
+              "Error deserializing FailedPrecondition proto: {:?}",
+              e
+            ))
+          })?;
+
+        return Err(self.extract_missing_digests(&precondition_failure));
+      }
+
+      code => match code {
+        grpcio::RpcStatusCode::ABORTED
+        | grpcio::RpcStatusCode::INTERNAL
+        | grpcio::RpcStatusCode::RESOURCE_EXHAUSTED
+        | grpcio::RpcStatusCode::UNAVAILABLE
+        | grpcio::RpcStatusCode::UNKNOWN => {
+          Err(ExecutionError::Retryable(status.get_message().to_owned()))
+        }
+        _ => Err(ExecutionError::Fatal(format!(
+          "Error from remote execution: {:?}: {:?}",
+          code,
+          status.get_message()
+        ))),
+      },
+    }
+  }
+}
+
+#[async_trait]
+impl crate::CommandRunner for StreamingCommandRunner {
+  /// Run the given MultiPlatformProcess via the Remote Execution API.
+  async fn run(
+    &self,
+    request: MultiPlatformProcess,
+    context: Context,
+  ) -> Result<FallibleProcessResultWithPlatform, String> {
+    // Construct the REv2 ExecuteRequest and related data for this execution request.
+    let compatible_underlying_request = self.extract_compatible_request(&request).unwrap();
+    let store = self.store.clone();
+    let (action, command, execute_request) =
+      super::make_execute_request(&compatible_underlying_request, self.metadata.clone())?;
+    let Process {
+      description,
+      // timeout,
+      input_files,
+      ..
+    } = compatible_underlying_request;
+
+    debug!("Remote execution: {}", description);
+
+    // Record the time that we started to process this request, then compute the ultimate
+    // deadline for execution of this request.
+    // let request_start_time = Instant::now();
+    // let request_deadline_duration = timeout.unwrap_or(Duration::from_secs(5 * 60)); // TODO: Make this configurable.
+    // let equestDeadlineTime = requestStartTime
+    //   .checked_add(requestDeadlineDuration)
+    //   .unwrap();
+
+    // Upload the action (and related data, i.e. the embedded command and input files).
+    self
+      .ensure_action_uploaded(&store, &command, &action, input_files)
+      .await?;
+
+    // Main loop: This loop connects to the RE server and either (1) submits the request using
+    // the REv2 Execute method; or (2) reconnects to the server via the REv2 WaitExecution
+    // method if the request is already in-flight. That status is tracked in the
+    // operation_name variable.
+    //
+    // It then processes the resulting errors and status updates until either the
+    // request completes (whether success or error), or the overall deadline occurs.
+    let mut current_operation_name: Option<String> = None;
+
+    loop {
+      let call_opt = call_option(&self.headers, Some(context.build_id.clone()))?;
+      let rpc_result = match current_operation_name {
+        None => {
+          // The request has not been submitted yet. Submit the request using the REv2
+          // Execute method.
+          self
+            .execution_client
+            .execute_opt(&execute_request, call_opt)
+        }
+
+        Some(ref operation_name) => {
+          // The request has been submitted already. Reconnect to the status stream
+          // using the REv2 WaitExecution method.
+          let mut wait_execution_request = WaitExecutionRequest::new();
+          wait_execution_request.set_name(operation_name.to_owned());
+          self
+            .execution_client
+            .wait_execution_opt(&wait_execution_request, call_opt)
+        }
+      };
+
+      // Take action based on whether we received an output stream or whether there is an
+      // error to resolve.
+      let actionable_result = match rpc_result {
+        Ok(operation_stream) => {
+          // Monitor the operation stream until there is an actionable operation
+          // or status to interpret.
+          let compat_stream = operation_stream.compat();
+          let (operation_name_opt, actionable_result) =
+            self.wait_on_operation_stream(compat_stream).await;
+
+          // Save the operation name in case we need to reconnect via WaitExecution.
+          if let Some(name) = operation_name_opt {
+            current_operation_name = Some(name);
+          } else {
+            panic!("no operation name returned from monitor_operation_stream");
+          }
+
+          actionable_result
+        }
+        Err(err) => match err {
+          grpcio::Error::RpcFailure(rpc_status) => {
+            let mut status = Status::new();
+            status.code = rpc_status.status.into();
+            OperationOrStatus::Status(status)
+          }
+          _ => {
+            return Err(format!("total failure dude: {}", err));
+          }
+        },
+      };
+
+      match self.extract_execute_response(actionable_result).await {
+        Ok(result) => return Ok(result),
+        Err(err) => match err {
+          ExecutionError::Fatal(e) => return Err(e),
+          ExecutionError::Retryable(e) => {
+            // do nothing, will retry
+            debug!("retryable error: {}", e);
+          }
+          ExecutionError::MissingDigests(missing_digests) => {
+            trace!(
+              "Server reported missing digests; trying to upload: {:?}",
+              missing_digests,
+            );
+
+            let _ = store
+              .ensure_remote_has_recursive(missing_digests)
+              .compat()
+              .await?;
+          }
+          ExecutionError::NotFinished(_) => unreachable!(),
+        },
+      }
+    }
+  }
+
+  // TODO: This is a copy of the same method on crate::remote::CommandRunner.
+  fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process> {
+    for compatible_constraint in vec![
+      &(PlatformConstraint::None, PlatformConstraint::None),
+      &(self.platform.into(), PlatformConstraint::None),
+      &(
+        self.platform.into(),
+        PlatformConstraint::current_platform_constraint().unwrap(),
+      ),
+    ]
+    .iter()
+    {
+      if let Some(compatible_req) = req.0.get(compatible_constraint) {
+        return Some(compatible_req.clone());
+      }
+    }
+    None
+  }
+}

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -414,7 +414,7 @@ impl StreamingCommandRunner {
             ))
           })?;
 
-        return Err(self.extract_missing_digests(&precondition_failure));
+        Err(self.extract_missing_digests(&precondition_failure))
       }
 
       code => match code {
@@ -560,15 +560,13 @@ impl crate::CommandRunner for StreamingCommandRunner {
 
     let result_fut = self.run_execute_request(execute_request, context);
     let timeout_fut = tokio::time::timeout(deadline_duration, result_fut);
-    let result = match timeout_fut.await {
+    match timeout_fut.await {
       Ok(r) => r,
       Err(_) => {
         trace!("remote execution timed out after {:?}", deadline_duration);
         Err("remote execution request timed out".to_owned())
       }
-    };
-
-    result
+    }
   }
 
   // TODO: This is a copy of the same method on crate::remote::CommandRunner.

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -541,18 +541,10 @@ async fn successful_execution_after_one_getoperation() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
-
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
   assert_cancellation_requests(&mock_server, vec![]);
 }
 
@@ -604,17 +596,11 @@ async fn retries_retriable_errors() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 
   assert_cancellation_requests(&mock_server, vec![]);
 }
@@ -819,31 +805,26 @@ async fn extract_response_with_digest_stdout() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Digest(testdata.digest()),
-        StderrType::Raw(testdata_empty.string()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Linux,
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Digest(testdata.digest()),
+      StderrType::Raw(testdata_empty.string()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata.bytes(),
-      stderr: testdata_empty.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata.bytes());
+  assert_eq!(result.stderr, testdata_empty.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -851,31 +832,26 @@ async fn extract_response_with_digest_stderr() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Raw(testdata_empty.string()),
-        StderrType::Digest(testdata.digest()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Linux,
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Raw(testdata_empty.string()),
+      StderrType::Digest(testdata.digest()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata_empty.bytes(),
-      stderr: testdata.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata_empty.bytes());
+  assert_eq!(result.stderr, testdata.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -883,31 +859,26 @@ async fn extract_response_with_digest_stdout_osx_remote() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Digest(testdata.digest()),
-        StderrType::Raw(testdata_empty.string()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Darwin
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Digest(testdata.digest()),
+      StderrType::Raw(testdata_empty.string()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata.bytes(),
-      stderr: testdata_empty.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Darwin,
-    }
-  );
+    .unwrap(),
+    Platform::Darwin,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata.bytes());
+  assert_eq!(result.stderr, testdata_empty.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Darwin);
 }
 
 #[tokio::test]
@@ -983,17 +954,11 @@ async fn ensure_inline_stdio_is_stored() {
     .run(echo_roland_request(), Context::default())
     .await
     .unwrap();
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: test_stdout.bytes(),
-      stderr: test_stderr.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+
+  assert_eq!(result.stdout, test_stdout.bytes());
+  assert_eq!(result.stderr, test_stderr.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
 
   let local_store =
     Store::local_only(runtime.clone(), &store_dir_path).expect("Error creating local store");
@@ -1071,17 +1036,11 @@ async fn successful_execution_after_four_getoperations() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -1255,17 +1214,11 @@ async fn retry_for_cancelled_channel() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -1569,17 +1522,12 @@ async fn execute_missing_file_uploads_if_known() {
     .run(cat_roland_request(), Context::default())
     .await
     .unwrap();
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: roland.bytes(),
-      stderr: Bytes::from(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+
+  assert_eq!(result.stdout, roland.bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
+
   {
     let blobs = cas.blobs.lock();
     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
@@ -1678,18 +1626,13 @@ async fn execute_missing_file_uploads_if_known_status() {
   )
   .unwrap()
   .run(cat_roland_request(), Context::default())
-  .await;
-  assert_eq!(
-    result,
-    Ok(FallibleProcessResultWithPlatform {
-      stdout: roland.bytes(),
-      stderr: Bytes::from(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    })
-  );
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, roland.bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
   {
     let blobs = cas.blobs.lock();
     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 use bazel_protos;
 use bazel_protos::operations::Operation;
 use bazel_protos::remote_execution::ExecutedActionMetadata;
@@ -20,7 +21,7 @@ use crate::{
   MultiPlatformProcess, Platform, PlatformConstraint, Process, ProcessMetadata,
 };
 use maplit::{btreemap, hashset};
-use mock::execution_server::MockOperation;
+use mock::execution_server::{MockOperation, ExpectedAPICall};
 use protobuf::well_known_types::Timestamp;
 use spectral::prelude::*;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -484,21 +485,18 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
 async fn server_rejecting_execute_request_gives_error() {
   let execute_request = echo_foo_request();
 
-  let mock_server = {
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        "wrong-command".to_string(),
-        crate::remote::make_execute_request(
+  let mock_server = mock::execution_server::TestServer::new(
+    mock::execution_server::MockExecution::new(vec![
+      ExpectedAPICall::Execute {
+        execute_request: crate::remote::make_execute_request(
           &Process::new(owned_string_vec(&["/bin/echo", "-n", "bar"])),
           empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![],
-      ),
-      None,
-    )
-  };
+        ).map(|x| x.2).unwrap(),
+        stream_responses: Err(grpcio::RpcStatus::new(grpcio::RpcStatusCode::INVALID_ARGUMENT, None)),
+      }
+    ]),
+    None,
+  );
 
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
@@ -514,24 +512,26 @@ async fn successful_execution_after_one_getoperation() {
 
   let mock_server = {
     mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_successful_operation(
+      mock::execution_server::MockExecution::new(vec![
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          ).unwrap().2,
+          stream_responses: Ok(vec![
+            make_incomplete_operation(&op_name),
+          ]),
+        },
+        ExpectedAPICall::GetOperation {
+          operation_name: op_name.clone(),
+          operation: make_successful_operation(
             &op_name,
             StdoutType::Raw("foo".to_owned()),
             StderrType::Raw("".to_owned()),
             0,
           ),
-        ],
-      ),
+        }
+      ]),
       None,
     )
   };
@@ -540,10 +540,18 @@ async fn successful_execution_after_one_getoperation() {
     .await
     .unwrap();
 
-  assert_eq!(result.stdout, "foo".as_bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(
+    result.without_execution_attempts(),
+    FallibleProcessResultWithPlatform {
+      stdout: as_bytes("foo"),
+      stderr: as_bytes(""),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Linux,
+    }
+  );
+
   assert_cancellation_requests(&mock_server, vec![]);
 }
 
@@ -554,26 +562,35 @@ async fn retries_retriable_errors() {
 
   let mock_server = {
     mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-          make_incomplete_operation(&op_name),
-          make_successful_operation(
+      mock::execution_server::MockExecution::new(vec![
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          ).unwrap().2,
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::GetOperation {
+          operation_name: op_name.clone(),
+          operation: make_retryable_operation_failure(),
+        },
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          ).unwrap().2,
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::GetOperation {
+          operation_name: op_name.clone(),
+          operation: make_successful_operation(
             &op_name,
             StdoutType::Raw("foo".to_owned()),
             StderrType::Raw("".to_owned()),
             0,
           ),
-        ],
-      ),
+        },
+      ]),
       None,
     )
   };
@@ -582,187 +599,198 @@ async fn retries_retriable_errors() {
     .await
     .unwrap();
 
-  assert_eq!(result.stdout, "foo".as_bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Linux);
+  assert_eq!(
+    result.without_execution_attempts(),
+    FallibleProcessResultWithPlatform {
+      stdout: as_bytes("foo"),
+      stderr: as_bytes(""),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Linux,
+    }
+  );
 
   assert_cancellation_requests(&mock_server, vec![]);
 }
 
-#[tokio::test]
-async fn gives_up_after_many_retriable_errors() {
-  let execute_request = echo_foo_request();
-  let op_name = "gimme-foo".to_string();
+// #[tokio::test]
+// async fn gives_up_after_many_retriable_errors() {
+//   let execute_request = echo_foo_request();
+//   let op_name = "gimme-foo".to_string();
+//
+//   let mock_server = {
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_retryable_operation_failure(),
+//           make_incomplete_operation(&op_name),
+//           make_retryable_operation_failure(),
+//           make_incomplete_operation(&op_name),
+//           make_retryable_operation_failure(),
+//           make_incomplete_operation(&op_name),
+//           make_retryable_operation_failure(),
+//           make_incomplete_operation(&op_name),
+//           make_retryable_operation_failure(),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let err = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .unwrap_err();
+//
+//   assert_that!(err).contains("Gave up");
+//   assert_that!(err).contains("appears to be lost");
+//
+//   assert_cancellation_requests(&mock_server, vec![]);
+// }
 
-  let mock_server = {
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-          make_incomplete_operation(&op_name),
-          make_retryable_operation_failure(),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let err = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .unwrap_err();
-
-  assert_that!(err).contains("Gave up");
-  assert_that!(err).contains("appears to be lost");
-
-  assert_cancellation_requests(&mock_server, vec![]);
-}
-
-#[tokio::test]
-async fn sends_headers() {
-  let execute_request = echo_foo_request();
-  let op_name = "gimme-foo".to_string();
-
-  let mock_server = {
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_successful_operation(
-            &op_name,
-            StdoutType::Raw("foo".to_owned()),
-            StderrType::Raw("".to_owned()),
-            0,
-          ),
-        ],
-      ),
-      None,
-    )
-  };
-  let cas = mock::StubCAS::empty();
-  let runtime = task_executor::Executor::new(Handle::current());
-  let store_dir = TempDir::new().unwrap();
-  let store = Store::with_remote(
-    runtime.clone(),
-    store_dir,
-    vec![cas.address()],
-    None,
-    None,
-    None,
-    1,
-    10 * 1024 * 1024,
-    Duration::from_secs(1),
-    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
-    1,
-    1,
-  )
-  .expect("Failed to make store");
-
-  let command_runner = CommandRunner::new(
-    &mock_server.address(),
-    empty_request_metadata(),
-    None,
-    Some(String::from("catnip-will-get-you-anywhere")),
-    btreemap! {
-      String::from("cat") => String::from("roland"),
-    },
-    store,
-    Platform::Linux,
-    runtime.clone(),
-    Duration::from_secs(0),
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-  )
-  .unwrap();
-  let context = Context {
-    workunit_store: WorkunitStore::new(false),
-    build_id: String::from("marmosets"),
-  };
-  command_runner
-    .run(execute_request, context)
-    .await
-    .expect("Execution failed");
-
-  let received_messages = mock_server.mock_responder.received_messages.lock();
-  let message_headers: Vec<_> = received_messages
-    .iter()
-    .map(|received_message| received_message.headers.clone())
-    .collect();
-  assert_that!(message_headers).has_length(2);
-  for headers in message_headers {
-    {
-      let want_key = String::from("google.devtools.remoteexecution.v1test.requestmetadata-bin");
-      assert_that!(headers).contains_key(&want_key);
-      let mut proto = bazel_protos::remote_execution::RequestMetadata::new();
-      proto
-        .merge_from_bytes(&headers[&want_key])
-        .expect("Failed to parse metadata proto");
-      assert_eq!(proto.get_tool_details().get_tool_name(), "pants");
-      assert_eq!(proto.get_tool_invocation_id(), "marmosets");
-    }
-    {
-      let want_key = String::from("cat");
-      assert_that!(headers).contains_key(&want_key);
-      assert_eq!(headers[&want_key], "roland".as_bytes());
-    }
-    {
-      let want_key = String::from("authorization");
-      assert_that!(headers).contains_key(&want_key);
-      assert_eq!(
-        headers[&want_key],
-        "Bearer catnip-will-get-you-anywhere".as_bytes()
-      );
-    }
-  }
-}
+// #[tokio::test]
+// async fn sends_headers() {
+//   let execute_request = echo_foo_request();
+//   let op_name = "gimme-foo".to_string();
+//
+//   let mock_server = {
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_successful_operation(
+//             &op_name,
+//             StdoutType::Raw("foo".to_owned()),
+//             StderrType::Raw("".to_owned()),
+//             0,
+//           ),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//   let cas = mock::StubCAS::empty();
+//   let runtime = task_executor::Executor::new(Handle::current());
+//   let store_dir = TempDir::new().unwrap();
+//   let store = Store::with_remote(
+//     runtime.clone(),
+//     store_dir,
+//     vec![cas.address()],
+//     None,
+//     None,
+//     None,
+//     1,
+//     10 * 1024 * 1024,
+//     Duration::from_secs(1),
+//     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+//     1,
+//     1,
+//   )
+//   .expect("Failed to make store");
+//
+//   let command_runner = CommandRunner::new(
+//     &mock_server.address(),
+//     empty_request_metadata(),
+//     None,
+//     Some(String::from("catnip-will-get-you-anywhere")),
+//     btreemap! {
+//       String::from("cat") => String::from("roland"),
+//     },
+//     store,
+//     Platform::Linux,
+//     runtime.clone(),
+//     Duration::from_secs(0),
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//   )
+//   .unwrap();
+//   let context = Context {
+//     workunit_store: WorkunitStore::default(),
+//     build_id: String::from("marmosets"),
+//   };
+//   command_runner
+//     .run(execute_request, context)
+//     .await
+//     .expect("Execution failed");
+//
+//   let received_messages = mock_server.mock_responder.received_messages.lock();
+//   let message_headers: Vec<_> = received_messages
+//     .iter()
+//     .map(|received_message| received_message.headers.clone())
+//     .collect();
+//   assert_that!(message_headers).has_length(2);
+//   for headers in message_headers {
+//     {
+//       let want_key = String::from("google.devtools.remoteexecution.v1test.requestmetadata-bin");
+//       assert_that!(headers).contains_key(&want_key);
+//       let mut proto = bazel_protos::remote_execution::RequestMetadata::new();
+//       proto
+//         .merge_from_bytes(&headers[&want_key])
+//         .expect("Failed to parse metadata proto");
+//       assert_eq!(proto.get_tool_details().get_tool_name(), "pants");
+//       assert_eq!(proto.get_tool_invocation_id(), "marmosets");
+//     }
+//     {
+//       let want_key = String::from("cat");
+//       assert_that!(headers).contains_key(&want_key);
+//       assert_eq!(headers[&want_key], "roland".as_bytes());
+//     }
+//     {
+//       let want_key = String::from("authorization");
+//       assert_that!(headers).contains_key(&want_key);
+//       assert_eq!(
+//         headers[&want_key],
+//         "Bearer catnip-will-get-you-anywhere".as_bytes()
+//       );
+//     }
+//   }
+// }
 
 #[tokio::test]
 async fn extract_response_with_digest_stdout() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  let result = extract_execute_response(
-    make_successful_operation(
-      &op_name,
-      StdoutType::Digest(testdata.digest()),
-      StderrType::Raw(testdata_empty.string()),
-      0,
+  assert_eq!(
+    extract_execute_response(
+      make_successful_operation(
+        &op_name,
+        StdoutType::Digest(testdata.digest()),
+        StderrType::Raw(testdata_empty.string()),
+        0,
+      )
+      .op
+      .unwrap()
+      .unwrap(),
+      Platform::Linux,
     )
-    .op
+    .await
     .unwrap()
-    .unwrap(),
-    Platform::Linux,
-  )
-  .await
-  .unwrap();
-
-  assert_eq!(result.stdout, testdata.bytes());
-  assert_eq!(result.stderr, testdata_empty.bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Linux);
+    .without_execution_attempts(),
+    FallibleProcessResultWithPlatform {
+      stdout: testdata.bytes(),
+      stderr: testdata_empty.bytes(),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Linux,
+    }
+  );
 }
 
 #[tokio::test]
@@ -770,26 +798,31 @@ async fn extract_response_with_digest_stderr() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  let result = extract_execute_response(
-    make_successful_operation(
-      &op_name,
-      StdoutType::Raw(testdata_empty.string()),
-      StderrType::Digest(testdata.digest()),
-      0,
+  assert_eq!(
+    extract_execute_response(
+      make_successful_operation(
+        &op_name,
+        StdoutType::Raw(testdata_empty.string()),
+        StderrType::Digest(testdata.digest()),
+        0,
+      )
+      .op
+      .unwrap()
+      .unwrap(),
+      Platform::Linux,
     )
-    .op
+    .await
     .unwrap()
-    .unwrap(),
-    Platform::Linux,
-  )
-  .await
-  .unwrap();
-
-  assert_eq!(result.stdout, testdata_empty.bytes());
-  assert_eq!(result.stderr, testdata.bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Linux);
+    .without_execution_attempts(),
+    FallibleProcessResultWithPlatform {
+      stdout: testdata_empty.bytes(),
+      stderr: testdata.bytes(),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Linux,
+    }
+  );
 }
 
 #[tokio::test]
@@ -797,796 +830,829 @@ async fn extract_response_with_digest_stdout_osx_remote() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  let result = extract_execute_response(
-    make_successful_operation(
-      &op_name,
-      StdoutType::Digest(testdata.digest()),
-      StderrType::Raw(testdata_empty.string()),
-      0,
+  assert_eq!(
+    extract_execute_response(
+      make_successful_operation(
+        &op_name,
+        StdoutType::Digest(testdata.digest()),
+        StderrType::Raw(testdata_empty.string()),
+        0,
+      )
+      .op
+      .unwrap()
+      .unwrap(),
+      Platform::Darwin
     )
-    .op
+    .await
     .unwrap()
-    .unwrap(),
-    Platform::Darwin,
-  )
-  .await
-  .unwrap();
-
-  assert_eq!(result.stdout, testdata.bytes());
-  assert_eq!(result.stderr, testdata_empty.bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Darwin);
-}
-
-#[tokio::test]
-async fn ensure_inline_stdio_is_stored() {
-  let runtime = task_executor::Executor::new(Handle::current());
-
-  let test_stdout = TestData::roland();
-  let test_stderr = TestData::catnip();
-
-  let mock_server = {
-    let op_name = "cat".to_owned();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &echo_roland_request().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![make_successful_operation(
-          &op_name.clone(),
-          StdoutType::Raw(test_stdout.string()),
-          StderrType::Raw(test_stderr.string()),
-          0,
-        )],
-      ),
-      None,
-    )
-  };
-
-  let store_dir = TempDir::new().unwrap();
-  let store_dir_path = store_dir.path();
-
-  let cas = mock::StubCAS::empty();
-  let store = Store::with_remote(
-    runtime.clone(),
-    &store_dir_path,
-    vec![cas.address()],
-    None,
-    None,
-    None,
-    1,
-    10 * 1024 * 1024,
-    Duration::from_secs(1),
-    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
-    1,
-    1,
-  )
-  .expect("Failed to make store");
-
-  let cmd_runner = CommandRunner::new(
-    &mock_server.address(),
-    empty_request_metadata(),
-    None,
-    None,
-    BTreeMap::new(),
-    store,
-    Platform::Linux,
-    runtime.clone(),
-    Duration::from_secs(0),
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-  )
-  .unwrap();
-  let result = cmd_runner
-    .run(echo_roland_request(), Context::default())
-    .await
-    .unwrap();
-
-  assert_eq!(result.stdout, test_stdout.bytes());
-  assert_eq!(result.stderr, test_stderr.bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.platform, Platform::Linux);
-
-  let local_store =
-    Store::local_only(runtime.clone(), &store_dir_path).expect("Error creating local store");
-  {
-    assert_eq!(
-      local_store
-        .load_file_bytes_with(test_stdout.digest(), |v| Bytes::from(v))
-        .await
-        .unwrap()
-        .unwrap()
-        .0,
-      test_stdout.bytes()
-    );
-    assert_eq!(
-      local_store
-        .load_file_bytes_with(test_stderr.digest(), |v| Bytes::from(v))
-        .await
-        .unwrap()
-        .unwrap()
-        .0,
-      test_stderr.bytes()
-    );
-  }
-}
-
-#[tokio::test]
-async fn successful_execution_after_four_getoperations() {
-  let execute_request = echo_foo_request();
-
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        Vec::from_iter(
-          iter::repeat(make_incomplete_operation(&op_name))
-            .take(4)
-            .chain(iter::once(make_successful_operation(
-              &op_name,
-              StdoutType::Raw("foo".to_owned()),
-              StderrType::Raw("".to_owned()),
-              0,
-            ))),
-        ),
-      ),
-      None,
-    )
-  };
-
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .unwrap();
-
-  assert_eq!(result.stdout, "foo".as_bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Linux);
-}
-
-#[tokio::test]
-async fn timeout_after_sufficiently_delayed_getoperations() {
-  let request_timeout = Duration::new(1, 0);
-  // The request should timeout after 2 seconds, with 1 second due to the queue_buffer_time and
-  // 1 due to the request_timeout.
-  let delayed_operation_time = Duration::new(2, 500);
-
-  let execute_request = Process {
-    argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: Some(request_timeout),
-    description: "echo-a-foo".to_string(),
-    append_only_caches: BTreeSet::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
-
-  let op_name = "gimme-foo".to_string();
-
-  let mock_server = {
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(&execute_request, empty_request_metadata())
-          .unwrap()
-          .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_delayed_incomplete_operation(&op_name, delayed_operation_time),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let result = run_command_remote(mock_server.address(), execute_request.into())
-    .await
-    .unwrap();
-  assert_eq!(result.exit_code, -15);
-  let error_msg = String::from_utf8(result.stdout.to_vec()).unwrap();
-  assert_that(&error_msg).contains("Exceeded timeout");
-  assert_that(&error_msg).contains("echo-a-foo");
-  assert_eq!(result.execution_attempts.len(), 1);
-  let maybe_execution_duration = result.execution_attempts[0].remote_execution;
-  assert!(maybe_execution_duration.is_some());
-  assert_that(&maybe_execution_duration.unwrap()).is_greater_than_or_equal_to(request_timeout);
-
-  assert_cancellation_requests(&mock_server, vec![op_name.to_owned()]);
-}
-
-#[ignore] // flaky: https://github.com/pantsbuild/pants/issues/8405
-#[tokio::test]
-async fn dropped_request_cancels() {
-  let request_timeout = Duration::new(10, 0);
-  let delayed_operation_time = Duration::new(5, 0);
-
-  let execute_request = Process {
-    argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: Some(request_timeout),
-    description: "echo-a-foo".to_string(),
-    append_only_caches: BTreeSet::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
-
-  let op_name = "gimme-foo".to_string();
-
-  let mock_server = {
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(&execute_request, empty_request_metadata())
-          .unwrap()
-          .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_delayed_incomplete_operation(&op_name, delayed_operation_time),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let cas = mock::StubCAS::builder()
-    .file(&TestData::roland())
-    .directory(&TestDirectory::containing_roland())
-    .build();
-  let command_runner = create_command_runner(
-    mock_server.address(),
-    &cas,
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-    Platform::Linux,
+    .without_execution_attempts(),
+    FallibleProcessResultWithPlatform {
+      stdout: testdata.bytes(),
+      stderr: testdata_empty.bytes(),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+      platform: Platform::Darwin,
+    }
   );
-
-  // Give the command only 100 ms to run (although it needs a lot more than that).
-  let run_future = command_runner.run(execute_request.into(), Context::default());
-  if let Ok(_) = timeout(Duration::from_millis(100), run_future).await {
-    panic!("Should have timed out.");
-  }
-
-  // Wait a bit longer for the cancellation to have been sent to the server.
-  // TODO: Would be better to be able to await a notification from the server that "something"
-  // had happened.
-  delay_for(Duration::from_secs(3)).await;
-
-  assert_cancellation_requests(&mock_server, vec![op_name.to_owned()]);
 }
 
-#[ignore] // flaky: https://github.com/pantsbuild/pants/issues/7149
-#[tokio::test]
-async fn retry_for_cancelled_channel() {
-  let execute_request = echo_foo_request();
+// #[tokio::test]
+// async fn ensure_inline_stdio_is_stored() {
+//   let runtime = task_executor::Executor::new(Handle::current());
+//
+//   let test_stdout = TestData::roland();
+//   let test_stderr = TestData::catnip();
+//
+//   let mock_server = {
+//     let op_name = "cat".to_owned();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &echo_roland_request().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![make_successful_operation(
+//           &op_name.clone(),
+//           StdoutType::Raw(test_stdout.string()),
+//           StderrType::Raw(test_stderr.string()),
+//           0,
+//         )],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let store_dir = TempDir::new().unwrap();
+//   let store_dir_path = store_dir.path();
+//
+//   let cas = mock::StubCAS::empty();
+//   let store = Store::with_remote(
+//     runtime.clone(),
+//     &store_dir_path,
+//     vec![cas.address()],
+//     None,
+//     None,
+//     None,
+//     1,
+//     10 * 1024 * 1024,
+//     Duration::from_secs(1),
+//     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+//     1,
+//     1,
+//   )
+//   .expect("Failed to make store");
+//
+//   let cmd_runner = CommandRunner::new(
+//     &mock_server.address(),
+//     empty_request_metadata(),
+//     None,
+//     None,
+//     BTreeMap::new(),
+//     store,
+//     Platform::Linux,
+//     runtime.clone(),
+//     Duration::from_secs(0),
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//   )
+//   .unwrap();
+//   let result = cmd_runner
+//     .run(echo_roland_request(), Context::default())
+//     .await
+//     .unwrap();
+//   assert_eq!(
+//     result.without_execution_attempts(),
+//     FallibleProcessResultWithPlatform {
+//       stdout: test_stdout.bytes(),
+//       stderr: test_stderr.bytes(),
+//       exit_code: 0,
+//       output_directory: EMPTY_DIGEST,
+//       execution_attempts: vec![],
+//       platform: Platform::Linux,
+//     }
+//   );
+//
+//   let local_store =
+//     Store::local_only(runtime.clone(), &store_dir_path).expect("Error creating local store");
+//   {
+//     assert_eq!(
+//       local_store
+//         .load_file_bytes_with(test_stdout.digest(), |v| Bytes::from(v))
+//         .await
+//         .unwrap()
+//         .unwrap()
+//         .0,
+//       test_stdout.bytes()
+//     );
+//     assert_eq!(
+//       local_store
+//         .load_file_bytes_with(test_stderr.digest(), |v| Bytes::from(v))
+//         .await
+//         .unwrap()
+//         .unwrap()
+//         .0,
+//       test_stderr.bytes()
+//     );
+//   }
+// }
 
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
+// #[tokio::test]
+// async fn successful_execution_after_four_getoperations() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         Vec::from_iter(
+//           iter::repeat(make_incomplete_operation(&op_name))
+//             .take(4)
+//             .chain(iter::once(make_successful_operation(
+//               &op_name,
+//               StdoutType::Raw("foo".to_owned()),
+//               StderrType::Raw("".to_owned()),
+//               0,
+//             ))),
+//         ),
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .unwrap();
+//
+//   assert_eq!(
+//     result.without_execution_attempts(),
+//     FallibleProcessResultWithPlatform {
+//       stdout: as_bytes("foo"),
+//       stderr: as_bytes(""),
+//       exit_code: 0,
+//       output_directory: EMPTY_DIGEST,
+//       execution_attempts: vec![],
+//       platform: Platform::Linux,
+//     }
+//   );
+// }
 
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_canceled_operation(Some(Duration::from_millis(100))),
-          make_successful_operation(
-            &op_name,
-            StdoutType::Raw("foo".to_owned()),
-            StderrType::Raw("".to_owned()),
-            0,
-          ),
-        ],
-      ),
-      None,
-    )
-  };
+// #[tokio::test]
+// async fn timeout_after_sufficiently_delayed_getoperations() {
+//   let request_timeout = Duration::new(1, 0);
+//   // The request should timeout after 2 seconds, with 1 second due to the queue_buffer_time and
+//   // 1 due to the request_timeout.
+//   let delayed_operation_time = Duration::new(2, 500);
+//
+//   let execute_request = Process {
+//     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
+//     env: BTreeMap::new(),
+//     working_directory: None,
+//     input_files: EMPTY_DIGEST,
+//     output_files: BTreeSet::new(),
+//     output_directories: BTreeSet::new(),
+//     timeout: Some(request_timeout),
+//     description: "echo-a-foo".to_string(),
+//     append_only_caches: BTreeSet::new(),
+//     jdk_home: None,
+//     target_platform: PlatformConstraint::None,
+//     is_nailgunnable: false,
+//   };
+//
+//   let op_name = "gimme-foo".to_string();
+//
+//   let mock_server = {
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(&execute_request, empty_request_metadata())
+//           .unwrap()
+//           .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_delayed_incomplete_operation(&op_name, delayed_operation_time),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request.into())
+//     .await
+//     .unwrap();
+//   assert_eq!(result.exit_code, -15);
+//   let error_msg = String::from_utf8(result.stdout.to_vec()).unwrap();
+//   assert_that(&error_msg).contains("Exceeded timeout");
+//   assert_that(&error_msg).contains("echo-a-foo");
+//   assert_eq!(result.execution_attempts.len(), 1);
+//   let maybe_execution_duration = result.execution_attempts[0].remote_execution;
+//   assert!(maybe_execution_duration.is_some());
+//   assert_that(&maybe_execution_duration.unwrap()).is_greater_than_or_equal_to(request_timeout);
+//
+//   assert_cancellation_requests(&mock_server, vec![op_name.to_owned()]);
+// }
 
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .unwrap();
+// #[ignore] // flaky: https://github.com/pantsbuild/pants/issues/8405
+// #[tokio::test]
+// async fn dropped_request_cancels() {
+//   let request_timeout = Duration::new(10, 0);
+//   let delayed_operation_time = Duration::new(5, 0);
+//
+//   let execute_request = Process {
+//     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
+//     env: BTreeMap::new(),
+//     working_directory: None,
+//     input_files: EMPTY_DIGEST,
+//     output_files: BTreeSet::new(),
+//     output_directories: BTreeSet::new(),
+//     timeout: Some(request_timeout),
+//     description: "echo-a-foo".to_string(),
+//     append_only_caches: BTreeSet::new(),
+//     jdk_home: None,
+//     target_platform: PlatformConstraint::None,
+//     is_nailgunnable: false,
+//   };
+//
+//   let op_name = "gimme-foo".to_string();
+//
+//   let mock_server = {
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(&execute_request, empty_request_metadata())
+//           .unwrap()
+//           .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_delayed_incomplete_operation(&op_name, delayed_operation_time),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let cas = mock::StubCAS::builder()
+//     .file(&TestData::roland())
+//     .directory(&TestDirectory::containing_roland())
+//     .build();
+//   let command_runner = create_command_runner(
+//     mock_server.address(),
+//     &cas,
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//     Platform::Linux,
+//   );
+//
+//   // Give the command only 100 ms to run (although it needs a lot more than that).
+//   let run_future = command_runner.run(execute_request.into(), Context::default());
+//   if let Ok(_) = timeout(Duration::from_millis(100), run_future).await {
+//     panic!("Should have timed out.");
+//   }
+//
+//   // Wait a bit longer for the cancellation to have been sent to the server.
+//   // TODO: Would be better to be able to await a notification from the server that "something"
+//   // had happened.
+//   delay_for(Duration::from_secs(3)).await;
+//
+//   assert_cancellation_requests(&mock_server, vec![op_name.to_owned()]);
+// }
 
-  assert_eq!(result.stdout, "foo".as_bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.output_directory, EMPTY_DIGEST);
-  assert_eq!(result.platform, Platform::Linux);
-}
+// #[ignore] // flaky: https://github.com/pantsbuild/pants/issues/7149
+// #[tokio::test]
+// async fn retry_for_cancelled_channel() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_canceled_operation(Some(Duration::from_millis(100))),
+//           make_successful_operation(
+//             &op_name,
+//             StdoutType::Raw("foo".to_owned()),
+//             StderrType::Raw("".to_owned()),
+//             0,
+//           ),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .unwrap();
+//
+//   assert_eq!(
+//     result.without_execution_attempts(),
+//     FallibleProcessResultWithPlatform {
+//       stdout: as_bytes("foo"),
+//       stderr: as_bytes(""),
+//       exit_code: 0,
+//       output_directory: EMPTY_DIGEST,
+//       execution_attempts: vec![],
+//       platform: Platform::Linux,
+//     }
+//   );
+// }
 
-#[tokio::test]
-async fn bad_result_bytes() {
-  let execute_request = echo_foo_request();
+// #[tokio::test]
+// async fn bad_result_bytes() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           MockOperation::new({
+//             let mut op = bazel_protos::operations::Operation::new();
+//             op.set_name(op_name.clone());
+//             op.set_done(true);
+//             op.set_response({
+//               let mut response_wrapper = protobuf::well_known_types::Any::new();
+//               response_wrapper.set_type_url(format!(
+//                 "type.googleapis.com/{}",
+//                 bazel_protos::remote_execution::ExecuteResponse::new()
+//                   .descriptor()
+//                   .full_name()
+//               ));
+//               response_wrapper.set_value(vec![0x00, 0x00, 0x00]);
+//               response_wrapper
+//             });
+//             op
+//           }),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .expect_err("Want Err");
+// }
 
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
+// #[tokio::test]
+// async fn initial_response_error() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![MockOperation::new({
+//           let mut op = bazel_protos::operations::Operation::new();
+//           op.set_name(op_name.to_string());
+//           op.set_done(true);
+//           op.set_error({
+//             let mut error = bazel_protos::status::Status::new();
+//             error.set_code(bazel_protos::code::Code::INTERNAL.value());
+//             error.set_message("Something went wrong".to_string());
+//             error
+//           });
+//           op
+//         })],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .expect_err("Want Err");
+//
+//   assert_eq!(result, "INTERNAL: Something went wrong");
+// }
 
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          MockOperation::new({
-            let mut op = bazel_protos::operations::Operation::new();
-            op.set_name(op_name.clone());
-            op.set_done(true);
-            op.set_response({
-              let mut response_wrapper = protobuf::well_known_types::Any::new();
-              response_wrapper.set_type_url(format!(
-                "type.googleapis.com/{}",
-                bazel_protos::remote_execution::ExecuteResponse::new()
-                  .descriptor()
-                  .full_name()
-              ));
-              response_wrapper.set_value(vec![0x00, 0x00, 0x00]);
-              response_wrapper
-            });
-            op
-          }),
-        ],
-      ),
-      None,
-    )
-  };
+// #[tokio::test]
+// async fn getoperation_response_error() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           MockOperation::new({
+//             let mut op = bazel_protos::operations::Operation::new();
+//             op.set_name(op_name.to_string());
+//             op.set_done(true);
+//             op.set_error({
+//               let mut error = bazel_protos::status::Status::new();
+//               error.set_code(bazel_protos::code::Code::INTERNAL.value());
+//               error.set_message("Something went wrong".to_string());
+//               error
+//             });
+//             op
+//           }),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .expect_err("Want Err");
+//
+//   assert_eq!(result, "INTERNAL: Something went wrong");
+//
+//   assert_cancellation_requests(&mock_server, vec![]);
+// }
 
-  run_command_remote(mock_server.address(), execute_request)
-    .await
-    .expect_err("Want Err");
-}
+// #[tokio::test]
+// async fn initial_response_missing_response_and_error() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![MockOperation::new({
+//           let mut op = bazel_protos::operations::Operation::new();
+//           op.set_name(op_name.to_string());
+//           op.set_done(true);
+//           op
+//         })],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .expect_err("Want Err");
+//
+//   assert_eq!(result, "Operation finished but no response supplied");
+// }
 
-#[tokio::test]
-async fn initial_response_error() {
-  let execute_request = echo_foo_request();
+// #[tokio::test]
+// async fn getoperation_missing_response_and_error() {
+//   let execute_request = echo_foo_request();
+//
+//   let mock_server = {
+//     let op_name = "gimme-foo".to_string();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &execute_request.clone().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           MockOperation::new({
+//             let mut op = bazel_protos::operations::Operation::new();
+//             op.set_name(op_name.to_string());
+//             op.set_done(true);
+//             op
+//           }),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let result = run_command_remote(mock_server.address(), execute_request)
+//     .await
+//     .expect_err("Want Err");
+//
+//   assert_eq!(result, "Operation finished but no response supplied");
+// }
 
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
+// #[tokio::test]
+// async fn execute_missing_file_uploads_if_known() {
+//   let runtime = task_executor::Executor::new(Handle::current());
+//
+//   let roland = TestData::roland();
+//
+//   let mock_server = {
+//     let op_name = "cat".to_owned();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &cat_roland_request().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           make_incomplete_operation(&op_name),
+//           make_precondition_failure_operation(vec![missing_preconditionfailure_violation(
+//             &roland.digest(),
+//           )]),
+//           make_successful_operation(
+//             "cat2",
+//             StdoutType::Raw(roland.string()),
+//             StderrType::Raw("".to_owned()),
+//             0,
+//           ),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let store_dir = TempDir::new().unwrap();
+//   let cas = mock::StubCAS::builder()
+//     .directory(&TestDirectory::containing_roland())
+//     .build();
+//   let store = Store::with_remote(
+//     runtime.clone(),
+//     store_dir,
+//     vec![cas.address()],
+//     None,
+//     None,
+//     None,
+//     1,
+//     10 * 1024 * 1024,
+//     Duration::from_secs(1),
+//     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+//     1,
+//     1,
+//   )
+//   .expect("Failed to make store");
+//   store
+//     .store_file_bytes(roland.bytes(), false)
+//     .await
+//     .expect("Saving file bytes to store");
+//   store
+//     .record_directory(&TestDirectory::containing_roland().directory(), false)
+//     .await
+//     .expect("Saving directory bytes to store");
+//   let command_runner = CommandRunner::new(
+//     &mock_server.address(),
+//     empty_request_metadata(),
+//     None,
+//     None,
+//     BTreeMap::new(),
+//     store,
+//     Platform::Linux,
+//     runtime.clone(),
+//     Duration::from_secs(0),
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//   )
+//   .unwrap();
+//
+//   let result = command_runner
+//     .run(cat_roland_request(), Context::default())
+//     .await
+//     .unwrap();
+//   assert_eq!(
+//     result.without_execution_attempts(),
+//     FallibleProcessResultWithPlatform {
+//       stdout: roland.bytes(),
+//       stderr: Bytes::from(""),
+//       exit_code: 0,
+//       output_directory: EMPTY_DIGEST,
+//       execution_attempts: vec![],
+//       platform: Platform::Linux,
+//     }
+//   );
+//   {
+//     let blobs = cas.blobs.lock();
+//     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
+//   }
+// }
 
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![MockOperation::new({
-          let mut op = bazel_protos::operations::Operation::new();
-          op.set_name(op_name.to_string());
-          op.set_done(true);
-          op.set_error({
-            let mut error = bazel_protos::status::Status::new();
-            error.set_code(bazel_protos::code::Code::INTERNAL.value());
-            error.set_message("Something went wrong".to_string());
-            error
-          });
-          op
-        })],
-      ),
-      None,
-    )
-  };
+// #[tokio::test]
+// //// TODO: Unignore this test when the server can actually fail with status protos.
+// #[ignore] // https://github.com/pantsbuild/pants/issues/6597
+// async fn execute_missing_file_uploads_if_known_status() {
+//   let roland = TestData::roland();
+//
+//   let mock_server = {
+//     let op_name = "cat".to_owned();
+//
+//     let status = grpcio::RpcStatus {
+//       status: grpcio::RpcStatusCode::FAILED_PRECONDITION,
+//       details: None,
+//       status_proto_bytes: Some(
+//         make_precondition_failure_status(vec![missing_preconditionfailure_violation(
+//           &roland.digest(),
+//         )])
+//         .write_to_bytes()
+//         .unwrap(),
+//       ),
+//     };
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &cat_roland_request().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         vec![
+//           //make_incomplete_operation(&op_name),
+//           MockOperation {
+//             op: Err(status),
+//             duration: None,
+//           },
+//           make_successful_operation(
+//             "cat2",
+//             StdoutType::Raw(roland.string()),
+//             StderrType::Raw("".to_owned()),
+//             0,
+//           ),
+//         ],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let store_dir = TempDir::new().unwrap();
+//   let cas = mock::StubCAS::builder()
+//     .directory(&TestDirectory::containing_roland())
+//     .build();
+//   let runtime = task_executor::Executor::new(Handle::current());
+//   let store = Store::with_remote(
+//     runtime.clone(),
+//     store_dir,
+//     vec![cas.address()],
+//     None,
+//     None,
+//     None,
+//     1,
+//     10 * 1024 * 1024,
+//     Duration::from_secs(1),
+//     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+//     1,
+//     1,
+//   )
+//   .expect("Failed to make store");
+//   store
+//     .store_file_bytes(roland.bytes(), false)
+//     .await
+//     .expect("Saving file bytes to store");
+//
+//   let result = CommandRunner::new(
+//     &mock_server.address(),
+//     empty_request_metadata(),
+//     None,
+//     None,
+//     BTreeMap::new(),
+//     store,
+//     Platform::Linux,
+//     runtime.clone(),
+//     Duration::from_secs(0),
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//   )
+//   .unwrap()
+//   .run(cat_roland_request(), Context::default())
+//   .await;
+//   assert_eq!(
+//     result,
+//     Ok(FallibleProcessResultWithPlatform {
+//       stdout: roland.bytes(),
+//       stderr: Bytes::from(""),
+//       exit_code: 0,
+//       output_directory: EMPTY_DIGEST,
+//       execution_attempts: vec![],
+//       platform: Platform::Linux,
+//     })
+//   );
+//   {
+//     let blobs = cas.blobs.lock();
+//     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
+//   }
+//
+//   assert_cancellation_requests(&mock_server, vec![]);
+// }
 
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .expect_err("Want Err");
-
-  assert_eq!(result, "INTERNAL: Something went wrong");
-}
-
-#[tokio::test]
-async fn getoperation_response_error() {
-  let execute_request = echo_foo_request();
-
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          MockOperation::new({
-            let mut op = bazel_protos::operations::Operation::new();
-            op.set_name(op_name.to_string());
-            op.set_done(true);
-            op.set_error({
-              let mut error = bazel_protos::status::Status::new();
-              error.set_code(bazel_protos::code::Code::INTERNAL.value());
-              error.set_message("Something went wrong".to_string());
-              error
-            });
-            op
-          }),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .expect_err("Want Err");
-
-  assert_eq!(result, "INTERNAL: Something went wrong");
-
-  assert_cancellation_requests(&mock_server, vec![]);
-}
-
-#[tokio::test]
-async fn initial_response_missing_response_and_error() {
-  let execute_request = echo_foo_request();
-
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![MockOperation::new({
-          let mut op = bazel_protos::operations::Operation::new();
-          op.set_name(op_name.to_string());
-          op.set_done(true);
-          op
-        })],
-      ),
-      None,
-    )
-  };
-
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .expect_err("Want Err");
-
-  assert_eq!(result, "Operation finished but no response supplied");
-}
-
-#[tokio::test]
-async fn getoperation_missing_response_and_error() {
-  let execute_request = echo_foo_request();
-
-  let mock_server = {
-    let op_name = "gimme-foo".to_string();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          MockOperation::new({
-            let mut op = bazel_protos::operations::Operation::new();
-            op.set_name(op_name.to_string());
-            op.set_done(true);
-            op
-          }),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let result = run_command_remote(mock_server.address(), execute_request)
-    .await
-    .expect_err("Want Err");
-
-  assert_eq!(result, "Operation finished but no response supplied");
-}
-
-#[tokio::test]
-async fn execute_missing_file_uploads_if_known() {
-  let runtime = task_executor::Executor::new(Handle::current());
-
-  let roland = TestData::roland();
-
-  let mock_server = {
-    let op_name = "cat".to_owned();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &cat_roland_request().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          make_incomplete_operation(&op_name),
-          make_precondition_failure_operation(vec![missing_preconditionfailure_violation(
-            &roland.digest(),
-          )]),
-          make_successful_operation(
-            "cat2",
-            StdoutType::Raw(roland.string()),
-            StderrType::Raw("".to_owned()),
-            0,
-          ),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let store_dir = TempDir::new().unwrap();
-  let cas = mock::StubCAS::builder()
-    .directory(&TestDirectory::containing_roland())
-    .build();
-  let store = Store::with_remote(
-    runtime.clone(),
-    store_dir,
-    vec![cas.address()],
-    None,
-    None,
-    None,
-    1,
-    10 * 1024 * 1024,
-    Duration::from_secs(1),
-    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
-    1,
-    1,
-  )
-  .expect("Failed to make store");
-  store
-    .store_file_bytes(roland.bytes(), false)
-    .await
-    .expect("Saving file bytes to store");
-  store
-    .record_directory(&TestDirectory::containing_roland().directory(), false)
-    .await
-    .expect("Saving directory bytes to store");
-  let command_runner = CommandRunner::new(
-    &mock_server.address(),
-    empty_request_metadata(),
-    None,
-    None,
-    BTreeMap::new(),
-    store,
-    Platform::Linux,
-    runtime.clone(),
-    Duration::from_secs(0),
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-  )
-  .unwrap();
-
-  let result = command_runner
-    .run(cat_roland_request(), Context::default())
-    .await
-    .unwrap();
-
-  assert_eq!(result.stdout, roland.bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.platform, Platform::Linux);
-
-  {
-    let blobs = cas.blobs.lock();
-    assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
-  }
-}
-
-#[tokio::test]
-//// TODO: Unignore this test when the server can actually fail with status protos.
-#[ignore] // https://github.com/pantsbuild/pants/issues/6597
-async fn execute_missing_file_uploads_if_known_status() {
-  let roland = TestData::roland();
-
-  let mock_server = {
-    let op_name = "cat".to_owned();
-
-    let status = grpcio::RpcStatus {
-      status: grpcio::RpcStatusCode::FAILED_PRECONDITION,
-      details: None,
-      status_proto_bytes: Some(
-        make_precondition_failure_status(vec![missing_preconditionfailure_violation(
-          &roland.digest(),
-        )])
-        .write_to_bytes()
-        .unwrap(),
-      ),
-    };
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &cat_roland_request().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        vec![
-          //make_incomplete_operation(&op_name),
-          MockOperation {
-            op: Err(status),
-            duration: None,
-          },
-          make_successful_operation(
-            "cat2",
-            StdoutType::Raw(roland.string()),
-            StderrType::Raw("".to_owned()),
-            0,
-          ),
-        ],
-      ),
-      None,
-    )
-  };
-
-  let store_dir = TempDir::new().unwrap();
-  let cas = mock::StubCAS::builder()
-    .directory(&TestDirectory::containing_roland())
-    .build();
-  let runtime = task_executor::Executor::new(Handle::current());
-  let store = Store::with_remote(
-    runtime.clone(),
-    store_dir,
-    vec![cas.address()],
-    None,
-    None,
-    None,
-    1,
-    10 * 1024 * 1024,
-    Duration::from_secs(1),
-    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
-    1,
-    1,
-  )
-  .expect("Failed to make store");
-  store
-    .store_file_bytes(roland.bytes(), false)
-    .await
-    .expect("Saving file bytes to store");
-
-  let result = CommandRunner::new(
-    &mock_server.address(),
-    empty_request_metadata(),
-    None,
-    None,
-    BTreeMap::new(),
-    store,
-    Platform::Linux,
-    runtime.clone(),
-    Duration::from_secs(0),
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-  )
-  .unwrap()
-  .run(cat_roland_request(), Context::default())
-  .await
-  .unwrap();
-
-  assert_eq!(result.stdout, roland.bytes());
-  assert_eq!(result.stderr, "".as_bytes());
-  assert_eq!(result.exit_code, 0);
-  assert_eq!(result.platform, Platform::Linux);
-  {
-    let blobs = cas.blobs.lock();
-    assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
-  }
-
-  assert_cancellation_requests(&mock_server, vec![]);
-}
-
-#[tokio::test]
-async fn execute_missing_file_errors_if_unknown() {
-  let missing_digest = TestDirectory::containing_roland().digest();
-
-  let mock_server = {
-    let op_name = "cat".to_owned();
-
-    mock::execution_server::TestServer::new(
-      mock::execution_server::MockExecution::new(
-        op_name.clone(),
-        crate::remote::make_execute_request(
-          &cat_roland_request().try_into().unwrap(),
-          empty_request_metadata(),
-        )
-        .unwrap()
-        .2,
-        // We won't get as far as trying to run the operation, so don't expect any requests whose
-        // responses we would need to stub.
-        vec![],
-      ),
-      None,
-    )
-  };
-
-  let store_dir = TempDir::new().unwrap();
-  let cas = mock::StubCAS::builder()
-    .file(&TestData::roland())
-    .directory(&TestDirectory::containing_roland())
-    .build();
-  let runtime = task_executor::Executor::new(Handle::current());
-  let store = Store::with_remote(
-    runtime.clone(),
-    store_dir,
-    vec![cas.address()],
-    None,
-    None,
-    None,
-    1,
-    10 * 1024 * 1024,
-    Duration::from_secs(1),
-    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
-    1,
-    1,
-  )
-  .expect("Failed to make store");
-
-  let runner = CommandRunner::new(
-    &mock_server.address(),
-    empty_request_metadata(),
-    None,
-    None,
-    BTreeMap::new(),
-    store,
-    Platform::Linux,
-    runtime.clone(),
-    Duration::from_secs(0),
-    Duration::from_millis(0),
-    Duration::from_secs(0),
-  )
-  .unwrap();
-
-  let error = runner
-    .run(cat_roland_request(), Context::default())
-    .await
-    .expect_err("Want error");
-  assert_contains(&error, &format!("{}", missing_digest.0));
-}
+// #[tokio::test]
+// async fn execute_missing_file_errors_if_unknown() {
+//   let missing_digest = TestDirectory::containing_roland().digest();
+//
+//   let mock_server = {
+//     let op_name = "cat".to_owned();
+//
+//     mock::execution_server::TestServer::new(
+//       mock::execution_server::MockExecution::new(
+//         op_name.clone(),
+//         crate::remote::make_execute_request(
+//           &cat_roland_request().try_into().unwrap(),
+//           empty_request_metadata(),
+//         )
+//         .unwrap()
+//         .2,
+//         // We won't get as far as trying to run the operation, so don't expect any requests whose
+//         // responses we would need to stub.
+//         vec![],
+//       ),
+//       None,
+//     )
+//   };
+//
+//   let store_dir = TempDir::new().unwrap();
+//   let cas = mock::StubCAS::builder()
+//     .file(&TestData::roland())
+//     .directory(&TestDirectory::containing_roland())
+//     .build();
+//   let runtime = task_executor::Executor::new(Handle::current());
+//   let store = Store::with_remote(
+//     runtime.clone(),
+//     store_dir,
+//     vec![cas.address()],
+//     None,
+//     None,
+//     None,
+//     1,
+//     10 * 1024 * 1024,
+//     Duration::from_secs(1),
+//     store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+//     1,
+//     1,
+//   )
+//   .expect("Failed to make store");
+//
+//   let runner = CommandRunner::new(
+//     &mock_server.address(),
+//     empty_request_metadata(),
+//     None,
+//     None,
+//     BTreeMap::new(),
+//     store,
+//     Platform::Linux,
+//     runtime.clone(),
+//     Duration::from_secs(0),
+//     Duration::from_millis(0),
+//     Duration::from_secs(0),
+//   )
+//   .unwrap();
+//
+//   let error = runner
+//     .run(cat_roland_request(), Context::default())
+//     .await
+//     .expect_err("Want error");
+//   assert_contains(&error, &format!("{}", missing_digest.0));
+// }
 
 #[tokio::test]
 async fn format_error_complete() {
@@ -1789,133 +1855,133 @@ async fn digest_command() {
   assert_eq!(digest.1, 32)
 }
 
-#[tokio::test]
-async fn wait_between_request_1_retry() {
-  // wait at least 100 milli for one retry
-  {
-    let execute_request = echo_foo_request();
-    let mock_server = {
-      let op_name = "gimme-foo".to_string();
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          crate::remote::make_execute_request(
-            &execute_request.clone().try_into().unwrap(),
-            empty_request_metadata(),
-          )
-          .unwrap()
-          .2,
-          vec![
-            make_incomplete_operation(&op_name),
-            make_successful_operation(
-              &op_name,
-              StdoutType::Raw("foo".to_owned()),
-              StderrType::Raw("".to_owned()),
-              0,
-            ),
-          ],
-        ),
-        None,
-      )
-    };
-    let cas = mock::StubCAS::empty();
-    let command_runner = create_command_runner(
-      mock_server.address(),
-      &cas,
-      Duration::from_millis(100),
-      Duration::from_secs(1),
-      Platform::Linux,
-    );
-    command_runner
-      .run(execute_request, Context::default())
-      .await
-      .unwrap();
+// #[tokio::test]
+// async fn wait_between_request_1_retry() {
+//   // wait at least 100 milli for one retry
+//   {
+//     let execute_request = echo_foo_request();
+//     let mock_server = {
+//       let op_name = "gimme-foo".to_string();
+//       mock::execution_server::TestServer::new(
+//         mock::execution_server::MockExecution::new(
+//           op_name.clone(),
+//           crate::remote::make_execute_request(
+//             &execute_request.clone().try_into().unwrap(),
+//             empty_request_metadata(),
+//           )
+//           .unwrap()
+//           .2,
+//           vec![
+//             make_incomplete_operation(&op_name),
+//             make_successful_operation(
+//               &op_name,
+//               StdoutType::Raw("foo".to_owned()),
+//               StderrType::Raw("".to_owned()),
+//               0,
+//             ),
+//           ],
+//         ),
+//         None,
+//       )
+//     };
+//     let cas = mock::StubCAS::empty();
+//     let command_runner = create_command_runner(
+//       mock_server.address(),
+//       &cas,
+//       Duration::from_millis(100),
+//       Duration::from_secs(1),
+//       Platform::Linux,
+//     );
+//     command_runner
+//       .run(execute_request, Context::default())
+//       .await
+//       .unwrap();
+//
+//     let messages = mock_server.mock_responder.received_messages.lock();
+//     assert!(messages.len() == 2);
+//     assert!(
+//       messages
+//         .get(1)
+//         .unwrap()
+//         .received_at
+//         .sub(messages.get(0).unwrap().received_at)
+//         >= Duration::from_millis(100)
+//     );
+//   }
+// }
 
-    let messages = mock_server.mock_responder.received_messages.lock();
-    assert!(messages.len() == 2);
-    assert!(
-      messages
-        .get(1)
-        .unwrap()
-        .received_at
-        .sub(messages.get(0).unwrap().received_at)
-        >= Duration::from_millis(100)
-    );
-  }
-}
-
-#[tokio::test]
-async fn wait_between_request_3_retry() {
-  // wait at least 50 + 100 + 150 = 300 milli for 3 retries.
-  {
-    let execute_request = echo_foo_request();
-    let mock_server = {
-      let op_name = "gimme-foo".to_string();
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          crate::remote::make_execute_request(
-            &execute_request.clone().try_into().unwrap(),
-            empty_request_metadata(),
-          )
-          .unwrap()
-          .2,
-          vec![
-            make_incomplete_operation(&op_name),
-            make_incomplete_operation(&op_name),
-            make_incomplete_operation(&op_name),
-            make_successful_operation(
-              &op_name,
-              StdoutType::Raw("foo".to_owned()),
-              StderrType::Raw("".to_owned()),
-              0,
-            ),
-          ],
-        ),
-        None,
-      )
-    };
-    let cas = mock::StubCAS::empty();
-    let command_runner = create_command_runner(
-      mock_server.address(),
-      &cas,
-      Duration::from_millis(50),
-      Duration::from_secs(5),
-      Platform::Linux,
-    );
-    command_runner
-      .run(execute_request, Context::default())
-      .await
-      .unwrap();
-
-    let messages = mock_server.mock_responder.received_messages.lock();
-    assert!(messages.len() == 4);
-    assert!(
-      messages
-        .get(1)
-        .unwrap()
-        .received_at
-        .sub(messages.get(0).unwrap().received_at)
-        >= Duration::from_millis(50)
-    );
-    assert!(
-      messages
-        .get(2)
-        .unwrap()
-        .received_at
-        .sub(messages.get(1).unwrap().received_at)
-        >= Duration::from_millis(100)
-    );
-    assert!(
-      messages
-        .get(3)
-        .unwrap()
-        .received_at
-        .sub(messages.get(2).unwrap().received_at)
-        >= Duration::from_millis(150)
-    );
-  }
-}
+// #[tokio::test]
+// async fn wait_between_request_3_retry() {
+//   // wait at least 50 + 100 + 150 = 300 milli for 3 retries.
+//   {
+//     let execute_request = echo_foo_request();
+//     let mock_server = {
+//       let op_name = "gimme-foo".to_string();
+//       mock::execution_server::TestServer::new(
+//         mock::execution_server::MockExecution::new(
+//           op_name.clone(),
+//           crate::remote::make_execute_request(
+//             &execute_request.clone().try_into().unwrap(),
+//             empty_request_metadata(),
+//           )
+//           .unwrap()
+//           .2,
+//           vec![
+//             make_incomplete_operation(&op_name),
+//             make_incomplete_operation(&op_name),
+//             make_incomplete_operation(&op_name),
+//             make_successful_operation(
+//               &op_name,
+//               StdoutType::Raw("foo".to_owned()),
+//               StderrType::Raw("".to_owned()),
+//               0,
+//             ),
+//           ],
+//         ),
+//         None,
+//       )
+//     };
+//     let cas = mock::StubCAS::empty();
+//     let command_runner = create_command_runner(
+//       mock_server.address(),
+//       &cas,
+//       Duration::from_millis(50),
+//       Duration::from_secs(5),
+//       Platform::Linux,
+//     );
+//     command_runner
+//       .run(execute_request, Context::default())
+//       .await
+//       .unwrap();
+//
+//     let messages = mock_server.mock_responder.received_messages.lock();
+//     assert!(messages.len() == 4);
+//     assert!(
+//       messages
+//         .get(1)
+//         .unwrap()
+//         .received_at
+//         .sub(messages.get(0).unwrap().received_at)
+//         >= Duration::from_millis(50)
+//     );
+//     assert!(
+//       messages
+//         .get(2)
+//         .unwrap()
+//         .received_at
+//         .sub(messages.get(1).unwrap().received_at)
+//         >= Duration::from_millis(100)
+//     );
+//     assert!(
+//       messages
+//         .get(3)
+//         .unwrap()
+//         .received_at
+//         .sub(messages.get(2).unwrap().received_at)
+//         >= Duration::from_millis(150)
+//     );
+//   }
+// }
 
 #[tokio::test]
 async fn extract_output_files_from_response_one_file() {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -367,26 +367,41 @@ async fn main() {
           None
         };
 
-      Box::new(
-        process_execution::remote::CommandRunner::new(
-          address,
-          ProcessMetadata {
-            instance_name: remote_instance_arg,
-            cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
-            platform_properties,
-          },
-          root_ca_certs,
-          oauth_bearer_token,
-          headers,
-          store.clone(),
-          Platform::Linux,
-          executor,
-          std::time::Duration::from_secs(320),
-          std::time::Duration::from_millis(500),
-          std::time::Duration::from_secs(5),
-        )
-        .expect("Failed to make command runner"),
-      ) as Box<dyn process_execution::CommandRunner>
+      // let command_runner = process_execution::remote::CommandRunner::new(
+      //   address,
+      //   ProcessMetadata {
+      //     instance_name: remote_instance_arg,
+      //     cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
+      //     platform_properties,
+      //   },
+      //   root_ca_certs,
+      //   oauth_bearer_token,
+      //   headers,
+      //   store.clone(),
+      //   Platform::Linux,
+      //   executor,
+      //   std::time::Duration::from_secs(320),
+      //   std::time::Duration::from_millis(500),
+      //   std::time::Duration::from_secs(5),
+      // )
+      // .expect("Failed to make command runner");
+
+      let command_runner = process_execution::remote::StreamingCommandRunner::new(
+        address,
+        ProcessMetadata {
+          instance_name: remote_instance_arg,
+          cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
+          platform_properties,
+        },
+        root_ca_certs,
+        oauth_bearer_token,
+        headers,
+        store.clone(),
+        Platform::Linux,
+      )
+      .expect("Failed to make command runner");
+
+      Box::new(command_runner) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(
       store.clone(),

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -194,7 +194,15 @@ async fn main() {
               .help("Whether or not to enable running the process through a Nailgun server.\
                         This will likely start a new Nailgun server as a side effect.")
       )
-    .setting(AppSettings::TrailingVarArg)
+      .arg(
+        Arg::with_name("enable-streaming-client")
+            .long("enable-streaming-client")
+            .takes_value(false)
+            .required(false)
+            .default_value("false")
+            .help("Enable the experimental streaming remote execution client.")
+      )
+      .setting(AppSettings::TrailingVarArg)
     .arg(
       Arg::with_name("argv")
         .multiple(true)
@@ -276,6 +284,7 @@ async fn main() {
     .values_of("headers")
     .map(collection_from_keyvalues::<_, BTreeMap<_, _>>)
     .unwrap_or_default();
+  let enable_streaming_client = args.is_present("enable-streaming-client");
 
   let executor = task_executor::Executor::new(Handle::current());
 
@@ -367,41 +376,48 @@ async fn main() {
           None
         };
 
-      // let command_runner = process_execution::remote::CommandRunner::new(
-      //   address,
-      //   ProcessMetadata {
-      //     instance_name: remote_instance_arg,
-      //     cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
-      //     platform_properties,
-      //   },
-      //   root_ca_certs,
-      //   oauth_bearer_token,
-      //   headers,
-      //   store.clone(),
-      //   Platform::Linux,
-      //   executor,
-      //   std::time::Duration::from_secs(320),
-      //   std::time::Duration::from_millis(500),
-      //   std::time::Duration::from_secs(5),
-      // )
-      // .expect("Failed to make command runner");
+      let command_runner_box: Box<dyn process_execution::CommandRunner> = if enable_streaming_client
+      {
+        Box::new(
+          process_execution::remote::StreamingCommandRunner::new(
+            address,
+            ProcessMetadata {
+              instance_name: remote_instance_arg,
+              cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
+              platform_properties,
+            },
+            root_ca_certs,
+            oauth_bearer_token,
+            headers,
+            store.clone(),
+            Platform::Linux,
+          )
+          .expect("Failed to make command runner"),
+        )
+      } else {
+        Box::new(
+          process_execution::remote::CommandRunner::new(
+            address,
+            ProcessMetadata {
+              instance_name: remote_instance_arg,
+              cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
+              platform_properties,
+            },
+            root_ca_certs,
+            oauth_bearer_token,
+            headers,
+            store.clone(),
+            Platform::Linux,
+            executor,
+            std::time::Duration::from_secs(320),
+            std::time::Duration::from_millis(500),
+            std::time::Duration::from_secs(5),
+          )
+          .expect("Failed to make command runner"),
+        )
+      };
 
-      let command_runner = process_execution::remote::StreamingCommandRunner::new(
-        address,
-        ProcessMetadata {
-          instance_name: remote_instance_arg,
-          cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
-          platform_properties,
-        },
-        root_ca_certs,
-        oauth_bearer_token,
-        headers,
-        store.clone(),
-        Platform::Linux,
-      )
-      .expect("Failed to make command runner");
-
-      Box::new(command_runner) as Box<dyn process_execution::CommandRunner>
+      command_runner_box
     }
     None => Box::new(process_execution::local::CommandRunner::new(
       store.clone(),

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -349,6 +349,7 @@ py_module_initializer!(native_engine, |py, m| {
         process_execution_speculation_strategy_buf: String,
         process_execution_use_local_cache: bool,
         remote_execution_headers: Vec<(String, String)>,
+        remote_execution_enable_streaming: bool,
         process_execution_local_enable_nailgun: bool
       )
     ),
@@ -677,6 +678,7 @@ fn scheduler_create(
   process_execution_speculation_strategy: String,
   process_execution_use_local_cache: bool,
   remote_execution_headers: Vec<(String, String)>,
+  remote_execution_enable_streaming: bool,
   process_execution_local_enable_nailgun: bool,
 ) -> CPyResult<PyScheduler> {
   let core: Result<Core, String> = Ok(()).and_then(move |()| {
@@ -722,6 +724,7 @@ fn scheduler_create(
       process_execution_speculation_strategy,
       process_execution_use_local_cache,
       remote_execution_headers.into_iter().collect(),
+      remote_execution_enable_streaming,
       process_execution_local_enable_nailgun,
     )
   });

--- a/src/rust/engine/testutil/local_execution_server/src/main.rs
+++ b/src/rust/engine/testutil/local_execution_server/src/main.rs
@@ -29,7 +29,7 @@ use bazel_protos::{
   operations::Operation,
   remote_execution::{Digest, ExecuteRequest},
 };
-use mock::execution_server::{MockExecution, MockOperation, TestServer};
+use mock::execution_server::{ExpectedAPICall, MockExecution, MockOperation, TestServer};
 use std::io::Read;
 
 use structopt::StructOpt;
@@ -70,7 +70,10 @@ fn main() {
   digest.set_size_bytes(options.request_size);
   request.set_action_digest(digest);
 
-  let execution = MockExecution::new("Mock execution".to_string(), request, vec![operation]);
+  let execution = MockExecution::new(vec![ExpectedAPICall::Execute {
+    execute_request: request,
+    stream_responses: Ok(vec![operation]),
+  }]);
 
   // Start the server
   let server = TestServer::new(execution, options.port);

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -7,11 +7,14 @@ publish = false
 
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
+boxfuture = { path = "../../boxfuture" }
 bytes = "0.4.5"
 futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
 # TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457 + a workaround for https://github.com/rust-lang/cargo/issues/8258
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "ed3afa3c24ddf1fdd86826e836f57c00757dfc00", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 testutil = { path = ".." }
+tokio = { version = "0.2", features = ["time"] }

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -259,15 +259,7 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
         execute_request,
         stream_responses,
       }) => {
-        if req != execute_request {
-          error_to_send = Some(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::INVALID_ARGUMENT,
-            Some(format!(
-              "Did not expect this request. Expected: {:?}, Got: {:?}",
-              execute_request, req
-            )),
-          ));
-        } else {
+        if req == execute_request {
           match stream_responses {
             Ok(operations) => {
               self.spawn_send_to_operation_stream(ctx, sink, operations);
@@ -277,6 +269,14 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
               error_to_send = Some(rpc_status);
             }
           }
+        } else {
+          error_to_send = Some(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
+            Some(format!(
+              "Did not expect this request. Expected: {:?}, Got: {:?}",
+              execute_request, req
+            )),
+          ));
         }
       }
 
@@ -315,15 +315,7 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
         operation_name,
         stream_responses,
       }) => {
-        if req.name != operation_name {
-          error_to_send = Some(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::INVALID_ARGUMENT,
-            Some(format!(
-              "Did not expect WaitExecution for this operation. Expected: {:?}, Got: {:?}",
-              operation_name, req.name
-            )),
-          ));
-        } else {
+        if req.name == operation_name {
           match stream_responses {
             Ok(operations) => {
               self.spawn_send_to_operation_stream(ctx, sink, operations);
@@ -333,6 +325,14 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
               error_to_send = Some(rpc_status);
             }
           }
+        } else {
+          error_to_send = Some(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
+            Some(format!(
+              "Did not expect WaitExecution for this operation. Expected: {:?}, Got: {:?}",
+              operation_name, req.name
+            )),
+          ));
         }
       }
 
@@ -376,15 +376,7 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
         operation_name,
         operation,
       }) => {
-        if req.name != operation_name {
-          error_to_send = Some(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::INVALID_ARGUMENT,
-            Some(format!(
-              "Did not expect GetOperation for this operation. Expected: {:?}, Got: {:?}",
-              operation_name, req.name
-            )),
-          ));
-        } else {
+        if req.name == operation_name {
           if let Some(d) = operation.duration {
             sleep(d);
           }
@@ -395,6 +387,14 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
             sink.fail(status);
           }
           return;
+        } else {
+          error_to_send = Some(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
+            Some(format!(
+              "Did not expect GetOperation for this operation. Expected: {:?}, Got: {:?}",
+              operation_name, req.name
+            )),
+          ));
         }
       }
 

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -7,8 +7,31 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
 
-use futures01::{Future, Sink};
+use futures::future::{FutureExt, TryFutureExt};
+use futures::sink::SinkExt;
+use futures::compat::{Sink01CompatExt};
 use parking_lot::Mutex;
+use grpcio::RpcStatus;
+
+///
+/// Represents an expected API call from the REv2 client. The data carried by each enum
+/// variant are the parameters to verify and the results to return to the client.
+///
+#[derive(Clone, Debug)]
+pub enum ExpectedAPICall {
+  Execute {
+    execute_request: bazel_protos::remote_execution::ExecuteRequest,
+    stream_responses: Result<Vec<MockOperation>, grpcio::RpcStatus>,
+  },
+  WaitExecution {
+    operation_name: String,
+    stream_responses: Result<Vec<MockOperation>, grpcio::RpcStatus>,
+  },
+  GetOperation {
+    operation_name: String,
+    operation: MockOperation,
+  },
+}
 
 ///
 /// A MockOperation to be used with MockExecution.
@@ -34,9 +57,7 @@ impl MockOperation {
 
 #[derive(Clone, Debug)]
 pub struct MockExecution {
-  name: String,
-  execute_request: bazel_protos::remote_execution::ExecuteRequest,
-  operation_responses: Arc<Mutex<VecDeque<MockOperation>>>,
+  expected_api_calls: Arc<Mutex<VecDeque<ExpectedAPICall>>>,
 }
 
 impl MockExecution {
@@ -44,26 +65,21 @@ impl MockExecution {
   /// # Arguments:
   ///  * `name` - The name of the operation. It is assumed that all operation_responses use this
   ///             name.
-  ///  * `execute_request` - The expected ExecuteRequest.
-  ///  * `operation_responses` - Vec of Operation response for Execution or GetOperation requests.
-  ///                            Will be returned in order.
+  ///  * `expected_api_calls` - Vec of ExpectedAPICall instances representing the API calls
+  ///                            to expect from the client. Will be returned in order.
   ///
   pub fn new(
-    name: String,
-    execute_request: bazel_protos::remote_execution::ExecuteRequest,
-    operation_responses: Vec<MockOperation>,
+    expected_api_calls: Vec<ExpectedAPICall>,
   ) -> MockExecution {
     MockExecution {
-      name: name,
-      execute_request: execute_request,
-      operation_responses: Arc::new(Mutex::new(VecDeque::from(operation_responses))),
+      expected_api_calls: Arc::new(Mutex::new(VecDeque::from(expected_api_calls))),
     }
   }
 }
 
 ///
-/// A server which will answer ExecuteRequest and GetOperation gRPC requests with pre-canned
-/// responses.
+/// A server which will answer Execute/WaitExecution and GetOperation/CancelOperation gRPC
+/// requests with pre-canned responses.
 ///
 pub struct TestServer {
   pub mock_responder: MockResponder,
@@ -117,7 +133,7 @@ impl Drop for TestServer {
     let remaining_expected_responses = self
       .mock_responder
       .mock_execution
-      .operation_responses
+      .expected_api_calls
       .lock()
       .len();
     if remaining_expected_responses != 0 {
@@ -128,7 +144,7 @@ impl Drop for TestServer {
           self
             .mock_responder
             .mock_execution
-            .operation_responses
+            .expected_api_calls
             .lock()
             .clone(),
         )),
@@ -172,10 +188,10 @@ impl MockResponder {
 
   fn log<T: protobuf::Message + Sized>(&self, ctx: &grpcio::RpcContext, message: T) {
     let headers = ctx
-      .request_headers()
-      .iter()
-      .map(|(name, value)| (name.to_string(), value.to_vec()))
-      .collect();
+        .request_headers()
+        .iter()
+        .map(|(name, value)| (name.to_string(), value.to_vec()))
+        .collect();
     self.received_messages.lock().push(ReceivedMessage {
       message_type: message.descriptor().name().to_string(),
       message: Box::new(message),
@@ -186,80 +202,59 @@ impl MockResponder {
 
   fn display_all<D: Debug>(items: &[D]) -> String {
     items
-      .iter()
-      .map(|i| format!("{:?}\n", i))
-      .collect::<Vec<_>>()
-      .concat()
+        .iter()
+        .map(|i| format!("{:?}\n", i))
+        .collect::<Vec<_>>()
+        .concat()
   }
 
-  fn send_next_operation_unary(
-    &self,
-    sink: grpcio::UnarySink<bazel_protos::operations::Operation>,
-  ) {
-    if let Some(MockOperation { op, duration }) =
-      self.mock_execution.operation_responses.lock().pop_front()
-    {
-      if let Some(d) = duration {
-        sleep(d);
-      }
-      if let Ok(Some(op)) = op {
-        // Complete the channel with the op.
-        sink.success(op);
-      } else if let Err(status) = op {
-        sink.fail(status);
-      } else {
-        // Cancel the request by dropping the sink.
-        drop(sink);
-      }
-    } else {
-      sink.fail(grpcio::RpcStatus::new(
-        grpcio::RpcStatusCode::INVALID_ARGUMENT,
-        Some("Did not expect further requests from client.".to_string()),
-      ));
-    }
-  }
+  // async fn send_operation_stream_tail(
+  //   &self,
+  //   ctx: grpcio::RpcContext<'_>,
+  //   sink: grpcio::ServerStreamingSink<bazel_protos::operations::Operation>,
+  //   mut operations: VecDeque<MockOperation>,
+  // ) {
+  //   let operation_opt = operations.pop_front();
+  //   if let Some(operation) = operation_opt {
+  //   }
+  // }
 
-  fn send_next_operation_stream(
+  fn spawn_send_to_operation_stream(
     &self,
-    ctx: &grpcio::RpcContext<'_>,
+    ctx: grpcio::RpcContext<'_>,
     sink: grpcio::ServerStreamingSink<bazel_protos::operations::Operation>,
+    operations: Vec<MockOperation>,
   ) {
-    match self.mock_execution.operation_responses.lock().pop_front() {
-      Some(MockOperation { op, duration }) => {
-        if let Some(d) = duration {
-          sleep(d);
+    let mut sink = sink.sink_compat();
+
+    let fut = async move {
+      let mut error_to_send: Option<RpcStatus> = None;
+      for op in operations {
+        if let Some(d) = op.duration {
+          tokio::time::delay_for(d).await;
         }
-        if let Ok(Some(op)) = op {
-          ctx.spawn(
-            sink
-              .send((op, grpcio::WriteFlags::default()))
-              .map(|mut stream| stream.close())
-              .map(|_| ())
-              .map_err(|_| ()),
-          )
-        } else if let Err(status) = op {
-          ctx.spawn(sink.fail(status).then(|_| Ok(())));
+
+        if let Ok(Some(op)) = op.op {
+          let _ = sink.send((op, grpcio::WriteFlags::default())).await;
+        } else if let Err(status) = op.op {
+          error_to_send = Some(status);
+          break;
         } else {
-          // Cancel the request by dropping the sink.
-          drop(sink)
+          break;
         }
       }
-      None => ctx.spawn(
-        sink
-          .fail(grpcio::RpcStatus::new(
-            grpcio::RpcStatusCode::INVALID_ARGUMENT,
-            Some("Did not expect further requests from client.".to_string()),
-          ))
-          .map(|_| ())
-          .map_err(|_| ()),
-      ),
-    }
+
+      if let Some(err) = error_to_send {
+        let _ = sink.into_inner().fail(err);
+      }
+
+      Ok(())
+    };
+    ctx.spawn(fut.boxed().compat());
   }
 }
 
 impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
-  // We currently only support the one-shot "stream and disconnect" client behavior.
-  // If we start supporting the "stream updates" variant, we will need to do so here.
   fn execute(
     &self,
     ctx: grpcio::RpcContext<'_>,
@@ -268,31 +263,108 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
   ) {
     self.log(&ctx, req.clone());
 
-    if self.mock_execution.execute_request != req {
-      ctx.spawn(
-        sink
-          .fail(grpcio::RpcStatus::new(
+    let expected_api_call = self.mock_execution.expected_api_calls.lock().pop_front();
+    let error_to_send: Option<RpcStatus>;
+    match expected_api_call {
+      Some(ExpectedAPICall::Execute { execute_request, stream_responses}) => {
+        if req != execute_request {
+          error_to_send = Some(grpcio::RpcStatus::new(
             grpcio::RpcStatusCode::INVALID_ARGUMENT,
             Some(format!(
               "Did not expect this request. Expected: {:?}, Got: {:?}",
-              self.mock_execution.execute_request, req
-            )),
-          ))
-          .map_err(|_| ()),
-      );
-      return;
+              execute_request, req
+            ))));
+        } else {
+          match stream_responses {
+            Ok(operations) => {
+              self.spawn_send_to_operation_stream(ctx, sink, operations);
+              return;
+            },
+            Err(rpc_status) => {
+              error_to_send = Some(rpc_status);
+            },
+          }
+        }
+      },
+
+      Some(api_call) => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some(format!(
+            "Execute endpoint called. Expected: {:?}",
+            api_call,
+          )),
+        ));
+      },
+
+      None => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some("Execute endpoint called. Did not expect this call.".to_owned()),
+        ));
+      },
     }
 
-    self.send_next_operation_stream(&ctx, sink);
+    if let Some(status) = error_to_send {
+      let _ = sink.fail(status);
+    }
   }
 
   fn wait_execution(
     &self,
-    _ctx: grpcio::RpcContext<'_>,
-    _req: bazel_protos::remote_execution::WaitExecutionRequest,
-    _sink: grpcio::ServerStreamingSink<bazel_protos::operations::Operation>,
+    ctx: grpcio::RpcContext<'_>,
+    req: bazel_protos::remote_execution::WaitExecutionRequest,
+    sink: grpcio::ServerStreamingSink<bazel_protos::operations::Operation>,
   ) {
-    unimplemented!()
+    self.log(&ctx, req.clone());
+
+    let expected_api_call = self.mock_execution.expected_api_calls.lock().pop_front();
+    let error_to_send: Option<RpcStatus>;
+    match expected_api_call {
+      Some(ExpectedAPICall::WaitExecution { operation_name, stream_responses}) => {
+        if req.name != operation_name {
+          error_to_send = Some(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
+            Some(format!(
+              "Did not expect WaitExecution for this operation. Expected: {:?}, Got: {:?}",
+              operation_name, req.name
+            )),
+          ));
+        } else {
+          match stream_responses {
+            Ok(operations) => {
+              self.spawn_send_to_operation_stream(ctx, sink, operations);
+              return;
+            },
+            Err(rpc_status) => {
+              error_to_send = Some(rpc_status);
+            },
+          }
+        }
+      },
+
+      Some(api_call) => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some(format!(
+            "WaitExecution endpoint called. Expected: {:?}",
+            api_call,
+          )),
+        ));
+      },
+
+      None => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some("WaitExecution endpoint called. Did not expect this call.".to_owned(),
+          ),
+        ));
+      },
+    }
+
+    if let Some(status) = error_to_send {
+      let _ = sink.fail(status);
+    }
   }
 }
 
@@ -303,9 +375,55 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
     req: bazel_protos::operations::GetOperationRequest,
     sink: grpcio::UnarySink<bazel_protos::operations::Operation>,
   ) {
-    self.log(&ctx, req);
+    self.log(&ctx, req.clone());
 
-    self.send_next_operation_unary(sink)
+    let expected_api_call = self.mock_execution.expected_api_calls.lock().pop_front();
+    let error_to_send: Option<RpcStatus>;
+    match expected_api_call {
+      Some(ExpectedAPICall::GetOperation { operation_name, operation}) => {
+        if req.name != operation_name {
+          error_to_send = Some(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::INVALID_ARGUMENT,
+            Some(format!(
+              "Did not expect GetOperation for this operation. Expected: {:?}, Got: {:?}",
+              operation_name, req.name
+            )),
+          ));
+        } else {
+          if let Some(d) = operation.duration {
+            sleep(d);
+          }
+          if let Ok(Some(op)) = operation.op {
+            // Complete the channel with the op.
+            sink.success(op);
+          } else if let Err(status) = operation.op {
+            sink.fail(status);
+          }
+          return;
+        }
+      },
+
+      Some(api_call) => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some(format!(
+            "GetOperation endpoint called. Expected: {:?}",
+            api_call,
+          )),
+        ));
+      },
+
+      None => {
+        error_to_send = Some(grpcio::RpcStatus::new(
+          grpcio::RpcStatusCode::INVALID_ARGUMENT,
+          Some("GetOperation endpoint called. Did not expect this call.".to_owned()),
+        ));
+      },
+    }
+
+    if let Some(status) = error_to_send {
+      let _ = sink.fail(status);
+    }
   }
 
   fn list_operations(

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -156,7 +156,7 @@ impl Drop for TestServer {
           message
         );
       } else {
-        // assert_eq!(remaining_expected_responses, 0, "{}", message,);
+        assert_eq!(remaining_expected_responses, 0, "{}", message,);
       }
     }
   }


### PR DESCRIPTION
This PR is a prototype of a "streaming" remote execution client.

## Problem

The existing remote execution client polls for completion of remote execution requests by calling the `GetOperation` method of the Google Operations API. Not all REv2 servers implement GetOperation though (e.g., BuildBarn) and thus Pants encounters `UNIMPLEMENTED` errors when conversing with those services. We would like Pants to be able to talk to those RE services.

## Solution

The REv2 specification supports clients receiving a stream of `Operation`'s from calls to the [`Execute`](https://github.com/bazelbuild/remote-apis/blob/7802003e00901b4e740fe0ebec1243c221e02ae2/build/bazel/remote/execution/v2/remote_execution.proto#L107) and [`WaitExecution`](https://github.com/bazelbuild/remote-apis/blob/7802003e00901b4e740fe0ebec1243c221e02ae2/build/bazel/remote/execution/v2/remote_execution.proto#L117) methods on the [`Execution` service](https://github.com/bazelbuild/remote-apis/blob/7802003e00901b4e740fe0ebec1243c221e02ae2/build/bazel/remote/execution/v2/remote_execution.proto#L43-L120). With this PR, Pants is able to submit requests and receive responses from BuildBarn.

This PR will need some follow-on work in subsequent PRs before being ready to be enabled by default.

Caveats:

- This is landing with only the existing tests ported to an updated test framework in order to avoid merge conflicts with other work in these files. Unit tests for the streaming client will land in a subsequent PR.

- I left out the start/end timing code and use of `ExecutionHistory`. Some form of that will be added back in before this is marked ready for review. (Note that workunit timings are still saved though.) Will have to give it some thought about what a "retry" means now that the client no longer polls.

- Some logs that should be `trace!` are `debug!` in this PR currently to permit me to log without the log spam of full trace logging. (It would be nice if there were a way to enable trace logging for only section of the code.)