### PR TITLE
Remove deprecated source root trie.

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -24,7 +24,7 @@ class GoLocalSourceTestBase(ABC):
     def setUp(self):
         super().setUp()
         # Force setup of SourceRootConfig subsystem, as go targets do computation on source roots.
-        self.context()
+        self.context(options={"source": {"root_patterns": ["/src/go/src"]}})
 
     @property
     @abstractmethod

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/test_go_remote_library.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/test_go_remote_library.py
@@ -16,7 +16,7 @@ class GoRemoteLibraryTest(TestBase):
     def setUp(self):
         super().setUp()
         # Force setup of SourceRootConfig subsystem, as go targets do computation on source roots.
-        self.context()
+        self.context(options={"source": {"root_patterns": ["3rdparty/go"]}})
 
     @classmethod
     def alias_groups(cls):

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/go_task_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/go_task_test_base.py
@@ -16,3 +16,4 @@ class GoTaskTestBase(TaskTestBase):
                 "src/main/go/src",
                 "3rdparty/go",
             ]
+        return super().context(for_task_types, **kwargs)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/go_task_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/go_task_test_base.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.testutil.task_test_base import TaskTestBase
+
+
+class GoTaskTestBase(TaskTestBase):
+    def context(self, for_task_types=None, **kwargs):
+        options = kwargs.get("options", {})
+        kwargs["options"] = options
+        source = options.get("source", {})
+        options["source"] = source
+        if "root_patterns" not in source:
+            source["root_patterns"] = [
+                "src/go/src",
+                "src/main/go/src",
+                "3rdparty/go",
+            ]

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
@@ -5,7 +5,7 @@ import types
 from textwrap import dedent
 
 from pants.build_graph.target import Target
-from pants.testutil.task_test_base import TaskTestBase
+from pants_test.contrib.go.tasks.go_task_test_base import GoTaskTestBase
 
 from pants.contrib.go import register
 from pants.contrib.go.subsystems.fetcher import Fetcher
@@ -28,7 +28,7 @@ class FakeFetcherFactory:
         return FakeFetcher(import_path)
 
 
-class GoBuildgenTest(TaskTestBase):
+class GoBuildgenTest(GoTaskTestBase):
     @classmethod
     def task_type(cls):
         return GoBuildgen

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -6,15 +6,15 @@ import shutil
 from collections import defaultdict
 
 from pants.build_graph.address import Address
-from pants.testutil.task_test_base import TaskTestBase
 from pants.util.contextutil import temporary_dir
+from pants_test.contrib.go.tasks.go_task_test_base import GoTaskTestBase
 
 from pants.contrib.go.subsystems.fetcher import ArchiveFetcher
 from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
 from pants.contrib.go.tasks.go_fetch import GoFetch
 
 
-class GoFetchTest(TaskTestBase):
+class GoFetchTest(GoTaskTestBase):
 
     address = Address.parse
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
@@ -65,7 +65,9 @@ class GoWorkspaceTaskTest(GoTaskTestBase):
             self.add_to_build_file(spec, "go_library()")
 
             go_lib = self.target(spec)
-            ws_task = self.create_task(self.context())
+            ws_task = self.create_task(
+                self.context(options={"source": {"root_patterns": ["src/main/go"]}})
+            )
             gopath = ws_task.get_gopath(go_lib)
 
             def assert_is_linked(src):

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
@@ -7,9 +7,9 @@ from collections import defaultdict
 from itertools import chain
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.testutil.task_test_base import TaskTestBase
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, touch
+from pants_test.contrib.go.tasks.go_task_test_base import GoTaskTestBase
 
 from pants.contrib.go.targets.go_library import GoLibrary
 from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
@@ -23,7 +23,7 @@ class MockGoWorkspaceTask(GoWorkspaceTask):
         pass
 
 
-class GoWorkspaceTaskTest(TaskTestBase):
+class GoWorkspaceTaskTest(GoTaskTestBase):
     @classmethod
     def task_type(cls):
         return MockGoWorkspaceTask

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
@@ -19,6 +19,7 @@ class ScroogeGenTest(PantsRunIntegrationTest):
                     "pants.contrib.scrooge",
                 ],
             },
+            "source": {"root_patterns": ["src/*", "tests/*"]},
             "scala": {"version": "2.11"},
             "gen.scrooge": {
                 "service_deps": {

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -52,6 +52,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
                     "pants.contrib.scrooge",
                 ],
             },
+            "source": {"root_patterns": ["tests/*", "src/*"]},
         }
         if config:
             for scope, scoped_cfgs in config.items():

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -17,7 +17,6 @@ from pants.backend.python.target_types import (
 from pants.backend.python.targets.python_library import PythonLibrary as PythonLibraryV1
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.target import Target
-from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.version import PANTS_SEMVER, VERSION
@@ -122,14 +121,21 @@ def contrib_setup_py_context_aware_object_factory(parse_context) -> Callable:
 
         if build_file_aliases or register_goals or global_subsystems or rules or target_types:
             rel_path = parse_context.rel_path
-            source_root = (
-                SourceRootConfig.global_instance().get_source_roots().strict_find_by_path(rel_path)
-            )
+            # NB: We don't have proper access to SourceRoot computation here, but
+            #
+            #  we happen to know that:
+            #  A) All existing contribs have their contrib_setup_py() invocation in a BUILD file
+            #    exactly three path segments under the source root (i.e., they all have a source
+            #    root of src/<name>src/python/, and are defined in pants/contrib/<name>/BUILD under
+            #    that.)
+            #  B) We are not adding any new contribs in the future, as this idiom is going away.
+            #
+            # So we can semi-hackily compute the register module using this knowledge.
             module = (
                 PurePath(rel_path)
-                .relative_to(source_root.path)
+                .relative_to(PurePath(rel_path).parent.parent.parent)
                 .as_posix()
-                .replace(os.path.sep, ".")
+                .replace("/", ".")
             )
             entry_points = []
             if build_file_aliases:

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 from pathlib import Path, PurePath
 from typing import Callable, Dict, List, Optional, cast
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -40,7 +40,10 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
             Params(
                 PythonAwsLambdaFieldSet.create(target),
                 create_options_bootstrapper(
-                    args=["--backend-packages2=pants.backend.awslambda.python"]
+                    args=[
+                        "--backend-packages2=pants.backend.awslambda.python",
+                        "--source-root-patterns=src/python",
+                    ]
                 ),
             ),
         )
@@ -54,7 +57,7 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
             textwrap.dedent(
                 """
                 def handler(event, context):
-                  print('Hello, World!')
+                    print('Hello, World!')
                 """
             ),
         )

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -115,7 +115,12 @@ class ProtobufPythonIntegrationTest(TestBase):
                 GeneratedSources,
                 Params(
                     GeneratePythonFromProtobufRequest(protocol_sources.snapshot, tgt),
-                    create_options_bootstrapper(),
+                    create_options_bootstrapper(
+                        args=[
+                            "--source-root-patterns=src/protobuf",
+                            "--source-root-patterns=tests/protobuf",
+                        ]
+                    ),
                 ),
             )
             assert set(generated_sources.snapshot.files) == set(expected_files)

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -28,29 +28,20 @@ class Roots(Goal):
 
 @rule
 async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
-    source_roots = source_root_config.get_source_roots()
+    source_root_pattern_matcher = source_root_config.get_pattern_matcher()
 
+    # Create globs corresponding to all source root patterns.
     all_paths: Set[str] = set()
-    for path in source_roots.get_patterns():
-        # Remove these first two branches in 1.30.0.dev0, after the trie implementation is deleted.
-        if path == "^":
-            all_paths.add("**")
-        elif path.startswith("^/"):
-            all_paths.add(f"{path[2:]}/")
-
-        elif path == "/":
+    for path in source_root_pattern_matcher.get_patterns():
+        if path == "/":
             all_paths.add("**")
         elif path.startswith("/"):
             all_paths.add(f"{path[1:]}/")
         else:
             all_paths.add(f"**/{path}/")
 
+    # Match the patterns against actual files, to find the roots that actually exist.
     snapshot = await Get[Snapshot](PathGlobs(globs=sorted(all_paths)))
