### PR TITLE
Remove redundant names and logging.

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -43,7 +43,7 @@ from pants.engine.fs import (
 )
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.process import MultiPlatformProcess, ProcessResult
-from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
+from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -304,7 +304,7 @@ class PexDebug:
         self.log_level.log(logger, *args, **kwargs)
 
 
-@named_rule(desc="Create PEX")
+@rule
 async def create_pex(
     request: PexRequest,
     pex_bin: DownloadedPexBin,

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -19,7 +19,7 @@ from pants.backend.python.target_types import (
 )
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import RootRule, named_rule, rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import Targets, TransitiveTargets
 from pants.python.python_setup import PythonSetup
@@ -85,7 +85,7 @@ class TwoStepPexFromTargetsRequest:
     pex_from_targets_request: PexFromTargetsRequest
 
 
-@named_rule(desc="Create a PEX from targets")
+@rule
 async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonSetup) -> PexRequest:
     transitive_targets = await Get[TransitiveTargets](Addresses, request.addresses)
     all_targets = transitive_targets.closure

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -226,7 +226,7 @@ async def setup_pytest_for_target(
     )
 
 
-@named_rule(desc="Run pytest")
+@rule
 async def run_python_test(
     field_set: PythonTestFieldSet,
     test_setup: TestTargetSetup,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
-import logging
 from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
@@ -31,9 +30,6 @@ from pants.engine.target import (
     TargetsToValidFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership, union
-
-# TODO(#6004): use proper Logging singleton, rather than static logger.
-logger = logging.getLogger(__name__)
 
 
 class Status(Enum):
@@ -311,16 +307,7 @@ async def run_tests(
 @rule
 async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> AddressAndTestResult:
     field_set = wrapped_field_set.field_set
-
-    # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
-    # live TTY, periodically dump heavy hitters to stderr. See
-    # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
-    logger.info(f"Starting tests: {field_set.address.reference()}")
     result = await Get[TestResult](TestFieldSet, field_set)
-    logger.info(
-        f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
-        f"{field_set.address.reference()}"
-    )
     return AddressAndTestResult(field_set.address, result)
 
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+import logging
 from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
@@ -30,6 +31,10 @@ from pants.engine.target import (
     TargetsToValidFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership, union
+
+# TODO: Until we have templating of rule names (#7907) or some other way to affect the level
+# of a workunit for a failed test, we should continue to log tests completing.
+logger = logging.getLogger(__name__)
 
 
 class Status(Enum):
@@ -308,6 +313,10 @@ async def run_tests(
 async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> AddressAndTestResult:
     field_set = wrapped_field_set.field_set
     result = await Get[TestResult](TestFieldSet, field_set)
+    logger.info(
+        f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
+        f"{field_set.address.reference()}"
+    )
     return AddressAndTestResult(field_set.address, result)
 
 


### PR DESCRIPTION
### Problem

Post #9894, it's clear that many named rules are redundant, because the processes that run below them have better descriptions (relates to #7907, although it's possible that we'd like to drive the names of a workunit in some other way).

Example for a `--no-process-execution-use-local-cache` run:
```
18:00:22:852 [INFO] Starting tests: tests/python/pants_test/util:strutil
18:00:22:870 [INFO] Completed: Create a PEX from targets
18:00:24:029 [INFO] Completed: Building test_runner.pex
18:00:24:030 [INFO] Completed: Building requirements.pex
18:00:24:031 [INFO] Completed: Create PEX
18:00:24:031 [INFO] Completed: Create PEX
18:00:32:638 [INFO] Completed: Building pytest.pex with 8 requirements: ipdb, pygments, <snip>
18:00:32:639 [INFO] Completed: Create PEX
18:00:34:480 [INFO] Completed: Run Pytest for tests/python/pants_test/util:strutil
18:00:34:480 [INFO] Completed: Run pytest
18:00:34:481 [INFO] Tests succeeded: tests/python/pants_test/util:strutil
✓ tests/python/pants_test/util:strutil
============================= test session starts ==============================
<snip>
============================== 6 passed in 0.03s ===============================

18:00:34:481 [INFO] Completed: `test` goal
```

Likewise, when the process cache is hit on a run without `pantsd`, the `@rules` will run ("Create PEX" etc) but the processes won't because they'll have been persistently cached... which makes the output even less useful.

### Solution

While we should pursue #7907, and likely also allow `@rule`s to explicitly declare their level, some rule names just won't be useful when compared to the process names we've generated. Prune a few.

### Result

Output for the same uncached command is:
```
00:35:51:820 [INFO] Completed: Building requirements.pex
00:35:51:821 [INFO] Completed: Building test_runner.pex
00:36:02:208 [INFO] Completed: Building pytest.pex with 8 requirements: ipdb, pygments, <snip>
00:36:04:487 [INFO] Completed: Run Pytest for tests/python/pants_test/util:strutil
00:36:04:488 [INFO] Tests succeeded: tests/python/pants_test/util:strutil
✓ tests/python/pants_test/util:strutil
============================= test session starts ==============================
<snip>
============================== 6 passed in 0.03s ===============================

18:05:23:318 [INFO] Completed: `test` goal
```

See also: the travis output for this run.

[ci skip-jvm-tests]
[ci skip-rust-tests]
