### PR TITLE
Add flake8-2020 plugin - checks for misuse of sys.version or sys.version_info

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -229,7 +229,10 @@ ignore = "%(pants_supportdir)s/eslint/.eslintignore"
 
 [flake8]
 config = "build-support/flake8/.flake8"
-extra_requirements.add = ["flake8-pantsbuild>=2.0,<3"]
+extra_requirements.add = [
+  "flake8-pantsbuild>=2.0,<3",
+  "flake8-2020>=1.6.0,<1.7.0"
+]
 
 [isort]
 config = [".isort.cfg", "contrib/.isort.cfg", "examples/.isort.cfg"]


### PR DESCRIPTION

### Problem

sys.version or sys.version_info can be used in a way that will introduce bugs once Python 3.10 will be released.

### Solution

Add a flake8 plugin: https://github.com/asottile/flake8-2020#flake8-2020 thay checks for those miuses