### PR TITLE
Ensure BuildConfiguration is immutable.

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -5,203 +5,245 @@ import logging
 import typing
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Dict, Type, Union
+from typing import Any, Callable, Dict, Type, Union
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.rules import RuleIndex
+from pants.engine.rules import Rule, RuleIndex
 from pants.engine.target import Target
 from pants.option.optionable import Optionable
-from pants.util.ordered_set import OrderedSet
+from pants.util.frozendict import FrozenDict
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class BuildConfiguration:
     """Stores the types and helper functions exposed to BUILD files."""
 
-    _target_by_alias: Dict[Any, Any] = field(default_factory=dict)
-    _target_macro_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
-    _exposed_object_by_alias: Dict[Any, Any] = field(default_factory=dict)
-    _exposed_context_aware_object_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
-    _optionables: OrderedSet = field(default_factory=OrderedSet)
-    _rules: OrderedSet = field(default_factory=OrderedSet)
-    _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
-    _target_types: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
+    _registered_aliases: BuildFileAliases
+    _optionables: FrozenOrderedSet[Optionable]
+    _rules: FrozenOrderedSet[Union[Rule, Callable]]
+    _union_rules: FrozenDict[Type, FrozenOrderedSet[Type]]
+    _target_types: FrozenOrderedSet[Type[Target]]
 
     def registered_aliases(self) -> BuildFileAliases:
         """Return the registered aliases exposed in BUILD files.
 
-        These returned aliases aren't so useful for actually parsing BUILD files.
-        They are useful for generating things like http://pantsbuild.github.io/build_dictionary.html.
-
-        :returns: A new BuildFileAliases instance containing this BuildConfiguration's registered alias
-                  mappings.
+        These returned aliases aren't so useful for actually parsing BUILD files. They are useful
+        for generating things like http://pantsbuild.github.io/build_dictionary.html.
         """
-        target_factories_by_alias = self._target_by_alias.copy()
-        target_factories_by_alias.update(self._target_macro_factory_by_alias)
-        return BuildFileAliases(
-            targets=target_factories_by_alias,
-            objects=self._exposed_object_by_alias.copy(),
-            context_aware_object_factories=self._exposed_context_aware_object_factory_by_alias.copy(),
-        )
+        return self._registered_aliases
 
-    def register_aliases(self, aliases):
-        """Registers the given aliases to be exposed in parsed BUILD files.
-
-        :param aliases: The BuildFileAliases to register.
-        :type aliases: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
-        """
-        if not isinstance(aliases, BuildFileAliases):
-            raise TypeError("The aliases must be a BuildFileAliases, given {}".format(aliases))
-
-        for alias, target_type in aliases.target_types.items():
-            self._register_target_alias(alias, target_type)
-
-        for alias, target_macro_factory in aliases.target_macro_factories.items():
-            self._register_target_macro_factory_alias(alias, target_macro_factory)
-
-        for alias, obj in aliases.objects.items():
-            self._register_exposed_object(alias, obj)
-
-        for alias, context_aware_object_factory in aliases.context_aware_object_factories.items():
-            self._register_exposed_context_aware_object_factory(alias, context_aware_object_factory)
-
-    # TODO(John Sirois): Warn on alias override across all aliases since they share a global
-    # namespace in BUILD files.
-    # See: https://github.com/pantsbuild/pants/issues/2151
-    def _register_target_alias(self, alias, target_type):
-        if alias in self._target_by_alias:
-            logger.debug("Target alias {} has already been registered. Overwriting!".format(alias))
-
-        self._target_by_alias[alias] = target_type
-        self.register_optionables(target_type.subsystems())
-
-    def _register_target_macro_factory_alias(self, alias, target_macro_factory):
-        if alias in self._target_macro_factory_by_alias:
-            logger.debug(
-                "TargetMacro alias {} has already been registered. Overwriting!".format(alias)
-            )
-
-        self._target_macro_factory_by_alias[alias] = target_macro_factory
-        for target_type in target_macro_factory.target_types:
-            self.register_optionables(target_type.subsystems())
-
-    def _register_exposed_object(self, alias, obj):
-        if alias in self._exposed_object_by_alias:
-            logger.debug("Object alias {} has already been registered. Overwriting!".format(alias))
-
-        self._exposed_object_by_alias[alias] = obj
-        # obj doesn't implement any common base class, so we have to test for this attr.
-        if hasattr(obj, "subsystems"):
-            self.register_optionables(obj.subsystems())
-
-    def _register_exposed_context_aware_object_factory(self, alias, context_aware_object_factory):
-        if alias in self._exposed_context_aware_object_factory_by_alias:
-            logger.debug(
-                "This context aware object factory alias {} has already been registered. "
-                "Overwriting!".format(alias)
-            )
-
-        self._exposed_context_aware_object_factory_by_alias[alias] = context_aware_object_factory
-
-    def register_optionables(self, optionables):
-        """Registers the given subsystem types.
-
-        :param optionables: The Optionable types to register.
-        :type optionables: :class:`collections.Iterable` containing
-                           :class:`pants.option.optionable.Optionable` subclasses.
-        """
-        if not isinstance(optionables, Iterable):
-            raise TypeError("The optionables must be an iterable, given {}".format(optionables))
-        optionables = tuple(optionables)
-        if not optionables:
-            return
-
-        invalid_optionables = [
-            s for s in optionables if not isinstance(s, type) or not issubclass(s, Optionable)
-        ]
-        if invalid_optionables:
-            raise TypeError(
-                "The following items from the given optionables are not Optionable "
-                "subclasses:\n\t{}".format("\n\t".join(str(i) for i in invalid_optionables))
-            )
-
-        self._optionables.update(optionables)
-
-    def optionables(self):
-        """Returns the registered Optionable types.
-
-        :rtype set
-        """
+    def optionables(self) -> FrozenOrderedSet[Optionable]:
+        """Returns the registered Optionable types."""
         return self._optionables
 