-
-    # The globs above can match on subdirectories of the source roots.
-    # For instance, `src/*/` might match 'src/rust/' as well as
-    # 'src/rust/engine/process_execution/bazel_protos/src/gen'.
-    # So we use find_by_path to verify every candidate source root.
     responses = await MultiGet(Get[OptionalSourceRoot](SourceRootRequest(d)) for d in snapshot.dirs)
     all_source_roots = {
         response.source_root for response in responses if response.source_root is not None

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -95,7 +95,10 @@ class PylintIntegrationTest(ExternalToolTestBase):
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
     ) -> LintResults:
-        args = ["--backend-packages2=pants.backend.python.lint.pylint"]
+        args = [
+            "--backend-packages2=pants.backend.python.lint.pylint",
+            "--source-root-patterns=src/python",
+        ]
         if config:
             self.create_file(relpath="pylintrc", contents=config)
             args.append("--pylint-config=pylintrc")

--- a/src/python/pants/backend/python/rules/importable_python_sources_test.py
+++ b/src/python/pants/backend/python/rules/importable_python_sources_test.py
@@ -54,7 +54,7 @@ class ImportablePythonSourcesTest(TestBase):
             ImportablePythonSources,
             Params(
                 Targets([target_with_init, target_without_init, files_target]),
-                create_options_bootstrapper(),
+                create_options_bootstrapper(args=["--source-root-patterns=src/python"]),
             ),
         )
         assert sorted(result.snapshot.files) == sorted(
@@ -82,6 +82,10 @@ class ImportablePythonSourcesTest(TestBase):
             ),
         ]
         result = self.request_single_product(
-            ImportablePythonSources, Params(Targets(targets), create_options_bootstrapper()),
+            ImportablePythonSources,
+            Params(
+                Targets(targets),
+                create_options_bootstrapper(args=["--source-root-patterns=src/python"]),
+            ),
         )
         assert sorted(result.snapshot.files) == sorted(["p.py", "src/python/f.txt", "r.txt"])

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
 from functools import partialmethod
 from pathlib import Path, PurePath

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import os
 from functools import partialmethod
 from pathlib import Path, PurePath
 from textwrap import dedent
@@ -42,19 +42,20 @@ from pants.testutil.option.util import create_options_bootstrapper
 #  self.add_to_build_file(), for example?
 class PytestRunnerIntegrationTest(ExternalToolTestBase):
 
-    source_root = "tests/python/pants_test"
+    source_root = "tests/python"
+    package = os.path.join(source_root, "pants_test")
     good_source = FileContent(path="test_good.py", content=b"def test():\n  pass\n")
     bad_source = FileContent(path="test_bad.py", content=b"def test():\n  assert False\n")
     py3_only_source = FileContent(path="test_py3.py", content=b"def test() -> None:\n  pass\n")
     library_source = FileContent(path="library.py", content=b"def add_two(x):\n  return x + 2\n")
 
     create_python_library = partialmethod(
-        ExternalToolTestBase.create_library, path=source_root, target_type="python_library",
+        ExternalToolTestBase.create_library, path=package, target_type="python_library",
     )
 
     def write_file(self, file_content: FileContent) -> None:
         self.create_file(
-            relpath=PurePath(self.source_root, file_content.path).as_posix(),
+            relpath=PurePath(self.package, file_content.path).as_posix(),
             contents=file_content.content.decode(),
         )
 
