### PR TITLE
Log timestamps should be in the local time zone

### DIFF
--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -157,7 +157,7 @@ impl Log for Logger {
     let destination = get_destination();
     match destination {
       Destination::Stderr => {
-        let cur_time = chrono::Utc::now().format(TIME_FORMAT_STR);
+        let cur_time = chrono::Local::now().format(TIME_FORMAT_STR);
         let level = record.level();
         let log_string: String = format!("{} [{}] {}", cur_time, level, record.args());
 


### PR DESCRIPTION
This makes timestamp'd log messages a little bit shorter in the console and friendlier for a human user. If UTC timestamps are desired (for instance in a CI/CD context on a remote machine), the build machine's timezone can be set to UTC. Also use exactly two digits of subsecond precision for log timestamps.