### PR TITLE
add cargo_util binary [NOT FOR MERGING]

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -22,9 +22,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "app_dirs2"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "arc-swap"
@@ -40,6 +54,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "async-std"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-task 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kv-log-macro 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "async-tar"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "async-task"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "async-trait"
@@ -226,6 +287,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "broadcaster"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +404,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-fetcher"
+version = "0.7.0"
+source = "git+https://github.com/cosmicexplorer/cargo-fetcher?rev=442b801abfefac420ef922aec97f5fba8cba63ba#442b801abfefac420ef922aec97f5fba8cba63ba"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_dirs2 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-tar 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo_util"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boxfuture 0.0.1",
+ "cargo-fetcher 0.7.0 (git+https://github.com/cosmicexplorer/cargo-fetcher?rev=442b801abfefac420ef922aec97f5fba8cba63ba)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sharded_lmdb 0.0.1",
+ "store 0.1.0",
+ "task_executor 0.0.1",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testutil 0.0.1",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +471,9 @@ dependencies = [
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cexpr"
@@ -1125,6 +1258,11 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-timer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-util"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1716,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1843,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1885,14 @@ dependencies = [
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "matches"
@@ -2048,6 +2210,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "oorandom"
 version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2341,19 @@ dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2267,6 +2456,30 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2704,6 +2917,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2998,6 +3212,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sharded_lmdb"
 version = "0.0.1"
 dependencies = [
@@ -3156,6 +3378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "structopt-derive"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,6 +3396,18 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3194,6 +3438,16 @@ dependencies = [
  "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3523,6 +3777,81 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-direct-service 0.1.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)",
  "tower-service 0.2.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-attributes 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sharded-slab 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3892,14 +4221,52 @@ dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "zstd"
+version = "0.5.2+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zstd-safe 2.0.4+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.4+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zstd-sys 1.4.16+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.16+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+"checksum app_dirs2 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "61b1fa4b1eeb18470c454bbed5406f02463aad37fd20f3a16c65bed88d4e115a"
 "checksum arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
+"checksum async-tar 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf8c4fd45c1ef482f5f79c78e097c6c49b62f3faa0a048cd606e6a2e3fa4ad7"
+"checksum async-task 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
 "checksum async-trait 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "21a03abb7c9b93ae229356151a083d26218c0358866a2a59d4280c856e9482e6"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
@@ -3913,6 +4280,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum broadcaster 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
 "checksum bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
@@ -3921,6 +4289,7 @@ dependencies = [
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum cargo 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7e90b5f23ae79af3ec0e4dc670349167fd47d6c1134f139cf0627817a4792bf"
+"checksum cargo-fetcher 0.7.0 (git+https://github.com/cosmicexplorer/cargo-fetcher?rev=442b801abfefac420ef922aec97f5fba8cba63ba)" = "<none>"
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
@@ -3999,6 +4368,7 @@ dependencies = [
 "checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 "checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 "checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+"checksum futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 "checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 "checksum fwdansi 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
@@ -4041,6 +4411,7 @@ dependencies = [
 "checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 "checksum js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum kv-log-macro 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
@@ -4052,9 +4423,11 @@ dependencies = [
 "checksum lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lmdb-sys 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+"checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -4085,6 +4458,7 @@ dependencies = [
 "checksum num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
 "checksum num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 "checksum number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum oorandom 11.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum opener 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "04b1d6b086d9b3009550f9b6f81b10ad9428cf14f404b8e1a3a06f6f012c8ec9"
@@ -4095,10 +4469,12 @@ dependencies = [
 "checksum os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "db4d06355a7090ce852965b2d08e11426c315438462638c6d721448d0b47aa22"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+"checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 "checksum paste 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
 "checksum paste-impl 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
@@ -4113,6 +4489,8 @@ dependencies = [
 "checksum plotters 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f9b1d9ca091d370ea3a78d5619145d1b59426ab0c9eedbad2514a4cee08bf389"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+"checksum proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+"checksum proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 "checksum proc-macro-hack 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f918f2b601f93baa836c1c2945faef682ba5b6d4828ecb45eeb7cc3c71b811b4"
 "checksum proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -4183,6 +4561,7 @@ dependencies = [
 "checksum serde_test 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "4a6563891298bffe3306cbd5f058845f406f3ceb505c8cb2e4e103d12807d7ee"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+"checksum sharded-slab 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
@@ -4198,10 +4577,13 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+"checksum structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+"checksum structopt-derive 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
@@ -4231,6 +4613,13 @@ dependencies = [
 "checksum tower-service 0.2.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)" = "<none>"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum tower-util 0.1.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)" = "<none>"
+"checksum tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+"checksum tracing-attributes 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+"checksum tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+"checksum tracing-futures 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+"checksum tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+"checksum tracing-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+"checksum tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
@@ -4273,3 +4662,7 @@ dependencies = [
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+"checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
+"checksum zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "644352b10ce7f333d6e0af85bd4f5322dc449416dc1211c6308e95bca8923db4"
+"checksum zstd-safe 2.0.4+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7113c0c9aed2c55181f2d9f5b0a36e7d2c0183b11c058ab40b35987479efe4d7"
+"checksum zstd-sys 1.4.16+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c442965efc45353be5a9b9969c9b0872fff6828c7e06d118dda2cb2d0bb11d5a"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   ".",
   "async_semaphore",
   "boxfuture",
+  "cargo_util",
   "concrete_time",
   "fs",
   "fs/brfs",
@@ -58,6 +59,7 @@ default-members = [
   ".",
   "async_semaphore",
   "boxfuture",
+  "cargo_util",
   "concrete_time",
   "fs",
   "fs/fs_util",
@@ -141,6 +143,9 @@ fs = { path = "./fs" }
 env_logger = "0.5.4"
 
 [patch.crates-io]
+# TODO: Remove patch when we can upgrade to an official released version of cargo-fetcher with a fix.
+# See: https://github.com/pantsbuild/pants/issues/9974 for context.
+cargo-fetcher = { git = "https://github.com/cosmicexplorer/cargo-fetcher", rev = "442b801abfefac420ef922aec97f5fba8cba63ba", version = "0.7.0" }
 # TODO: Remove patch when we can upgrade to an official released version of protobuf with a fix.
 # See: https://github.com/pantsbuild/pants/issues/7760 for context.
 protobuf = { git="https://github.com/pantsbuild/rust-protobuf", rev="171611c33ec92f07e1b7107327f6d0139a7afebf", version="2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/cargo_util/Cargo.toml
+++ b/src/rust/engine/cargo_util/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "cargo_util"
+version = "0.1.0"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1"
+anyhow = "1.0.26"
+boxfuture = { path = "../boxfuture" }
+cargo-fetcher = "0.7.0"
+chrono = "0.4.10"
+clap = "2"
+env_logger = "0.5.4"
+fs = { path = "../fs" }
+futures01 = { package = "futures", version = "0.1" }
+futures = { version = "0.3", features = ["compat"] }
+hashing = { path = "../hashing" }
+serde_json = "1.0"
+store = { path = "../fs/store" }
+sharded_lmdb = { path = "../sharded_lmdb" }
+task_executor = { path = "../task_executor" }
+tokio = { version = "0.2", features = ["rt-threaded"] }
+
+[dev-dependencies]
+tempfile = "3"
+testutil = { path = "../testutil" }

--- a/src/rust/engine/cargo_util/src/cargo_fetcher.rs
+++ b/src/rust/engine/cargo_util/src/cargo_fetcher.rs
@@ -1,0 +1,567 @@
+use boxfuture::{BoxFuture, Boxable};
+use fs::{
+  File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching, PosixFS, PreparedPathGlobs,
+  StrictGlobMatching,
+};
+use hashing::{Digest, Fingerprint};
+use sharded_lmdb::{Bytes as PantsBytes, ShardedLmdb, VersionedFingerprint};
+use store::{Snapshot, Store, StoreFileByDigest};
+use task_executor::Executor;
+
+use anyhow;
+use async_trait::async_trait;
+pub use cargo_fetcher::{self, Bytes, Krate, Source as KrateSource};
+use chrono;
+use futures::future::{join_all, TryFutureExt};
+use serde_json;
+
+use std::collections::HashMap;
+use std::convert::{From, TryFrom};
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+use std::process;
+use std::str;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub enum CargoFetcherError {
+  IoError(io::Error),
+  Anyhow(anyhow::Error),
+  Serde(serde_json::Error),
+  Utf8(str::Utf8Error),
+}
+
+impl From<io::Error> for CargoFetcherError {
+  fn from(err: io::Error) -> Self {
+    CargoFetcherError::IoError(err)
+  }
+}
+
+impl From<anyhow::Error> for CargoFetcherError {
+  fn from(err: anyhow::Error) -> Self {
+    CargoFetcherError::Anyhow(err)
+  }
+}
+
+impl From<String> for CargoFetcherError {
+  fn from(err: String) -> Self {
+    CargoFetcherError::Anyhow(anyhow::Error::msg(err))
+  }
+}
+
+impl From<serde_json::Error> for CargoFetcherError {
+  fn from(err: serde_json::Error) -> Self {
+    CargoFetcherError::Serde(err)
+  }
+}
+
+impl From<str::Utf8Error> for CargoFetcherError {
+  fn from(err: str::Utf8Error) -> Self {
+    CargoFetcherError::Utf8(err)
+  }
+}
+
+pub fn registry_index_reldir() -> PathBuf {
+  PathBuf::from(cargo_fetcher::sync::INDEX_DIR)
+}
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub struct GitRevision(String);
+
+pub async fn get_registry_git_revision(
+  registry_download_dir: PathBuf,
+  executor: Executor,
+) -> Result<GitRevision, CargoFetcherError> {
+  let get_git_revision: Result<String, CargoFetcherError> = executor
+    .spawn_blocking(move || {
+      let output = process::Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .current_dir(&registry_download_dir)
+        .output()?;
+      let trimmed_output = str::from_utf8(&output.stdout)?.trim_end();
+      Ok(trimmed_output.to_string())
+    })
+    .await;
+  Ok(GitRevision(get_git_revision?))
+}
+
+const REGISTRY_INDEX_URL: &str = "git+https://github.com/rust-lang/crates.io-index.git";
+
+///
+/// Synthesize a Krate instance representing a specific revision of the git repo. We will use this
+/// to avoid snapshotting the registry more than once per (time the registry's git repository is
+/// fetched).
+///
+fn registry_index_crate(git_revision: GitRevision) -> Result<Krate, anyhow::Error> {
+  let GitRevision(git_revision) = git_revision;
+  let url = cargo_fetcher::Url::parse(REGISTRY_INDEX_URL).unwrap();
+  let canonicalized = cargo_fetcher::util::Canonicalized::try_from(&url).unwrap();
+  Ok(Krate {
+    name: "crates.io-index".to_string(),
+    version: git_revision.clone(),
+    source: cargo_fetcher::Source::Git {
+      url: cargo_fetcher::UrlWrapper {
+        url: canonicalized.as_ref().clone(),
+      },
+      ident: canonicalized.ident(),
+      rev: git_revision,
+    },
+  })
+}
+
+fn fingerprint_krate(krate: &Krate) -> Result<Fingerprint, serde_json::Error> {
+  let krate_json = serde_json::to_string(krate)?;
+  let Digest(fingerprint, _) = Digest::of_bytes(krate_json.as_bytes());
+  Ok(fingerprint)
+}
+
+#[derive(Clone)]
+pub struct FileDigester {
+  pub vfs: Arc<PosixFS>,
+  pub store: Store,
+}
+
+impl StoreFileByDigest<String> for FileDigester {
+  fn store_by_digest(&self, file: File) -> BoxFuture<Digest, String> {
+    let digester = self.clone();
+    Box::pin(async move {
+      let content = digester
+        .vfs
+        .read_file(&file)
+        .await
+        .map_err(|e| format!("{:?}", e))?;
+      digester.store.store_file_bytes(content.content, true).await
+    })
+    .compat()
+    .to_boxed()
+  }
+}
+
+pub struct CargoPackageFetcher {
+  pub krate_lookup: ShardedLmdb,
+  pub krate_data: ShardedLmdb,
+  pub krate_digest_mapping: ShardedLmdb,
+  pub fetch_cache: ShardedLmdb,
+  pub store: Store,
+  pub executor: Executor,
+  pub download_dir: PathBuf,
+  pub timeout: Duration,
+}
+
+pub struct PackageFetchResult {
+  pub krate_mapping: HashMap<Krate, Digest>,
+  pub current_registry_index_krate: Krate,
+  pub current_registry_index_digest: Digest,
+}
+
+impl PackageFetchResult {
+  pub fn registry_index_revision(&self) -> GitRevision {
+    GitRevision(self.current_registry_index_krate.version.clone())
+  }
+
+  pub fn to_json(&self) -> Result<serde_json::Value, CargoFetcherError> {
+    let mut result: HashMap<String, serde_json::Value> = HashMap::new();
+    result.insert(
+      "current_registry_index_krate".to_string(),
+      serde_json::to_value(&self.current_registry_index_krate)?,
+    );
+    result.insert(
+      "current_registry_index_digest".to_string(),
+      serde_json::to_value(&self.current_registry_index_digest)?,
+    );
+
+    let mapping: HashMap<String, serde_json::Value> = self
+      .krate_mapping
+      .iter()
+      .map(|(krate, digest)| {
+        Ok((
+          serde_json::to_string(&krate)?,
+          serde_json::to_value(&digest)?,
+        ))
+      })
+      .collect::<Result<HashMap<String, serde_json::Value>, CargoFetcherError>>()?;
+    result.insert("krate_mapping".to_string(), serde_json::to_value(&mapping)?);
+
+    Ok(serde_json::to_value(&result)?)
+  }
+
+  pub fn from_json(json: serde_json::Value) -> Result<Self, CargoFetcherError> {
+    let current_registry_index_krate: Krate = serde_json::from_value(
+      json
+        .get("current_registry_index_krate")
+        .cloned()
+        .ok_or_else(|| "failed to extract current_registry_index_krate".to_string())?,
+    )?;
+    let current_registry_index_digest: Digest = serde_json::from_value(
+      json
+        .get("current_registry_index_digest")
+        .cloned()
+        .ok_or_else(|| "failed to extract current_registry_index_digest".to_string())?,
+    )?;
+
+    let mapping: HashMap<String, serde_json::Value> = serde_json::from_value(
+      json
+        .get("krate_mapping")
+        .cloned()
+        .ok_or_else(|| "failed to extract krate_mapping".to_string())?,
+    )?;
+    let krate_mapping: HashMap<Krate, Digest> = mapping
+      .into_iter()
+      .map(|(krate_str, digest_str)| {
+        let krate: Krate = serde_json::from_str(&krate_str)?;
+        let digest: Digest = serde_json::from_value(digest_str)?;
+        Ok((krate, digest))
+      })
+      .collect::<Result<HashMap<Krate, Digest>, CargoFetcherError>>()?;
+
+    Ok(PackageFetchResult {
+      krate_mapping,
+      current_registry_index_krate,
+      current_registry_index_digest,
+    })
+  }
+}
+
+impl CargoPackageFetcher {
+  pub async fn fetch_packages_from_lockfile(
+    &self,
+    cargo_lock_file_contents: &str,
+  ) -> Result<PackageFetchResult, CargoFetcherError> {
+    // 1. Determine the crates to download from the Cargo.lock file.
+    let krates = cargo_fetcher::read_lock_file_contents(cargo_lock_file_contents)?;
+    self.fetch_packages(&krates).await
+  }
+
+  pub async fn fetch_packages(
+    &self,
+    krates: &[Krate],
+  ) -> Result<PackageFetchResult, CargoFetcherError> {
+    // 2. Check if we have performed this fetch already.
+    if let Some(cached_result) = self.try_cached_fetch(krates).await? {
+      return Ok(cached_result);
+    }
+
+    // 3. Update the index, and ensure all git and crates.io packages have been downloaded into
+    // `self.download_dir`.
+    let vfs = Arc::new(PosixFS::new(
+      &self.download_dir,
+      GitignoreStyleExcludes::empty(),
+      self.executor.clone(),
+    )?);
+    let backend: Arc<dyn cargo_fetcher::Backend + Send + Sync> = Arc::new(PantsBackend {
+      krate_lookup: self.krate_lookup.clone(),
+      krate_data: self.krate_data.clone(),
+      store: self.store.clone(),
+      executor: self.executor.clone(),
+      download_dir: self.download_dir.clone(),
+      prefix: "".to_string(),
+    });
+    let ctx = cargo_fetcher::Ctx::new(
+      Some(self.download_dir.clone()),
+      Arc::clone(&backend),
+      krates.to_vec(),
+    )?;
+    // From diff_cargo.rs in the `cargo-fetcher` package:
+    cargo_fetcher::mirror::registry_index(Arc::clone(&backend), self.timeout).await?;
+    cargo_fetcher::mirror::crates(&ctx).await?;
+    ctx.prep_sync_dirs()?;
+    // In the diff_cargo.rs file, these operations are in reverse order. It appears that the
+    // crates.io git registry isn't used to fetch crates, and is purely for the use of cargo, so
+    // switching the order should not change behavior.
+    cargo_fetcher::sync::registry_index(ctx.root_dir.clone(), Arc::clone(&backend)).await?;
+    cargo_fetcher::sync::crates(&ctx).await?;
+    // `self.download_dir` should now contain all the necessary dependency crates!
+
+    // 4. Snapshot all the now-downloaded crates.
+    let digester = FileDigester {
+      vfs: Arc::clone(&vfs),
+      store: self.store.clone(),
+    };
+    let digests = join_all(krates.iter().map(|krate| {
+      self.snapshot_package(&krate, self.get_krate_download_dir(&krate), &vfs, &digester)
+    }))
+    .await
+    .into_iter()
+    .collect::<Result<Vec<Digest>, CargoFetcherError>>()?;
+
+    let krate_mapping: HashMap<Krate, Digest> =
+      krates.iter().cloned().zip(digests.into_iter()).collect();
+
+    // 5. If the registry was updated, snapshot it.
+    let registry_reldir = registry_index_reldir();
+    let git_revision = get_registry_git_revision(
+      self.download_dir.join(&registry_reldir),
+      self.executor.clone(),
+    )
+    .await?;
+    let current_registry_index_krate = registry_index_crate(git_revision)?;
+    let current_registry_index_digest = self
+      .snapshot_package(
+        &current_registry_index_krate,
+        registry_reldir,
+        &vfs,
+        &digester,
+      )
+      .await?;
+
+    // 6. Write this result to the fetch cache.
+    let krates_json = serde_json::to_string(krates)?;
+    let Digest(krates_fingerprint, _) = Digest::of_bytes(krates_json.as_bytes());
+    let ret = PackageFetchResult {
+      krate_mapping,
+      current_registry_index_krate,
+      current_registry_index_digest,
+    };
+    let ret_json = serde_json::to_string(&ret.to_json()?)?;
+    self
+      .fetch_cache
+      .store_bytes(
+        krates_fingerprint,
+        PantsBytes::from(ret_json.as_bytes()),
+        true,
+      )
+      .await?;
+
+    Ok(ret)
+  }
+
+  fn get_crates_io_src_dir(&self) -> PathBuf {
+    PathBuf::from(cargo_fetcher::sync::SRC_DIR)
+  }
+
+  fn get_git_checkout_dir(&self) -> PathBuf {
+    PathBuf::from(cargo_fetcher::sync::GIT_CO_DIR)
+  }
+
+  // Cobbled together from multiple different sections of sync.rs in the cargo-fetcher package.
+  fn get_krate_download_dir(&self, krate: &Krate) -> PathBuf {
+    match &krate.source {
+      KrateSource::CratesIo(_) => self
+        .get_crates_io_src_dir()
+        .join(format!("{}", krate.local_id()))
+        // A .crate extension is applied to the krate's local id. This is removed when untarring
+        // the crate in sync.rs in the cargo-fetcher package.
+        .with_extension(""),
+      KrateSource::Git { rev, .. } => {
+        self
+          .get_git_checkout_dir()
+          .join(format!("{}/{}", krate.local_id(), rev))
+      }
+    }
+  }
+
+  pub async fn try_cached_fetch(
+    &self,
+    krates: &[Krate],
+  ) -> Result<Option<PackageFetchResult>, CargoFetcherError> {
+    let krates_json = serde_json::to_string(krates)?;
+    let Digest(fingerprint, _) = Digest::of_bytes(krates_json.as_bytes());
+
+    match self
+      .fetch_cache
+      .load_bytes_with(fingerprint, |bytes| Ok(Bytes::copy_from_slice(&bytes[..])))
+      .await?
+    {
+      Some(result_bytes) => {
+        let json_str = str::from_utf8(&result_bytes)?;
+        let ret = PackageFetchResult::from_json(serde_json::from_str(&json_str)?)?;
+        Ok(Some(ret))
+      }
+      None => Ok(None),
+    }
+  }
+
+  pub async fn lookup_digest(&self, krate: &Krate) -> Result<Option<Digest>, CargoFetcherError> {
+    let krate_fingerprint = fingerprint_krate(krate)?;
+    if let Some(digest_bytes) = self
+      .krate_digest_mapping
+      .load_bytes_with(krate_fingerprint, |bytes| {
+        Ok(Bytes::copy_from_slice(&bytes[..]))
+      })
+      .await?
+    {
+      let digest_str = str::from_utf8(&digest_bytes)?;
+      let digest: Digest = serde_json::from_str(digest_str)?;
+      Ok(Some(digest))
+    } else {
+      Ok(None)
+    }
+  }
+
+  async fn snapshot_package(
+    &self,
+    krate: &Krate,
+    krate_download_reldir: PathBuf,
+    vfs: &Arc<PosixFS>,
+    digester: &FileDigester,
+  ) -> Result<Digest, CargoFetcherError> {
+    // Check if the krate was previously snapshotted by this method from a separate, usually
+    // previous fetch_packages() invocation.
+    if let Some(digest) = self.lookup_digest(krate).await? {
+      return Ok(digest);
+    }
+
+    // If the krate was not already snapshotted, do so now from the expected download
+    // directory. This will work equally for git and crates.io downloads.
+
+    // 1. Snapshot the untarred contents. This is composed of two steps -- getting all the
+    // PathStats for the download directory contents, then uploading those to the file store.
+    let download_globs = PreparedPathGlobs::create(
+      vec![format!("{}/**", krate_download_reldir.as_path().display())],
+      StrictGlobMatching::Error(format!(
+        "failed to expand the contents of krate {} at {}",
+        krate,
+        krate_download_reldir.as_path().display()
+      )),
+      GlobExpansionConjunction::AllMatch,
+    )?;
+    let path_stats = vfs.expand(download_globs).await?;
+    let snapshot =
+      Snapshot::from_path_stats(self.store.clone(), digester.clone(), path_stats).await?;
+
+    // 2. Enter the digest for the krate into the third lmdb instance so it can be retrieved in
+    // subsequent invocations of this method.
+    let serialized_digest = serde_json::to_string(&snapshot.digest)?;
+    let krate_fingerprint = fingerprint_krate(krate)?;
+    self
+      .krate_digest_mapping
+      .store_bytes(
+        krate_fingerprint,
+        PantsBytes::from(serialized_digest.as_bytes()),
+        true,
+      )
+      .await?;
+
+    Ok(snapshot.digest)
+  }
+}
+
+struct PantsBackend {
+  pub krate_lookup: ShardedLmdb,
+  pub krate_data: ShardedLmdb,
+  pub store: Store,
+  pub executor: Executor,
+  pub download_dir: PathBuf,
+  // FIXME: this appears to be a leaky implementation detail of the cargo-fetcher crate.
+  pub prefix: String,
+}
+
+impl fmt::Debug for PantsBackend {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "PantsBackend(prefix = {}, krate_data = ...)",
+      self.prefix
+    )
+  }
+}
+
+impl PantsBackend {
+  fn prefix_len(&self) -> usize {
+    self.prefix.len()
+  }
+}
+
+#[async_trait]
+impl cargo_fetcher::Backend for PantsBackend {
+  async fn fetch(&self, krate: &Krate) -> Result<Bytes, anyhow::Error> {
+    let krate_fingerprint = fingerprint_krate(krate)?;
+    self
+      .krate_data
+      .load_bytes_with(krate_fingerprint, |bytes| {
+        Ok(Bytes::copy_from_slice(&bytes[..]))
+      })
+      .await
+      .map_err(anyhow::Error::msg)?
+      .ok_or_else(|| anyhow::Error::msg(format!("krate {:?} not found!", krate)))
+  }
+
+  async fn upload(&self, source: Bytes, krate: &Krate) -> Result<usize, anyhow::Error> {
+    let source = PantsBytes::from(&source[..]);
+    let len = source.len();
+    let krate_fingerprint = fingerprint_krate(krate)?;
+
+    // 1. Serialize the krate to json and store that in a separate table than the package contents
+    // table. This will be consumed by list().
+    let krate_json = serde_json::to_string(krate)?;
+    self
+      .krate_lookup
+      .store_bytes(
+        krate_fingerprint,
+        PantsBytes::from(krate_json.as_bytes()),
+        false,
+      )
+      .await
+      .map_err(anyhow::Error::msg)?;
+
+    // 2. Using the same key, store the package bytes into the package contents table. This will be
+    // consumed by fetch().
+    self
+      .krate_data
+      .store_bytes(krate_fingerprint, source, false)
+      .await
+      .map_err(anyhow::Error::msg)?;
+
+    Ok(len)
+  }
+
+  async fn list(&self) -> Result<Vec<String>, anyhow::Error> {
+    let keys_as_bytes: Vec<&[u8]> = self
+      .krate_lookup
+      .all_entry_keys()
+      .await
+      .map_err(anyhow::Error::msg)?;
+
+    let krates_as_bytes: Vec<PantsBytes> = join_all(keys_as_bytes.into_iter().map(|key| {
+      let fp = VersionedFingerprint::from_bytes_unsafe(key);
+      self
+        .krate_lookup
+        .load_bytes_with(fp.get_fingerprint(), |bytes| {
+          Ok(PantsBytes::from(&bytes[..]))
+        })
+    }))
+    .await
+    .into_iter()
+    .map(|maybe_bytes| maybe_bytes.map(|bytes| bytes.unwrap()))
+    .collect::<Result<Vec<PantsBytes>, String>>()
+    .map_err(|e| anyhow::Error::msg(format!("{:?}", e)))?;
+
+    let pfx_len = self.prefix_len();
+    let ret: Vec<String> = krates_as_bytes
+      .into_iter()
+      .map(|krate_bytes| {
+        let krate_str = str::from_utf8(&krate_bytes[..]).map_err(|e| format!("{:?}", e))?;
+        let krate: Krate = serde_json::from_str(krate_str).map_err(|e| format!("{:?}", e))?;
+        let ret: String = krate.name[pfx_len..].to_owned();
+        Ok(ret)
+      })
+      .collect::<Result<Vec<String>, String>>()
+      .map_err(anyhow::Error::msg)?;
+    Ok(ret)
+  }
+
+  async fn updated(
+    &self,
+    krate: &Krate,
+  ) -> Result<Option<chrono::DateTime<chrono::Utc>>, anyhow::Error> {
+    let krate_fingerprint = fingerprint_krate(krate)?;
+    Ok(
+      self
+        .krate_data
+        .get_lease_time(krate_fingerprint)
+        .map_err(anyhow::Error::msg)?
+        .map(|unix_time: u64| {
+          // FIXME: why does this `chrono` package read time as an i64 instead of a u64 like the
+          // stdlib???
+          let native_time = chrono::NaiveDateTime::from_timestamp(unix_time as i64, 0);
+          chrono::DateTime::<chrono::Utc>::from_utc(native_time, chrono::Utc)
+        }),
+    )
+  }
+
+  fn set_prefix(&mut self, prefix: &str) {
+    self.prefix = prefix.to_owned();
+  }
+}

--- a/src/rust/engine/cargo_util/src/cargo_fetcher_tests.rs
+++ b/src/rust/engine/cargo_util/src/cargo_fetcher_tests.rs
@@ -1,0 +1,153 @@
+use crate::cargo_fetcher::*;
+
+use fs;
+use sharded_lmdb::ShardedLmdb;
+use store::Store;
+use task_executor::Executor;
+
+use cargo_fetcher;
+use tempfile::TempDir;
+use tokio::runtime::Handle;
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+fn new_executor() -> Executor {
+  Executor::new(Handle::current())
+}
+
+fn new_store<P: AsRef<Path>>(dir: P, executor: Executor) -> Store {
+  Store::local_only(executor, &dir).unwrap()
+}
+
+struct Environment {
+  executor: Executor,
+  #[allow(dead_code)]
+  temp_dir: TempDir,
+}
+
+// 50 MB - I didn't pick that number but it seems reasonable.
+const MAX_LMDB_SIZE: usize = 50 * 1024 * 1024;
+
+impl Environment {
+  pub fn new() -> io::Result<Self> {
+    Ok(Environment {
+      executor: new_executor(),
+      temp_dir: TempDir::new()?,
+    })
+  }
+
+  fn root_dir(&self) -> PathBuf {
+    self.temp_dir.path().to_path_buf()
+  }
+
+  fn download_dir(&self) -> PathBuf {
+    let ret = self.root_dir().join("downloads");
+    fs::safe_create_dir_all(&ret).unwrap();
+    ret
+  }
+
+  pub fn index_download_dir(&self) -> PathBuf {
+    self.download_dir().join(registry_index_reldir())
+  }
+
+  fn store(&self) -> Store {
+    new_store(&self.root_dir(), self.executor.clone())
+  }
+
+  fn new_lmdb<P: AsRef<Path>>(&self, relative_dir: P) -> ShardedLmdb {
+    let dir = self.root_dir().join(relative_dir.as_ref());
+    fs::safe_create_dir_all(&dir).unwrap();
+    ShardedLmdb::new(dir, MAX_LMDB_SIZE, self.executor.clone()).unwrap()
+  }
+
+  fn krate_lookup(&self) -> ShardedLmdb {
+    self.new_lmdb("krate_lookup")
+  }
+
+  fn krate_data(&self) -> ShardedLmdb {
+    self.new_lmdb("krate_data")
+  }
+
+  fn krate_digest_mapping(&self) -> ShardedLmdb {
+    self.new_lmdb("krate_digest_mapping")
+  }
+
+  fn fetch_cache(&self) -> ShardedLmdb {
+    self.new_lmdb("fetch_cache")
+  }
+
+  pub fn make_fetcher(&self) -> CargoPackageFetcher {
+    CargoPackageFetcher {
+      krate_lookup: self.krate_lookup(),
+      krate_data: self.krate_data(),
+      krate_digest_mapping: self.krate_digest_mapping(),
+      fetch_cache: self.fetch_cache(),
+      store: self.store(),
+      executor: self.executor.clone(),
+      download_dir: self.download_dir(),
+      timeout: Duration::from_secs(10),
+    }
+  }
+}
+
+#[tokio::test]
+async fn fetch_package() {
+  let environment = Environment::new().unwrap();
+  let fetcher = environment.make_fetcher();
+
+  // This is a known-good sha for this version of the bytes crate.
+  let bytes_krate = Krate {
+    name: "bytes".to_string(),
+    version: "0.5.4".to_string(),
+    source: cargo_fetcher::Source::CratesIo(
+      "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1".to_string(),
+    ),
+  };
+
+  let result = fetcher
+    .fetch_packages(&[bytes_krate.clone()])
+    .await
+    .unwrap();
+
+  // Check that the recorded registry revision was the same as in the actual checked-out git dir for
+  // the registry.
+  let index_download_dir = environment.index_download_dir();
+  assert_eq!(
+    result.registry_index_revision(),
+    get_registry_git_revision(index_download_dir, fetcher.executor.clone())
+      .await
+      .unwrap(),
+  );
+
+  // Check that the registry digest was uploaded to the store.
+  let registry_digest = fetcher
+    .lookup_digest(&result.current_registry_index_krate)
+    .await
+    .unwrap()
+    .unwrap();
+  assert!(fetcher
+    .store
+    .load_directory(registry_digest)
+    .await
+    .unwrap()
+    .is_some());
+
+  // Check that the `bytes` crate was uploaded to the store.
+  let bytes_digest = fetcher.lookup_digest(&bytes_krate).await.unwrap().unwrap();
+  assert!(fetcher
+    .store
+    .load_directory(bytes_digest)
+    .await
+    .unwrap()
+    .is_some());
+
+  // Check that the cache for the fetch was populated, so we won't have to make any network calls at
+  // all if we've run this resolve before.
+  assert!(fetcher
+    .try_cached_fetch(&[bytes_krate.clone()])
+    .await
+    .unwrap()
+    .is_some());
+}

--- a/src/rust/engine/cargo_util/src/main.rs
+++ b/src/rust/engine/cargo_util/src/main.rs
@@ -1,0 +1,172 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+// We only use unsafe pointer dereferences in our no_mangle exposed API, but it is nicer to list
+// just the one minor call as unsafe, than to mark the whole function as unsafe which may hide
+// other unsafeness.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+pub mod cargo_fetcher;
+#[cfg(test)]
+mod cargo_fetcher_tests;
+
+use sharded_lmdb::ShardedLmdb;
+use store::Store;
+
+use clap::{App, Arg, SubCommand};
+use tokio::runtime::Handle;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const MEGABYTES: usize = 1024 * 1024;
+const GIGABYTES: usize = MEGABYTES * 1024;
+const LEASE_DURATION: Duration = Duration::from_secs(100000);
+
+#[tokio::main]
+async fn main() -> Result<(), cargo_fetcher::CargoFetcherError> {
+  env_logger::init();
+
+  let default_store_path = format!("{}", Store::default_path().display());
+
+  let arg_match = App::new("cargo_fetcher")
+    .arg(
+      Arg::with_name("local_store_dir")
+        .required(false)
+        .takes_value(true)
+        .default_value(&default_store_path)
+        .help("???"),
+    )
+    .subcommand(
+      SubCommand::with_name("fetch").about("???").arg(
+        Arg::with_name("cargo_lockfile")
+          .required(true)
+          .takes_value(true)
+          .help("???"),
+      ),
+    )
+    .get_matches();
+
+  let local_store_dir = arg_match
+    .value_of("local_store_dir")
+    .map(PathBuf::from)
+    .unwrap();
+
+  let runtime = task_executor::Executor::new(Handle::current());
+  let store = Store::local_only(runtime.clone(), &local_store_dir)?;
+
+  match arg_match.subcommand() {
+    ("fetch", Some(arg_match)) => {
+      let cargo_lockfile = arg_match
+        .value_of("cargo_lockfile")
+        .map(PathBuf::from)
+        .unwrap();
+
+      let cargo_krate_dir = local_store_dir.join("cargo_crate_data");
+      fs::create_dir_all(&cargo_krate_dir)?;
+      let cargo_krate_lookup = ShardedLmdb::new(
+        cargo_krate_dir,
+        5 * MEGABYTES,
+        runtime.clone(),
+        LEASE_DURATION,
+      )
+      .map_err(|err| {
+        format!(
+          "Could not initialize store for cargo krate lookup: {:?}",
+          err
+        )
+      })?;
+
+      let cargo_packages_dir = local_store_dir.join("cargo_packages");
+      fs::create_dir_all(&cargo_packages_dir)?;
+      let cargo_krate_data = ShardedLmdb::new(
+        cargo_packages_dir,
+        5 * GIGABYTES,
+        runtime.clone(),
+        LEASE_DURATION,
+      )
+      .map_err(|err| format!("Could not initialize store for cargo krate data: {:?}", err))?;
+
+      let cargo_krate_digest_dir = local_store_dir.join("cargo_krate_digest_mapping");
+      fs::create_dir_all(&cargo_krate_digest_dir)?;
+      let cargo_krate_digest_mapping = ShardedLmdb::new(
+        cargo_krate_digest_dir,
+        5 * MEGABYTES,
+        runtime.clone(),
+        LEASE_DURATION,
+      )
+      .map_err(|err| {
+        format!(
+          "Could not initialize store for cargo krate digest mapping: {:?}",
+          err
+        )
+      })?;
+
+      let cargo_fetch_dir = local_store_dir.join("cargo_fetch_cache");
+      fs::create_dir_all(&cargo_fetch_dir)?;
+      let cargo_fetch_cache = ShardedLmdb::new(
+        cargo_fetch_dir,
+        5 * GIGABYTES,
+        runtime.clone(),
+        LEASE_DURATION,
+      )
+      .map_err(|err| {
+        format!(
+          "Could not initialize store for cargo fetch cache: {:?}",
+          err
+        )
+      })?;
+
+      let cargo_download_dir = local_store_dir.join("cargo_download_dir");
+      fs::create_dir_all(&cargo_download_dir)?;
+      let cargo_fetcher = cargo_fetcher::CargoPackageFetcher {
+        krate_lookup: cargo_krate_lookup,
+        krate_data: cargo_krate_data,
+        krate_digest_mapping: cargo_krate_digest_mapping,
+        fetch_cache: cargo_fetch_cache,
+        store: store.clone(),
+        executor: runtime.clone(),
+        download_dir: cargo_download_dir,
+        timeout: Duration::from_secs(10),
+      };
+
+      let metadata_contents = fs::read_to_string(&cargo_lockfile).map_err(|err| {
+        format!(
+          "failed to read cargo lockfile {:?}: {:?}",
+          &cargo_lockfile, err
+        )
+      })?;
+
+      let fetch_result = cargo_fetcher
+        .fetch_packages_from_lockfile(&metadata_contents)
+        .await?;
+      println!("{}", fetch_result.to_json()?);
+    }
+    x => unimplemented!("unrecognized command {:?}", x),
+  }
+  Ok(())
+}


### PR DESCRIPTION
## NOT FOR MERGING
It should be possible to refactor this binary to read and write to the filesystem, and to avoid having any dependency on `ShardedLmdb` instances or the pants file store. We should be able to do this as a modification to the `cargo-fetcher` crate.

[ci skip-jvm-tests]

### Problem

In #9781, we want to introduce a rust backend to pants. There is a fantastic crate called [`cargo-fetcher`](https://github.com/EmbarkStudios/cargo-fetcher) which will allow us to resolve rust dependencies in a cacheable, remoting-friendly way. We initially tried to create a rust intrinsic to bridge our wrapper around the `cargo-fetcher` crate to the rust backend, but then @stuhood noted in https://github.com/pantsbuild/pants/pull/9781#discussion_r426062455 that we could instead bridge the rust crate to a our rust `@rule` backend by making `cargo-fetcher` into a standalone binary.

### Solution

- Create `cargo_fetcher.rs` exporting the `CargoPackageFetcher` struct to wrap the `cargo-fetcher` crate.
- Create the `cargo_util` standalone binary which consumes a `Cargo.lock` file and resolves all of the dependencies, storing their contents in the pants LMDB store and printing a json blob with a content-addressed mapping of `(crate info) -> (digest)`.

### Result

A `cargo_util` binary now exists which can resolve rust dependencies with:
```bash
> ./src/rust/engine/target/debug/cargo_util fetch src/rust/engine/Cargo.lock | jq
...
    "{\"name\":\"zstd-safe\",\"version\":\"2.0.4+zstd.1.4.5\",\"source\":{\"CratesIo\":\"7113c0c9aed2c55181f2d9f5b0a36e7d2c0183b11c058ab40b35987479efe4d7\"}}": {
      "fingerprint": "ca0c9d28850d339c713a1e340e75fa2ef599b4382b4efa351469aa1b7fbbf88b",
      "size_bytes": 82
    },
    "{\"name\":\"zstd-sys\",\"version\":\"1.4.16+zstd.1.4.5\",\"source\":{\"CratesIo\":\"c442965efc45353be5a9b9969c9b0872fff6828c7e06d118dda2cb2d0bb11d5a\"}}": {
      "fingerprint": "2365f4f02caf52aca28c7b341ebf0c55f0093826865201410f65e7608db36656",
      "size_bytes": 82
    }
  }
}
```