### PR TITLE
Enable pantsd by default

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,6 @@ local_artifact_cache = "%(pants_bootstrapdir)s/artifact_cache"
 [GLOBAL]
 print_exception_stacktrace = true
 v2 = false
-enable_pantsd = true
 
 # Enable our own custom loose-source plugins as well as contribs.
 pythonpath = [

--- a/src/docs/architecture_pantsd.md
+++ b/src/docs/architecture_pantsd.md
@@ -54,7 +54,7 @@ To understand what the process is for spinning up and closing down pantsd, here 
 
 If we run the command `./pants --enable-pantsd list src/scala::`, the following happens:
 
-1. `PantsRunner::run()` is called, which will prompt parsing of bootstrap options. `--enable-pantsd` and `--shutdown-pantsd-after-run` are both bootstrap options.
+1. `PantsRunner::run()` is called, which will prompt parsing of bootstrap options. `--enable-pantsd` is a bootstrap option.
   * In that function, we determine whether we need to run in pantsd mode or local mode.
     If we choose local mode, an instance of `LocalPantsRunner` is created and the run will continue as if pantsd didn't exist.
 

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -8,7 +8,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:cmd_line_spec_parser',
-    'src/python/pants/base:deprecated',
     'src/python/pants/base:exception_sink',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:exiter',

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -6,7 +6,6 @@ import os
 from dataclasses import dataclass
 from typing import List, Mapping
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import ExitCode
 from pants.bin.remote_pants_runner import RemotePantsRunner
@@ -80,18 +79,6 @@ class PantsRunner:
 
         ExceptionSink.reset_should_print_backtrace_to_terminal(
             global_bootstrap_options.print_exception_stacktrace
-        )
-
-        # TODO: When we remove this deprecation, we'll change the default for the option to true.
-        deprecated_conditional(
-            lambda: global_bootstrap_options.is_default("enable_pantsd"),
-            removal_version="1.30.0.dev0",
-            entity_description="--enable-pantsd defaulting to False",
-            hint_message=(
-                "Pantsd improves runtime performance and will be enabled by default in the 1.30.x "
-                "stable releases. To prepare for that change, we recommend setting the "
-                "`[GLOBAL] enable_pantsd` setting to `True` in your pants.toml or pants.ini file."
-            ),
         )
 
         if self._should_run_with_pantsd(global_bootstrap_options):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -600,15 +600,6 @@ class GlobalOptions(Subsystem):
 
         # Pants Daemon options.
         register(
-            "--pantsd-pailgun-host",
-            advanced=True,
-            default="127.0.0.1",
-            removal_version="1.30.0.dev0",
-            removal_hint="The nailgun protocol is not authenticated, and so only binds to "
-            "127.0.0.1.",
-            help="The host to bind the pants nailgun server to.",
-        )
-        register(
             "--pantsd-pailgun-port",
             advanced=True,
             type=int,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -526,20 +526,6 @@ class GlobalOptions(Subsystem):
             help="The build ID of the other pants run which spawned this one, if any.",
         )
 
-        # Shutdown pantsd after the current run.
-        # This needs to be accessed at the same time as enable_pantsd,
-        # so we register it at bootstrap time.
-        register(
-            "--shutdown-pantsd-after-run",
-            advanced=True,
-            type=bool,
-            default=False,
-            removal_version="1.30.0.dev0",
-            removal_hint="Not widely used, and will soon be rewritten to be inherent.",
-            help="Create a new pantsd server, and use it, and shut it down immediately after. "
-            "If pantsd is already running, it will shut it down and spawn a new instance (Beta)",
-        )
-
         # NB: We really don't want this option to invalidate the daemon, because different clients might have
         # different needs. For instance, an IDE might have a very long timeout because it only wants to refresh
         # a project in the background, while a user might want a shorter timeout for interactivity.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -865,16 +865,6 @@ class GlobalOptions(Subsystem):
             help="Whether or not to use nailgun to run the requests that are marked as nailgunnable.",
             advanced=True,
         )