@@ -70,7 +71,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         interpreter_constraints: Optional[str] = None,
     ) -> None:
         self.add_to_build_file(
-            relpath=self.source_root,
+            relpath=self.package,
             target=dedent(
                 f"""\
                 python_tests(
@@ -136,6 +137,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
     ) -> TestResult:
         args = [
             "--backend-packages2=pants.backend.python",
+            f"--source-root-patterns={self.source_root}",
             # pin to lower versions so that we can run Python 2 tests
             "--pytest-version=pytest>=4.6.6,<4.7",
             "--pytest-pytest-plugins=['zipp==1.0.0']",
@@ -143,7 +145,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         if passthrough_args:
             args.append(f"--pytest-args='{passthrough_args}'")
         options_bootstrapper = create_options_bootstrapper(args=args)
-        address = Address(self.source_root, "target")
+        address = Address(self.package, "target")
         if origin is None:
             origin = SingleAddress(directory=address.spec_path, name=address.target_name)
         tgt = PythonTests({}, address=address)
@@ -182,9 +184,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
 
     def test_precise_file_args(self) -> None:
         self.create_python_test_target([self.good_source, self.bad_source])
-        file_arg = FilesystemLiteralSpec(
-            PurePath(self.source_root, self.good_source.path).as_posix()
-        )
+        file_arg = FilesystemLiteralSpec(PurePath(self.package, self.good_source.path).as_posix())
         result = self.run_pytest(origin=file_arg)
         assert result.status == Status.SUCCESS
         assert "test_good.py ." in result.stdout
@@ -321,7 +321,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert py2_result.status == Status.FAILURE
         assert "SyntaxError: invalid syntax" in py2_result.stdout
         Path(
-            self.build_root, self.source_root, "BUILD"
+            self.build_root, self.package, "BUILD"
         ).unlink()  # Cleanup in order to recreate the target
         self.create_python_test_target(
             [self.py3_only_source], interpreter_constraints="CPython>=3.6"

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -65,6 +65,10 @@ class TestSetupPyBase(TestBase):
         return self.request_single_product(WrappedTarget, Params(Address.parse(addr))).target
 
 
+def init_source_root():
+    init_subsystem(SourceRootConfig, options={"source": {"root_patterns": ["src/python"]}})
+
+
 class TestGenerateChroot(TestSetupPyBase):
     @classmethod
     def rules(cls):
@@ -108,7 +112,7 @@ class TestGenerateChroot(TestSetupPyBase):
         assert type(ex.wrapped_exceptions[0]) == exc_cls
 
     def test_generate_chroot(self) -> None:
-        init_subsystem(SourceRootConfig)
+        init_source_root()
         self.create_file(
             "src/python/foo/bar/baz/BUILD",
             "python_library(provides=setup_py(name='baz', version='1.1.1'))",
@@ -172,7 +176,7 @@ class TestGenerateChroot(TestSetupPyBase):
         )
 
     def test_invalid_binary(self) -> None:
-        init_subsystem(SourceRootConfig)
+        init_source_root()
         self.create_file(
             "src/python/invalid_binary/BUILD",
             textwrap.dedent(
@@ -236,7 +240,7 @@ class TestGetSources(TestSetupPyBase):
         assert expected_package_data == dict(srcs.package_data)
 
     def test_get_sources(self) -> None:
-        init_subsystem(SourceRootConfig)
+        init_source_root()
         self.create_file(
             "src/python/foo/bar/baz/BUILD",
             textwrap.dedent(
@@ -418,7 +422,7 @@ class TestGetAncestorInitPy(TestSetupPyBase):
         assert sorted(expected_init_pys) == sorted(init_py_files_found)
 
     def test_get_ancestor_init_py(self) -> None:
-        init_subsystem(SourceRootConfig)
+        init_source_root()
         # NB: src/python/foo/bar/baz/qux/__init__.py is a target's source.
         self.create_file("src/python/foo/bar/baz/qux/BUILD", "python_library()")
         self.create_file("src/python/foo/bar/baz/qux/qux.py", "")

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -426,7 +426,7 @@ class PytestRun(ChrootedTestRunnerTaskMixin, Task):
                 with self._maybe_run_in_chroot():
                     # On failures or timeouts, the .coverage file won't be written.
                     if not os.path.exists(".coverage"):
-                        self.context.log.warning(
+                        self.context.log.warn(
                             "No .coverage file was found! Skipping coverage reporting."
                         )
                     else:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -426,7 +426,7 @@ class PytestRun(ChrootedTestRunnerTaskMixin, Task):
                 with self._maybe_run_in_chroot():
                     # On failures or timeouts, the .coverage file won't be written.
                     if not os.path.exists(".coverage"):
-                        self.context.log.warn(
+                        self.context.log.warning(
                             "No .coverage file was found! Skipping coverage reporting."
                         )
                     else:

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -20,6 +20,7 @@ from pants.build_graph.target_addressable import TargetAddressable
 from pants.build_graph.target_scopes import Scope
 from pants.fs.fs import safe_filename
 from pants.source.payload_fields import SourcesField
+from pants.source.source_root import SourceRootConfig
 from pants.source.wrapped_globs import FilesetWithSpec
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
@@ -190,10 +191,14 @@ class Target(AbstractTarget):
 
         :returns: the source root path for this target.
         """
-        source_root = self._sources_field.source_root
-        if not source_root:
+        source_root_path = (
+            SourceRootConfig.global_instance()
+            .get_pattern_matcher()
+            .find_root(self._sources_field.rel_path)
+        )
+        if not source_root_path:
             raise TargetDefinitionException(self, "Not under any configured source root.")
-        return source_root.path
+        return str(source_root_path)
 
     @classmethod
     def identify(cls, targets):

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -20,7 +20,6 @@ from pants.build_graph.target_addressable import TargetAddressable
 from pants.build_graph.target_scopes import Scope
 from pants.fs.fs import safe_filename
 from pants.source.payload_fields import SourcesField
-from pants.source.source_root import SourceRootConfig
 from pants.source.wrapped_globs import FilesetWithSpec
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
@@ -191,14 +190,10 @@ class Target(AbstractTarget):
 
         :returns: the source root path for this target.
         """
-        source_root_path = (
-            SourceRootConfig.global_instance()
-            .get_pattern_matcher()
-            .find_root(self._sources_field.rel_path)
-        )
-        if not source_root_path:
+        source_root = self._sources_field.source_root
+        if not source_root:
             raise TargetDefinitionException(self, "Not under any configured source root.")
-        return str(source_root_path)
+        return source_root.path
 
     @classmethod
     def identify(cls, targets):

--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -51,7 +51,10 @@ class ReplTest(GoalRuleTestBase):
     def test_repl_with_targets(self) -> None:
         self.setup_python_library()
         self.execute_rule(
-            global_args=["--backend-packages2=pants.backend.python"],
+            global_args=[
+                "--backend-packages2=pants.backend.python",
+                "--source-root-patterns=src/python",
+            ],
             args=["src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
@@ -59,7 +62,10 @@ class ReplTest(GoalRuleTestBase):
     def test_repl_ipython(self) -> None:
         self.setup_python_library()
         self.execute_rule(
-            global_args=["--backend-packages2=pants.backend.python"],
+            global_args=[
+                "--backend-packages2=pants.backend.python",
+                "--source-root-patterns=src/python",
+            ],
             args=["--shell=ipython", "src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
         )
@@ -67,7 +73,10 @@ class ReplTest(GoalRuleTestBase):
     def test_repl_bogus_repl_name(self) -> None:
         self.setup_python_library()
         result = self.execute_rule(
-            global_args=["--backend-packages2=pants.backend.python"],
+            global_args=[
+                "--backend-packages2=pants.backend.python",
+                "--source-root-patterns=src/python",
+            ],
             args=["--shell=bogus-repl", "src/python/lib.py"],
             additional_params=[InteractiveRunner(self.scheduler)],
             exit_code=-1,

--- a/src/python/pants/core/util_rules/determine_source_files_test.py
+++ b/src/python/pants/core/util_rules/determine_source_files_test.py
@@ -82,7 +82,17 @@ class DetermineSourceFilesTest(TestBase):
             strip_source_roots=strip_source_roots,
         )
         result = self.request_single_product(
-            SourceFiles, Params(request, create_options_bootstrapper())
+            SourceFiles,
+            Params(
+                request,
+                create_options_bootstrapper(
+                    args=[
+                        "--source-root-patterns=src/python",
+                        "--source-root-patterns=src/java",
+                        "--source-root-patterns=tests/python",
+                    ]
+                ),
+            ),
         )
         return sorted(result.snapshot.files)
 
@@ -96,7 +106,17 @@ class DetermineSourceFilesTest(TestBase):
             sources_fields_with_origins, strip_source_roots=strip_source_roots,
         )
         result = self.request_single_product(
-            SourceFiles, Params(request, create_options_bootstrapper())
+            SourceFiles,
+            Params(
+                request,
+                create_options_bootstrapper(
+                    args=[
+                        "--source-root-patterns=src/python",
+                        "--source-root-patterns=src/java",
+                        "--source-root-patterns=tests/python",
+                    ]
+                ),
+            ),
         )
         return sorted(result.snapshot.files)
 

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -35,6 +35,10 @@ class StripSourceRootsTest(TestBase):
         *,
         args: Optional[List[str]] = None,
     ) -> StrippedResponseData:
+        args = args or []
+        args.append("--source-root-patterns=src/python")
+        args.append("--source-root-patterns=src/java")
+        args.append("--source-root-patterns=tests/python")
         result = self.request_single_product(
             SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),
         )
@@ -156,6 +160,9 @@ class StripSourceRootsTest(TestBase):
         def get_stripped_file_mapping(
             paths: List[str], args: Optional[List[str]] = None
         ) -> Dict[str, str]:
+            args = args or []
+            args.append("--source-root-patterns=src/python")
+            args.append("--source-root-patterns=src/java")
             request = StripSnapshotRequest(self.make_snapshot_of_empty_files(paths))
             result = self.request_single_product(
                 SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from typing import Dict
 
 from pants.base.build_environment import get_buildroot, get_scm
+from pants.base.deprecated import deprecated_conditional
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.target import Target
@@ -112,6 +113,13 @@ class Context:
 
         :API: public
         """
+        deprecated_conditional(
+            lambda: True,
+            removal_version="1.31.0.dev0",
+            entity_description="the source_roots property",
+            hint_message="Contact us (https://pants.readme.io/docs/community) if you need this "
+            "functionality.",
+        )
         return self._source_roots
 
     @property
@@ -307,8 +315,8 @@ class Context:
             # TODO: Adding source roots on the fly like this is yucky, but hopefully this
             # method will go away entirely under the new engine. It's primarily used for injecting
             # synthetic codegen targets, and that isn't how codegen will work in the future.
-        if not self.source_roots.find_by_path(rel_target_base):
-            self.source_roots.add_source_root(rel_target_base)
+        if not self._source_roots.find_by_path(rel_target_base):
+            self._source_roots.add_source_root(rel_target_base)
         if dependencies:
             dependencies = [dep.address for dep in dependencies]
 

--- a/src/python/pants/python/pex_build_util_test.py
+++ b/src/python/pants/python/pex_build_util_test.py
@@ -47,7 +47,7 @@ class TestPexBuilderWrapper(TestBase):
             yield pathlib.Path(chroot)
 
     def test(self):
-        init_subsystem(SourceRootConfig)
+        init_subsystem(SourceRootConfig, {"source": {"root_patterns": ["src/python"]}})
         self.create_file("src/python/package/module.py")
         implicit_package_target = self.make_target(
             spec="src/python/package", target_type=PythonLibrary, sources=["module.py"]

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 from pants.base.payload_field import PayloadField
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.source.filespec import matches_filespec
-from pants.source.source_root import SourceRootConfig
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetWithSpec, Filespec
 from pants.util.memo import memoized_property
 
@@ -34,14 +33,6 @@ class SourcesField(PayloadField):
         """
         self._sources = self._validate_sources(sources)
         self._ref_address = ref_address
-
-    @property
-    def source_root(self):
-        """:returns: the source root for these sources, or None if they're not under a source root."""
-        # TODO: It's a shame that we have to access the singleton directly here, instead of getting
-        # the SourceRoots instance from context, as tasks do.  In the new engine we could inject
-        # this into the target, rather than have it reach out for global singletons.
-        return SourceRootConfig.global_instance().get_source_roots().find_by_path(self.rel_path)
 
     def matches(self, path: str) -> bool:
         return self.sources.matches(path) or matches_filespec(path, self.filespec)

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 from pants.base.payload_field import PayloadField
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.source.filespec import matches_filespec
+from pants.source.source_root import SourceRootConfig
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetWithSpec, Filespec
 from pants.util.memo import memoized_property
 
@@ -33,6 +34,13 @@ class SourcesField(PayloadField):
         """
         self._sources = self._validate_sources(sources)
         self._ref_address = ref_address
+
+    @property
+    def source_root(self):
+        """:returns: the source root for these sources, or None if they're not under a source root."""
+        # TODO: It's a shame that we have to access the singleton directly here, instead of getting
+        # the SourceRoots instance from context, as tasks do.
+        return SourceRootConfig.global_instance().get_source_roots().find_by_path(self.rel_path)
 
     def matches(self, path: str) -> bool:
         return self.sources.matches(path) or matches_filespec(path, self.filespec)

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -5,9 +5,8 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Dict, Iterable, Optional, Sequence, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
-from pants.base.deprecated import deprecated_conditional
 from pants.engine.collection import Collection
 from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.subsystem.subsystem import Subsystem
@@ -26,8 +25,7 @@ class SourceRootError(Exception):
 
     def __init__(self, msg: str):
         super().__init__(
-            f"{msg}See https://pants.readme.io/docs/source-roots for how to define "
-            f"source roots."
+            f"{msg}See https://pants.readme.io/docs/source-roots for how to define source roots."
         )
 
 
@@ -77,9 +75,6 @@ class SourceRootPatternMatcher:
         if ".." in relpath.split(os.path.sep):
             raise NoSourceRootError(relpath, "`..` disallowed in source root searches. ")
         putative_root = _repo_root / relpath
-        # TODO: Once we get rid of the trie, and all source root computation goes through this
-        #  logic, we may want to delegate the check of each putative root to a rule, so that
-        #  results are memoized on each ancestor instead of just on the original path.
         while putative_root != _repo_root:
             if self._match_root_patterns(putative_root):
                 return putative_root.relative_to(_repo_root)
@@ -90,23 +85,19 @@ class SourceRootPatternMatcher:
 
 
 class SourceRoots:
-    """An interface for querying source roots."""
+    """An interface for querying source roots.
 
-    # TODO: Can be simplified/merged into SourceRootPatternMatcher once the deprecated trie is gone.
+    This is a v1-only class. It exists only because in v1 we need to mutate the source roots (e.g.,
+    when injecting a codegen target). v2 code should use the engine to get a SourceRoot or
+    OptionalSourceRoot product for a SourceRootRequest subject (see rules below).
+    """
 
-    def __init__(
-        self,
-        root_patterns: Iterable[str],
-        fail_if_unmatched: bool = True,
-        source_root_config: Optional["SourceRootConfig"] = None,
-    ) -> None:
-        """Create an object for querying source roots via patterns in a trie.
+    def __init__(self, root_patterns: Iterable[str], fail_if_unmatched: bool = True,) -> None:
+        """Create an object for querying source roots.
 
         Non-test code should not instantiate directly. See SourceRootConfig.get_source_roots().
         """
         self._pattern_matcher = SourceRootPatternMatcher(tuple(root_patterns))
-        # TODO: In 1.30.0.dev0 remove the trie entirely.
-        self._trie = None if self._pattern_matcher.get_patterns() else source_root_config.create_trie()  # type: ignore[union-attr]
         self._fail_if_unmatched = fail_if_unmatched
 
     # We perform pattern matching against absolute paths, where "/" represents the repo root.
@@ -123,85 +114,29 @@ class SourceRoots:
             (*self._pattern_matcher.root_patterns, path)
         )
 
-    def strict_find_by_path(self, path: str) -> SourceRoot:
-        """Find the source root for the given path.
-
-        Raises an error if there is no known source root for the path.
-        """
-        matched_path = self._pattern_matcher.find_root(path)
-        if matched_path:
-            return SourceRoot(path=str(matched_path))
-        if self._trie:
-            matched = self._trie.find(path)
-            if matched:
-                return matched
-        raise NoSourceRootError(path)
-
     def find_by_path(self, path: str) -> Optional[SourceRoot]:
         """Find the source root for the given path, or None.
 
         :param path: Find the source root for this path, relative to the buildroot.
         :return: A SourceRoot instance, or None if the path is not located under a source root
                  and `unmatched == fail`.
-
-        TODO: Only v1 code should call this method. v2 code should use strict_find_by_path().
-         Silently creating source roots on the fly is confusing legacy behavior that we shouldn't
-         carry over into v2.
         """
-        try:
-            return self.strict_find_by_path(path)
-        except NoSourceRootError:
-            if self._fail_if_unmatched:
-                return None
-            # If no source root is found, use the path directly.
-            return SourceRoot(path)
+        matched_path = self._pattern_matcher.find_root(path)
+        if matched_path:
+            return SourceRoot(path=str(matched_path))
+        if self._fail_if_unmatched:
+            return None
+        # If no source root is found, use the path directly.
+        return SourceRoot(path)
 
     def get_patterns(self) -> Set[str]:
-        return self._trie.traverse() if self._trie else sorted(self._pattern_matcher.get_patterns())
+        return set(self._pattern_matcher.get_patterns())
 
 
 class SourceRootConfig(Subsystem):
     """Configuration for roots of source trees."""
 
     options_scope = "source"
-
-    _DEFAULT_LANG_CANONICALIZATIONS = {
-        "jvm": ("java", "scala"),
-        "protobuf": ("proto",),
-        "py": ("python",),
-        "golang": ("go",),
-    }
-
-    _DEFAULT_SOURCE_ROOT_PATTERNS = [
-        "src/*",
-        "src/main/*",
-    ]
-
-    _DEFAULT_TEST_ROOT_PATTERNS = [
-        "test/*",
-        "tests/*",
-        "src/test/*",
-    ]
-
-    _DEFAULT_THIRDPARTY_ROOT_PATTERNS = [
-        "3rdparty/*",
-        "3rd_party/*",
-        "thirdparty/*",
-        "third_party/*",
-    ]
-
-    _DEFAULT_SOURCE_ROOTS = {
-        # Our default patterns will detect src/go as a go source root.
-        # However a typical repo might have src/go in the GOPATH, meaning src/go/src is the
-        # actual source root (the root of the package namespace).
-        # These fixed source roots will correct the patterns' incorrect guess.
-        "src/go/src": ("go",),
-        "src/main/go/src": ("go",),
-    }
-
-    _DEFAULT_TEST_ROOTS: Dict[str, Tuple[str, ...]] = {}
-
-    _DEFAULT_THIRDPARTY_ROOTS: Dict[str, Tuple[str, ...]] = {}
 
     @classmethod
     def register_options(cls, register):
@@ -215,95 +150,6 @@ class SourceRootConfig(Subsystem):
             help="Configures the behavior when sources are defined outside of any configured "
             "source root. `create` will cause a source root to be implicitly created at "
             "the definition location of the sources; `fail` will trigger an error.",
-        )
-        register(
-            "--lang-canonicalizations",
-            metavar="<map>",
-            type=dict,
-            fingerprint=True,
-            default=cls._DEFAULT_LANG_CANONICALIZATIONS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="No longer necessary. Source roots are no longer associated with "
-            "languages.",
-            help="Map of language aliases to their canonical names.",
-        )
-
-        pattern_help_fmt = (
-            'A list of source root patterns for {} code. Use a "*" wildcard path '
-            "segment to match the language name, which will be canonicalized."
-        )
-        register(
-            "--source-root-patterns",
-            metavar="<list>",
-            type=list,
-            fingerprint=True,
-            default=cls._DEFAULT_SOURCE_ROOT_PATTERNS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=pattern_help_fmt.format("source"),
-        )
-        register(
-            "--test-root-patterns",
-            metavar="<list>",
-            type=list,
-            fingerprint=True,
-            default=cls._DEFAULT_TEST_ROOT_PATTERNS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=pattern_help_fmt.format("test"),
-        )
-        register(
-            "--thirdparty-root-patterns",
-            metavar="<list>",
-            type=list,
-            fingerprint=True,
-            default=cls._DEFAULT_THIRDPARTY_ROOT_PATTERNS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=pattern_help_fmt.format("third-party"),
-        )
-
-        fixed_help_fmt = (
-            "A map of source roots for {} code to list of languages. "
-            "Useful when you want to enumerate fixed source roots explicitly, "
-            "instead of relying on patterns."
-        )
-        register(
-            "--source-roots",
-            metavar="<map>",
-            type=dict,
-            fingerprint=True,
-            default=cls._DEFAULT_SOURCE_ROOTS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=fixed_help_fmt.format("source"),
-        )
-        register(
-            "--test-roots",
-            metavar="<map>",
-            type=dict,
-            fingerprint=True,
-            default=cls._DEFAULT_TEST_ROOTS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=fixed_help_fmt.format("test"),
-        )
-        register(
-            "--thirdparty-roots",
-            metavar="<map>",
-            type=dict,
-            fingerprint=True,
-            default=cls._DEFAULT_THIRDPARTY_ROOTS,
-            advanced=True,
-            removal_version="1.30.0.dev0",
-            removal_hint="Use --root-patterns instead.",
-            help=fixed_help_fmt.format("third-party"),
         )
 
         register(
@@ -327,163 +173,13 @@ class SourceRootConfig(Subsystem):
         )
 
     @memoized_method
+    def get_pattern_matcher(self) -> SourceRootPatternMatcher:
+        return SourceRootPatternMatcher(self.options.root_patterns)
+
+    @memoized_method
     def get_source_roots(self) -> SourceRoots:
-        return SourceRoots(self.options.root_patterns, self.options.unmatched == "fail", self)
-
-    def create_trie(self) -> "SourceRootTrie":
-        """Create a trie of source root patterns from options."""
-        trie = SourceRootTrie()
-        options = self.get_options()
-
-        legacy_patterns = []
-        for category in ["source", "test", "thirdparty"]:
-            # Add patterns.
-            for pattern in options.get("{}_root_patterns".format(category), []):
-                trie.add_pattern(pattern)
-                legacy_patterns.append(pattern)
-            # Add fixed source roots.
-            for path, langs in options.get("{}_roots".format(category), {}).items():
-                trie.add_fixed(path)
-                legacy_patterns.append(f"^/{path}")
-        # We need to issue a deprecation warning even if relying on the default values
-        # of the deprecated options.
-        deprecated_conditional(
-            lambda: True,
-            removal_version="1.30.0.dev0",
-            entity_description="the *_root_patterns and *_roots options",
-            hint_message="Explicitly list your source roots with the `root_patterns` option in "
-            "the [source] scope. See https://pants.readme.io/docs/source-roots. "
-            f"See your current roots with `{self.options.pants_bin_name} roots`.",
-        )
-        return trie
-
-
-class SourceRootTrie:
-    """A trie for efficiently finding the source root for a path.
-
-    Finds the first outermost pattern that matches. E.g., the pattern src/* will match
-    my/project/src/python/src/java/java.py on src/python, not on src/java.
-
-    Implements fixed source roots by prepending a '^/' to them, and then prepending a '^' key to
-    the path we're matching. E.g., ^/src/java/foo/bar will match both the fixed root ^/src/java and
-    the pattern src/java, but ^/my/project/src/java/foo/bar will match only the pattern.
-    """
-
-    class InvalidPath(Exception):
-        def __init__(self, path, reason):
-            super().__init__(f"Invalid source root path or pattern: {path}. Reason: {reason}.")
-
-    class Node:
-        def __init__(self):
-            self.children = {}
-            self.is_terminal = False
-            # We need an explicit terminal flag because not all terminals are leaf nodes,  e.g.,
-            # if we have patterns src/* and src/main/* then the '*' is a terminal (for the first pattern)
-            # but not a leaf.
-
-        def get_child(self, key):
-            """Return the child node for the given key, or None if no such child.
-
-            :param key: The child to return.
-            """
-            # An exact match takes precedence over a wildcard match, to support situations such as
-            # src/* and src/main/*.
-            ret = self.children.get(key)
-            if not ret and key != "^":
-                ret = self.children.get("*")
-            return ret
-
-        def new_child(self, key):
-            child = SourceRootTrie.Node()
-            self.children[key] = child
-            return child
-
-        def subpatterns(self):
-            if self.children:
-                for key, child in self.children.items():
-                    for sp in child.subpatterns():
-                        if sp:
-                            yield os.path.join(key, sp)
-                        else:
-                            yield key
-            else:
-                yield ""
-
-    def __init__(self) -> None:
-        self._root = SourceRootTrie.Node()
-
-    def add_pattern(self, pattern):
-        """Add a pattern to the trie."""
-        self._do_add_pattern(pattern)
-
-    def add_fixed(self, path):
-        """Add a fixed source root to the trie."""
-        if "*" in path:
-            raise self.InvalidPath(path, "fixed path cannot contain the * character")
-        fixed_path = os.path.join("^", path) if path else "^"
-        self._do_add_pattern(fixed_path)
-
-    def fixed(self):
-        """Returns a list of just the fixed source roots in the trie."""
-        for key, child in self._root.children.items():
-            if key == "^":
-                return list(child.subpatterns())
-        return []
-
-    def _do_add_pattern(self, pattern):
-        if pattern != os.path.normpath(pattern):
-            raise self.InvalidPath(pattern, "must be a normalized path")
-        keys = pattern.split(os.path.sep)
-
-        node = self._root
-        for key in keys:
-            # Can't use get_child, as we don't want to wildcard-match.
-            child = node.children.get(key)
-            if not child:
-                child = node.new_child(key)
-            node = child
-        node.is_terminal = True
-
-    def is_empty(self) -> bool:
-        return not bool(self._root.children)
-
-    def traverse(self) -> Set[str]:
-        source_roots: Set[str] = set()
-
-        def traverse_helper(node: SourceRootTrie.Node, path_components: Sequence[str]):
-            for name in node.children:
-                child = node.children[name]
-                if child.is_terminal:
-                    effective_path = "/".join([*path_components, name])
-                    source_roots.add(effective_path)
-                traverse_helper(node=child, path_components=[*path_components, name])
-
-        traverse_helper(self._root, [])
-        return source_roots
-
-    def find(self, path) -> Optional[SourceRoot]:
-        """Find the source root for the given path."""
-        keys = ["^"] + path.split(os.path.sep)
-        for i in range(len(keys)):
-            # See if we have a match at position i.  We have such a match if following the path
-            # segments into the trie, from the root, leads us to a terminal.
-            node = self._root
-            j = i
-            while j < len(keys):
-                child = node.get_child(keys[j])
-                if child is None:
-                    break
-                else:
-                    node = child
-                    j += 1
-            if node.is_terminal:
-                if j == 1:  # The match was on the root itself.
-                    path = ""
-                else:
-                    path = os.path.join(*keys[1:j])
-                return SourceRoot(path)
-            # Otherwise, try the next value of i.
-        return None
+        # Only v1 code should call this method.
+        return SourceRoots(self.options.root_patterns, self.options.unmatched == "fail")
 
 
 @dataclass(frozen=True)
@@ -510,9 +206,11 @@ def get_source_root(
     source_root_request: SourceRootRequest, source_root_config: SourceRootConfig
 ) -> OptionalSourceRoot:
     """Rule to request a SourceRoot that may not exist."""
-    return OptionalSourceRoot(
-        source_root_config.get_source_roots().find_by_path(source_root_request.path)
-    )
+    matched_path = source_root_config.get_pattern_matcher().find_root(source_root_request.path)
+    if matched_path:
+        return OptionalSourceRoot(SourceRoot(path=str(matched_path)))
+    else:
+        return OptionalSourceRoot(None)
 
 
 @rule
@@ -524,7 +222,11 @@ def get_source_root_strict(
     That way callers don't have to unpack an OptionalSourceRoot if they know they expect a
     SourceRoot to exist and are willing to error if it doesn't.
     """
-    return source_root_config.get_source_roots().strict_find_by_path(source_root_request.path)
+    matched_path = source_root_config.get_pattern_matcher().find_root(source_root_request.path)
+    if matched_path:
+        return SourceRoot(path=str(matched_path))
+    else:
+        raise NoSourceRootError(source_root_request.path)
 
 
 def rules():

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -1,238 +1,44 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pathlib import PurePath
+
 import pytest
 
-from pants.source.source_root import NoSourceRootError, SourceRoot, SourceRoots, SourceRootTrie
-from pants.testutil.test_base import TestBase
+from pants.source.source_root import NoSourceRootError, SourceRootPatternMatcher
 
 
 def test_source_root_at_buildroot() -> None:
-    srs = SourceRoots(["/"])
-    assert SourceRoot(".") == srs.strict_find_by_path("foo/bar.py")
-    assert SourceRoot(".") == srs.strict_find_by_path("foo/")
-    assert SourceRoot(".") == srs.strict_find_by_path("foo")
+    srpm = SourceRootPatternMatcher(("/",))
+    assert PurePath(".") == srpm.find_root("foo/bar.py")
+    assert PurePath(".") == srpm.find_root("foo/")
+    assert PurePath(".") == srpm.find_root("foo")
     with pytest.raises(NoSourceRootError):
-        srs.strict_find_by_path("../foo/bar.py")
+        srpm.find_root("../foo/bar.py")
 
 
 def test_fixed_source_roots() -> None:
-    srs = SourceRoots(["/root1", "/foo/root2", "/root1/root3"])
-    assert SourceRoot("root1") == srs.strict_find_by_path("root1/bar.py")
-    assert SourceRoot("foo/root2") == srs.strict_find_by_path("foo/root2/bar/baz.py")
-    assert SourceRoot("root1/root3") == srs.strict_find_by_path("root1/root3/qux.py")
-    assert SourceRoot("root1/root3") == srs.strict_find_by_path("root1/root3/qux/quux.py")
-    assert SourceRoot("root1/root3") == srs.strict_find_by_path("root1/root3")
-    with pytest.raises(NoSourceRootError):
-        srs.strict_find_by_path("blah/blah.py")
+    srpm = SourceRootPatternMatcher(("/root1", "/foo/root2", "/root1/root3"))
+    assert PurePath("root1") == srpm.find_root("root1/bar.py")
+    assert PurePath("foo/root2") == srpm.find_root("foo/root2/bar/baz.py")
+    assert PurePath("root1/root3") == srpm.find_root("root1/root3/qux.py")
+    assert PurePath("root1/root3") == srpm.find_root("root1/root3/qux/quux.py")
+    assert PurePath("root1/root3") == srpm.find_root("root1/root3")
+    assert srpm.find_root("blah/blah.py") is None
 
 
 def test_source_root_suffixes() -> None:
-    srs = SourceRoots(["src/python", "/"])
-    assert SourceRoot("src/python") == srs.strict_find_by_path("src/python/foo/bar.py")
-    assert SourceRoot("src/python/foo/src/python") == srs.strict_find_by_path(
+    srpm = SourceRootPatternMatcher(("src/python", "/"))
+    assert PurePath("src/python") == srpm.find_root("src/python/foo/bar.py")
+    assert PurePath("src/python/foo/src/python") == srpm.find_root(
         "src/python/foo/src/python/bar.py"
     )
-    assert SourceRoot(".") == srs.strict_find_by_path("foo/bar.py")
+    assert PurePath(".") == srpm.find_root("foo/bar.py")
 
 
 def test_source_root_patterns() -> None:
-    srs = SourceRoots(["src/*", "/project/*"])
-    assert SourceRoot("src/python") == srs.strict_find_by_path("src/python/foo/bar.py")
-    assert SourceRoot("src/python/foo/src/shell") == srs.strict_find_by_path(
-        "src/python/foo/src/shell/bar.sh"
-    )
-    assert SourceRoot("project/python") == srs.strict_find_by_path("project/python/foo/bar.py")
-    with pytest.raises(NoSourceRootError):
-        srs.strict_find_by_path("prefix/project/python/foo/bar.py")
-
-
-class SourceRootTest(TestBase):
-    # TODO: Delete all the *_deprecated tests below in 1.30.0.dev0.
-    def test_source_root_trie_deprecated(self):
-        trie = SourceRootTrie()
-        self.assertIsNone(trie.find("src/java/org/pantsbuild/foo/Foo.java"))
-
-        def root(path):
-            return SourceRoot(path)
-
-        # Wildcard at the end.
-        trie.add_pattern("src/*")
-        self.assertEqual(root("src/java"), trie.find("src/java/org/pantsbuild/foo/Foo.java"))
-        self.assertEqual(
-            root("my/project/src/java"),
-            trie.find("my/project/src/java/org/pantsbuild/foo/Foo.java"),
-        )
-        self.assertEqual(root("src/python"), trie.find("src/python/pantsbuild/foo/foo.py"))
-        self.assertEqual(
-            root("my/project/src/python"),
-            trie.find("my/project/src/python/org/pantsbuild/foo/foo.py"),
-        )
-
-        # Overlapping pattern.
-        trie.add_pattern("src/main/*")
-        self.assertEqual(
-            root("src/main/java"), trie.find("src/main/java/org/pantsbuild/foo/Foo.java")
-        )
-        self.assertEqual(
-            root("my/project/src/main/java"),
-            trie.find("my/project/src/main/java/org/pantsbuild/foo/Foo.java"),
-        )
-        self.assertEqual(
-            root("src/main/python"), trie.find("src/main/python/pantsbuild/foo/foo.py")
-        )
-        self.assertEqual(
-            root("my/project/src/main/python"),
-            trie.find("my/project/src/main/python/org/pantsbuild/foo/foo.py"),
-        )
-
-        # Wildcard in the middle.
-        trie.add_pattern("src/*/code")
-        self.assertEqual(
-            root("src/java/code"), trie.find("src/java/code/org/pantsbuild/foo/Foo.java")
-        )
-        self.assertEqual(
-            root("my/project/src/java/code"),
-            trie.find("my/project/src/java/code/org/pantsbuild/foo/Foo.java"),
-        )
-        self.assertEqual(
-            root("src/python/code"), trie.find("src/python/code/pantsbuild/foo/foo.py")
-        )
-        self.assertEqual(
-            root("my/project/src/python/code"),
-            trie.find("my/project/src/python/code/org/pantsbuild/foo/foo.py"),
-        )
-
-        # Verify that the now even-more-overlapping pattern still works.
-        self.assertEqual(
-            root("src/main/java"), trie.find("src/main/java/org/pantsbuild/foo/Foo.java")
-        )
-        self.assertEqual(
-            root("my/project/src/main/java"),
-            trie.find("my/project/src/main/java/org/pantsbuild/foo/Foo.java"),
-        )
-        self.assertEqual(
-            root("src/main/python"), trie.find("src/main/python/pantsbuild/foo/foo.py")
-        )
-        self.assertEqual(
-            root("my/project/src/main/python"),
-            trie.find("my/project/src/main/python/org/pantsbuild/foo/foo.py"),
-        )
-
-        # Verify that we take the first matching prefix.
-        self.assertEqual(root("src/java"), trie.find("src/java/src/python/Foo.java"))
-
-        # Test canonicalization.
-        self.assertEqual(root("src/jvm"), trie.find("src/jvm/org/pantsbuild/foo/Foo.java"))
-        self.assertEqual(root("src/jvm"), trie.find("src/jvm/org/pantsbuild/foo/Foo.scala"))
-        self.assertEqual(root("src/py"), trie.find("src/py/pantsbuild/foo/foo.py"))
-
-        # Non-canonicalized language names should also be detected.
-        self.assertEqual(root("src/kotlin"), trie.find("src/kotlin/org/pantsbuild/foo/Foo.kotlin"))
-
-        # Test fixed roots.
-        trie.add_fixed("mysrc/scalastuff")
-        self.assertEqual(
-            SourceRoot("mysrc/scalastuff"),
-            trie.find("mysrc/scalastuff/org/pantsbuild/foo/Foo.scala"),
-        )
-        self.assertIsNone(trie.find("my/project/mysrc/scalastuff/org/pantsbuild/foo/Foo.scala"))
-
-        # Verify that a fixed root wins over a pattern that is a prefix of it
-        # (e.g., that src/go/src wins over src/go).
-        trie.add_fixed("src/go/src")
-        self.assertEqual(root("src/go/src"), trie.find("src/go/src/foo/bar/baz.go"))
-
-        # Verify that the repo root can be a fixed source root.
-        trie.add_fixed("")
-        self.assertEqual(root(""), trie.find("foo/bar/baz.py"))
-
-    def test_source_root_trie_traverse_deprecated(self):
-        def make_trie() -> SourceRootTrie:
-            return SourceRootTrie()
-
-        trie = make_trie()
-        self.assertEqual(set(), trie.traverse())
-
-        trie.add_pattern("src/*")
-        trie.add_pattern("src/main/*")
-        self.assertEqual({"src/*", "src/main/*"}, trie.traverse())
-
-        trie = make_trie()
-        trie.add_pattern("*")
-        trie.add_pattern("src/*/code")
-        trie.add_pattern("src/main/*/code")
-        trie.add_pattern("src/main/*")
-        trie.add_pattern("src/main/*/foo")
-        self.assertEqual(
-            {"*", "src/*/code", "src/main/*/code", "src/main/*", "src/main/*", "src/main/*/foo"},
-            trie.traverse(),
-        )
-
-        trie = make_trie()
-        trie.add_fixed("src/scala-source-code")
-        trie.add_pattern("src/*/code")
-        trie.add_pattern("src/main/*/code")
-        self.assertEqual(
-            {"src/*/code", "^/src/scala-source-code", "src/main/*/code"}, trie.traverse()
-        )
-
-    def test_fixed_source_root_at_buildroot_deprecated(self):
-        trie = SourceRootTrie()
-        trie.add_fixed("",)
-
-        self.assertEqual(SourceRoot(""), trie.find("foo/proto/bar/baz.proto"))
-
-    def test_source_root_pattern_at_buildroot_deprecated(self):
-        trie = SourceRootTrie()
-        trie.add_pattern("*")
-
-        self.assertEqual(SourceRoot("java"), trie.find("java/bar/baz.proto"))
-
-    def test_invalid_patterns_deprecated(self):
-        trie = SourceRootTrie()
-        # Bad normalization.
-        self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_fixed("foo/bar/"))
-        self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_pattern("foo//*"))
-        self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_pattern("foo/*/"))
-
-        # Asterisk in fixed pattern.
-        self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_fixed("src/*"))
-
-    def test_trie_traversal_deprecated(self):
-        trie = SourceRootTrie()
-        trie.add_pattern("foo1/bar1/baz1")
-        trie.add_pattern("foo1/bar1/baz2/qux")
-        trie.add_pattern("foo1/bar2/baz1")
-        trie.add_pattern("foo1/bar2/baz2")
-        trie.add_pattern("foo2/bar1")
-        trie.add_fixed("fixed1/bar1")
-        trie.add_fixed("fixed2/bar2")
-
-        # Test raw traversal.
-        self.assertEqual(
-            {"baz1", "baz2/qux"}, set(trie._root.children["foo1"].children["bar1"].subpatterns()),
-        )
-
-        self.assertEqual(
-            {"bar1/baz1", "bar1/baz2/qux", "bar2/baz1", "bar2/baz2",},
-            set(trie._root.children["foo1"].subpatterns()),
-        )
-
-        self.assertEqual(
-            {
-                "foo1/bar1/baz1",
-                "foo1/bar1/baz2/qux",
-                "foo1/bar2/baz1",
-                "foo1/bar2/baz2",
-                "foo2/bar1",
-                "^/fixed1/bar1",
-                "^/fixed2/bar2",
-            },
-            set(trie._root.subpatterns()),
-        )
-
-        # Test the fixed() method.
-        self.assertEqual(
-            {"fixed1/bar1", "fixed2/bar2"}, set(trie.fixed()),
-        )
+    srpm = SourceRootPatternMatcher(("src/*", "/project/*"))
+    assert PurePath("src/python") == srpm.find_root("src/python/foo/bar.py")
+    assert PurePath("src/python/foo/src/shell") == srpm.find_root("src/python/foo/src/shell/bar.sh")
+    assert PurePath("project/python") == srpm.find_root("project/python/foo/bar.py")
+    assert srpm.find_root("prefix/project/python/foo/bar.py") is None

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -543,6 +543,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             # We set those defaults here so we don't have to modify many dozens of call sites.
             source_options["root_patterns"] = [
                 "src/*",
+                "src/main/*",
             ]
             options["source"] = source_options
 

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -537,6 +537,15 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             scoped_opts = options.setdefault(s, {})
             scoped_opts.update(opts)
 
