### PR TITLE
remoting: add initial unit tests for streaming client and fix a bug

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -33,6 +33,8 @@ use workunit_store::WorkunitStore;
 // module.
 mod streaming;
 pub use streaming::StreamingCommandRunner;
+#[cfg(test)]
+mod streaming_tests;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -168,6 +168,10 @@ impl StreamingCommandRunner {
             build_id,
             &operation
           );
+
+          // Extract the operation name.
+          // Note: protobuf can return empty string for an empty field so convert empty strings
+          // to None.
           operation_name_opt =
             Some(operation.get_name().to_string()).filter(|s| !s.trim().is_empty());
 

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -169,7 +169,7 @@ impl StreamingCommandRunner {
             &operation
           );
           operation_name_opt =
-            Some(operation.get_name().to_string()).filter(|s| s.trim().len() > 0);
+            Some(operation.get_name().to_string()).filter(|s| !s.trim().is_empty());
 
           // Continue monitoring if the operation is not complete.
           if !operation.get_done() {

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -168,7 +168,8 @@ impl StreamingCommandRunner {
             build_id,
             &operation
           );
-          operation_name_opt = Some(operation.get_name().to_string());
+          operation_name_opt =
+            Some(operation.get_name().to_string()).filter(|s| s.trim().len() > 0);
 
           // Continue monitoring if the operation is not complete.
           if !operation.get_done() {

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -145,19 +145,29 @@ impl StreamingCommandRunner {
   // Outputs progress reported by the server and returns the next actionable operation
   // or gRPC status back to the main loop (plus the operation name so the main loop can
   // reconnect).
-  async fn wait_on_operation_stream<S>(&self, mut stream: S) -> (Option<String>, OperationOrStatus)
+  async fn wait_on_operation_stream<S>(
+    &self,
+    mut stream: S,
+    build_id: &str,
+  ) -> (Option<String>, OperationOrStatus)
   where
     S: Stream<Item = Result<bazel_protos::operations::Operation, grpcio::Error>> + Unpin,
   {
     let mut operation_name_opt: Option<String> = None;
 
-    debug!("monitor_operation_stream: monitoring stream");
+    trace!(
+      "wait_on_operation_stream (build_id={}): monitoring stream",
+      build_id
+    );
 
     loop {
-      // TODO: Add deadline timeout.
       match stream.next().await {
         Some(Ok(operation)) => {
-          debug!("wait_on_operation_stream: got operation: {:?}", &operation);
+          trace!(
+            "wait_on_operation_stream (build_id={}): got operation: {:?}",
+            build_id,
+            &operation
+          );
           operation_name_opt = Some(operation.get_name().to_string());
 
           // Continue monitoring if the operation is not complete.
@@ -455,6 +465,11 @@ impl StreamingCommandRunner {
         None => {
           // The request has not been submitted yet. Submit the request using the REv2
           // Execute method.
+          trace!(
+            "no current operation: submitting execute request: build_id={}; execute_request={:?}",
+            context.build_id,
+            execute_request
+          );
           self
             .execution_client
             .execute_opt(&execute_request, call_opt)
@@ -463,6 +478,11 @@ impl StreamingCommandRunner {
         Some(ref operation_name) => {
           // The request has been submitted already. Reconnect to the status stream
           // using the REv2 WaitExecution method.
+          trace!(
+            "existing operation: reconnecting to operation stream: build_id={}; operation_name={}",
+            context.build_id,
+            operation_name
+          );
           let mut wait_execution_request = WaitExecutionRequest::new();
           wait_execution_request.set_name(operation_name.to_owned());
           self
@@ -478,8 +498,10 @@ impl StreamingCommandRunner {
           // Monitor the operation stream until there is an actionable operation
           // or status to interpret.
           let compat_stream = operation_stream.compat();
-          let (operation_name_opt, actionable_result) =
-            self.wait_on_operation_stream(compat_stream).await;
+          let (operation_name_opt, actionable_result) = self
+            .wait_on_operation_stream(compat_stream, &context.build_id)
+            .await;
+          trace!("wait_on_operation_stream (build_id={}) returned: operation_name_opt={:?}; actionable_result={:?}", context.build_id, operation_name_opt, actionable_result);
 
           // Save the operation name in case we need to reconnect via WaitExecution.
           if let Some(name) = operation_name_opt {
@@ -548,6 +570,13 @@ impl crate::CommandRunner for StreamingCommandRunner {
     } = compatible_underlying_request;
 
     debug!("Remote execution: {}", description);
+    trace!(
+      "built REv2 request (build_id={}): action={:?}; command={:?}; execute_request={:?}",
+      context.build_id,
+      action,
+      command,
+      execute_request
+    );
 
     // Record the time that we started to process this request, then compute the ultimate
     // deadline for execution of this request.
@@ -563,8 +592,14 @@ impl crate::CommandRunner for StreamingCommandRunner {
     match timeout_fut.await {
       Ok(r) => r,
       Err(_) => {
-        trace!("remote execution timed out after {:?}", deadline_duration);
-        Err("remote execution request timed out".to_owned())
+        debug!(
+          "remote execution for build_id={} timed out after {:?}",
+          context.build_id, deadline_duration
+        );
+        Err(format!(
+          "remote execution timed out after {:?}",
+          deadline_duration
+        ))
       }
     }
   }

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -568,11 +568,12 @@ impl crate::CommandRunner for StreamingCommandRunner {
       input_files,
       ..
     } = compatible_underlying_request;
+    let build_id = context.build_id.clone();
 
     debug!("Remote execution: {}", description);
     trace!(
       "built REv2 request (build_id={}): action={:?}; command={:?}; execute_request={:?}",
-      context.build_id,
+      &build_id,
       action,
       command,
       execute_request
@@ -594,7 +595,7 @@ impl crate::CommandRunner for StreamingCommandRunner {
       Err(_) => {
         debug!(
           "remote execution for build_id={} timed out after {:?}",
-          context.build_id, deadline_duration
+          &build_id, deadline_duration
         );
         Err(format!(
           "remote execution timed out after {:?}",

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -1,0 +1,202 @@
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+
+use hashing::EMPTY_DIGEST;
+use mock::execution_server::ExpectedAPICall;
+use store::Store;
+use tempfile::TempDir;
+use testutil::data::{TestData, TestDirectory};
+use tokio::runtime::Handle;
+
+use crate::remote::StreamingCommandRunner;
+use crate::remote_tests::{
+  assert_cancellation_requests, echo_foo_request, empty_request_metadata,
+  make_incomplete_operation, make_retryable_operation_failure, make_store,
+  make_successful_operation, RemoteTestResult, StderrType, StdoutType,
+};
+use crate::CommandRunner;
+use crate::{Context, MultiPlatformProcess, Platform};
+
+fn create_command_runner(
+  address: String,
+  cas: &mock::StubCAS,
+  platform: Platform,
+) -> (StreamingCommandRunner, Store) {
+  let runtime = task_executor::Executor::new(Handle::current());
+  let store_dir = TempDir::new().unwrap();
+  let store = make_store(store_dir.path(), cas, runtime.clone());
+  let command_runner = StreamingCommandRunner::new(
+    &address,
+    empty_request_metadata(),
+    None,
+    None,
+    BTreeMap::new(),
+    store.clone(),
+    platform,
+  )
+  .expect("Failed to make command runner");
+  (command_runner, store)
+}
+
+async fn run_command_remote(
+  address: String,
+  request: MultiPlatformProcess,
+) -> Result<RemoteTestResult, String> {
+  let cas = mock::StubCAS::builder()
+    .file(&TestData::roland())
+    .directory(&TestDirectory::containing_roland())
+    .build();
+  let (command_runner, store) = create_command_runner(address, &cas, Platform::Linux);
+  let original = command_runner.run(request, Context::default()).await?;
+
+  let stdout_bytes: Vec<u8> = store
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+    .await?
+    .unwrap()
+    .0;
+  let stderr_bytes: Vec<u8> = store
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .await?
+    .unwrap()
+    .0;
+  Ok(RemoteTestResult {
+    original,
+    stdout_bytes,
+    stderr_bytes,
+  })
+}
+
+#[tokio::test]
+async fn successful_with_only_call_to_execute() {
+  let execute_request = echo_foo_request();
+  let op_name = "gimme-foo".to_string();
+
+  let mock_server = {
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
+        execute_request: crate::remote::make_execute_request(
+          &execute_request.clone().try_into().unwrap(),
+          empty_request_metadata(),
+        )
+        .unwrap()
+        .2,
+        stream_responses: Ok(vec![
+          make_incomplete_operation(&op_name),
+          make_successful_operation(
+            &op_name,
+            StdoutType::Raw("foo".to_owned()),
+            StderrType::Raw("".to_owned()),
+            0,
+          ),
+        ]),
+      }]),
+      None,
+    )
+  };
+
+  let result = run_command_remote(mock_server.address(), execute_request)
+    .await
+    .unwrap();
+
+  assert_eq!(result.stdout_bytes, "foo".as_bytes());
+  assert_eq!(result.stderr_bytes, "".as_bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(result.original.output_directory, EMPTY_DIGEST);
+  assert_cancellation_requests(&mock_server, vec![]);
+}
+
+#[tokio::test]
+async fn successful_after_reconnect_with_wait_execution() {
+  let execute_request = echo_foo_request();
+  let op_name = "gimme-foo".to_string();
+
+  let mock_server = {
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          )
+          .unwrap()
+          .2,
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_successful_operation(
+            &op_name,
+            StdoutType::Raw("foo".to_owned()),
+            StderrType::Raw("".to_owned()),
+            0,
+          )]),
+        },
+      ]),
+      None,
+    )
+  };
+
+  let result = run_command_remote(mock_server.address(), execute_request)
+    .await
+    .unwrap();
+
+  assert_eq!(result.stdout_bytes, "foo".as_bytes());
+  assert_eq!(result.stderr_bytes, "".as_bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(result.original.output_directory, EMPTY_DIGEST);
+  assert_cancellation_requests(&mock_server, vec![]);
+}
+
+#[tokio::test]
+async fn successful_after_reconnect_from_retryable_error() {
+  let execute_request = echo_foo_request();
+  let op_name_1 = "gimme-foo".to_string();
+  let op_name_2 = "gimme-bar".to_string();
+
+  let mock_server = {
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          )
+          .unwrap()
+          .2,
+          stream_responses: Ok(vec![
+            make_incomplete_operation(&op_name_1),
+            make_retryable_operation_failure(),
+          ]),
+        },
+        ExpectedAPICall::Execute {
+          execute_request: crate::remote::make_execute_request(
+            &execute_request.clone().try_into().unwrap(),
+            empty_request_metadata(),
+          )
+          .unwrap()
+          .2,
+          stream_responses: Ok(vec![
+            make_incomplete_operation(&op_name_2),
+            make_successful_operation(
+              &op_name_2,
+              StdoutType::Raw("foo".to_owned()),
+              StderrType::Raw("".to_owned()),
+              0,
+            ),
+          ]),
+        },
+      ]),
+      None,
+    )
+  };
+
+  let result = run_command_remote(mock_server.address(), execute_request)
+    .await
+    .unwrap();
+
+  assert_eq!(result.stdout_bytes, "foo".as_bytes());
+  assert_eq!(result.stderr_bytes, "".as_bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(result.original.output_directory, EMPTY_DIGEST);
+  assert_cancellation_requests(&mock_server, vec![]);
+}

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -32,20 +32,20 @@ use tokio::time::{delay_for, timeout};
 use workunit_store::{Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 #[derive(Debug, PartialEq)]
-struct RemoteTestResult {
-  original: FallibleProcessResultWithPlatform,
-  stdout_bytes: Vec<u8>,
-  stderr_bytes: Vec<u8>,
+pub(crate) struct RemoteTestResult {
+  pub(crate) original: FallibleProcessResultWithPlatform,
+  pub(crate) stdout_bytes: Vec<u8>,
+  pub(crate) stderr_bytes: Vec<u8>,
 }
 
 #[derive(Debug, PartialEq)]
-enum StdoutType {
+pub(crate) enum StdoutType {
   Raw(String),
   Digest(Digest),
 }
 
 #[derive(Debug, PartialEq)]
-enum StderrType {
+pub(crate) enum StderrType {
   Raw(String),
   Digest(Digest),
 }
@@ -2349,14 +2349,14 @@ fn make_canceled_operation(duration: Option<Duration>) -> MockOperation {
   }
 }
 
-fn make_incomplete_operation(operation_name: &str) -> MockOperation {
+pub(crate) fn make_incomplete_operation(operation_name: &str) -> MockOperation {
   let mut op = bazel_protos::operations::Operation::new();
   op.set_name(operation_name.to_string());
   op.set_done(false);
   MockOperation::new(op)
 }
 
-fn make_retryable_operation_failure() -> MockOperation {
+pub(crate) fn make_retryable_operation_failure() -> MockOperation {
   let mut status = bazel_protos::status::Status::new();
   status.set_code(grpcio::RpcStatusCode::ABORTED.into());
   status.set_message(String::from("the bot running the task appears to be lost"));
@@ -2434,7 +2434,7 @@ fn make_successful_operation_with_maybe_metadata(
   op
 }
 
-fn make_successful_operation(
+pub(crate) fn make_successful_operation(
   operation_name: &str,
   stdout: StdoutType,
   stderr: StderrType,
@@ -2590,7 +2590,11 @@ fn create_command_runner(
   (command_runner, store)
 }
 
-fn make_store(store_dir: &Path, cas: &mock::StubCAS, executor: task_executor::Executor) -> Store {
+pub(crate) fn make_store(
+  store_dir: &Path,
+  cas: &mock::StubCAS,
+  executor: task_executor::Executor,
+) -> Store {
   Store::with_remote(
     executor,
     store_dir,
@@ -2734,7 +2738,7 @@ fn echo_roland_request() -> MultiPlatformProcess {
   req.into()
 }
 
-fn empty_request_metadata() -> ProcessMetadata {
+pub(crate) fn empty_request_metadata() -> ProcessMetadata {
   ProcessMetadata {
     instance_name: None,
     cache_key_gen_version: None,
@@ -2742,7 +2746,7 @@ fn empty_request_metadata() -> ProcessMetadata {
   }
 }
 
-fn assert_cancellation_requests(
+pub(crate) fn assert_cancellation_requests(
   mock_server: &mock::execution_server::TestServer,
   expected: Vec<String>,
 ) {


### PR DESCRIPTION
### Problem

The streaming remote execution client did not have unit tests when it landed because we wanted to land it early to avoid some merge conflicts. There was also a bug related to decoding an empty string (for the operation name) from the applicable protobuf.

### Solution

1. Adds some initial unit tests.
2. Fixes a bug in decoding empty operation names found with the unit tests.
3. Adds better logging.

### Result

The failing unit test now passes.