### PR TITLE
Set the pex_root cache only at build time

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -77,6 +77,9 @@ class DownloadedPexBin(HermeticPex):
 
         env = dict(env) if env else {}
         env.update(**pex_build_environment.invocation_environment_dict,)
+        if "--pex-root" in pex_args:
+            raise ValueError("--pex-root flag not allowed. We set its value for you.")
+        pex_args = ("--pex-root", ".cache/pex_root") + tuple(pex_args)
 
         return super().create_process(
             python_setup=python_setup,
@@ -86,6 +89,7 @@ class DownloadedPexBin(HermeticPex):
             description=description,
             input_digest=input_digest or self.digest,
             env=env,
+            append_only_caches={"pex_root"},
             **kwargs,
         )
 

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -52,7 +52,6 @@ class HermeticPex:
         hermetic_env = dict(
             PATH=create_path_env_var(python_setup.interpreter_search_paths),
             PEX_ROOT=".cache/pex_root",
-            RUNTIME_PEX_ROOT=".cache/pex_root",
             PEX_INHERIT_PATH="false",
             PEX_IGNORE_RCFILES="true",
             **subprocess_encoding_environment.invocation_environment_dict,

--- a/src/python/pants/backend/python/rules/hermetic_pex.py
+++ b/src/python/pants/backend/python/rules/hermetic_pex.py
@@ -51,7 +51,6 @@ class HermeticPex:
 
         hermetic_env = dict(
             PATH=create_path_env_var(python_setup.interpreter_search_paths),
-            PEX_ROOT=".cache/pex_root",
             PEX_INHERIT_PATH="false",
             PEX_IGNORE_RCFILES="true",
             **subprocess_encoding_environment.invocation_environment_dict,
@@ -64,6 +63,5 @@ class HermeticPex:
             input_digest=input_digest,
             description=description,
             env=hermetic_env,
-            append_only_caches={"pex_root"},
             **kwargs,
         )


### PR DESCRIPTION
Previously we set it using the PEX_ROOT env var, which affected
both runtime (of all pexes) and build time (of the pex binary pex).

This led to running pexes compiling python code into `__pycache__` 
directories under the shared pex root, which interacted badly with 
concurrent copying of dists from the pex cache into chroots at
pex build time.

Leaving PEX_ROOT unset at pex runtime causes it default to either
 ~/.pex, or if that's unwriteable, a tmpdir.

Fixes https://github.com/pantsbuild/pex/issues/984

[ci skip-rust-tests]
[ci skip-jvm-tests]