-    def register_rules(self, rules):
-        """Registers the given rules.
+    def rules(self) -> FrozenOrderedSet[Union[Callable, Rule]]:
+        """Returns the registered rules."""
+        return self._rules
 
-        param rules: The rules to register.
-        :type rules: :class:`collections.Iterable` containing
-                     :class:`pants.engine.rules.Rule` instances.
-        """
-        if not isinstance(rules, Iterable):
-            raise TypeError("The rules must be an iterable, given {!r}".format(rules))
-
-        # "Index" the rules to normalize them and expand their dependencies.
-        normalized_rules = RuleIndex.create(rules).normalized_rules()
-        indexed_rules = normalized_rules.rules
-        union_rules = normalized_rules.union_rules
-
-        # Store the rules and record their dependency Optionables.
-        self._rules.update(indexed_rules)
-        for union_base, new_members in union_rules.items():
-            existing_members = self._union_rules.get(union_base, None)
-            if existing_members is None:
-                self._union_rules[union_base] = new_members
-            else:
-                existing_members.update(new_members)
-        dependency_optionables = {
-            do
-            for rule in indexed_rules
-            for do in rule.dependency_optionables
-            if rule.dependency_optionables
-        }
-        self.register_optionables(dependency_optionables)
-
-    def rules(self):
-        """Returns the registered rules.
-
-        :rtype: list
-        """
-        return list(self._rules)
-
-    def union_rules(self) -> Dict[Type, OrderedSet[Type]]:
-        """Returns a mapping of registered union base types -> [OrderedSet of union member
-        types]."""
+    def union_rules(self) -> FrozenDict[Type, FrozenOrderedSet[Type]]:
+        """Returns a mapping of registered union base types to the types of the union members."""
         return self._union_rules
 
-    # NB: We expect the parameter to be Iterable[Type[Target]], but we can't be confident in this
-    # because we pass whatever people put in their `register.py`s to this function; i.e., this is
-    # an impure function that reads from the outside world. So, we use the type hint `Any` and
-    # perform runtime type checking.
-    def register_target_types(
-        self, target_types: Union[typing.Iterable[Type[Target]], Any]
-    ) -> None:
-        """Registers the given target types."""
-        if not isinstance(target_types, Iterable):
-            raise TypeError(
-                f"The entrypoint `target_types` must return an iterable. Given {repr(target_types)}"
-            )
-        bad_elements = [
-            tgt_type
-            for tgt_type in target_types
-            if not isinstance(tgt_type, type) or not issubclass(tgt_type, Target)
-        ]
-        if bad_elements:
-            raise TypeError(
-                "Every element of the entrypoint `target_types` must be a subclass of "
-                f"{Target.__name__}. Bad elements: {bad_elements}."
-            )
-        self._target_types.update(target_types)
-
-    def target_types(self) -> OrderedSet[Type[Target]]:
+    def target_types(self) -> FrozenOrderedSet[Type[Target]]:
         return self._target_types
