### PR TITLE
Allow @rules to set their levels, and default to debug

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -36,7 +36,7 @@ from pants.core.util_rules import strip_source_roots
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, named_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -55,7 +55,7 @@ class LambdexSetup:
     requirements_pex: Pex
 
 
-@named_rule(desc="Create Python AWS Lambda")
+@rule(desc="Create Python AWS Lambda")
 async def create_python_awslambda(
     field_set: PythonAwsLambdaFieldSet,
     lambdex_setup: LambdexSetup,
@@ -110,7 +110,7 @@ async def create_python_awslambda(
     )
 
 
-@named_rule(desc="Set up lambdex")
+@rule(desc="Set up lambdex")
 async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
     requirements_pex = await Get[Pex](
         PexRequest(

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -10,7 +10,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, named_rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -21,7 +21,7 @@ class GeneratePythonFromProtobufRequest(GenerateSourcesRequest):
     output = PythonSources
 
 
-@named_rule(desc="Generate Python from Protobuf")
+@rule(desc="Generate Python from Protobuf")
 async def generate_python_from_protobuf(
     request: GeneratePythonFromProtobufRequest, protoc: Protoc
 ) -> GeneratedSources:

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -128,7 +128,7 @@ async def bandit_lint_partition(
     return LintResult.from_fallible_process_result(result, linter_name="Bandit")
 
 
-@named_rule(desc="Lint using Bandit")
+@rule(desc="Lint using Bandit")
 async def bandit_lint(
     request: BanditRequest, bandit: Bandit, python_setup: PythonSetup
 ) -> LintResults:

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -155,7 +155,7 @@ async def setup(
     return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
-@named_rule(desc="Format using Black")
+@rule(desc="Format using Black")
 async def black_fmt(field_sets: BlackRequest, black: Black) -> FmtResult:
     if black.options.skip:
         return FmtResult.noop()
@@ -169,7 +169,7 @@ async def black_fmt(field_sets: BlackRequest, black: Black) -> FmtResult:
     )
 
 
-@named_rule(desc="Lint using Black")
+@rule(desc="Lint using Black")
 async def black_lint(field_sets: BlackRequest, black: Black) -> LintResults:
     if black.options.skip:
         return LintResults()

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -133,7 +133,7 @@ async def setup(
     return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
-@named_rule(desc="Format Python docstrings with docformatter")
+@rule(desc="Format Python docstrings with docformatter")
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.options.skip:
         return FmtResult.noop()
@@ -144,7 +144,7 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
     )
 
 
-@named_rule(desc="Lint Python docstrings with docformatter")
+@rule(desc="Lint Python docstrings with docformatter")
 async def docformatter_lint(
     request: DocformatterRequest, docformatter: Docformatter
 ) -> LintResults:

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -128,7 +128,7 @@ async def flake8_lint_partition(
     return LintResult.from_fallible_process_result(result, linter_name="Flake8")
 
 
-@named_rule(desc="Lint using Flake8")
+@rule(desc="Lint using Flake8")
 async def flake8_lint(
     request: Flake8Request, flake8: Flake8, python_setup: PythonSetup
 ) -> LintResults:

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -153,7 +153,7 @@ async def setup(
     return Setup(process, original_digest=all_source_files_snapshot.digest)
 
 
-@named_rule(desc="Format using isort")
+@rule(desc="Format using isort")
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.options.skip:
         return FmtResult.noop()
@@ -167,7 +167,7 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     )
 
 
-@named_rule(desc="Lint using isort")
+@rule(desc="Lint using isort")
 async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
     if isort.options.skip:
         return LintResults()

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedS
 from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -228,7 +228,7 @@ async def pylint_lint_partition(
     return LintResult.from_fallible_process_result(result, linter_name="Pylint")
 
 
-@named_rule(desc="Lint using Pylint")
+@rule(desc="Lint using Pylint")
 async def pylint_lint(
     request: PylintRequest, pylint: Pylint, python_setup: PythonSetup
 ) -> LintResults:

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -41,7 +41,7 @@ from pants.engine.fs import (
     MergeDigests,
 )
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, SubsystemRule, named_rule, rule
+from pants.engine.rules import RootRule, SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Sources, Targets, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -266,7 +266,7 @@ class MergedCoverageData:
     coverage_data: Digest
 
 
-@named_rule(desc="Merge Pytest coverage reports")
+@rule(desc="Merge Pytest coverage reports")
 async def merge_coverage_data(
     data_collection: PytestCoverageDataCollection,
     coverage_setup: CoverageSetup,
@@ -316,7 +316,7 @@ async def merge_coverage_data(
     return MergedCoverageData(coverage_data=result.output_digest)
 
 
-@named_rule(desc="Generate Pytest coverage report")
+@rule(desc="Generate Pytest coverage report")
 async def generate_coverage_report(
     merged_coverage_data: MergedCoverageData,
     coverage_setup: CoverageSetup,

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -43,7 +43,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_runner import InteractiveProcessRequest
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, named_rule, rule
+from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Targets, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -282,7 +282,7 @@ async def run_python_test(
     )
 
 
-@named_rule(desc="Run pytest in an interactive process")
+@rule(desc="Run pytest in an interactive process")
 async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
     run_request = InteractiveProcessRequest(
         argv=(test_setup.test_runner_pex.output_filename, *test_setup.args),

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -52,7 +52,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, goal_rule, named_rule, rule
+from pants.engine.rules import SubsystemRule, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -554,7 +554,7 @@ def _is_exported(target: Target) -> bool:
     return target.has_field(PythonProvidesField) and target[PythonProvidesField].value is not None
 
 
-@named_rule(desc="Compute distribution's 3rd party requirements")
+@rule(desc="Compute distribution's 3rd party requirements")
 async def get_requirements(
     dep_owner: DependencyOwner, union_membership: UnionMembership
 ) -> ExportedTargetRequirements:
@@ -604,7 +604,7 @@ async def get_requirements(
     return ExportedTargetRequirements(req_strs)
 
 
-@named_rule(desc="Find all code to be published in the distribution", level=LogLevel.INFO)
+@rule(desc="Find all code to be published in the distribution", level=LogLevel.INFO)
 async def get_owned_dependencies(
     dependency_owner: DependencyOwner, union_membership: UnionMembership
 ) -> OwnedDependencies:
@@ -627,7 +627,7 @@ async def get_owned_dependencies(
     return OwnedDependencies(OwnedDependency(t) for t in owned_dependencies)
 
 
-@named_rule(desc="Get exporting owner for target")
+@rule(desc="Get exporting owner for target")
 async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarget:
     """Find the exported target that owns the given target (and therefore exports it).
 
@@ -674,7 +674,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     raise NoOwnerError(f"No exported target owner found for {target.address.reference()}")
 
 
-@named_rule(desc="Set up setuptools")
+@rule(desc="Set up setuptools")
 async def setup_setuptools(setuptools: Setuptools) -> SetuptoolsSetup:
     # Note that this pex has no entrypoint. We use it to run our generated setup.py, which
     # in turn imports from and invokes setuptools.

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -67,6 +67,7 @@ from pants.engine.unions import UnionMembership
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
@@ -603,7 +604,7 @@ async def get_requirements(
     return ExportedTargetRequirements(req_strs)
 
 
-@named_rule(desc="Find all code to be published in the distribution")
+@named_rule(desc="Find all code to be published in the distribution", level=LogLevel.INFO)
 async def get_owned_dependencies(
     dependency_owner: DependencyOwner, union_membership: UnionMembership
 ) -> OwnedDependencies:

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -12,7 +12,7 @@ from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, named_rule, rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.testutil.engine.util import (
@@ -54,7 +54,7 @@ class Fib:
     val: int
 
 
-@named_rule(desc="Fibonacci")
+@rule(desc="Fibonacci", level=LogLevel.INFO)
 async def fib(n: int) -> Fib:
     if n < 2:
         return Fib(n)
@@ -105,7 +105,7 @@ class Epsilon:
     pass
 
 
-@named_rule(canonical_name="rule_one", desc="Rule number 1")
+@rule(canonical_name="rule_one", desc="Rule number 1", level=LogLevel.INFO)
 async def rule_one_function(i: Input) -> Beta:
     """This rule should be the first one executed by the engine, and thus have no parent."""
     a = Alpha()
@@ -115,7 +115,7 @@ async def rule_one_function(i: Input) -> Beta:
     return b
 
 
-@named_rule(desc="Rule number 2")
+@rule(desc="Rule number 2", level=LogLevel.INFO)
 async def rule_two(a: Alpha) -> Omega:
     """This rule should be invoked in the body of `rule_one` and therefore its workunit should be a
     child of `rule_one`'s workunit."""
@@ -123,21 +123,21 @@ async def rule_two(a: Alpha) -> Omega:
     return Omega()
 
 
-@named_rule(desc="Rule number 3")
+@rule(desc="Rule number 3", level=LogLevel.INFO)
 async def rule_three(o: Omega) -> Beta:
     """This rule should be invoked in the body of `rule_one` and therefore its workunit should be a
     child of `rule_one`'s workunit."""
     return Beta()
 
 
-@named_rule(desc="Rule number 4")
+@rule(desc="Rule number 4", level=LogLevel.INFO)
 def rule_four(a: Alpha) -> Gamma:
     """This rule should be invoked in the body of `rule_two` and therefore its workunit should be a
     child of `rule_two`'s workunit."""
     return Gamma()
 
 
-@named_rule(desc="Rule A")
+@rule(desc="Rule A", level=LogLevel.INFO)
 async def rule_A(i: Input) -> Alpha:
     o = Omega()
     a = await Get[Alpha](Omega, o)
@@ -151,7 +151,7 @@ async def rule_B(o: Omega) -> Alpha:
     return a
 
 
-@named_rule(desc="Rule C")
+@rule(desc="Rule C", level=LogLevel.INFO)
 def rule_C(e: Epsilon) -> Alpha:
     return Alpha()
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -164,15 +164,17 @@ class Scheduler:
         self, tasks, output_type, rule: TaskRule, union_rules: Dict[Type, OrderedSet[Type]]
     ) -> None:
         """Register the given TaskRule with the native scheduler."""
-        self._native.lib.tasks_task_begin(tasks, rule.func, output_type, rule.cacheable)
+        self._native.lib.tasks_task_begin(
+            tasks,
+            rule.func,
+            output_type,
+            rule.cacheable,
+            rule.canonical_name,
+            rule.desc or "",
+            rule.level.level,
+        )
         for selector in rule.input_selectors:
             self._native.lib.tasks_add_select(tasks, selector)
-
-        anno = rule.annotations
-        if anno.canonical_name:
-            name = anno.canonical_name
-            desc = anno.desc if anno.desc else ""
-            self._native.lib.tasks_add_display_info(tasks, name, desc)
 
         def add_get_edge(product, subject):
             self._native.lib.tasks_add_get(tasks, product, subject)

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 from typing import Any
 
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.rules import RootRule, named_rule, rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Params
 from pants.engine.unions import UnionRule, union
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
@@ -29,7 +29,7 @@ def fn_raises(x):
     raise Exception(f"An exception for {type(x).__name__}")
 
 
-@named_rule(desc="Nested raise")
+@rule(desc="Nested raise")
 def nested_raise(x: B) -> A:  # type: ignore[return]
     fn_raises(x)
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -317,7 +317,7 @@ PUBLIC_RULE_DECORATOR_ARGUMENTS = {"canonical_name", "desc", "level"}
 # We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
 # set it implicitly based on whether the rule annotation is @rule or @goal_rule.
 # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
-IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"cacheable", "named_rule"}
+IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"cacheable"}
 
 
 def rule_decorator(func, **kwargs) -> Callable:
@@ -333,7 +333,7 @@ def rule_decorator(func, **kwargs) -> Callable:
         != 0
     ):
         raise UnrecognizedRuleArgument(
-            f"`@named_rule`s and `@goal_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
+            f"`@rule`s and `@goal_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
         )
 
     cacheable: bool = kwargs["cacheable"]
@@ -412,11 +412,6 @@ def rule(*args, **kwargs) -> Callable:
 
 def goal_rule(*args, **kwargs) -> Callable:
     return inner_rule(*args, **kwargs, cacheable=False)
-
-
-def named_rule(*args, **kwargs) -> Callable:
-    # TODO: Remove this type.
-    return inner_rule(*args, **kwargs, cacheable=True)
 
 
 class Rule(ABC):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -15,18 +15,10 @@ from pants.engine.selectors import GetConstraints
 from pants.engine.unions import UnionRule, union
 from pants.option.optionable import Optionable, OptionableFactory
 from pants.util.collections import assert_single_element
+from pants.util.logging import LogLevel
 from pants.util.memo import memoized
 from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
-
-
-@dataclass(frozen=True)
-class RuleAnnotations:
-    canonical_name: Optional[str] = None
-    desc: Optional[str] = None
-
-
-DEFAULT_RULE_ANNOTATIONS = RuleAnnotations()
 
 
 @decorated_type_checkable
@@ -197,7 +189,9 @@ def _make_rule(
     parameter_types: Iterable[Type],
     *,
     cacheable: bool,
-    annotations: RuleAnnotations,
+    canonical_name: str,
+    desc: Optional[str],
+    level: LogLevel,
 ) -> Callable[[Callable], Callable]:
     """A @decorator that declares that a particular static function may be used as a TaskRule.
 
@@ -211,14 +205,13 @@ def _make_rule(
                       its inputs.
     """
 
-    has_goal_return_type = issubclass(return_type, Goal)
-    if cacheable and has_goal_return_type:
+    is_goal_cls = issubclass(return_type, Goal)
+    if cacheable and is_goal_cls:
         raise TypeError(
             "An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`."
         )
-    if not cacheable and not has_goal_return_type:
+    if not cacheable and not is_goal_cls:
         raise TypeError("An `@goal_rule` must return a subclass of `engine.goal.Goal`.")
-    is_goal_cls = has_goal_return_type
 
     def wrapper(func):
         if not inspect.isfunction(func):
@@ -268,18 +261,6 @@ def _make_rule(
         # Register dependencies for @goal_rule/Goal.
         dependency_rules = (SubsystemRule(return_type.subsystem_cls),) if is_goal_cls else None
 
-        # Set a default canonical name if one is not explicitly provided. For Goal classes
-        # this is the name of the Goal; for other named ruled this is the __name__ of the function
-        # that implements it.
-        effective_name = annotations.canonical_name
-        if effective_name is None:
-            effective_name = return_type.name if is_goal_cls else func.__name__
-
-        effective_desc = annotations.desc
-        if effective_desc is None and is_goal_cls:
-            effective_desc = f"`{effective_name}` goal"
-        normalized_annotations = RuleAnnotations(canonical_name=effective_name, desc=effective_desc)
-
         # Set our own custom `__line_number__` dunder so that the engine may visualize the line number.
         func.__line_number__ = func.__code__.co_firstlineno
 
@@ -288,9 +269,11 @@ def _make_rule(
             parameter_types,
             func,
             input_gets=gets,
+            canonical_name=canonical_name,
+            desc=desc,
+            level=level,
             dependency_rules=dependency_rules,
             cacheable=cacheable,
-            annotations=normalized_annotations,
         )
 
         return func
@@ -330,31 +313,16 @@ def _ensure_type_annotation(
     return type_annotation
 
 
-PUBLIC_RULE_DECORATOR_ARGUMENTS = {"canonical_name", "desc"}
+PUBLIC_RULE_DECORATOR_ARGUMENTS = {"canonical_name", "desc", "level"}
 # We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
 # set it implicitly based on whether the rule annotation is @rule or @goal_rule.
 # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
 IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"cacheable", "named_rule"}
 
 
-def rule_decorator(*args, **kwargs) -> Callable:
-    if len(args) != 1 and not inspect.isfunction(args[0]):
-        raise ValueError(
-            "The @rule decorator expects no arguments and for the function it decorates to be "
-            f"type-annotated. Given {args}."
-        )
-
-    canonical_name: Optional[str] = kwargs.get("canonical_name")
-    desc: Optional[str] = kwargs.get("desc")
-
-    if kwargs.get("named_rule"):
-        annotations = RuleAnnotations(canonical_name=canonical_name, desc=desc)
-    else:
-        annotations = DEFAULT_RULE_ANNOTATIONS
-        if any(x is not None for x in (canonical_name, desc)):
-            raise UnrecognizedRuleArgument(
-                "@rules that are not @named_rules or @goal_rules do not accept keyword arguments"
-            )
+def rule_decorator(func, **kwargs) -> Callable:
+    if not inspect.isfunction(func):
+        raise ValueError("The @rule decorator expects to be placed on a function.")
 
     if (
         len(
@@ -367,8 +335,6 @@ def rule_decorator(*args, **kwargs) -> Callable:
         raise UnrecognizedRuleArgument(
             f"`@named_rule`s and `@goal_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
         )
-
-    func = args[0]
 
     cacheable: bool = kwargs["cacheable"]
 
@@ -387,10 +353,35 @@ def rule_decorator(*args, **kwargs) -> Callable:
         )
         for parameter in inspect.signature(func).parameters
     )
+    is_goal_cls = issubclass(return_type, Goal)
     validate_parameter_types(func_id, parameter_types, cacheable)
-    return _make_rule(return_type, parameter_types, cacheable=cacheable, annotations=annotations)(
-        func
-    )
+
+    # Set a default canonical name if one is not explicitly provided. For Goal classes
+    # this is the name of the Goal; for other named ruled this is the __name__ of the function
+    # that implements it.
+    effective_name = kwargs.get("canonical_name")
+    if effective_name is None:
+        effective_name = return_type.name if is_goal_cls else func.__name__
+
+    effective_desc = kwargs.get("desc")
+    if effective_desc is None and is_goal_cls:
+        effective_desc = f"`{effective_name}` goal"
+
+    effective_level = kwargs.get("level", LogLevel.DEBUG)
+    if not isinstance(effective_level, LogLevel):
+        raise ValueError(
+            "Expected to receive a value of type LogLevel for the level "
+            f"argument, but got: {effective_level}"
+        )
+
+    return _make_rule(
+        return_type,
+        parameter_types,
+        cacheable=cacheable,
+        canonical_name=effective_name,
+        desc=effective_desc,
+        level=effective_level,
+    )(func)
 
 
 def validate_parameter_types(
@@ -420,11 +411,12 @@ def rule(*args, **kwargs) -> Callable:
 
 
 def goal_rule(*args, **kwargs) -> Callable:
-    return inner_rule(*args, **kwargs, cacheable=False, named_rule=True)
+    return inner_rule(*args, **kwargs, cacheable=False)
 
 
 def named_rule(*args, **kwargs) -> Callable:
-    return inner_rule(*args, **kwargs, cacheable=True, named_rule=True)
+    # TODO: Remove this type.
+    return inner_rule(*args, **kwargs, cacheable=True)
 
 
 class Rule(ABC):
@@ -461,9 +453,8 @@ class Rule(ABC):
 class TaskRule(Rule):
     """A Rule that runs a task function when all of its input selectors are satisfied.
 
-    NB: This API is experimental, and not meant for direct consumption. To create a `TaskRule` you
-    should always prefer the `@rule` constructor, and in cases where that is too constraining
-    (likely due to #4535) please bump or open a ticket to explain the usecase.
+    NB: This API is not meant for direct consumption. To create a `TaskRule` you should always
+    prefer the `@rule` constructor.
     """
 
     _output_type: Type
@@ -473,7 +464,9 @@ class TaskRule(Rule):
     _dependency_rules: Tuple["TaskRule", ...]
     _dependency_optionables: Tuple[Type[Optionable], ...]
     cacheable: bool
-    annotations: RuleAnnotations
+    canonical_name: str
+    desc: Optional[str]
+    level: LogLevel
 
     def __init__(
         self,
@@ -481,10 +474,12 @@ class TaskRule(Rule):
         input_selectors: Iterable[Type],
         func: Callable,
         input_gets: Iterable[GetConstraints],
+        canonical_name: str,
+        desc: Optional[str] = None,
+        level: LogLevel = LogLevel.DEBUG,
         dependency_rules: Optional[Iterable["TaskRule"]] = None,
         dependency_optionables: Optional[Iterable[Type[Optionable]]] = None,
         cacheable: bool = True,
-        annotations: RuleAnnotations = DEFAULT_RULE_ANNOTATIONS,
     ):
         self._output_type = output_type
         self.input_selectors = tuple(input_selectors)
@@ -493,7 +488,9 @@ class TaskRule(Rule):
         self._dependency_rules = tuple(dependency_rules or ())
         self._dependency_optionables = tuple(dependency_optionables or ())
         self.cacheable = cacheable
-        self.annotations = annotations
+        self.canonical_name = canonical_name
+        self.desc = desc
+        self.level = level
 
     def __str__(self):
         return "(name={}, {}, {!r}, {}, gets={}, opts={})".format(

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -49,7 +49,8 @@ class OptionableFactory(ABC):
         # functions do not have these defined by default and the engine uses these values to
         # visualize functions in error messages and the rule graph.
         snake_scope = cls.options_scope.replace("-", "_")
-        partial_construct_optionable.__name__ = f"construct_scope_{snake_scope}"
+        name = f"construct_scope_{snake_scope}"
+        partial_construct_optionable.__name__ = name
         partial_construct_optionable.__module__ = cls.__module__
         _, class_definition_lineno = inspect.getsourcelines(cls)
         partial_construct_optionable.__line_number__ = class_definition_lineno
@@ -59,6 +60,7 @@ class OptionableFactory(ABC):
             input_selectors=(),
             func=partial_construct_optionable,
             input_gets=(GetConstraints(product_type=ScopedOptions, subject_declared_type=Scope),),
+            canonical_name=name,
             dependency_optionables=(cls.optionable_cls,),
         )
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -39,19 +39,6 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   /// If the node result is cacheable, return true.
   ///
   fn cacheable(&self) -> bool;
-
-  /// Nodes optionally have a user-facing name (distinct from their Debug and Display
-  /// implementations). This user-facing name is intended to provide high-level information
-  /// to end users of pants about what computation pants is currently doing. Not all
-  /// `Node`s need a user-facing name. For `Node`s derived from Python `@rule`s, the
-  /// user-facing name should be the same as the `desc` annotation on the rule decorator.
-  fn user_facing_name(&self) -> Option<String> {
-    None
-  }
-
-  /// Provides the `name` field in workunits associated with this node. These names
-  /// should be friendly to machine-parsing (i.e. "my_node" rather than "My awesome node!").
-  fn workunit_name(&self) -> String;
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -631,10 +631,6 @@ impl Node for TNode {
   fn cacheable(&self) -> bool {
     self.1
   }
-
-  fn workunit_name(&self) -> String {
-    format!("{}", self)
-  }
 }
 
 impl std::fmt::Display for TNode {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -964,8 +964,7 @@ impl NodeKey {
 
   fn workunit_level(&self) -> Level {
     match self {
-      NodeKey::Task(_) if self.user_facing_name().is_some() => Level::Info,
-      NodeKey::Task(_) => Level::Debug,
+      NodeKey::Task(ref task) => task.task.display_info.level,
       _ => Level::Debug,
     }
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -8,6 +8,8 @@ use crate::core::{Function, TypeId};
 use crate::intrinsics::Intrinsics;
 use crate::selectors::{DependencyKey, Get, Select};
 
+use log::Level;
+
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
 pub enum Rule {
   // Intrinsic rules are implemented in rust.
@@ -211,10 +213,11 @@ pub struct Task {
   pub display_info: DisplayInfo,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DisplayInfo {
-  pub name: Option<String>,
+  pub name: String,
   pub desc: Option<String>,
+  pub level: Level,
 }
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
@@ -265,7 +268,15 @@ impl Tasks {
   ///
   /// The following methods define the Task registration lifecycle.
   ///
-  pub fn task_begin(&mut self, func: Function, product: TypeId, cacheable: bool) {
+  pub fn task_begin(
+    &mut self,
+    func: Function,
+    product: TypeId,
+    cacheable: bool,
+    name: String,
+    desc: Option<String>,
+    level: Level,
+  ) {
     assert!(
       self.preparing.is_none(),
       "Must `end()` the previous task creation before beginning a new one!"
@@ -277,7 +288,7 @@ impl Tasks {
       clause: Vec::new(),
       gets: Vec::new(),
       func: func,
-      display_info: DisplayInfo::default(),
+      display_info: DisplayInfo { name, desc, level },
     });
   }
 
@@ -300,17 +311,6 @@ impl Tasks {
       .expect("Must `begin()` a task creation before adding clauses!")
       .clause
       .push(product);
-  }
-
-  pub fn add_display_info(&mut self, name: String, desc: String) {
-    let mut task = self
-      .preparing
-      .as_mut()
-      .expect("Must `begin()` a task creation before adding display info!");
-    task.display_info = DisplayInfo {
-      name: Some(name),
-      desc: if desc.is_empty() { None } else { Some(desc) },
-    };
   }
 
   pub fn task_end(&mut self) {


### PR DESCRIPTION
### Problem

#9894 and #9921 added workunit completion logging in order to improve the experience when the `--dynamic-ui` is disabled, and to prepare to render streaming warnings/errors and stdio when tests or lints fail, even when the UI is enabled. But further tweaks are needed in order to achieve minimal output in the common case.

### Solution

After those changes, it's become clear that `@rules` should default to debug level, because it continues to be the case that processes are the bread and butter of our runs. Even if/when we implement #7907, the processes that run will continue to represent the bulk of the work and the thing that we cache.

This change defaults all `@rules` to debug, and allows `@rules` to set their own `level`s. Additionally, it removes `@named_rule`, because it's become clear that any `@rule` should be able to set a `canonical_name` (all rules already have one, so we might as well let them set it), `description`, or `level`.

### Result

After this change, only processes (that actually ran, as opposed to hitting cache) will be rendered. `@rules` can opt in to higher log levels, but most should not (unless they are computationally expensive...?): 
```
$ ./v2 --changed-parent=master fmt
18:35:35:904 [INFO] Completed: Run Black on 14 targets: src/python/pants/backend/awslambda/python, src/python/pants/backend/codegen/protobuf/python, src/python/pants/backend/python/lint/bandit, src/python/pants/backend/python/lint/... (403 characters truncated)
18:35:38:233 [INFO] Completed: Run Docformatter on 14 targets: src/python/pants/backend/awslambda/python, src/python/pants/backend/codegen/protobuf/python, src/python/pants/backend/python/lint/bandit, src/python/pants/backend/pytho... (410 characters truncated)
18:35:40:530 [INFO] Completed: Run isort on 14 targets: src/python/pants/backend/awslambda/python, src/python/pants/backend/codegen/protobuf/python, src/python/pants/backend/python/lint/bandit, src/python/pants/backend/python/lint/... (403 characters truncated)
𐄂 Black made changes.
reformatted src/python/pants/engine/internals/engine_test.py
All done! ✨ 🍰 ✨
1 file reformatted, 84 files left unchanged.


✓ Docformatter made no changes.

𐄂 isort made changes.
Fixing src/python/pants/engine/internals/engine_test.py
```
