### PR TITLE
Attach stdout/stderr digests to workunits

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -543,8 +543,8 @@ class StreamingWorkunitProcessTests(TestBase):
             item for item in finished if item["name"] == "multi_platform_process-running"
         )
         assert process_workunit is not None
-        stdout_digest = process_workunit["stdout_digest"]
-        stderr_digest = process_workunit["stderr_digest"]
+        stdout_digest = process_workunit["artifacts"]["stdout_digest"]
+        stderr_digest = process_workunit["artifacts"]["stderr_digest"]
 
         assert result.stdout == b"stdout output\n"
         assert stderr_digest == EMPTY_DIGEST
@@ -572,8 +572,8 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         assert process_workunit is not None
-        stdout_digest = process_workunit["stdout_digest"]
-        stderr_digest = process_workunit["stderr_digest"]
+        stdout_digest = process_workunit["artifacts"]["stdout_digest"]
+        stderr_digest = process_workunit["artifacts"]["stderr_digest"]
 
         assert result.stderr == b"stderr output\n"
         assert stdout_digest == EMPTY_DIGEST

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -8,8 +8,10 @@ from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import List
 
+from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import RootRule, named_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
@@ -18,6 +20,7 @@ from pants.testutil.engine.util import (
     fmt_rule,
     remove_locations_from_traceback,
 )
+from pants.testutil.test_base import TestBase
 from pants.util.logging import LogLevel
 
 
@@ -330,33 +333,36 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
             str(cm.exception),
         )
 
-    @dataclass
-    class WorkunitTracker:
-        """This class records every non-empty batch of started and completed workunits received from
-        the engine."""
 
-        finished_workunit_chunks: List[List[dict]] = field(default_factory=list)
-        started_workunit_chunks: List[List[dict]] = field(default_factory=list)
-        finished: bool = False
+@dataclass
+class WorkunitTracker:
+    """This class records every non-empty batch of started and completed workunits received from the
+    engine."""
 
-        def add(self, workunits, **kwargs) -> None:
-            if kwargs["finished"] is True:
-                self.finished = True
+    finished_workunit_chunks: List[List[dict]] = field(default_factory=list)
+    started_workunit_chunks: List[List[dict]] = field(default_factory=list)
+    finished: bool = False
 
-            started_workunits = kwargs.get("started_workunits")
-            if started_workunits:
-                self.started_workunit_chunks.append(started_workunits)
+    def add(self, workunits, **kwargs) -> None:
+        if kwargs["finished"] is True:
+            self.finished = True
 
-            if workunits:
-                self.finished_workunit_chunks.append(workunits)
+        started_workunits = kwargs.get("started_workunits")
+        if started_workunits:
+            self.started_workunit_chunks.append(started_workunits)
 
+        if workunits:
+            self.finished_workunit_chunks.append(workunits)
+
+
+class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
     def test_streaming_workunits_reporting(self):
         rules = [fib, RootRule(int)]
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
         )
 
-        tracker = self.WorkunitTracker()
+        tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             scheduler, callbacks=[tracker.add], report_interval_seconds=0.01
         )
@@ -382,7 +388,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
         )
-        tracker = self.WorkunitTracker()
+        tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             scheduler, callbacks=[tracker.add], report_interval_seconds=0.01
         )
@@ -430,7 +436,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
         )
-        tracker = self.WorkunitTracker()
+        tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             scheduler,
             callbacks=[tracker.add],
@@ -462,7 +468,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
         )
