### PR TITLE
Finish removing Bytes fields from FallibleProcessResultWithPlatform

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
-use futures::future;
 use futures01::Future;
 use log::{debug, warn};
 use protobuf::Message;
@@ -149,15 +148,8 @@ impl CommandRunner {
     // (This isn't super urgent because we don't ever actually GC this store. So also...)
     // TODO: GC the local process execution cache.
 
-    let (stdout_digest, stderr_digest) = future::try_join(
-      self
-        .file_store
-        .store_file_bytes(result.stdout.clone(), true),
-      self
-        .file_store
-        .store_file_bytes(result.stderr.clone(), true),
-    )
-    .await?;
+    let stdout_digest = result.stdout_digest;
+    let stderr_digest = result.stderr_digest;
 
     let action_result = execute_response.mut_result();
     action_result.set_stdout_digest((&stdout_digest).into());

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -29,7 +29,6 @@
 extern crate derivative;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 pub use log::Level;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -379,9 +378,7 @@ pub struct ProcessMetadata {
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FallibleProcessResultWithPlatform {
-  pub stdout: Bytes,
   pub stdout_digest: Digest,
-  pub stderr: Bytes,
   pub stderr_digest: Digest,
   pub exit_code: i32,
   pub platform: Platform,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -460,9 +460,7 @@ pub trait CapturedWorkdir {
         let stderr_digest = store.store_file_bytes(stderr.clone(), true).await?;
 
         Ok(FallibleProcessResultWithPlatform {
-          stdout,
           stdout_digest,
-          stderr,
           stderr_digest,
           exit_code: child_results.exit_code,
           output_directory: output_snapshot.digest,
@@ -479,9 +477,7 @@ pub trait CapturedWorkdir {
           let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
 
           Ok(FallibleProcessResultWithPlatform {
-            stdout,
             stdout_digest,
-            stderr: Bytes::new(),
             stderr_digest: hashing::EMPTY_DIGEST,
             exit_code: -libc::SIGTERM,
             output_directory: hashing::EMPTY_DIGEST,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -395,9 +395,7 @@ impl super::CommandRunner for CommandRunner {
                 let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
 
                 break FallibleProcessResultWithPlatform {
-                  stdout,
                   stdout_digest,
-                  stderr: Bytes::new(),
                   stderr_digest: hashing::EMPTY_DIGEST,
                   exit_code: -libc::SIGTERM,
                   output_directory: hashing::EMPTY_DIGEST,
@@ -914,9 +912,7 @@ pub fn populate_fallible_execution_result(
     .and_then(
       move |(((stdout, stdout_digest), (stderr, stderr_digest)), output_directory)| {
         Ok(FallibleProcessResultWithPlatform {
-          stdout,
           stdout_digest,
-          stderr,
           stderr_digest,
           exit_code: execute_response.get_result().get_exit_code(),
           output_directory: output_directory,

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -192,9 +192,7 @@ async fn make_delayed_command_runner(
     Err(msg.into())
   } else {
     Ok(FallibleProcessResultWithPlatform {
-      stdout: msg.into(),
       stdout_digest,
-      stderr: "".into(),
       stderr_digest: EMPTY_DIGEST,
       exit_code: 0,
       output_directory: EMPTY_DIGEST,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -441,8 +441,22 @@ async fn main() {
       .unwrap();
   }
 
-  print!("{}", String::from_utf8(result.stdout.to_vec()).unwrap());
-  eprint!("{}", String::from_utf8(result.stderr.to_vec()).unwrap());
+  let stdout: Vec<u8> = store
+    .load_file_bytes_with(result.stdout_digest, |bytes| bytes.to_vec())
+    .await
+    .unwrap()
+    .unwrap()
+    .0;
+
+  let stderr: Vec<u8> = store
+    .load_file_bytes_with(result.stderr_digest, |bytes| bytes.to_vec())
+    .await
+    .unwrap()
+    .unwrap()
+    .0;
+
+  print!("{}", String::from_utf8(stdout).unwrap());
+  eprint!("{}", String::from_utf8(stderr).unwrap());
   exit(result.exit_code);
 }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -45,7 +45,7 @@ pub struct Core {
   pub intrinsics: Intrinsics,
   pub runtime: Runtime,
   pub executor: task_executor::Executor,
-  store: Store,
+  pub store: Store,
   pub command_runner: Box<dyn process_execution::CommandRunner>,
   pub http_client: reqwest::Client,
   pub vfs: PosixFS,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -45,7 +45,7 @@ pub struct Core {
   pub intrinsics: Intrinsics,
   pub runtime: Runtime,
   pub executor: task_executor::Executor,
-  pub store: Store,
+  store: Store,
   pub command_runner: Box<dyn process_execution::CommandRunner>,
   pub http_client: reqwest::Client,
   pub vfs: PosixFS,

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -142,14 +142,23 @@ fn multi_platform_process_request_to_process_result(
       .await
       .map_err(|s| throw(&s))?;
 
-    let extract_bytes = |maybe_digest: Option<(Vec<u8>, _)>| {
-      maybe_digest
-        .map(|(bytes, _load_metadata)| bytes)
-        .ok_or_else(|| throw("Bytes from Digest not found in store"))
-    };
+    let stdout_bytes = maybe_stdout
+      .map(|(bytes, _load_metadata)| bytes)
+      .ok_or_else(|| {
+        throw(&format!(
+          "Bytes from stdout Digest {:?} not found in store",
+          result.stdout_digest
+        ))
+      })?;
 
-    let stdout_bytes = extract_bytes(maybe_stdout)?;
-    let stderr_bytes = extract_bytes(maybe_stderr)?;
+    let stderr_bytes = maybe_stderr
+      .map(|(bytes, _load_metadata)| bytes)
+      .ok_or_else(|| {
+        throw(&format!(
+          "Bytes from stderr Digest {:?} not found in store",
+          result.stderr_digest
+        ))
+      })?;
 
     let platform_name: String = result.platform.into();
     Ok(externs::unsafe_call(


### PR DESCRIPTION
This commit removes the last bits of code that make use of the `stdout` and `stderr` fields on the `FallibleProcessResultWithPlatform`. Now, only the Digests are the authoritative source of stdout and stderr information in process result data structures.