### PR TITLE
Create FFI functions for handling digests on workunits

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -550,6 +550,8 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stderr_digest == EMPTY_DIGEST
         assert stdout_digest.serialized_bytes_length == len(result.stdout)
 
+        stdout_bytes = self._scheduler.digest_to_bytes(stdout_digest)
+
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             self._scheduler,
@@ -578,3 +580,9 @@ class StreamingWorkunitProcessTests(TestBase):
         assert result.stderr == b"stderr output\n"
         assert stdout_digest == EMPTY_DIGEST
         assert stderr_digest.serialized_bytes_length == len(result.stderr)
+
+        stdout_bytes = self._scheduler.digest_to_bytes(stdout_digest)
+        stderr_bytes = self._scheduler.digest_to_bytes(stderr_digest)
+        assert stdout_bytes == result.stdout
+        assert stderr_bytes == result.stderr
+

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -550,8 +550,6 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stderr_digest == EMPTY_DIGEST
         assert stdout_digest.serialized_bytes_length == len(result.stdout)
 
-        stdout_bytes = self._scheduler.digest_to_bytes(stdout_digest)
-
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
             self._scheduler,
@@ -581,8 +579,8 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stdout_digest == EMPTY_DIGEST
         assert stderr_digest.serialized_bytes_length == len(result.stderr)
 
-        stdout_bytes = self._scheduler.digest_to_bytes(stdout_digest)
-        stderr_bytes = self._scheduler.digest_to_bytes(stderr_digest)
-        assert stdout_bytes == result.stdout
-        assert stderr_bytes == result.stderr
+        stdout_bytes = self._scheduler.digests_to_bytes([stdout_digest])
+        stderr_bytes = self._scheduler.digests_to_bytes([stderr_digest])
+        assert stdout_bytes[0] == result.stdout
+        assert stderr_bytes[0] == result.stderr
 

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -579,8 +579,6 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stdout_digest == EMPTY_DIGEST
         assert stderr_digest.serialized_bytes_length == len(result.stderr)
 
-        stdout_bytes = self._scheduler.digests_to_bytes([stdout_digest])
-        stderr_bytes = self._scheduler.digests_to_bytes([stderr_digest])
-        assert stdout_bytes[0] == result.stdout
-        assert stderr_bytes[0] == result.stderr
-
+        byte_outputs = self._scheduler.digests_to_bytes([stdout_digest, stderr_digest])
+        assert byte_outputs[0] == result.stdout
+        assert byte_outputs[1] == result.stderr

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -579,6 +579,13 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stdout_digest == EMPTY_DIGEST
         assert stderr_digest.serialized_bytes_length == len(result.stderr)
 
+        try:
+            self._scheduler.ensure_remote_has_recursive([stdout_digest, stderr_digest])
+        except Exception as e:
+            # This is the exception message we should expect from invoking ensure_remote_has_recursive()
+            # in rust.
+            assert str(e) == "Cannot ensure remote has blobs without a remote"
+
         byte_outputs = self._scheduler.digests_to_bytes([stdout_digest, stderr_digest])
         assert byte_outputs[0] == result.stdout
         assert byte_outputs[1] == result.stderr

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -578,9 +578,9 @@ class SchedulerSession:
             self._scheduler._scheduler, self._session, _DirectoryDigests(digests)
         )
 
-    def digest_to_bytes(self, digest: Digest) -> bytes:
+    def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
         sched_pointer = self._scheduler._scheduler
-        return self._scheduler._native.lib.digest_to_bytes(sched_pointer, digest)
+        return self._scheduler._native.lib.digests_to_bytes(sched_pointer, digests)
 
     def run_local_interactive_process(
         self, request: "InteractiveProcessRequest"

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -584,6 +584,10 @@ class SchedulerSession:
             List[bytes], self._scheduler._native.lib.digests_to_bytes(sched_pointer, digests)
         )
 
