### PR TITLE
Make FrozenDict more ergonomic.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/target_types.py
+++ b/contrib/node/src/python/pants/contrib/node/target_types.py
@@ -159,7 +159,7 @@ class NodeBinExecutables(PrimitiveField):
 
     def normalized_value(self, *, package_name: NodePackageName) -> FrozenDict[str, str]:
         if self.value is None:
-            return FrozenDict({})
+            return FrozenDict()
         if isinstance(self.value, str):
             return FrozenDict({package_name.value: self.value})
         return self.value

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -1,19 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Iterable, Iterator, Mapping, Tuple, TypeVar, Union, overload
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -39,18 +27,14 @@ class FrozenDict(Mapping[K, V]):
     def __init__(self, **kwargs: V) -> None:
         ...
 
-    def __init__(
-        self, *item: Optional[Union[Mapping[K, V], Iterable[Tuple[K, V]]]], **kwargs: V
-    ) -> None:
+    def __init__(self, *item: Union[Mapping[K, V], Iterable[Tuple[K, V]]], **kwargs: V) -> None:
         """Creates a `FrozenDict` with arguments accepted by `dict` that also must be hashable."""
         if len(item) > 1:
             raise ValueError(
-                f"FrozenDict was called with {len(item)} positional arguments but it expects one"
+                f"FrozenDict was called with {len(item)} positional arguments but it expects one."
             )
 
-        self._data: Dict[K, V] = dict(
-            cast(Union[Mapping[K, V], Iterable[Tuple[K, V]]], item[0])
-        ) if item else dict()
+        self._data = dict(item[0]) if item else dict()
         self._data.update(**kwargs)
 
         # NB: We eagerly compute the hash to validate that the values are hashable and to avoid

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -14,6 +14,18 @@ def test_flexible_constructor() -> None:
     assert FrozenDict(OrderedDict({"a": 0, "b": 1})) == expected
     assert FrozenDict([("a", 0), ("b", 1)]) == expected
     assert FrozenDict((("a", 0), ("b", 1))) == expected
+    assert FrozenDict(a=0, b=1) == expected
+    assert FrozenDict({"a": 0}, b=1) == expected
+    assert FrozenDict([("a", 0)], b=1) == expected
+
+
+def test_empty_construction() -> None:
+    assert FrozenDict() == FrozenDict({})
+
+
+def test_invalid_arguments() -> None:
+    with pytest.raises(ValueError):
+        FrozenDict({}, {})  # type: ignore[call-overload]
 
 
 def test_unhashable_items_rejected() -> None:
@@ -31,7 +43,7 @@ def test_original_data_gets_copied() -> None:
 
 
 def test_len() -> None:
-    assert len(FrozenDict({})) == 0
+    assert len(FrozenDict()) == 0
     assert len(FrozenDict({"a": 0, "b": 1})) == 2
 
 


### PR DESCRIPTION
With some overloads it now continues to type check while supporting
kwargs and no args like dict() does.

[ci skip-rust-tests]
[ci skip-jvm-tests]