### PR TITLE
Attempt to parse unsuffixed config files as TOML, and fall back to INI.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -382,8 +382,10 @@ class GlobalOptions(Subsystem):
             metavar="<path>",
             daemon=False,
             default=["/etc/pantsrc", "~/.pants.rc"],
-            help="Override config with values from these files. "
-            "Later files override earlier ones.",
+            help=(
+                "Override config with values from these files, using syntax matching that of "
+                "`--pants-config-files`."
+            ),
         )
         register(
             "--pythonpath",


### PR DESCRIPTION
### Problem

Since rc files do not have file suffixes, they are always parsed as `ini` today, triggering a deprecation even for files that are already in `toml` format.

### Solution

Attempt to parse unsuffixed config files first as `toml`, and then as `ini`. Trigger the deprecation only if they were successfully parsed as `ini`.

[ci skip-rust-tests]
[ci skip-jvm-tests]