### PR TITLE
Support Tuple-style MultiGet.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -1,8 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple, cast
-
 from pants.backend.codegen.protobuf.subsystems.protoc import Protoc
 from pants.backend.codegen.protobuf.target_types import ProtobufSources
 from pants.backend.python.target_types import PythonSources
@@ -58,23 +56,16 @@ async def generate_python_from_protobuf(
         AllSourceFilesRequest([request.protocol_target[ProtobufSources]], strip_source_roots=True)
     )
 
-    # TODO(#9294): make support for a heterogeneous MultiGet more ergonomic. We have this awkward
-    #  code to improve concurrency.
     (
         downloaded_protoc_binary,
         create_output_dir_result,
         all_sources,
         stripped_target_sources,
-    ) = cast(
-        Tuple[DownloadedExternalTool, ProcessResult, SourceFiles, SourceFiles],
-        await MultiGet(
-            [
-                download_protoc_request,
-                create_output_dir_request,
-                all_sources_request,
-                stripped_target_sources_request,
-            ]
-        ),
+    ) = await MultiGet(
+        download_protoc_request,
+        create_output_dir_request,
+        all_sources_request,
+        stripped_target_sources_request,
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple
 
 from pants.backend.python.lint.bandit.subsystem import Bandit
 from pants.backend.python.rules import download_pex_bin, pex
@@ -97,16 +97,11 @@ async def bandit_lint_partition(
         )
     )
 