+
+    @dataclass
+    class Builder:
+        _target_by_alias: Dict[Any, Any] = field(default_factory=dict)
+        _target_macro_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
+        _exposed_object_by_alias: Dict[Any, Any] = field(default_factory=dict)
+        _exposed_context_aware_object_factory_by_alias: Dict[Any, Any] = field(default_factory=dict)
+        _optionables: OrderedSet = field(default_factory=OrderedSet)
+        _rules: OrderedSet = field(default_factory=OrderedSet)
+        _union_rules: Dict[Type, OrderedSet[Type]] = field(default_factory=dict)
+        _target_types: OrderedSet[Type[Target]] = field(default_factory=OrderedSet)
+
+        def registered_aliases(self) -> BuildFileAliases:
+            """Return the registered aliases exposed in BUILD files.
+
+            These returned aliases aren't so useful for actually parsing BUILD files.
+            They are useful for generating things like http://pantsbuild.github.io/build_dictionary.html.
+
+            :returns: A new BuildFileAliases instance containing this BuildConfiguration's registered alias
+                      mappings.
+            """
+            target_factories_by_alias = self._target_by_alias.copy()
+            target_factories_by_alias.update(self._target_macro_factory_by_alias)
+            return BuildFileAliases(
+                targets=target_factories_by_alias,
+                objects=self._exposed_object_by_alias.copy(),
+                context_aware_object_factories=self._exposed_context_aware_object_factory_by_alias.copy(),
+            )
+
+        def register_aliases(self, aliases):
+            """Registers the given aliases to be exposed in parsed BUILD files.
+
+            :param aliases: The BuildFileAliases to register.
+            :type aliases: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
+            """
+            if not isinstance(aliases, BuildFileAliases):
+                raise TypeError("The aliases must be a BuildFileAliases, given {}".format(aliases))
+
+            for alias, target_type in aliases.target_types.items():
+                self._register_target_alias(alias, target_type)
+
+            for alias, target_macro_factory in aliases.target_macro_factories.items():
+                self._register_target_macro_factory_alias(alias, target_macro_factory)
+
+            for alias, obj in aliases.objects.items():
+                self._register_exposed_object(alias, obj)
+
+            for (
+                alias,
+                context_aware_object_factory,
+            ) in aliases.context_aware_object_factories.items():
+                self._register_exposed_context_aware_object_factory(
+                    alias, context_aware_object_factory
+                )
+
+        # TODO(John Sirois): Warn on alias override across all aliases since they share a global
+        # namespace in BUILD files.
+        # See: https://github.com/pantsbuild/pants/issues/2151
+        def _register_target_alias(self, alias, target_type):
+            if alias in self._target_by_alias:
+                logger.debug(
+                    "Target alias {} has already been registered. Overwriting!".format(alias)
+                )
+
+            self._target_by_alias[alias] = target_type
+            self.register_optionables(target_type.subsystems())
+
+        def _register_target_macro_factory_alias(self, alias, target_macro_factory):
+            if alias in self._target_macro_factory_by_alias:
+                logger.debug(
+                    "TargetMacro alias {} has already been registered. Overwriting!".format(alias)
+                )
+
+            self._target_macro_factory_by_alias[alias] = target_macro_factory
+            for target_type in target_macro_factory.target_types:
+                self.register_optionables(target_type.subsystems())
+
+        def _register_exposed_object(self, alias, obj):
+            if alias in self._exposed_object_by_alias:
+                logger.debug(
+                    "Object alias {} has already been registered. Overwriting!".format(alias)
+                )
+
+            self._exposed_object_by_alias[alias] = obj
+            # obj doesn't implement any common base class, so we have to test for this attr.
+            if hasattr(obj, "subsystems"):
+                self.register_optionables(obj.subsystems())
+
+        def _register_exposed_context_aware_object_factory(
+            self, alias, context_aware_object_factory
+        ):
+            if alias in self._exposed_context_aware_object_factory_by_alias:
+                logger.debug(
+                    "This context aware object factory alias {} has already been registered. "
+                    "Overwriting!".format(alias)
+                )
+
+            self._exposed_context_aware_object_factory_by_alias[
+                alias
+            ] = context_aware_object_factory
+
+        def register_optionables(self, optionables):
+            """Registers the given subsystem types.
+
+            :param optionables: The Optionable types to register.
+            :type optionables: :class:`collections.Iterable` containing
+                               :class:`pants.option.optionable.Optionable` subclasses.
+            """
+            if not isinstance(optionables, Iterable):
+                raise TypeError("The optionables must be an iterable, given {}".format(optionables))
+            optionables = tuple(optionables)
+            if not optionables:
+                return
+
+            invalid_optionables = [
+                s for s in optionables if not isinstance(s, type) or not issubclass(s, Optionable)
+            ]
+            if invalid_optionables:
+                raise TypeError(
+                    "The following items from the given optionables are not Optionable "
+                    "subclasses:\n\t{}".format("\n\t".join(str(i) for i in invalid_optionables))
+                )
+
+            self._optionables.update(optionables)
+
+        def register_rules(self, rules):
+            """Registers the given rules.
+
+            param rules: The rules to register.
+            :type rules: :class:`collections.Iterable` containing
+                         :class:`pants.engine.rules.Rule` instances.
+            """
+            if not isinstance(rules, Iterable):
+                raise TypeError("The rules must be an iterable, given {!r}".format(rules))
+
+            # "Index" the rules to normalize them and expand their dependencies.
+            normalized_rules = RuleIndex.create(rules).normalized_rules()
+            indexed_rules = normalized_rules.rules
+            union_rules = normalized_rules.union_rules
+
+            # Store the rules and record their dependency Optionables.
+            self._rules.update(indexed_rules)
+            for union_base, new_members in union_rules.items():
+                existing_members = self._union_rules.get(union_base, None)
+                if existing_members is None:
+                    self._union_rules[union_base] = new_members
+                else:
+                    existing_members.update(new_members)
+            dependency_optionables = {
+                do
+                for rule in indexed_rules
+                for do in rule.dependency_optionables
+                if rule.dependency_optionables
+            }
+            self.register_optionables(dependency_optionables)
+
+        # NB: We expect the parameter to be Iterable[Type[Target]], but we can't be confident in this
+        # because we pass whatever people put in their `register.py`s to this function; i.e., this is
+        # an impure function that reads from the outside world. So, we use the type hint `Any` and
+        # perform runtime type checking.
+        def register_target_types(
+            self, target_types: Union[typing.Iterable[Type[Target]], Any]
+        ) -> None:
+            """Registers the given target types."""
+            if not isinstance(target_types, Iterable):
+                raise TypeError(
+                    f"The entrypoint `target_types` must return an iterable. Given {repr(target_types)}"
+                )
+            bad_elements = [
+                tgt_type
+                for tgt_type in target_types
+                if not isinstance(tgt_type, type) or not issubclass(tgt_type, Target)
+            ]
+            if bad_elements:
+                raise TypeError(
+                    "Every element of the entrypoint `target_types` must be a subclass of "
+                    f"{Target.__name__}. Bad elements: {bad_elements}."
+                )
+            self._target_types.update(target_types)
+
+        def create(self) -> "BuildConfiguration":
+            target_factories_by_alias = self._target_by_alias.copy()
+            target_factories_by_alias.update(self._target_macro_factory_by_alias)
+            registered_aliases = BuildFileAliases(
+                targets=target_factories_by_alias,
+                objects=self._exposed_object_by_alias.copy(),
+                context_aware_object_factories=self._exposed_context_aware_object_factory_by_alias.copy(),
+            )
+            return BuildConfiguration(
+                _registered_aliases=registered_aliases,
+                _optionables=FrozenOrderedSet(self._optionables),
+                _rules=FrozenOrderedSet(self._rules),
+                _union_rules=FrozenDict(
+                    (union_base, FrozenOrderedSet(union_members))
+                    for union_base, union_members in self._union_rules.items()
+                ),
+                _target_types=FrozenOrderedSet(self._target_types),
+            )

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -5,19 +5,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    NoReturn,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Dict, List, NoReturn, Optional, Sequence, Tuple, Type, Union, cast
 
 from typing_extensions import TypedDict
 
