### PR TITLE
Pants.d can't start if .pids directory is an absolute symlink

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -430,7 +430,11 @@ class PantsDaemon(FingerprintedProcessManager):
         )
 
         # Add the pidfile to watching via the scheduler.
-        pidfile_absolute = self._metadata_file_path("pantsd", "pid")
+        # We take the realpath here because if the metadata file path is a symlink, which it
+        # is for VCFS, pants will not agree to watch the absolute symilnk. Taking the realpath
+        # means we find out before trying to add the path as an invalidation glob if it points
+        # somewhere outside the workspace.
+        pidfile_absolute = os.path.realpath(self._metadata_file_path("pantsd", "pid"))
         if pidfile_absolute.startswith(self._build_root):
             scheduler_service = next(
                 s for s in self._services.services if isinstance(s, SchedulerService)


### PR DESCRIPTION
### Problem

If the pants subprocess dir is an absolute symlink pants.d will fail to start because it uses the subprocess directory as part of its invalidation globs; but the pants engine won't take a digest of an absolute symlink, or a directory outside of the build root.

### Solution
Canonicalize the path to the subprocess dir so that the pants daemon knows if it should use a symlinked subprocess dir as part of its invalidation globs.

### Result

Pants.d can start in a workspace with a symlinked subprocess dir.