### PR TITLE
Add py3.8 to PythonVersion enum.

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -73,6 +73,7 @@ def main() -> None:
 class PythonVersion(Enum):
     py36 = "3.6"
     py37 = "3.7"
+    py38 = "3.8"
 
     def __str__(self) -> str:
         return str(self.value)


### PR DESCRIPTION
### Problem

Night CI build fails because of missing value in enum.
Python 3.8 was added to nightly build here: https://github.com/pantsbuild/pants/pull/9881
<img width="1008" alt="Screen Shot 2020-06-05 at 12 39 17 AM" src="https://user-images.githubusercontent.com/1268088/83849917-fefcc280-a6c4-11ea-869e-4c8c97a1aa54.png">
https://travis-ci.com/github/pantsbuild/pants/jobs/343972610#L868

### Solution

Add missing value


### Result

Nightly CI build will be able to run and become green.