### PR TITLE
Fix lease extension, and make it recursive

### DIFF
--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -44,17 +44,17 @@ class StoreGCService(PantsService):
     def _maybe_extend_lease(self):
         if time.time() < self._next_lease_extension:
             return
-        self._logger.debug("Extending leases")
+        self._logger.info("Extending leases")
         self._scheduler_session.lease_files_in_graph()
-        self._logger.debug("Done extending leases")
+        self._logger.info("Done extending leases")
         self._set_next_lease_extension()
 
     def _maybe_garbage_collect(self):
         if time.time() < self._next_gc:
             return
-        self._logger.debug("Garbage collecting store")
+        self._logger.info("Garbage collecting store")
         self._scheduler_session.garbage_collect_store()
-        self._logger.debug("Done garbage collecting store")
+        self._logger.info("Done garbage collecting store")
         self._set_next_gc()
 
     def run(self):

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1230,7 +1230,6 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -609,8 +609,11 @@ impl Store {
       .to_boxed()
   }
 
-  pub fn lease_all<'a, Ds: Iterator<Item = &'a Digest>>(&self, digests: Ds) -> Result<(), String> {
-    self.local.lease_all(digests)
+  pub async fn lease_all<'a, Ds: Iterator<Item = &'a Digest>>(
+    &self,
+    digests: Ds,
+  ) -> Result<(), String> {
+    self.local.lease_all(digests).await
   }
 
   pub fn garbage_collect(

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -587,11 +587,15 @@ impl Store {
       .to_boxed()
   }
 
-  pub async fn lease_all<'a, Ds: Iterator<Item = &'a Digest>>(
+  pub async fn lease_all_recursively<'a, Ds: Iterator<Item = &'a Digest>>(
     &self,
     digests: Ds,
   ) -> Result<(), String> {
-    self.local.lease_all(digests).await
+    let reachable_digests_and_types = self.expand_local_digests(digests, true).await?;
+    self
+      .local
+      .lease_all(reachable_digests_and_types.into_iter())
+      .await
   }
 
   pub fn garbage_collect(

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -39,7 +39,7 @@ use bytes::Bytes;
 use concrete_time::TimeSpan;
 use fs::FileContent;
 use futures::compat::Future01CompatExt;
-use futures::future::{FutureExt, TryFutureExt};
+use futures::future::{self as future03, Either, FutureExt, TryFutureExt};
 use futures01::{future, Future};
 use hashing::Digest;
 use protobuf::Message;
@@ -216,6 +216,19 @@ impl Store {
       local: local::ByteStore::new(executor, path)?,
       remote: None,
     })
+  }
+
+  ///
+  /// Converts this (copy of) a Store to local only by dropping the remote half.
+  ///
+  /// Because both underlying stores are reference counted, this is cheap, and has no effect on
+  /// other clones of the Store.
+  ///
+  fn into_local_only(self) -> Store {
+    Store {
+      local: self.local,
+      remote: None,
+    }
   }
 
   ///
@@ -468,93 +481,58 @@ impl Store {
       return future::err("Cannot ensure remote has blobs without a remote".to_owned()).to_boxed();
     };
 
-    let mut expanding_futures = Vec::new();
-
-    let mut expanded_digests = HashMap::new();
-    for digest in digests {
-      match self.local.entry_type(&digest.0) {
-        Ok(Some(EntryType::File)) => {
-          expanded_digests.insert(digest, EntryType::File);
-        }
-        Ok(Some(EntryType::Directory)) => {
-          expanding_futures.push(self.expand_directory(digest));
-        }
-        Ok(None) => {
-          return future::err(format!("Failed to upload digest {:?}: Not found", digest))
-            .to_boxed();
-        }
-        Err(err) => {
-          return future::err(format!("Failed to upload digest {:?}: {:?}", digest, err))
-            .to_boxed();
-        }
-      };
-    }
-
-    let local = self.local.clone();
+    let store = self.clone();
     let remote = remote.clone();
-    let remote2 = remote.clone();
-    future::join_all(expanding_futures)
-      .map(move |futures| {
-        for mut digests in futures {
-          for (digest, entry_type) in digests.drain() {
-            expanded_digests.insert(digest, entry_type);
-          }
-        }
-        expanded_digests
-      })
-      .and_then(move |ingested_digests| {
+    async move {
+      let ingested_digests = store.expand_local_digests(digests.iter(), false).await?;
+      let digests_to_upload =
         if Store::upload_is_faster_than_checking_whether_to_upload(&ingested_digests) {
-          return future::ok((ingested_digests.keys().cloned().collect(), ingested_digests))
-            .to_boxed();
-        }
-        let request = remote.find_missing_blobs_request(ingested_digests.keys());
-        let f = remote.list_missing_digests(request);
-        f.map(move |digests_to_upload| (digests_to_upload, ingested_digests))
-          .to_boxed()
-      })
-      .and_then(move |(digests_to_upload, ingested_digests)| {
-        future::join_all(
-          digests_to_upload
-            .into_iter()
-            .map(|digest| {
-              let entry_type = ingested_digests[&digest];
-              let local = local.clone();
-              let remote = remote2.clone();
+          ingested_digests.keys().cloned().collect()
+        } else {
+          let request = remote.find_missing_blobs_request(ingested_digests.keys());
+          remote.list_missing_digests(request).compat().await?
+        };
 
-              Box::pin(async move {
-                let executor = local.executor().clone();
-                let maybe_upload = local
-                  .load_bytes_with(entry_type, digest, move |bytes| {
-                    // NB: `load_bytes_with` runs on a spawned thread which we can safely block.
-                    executor.block_on(remote.store_bytes(bytes))
-                  })
-                  .await?;
-                match maybe_upload {
-                  Some(future) => Ok(future),
-                  None => Err(format!("Failed to upload digest {:?}: Not found", digest)),
-                }
-              })
-              .compat()
-              .to_boxed()
-            })
-            .collect::<Vec<_>>(),
-        )
-        .and_then(future::join_all)
-        .map(|uploaded_digests| (uploaded_digests, ingested_digests))
-      })
-      .map(move |(uploaded_digests, ingested_digests)| {
-        let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.1);
-        let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.1);
+      let uploaded_digests = future03::try_join_all(
+        digests_to_upload
+          .into_iter()
+          .map(|digest| {
+            let entry_type = ingested_digests[&digest];
+            let local = store.local.clone();
+            let remote = remote.clone();
 
-        UploadSummary {
-          ingested_file_count: ingested_file_sizes.len(),
-          ingested_file_bytes: ingested_file_sizes.sum(),
-          uploaded_file_count: uploaded_file_sizes.len(),
-          uploaded_file_bytes: uploaded_file_sizes.sum(),
-          upload_wall_time: start_time.elapsed(),
-        }
+            async move {
+              let executor = local.executor().clone();
+              let maybe_upload = local
+                .load_bytes_with(entry_type, digest, move |bytes| {
+                  // NB: `load_bytes_with` runs on a spawned thread which we can safely block.
+                  executor.block_on(remote.store_bytes(bytes))
+                })
+                .await?;
+              match maybe_upload {
+                Some(res) => res,
+                None => Err(format!("Failed to upload digest {:?}: Not found", digest)),
+              }
+            }
+          })
+          .collect::<Vec<_>>(),
+      )
+      .await?;
+
+      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.1);
+      let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.1);
+
+      Ok(UploadSummary {
+        ingested_file_count: ingested_file_sizes.len(),
+        ingested_file_bytes: ingested_file_sizes.sum(),
+        uploaded_file_count: uploaded_file_sizes.len(),
+        uploaded_file_bytes: uploaded_file_sizes.sum(),
+        upload_wall_time: start_time.elapsed(),
       })
