### PR TITLE
Move `fs_util` building and release tagging to Python script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1597,7 +1597,6 @@ jobs:
     dist: xenial
     env:
     - CACHE_NAME=rust_tests.linux
-    - PREPARE_DEPLOY=1
     if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Rust tests - Linux
     os: linux
@@ -1607,7 +1606,6 @@ jobs:
     - '3.7'
     script:
     - ./build-support/bin/ci.py --rust-tests
-    - ./build-support/bin/release.sh -f
     stage: Test Pants
     sudo: required
   - before_cache:
@@ -1636,14 +1634,12 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - CACHE_NAME=rust_tests.osx
-    - PREPARE_DEPLOY=1
     if: commit_message !~ /\[ci skip-rust-tests\]/
     name: Rust tests - OSX
     os: osx
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --rust-tests
-    - ./build-support/bin/release.sh -f
     stage: Test Pants
   - addons:
       apt:
@@ -1691,7 +1687,7 @@ jobs:
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.linux
     language: python
-    name: Build Linux wheels
+    name: Build Linux wheels and fs_util
     os: linux
     python:
     - '2.7'
@@ -1703,7 +1699,8 @@ jobs:
       -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/release.sh -n && USE_PY37=true ./build-support/bin/release.sh
-      -n && USE_PY38=true ./build-support/bin/release.sh -n"
+      -n && USE_PY38=true ./build-support/bin/release.sh -n && ./build-support/bin/release.sh
+      -f"
     services:
     - docker
     stage: Test Pants
@@ -1742,13 +1739,14 @@ jobs:
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.osx
     language: generic
-    name: Build macOS wheels
+    name: Build macOS wheels and fs_util
     os: osx
     osx_image: xcode8
     script:
     - ./build-support/bin/release.sh -n
     - USE_PY37=true ./build-support/bin/release.sh -n
     - USE_PY38=true ./build-support/bin/release.sh -n
+    - ./build-support/bin/release.sh -f
     stage: Test Pants
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -576,6 +576,8 @@ def _build_wheels_command() -> List[str]:
         "./build-support/bin/release.sh -n",
         "USE_PY37=true ./build-support/bin/release.sh -n",
         "USE_PY38=true ./build-support/bin/release.sh -n",
+        # NB: We also build `fs_util` in this shard to leverage having had compiled the engine.
+        "./build-support/bin/release.sh -f",
     ]
 
 
@@ -588,7 +590,7 @@ def build_wheels_linux() -> Dict:
     shard: Dict = {
         **CACHE_NATIVE_ENGINE,
         **linux_shard(use_docker=True),
-        "name": "Build Linux wheels",
+        "name": "Build Linux wheels and fs_util",
         "script": [docker_build_travis_ci_image(), docker_run_travis_ci_image(command)],
     }
     safe_extend(shard, "env", _build_wheels_env(platform=Platform.linux))
@@ -599,7 +601,7 @@ def build_wheels_osx() -> Dict:
     shard: Dict = {
         **CACHE_NATIVE_ENGINE,
         **osx_shard(osx_image="xcode8"),
-        "name": "Build macOS wheels",
+        "name": "Build macOS wheels and fs_util",
         "script": _build_wheels_command(),
         "before_install": _osx_before_install(
             python_versions=[PythonVersion.py36, PythonVersion.py37, PythonVersion.py38],
@@ -660,9 +662,7 @@ _RUST_TESTS_BASE: Dict = {
     **CACHE_NATIVE_ENGINE,
     "stage": Stage.test.value,
     "before_script": ["ulimit -n 8192"],
-    # NB: We also build `fs_util` in this shard to leverage having had compiled the engine. This
-    # requires setting PREPARE_DEPLOY=1.
-    "script": ["./build-support/bin/ci.py --rust-tests", "./build-support/bin/release.sh -f"],
+    "script": ["./build-support/bin/ci.py --rust-tests"],
     "if": SKIP_RUST_CONDITION,
 }
 
@@ -672,7 +672,7 @@ def rust_tests_linux() -> Dict:
         **_RUST_TESTS_BASE,
         **linux_fuse_shard(),
         "name": "Rust tests - Linux",
-        "env": ["CACHE_NAME=rust_tests.linux", "PREPARE_DEPLOY=1"],
+        "env": ["CACHE_NAME=rust_tests.linux"],
     }
 
 
@@ -701,7 +701,7 @@ def rust_tests_osx() -> Dict:
             # This is good, because `brew install openssl` would trigger the same issues as noted on why
             # we don't use the `addons` section.
         ],
-        "env": [*_osx_env_with_pyenv(), "CACHE_NAME=rust_tests.osx", "PREPARE_DEPLOY=1"],
+        "env": [*_osx_env_with_pyenv(), "CACHE_NAME=rust_tests.osx"],
     }
 
 

--- a/build-support/bin/packages.py
+++ b/build-support/bin/packages.py
@@ -232,6 +232,8 @@ def build_pants_wheels() -> None:
         formatted_flags = " ".join(bdist_wheel_flags)
         args = (
             "./v2",
+            # TODO(#9924).
+            "--no-dynamic-ui",
             # TODO(#7654): It's not safe to use Pantsd because we're already using Pants to run
             #  this script.
             "--concurrent",

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -192,25 +192,6 @@ function build_3rdparty_packages() {
   end_travis_section
 }
 
-function build_fs_util() {
-  start_travis_section "fs_util" "Building fs_util binary"
-  # fs_util is a standalone tool which can be used to inspect and manipulate
-  # Pants's engine's file store, and interact with content addressable storage
-  # services which implement the Bazel remote execution API.
-  # It is a useful standalone tool which people may want to consume, for
-  # instance when debugging pants issues, or if they're implementing a remote
-  # execution API. Accordingly, we include it in our releases.
-  (
-    set -e
-    RUST_BACKTRACE=1 "${ROOT}/build-support/bin/native/cargo" build --release \
-      --manifest-path="${ROOT}/src/rust/engine/Cargo.toml" -p fs_util
-    dst_dir="${DEPLOY_DIR}/bin/fs_util/$("${ROOT}/build-support/bin/get_os.sh")/${PANTS_UNSTABLE_VERSION}"
-    mkdir -p "${dst_dir}"
-    cp "${ROOT}/src/rust/engine/target/release/fs_util" "${dst_dir}/"
-  ) || die "Failed to build fs_util"
-  end_travis_section
-}
-
 function activate_tmp_venv() {
   # Because the venv/bin/activate script's location is dynamic and not located in a fixed
   # place, Shellcheck will not be able to find it so we tell Shellcheck to ignore the file.
@@ -490,7 +471,7 @@ while getopts ":${_OPTS}" opt; do
     h) usage ;;
     d) debug="true" ;;
     n) dry_run="true" ;;
-    f) build_fs_util ; exit $? ;;
+    f) run_packages_script build-fs-util ; exit $? ;;
     t) test_release="true" ;;
     l) run_packages_script list-packages ; exit $? ;;
     o) run_packages_script list-owners ; exit $? ;;

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -11,6 +11,7 @@ travis_parallelism = 4
 [GLOBAL]
 # Override color support detection - we want colors and Travis supports them.
 colors = true
+# TODO: See #9924.
 dynamic_ui = false
 
 # TODO: Eventually we would like pantsd enabled in CI as well, but we blanket disable it for


### PR DESCRIPTION
This also fixes https://github.com/pantsbuild/pants/issues/9803. We now build `fs_util` in the wheel building shards, meaning that we will always release `fs_util`. We can do this because we are already paying the cost of Rust compilation due to https://github.com/pantsbuild/pants/pull/9881.