+        source_options = options.get("source", {})
+        if "root_patterns" not in source_options:
+            # We have many tests that relied on old defaults that we've since changed.
+            # We set those defaults here so we don't have to modify many dozens of call sites.
+            source_options["root_patterns"] = [
+                "src/*",
+            ]
+            options["source"] = source_options
+
         fake_options = create_options_for_optionables(all_optionables, options=options, **kwargs)
 
         Subsystem.reset(reset_options=True)

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
@@ -3,7 +3,7 @@ python_binary(
   dependencies=[
     'testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project',
   ],
-  entry_point='interpreter_selection.test_target_with_no_sources.src.python.test_project',
+  entry_point='test_project',
   compatibility=['CPython>3'],
   tags={"nolint"},
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -64,7 +64,12 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     def test_working_210(self):
         with self.tmp_scalastyle_config() as scalastyle_config_option:
             pants_run = self.pants_run(
-                options=["-ldebug", "--scala-version=2.10", scalastyle_config_option]
+                options=[
+                    "-ldebug",
+                    "--source-root-patterns=src/scala",
+                    "--scala-version=2.10",
+                    scalastyle_config_option,
+                ]
             )
             self.assert_success(pants_run)
             assert re.search(
@@ -74,7 +79,12 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     def test_working_211(self):
         with self.tmp_scalastyle_config() as scalastyle_config_option:
             pants_run = self.pants_run(
-                options=["-ldebug", "--scala-version=2.11", scalastyle_config_option]
+                options=[
+                    "-ldebug",
+                    "--source-root-patterns=src/scala",
+                    "--scala-version=2.11",
+                    scalastyle_config_option,
+                ]
             )
             self.assert_success(pants_run)
             assert re.search(
@@ -84,7 +94,12 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     def test_working_212(self):
         with self.tmp_scalastyle_config() as scalastyle_config_option:
             pants_run = self.pants_run(
-                options=["-ldebug", "--scala-version=2.12", scalastyle_config_option]
+                options=[
+                    "-ldebug",
+                    "--source-root-patterns=src/scala",
+                    "--scala-version=2.12",
+                    scalastyle_config_option,
+                ]
             )
             self.assert_success(pants_run)
             assert re.search(
@@ -102,6 +117,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
                     """
                 ),
                 options=[
+                    "--source-root-patterns=src/scala",
                     "--scala-version=custom",
                     "--scala-suffix-version=2.11",
                     scalastyle_config_option,
@@ -117,6 +133,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
             pants_run = self.pants_run(
                 options=[
                     "-ldebug",
+                    "--source-root-patterns=src/scala",
                     "--scala-version=custom",
                     "--scala-suffix-version=2.11",
                     scalastyle_config_option,
@@ -131,6 +148,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
             pants_run = self.pants_run(
                 options=[
                     "-ldebug",
+                    "--source-root-patterns=src/scala",
                     "--scala-version=custom",
                     "--scala-suffix-version=2.12",
                     scalastyle_config_option,
@@ -144,6 +162,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
         with self.tmp_custom_scala("custom_211_missing_compiler.build") as scalastyle_config_option:
             pants_run = self.pants_run(
                 options=[
+                    "--source-root-patterns=src/scala",
                     "--scala-version=custom",
                     "--scala-suffix-version=2.11",
                     scalastyle_config_option,
@@ -156,6 +175,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
         with self.tmp_custom_scala("custom_211_missing_runtime.build") as scalastyle_config_option:
             pants_run = self.pants_run(
                 options=[
+                    "--source-root-patterns=src/scala",
                     "--scala-version=custom",
                     "--scala-suffix-version=2.11",
                     scalastyle_config_option,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -27,7 +27,12 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
             target_dir, target_name = target.rsplit(":", 1)
             shutil.copytree(target_dir, src_dir)
             with self.temporary_workdir() as workdir:
-                cmd = ["compile", "--scalafmt-skip", f"{src_dir}:{target_name}"]
+                cmd = [
+                    "compile",
+                    "--source-root-patterns=tests/*",
+                    "--scalafmt-skip",
+                    f"{src_dir}:{target_name}",
+                ]
                 pants_run = self.run_pants_with_workdir(command=cmd, workdir=workdir)
                 self.assert_success(pants_run)
 
@@ -49,6 +54,7 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(
             [
                 "compile",
+                "--source-root-patterns=tests/scala",
                 "--scalafmt-skip",
                 "testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C",
             ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -47,6 +47,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
 
         rules = {"rules": "RemoveUnused", "semantic": True}
         options = {
+            "source": {"root_patterns": ["src/*", "tests/*"]},
             "scala": {
                 "scalac_plugin_dep": f"{TEST_DIR}/rsc_compat:semanticdb-scalac",
                 "scalac_plugins": '+["semanticdb"]',

--- a/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/jvm/test_backend_independence_integration.py
@@ -23,7 +23,8 @@ class BackendIndependenceTest(PantsRunIntegrationTest):
                     # We need the internal backend for the repo specifications in the example BUILD files.
                     # TODO: Don't use the real pants repos in example code, which are ideally self-contained.
                     "backend_packages": ["pants.backend.jvm", "internal_backend.repositories"],
-                }
+                },
+                "source": {"root_patterns": ["tests/java"]},
             },
         )
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -44,7 +44,10 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
     def _echo_version(self, version):
         with temporary_dir() as distdir:
-            config = {"GLOBAL": {"pants_distdir": distdir}}
+            config = {
+                "GLOBAL": {"pants_distdir": distdir},
+                "source": {"root_patterns": ["src/python"]},
+            }
             binary_name = f"echo_interpreter_version_{version}"
             binary_target = f"{self.testproject}:{binary_name}"
             pants_run = self._build_pex(binary_target, config, version=version)
@@ -106,7 +109,10 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
         # test that it ends up with the version we request (and not the lower version specified on its
         # dependency).
         with temporary_dir() as distdir:
-            config = {"GLOBAL": {"pants_distdir": distdir}}
+            config = {
+                "GLOBAL": {"pants_distdir": distdir},
+                "source": {"root_patterns": ["src/python"]},
+            }
             args = [
                 '--python-setup-interpreter-constraints=["CPython>=3.6"]',
             ]
@@ -128,7 +134,10 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
     def test_stale_interpreter_purge_integration(self):
         target = f"{self.testproject}:{'echo_interpreter_version'}"
-        config = {"python-setup": {"interpreter_constraints": ["CPython>=2.7,<4"]}}
+        config = {
+            "python-setup": {"interpreter_constraints": ["CPython>=2.7,<4"]},
+            "source": {"root_patterns": ["src/python"]},
+        }
         with self.temporary_workdir() as workdir:
             pants_run = self.run_pants_with_workdir(["run", target], workdir=workdir, config=config)
             self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -61,6 +61,7 @@ class PytestTestBase(PythonTaskTestBase, DeclarativeTaskTestMixin):
         self.set_options_for_scope(
             PythonSetup.options_scope, resolver_cache_dir=self.resolver_cache_dir,
         )
+        self.set_options_for_scope("source", root_patterns=["src/python", "test/python"])
 
     _CONFTEST_CONTENT = "# I am an existing root-level conftest file."
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -228,11 +228,12 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     @skip_unless_python3_present
     def test_target_constraints_with_no_sources(self):
         with temporary_dir() as interpreters_cache:
-            pants_ini_config = {
+            pants_config = {
                 "python-setup": {
                     "interpreter_cache_dir": interpreters_cache,
                     "interpreter_constraints": ["CPython>3"],
-                }
+                },
+                "source": {"root_patterns": ["src/python"]},
             }
             # Run task.
             pants_run = self.run_pants(
@@ -242,7 +243,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
                         os.path.join(self.testproject, "test_target_with_no_sources")
                     ),
                 ],
-                config=pants_ini_config,
+                config=pants_config,
             )
             self.assert_success(pants_run)
             self.assertIn("python3", pants_run.stdout_data)
@@ -255,7 +256,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
                         os.path.join(self.testproject, "test_target_with_no_sources")
                     ),
                 ],
-                config=pants_ini_config,
+                config=pants_config,
             )
             self.assert_success(pants_run)
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -13,7 +13,11 @@ from pants.testutil.interpreter_selection_utils import (
     skip_unless_python27_and_python3_present,
     skip_unless_python27_present,
 )
-from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
+from pants.testutil.pants_run_integration_test import (
+    PantsResult,
+    PantsRunIntegrationTest,
+    ensure_daemon,
+)
 from pants.testutil.pexrc_util import setup_pexrc_with_pex_python_path
 from pants.util.contextutil import temporary_dir
 
@@ -26,6 +30,15 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     @classmethod
     def hermetic(cls):
         return True
+
+    def run_pants(
+        self, command, config=None, stdin_data=None, extra_env=None, cleanup_workdir=True, **kwargs
+    ) -> PantsResult:
+        config = config or {}
+        source = config.get("source", {})
+        config["source"] = source
+        source["root_patterns"] = ["src/python"]
+        return super().run_pants(command, config, stdin_data, extra_env, cleanup_workdir, **kwargs)
 
     @skip_unless_python3_present
     @ensure_daemon

--- a/tests/python/pants_test/backend/python/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/python/test_backend_independence_integration.py
@@ -15,11 +15,8 @@ class BackendIndependenceTest(PantsRunIntegrationTest):
         pants_run = self.run_pants(
             command=["test", "examples/tests/python/example_test/hello/greet"],
             config={
-                "GLOBAL": {
-                    "pythonpath": [],
-                    "backend_packages": ["pants.backend.python"],
-                    "source": {"root_patterns": ["tests/python"]},
-                }
+                "GLOBAL": {"pythonpath": [], "backend_packages": ["pants.backend.python"],},
+                "source": {"root_patterns": ["tests/python"]},
             },
         )
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/python/test_backend_independence_integration.py
@@ -16,7 +16,7 @@ class BackendIndependenceTest(PantsRunIntegrationTest):
             command=["test", "examples/tests/python/example_test/hello/greet"],
             config={
                 "GLOBAL": {"pythonpath": [], "backend_packages": ["pants.backend.python"],},
-                "source": {"root_patterns": ["tests/python"]},
+                "source": {"root_patterns": ["src/python", "tests/python"]},
             },
         )
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/test_backend_independence_integration.py
+++ b/tests/python/pants_test/backend/python/test_backend_independence_integration.py
@@ -14,6 +14,12 @@ class BackendIndependenceTest(PantsRunIntegrationTest):
     def test_independent_test_run(self):
         pants_run = self.run_pants(
             command=["test", "examples/tests/python/example_test/hello/greet"],
-            config={"GLOBAL": {"pythonpath": [], "backend_packages": ["pants.backend.python"]}},
+            config={
+                "GLOBAL": {
+                    "pythonpath": [],
+                    "backend_packages": ["pants.backend.python"],
+                    "source": {"root_patterns": ["tests/python"]},
+                }
+            },
         )
         self.assert_success(pants_run)

--- a/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
+++ b/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
@@ -25,7 +25,7 @@ class StrictDepsInvalidationIntegrationTest(PantsRunIntegrationTest):
             )
             shutil.copytree(self.TEST_SRC, src_dir)
             with self.temporary_workdir() as workdir:
-                cmd = ["compile", f"{src_dir}:{target_name}"]
+                cmd = ["compile", "--source-root-patterns=tests/java", f"{src_dir}:{target_name}"]
                 cmd.extend(extra_args)
                 pants_run = self.run_pants_with_workdir(command=cmd, workdir=workdir)
                 self.assert_success(pants_run)


### PR DESCRIPTION
Removes all use of the SourceRoots class in v2,
retains it in v1, so that v1 codegen tasks can continue
to mutate source roots at runtime.

[ci skip-rust-tests]
[ci skip-jvm-tests]
