### PR TITLE
Release the gil while polling workunits.

### DIFF
--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -848,17 +848,19 @@ fn poll_session_workunits(
     .map_err(|e| PyErr::new::<exc::Exception, _>(py, (format!("{}", e),)))?;
   with_scheduler(py, scheduler_ptr, |scheduler| {
     with_session(py, session_ptr, |session| {
-      session
-        .workunit_store()
-        .with_latest_workunits(py_level.into(), |started, completed| {
-          let mut started_iter = started.iter();
-          let started = workunits_to_py_tuple_value(&mut started_iter, &scheduler.core)?;
+      py.allow_threads(|| {
+        session
+          .workunit_store()
+          .with_latest_workunits(py_level.into(), |started, completed| {
+            let mut started_iter = started.iter();
+            let started = workunits_to_py_tuple_value(&mut started_iter, &scheduler.core)?;
 
-          let mut completed_iter = completed.iter();
-          let completed = workunits_to_py_tuple_value(&mut completed_iter, &scheduler.core)?;
+            let mut completed_iter = completed.iter();
+            let completed = workunits_to_py_tuple_value(&mut completed_iter, &scheduler.core)?;
 
-          Ok(externs::store_tuple(vec![started, completed]).into())
-        })
+            Ok(externs::store_tuple(vec![started, completed]).into())
+          })
+      })
     })
   })
 }


### PR DESCRIPTION
### Problem

As reported on #9926 and shown in https://github.com/pantsbuild/pants/files/4732596/gdb.txt, threads 5 and 25 were deadlocked accessing the `WorkunitStore` (in `complete_workunit` and `poll_session_workunits`, respectively) and the GIL (to get `Node` information, and via the `poll_session_workunits` method in `interface.rs`, respectively).

### Solution

Release the GIL before interacting with the `WorkunitStore` in `poll_session_workunits`. I'd like to refactor `interface.rs` to make this kind of issue more challenging to trigger, but this fix is self-contained. 

### Result

Fixes #9926 some more.

[ci skip-jvm-tests]