@@ -30,6 +18,7 @@ from pants.engine.fs import (
     MaterializeDirectoryResult,
     PathGlobsAndRoot,
 )
+from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.internals.native import RawFdRunner
 from pants.engine.internals.nodes import Return, Throw
 from pants.engine.rules import Rule, RuleIndex, TaskRule
@@ -38,13 +27,10 @@ from pants.engine.unions import union
 from pants.option.global_options import ExecutionOptions
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import check_no_overlapping_paths
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize
-
-if TYPE_CHECKING:
-    from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
-    from pants.util.ordered_set import OrderedSet  # noqa
-
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +79,7 @@ class Scheduler:
         local_execution_root_dir: str,
         named_caches_dir: str,
         rules: Tuple[Rule, ...],
-        union_rules: Dict[Type, "OrderedSet[Type]"],
+        union_rules: FrozenDict[Type, FrozenOrderedSet[Type]],
         execution_options: ExecutionOptions,
         include_trace_on_error: bool = True,
         visualize_to_dir: Optional[str] = None,
@@ -175,7 +161,7 @@ class Scheduler:
         return tasks
 
     def _register_task(
-        self, tasks, output_type, rule: TaskRule, union_rules: Dict[Type, "OrderedSet[Type]"]
+        self, tasks, output_type, rule: TaskRule, union_rules: Dict[Type, OrderedSet[Type]]
     ) -> None:
         """Register the given TaskRule with the native scheduler."""
         self._native.lib.tasks_task_begin(tasks, rule.func, output_type, rule.cacheable)

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -3,7 +3,7 @@
 
 import importlib
 import traceback
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pkg_resources import Requirement, WorkingSet
 
