### PR TITLE
Add `--` style passthrough args to V2 `run` and `setup-py` goals

### DIFF
--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -242,15 +242,16 @@ def build_pants_wheels() -> None:
     destination.mkdir(parents=True, exist_ok=True)
 
     def build(packages: Iterable[Package], bdist_wheel_flags: Iterable[str]) -> None:
-        formatted_flags = " ".join(bdist_wheel_flags)
         args = (
             "./v2",
             # TODO(#7654): It's not safe to use Pantsd because we're already using Pants to run
             #  this script.
             "--concurrent",
             "setup-py2",
-            f"--args=bdist_wheel {formatted_flags}",
             *(package.target for package in packages),
+            "--",
+            "bdist_wheel",
+            *bdist_wheel_flags,
         )
         try:
             subprocess.run(args, check=True)

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -98,8 +98,7 @@ function run_pex() {
 function run_packages_script() {
   (
     cd "${ROOT}"
-    # TODO: use V2 once we either figure out how to safely expand $@ to --run-args or we land 9835.
-    ./pants --quiet --concurrent run "${ROOT}/build-support/bin/packages.py" -- "$@"
+    ./v2 --concurrent run "${ROOT}/build-support/bin/packages.py" -- "$@"
   )
 }
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_run.py
@@ -17,6 +17,16 @@ class GoRun(GoTask):
         return True
 
     @classmethod
+    def passthru_args_kwargs(cls):
+        return dict(
+            passthrough=False,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "This task now receives passthrough arguments via the `--run-args` option."
+            ),
+        )
+
+    @classmethod
     def prepare(cls, options, round_manager):
         super().prepare(options, round_manager)
         round_manager.require_data("exec_binary")

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
@@ -21,6 +21,16 @@ class NodeRun(NodeTask):
     def supports_passthru_args(cls):
         return True
 
+    @classmethod
+    def passthru_args_kwargs(cls):
+        return dict(
+            passthrough=False,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "This task now receives passthrough arguments via the `--run-args` option."
+            ),
+        )
+
     def execute(self):
         target = self.require_single_root_target()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -49,6 +49,16 @@ class JvmRun(JvmTask):
     def supports_passthru_args(cls):
         return True
 
+    @classmethod
+    def passthru_args_kwargs(cls):
+        return dict(
+            passthrough=False,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "This task now receives passthrough arguments via the `--run-args` option."
+            ),
+        )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.only_write_cmd_line = self.get_options().only_write_cmd_line

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -230,6 +230,7 @@ class SetupPyOptions(GoalSubsystem):
             "--args",
             type=list,
             member_type=shell_str,
+            passthrough=True,
             help="Arguments to pass directly to setup.py, e.g. "
             '`--setup-py2-args="bdist_wheel --python-tag py36.py37"`. If unspecified, we just '
             "dump the setup.py chroot.",

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -17,6 +17,16 @@ class PythonRun(PythonExecutionTaskBase):
     def supports_passthru_args(cls):
         return True
 
+    @classmethod
+    def passthru_args_kwargs(cls):
+        return dict(
+            passthrough=False,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "This task now receives passthrough arguments via the `--run-args` option."
+            ),
+        )
+
     def execute(self):
         binary = self.require_single_root_target()
         if isinstance(binary, PythonBinary):

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -37,6 +37,7 @@ class RunOptions(GoalSubsystem):
             type=list,
             member_type=shell_str,
             fingerprint=True,
+            passthrough=True,
             help="Arguments to pass directly to the executed target, e.g. "
             '`--run-args="val1 val2 --debug"`',
         )

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -123,18 +123,33 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
         return False
 
     @classmethod
+    def passthru_args_kwargs(cls):
+        """Subclasses may override to include additional kwargs in their passthru arg registration.
+
+        This can be used to deprecate passthru args.
+
+        :API: public
+        """
+        return {}
+
+    @classmethod
     def register_options(cls, register):
         super().register_options(register)
         if cls.supports_passthru_args():
-            register(
-                "--passthrough-args",
+            kwargs = dict(
                 type=list,
                 advanced=True,
                 fingerprint=True,
                 passthrough=True,
-                help="Pass these options as pass-through args; ie: as if by appending "
-                "`-- <passthrough arg> ...` to the command line. Any passthrough args actually"
-                "supplied on the command line will be used as well.",
+                help=(
+                    "Pass these options as pass-through args; ie: as if by appending "
+                    "`-- <passthrough arg> ...` to the command line. Any passthrough args actually"
+                    "supplied on the command line will be used as well."
+                ),
+            )
+            kwargs.update(cls.passthru_args_kwargs())
+            register(
+                "--passthrough-args", **kwargs,
             )
 
     @classmethod


### PR DESCRIPTION
You can still use `--run-args` and `--setup-py2-args` like before, but now can use `--` at the end of the command.

[ci skip-rust-tests]
[ci skip-jvm-tests]