-    requirements_pex, config_snapshot, all_source_files, specified_source_files = cast(
-        Tuple[Pex, Snapshot, SourceFiles, SourceFiles],
-        await MultiGet(
-            [
-                requirements_pex_request,
-                config_snapshot_request,
-                all_source_files_request,
-                specified_source_files_request,
-            ]
-        ),
+    requirements_pex, config_snapshot, all_source_files, specified_source_files = await MultiGet(
+        requirements_pex_request,
+        config_snapshot_request,
+        all_source_files_request,
+        specified_source_files_request,
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -4,7 +4,7 @@
 import re
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import List, Optional, Tuple, Union, cast
+from typing import Optional, Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -115,22 +115,16 @@ async def setup(
         )
     )
 
-    requests: List[Get] = [
-        requirements_pex_request,
-        config_snapshot_request,
-        specified_source_files_request,
-    ]
-    if setup_request.request.prior_formatter_result is None:
-        requests.append(all_source_files_request)
-    requirements_pex, config_snapshot, specified_source_files, *rest = cast(
-        Union[Tuple[Pex, Snapshot, SourceFiles], Tuple[Pex, Snapshot, SourceFiles, SourceFiles]],
-        await MultiGet(requests),
+    requests = requirements_pex_request, config_snapshot_request, specified_source_files_request
+    all_source_files, requirements_pex, config_snapshot, specified_source_files = (
+        await MultiGet(all_source_files_request, *requests)
+        if setup_request.request.prior_formatter_result is None
+        else (SourceFiles(EMPTY_SNAPSHOT), *await MultiGet(*requests))
     )
-
     all_source_files_snapshot = (
-        setup_request.request.prior_formatter_result
-        if setup_request.request.prior_formatter_result
-        else rest[0].snapshot
+        all_source_files.snapshot
+        if setup_request.request.prior_formatter_result is None
+        else setup_request.request.prior_formatter_result
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import List, Tuple, Union, cast
+from typing import Tuple
 
 from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import Digest, MergeDigests
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -94,18 +94,16 @@ async def setup(
         )
     )
 
-    requests: List[Get] = [requirements_pex_request, specified_source_files_request]
-    if setup_request.request.prior_formatter_result is None:
-        requests.append(all_source_files_request)
-    requirements_pex, specified_source_files, *rest = cast(
-        Union[Tuple[Pex, SourceFiles], Tuple[Pex, SourceFiles, SourceFiles]],
-        await MultiGet(requests),
+    requests = requirements_pex_request, specified_source_files_request
+    all_source_files, requirements_pex, specified_source_files = (
+        await MultiGet(all_source_files_request, *requests)
+        if setup_request.request.prior_formatter_result is None
+        else (SourceFiles(EMPTY_SNAPSHOT), *await MultiGet(*requests))
     )
-
     all_source_files_snapshot = (
-        setup_request.request.prior_formatter_result
-        if setup_request.request.prior_formatter_result
-        else rest[0].snapshot
+        all_source_files.snapshot
+        if setup_request.request.prior_formatter_result is None
+        else setup_request.request.prior_formatter_result
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple
 
 from pants.backend.python.lint.flake8.subsystem import Flake8
 from pants.backend.python.rules import download_pex_bin, pex
@@ -97,16 +97,11 @@ async def flake8_lint_partition(
         )
     )
 
-    requirements_pex, config_snapshot, all_source_files, specified_source_files = cast(
-        Tuple[Pex, Snapshot, SourceFiles, SourceFiles],
-        await MultiGet(
-            [
-                requirements_pex_request,
-                config_snapshot_request,
-                all_source_files_request,
-                specified_source_files_request,
-            ]
-        ),
+    requirements_pex, config_snapshot, all_source_files, specified_source_files = await MultiGet(
+        requirements_pex_request,
+        config_snapshot_request,
+        all_source_files_request,
+        specified_source_files_request,
     )
 
     input_digest = await Get[Digest](

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -4,7 +4,7 @@
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Iterable, Tuple, cast
+from typing import Iterable, Tuple
 
 from pants.backend.python.lint.pylint.subsystem import Pylint
 from pants.backend.python.rules import download_pex_bin, importable_python_sources, pex
@@ -175,21 +175,14 @@ async def pylint_lint_partition(
         prepared_plugin_sources,
         prepared_python_sources,
         specified_source_files,
-    ) = cast(
-        Tuple[
-            Pex, Pex, Pex, Snapshot, ImportablePythonSources, ImportablePythonSources, SourceFiles
-        ],
-        await MultiGet(
-            [
-                pylint_pex_request,
-                requirements_pex_request,
-                pylint_runner_pex_request,
-                config_snapshot_request,
-                prepare_plugin_sources_request,
-                prepare_python_sources_request,
-                specified_source_files_request,
-            ]
-        ),
+    ) = await MultiGet(
+        pylint_pex_request,
+        requirements_pex_request,
+        pylint_runner_pex_request,
+        config_snapshot_request,
+        prepare_plugin_sources_request,
+        prepare_python_sources_request,
+        specified_source_files_request,
     )
 
     prefixed_plugin_sources = (
@@ -248,10 +241,7 @@ async def pylint_lint(
     linted_targets_request = Get[Targets](
         Addresses(field_set.address for field_set in request.field_sets)
     )
-    plugin_targets, linted_targets = cast(
-        Tuple[TransitiveTargets, Targets],
-        await MultiGet([plugin_targets_request, linted_targets_request]),
-    )
+    plugin_targets, linted_targets = await MultiGet(plugin_targets_request, linted_targets_request)
 
     plugin_targets_compatibility_fields = tuple(
         plugin_tgt[PythonInterpreterCompatibility]

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -537,12 +537,12 @@ async def get_ancestor_init_py(
 
     # Note that we must MultiGet single globs instead of a a single Get for all the globs, because
     # we match each result to its originating glob (see use of zip below).
-    ancestor_init_py_snapshots = await MultiGet[Snapshot](
+    ancestor_init_py_snapshots = await MultiGet(
         Get[Snapshot](PathGlobs, PathGlobs([os.path.join(source_dir_ancestor[1], "__init__.py")]))
         for source_dir_ancestor in source_dir_ancestors_list
     )
 
-    source_root_stripped_ancestor_init_pys = await MultiGet[Digest](
+    source_root_stripped_ancestor_init_pys = await MultiGet(
         Get[Digest](RemovePrefix(snapshot.digest, source_dir_ancestor[0]))
         for snapshot, source_dir_ancestor in zip(
             ancestor_init_py_snapshots, source_dir_ancestors_list

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -488,11 +488,11 @@ class _FFISpecification(object):
         try:
             res = c.from_value(func[0]).send(c.from_value(arg[0]))
 
-            if isinstance(res, Get):
+            if Get.isinstance(res):
                 # Get.
                 response.tag = self._lib.Get
                 response.get = (
-                    TypeId(c.to_id(res.product)),
+                    TypeId(c.to_id(res.product_type)),
                     c.to_value(res.subject),
                     c.identify(res.subject),
                     TypeId(c.to_id(res.subject_declared_type)),
@@ -501,7 +501,7 @@ class _FFISpecification(object):
                 # GetMulti.
                 response.tag = self._lib.GetMulti
                 response.get_multi = (
-                    c.type_ids_buf([TypeId(c.to_id(g.product)) for g in res]),
+                    c.type_ids_buf([TypeId(c.to_id(g.product_type)) for g in res]),
                     c.vals_buf([c.to_value(g.subject) for g in res]),
                     c.identities_buf([c.identify(g.subject) for g in res]),
                 )

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -231,10 +231,10 @@ class Scheduler:
             if union.is_instance(the_get.subject_declared_type):
                 # If the registered subject type is a union, add Get edges to all registered union members.
                 for union_member in union_rules.get(the_get.subject_declared_type, []):
-                    add_get_edge(the_get.product, union_member)
+                    add_get_edge(the_get.product_type, union_member)
             else:
                 # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.
-                add_get_edge(the_get.product, the_get.subject_declared_type)
+                add_get_edge(the_get.product_type, the_get.subject_declared_type)
 
         self._native.lib.tasks_task_end(tasks)
 

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -139,7 +139,7 @@ async def a_typecheck_fail_test(wrapper: TypeCheckFailWrapper) -> A:
 async def c_unhashable(_: TypeCheckFailWrapper) -> C:
     # This `await` would use the `nested_raise` rule, but it won't get to the point of raising since
     # the hashability check will fail.
-    _ = await Get(A, B, list())  # noqa: F841
+    _result = await Get(A, B, list())  # noqa: F841
     return C()
 
 
@@ -152,7 +152,7 @@ class CollectionType:
 async def c_unhashable_dataclass(_: CollectionType) -> C:
     # This `await` would use the `nested_raise` rule, but it won't get to the point of raising since
     # the hashability check will fail.
-    _ = await Get(A, B, list())  # noqa: F841
+    _result = await Get(A, B, list())  # noqa: F841
     return C()
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -106,7 +106,7 @@ class _RuleVisitor(ast.NodeVisitor):
         #  https://github.com/pantsbuild/pants/issues/9899
         deprecated_conditional(
             predicate=lambda: False,
-            removal_version="1.31.0.dev0",
+            removal_version="1.30.0.dev0",
             entity_description="Parameterized Get[...](...) calls",
             hint_message=(
                 f"In {self._identify_source(call_node)} Use "

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -106,7 +106,8 @@ class _RuleVisitor(ast.NodeVisitor):
         #  https://github.com/pantsbuild/pants/issues/9899
         deprecated_conditional(
             predicate=lambda: False,
-            removal_version="1.30.0.dev0",
+            deprecation_start_version="1.30.0.dev0",
+            removal_version="1.31.0.dev0",
             entity_description="Parameterized Get[...](...) calls",
             hint_message=(
                 f"In {self._identify_source(call_node)} Use "

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -57,7 +57,16 @@ class RuleVisitorTest(unittest.TestCase):
         return gets[0]
 
     def test_single_get(self) -> None:
-        get = self._parse_single_get("a = await Get[A](B, 42)", A=str, B=int)
+        get = self._parse_single_get(
+            dedent(
+                """
+                async def rule():
+                    a = await Get[A](B, 42)
+                """
+            ),
+            A=str,
+            B=int,
+        )
         assert get.product_type == str
         assert get.subject_declared_type == int
 
@@ -65,9 +74,10 @@ class RuleVisitorTest(unittest.TestCase):
         gets = self._parse_rule_gets(
             dedent(
                 """
-                a = await Get[A](B, 42)
-                if len(a) > 1:
-                    c = await Get[C](A("bob"))
+                async def rule():
+                    a = await Get[A](B, 42)
+                    if len(a) > 1:
+                        c = await Get[C](A("bob"))
                 """
             ),
             A=str,
@@ -86,14 +96,28 @@ class RuleVisitorTest(unittest.TestCase):
 
     def test_multiget_homogeneous(self) -> None:
         get = self._parse_single_get(
-            "a = await MultiGet(Get[A](B(x)) for x in range(5))", A=str, B=int
+            dedent(
+                """
+                async def rule():
+                    a = await MultiGet(Get[A](B(x)) for x in range(5))
+                """
+            ),
+            A=str,
+            B=int,
         )
         assert get.product_type == str
         assert get.subject_declared_type == int
 
     def test_multiget_heterogeneous(self) -> None:
         gets = self._parse_rule_gets(
-            "a = await MultiGet([Get[A](B, 42), Get[B](A('bob'))])", A=str, B=int
+            dedent(
+                """
+                async def rule():
+                    a = await MultiGet(Get[A](B, 42), Get[B](A('bob')))
+                """
+            ),
+            A=str,
+            B=int,
         )
 
         assert len(gets) == 2

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -56,12 +56,12 @@ class RuleVisitorTest(unittest.TestCase):
         assert len(gets) == 1, f"Expected 1 Get expression, found {len(gets)}."
         return gets[0]
 
-    def test_single_get(self):
+    def test_single_get(self) -> None:
         get = self._parse_single_get("a = await Get[A](B, 42)", A=str, B=int)
         assert get.product_type == str
         assert get.subject_declared_type == int
 
-    def test_multiple_gets(self):
+    def test_multiple_gets(self) -> None:
         gets = self._parse_rule_gets(
             dedent(
                 """
@@ -84,14 +84,14 @@ class RuleVisitorTest(unittest.TestCase):
         assert get_c.product_type == bool
         assert get_c.subject_declared_type == str
 
-    def test_multiget_homogeneous(self):
+    def test_multiget_homogeneous(self) -> None:
         get = self._parse_single_get(
             "a = await MultiGet(Get[A](B(x)) for x in range(5))", A=str, B=int
         )
         assert get.product_type == str
         assert get.subject_declared_type == int
 
-    def test_multiget_heterogeneous(self):
+    def test_multiget_heterogeneous(self) -> None:
         gets = self._parse_rule_gets(
             "a = await MultiGet([Get[A](B, 42), Get[B](A('bob'))])", A=str, B=int
         )
@@ -105,11 +105,11 @@ class RuleVisitorTest(unittest.TestCase):
         assert get_b.product_type == int
         assert get_b.subject_declared_type == str
 
-    def test_get_no_index_call_no_subject_call_allowed(self):
+    def test_get_no_index_call_no_subject_call_allowed(self) -> None:
         gets = self._parse_rule_gets("get_type: type = Get")
         assert len(gets) == 0
 
-    def test_get_index_call_deprecated(self):
+    def test_get_index_call_deprecated(self) -> None:
         pytest.xfail(
             "This should fail until deprecations are switched on: "
             "https://github.com/pantsbuild/pants/issues/9899"
@@ -123,27 +123,27 @@ class RuleVisitorTest(unittest.TestCase):
         assert emitted_warning.category == DeprecationWarning
         assert str(emitted_warning.message).endswith("Use Get(A, ...) instead of Get[A](...).")
 
-    def test_valid_get_unresolvable_product_type(self):
+    def test_valid_get_unresolvable_product_type(self) -> None:
         with pytest.raises(KeyError):
             self._parse_rule_gets("Get[DNE](A(42))", A=int)
 
-    def test_valid_get_unresolvable_subject_declared_type(self):
+    def test_valid_get_unresolvable_subject_declared_type(self) -> None:
         with pytest.raises(KeyError):
             self._parse_rule_gets("Get[int](DNE, 'bob')")
 
-    def test_invalid_get_no_subject_args(self):
+    def test_invalid_get_no_subject_args(self) -> None:
         with pytest.raises(ValueError):
             self._parse_rule_gets("Get[A]()", A=int)
 
-    def test_invalid_get_too_many_subject_args(self):
+    def test_invalid_get_too_many_subject_args(self) -> None:
         with pytest.raises(ValueError):
             self._parse_rule_gets("Get[A](B, 'bob', 3)", A=int, B=str)
 
-    def test_invalid_get_invalid_subject_arg_no_constructor_call(self):
+    def test_invalid_get_invalid_subject_arg_no_constructor_call(self) -> None:
         with pytest.raises(ValueError):
             self._parse_rule_gets("Get[A]('bob')", A=int)
 
-    def test_invalid_get_invalid_product_type_not_a_type_name(self):
+    def test_invalid_get_invalid_product_type_not_a_type_name(self) -> None:
         with pytest.raises(ValueError):
             self._parse_rule_gets("Get[call()](A('bob'))", A=str)
 

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -137,7 +137,8 @@ class _GetFactory:
         #  https://github.com/pantsbuild/pants/issues/9899
         deprecated_conditional(
             predicate=lambda: False,
-            removal_version="1.30.0.dev0",
+            deprecation_start_version="1.30.0.dev0",
+            removal_version="1.31.0.dev0",
             entity_description="Parameterized Get[...](...) calls",
             hint_message=(
                 f"Use Get({product_type.__name__}, ...) instead of "

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -137,7 +137,7 @@ class _GetFactory:
         #  https://github.com/pantsbuild/pants/issues/9899
         deprecated_conditional(
             predicate=lambda: False,
-            removal_version="1.31.0.dev0",
+            removal_version="1.30.0.dev0",
             entity_description="Parameterized Get[...](...) calls",
             hint_message=(
                 f"Use Get({product_type.__name__}, ...) instead of "
@@ -184,21 +184,16 @@ A Get can be constructed in 2 ways with two variants each:
   a. Get(<ProductType>, <SubjectDeclaredType>(<constructor args for subject>))
   b. Get[<ProductType>](<SubjectDeclaredType>(<constructor args for subject>))
 
-The long form supports two use cases:
-1. In order to provide type information to the rule engine that it could not otherwise infer from
-   the subject variable [1].
-2. The subject is a member of a union but not a subclass of the union base. In this case
-   SubjectDeclaredType should be the union base type.
-
-The short form must use inline construction of the subject in order to convey the subject type to
-the engine (reason 2 for the long form).
+The long form supports providing type information to the rule engine that it could not otherwise
+infer from the subject variable [1]. Likewise, the short form must use inline construction of the
+subject in order to convey the subject type to the engine.
 
 [1] The engine needs to determine all rule and Get input and output types statically before
 executing andy rules. Since Gets are declared inside function bodies, the only way to extract this
 information is through a parse of the rule function. The parse analysis is rudimentary and cannot
 infer more than names and calls; so a variable name does not give enough information to infer its
-type, only a constructor call unambiguosly gives this information without more in-depth parsing that
-includes following imports and more.
+type, only a constructor call unambiguously gives this information without more in-depth parsing
+that includes following imports and more.
 """
 
 
@@ -386,7 +381,7 @@ async def MultiGet(  # noqa: F811
     Tuple[_P0, _P1],
     Tuple[_P0],
 ]:
-    """Yield a tuple of Get instances with the same subject/product type pairs all at once.
+    """Yield a tuple of Get instances all at once.
 
     The `yield`ed value `self.gets` is interpreted by the engine within
     `extern_generator_send()` in `native.py`. This class will yield a tuple of Get instances,

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -1,36 +1,48 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import ast
+import itertools
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
+from typing import (
+    Any,
+    Generator,
+    Generic,
+    Iterable,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
+from pants.base.deprecated import deprecated_conditional
 from pants.util.meta import frozen_after_init
-from pants.util.objects import TypeConstraint
 
-# This type variable is used as the `product` field in a `Get`, and represents the type that the
-# engine will return from an `await Get[_Product](...)` expression. This type variable is also used
-# in the `Tuple[X, ...]` type returned by `await MultiGet(Get[X](...)...)`.
-_Product = TypeVar("_Product")
+# These type variables are used to type parameterize a `GetConstraints` (and consequently `_Get`).
+_ProductType = TypeVar("_ProductType")
+_SubjectDeclaredType = TypeVar("_SubjectDeclaredType")
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class Get(Generic[_Product]):
-    """Experimental synchronous generator API.
+@dataclass(frozen=True)
+class GetConstraints(Generic[_ProductType, _SubjectDeclaredType]):
+    product_type: Type[_ProductType]
+    subject_declared_type: Type[_SubjectDeclaredType]
 
-    May be called equivalently as either:   # verbose form: Get[product](subject_declared_type,
-    subject)   # shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
-    """
 
-    product: Type[_Product]
-    # TODO: Consider attempting to create a Get[_Product, _Subject] which still allows for the 2-arg
-    # Get form, and then making this Type[_Subject]!
-    subject_declared_type: Type
-    subject: Optional[Any]
+# This type variable is used to type parameterize the subject of a `_Get`.
+_SubjectType = TypeVar("_SubjectType")
 
-    def __await__(self) -> "Generator[Get[_Product], None, _Product]":
+
+@dataclass(frozen=True)
+class _Get(GetConstraints, Generic[_ProductType, _SubjectDeclaredType, _SubjectType]):
+    subject: _SubjectType
+
+    def __await__(
+        self,
+    ) -> ("Generator[_Get[_ProductType, _SubjectDeclaredType, _SubjectType], None, _ProductType]"):
         """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
         The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in
@@ -51,153 +63,550 @@ class Get(Generic[_Product]):
         https://www.python.org/dev/peps/pep-0492/#await-expression.
         """
         result = yield self
-        return cast(_Product, result)
+        return cast(_ProductType, result)
 
-    @classmethod
-    def __class_getitem__(cls, product_type):
-        """Override the behavior of Get[T] to shuffle over the product T into the constructor
-        args."""
-        return lambda *args: cls(product_type, *args)
 
-    def __init__(self, *args: Any) -> None:
-        # NB: Compat for Python 3.6, which doesn't recognize the __class_getitem__ override, but *does*
-        # contain an __orig_class__ attribute which is gone in later Pythons.
-        # TODO: Remove after we drop support for running pants with Python 3.6!
-        maybe_orig_class = getattr(self, "__orig_class__", None)
-        if maybe_orig_class:
-            (type_param,) = maybe_orig_class.__args__
-            args = (type_param,) + args
-
-        if len(args) not in (2, 3):
-            raise ValueError(
-                f"Expected either two or three arguments to {Get.__name__}; got {args}."
-            )
-        if len(args) == 2:
-            product, subject = args
-            if isinstance(subject, (type, TypeConstraint)):
-                raise TypeError(
-                    dedent(
-                        """\
-                        The two-argument form of Get does not accept a type as its second argument.
-
-                        args were: Get({args!r})
-
-                        Get.create_statically_for_rule_graph() should be used to generate a Get() for
-                        the `input_gets` field of a rule. If you are using a `await Get(...)` in a rule
-                        and a type was intended, use the 3-argument version:
-                        Get({product!r}, {subject_type!r}, {subject!r})
-                        """.format(
-                            args=args, product=product, subject_type=type(subject), subject=subject
-                        )
-                    )
-                )
-
-            subject_declared_type = type(subject)
-        else:
-            product, subject_declared_type, subject = args
-
-        self.product = product
-        self.subject_declared_type = subject_declared_type
-        self.subject = subject
+@dataclass(frozen=True)
+class _GetMaker(Generic[_ProductType]):
+    product_type: Type[_ProductType]
 
     @staticmethod
-    def extract_constraints(call_node):
-        """Parses a `Get(..)` call in one of its two legal forms to return its type constraints.
+    def _validate_subject_declared_type(subject_declared_type: Any) -> Type[_SubjectDeclaredType]:
+        if not isinstance(subject_declared_type, type):
+            raise TypeError(
+                f"The subject declared type argument must be a type, given {subject_declared_type} "
+                f"of type {type(subject_declared_type)}."
+            )
+        return cast(Type[_SubjectDeclaredType], subject_declared_type)
 
-        :param call_node: An `ast.Call` node representing a call to `Get(..)`.
-        :return: A tuple of product type id and subject type id.
-        """
+    @staticmethod
+    def _validate_subject(subject: Any) -> _SubjectType:
+        if isinstance(subject, type):
+            raise TypeError(f"The subject argument cannot be a type, given {subject}.")
+        return cast(_SubjectType, subject)
 
-        def render_args(args):
-            return ", ".join(
-                # Dump the Name's id to simplify output when available, falling back to the name of the
-                # node's class.
-                getattr(a, "id", type(a).__name__)
-                for a in args
+    @overload
+    def __call__(
+        self, __subject: _SubjectType
+    ) -> _Get[_ProductType, _SubjectType, _SubjectType]:  # noqa: F811
+        ...
+
+    @overload
+    def __call__(  # noqa: F811
+        self, __subject_declared_type: Type[_SubjectDeclaredType], __subject: _SubjectType
+    ) -> _Get[_ProductType, _SubjectDeclaredType, _SubjectType]:
+        ...
+
+    def __call__(  # noqa: F811
+        self,
+        __arg0: Union[Type[_SubjectDeclaredType], _SubjectType],
+        __arg1: Optional[_SubjectType] = None,
+    ) -> _Get[_ProductType, _SubjectDeclaredType, _SubjectType]:
+        return self._make_get(__arg0, __arg1)
+
+    def _make_get(
+        self,
+        __arg0: Union[Type[_SubjectDeclaredType], _SubjectType],
+        __arg1: Optional[_SubjectType] = None,
+    ) -> _Get[_ProductType, _SubjectDeclaredType, _SubjectType]:
+        subject_declared_type: Type[_SubjectDeclaredType] = self._validate_subject_declared_type(
+            __arg0 if __arg1 is not None else type(__arg0)
+        )
+        subject: _SubjectType = self._validate_subject(__arg1 if __arg1 is not None else __arg0)
+        return _Get(
+            product_type=self.product_type,
+            subject_declared_type=subject_declared_type,
+            subject=subject,
+        )
+
+
+class _GetFactory:
+    @staticmethod
+    def isinstance(item: Any) -> bool:
+        return isinstance(item, _Get)
+
+    def __getitem__(self, product_type: Type[_ProductType]) -> _GetMaker[_ProductType]:
+        if not isinstance(product_type, type):
+            raise TypeError(
+                f"The product type argument must be a type, given {product_type} of type "
+                f"{type(product_type)}."
             )
 
-        # If the Get was provided with a type parameter, use that as the `product_type`.
-        func = call_node.func
-        if isinstance(func, ast.Name):
-            subscript_args = ()
-        elif isinstance(func, ast.Subscript):
-            index_expr = func.slice.value
-            if isinstance(index_expr, ast.Name):
-                subscript_args = (index_expr,)
-            else:
-                raise ValueError(f"Unrecognized type argument T for Get[T]: {ast.dump(index_expr)}")
-        else:
-            raise ValueError(
-                f"Unrecognized Get call node type: expected Get or Get[T], received {ast.dump(call_node)}"
-            )
+        # TODO(John Sirois): Turn this on and update Pants own codebase to not trigger the warning
+        #  in a follow-up.
+        #  https://github.com/pantsbuild/pants/issues/9899
+        deprecated_conditional(
+            predicate=lambda: False,
+            removal_version="1.31.0.dev0",
+            entity_description="Parameterized Get[...](...) calls",
+            hint_message=(
+                f"Use Get({product_type.__name__}, ...) instead of "
+                f"Get[{product_type.__name__}](...)."
+            ),
+        )
 
-        # Shuffle over the type parameter to be the first argument, if provided.
-        combined_args = subscript_args + tuple(call_node.args)
+        return _GetMaker(product_type)
 
-        if len(combined_args) == 2:
-            product_type, subject_constructor = combined_args
-            if not isinstance(product_type, ast.Name) or not isinstance(
-                subject_constructor, ast.Call
-            ):
-                raise ValueError(
-                    f"Two arg form of {Get.__name__} expected (product_type, subject_type(subject)), but "
-                    f"got: ({render_args(combined_args)})"
-                )
-            return (product_type.id, subject_constructor.func.id)
-        elif len(combined_args) == 3:
-            product_type, subject_declared_type, _ = combined_args
-            if not isinstance(product_type, ast.Name) or not isinstance(
-                subject_declared_type, ast.Name
-            ):
-                raise ValueError(
-                    f"Three arg form of {Get.__name__} expected (product_type, subject_declared_type, subject), but "
-                    f"got: ({render_args(combined_args)})"
-                )
-            return (product_type.id, subject_declared_type.id)
-        else:
-            raise ValueError(
-                f"Invalid {Get.__name__}; expected either two or three args, but "
-                f"got: ({render_args(combined_args)})"
-            )
+    @overload
+    def __call__(
+        self, __product_type: Type[_ProductType], __subject: _SubjectType
+    ) -> _Get[_ProductType, _SubjectType, _SubjectType]:  # noqa: F811
+        ...
 
-    @classmethod
-    def create_statically_for_rule_graph(cls, product_type, subject_type) -> "Get":
-        """Construct a `Get` with a None value.
+    @overload
+    def __call__(  # noqa: F811
+        self,
+        __product_type: Type[_ProductType],
+        __subject_declared_type: Type[_SubjectDeclaredType],
+        __subject: _SubjectType,
+    ) -> _Get[_ProductType, _SubjectDeclaredType, _SubjectType]:
+        ...
 
-        This method is used to help make it explicit which `Get` instances are parsed from @rule
-        bodies and which are instantiated during rule execution.
-        """
-        return cls(product_type, subject_type, None)
+    def __call__(  # noqa: F811
+        self,
+        __product_type: Type[_ProductType],
+        __subject_arg0: Union[Type[_SubjectDeclaredType], _SubjectType],
+        __subject_arg1: Optional[_SubjectType] = None,
+    ) -> _Get[_ProductType, _SubjectDeclaredType, _SubjectType]:
+        return _GetMaker(product_type=__product_type)._make_get(__subject_arg0, __subject_arg1)
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class MultiGet(Generic[_Product]):
-    """Can be constructed with an iterable of `Get()`s and `await`ed to evaluate them in
-    parallel."""
+Get = _GetFactory()
+Get.__doc__ = """Experimental synchronous generator API.
 
-    gets: Tuple[Get[_Product], ...]
+A Get can be constructed in 2 ways with two variants each:
 
-    def __await__(self) -> Generator[Tuple[Get[_Product], ...], None, Tuple[_Product, ...]]:
-        """Yield a tuple of Get instances with the same subject/product type pairs all at once.
++ Long form:
+  a. Get(<ProductType>, <SubjectDeclaredType>, subject)
+  b. Get[<ProductType>](<SubjectDeclaredType>, subject)
 
-        The `yield`ed value `self.gets` is interpreted by the engine within `extern_generator_send()` in
-        `native.py`. This class will yield a tuple of Get instances, which is converted into
-        `PyGeneratorResponse::GetMulti` from `externs.rs`.
++ Short form
+  a. Get(<ProductType>, <SubjectDeclaredType>(<constructor args for subject>))
+  b. Get[<ProductType>](<SubjectDeclaredType>(<constructor args for subject>))
 
-        The engine will fulfill these Get instances in parallel, and return a tuple of _Product
-        instances to this method, which then returns this tuple to the `@rule` which called
-        `await MultiGet(Get[_Product](...) for ... in ...)`.
-        """
+The long form supports two use cases:
+1. In order to provide type information to the rule engine that it could not otherwise infer from
+   the subject variable [1].
+2. The subject is a member of a union but not a subclass of the union base. In this case
+   SubjectDeclaredType should be the union base type.
+
+The short form must use inline construction of the subject in order to convey the subject type to
+the engine (reason 2 for the long form).
+
+[1] The engine needs to determine all rule and Get input and output types statically before
+executing andy rules. Since Gets are declared inside function bodies, the only way to extract this
+information is through a parse of the rule function. The parse analysis is rudimentary and cannot
+infer more than names and calls; so a variable name does not give enough information to infer its
+type, only a constructor call unambiguosly gives this information without more in-depth parsing that
+includes following imports and more.
+"""
+
+
+@dataclass(frozen=True)
+class _MultiGet:
+    gets: Tuple[_Get, ...]
+
+    def __await__(self) -> Generator[Tuple[_Get, ...], None, Tuple]:
         result = yield self.gets
-        return cast(Tuple[_Product, ...], result)
+        return cast(Tuple, result)
 
-    def __init__(self, gets: Iterable[Get[_Product]]) -> None:
-        """Create a MultiGet from a generator expression.
 
-        This constructor will infer this class's _Product parameter from the input `gets`.
-        """
-        self.gets = tuple(gets)
+# These type variables are used to parameterize from 1 to 10 Gets when used in a tuple-style
+# MultiGet call.
+
+_P0 = TypeVar("_P0")
+_P1 = TypeVar("_P1")
+_P2 = TypeVar("_P2")
+_P3 = TypeVar("_P3")
+_P4 = TypeVar("_P4")
+_P5 = TypeVar("_P5")
+_P6 = TypeVar("_P6")
+_P7 = TypeVar("_P7")
+_P8 = TypeVar("_P8")
+_P9 = TypeVar("_P9")
+
+_SDT0 = TypeVar("_SDT0")
+_SDT1 = TypeVar("_SDT1")
+_SDT2 = TypeVar("_SDT2")
+_SDT3 = TypeVar("_SDT3")
+_SDT4 = TypeVar("_SDT4")
+_SDT5 = TypeVar("_SDT5")
+_SDT6 = TypeVar("_SDT6")
+_SDT7 = TypeVar("_SDT7")
+_SDT8 = TypeVar("_SDT8")
+_SDT9 = TypeVar("_SDT9")
+
+_S0 = TypeVar("_S0")
+_S1 = TypeVar("_S1")
+_S2 = TypeVar("_S2")
+_S3 = TypeVar("_S3")
+_S4 = TypeVar("_S4")
+_S5 = TypeVar("_S5")
+_S6 = TypeVar("_S6")
+_S7 = TypeVar("_S7")
+_S8 = TypeVar("_S8")
+_S9 = TypeVar("_S9")
+
+
+@overload
+async def MultiGet(
+    __gets: Iterable[_Get[_ProductType, _SubjectDeclaredType, _SubjectType]]
+) -> Tuple[_ProductType, ...]:  # noqa: F811
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+    __get5: _Get[_P5, _SDT5, _S5],
+    __get6: _Get[_P6, _SDT6, _S6],
+    __get7: _Get[_P7, _SDT7, _S7],
+    __get8: _Get[_P8, _SDT8, _S8],
+    __get9: _Get[_P9, _SDT9, _S9],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7, _P8, _P9]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+    __get5: _Get[_P5, _SDT5, _S5],
+    __get6: _Get[_P6, _SDT6, _S6],
+    __get7: _Get[_P7, _SDT7, _S7],
+    __get8: _Get[_P8, _SDT8, _S8],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7, _P8]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+    __get5: _Get[_P5, _SDT5, _S5],
+    __get6: _Get[_P6, _SDT6, _S6],
+    __get7: _Get[_P7, _SDT7, _S7],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+    __get5: _Get[_P5, _SDT5, _S5],
+    __get6: _Get[_P6, _SDT6, _S6],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+    __get5: _Get[_P5, _SDT5, _S5],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4, _P5]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+    __get4: _Get[_P4, _SDT4, _S4],
+) -> Tuple[_P0, _P1, _P2, _P3, _P4]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0],
+    __get1: _Get[_P1, _SDT1, _S1],
+    __get2: _Get[_P2, _SDT2, _S2],
+    __get3: _Get[_P3, _SDT3, _S3],
+) -> Tuple[_P0, _P1, _P2, _P3]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0], __get1: _Get[_P1, _SDT1, _S1], __get2: _Get[_P2, _SDT2, _S2]
+) -> Tuple[_P0, _P1, _P2]:
+    ...
+
+
+@overload
+async def MultiGet(  # noqa: F811
+    __get0: _Get[_P0, _SDT0, _S0], __get1: _Get[_P1, _SDT1, _S1]
+) -> Tuple[_P0, _P1]:
+    ...
+
+
+async def MultiGet(  # noqa: F811
+    __arg0: Union[
+        Iterable[_Get[_ProductType, _SubjectDeclaredType, _SubjectType]], _Get[_P0, _SDT0, _S0]
+    ],
+    __arg1: Optional[_Get[_P1, _SDT1, _S1]] = None,
+    __arg2: Optional[_Get[_P2, _SDT2, _S2]] = None,
+    __arg3: Optional[_Get[_P3, _SDT3, _S3]] = None,
+    __arg4: Optional[_Get[_P4, _SDT4, _S4]] = None,
+    __arg5: Optional[_Get[_P5, _SDT5, _S5]] = None,
+    __arg6: Optional[_Get[_P6, _SDT6, _S6]] = None,
+    __arg7: Optional[_Get[_P7, _SDT7, _S7]] = None,
+    __arg8: Optional[_Get[_P8, _SDT8, _S8]] = None,
+    __arg9: Optional[_Get[_P9, _SDT9, _S9]] = None,
+) -> Union[
+    Tuple[_ProductType, ...],
+    Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7, _P8, _P9],
+    Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7, _P8],
+    Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6, _P7],
+    Tuple[_P0, _P1, _P2, _P3, _P4, _P5, _P6],
+    Tuple[_P0, _P1, _P2, _P3, _P4, _P5],
+    Tuple[_P0, _P1, _P2, _P3, _P4],
+    Tuple[_P0, _P1, _P2, _P3],
+    Tuple[_P0, _P1, _P2],
+    Tuple[_P0, _P1],
+    Tuple[_P0],
+]:
+    """Yield a tuple of Get instances with the same subject/product type pairs all at once.
+
+    The `yield`ed value `self.gets` is interpreted by the engine within
+    `extern_generator_send()` in `native.py`. This class will yield a tuple of Get instances,
+    which is converted into `PyGeneratorResponse::GetMulti` from `externs.rs`.
+
+    The engine will fulfill these Get instances in parallel, and return a tuple of _Product
+    instances to this method, which then returns this tuple to the `@rule` which called
+    `await MultiGet(Get[_Product](...) for ... in ...)`.
+    """
+    if (
+        isinstance(__arg0, Iterable)
+        and __arg1 is None
+        and __arg2 is None
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        if any((__arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, __arg9)):
+            raise ValueError()
+        return await _MultiGet(tuple(__arg0))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and isinstance(__arg5, _Get)
+        and isinstance(__arg6, _Get)
+        and isinstance(__arg7, _Get)
+        and isinstance(__arg8, _Get)
+        and isinstance(__arg9, _Get)
+    ):
+        return await _MultiGet(
+            (__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, __arg9)
+        )
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and isinstance(__arg5, _Get)
+        and isinstance(__arg6, _Get)
+        and isinstance(__arg7, _Get)
+        and isinstance(__arg8, _Get)
+        and __arg9 is None
+    ):
+        return await _MultiGet(
+            (__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8)
+        )
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and isinstance(__arg5, _Get)
+        and isinstance(__arg6, _Get)
+        and isinstance(__arg7, _Get)
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and isinstance(__arg5, _Get)
+        and isinstance(__arg6, _Get)
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and isinstance(__arg5, _Get)
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and isinstance(__arg4, _Get)
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and isinstance(__arg3, _Get)
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and isinstance(__arg2, _Get)
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2))
+
+    if (
+        isinstance(__arg0, _Get)
+        and isinstance(__arg1, _Get)
+        and __arg2 is None
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0, __arg1))
+
+    if (
+        isinstance(__arg0, _Get)
+        and __arg1 is None
+        and __arg2 is None
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+    ):
+        return await _MultiGet((__arg0,))
+
+    args = __arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, __arg9
+
+    def render_arg(arg: Any) -> Optional[str]:
+        if arg is None:
+            return None
+        if isinstance(arg, _Get):
+            return f"Get({arg.product_type.__name__}, {arg.subject_declared_type.__name__}, ...)"
+        return repr(arg)
+
+    likely_args_exlicitly_passed = tuple(
+        reversed(
+            [
+                render_arg(arg)
+                for arg in itertools.dropwhile(lambda arg: arg is None, reversed(args))
+            ]
+        )
+    )
+    if any(arg is None for arg in likely_args_exlicitly_passed):
+        raise ValueError(
+            dedent(
+                f"""\
+                Unexpected MultiGet None arguments: {', '.join(
+                    map(str, likely_args_exlicitly_passed)
+                )}
+
+                When constructing a MultiGet from individual Gets all leading arguments must be
+                Gets.
+                """
+            )
+        )
+
+    raise TypeError(
+        dedent(
+            f"""\
+            Unexpected MultiGet argument types: {', '.join(map(str, likely_args_exlicitly_passed))}
+
+            A MultiGet can be constructed in two ways:
+            1. MultiGet(Iterable[Get[P]]) -> Tuple[P, ...]
+            2. MultiGet(Get[P1], Get[P2], ...) -> Tuple[P1, P2, ...]
+
+            The 1st form is intended for homogenous collections of Gets and emulates an
+            async for ... comprehension used to iterate over the collection in parallel and collect
+            the results in a homogenous Tuple when all are complete.
+
+            The 2nd form supports executing heterogeneous Gets in parallel and collecting them in a
+            heterogenous tuple when all are complete. Currently up to 10 heterogenous Gets can be
+            passed while still tracking their product types for type-checking by MyPy and similar
+            type checkers.
+            """
+        )
+    )
 
 
 @frozen_after_init

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -189,7 +189,7 @@ infer from the subject variable [1]. Likewise, the short form must use inline co
 subject in order to convey the subject type to the engine.
 
 [1] The engine needs to determine all rule and Get input and output types statically before
-executing andy rules. Since Gets are declared inside function bodies, the only way to extract this
+executing any rules. Since Gets are declared inside function bodies, the only way to extract this
 information is through a parse of the rule function. The parse analysis is rudimentary and cannot
 infer more than names and calls; so a variable name does not give enough information to infer its
 type, only a constructor call unambiguously gives this information without more in-depth parsing

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -688,18 +688,21 @@ class FieldSetWithOrigin(_AbstractFieldSet, metaclass=ABCMeta):
         )
 
 
+_AFS = TypeVar("_AFS", bound=_AbstractFieldSet)
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TargetsToValidFieldSets:
-    mapping: FrozenDict[TargetWithOrigin, Tuple[_AbstractFieldSet, ...]]
+class TargetsToValidFieldSets(Generic[_AFS]):
+    mapping: FrozenDict[TargetWithOrigin, Tuple[_AFS, ...]]
 
-    def __init__(self, mapping: Mapping[TargetWithOrigin, Iterable[_AbstractFieldSet]]) -> None:
+    def __init__(self, mapping: Mapping[TargetWithOrigin, Iterable[_AFS]]) -> None:
         self.mapping = FrozenDict(
             {tgt_with_origin: tuple(field_sets) for tgt_with_origin, field_sets in mapping.items()}
         )
 
     @memoized_property
-    def field_sets(self) -> Tuple[_AbstractFieldSet, ...]:
+    def field_sets(self) -> Tuple[_AFS, ...]:
         return tuple(
             itertools.chain.from_iterable(
                 field_sets_per_target for field_sets_per_target in self.mapping.values()
@@ -717,8 +720,8 @@ class TargetsToValidFieldSets:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TargetsToValidFieldSetsRequest:
-    field_set_superclass: Type[_AbstractFieldSet]
+class TargetsToValidFieldSetsRequest(Generic[_AFS]):
+    field_set_superclass: Type[_AFS]
     goal_description: str
     error_if_no_valid_targets: bool
     expect_single_field_set: bool
@@ -727,7 +730,7 @@ class TargetsToValidFieldSetsRequest:
 
     def __init__(
         self,
-        field_set_superclass: Type[_AbstractFieldSet],
+        field_set_superclass: Type[_AFS],
         *,
         goal_description: str,
         error_if_no_valid_targets: bool,

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -192,10 +192,10 @@ def run_rule(
     while True:
         try:
             res = rule_coroutine.send(rule_input)
-            if isinstance(res, Get):
-                rule_input = get(res.product, res.subject)
+            if Get.isinstance(res):
+                rule_input = get(res.product_type, res.subject)
             elif type(res) in (tuple, list):
-                rule_input = [get(g.product, g.subject) for g in res]
+                rule_input = [get(g.product_type, g.subject) for g in res]
             else:
                 return res
         except StopIteration as e:


### PR DESCRIPTION
MultiGet is currently only designed to work well with homogenous
collections of Gets under a type-checking regime. The underlying
mechanism supports heterogenous collections of Gets but these are
awkward to use when combined with type checking.

Add support for up to 10 heterogeneous type-tracked MultiGet parameters
in addition to the current support for a single homogenous collection
parameter.

As a practical matter, It's often convenient to define heterogenous Gets
outside MultiGet and assign them to local variables. If any of these
have name dependencies (e.g.: Simultaneously build a set of PEXes where
one uses PEX_PATH to join in the others) then it would be good to be
able to say get1.subject.output_filename and have it type check based on
Get.subject carrying a type. Support this by fully parameterizing Gets.

We currently support and implicitly encourage Get indexing as a way to
pass the product type parameter to a Get constructor. This complicates
adding type parameters to Get since mypy expects all subscript calls in
any position match the arity of the Generic declaration. Failures look
like (for Generic[P, S] iteration):
  ```
  src/python/pants/backend/awslambda/python/awslambda_python_rules.py:102:20: error:
  Type application has too few types (2 expected)  [misc]
          result = await Get[ProcessResult](Process, process)
  ```
This means to add more type parameters to Get we need to chose between:
a. Force all uses of Get[PT] in the wild to convert to Get[PT, SDT, ST]
b. Divorce the indexing operation from Get itself; i.e.: index on some
object that returns a callable that can produce a Get.

Here we choose the latter, moving Get to _Get and introducing a Get
object that can be indexed against to produce _Gets.

This complication highlights the oddity of the syntax support and #9899
has been filed with supporting code and tests in this change to
deprecate the syntax.

Fixes #9294

[ci skip-jvm-tests]