-      .to_boxed()
+    }
+    .boxed()
+    .compat()
+    .to_boxed()
   }
 
   ///
@@ -654,6 +632,64 @@ impl Store {
     } else {
       false
     }
+  }
+
+  ///
+  /// Return all Digests reachable locally from the given root Digests (which may represent either
+  /// Files or Directories).
+  ///
+  /// If `allow_missing`, root digests which do not exist locally will be ignored.
+  ///
+  pub async fn expand_local_digests<'a, Ds: Iterator<Item = &'a Digest>>(
+    &self,
+    digests: Ds,
+    allow_missing: bool,
+  ) -> Result<HashMap<Digest, EntryType>, String> {
+    // Expand each digest into either a single file digest, or a collection of recursive digests
+    // below a directory.
+    let expanded_digests = future03::try_join_all(
+      digests
+        .map(|digest| {
+          let store = self.clone();
+          async move {
+            match store.local.entry_type(digest.0).await {
+              Ok(Some(EntryType::File)) => Ok(Either::Left(*digest)),
+              Ok(Some(EntryType::Directory)) => {
+                // Locally expand the directory.
+                let reachable = store
+                  .into_local_only()
+                  .expand_directory(*digest)
+                  .compat()
+                  .await?;
+                Ok(Either::Right(reachable))
+              }
+              Ok(None) => {
+                if allow_missing {
+                  Ok(Either::Right(HashMap::new()))
+                } else {
+                  Err(format!("Failed to expand digest {:?}: Not found", digest))
+                }
+              }
+              Err(err) => Err(format!("Failed to expand digest {:?}: {:?}", digest, err)),
+            }
+          }
+        })
+        .collect::<Vec<_>>(),
+    )
+    .await?;
+
+    let mut result: HashMap<Digest, EntryType> = HashMap::new();
+    for e in expanded_digests {
+      match e {
+        Either::Left(digest) => {
+          result.insert(digest, EntryType::File);
+        }
+        Either::Right(reachable_digests) => {
+          result.extend(reachable_digests);
+        }
+      }
+    }
+    Ok(result)
   }
 
   pub fn expand_directory(&self, digest: Digest) -> BoxFuture<HashMap<Digest, EntryType>, String> {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -153,7 +153,7 @@ async fn garbage_collect_nothing_to_do_with_lease() {
   .unwrap();
   let file_digest = Digest(file_fingerprint, 10);
   store
-    .lease_all(vec![file_digest].iter())
+    .lease_all(vec![(file_digest, EntryType::File)].into_iter())
     .await
     .expect("Error leasing");
   store

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -485,7 +485,7 @@ async fn entry_type_for_file() {
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
-    store.entry_type(&testdata.fingerprint()),
+    store.entry_type(testdata.fingerprint()).await,
     Ok(Some(EntryType::File))
   )
 }
@@ -502,7 +502,7 @@ async fn entry_type_for_directory() {
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
-    store.entry_type(&testdir.fingerprint()),
+    store.entry_type(testdir.fingerprint()).await,
     Ok(Some(EntryType::Directory))
   )
 }
