### PR TITLE
Remove unused FmtRequest union.

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -18,7 +18,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
@@ -44,7 +44,7 @@ class BlackFieldSet(FieldSetWithOrigin):
     sources: PythonSources
 
 
-class BlackRequest(FmtRequest, LintRequest):
+class BlackRequest(PythonFmtRequest, LintRequest):
     field_set_type = BlackFieldSet
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
@@ -41,7 +41,7 @@ class DocformatterFieldSet(FieldSetWithOrigin):
     sources: PythonSources
 
 
-class DocformatterRequest(FmtRequest, LintRequest):
+class DocformatterRequest(PythonFmtRequest, LintRequest):
     field_set_type = DocformatterFieldSet
 
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -16,7 +16,7 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
@@ -43,7 +43,7 @@ class IsortFieldSet(FieldSetWithOrigin):
     sources: PythonSources
 
 
-class IsortRequest(FmtRequest, LintRequest):
+class IsortRequest(PythonFmtRequest, LintRequest):
     field_set_type = IsortFieldSet
 
 

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from typing import Iterable, List, Type
 
 from pants.backend.python.target_types import PythonSources
-from pants.core.goals.fmt import FmtRequest, FmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
+from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.rules import rule
@@ -19,7 +20,7 @@ class PythonFmtTargets(LanguageFmtTargets):
 
 
 @union
-class PythonFmtRequest(FmtRequest):
+class PythonFmtRequest(StyleRequest):
     pass
 
 
@@ -37,7 +38,9 @@ async def format_python_target(
     prior_formatter_result = original_sources.snapshot
 
     results: List[FmtResult] = []
-    fmt_request_types: Iterable[Type[FmtRequest]] = union_membership.union_rules[PythonFmtRequest]
+    fmt_request_types: Iterable[Type[PythonFmtRequest]] = union_membership.union_rules[
+        PythonFmtRequest
+    ]
     for fmt_request_type in fmt_request_types:
         result = await Get[FmtResult](
             PythonFmtRequest,

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -5,7 +5,6 @@ import itertools
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, List, Tuple, Type
 
-from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.console import Console
 from pants.engine.fs import EMPTY_DIGEST, Digest, DirectoryToMaterialize, MergeDigests, Workspace
@@ -54,14 +53,6 @@ class FmtResult:
     @property
     def did_change(self) -> bool:
         return self.output != self.input
-
-
-@union
-class FmtRequest(StyleRequest):
-    """A union for StyleRequests that should be formattable.
-
-    Subclass and install a member of this type to provide a formatter.
-    """
 
 
 @union


### PR DESCRIPTION
The FmtRequest union was never used as a UnionRule target base and
it was also unused in the declaring rule file as an extension point.

[ci skip-rust-tests]
[ci skip-jvm-tests]