### PR TITLE
Run code coverage on v2 unit tests.

### DIFF
--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -20,3 +20,9 @@ process_execution_local_parallelism = "%(travis_parallelism)s"
 [python-setup]
 # TODO: See https://github.com/pantsbuild/pants/issues/9964
 resolver_jobs = 2
+
+[test]
+use_coverage = true
+
+[coverage-py]
+report=["raw"]


### PR DESCRIPTION
### Problem

V2 pytest code coverage doesn't have enough tests so it is fragile.

### Solution

Long term we should have tests, but for now, just enabling it and dogfooding it will expose issues


### Result

Prevent regressions like: https://github.com/pantsbuild/pants/issues/9914