### PR TITLE
Fix a bug in pyest coverage report computation.

### DIFF
--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -12,7 +12,8 @@ from pants.python.pex_build_util import identify_missing_init_files
 # NB: Needed due to graph ambiguity.
 @dataclass(frozen=True)
 class InjectInitRequest:
-    snapshot: Snapshot
+    # NB: This must contain sources already stripped of their source roots.
+    stripped_sources_snapshot: Snapshot
 
 
 @dataclass(frozen=True)
@@ -26,7 +27,7 @@ async def inject_missing_init_files(request: InjectInitRequest) -> InitInjectedS
 
     This will preserve any `__init__.py` files already in the input snapshot.
     """
-    snapshot = request.snapshot
+    snapshot = request.stripped_sources_snapshot
     missing_init_files = sorted(identify_missing_init_files(snapshot.files))
     if not missing_init_files:
         return InitInjectedSnapshot(snapshot)


### PR DESCRIPTION
Previously, when computing the coverage mapping, we injected missing `__init__.py` files *before* stripping source roots. This means we injected up past the source root (e.g., we created `src/__init__.py`). These injected files then failed source root stripping, since they weren't under any source root. 

This change removes the injection entirely, since we shouldn't report coverage for synthetic source files that don't correspond to user-facing sources anyway (e.g., we also don't report coverage for codegenned sources, and probably rightly so).

It also changes the name of the `snapshot` field in `InjectInitRequest` to `stripped_sources_snapshot`, to emphasize that injection only makes sense on stripped sources.

Note: We urgently need to add robust tests to our coverage support.  This was tested manually just to get it out quickly.

Fixes #9914 

See also #8082 

[ci skip-rust-tests]
[ci skip-jvm-tests]