-        tracker = self.WorkunitTracker()
+        tracker = WorkunitTracker()
         info_level_handler = StreamingWorkunitHandler(
             scheduler,
             callbacks=[tracker.add],
@@ -486,7 +492,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         scheduler = self.mk_scheduler(
             rules, include_trace_on_error=False, should_report_workunits=True
         )
-        tracker = self.WorkunitTracker()
+        tracker = WorkunitTracker()
         debug_level_handler = StreamingWorkunitHandler(
             scheduler,
             callbacks=[tracker.add],
@@ -506,3 +512,69 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         r_C = next(item for item in finished if item["name"] == "rule_C")
         assert r_B["parent_id"] == r_A["span_id"]
         assert r_C["parent_id"] == r_B["span_id"]
+
+
+class StreamingWorkunitProcessTests(TestBase):
+
+    additional_options = ["--no-process-execution-use-local-cache"]
+
+    def test_process_digests_on_workunits(self):
+        self._init_engine()  # need to call this so that self._scheduler is not None when we pass it to StreamingWorkunitHandler
+
+        tracker = WorkunitTracker()
+        handler = StreamingWorkunitHandler(
+            self._scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
+        )
+
+        stdout_process = Process(
+            argv=("/bin/bash", "-c", "/bin/echo 'stdout output'"), description="Stdout process"
+        )
+
+        with handler.session():
+            result = self.request_single_product(ProcessResult, stdout_process)
+
+        assert tracker.finished
+        finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
+
+        process_workunit = next(
+            item for item in finished if item["name"] == "multi_platform_process-running"
+        )
+        assert process_workunit is not None
+        stdout_digest = process_workunit["stdout_digest"]
+        stderr_digest = process_workunit["stderr_digest"]
+
+        assert result.stdout == b"stdout output\n"
+        assert stderr_digest == EMPTY_DIGEST
+        assert stdout_digest.serialized_bytes_length == len(result.stdout)
+
+        tracker = WorkunitTracker()
+        handler = StreamingWorkunitHandler(
+            self._scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
+        )
+
+        stderr_process = Process(
+            argv=("/bin/bash", "-c", "1>&2 /bin/echo 'stderr output'"), description="Stderr process"
+        )
+
+        with handler.session():
+            result = self.request_single_product(ProcessResult, stderr_process)
+
+        assert tracker.finished
+        finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
+        process_workunit = next(
+            item for item in finished if item["name"] == "multi_platform_process-running"
+        )
+
+        assert process_workunit is not None
+        stdout_digest = process_workunit["stdout_digest"]
+        stderr_digest = process_workunit["stderr_digest"]
+
+        assert result.stderr == b"stderr output\n"
+        assert stdout_digest == EMPTY_DIGEST
+        assert stderr_digest.serialized_bytes_length == len(result.stderr)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -342,6 +342,7 @@ class EngineInitializer:
         build_file_prelude_globs: Tuple[str, ...],
         options_bootstrapper: OptionsBootstrapper,
         build_configuration: BuildConfiguration,
+        execution_options: ExecutionOptions,
         build_root: Optional[str] = None,
         native: Optional[Native] = None,
         glob_match_error_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.warn,
@@ -349,7 +350,6 @@ class EngineInitializer:
         exclude_target_regexps=None,
         subproject_roots=None,
         include_trace_on_error: bool = True,
-        execution_options: Optional[ExecutionOptions] = None,
     ) -> LegacyGraphScheduler:
         """Construct and return the components necessary for LegacyBuildGraph construction.
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3865,6 +3865,7 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time 0.0.1",
+ "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -382,12 +382,15 @@ impl super::CommandRunner for CommandRunner {
                 history.current_attempt.remote_execution = Some(elapsed);
                 history.complete_attempt();
 
-                break FallibleProcessResultWithPlatform {
-                  stdout: Bytes::from(format!(
+                let stdout = Bytes::from(format!(
                     "Exceeded timeout of {:?} ({:?} for the process and {:?} for remoting buffer time) with {:?} for operation {}, {}",
                     total_timeout, timeout, self.queue_buffer_time, elapsed, operation_name, description
-                  )),
-                  stdout_digest: hashing::EMPTY_DIGEST,
+                ));
+                let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
+
+                break FallibleProcessResultWithPlatform {
+                  stdout,
+                  stdout_digest,
                   stderr: Bytes::new(),
                   stderr_digest: hashing::EMPTY_DIGEST,
                   exit_code: -libc::SIGTERM,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
-use testutil::{as_bytes, owned_string_vec};
+use testutil::owned_string_vec;
 
 use crate::remote::{CommandRunner, ExecutionError, ExecutionHistory, OperationOrStatus};
 use crate::{
@@ -540,18 +540,10 @@ async fn successful_execution_after_one_getoperation() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
-
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
   assert_cancellation_requests(&mock_server, vec![]);
 }
 
@@ -590,17 +582,11 @@ async fn retries_retriable_errors() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 
   assert_cancellation_requests(&mock_server, vec![]);
 }
@@ -757,31 +743,26 @@ async fn extract_response_with_digest_stdout() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Digest(testdata.digest()),
-        StderrType::Raw(testdata_empty.string()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Linux,
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Digest(testdata.digest()),
+      StderrType::Raw(testdata_empty.string()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata.bytes(),
-      stderr: testdata_empty.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata.bytes());
+  assert_eq!(result.stderr, testdata_empty.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -789,31 +770,26 @@ async fn extract_response_with_digest_stderr() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Raw(testdata_empty.string()),
-        StderrType::Digest(testdata.digest()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Linux,
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Raw(testdata_empty.string()),
+      StderrType::Digest(testdata.digest()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata_empty.bytes(),
-      stderr: testdata.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata_empty.bytes());
+  assert_eq!(result.stderr, testdata.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -821,31 +797,26 @@ async fn extract_response_with_digest_stdout_osx_remote() {
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
-  assert_eq!(
-    extract_execute_response(
-      make_successful_operation(
-        &op_name,
-        StdoutType::Digest(testdata.digest()),
-        StderrType::Raw(testdata_empty.string()),
-        0,
-      )
-      .op
-      .unwrap()
-      .unwrap(),
-      Platform::Darwin
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Digest(testdata.digest()),
+      StderrType::Raw(testdata_empty.string()),
+      0,
     )
-    .await
+    .op
     .unwrap()
-    .without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: testdata.bytes(),
-      stderr: testdata_empty.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Darwin,
-    }
-  );
+    .unwrap(),
+    Platform::Darwin,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, testdata.bytes());
+  assert_eq!(result.stderr, testdata_empty.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Darwin);
 }
 
 #[tokio::test]
@@ -916,17 +887,11 @@ async fn ensure_inline_stdio_is_stored() {
     .run(echo_roland_request(), Context::default())
     .await
     .unwrap();
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: test_stdout.bytes(),
-      stderr: test_stderr.bytes(),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+
+  assert_eq!(result.stdout, test_stdout.bytes());
+  assert_eq!(result.stderr, test_stderr.bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
 
   let local_store =
     Store::local_only(runtime.clone(), &store_dir_path).expect("Error creating local store");
@@ -987,17 +952,11 @@ async fn successful_execution_after_four_getoperations() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -1156,17 +1115,11 @@ async fn retry_for_cancelled_channel() {
     .await
     .unwrap();
 
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: as_bytes("foo"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+  assert_eq!(result.stdout, "foo".as_bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]
@@ -1452,17 +1405,12 @@ async fn execute_missing_file_uploads_if_known() {
     .run(cat_roland_request(), Context::default())
     .await
     .unwrap();
-  assert_eq!(
-    result.without_execution_attempts(),
-    FallibleProcessResultWithPlatform {
-      stdout: roland.bytes(),
-      stderr: Bytes::from(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    }
-  );
+
+  assert_eq!(result.stdout, roland.bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
+
   {
     let blobs = cas.blobs.lock();
     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
@@ -1557,18 +1505,13 @@ async fn execute_missing_file_uploads_if_known_status() {
   )
   .unwrap()
   .run(cat_roland_request(), Context::default())
-  .await;
-  assert_eq!(
-    result,
-    Ok(FallibleProcessResultWithPlatform {
-      stdout: roland.bytes(),
-      stderr: Bytes::from(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-      platform: Platform::Linux,
-    })
-  );
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout, roland.bytes());
+  assert_eq!(result.stderr, "".as_bytes());
+  assert_eq!(result.exit_code, 0);
+  assert_eq!(result.platform, Platform::Linux);
   {
     let blobs = cas.blobs.lock();
     assert_eq!(blobs.get(&roland.fingerprint()), Some(&roland.bytes()));
@@ -1669,14 +1612,9 @@ async fn extract_execute_response_unknown_code() {
 
 #[tokio::test]
 async fn extract_execute_response_success() {
-  let want_result = FallibleProcessResultWithPlatform {
-    stdout: as_bytes("roland"),
-    stderr: Bytes::from("simba"),
-    exit_code: 17,
-    output_directory: TestDirectory::nested().digest(),
-    execution_attempts: vec![],
-    platform: Platform::Linux,
-  };
+  let wanted_exit_code = 17;
+  let wanted_stdout = Bytes::from("roland".as_bytes());
+  let wanted_stderr = Bytes::from("simba".as_bytes());
 
   let mut output_file = bazel_protos::remote_execution::OutputFile::new();
   output_file.set_path("cats/roland".into());
@@ -1692,22 +1630,24 @@ async fn extract_execute_response_success() {
     let mut response = bazel_protos::remote_execution::ExecuteResponse::new();
     response.set_result({
       let mut result = bazel_protos::remote_execution::ActionResult::new();
-      result.set_exit_code(want_result.exit_code);
-      result.set_stdout_raw(Bytes::from(want_result.stdout.clone()));
-      result.set_stderr_raw(Bytes::from(want_result.stderr.clone()));
+      result.set_exit_code(wanted_exit_code);
+      result.set_stdout_raw(Bytes::from(wanted_stdout.clone()));
+      result.set_stderr_raw(Bytes::from(wanted_stderr.clone()));
       result.set_output_files(output_files);
       result
     });
     response
   }));
 
-  assert_eq!(
-    extract_execute_response(operation, Platform::Linux)
-      .await
-      .unwrap()
-      .without_execution_attempts(),
-    want_result
-  );
+  let result = extract_execute_response(operation, Platform::Linux)
+    .await
+    .unwrap();
+
+  assert_eq!(result.stdout, wanted_stdout);
+  assert_eq!(result.stderr, wanted_stderr);
+  assert_eq!(result.exit_code, wanted_exit_code);
+  assert_eq!(result.output_directory, TestDirectory::nested().digest());
+  assert_eq!(result.platform, Platform::Linux);
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -153,7 +153,9 @@ fn make_delayed_command_runner(
   } else {
     Ok(FallibleProcessResultWithPlatform {
       stdout: msg.into(),
+      stdout_digest: EMPTY_DIGEST,
       stderr: "".into(),
+      stderr_digest: EMPTY_DIGEST,
       exit_code: 0,
       output_directory: EMPTY_DIGEST,
       execution_attempts: vec![],

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -999,6 +999,8 @@ impl Node for NodeKey {
         desc: user_facing_name.clone(),
         level: self.workunit_level(),
         blocked: false,
+        stdout: None,
+        stderr: None,
       };
 
       let started_workunit_id = context
@@ -1143,7 +1145,7 @@ pub enum NodeOutput {
   Digest(hashing::Digest),
   DirectoryListing(Arc<DirectoryListing>),
   LinkDest(LinkDest),
-  ProcessResult(ProcessResult),
+  ProcessResult(Box<ProcessResult>),
   Snapshot(Arc<store::Snapshot>),
   Value(Value),
 }
@@ -1168,7 +1170,7 @@ impl From<hashing::Digest> for NodeOutput {
 
 impl From<ProcessResult> for NodeOutput {
   fn from(v: ProcessResult) -> Self {
-    NodeOutput::ProcessResult(v)
+    NodeResult::ProcessResult(Box::new(v))
   }
 }
 
@@ -1222,7 +1224,7 @@ impl TryFrom<NodeOutput> for ProcessResult {
 
   fn try_from(nr: NodeOutput) -> Result<Self, ()> {
     match nr {
-      NodeOutput::ProcessResult(v) => Ok(v),
+      NodeResult::ProcessResult(v) => Ok(*v),
       _ => Err(()),
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1170,7 +1170,7 @@ impl From<hashing::Digest> for NodeOutput {
 
 impl From<ProcessResult> for NodeOutput {
   fn from(v: ProcessResult) -> Self {
-    NodeResult::ProcessResult(Box::new(v))
+    NodeOutput::ProcessResult(Box::new(v))
   }
 }
 
@@ -1224,7 +1224,7 @@ impl TryFrom<NodeOutput> for ProcessResult {
 
   fn try_from(nr: NodeOutput) -> Result<Self, ()> {
     match nr {
-      NodeResult::ProcessResult(v) => Ok(*v),
+      NodeOutput::ProcessResult(v) => Ok(*v),
       _ => Err(()),
     }
   }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 concrete_time = { path = "../concrete_time" }
+hashing = { path = "../hashing" }
 parking_lot = "0.6"
 rand = "0.6"
 tokio = { version = "0.2", features = ["rt-util"] }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -26,8 +26,8 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
-use log::{info, log};
 pub use log::Level;
+use log::{info, log};
 use parking_lot::Mutex;
 use petgraph::graph::{DiGraph, NodeIndex};
 use rand::thread_rng;


### PR DESCRIPTION
### Problem

One of the additional pieces of information we would like workunits report is the stdout and stderr of a process, for workunits associated with running a process.

### Solution

This commit represents the first part of the work involved in making this possible, namely, attaching `Digest`s representing the stdout and stderr output of processes to a new `artifacts` key on workunit Python objects. This involves adding new `stdout_digest` and `stderr_digest` fields on the `FallibleProcessResultWithPlatform` type in addition to the extant `stdout` and `stderr` `Bytes` fields. 

Note that this is not enough for the Digests to be useful in Python. A follow-up commit will add new foreign-function APIs that will allow the Python code that uses streaming workunits to materialize these Digests to bytes without using Engine rules directly, and to ensure that a remote store is populated with the contents of these digests. Once that is does, it should also be possible to drop the `stdout` and `stderr` fields from `FallibleProcessResultWithPlatform` completely, since the same information is currently redundantly contained in both fields.

In order to test these effectively, it was also necessary to make a slight change to the `TestBase` unit test framework. Now, a test that subclasses this class can set a class variable called `additional_options` with a list of additional bootstrap options that will be passed to the execution engine for the test. In this case the necessary option was `--no-process-execution-use-local-cache`, which forced a workunit associated with actually running a local `Process` to always be executed.