@@ -519,7 +519,9 @@ async fn entry_type_for_missing() {
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
   assert_eq!(
-    store.entry_type(&TestDirectory::recursive().fingerprint()),
+    store
+      .entry_type(TestDirectory::recursive().fingerprint())
+      .await,
     Ok(None)
   )
 }

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -1,11 +1,15 @@
 use crate::local::ByteStore;
 use crate::{EntryType, ShrinkBehavior};
+
+use std::path::Path;
+use std::time::Duration;
+
 use bytes::{BufMut, Bytes, BytesMut};
 use hashing::{Digest, Fingerprint};
-use std::path::Path;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 use tokio::runtime::Handle;
+use tokio::time::delay_for;
 use walkdir::WalkDir;
 
 #[tokio::test]
@@ -150,6 +154,7 @@ async fn garbage_collect_nothing_to_do_with_lease() {
   let file_digest = Digest(file_fingerprint, 10);
   store
     .lease_all(vec![file_digest].iter())
+    .await
     .expect("Error leasing");
   store
     .shrink(10, ShrinkBehavior::Fast)
@@ -157,6 +162,46 @@ async fn garbage_collect_nothing_to_do_with_lease() {
   assert_eq!(
     load_bytes(&store, EntryType::File, file_digest).await,
     Ok(Some(bytes))
+  );
+}
+
+#[tokio::test]
+async fn garbage_collect_expired() {
+  let lease_time = Duration::from_secs(1);
+  let dir = TempDir::new().unwrap();
+  let store = new_store_with_lease_time(dir.path(), lease_time);
+  let bytes = Bytes::from("0123456789");
+  let file_fingerprint = Fingerprint::from_hex_string(
+    "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+  )
+  .unwrap();
+  let file_len = 10;
+  let file_digest = Digest(file_fingerprint, file_len);
+
+  // Store something (in a store with a shortened lease). Confirm that it hasn't immediately
+  // expired, and then wait for it to expire.
+  store
+    .store_bytes(EntryType::File, bytes.clone(), true)
+    .await
+    .expect("Error storing");
+  assert_eq!(
+    file_len,
+    store
+      .shrink(0, ShrinkBehavior::Fast)
+      .expect("Error shrinking"),
+  );
+  assert_eq!(
+    load_bytes(&store, EntryType::File, file_digest).await,
+    Ok(Some(bytes))
+  );
+
+  // Wait for it to expire.
+  delay_for(lease_time * 2).await;
+  assert_eq!(
+    0,
+    store
+      .shrink(0, ShrinkBehavior::Fast)
+      .expect("Should have cleared expired lease")
   );
 }
 
@@ -515,6 +560,15 @@ async fn all_digests() {
 
 pub fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
   ByteStore::new(task_executor::Executor::new(Handle::current()), dir).unwrap()
+}
+
+pub fn new_store_with_lease_time<P: AsRef<Path>>(dir: P, lease_time: Duration) -> ByteStore {
+  ByteStore::new_with_lease_time(
+    task_executor::Executor::new(Handle::current()),
+    dir,
+    lease_time,
+  )
+  .unwrap()
 }
 
 pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -787,7 +787,7 @@ async fn upload_missing_files() {
     .expect_err("Want error");
   assert_eq!(
     error,
-    format!("Failed to upload digest {:?}: Not found", testdata.digest())
+    format!("Failed to expand digest {:?}: Not found", testdata.digest())
   );
 }
 

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 async-trait = "0.1"
 fnv = "1.0.5"
 futures = "0.3"
-hashing = { path = "../hashing" }
 log = "0.4"
 parking_lot = "0.6"
 petgraph = "0.4.5"

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -6,7 +6,6 @@ use std::future::Future;
 use std::hash::Hash;
 
 use async_trait::async_trait;
-use hashing::Digest;
 
 use petgraph::stable_graph;
 
@@ -29,11 +28,6 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   type Error: NodeError;
 
   async fn run(self, context: Self::Context) -> Result<Self::Item, Self::Error>;
-
-  ///
-  /// If the given Node output represents an FS operation, returns its Digest.
-  ///
-  fn digest(result: Self::Item) -> Option<Digest>;
 
   ///
   /// If the node result is cacheable, return true.

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -7,7 +7,6 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use hashing::Digest;
 use parking_lot::Mutex;
 use rand::{self, Rng};
 use tokio::time::{timeout, Elapsed};
@@ -622,10 +621,6 @@ impl Node for TNode {
     } else {
       Ok(vec![token])
     }
-  }
-
-  fn digest(_result: Self::Item) -> Option<Digest> {
-    None
   }
 
   fn cacheable(&self) -> bool {

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -2,10 +2,11 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, NamedCaches,
   Process, ProcessMetadata,
 };
-use sharded_lmdb::ShardedLmdb;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+use sharded_lmdb::{ShardedLmdb, DEFAULT_LEASE_TIME};
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::TestData;
@@ -54,8 +55,13 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
 
-  let process_execution_store =
-    ShardedLmdb::new(cache_dir.path().to_owned(), max_lmdb_size, runtime.clone()).unwrap();
+  let process_execution_store = ShardedLmdb::new(
+    cache_dir.path().to_owned(),
+    max_lmdb_size,
+    runtime.clone(),
+    DEFAULT_LEASE_TIME,
+  )
+  .unwrap();
 
   let metadata = ProcessMetadata {
     instance_name: None,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -25,7 +25,7 @@ use process_execution::{
 };
 use rand::seq::SliceRandom;
 use rule_graph::RuleGraph;
-use sharded_lmdb::ShardedLmdb;
+use sharded_lmdb::{ShardedLmdb, DEFAULT_LEASE_TIME};
 use store::Store;
 use tokio::runtime::{Builder, Runtime};
 use uuid::Uuid;
@@ -234,6 +234,7 @@ impl Core {
         local_store_dir2.join("processes"),
         5 * GIGABYTES,
         executor.clone(),
+        DEFAULT_LEASE_TIME,
       )
       .map_err(|err| format!("Could not initialize store for process cache: {:?}", err))?;
       command_runner = Box::new(process_execution::cache::CommandRunner::new(

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1200,9 +1200,14 @@ fn lease_files_in_graph(
   with_scheduler(py, scheduler_ptr, |scheduler| {
     with_session(py, session_ptr, |session| {
       let digests = scheduler.all_digests(session);
-      py.allow_threads(|| scheduler.core.store().lease_all(digests.iter()))
-        .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
-        .map(|()| None)
+      py.allow_threads(|| {
+        scheduler
+          .core
+          .executor
+          .block_on(scheduler.core.store().lease_all(digests.iter()))
+      })
+      .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
+      .map(|()| None)
     })
   })
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1204,7 +1204,7 @@ fn lease_files_in_graph(
         scheduler
           .core
           .executor
-          .block_on(scheduler.core.store().lease_all(digests.iter()))
+          .block_on(scheduler.core.store().lease_all_recursively(digests.iter()))
       })
       .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
       .map(|()| None)


### PR DESCRIPTION
### Problem

As was misdiagnosed on #9942, extension of leases is currently broken due to `Store::lease_all` using a separate implementation of `fn lease` that is not aware of `VersionedFingerprint` and thus has a different key. This means that the leases being read in `Store::shrink` are different from the leases being extended in `Store::lease_all`.

Additionally, lease extension is not currently recursive into all values held in memory in the `Graph`, which might mean that a value held in memory in `pantsd` can become invalidated.

### Solution

Fix the first issue by removing the duplicate implementation of `fn lease`, and making `ShardedLmdb` more directly responsible for lease management: add a test to cover the failing case.

In separate commits, adjust our lease extension of in-memory content to be recursive into `Snapshots` and `ProcessResults`.

### Result

Fixes #9942.
