### PR TITLE
Fix ABI string when building pants.pex

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -404,7 +404,7 @@ function build_pex() {
       ;;
     fetch)
       local distribution_target_flags=()
-      abis=("cp-36-m" "cp-37-m" "cp38")
+      abis=("cp-36-m" "cp-37-m" "cp-38-cp38")
       for platform in "${linux_platform_noabi}" "${osx_platform_noabi}"; do
         for abi in "${abis[@]}"; do
           distribution_target_flags=("${distribution_target_flags[@]}" "--platform=${platform}-${abi}")


### PR DESCRIPTION
The PEX we release fails to build because of an invalid platform tag.

We cannot use the abbreviated form because the abi is `cp38`, not `cp38m`, so `cp-38-m` would be invalid.

[ci skip-rust-tests]
[ci skip-jvm-tests]