+    def ensure_remote_has_recursive(self, digests: List[Digest]) -> None:
+        sched_pointer = self._scheduler._scheduler
+        self._scheduler._native.lib.ensure_remote_has_recursive(sched_pointer, digests)
+
     def run_local_interactive_process(
         self, request: "InteractiveProcessRequest"
     ) -> "InteractiveProcessResult":

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -578,6 +578,10 @@ class SchedulerSession:
             self._scheduler._scheduler, self._session, _DirectoryDigests(digests)
         )
 
+    def digest_to_bytes(self, digest: Digest) -> bytes:
+        sched_pointer = self._scheduler._scheduler
+        return self._scheduler._native.lib.digest_to_bytes(sched_pointer, digest)
+
     def run_local_interactive_process(
         self, request: "InteractiveProcessRequest"
     ) -> "InteractiveProcessResult":

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -580,7 +580,9 @@ class SchedulerSession:
 
     def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
         sched_pointer = self._scheduler._scheduler
-        return self._scheduler._native.lib.digests_to_bytes(sched_pointer, digests)
+        return cast(
+            List[bytes], self._scheduler._native.lib.digests_to_bytes(sched_pointer, digests)
+        )
 
     def run_local_interactive_process(
         self, request: "InteractiveProcessRequest"

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -51,6 +51,7 @@ use crate::{
   Params, Rule, Scheduler, Session, Tasks, Types, Value,
 };
 
+use futures::compat::Future01CompatExt;
 use futures::future::FutureExt;
 use futures::future::{self as future03, TryFutureExt};
 use futures01::{future, Future};
@@ -362,6 +363,12 @@ py_module_initializer!(native_engine, |py, m| {
     py,
     "digests_to_bytes",
     py_fn!(py, digests_to_bytes(a: PyScheduler, b: PyList)),
+  )?;
+
+  m.add(
+    py,
+    "ensure_remote_has_recursive",
+    py_fn!(py, ensure_remote_has_recursive(a: PyScheduler, b: PyList)),
   )?;
 
   m.add_class::<PyTasks>(py)?;
@@ -1328,6 +1335,29 @@ fn merge_directories(
       })
       .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
     })
+  })
+}
+
+fn ensure_remote_has_recursive(
+  py: Python,
+  scheduler_ptr: PyScheduler,
+  py_digests: PyList,
+) -> PyUnitResult {
+  with_scheduler(py, scheduler_ptr, |scheduler| {
+    let core = scheduler.core.clone();
+    let store = core.store();
+
+    let digests: Vec<Digest> = py_digests
+      .iter(py)
+      .map(|item| crate::nodes::lift_digest(&item.into()))
+      .collect::<Result<Vec<Digest>, _>>()
+      .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
+
+    let _upload_summary = py.allow_threads(|| {
+      core.executor.block_on(store.ensure_remote_has_recursive(digests).compat())
+    })
+    .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
+    Ok(None)
   })
 }
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1353,10 +1353,13 @@ fn ensure_remote_has_recursive(
       .collect::<Result<Vec<Digest>, _>>()
       .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
 
-    let _upload_summary = py.allow_threads(|| {
-      core.executor.block_on(store.ensure_remote_has_recursive(digests).compat())
-    })
-    .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
+    let _upload_summary = py
+      .allow_threads(|| {
+        core
+          .executor
+          .block_on(store.ensure_remote_has_recursive(digests).compat())
+      })
+      .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
     Ok(None)
   })
 }


### PR DESCRIPTION
### Problem

In order to make practical use of the `Digests` that are attached to Workunits as of https://github.com/pantsbuild/pants/pull/9906 , it is necessary to provide a way to get bytes from a Digest in a way that doesn't use an `@rule`, as well as to ensure that the contents of these digests are uploaded to a remote store.

### Solution

Provide a FFI function `digest_to_bytes` that can extract bytes from a `Digest` with just a reference to the `Scheduler`, bypassing the rest of the engine infrastructure. Also expose the `ensure_remote_has_recursive` store function to Python.