-        register(
-            "--experimental-fs-watcher",
-            type=bool,
-            default=True,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Enabled by default: flag is disabled.",
-            help="Whether to use the engine filesystem watcher which registers the workspace"
-            " for kernel file change events",
-        )
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -636,18 +636,34 @@ class GlobalOptions(Subsystem):
             type=bool,
             advanced=True,
             default=False,
-            removal_version="1.30.0.dev0",
-            removal_hint="The native watcher is now sufficient to monitor for filesystem changes.",
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
             help="Use the watchman daemon filesystem event watcher to watch for changes "
             "in the buildroot in addition to the built in watcher.",
         )
         register(
-            "--watchman-version", advanced=True, default="4.9.0-pants1", help="Watchman version."
+            "--watchman-version",
+            advanced=True,
+            default="4.9.0-pants1",
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
+            help="Watchman version.",
         )
         register(
             "--watchman-supportdir",
             advanced=True,
             default="bin/watchman",
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
             help="Find watchman binaries under this dir. Used as part of the path to lookup "
             "the binary with --binaries-baseurls and --pants-bootstrapdir.",
         )
@@ -656,6 +672,11 @@ class GlobalOptions(Subsystem):
             type=float,
             advanced=True,
             default=60.0,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
             help="The watchman socket timeout (in seconds) for the initial `watch-project` command. "
             "This may need to be set higher for larger repos due to watchman startup cost.",
         )
@@ -664,6 +685,11 @@ class GlobalOptions(Subsystem):
             type=float,
             advanced=True,
             default=0.1,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
             help="The watchman client socket timeout in seconds. Setting this to too high a "
             "value can negatively impact the latency of runs forked by pantsd.",
         )
@@ -672,6 +698,11 @@ class GlobalOptions(Subsystem):
             type=str,
             advanced=True,
             default=None,
+            removal_version="1.31.0.dev0",
+            removal_hint=(
+                "The native watcher is now sufficient to monitor for filesystem "
+                "changes, so watchman is being removed."
+            ),
             help="The path to the watchman UNIX socket. This can be overridden if the default "
             "absolute path length exceeds the maximum allowed by the OS.",
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -491,7 +491,7 @@ class GlobalOptions(Subsystem):
             "--enable-pantsd",
             advanced=True,
             type=bool,
-            default=False,
+            default=True,
             help=(
                 "Enables use of the pants daemon (pantsd). pantsd can significantly improve "
                 "runtime performance by lowering per-run startup cost, and by caching filesystem "

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -570,12 +570,7 @@ class PantsDaemon(FingerprintedProcessManager):
         :param option_fingerprint: A fingerprint of the global bootstrap options.
         :return: True if the daemon needs to restart.
         """
-        should_shutdown_after_run = (
-            self._bootstrap_options.for_global_scope().shutdown_pantsd_after_run
-        )
-        return super().needs_restart(option_fingerprint) or (
-            self.is_alive() and should_shutdown_after_run
-        )
+        return super().needs_restart(option_fingerprint)
 
 
 def launch():

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -323,7 +323,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
         if self.use_pantsd_env_var():
             args.append("--enable-pantsd=True")
-            args.append("--no-shutdown-pantsd-after-run")
 
         if config:
             toml_file_name = os.path.join(workdir, "pants.toml")

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -115,7 +115,6 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
                 pantsd_config = {
                     "GLOBAL": {
                         "enable_pantsd": True,
-                        "shutdown_pantsd_after_run": False,
                         # The absolute paths in CI can exceed the UNIX socket path limitation
                         # (>104-108 characters), so we override that here with a shorter path.
                         "watchman_socket_path": f"/tmp/watchman.{os.getpid()}.sock",


### PR DESCRIPTION
Enable pantsd by default, and remove related deprecated options.

Thank you to everyone who worked toward this end, particularly @kwlzn and @blorente!