### PR TITLE
Silence failures to close replacement stdio handles

### DIFF
--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -121,9 +121,9 @@ def _stdio_stream_as(src_fd: int, dst_fd: int, dst_sys_attribute: str, mode: str
                 termios.tcdrain(dst_fd)
             else:
                 new_dst.flush()
+            new_dst.close()
         except BaseException:
             pass
-        new_dst.close()
 
         # Restore the python and os level file handles.
         os.dup2(old_dst_fd, dst_fd)


### PR DESCRIPTION
### Problem

See #9941.

### Solution

In a stdio replacement context, failing on close would tend to mask other errors: we should never let it raise.

### Result

Fixes #9941.

[ci skip-rust-tests]
[ci skip-jvm-tests]