@@ -30,7 +30,7 @@ def load_backends_and_plugins(
     working_set: WorkingSet,
     backends1: List[str],
     backends2: List[str],
-    build_configuration: BuildConfiguration,
+    bc_builder: Optional[BuildConfiguration.Builder] = None,
 ) -> BuildConfiguration:
     """Load named plugins and source backends.
 
@@ -39,16 +39,17 @@ def load_backends_and_plugins(
     :param working_set: A pkg_resources.WorkingSet to load plugins from.
     :param backends1: v1 backends to load.
     :param backends2: v2 backends to load.
-    :param build_configuration: The BuildConfiguration (for adding aliases).
+    :param bc_builder: The BuildConfiguration (for adding aliases).
     """
-    load_build_configuration_from_source(build_configuration, backends1, backends2)
-    load_plugins(build_configuration, plugins1, working_set, is_v1_plugin=True)
-    load_plugins(build_configuration, plugins2, working_set, is_v1_plugin=False)
-    return build_configuration
+    bc_builder = bc_builder or BuildConfiguration.Builder()
+    load_build_configuration_from_source(bc_builder, backends1, backends2)
+    load_plugins(bc_builder, plugins1, working_set, is_v1_plugin=True)
+    load_plugins(bc_builder, plugins2, working_set, is_v1_plugin=False)
+    return bc_builder.create()
 
 
 def load_plugins(
-    build_configuration: BuildConfiguration,
+    build_configuration: BuildConfiguration.Builder,
     plugins: List[str],
     working_set: WorkingSet,
     is_v1_plugin: bool,
@@ -121,7 +122,7 @@ def load_plugins(
 
 
 def load_build_configuration_from_source(
-    build_configuration: BuildConfiguration, backends1: List[str], backends2: List[str]
+    build_configuration: BuildConfiguration.Builder, backends1: List[str], backends2: List[str]
 ) -> None:
     """Installs pants backend packages to provide BUILD file symbols and cli goals.
 
@@ -144,7 +145,7 @@ def load_build_configuration_from_source(
 
 
 def load_backend(
-    build_configuration: BuildConfiguration, backend_package: str, is_v1_backend: bool
+    build_configuration: BuildConfiguration.Builder, backend_package: str, is_v1_backend: bool
 ) -> None:
     """Installs the given backend package into the build configuration.
 

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import sys
+from typing import Optional
 
 import pkg_resources
 
@@ -15,6 +16,7 @@ from pants.init.extension_loader import load_backends_and_plugins
 from pants.init.global_subsystems import GlobalSubsystems
 from pants.init.plugin_resolver import PluginResolver
 from pants.option.global_options import GlobalOptions
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.ordered_set import OrderedSet
@@ -30,7 +32,7 @@ class BuildConfigInitializer:
     plugin loading, which can be expensive and cause issues (double task registration, etc).
     """
 
-    _cached_build_config = None
+    _cached_build_config: Optional[BuildConfiguration] = None
 
     @classmethod
     def get(cls, options_bootstrapper):
@@ -39,15 +41,15 @@ class BuildConfigInitializer:
         return cls._cached_build_config
 
     @classmethod
-    def reset(cls):
+    def reset(cls) -> None:
         cls._cached_build_config = None
 
-    def __init__(self, options_bootstrapper):
+    def __init__(self, options_bootstrapper: OptionsBootstrapper) -> None:
         self._options_bootstrapper = options_bootstrapper
         self._bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
         self._working_set = PluginResolver(self._options_bootstrapper).resolve()
 
-    def _load_plugins(self):
+    def _load_plugins(self) -> BuildConfiguration:
         # Add any extra paths to python path (e.g., for loading extra source backends).
         for path in self._bootstrap_options.pythonpath:
             if path not in sys.path:
@@ -61,10 +63,9 @@ class BuildConfigInitializer:
             self._working_set,
             self._bootstrap_options.backend_packages,
             self._bootstrap_options.backend_packages2,
-            BuildConfiguration(),
         )
 
-    def setup(self):
+    def setup(self) -> BuildConfiguration:
         """Load backends and plugins.
 
         :returns: A `BuildConfiguration` object constructed during backend/plugin loading.

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -299,11 +299,11 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
     @classmethod
     def build_config(cls):
-        build_config = BuildConfiguration()
+        build_config = BuildConfiguration.Builder()
         build_config.register_aliases(cls.alias_groups())
         build_config.register_rules(cls.rules())
         build_config.register_target_types(cls.target_types())
-        return build_config
+        return build_config.create()
 
     def setUp(self):
         """

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -501,7 +501,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
                     "You must set a scope on your subsystem type before using it in tests."
                 )
 
-        optionables = {SourceRootConfig} | self._build_configuration.optionables() | for_subsystems
+        optionables = {SourceRootConfig, *self._build_configuration.optionables(), *for_subsystems}
 
         for_task_types = for_task_types or ()
         for task_type in for_task_types:

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
+from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.testutil.subsystem.util import init_subsystem
 from pants.testutil.task_test_base import TaskTestBase
@@ -22,9 +23,7 @@ class PythonTaskTestBase(TaskTestBase):
         """
         :API: public
         """
-        aliases = register_python()
-        aliases.target_types["resources"] = Resources
-        return aliases
+        return register_python().merge(BuildFileAliases(targets={"resources": Resources}))
 
     def setUp(self):
         super().setUp()

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -47,6 +47,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/testutil/subsystem',
+    'src/python/pants/util:frozendict',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/build_graph/test_build_file_aliases.py
+++ b/tests/python/pants_test/build_graph/test_build_file_aliases.py
@@ -9,6 +9,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.build_graph.target import Target
 from pants.engine.legacy.graph import LegacyBuildGraph
 from pants.testutil.subsystem.util import init_subsystem
+from pants.util.frozendict import FrozenDict
 
 
 class BuildFileAliasesTest(unittest.TestCase):
@@ -109,7 +110,7 @@ class BuildFileAliasesTest(unittest.TestCase):
             # nothing to merge
             targets={"a": Target, "b": self.target_macro_factory},
             # second overrides first
-            objects={"c": 1, "d": 42},
+            objects={"d": 42, "c": 1},
             # combine
             context_aware_object_factories={"e": e_factory, "f": f_factory},
         )
@@ -117,14 +118,15 @@ class BuildFileAliasesTest(unittest.TestCase):
 
     def test_target_types(self):
         aliases = BuildFileAliases(targets={"jake": Target, "jill": self.target_macro_factory})
-        self.assertEqual({"jake": Target}, aliases.target_types)
+        self.assertEqual(FrozenDict(jake=Target), aliases.target_types)
 
     def test_target_macro_factories(self):
         aliases = BuildFileAliases(targets={"jake": Target, "jill": self.target_macro_factory})
-        self.assertEqual({"jill": self.target_macro_factory}, aliases.target_macro_factories)
+        self.assertEqual(FrozenDict(jill=self.target_macro_factory), aliases.target_macro_factories)
 
     def test_target_types_by_alias(self):
         aliases = BuildFileAliases(targets={"jake": Target, "jill": self.target_macro_factory})
         self.assertEqual(
-            {"jake": {Target}, "jill": {self.BlueTarget}}, aliases.target_types_by_alias
+            FrozenDict(jake=frozenset([Target]), jill=frozenset([self.BlueTarget])),
+            aliases.target_types_by_alias,
         )


### PR DESCRIPTION
Make BuildConfiguration immutable by lifting a Builder out of it. This
helps ensure the invariant that a unique BuildConfiguration is paired
with a unique scheduler going forward.

[ci skip-rust-tests]
[ci skip-jvm-tests]
