### PR TITLE
Support for marking source roots via a specially-named file.

### DIFF
--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pathlib import PurePath
 from typing import Set
 
 from pants.engine.console import Console
@@ -42,7 +43,9 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
 
     # Match the patterns against actual files, to find the roots that actually exist.
     snapshot = await Get[Snapshot](PathGlobs(globs=sorted(all_paths)))
-    responses = await MultiGet(Get[OptionalSourceRoot](SourceRootRequest(d)) for d in snapshot.dirs)
+    responses = await MultiGet(
+        Get[OptionalSourceRoot](SourceRootRequest(PurePath(d))) for d in snapshot.dirs
+    )
     all_source_roots = {
         response.source_root for response in responses if response.source_root is not None
     }

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -5,10 +5,12 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Optional, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple, Union
 
 from pants.engine.collection import Collection
+from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.rules import RootRule, SubsystemRule, rule
+from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
 
@@ -33,10 +35,14 @@ class InvalidSourceRootPatternError(SourceRootError):
     """Indicates an invalid pattern was provided."""
 
 
+class InvalidMarkerFileError(SourceRootError):
+    """Indicates an invalid marker file was provided."""
+
+
 class NoSourceRootError(SourceRootError):
     """Indicates we failed to map a source file to a source root."""
 
-    def __init__(self, path: str, extra_msg: str = ""):
+    def __init__(self, path: Union[str, PurePath], extra_msg: str = ""):
         super().__init__(f"No source root found for `{path}`. {extra_msg}")
 
 
@@ -62,26 +68,15 @@ class SourceRootPatternMatcher:
     def get_patterns(self) -> Tuple[str, ...]:
         return tuple(self.root_patterns)
 
-    def _match_root_patterns(self, putative_root: PurePath) -> bool:
+    def matches_root_patterns(self, relpath: PurePath) -> bool:
+        """Does this putative root match a pattern?"""
+        # Note: This is currently O(n) where n is the number of patterns, which
+        # we expect to be small.  We can optimize if it becomes necessary.
+        putative_root = _repo_root / relpath
         for pattern in self.root_patterns:
             if putative_root.match(pattern):
                 return True
         return False
-
-    def find_root(self, relpath: str) -> Optional[PurePath]:
-        """Return the source root for the given path, relative to the repo root."""
-        # Note: This is currently O(n) where n is the number of patterns, which
-        # we expect to be small.  We can optimize if it becomes necessary.
-        if ".." in relpath.split(os.path.sep):
-            raise NoSourceRootError(relpath, "`..` disallowed in source root searches. ")
-        putative_root = _repo_root / relpath
-        while putative_root != _repo_root:
-            if self._match_root_patterns(putative_root):
-                return putative_root.relative_to(_repo_root)
-            putative_root = putative_root.parent
-        if self._match_root_patterns(putative_root):
-            return putative_root.relative_to(_repo_root)
-        return None
 
 
 class SourceRoots:
@@ -121,13 +116,25 @@ class SourceRoots:
         :return: A SourceRoot instance, or None if the path is not located under a source root
                  and `unmatched == fail`.
         """
-        matched_path = self._pattern_matcher.find_root(path)
+        matched_path = self._find_root(PurePath(path))
         if matched_path:
             return SourceRoot(path=str(matched_path))
         if self._fail_if_unmatched:
             return None
         # If no source root is found, use the path directly.
         return SourceRoot(path)
+
+    def _find_root(self, relpath: PurePath) -> Optional[PurePath]:
+        """Return the source root for the given path, relative to the repo root."""
+
+        putative_root = _repo_root / relpath
+        while putative_root != _repo_root:
+            if self._pattern_matcher.matches_root_patterns(putative_root):
+                return putative_root.relative_to(_repo_root)
+            putative_root = putative_root.parent
+        if self._pattern_matcher.matches_root_patterns(putative_root):
+            return putative_root.relative_to(_repo_root)
+        return None
 
     def get_patterns(self) -> Set[str]:
         return set(self._pattern_matcher.get_patterns())
@@ -172,6 +179,19 @@ class SourceRootConfig(Subsystem):
             "See https://pants.readme.io/docs/source-roots.",
         )
 
+        register(
+            "--marker-filename",
+            metavar="filename",
+            type=str,
+            fingerprint=True,
+            default=None,
+            advanced=True,
+            help="The presence of a file of this name in a directory indicates that the directory "
+            "is a source root.  The content of the file doesn't matter, and may be empty. "
+            "Useful when you can't or don't wish to centrally enumerate source roots via "
+            "--root-patterns.",
+        )
+
     @memoized_method
     def get_pattern_matcher(self) -> SourceRootPatternMatcher:
         return SourceRootPatternMatcher(self.options.root_patterns)
@@ -186,14 +206,14 @@ class SourceRootConfig(Subsystem):
 class SourceRootRequest:
     """Find the source root for the given path."""
 
-    path: str
+    path: PurePath
 
     @classmethod
     def for_file(cls, file_path: str) -> "SourceRootRequest":
         """Create a request for the source root for the given file."""
         # The file itself cannot be a source root, so we may as well start the search
         # from its enclosing directory, and save on some superfluous checking.
-        return cls(str(PurePath(file_path).parent))
+        return cls(PurePath(file_path).parent)
 
 
 @dataclass(frozen=True)
@@ -202,31 +222,59 @@ class OptionalSourceRoot:
 
 
 @rule
-def get_source_root(
+async def get_source_root(
     source_root_request: SourceRootRequest, source_root_config: SourceRootConfig
 ) -> OptionalSourceRoot:
     """Rule to request a SourceRoot that may not exist."""
-    matched_path = source_root_config.get_pattern_matcher().find_root(source_root_request.path)
-    if matched_path:
-        return OptionalSourceRoot(SourceRoot(path=str(matched_path)))
-    else:
-        return OptionalSourceRoot(None)
+    if ".." in str(source_root_request):
+        raise NoSourceRootError(
+            str(source_root_request), "`..` disallowed in source root searches. "
+        )
+
+    pattern_matcher = source_root_config.get_pattern_matcher()
+    # Ensure a relpath.
+    path = source_root_request.path
+    relpath = path.relative_to(_repo_root) if path.is_absolute() else path
+
+    # Check if the requested path itself is a source root.
+
+    # A) Does it match a pattern?
+    if pattern_matcher.matches_root_patterns(relpath):
+        return OptionalSourceRoot(SourceRoot(str(relpath)))
+
+    # B) Does it contain a marker file?
+    marker_filename = source_root_config.options.marker_filename
+    if marker_filename:
+        if (
+            os.path.basename(marker_filename) != marker_filename
+            or "*" in marker_filename
+            or "!" in marker_filename
+        ):
+            raise InvalidMarkerFileError(f"Marker filename must be a base name: {marker_filename}")
+        # TODO: An intrinsic to check file existence at a fixed path?
+        snapshot = await Get[Snapshot](PathGlobs([str(relpath / marker_filename)]))
+        if len(snapshot.files) > 0:
+            return OptionalSourceRoot(SourceRoot(str(relpath)))
+
+    # The requested path itself is not a source root, but maybe its parent is.
+    if str(relpath) != ".":
+        return await Get[OptionalSourceRoot](SourceRootRequest(relpath.parent))
+
+    # The requested path is not under a source root.
+    return OptionalSourceRoot(None)
 
 
 @rule
-def get_source_root_strict(
-    source_root_request: SourceRootRequest, source_root_config: SourceRootConfig
-) -> SourceRoot:
+async def get_source_root_strict(source_root_request: SourceRootRequest) -> SourceRoot:
     """Convenience rule to allow callers to request a SourceRoot directly.
 
     That way callers don't have to unpack an OptionalSourceRoot if they know they expect a
     SourceRoot to exist and are willing to error if it doesn't.
     """
-    matched_path = source_root_config.get_pattern_matcher().find_root(source_root_request.path)
-    if matched_path:
-        return SourceRoot(path=str(matched_path))
-    else:
+    optional_source_root = await Get[OptionalSourceRoot](SourceRootRequest, source_root_request)
+    if optional_source_root.source_root is None:
         raise NoSourceRootError(source_root_request.path)
+    return optional_source_root.source_root
 
 
 def rules():

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -1,44 +1,140 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import os
 from pathlib import PurePath
+from typing import Iterable, Optional
 
 import pytest
 
-from pants.source.source_root import NoSourceRootError, SourceRootPatternMatcher
+from pants.engine.fs import Digest, PathGlobs, Snapshot
+from pants.source.source_root import (
+    NoSourceRootError,
+    OptionalSourceRoot,
+    SourceRootConfig,
+    SourceRootRequest,
+    get_source_root,
+)
+from pants.testutil.engine.util import MockGet, create_subsystem, run_rule
+
+
+def _find_root(
+    path: str,
+    patterns: Iterable[str],
+    marker_filename: str = None,
+    existing_marker_files: Iterable[str] = None,
+) -> Optional[str]:
+    # This inner function is passed as the callable to the mock, to allow recursion in the rule.
+    def _mock_fs_check(pathglobs: PathGlobs) -> Snapshot:
+        if pathglobs.globs[0] in existing_marker_files:
+            d, f = os.path.split(pathglobs.globs[0])
+            return Snapshot(digest=Digest("111", 111), files=(f,), dirs=(d,))
+        return Snapshot(digest=Digest("000", 000), files=tuple(), dirs=tuple())
+
+    def _do_find_root(src_root_req: SourceRootRequest) -> OptionalSourceRoot:
+        return run_rule(
+            get_source_root,
+            rule_args=[
+                src_root_req,
+                create_subsystem(
+                    SourceRootConfig, root_patterns=list(patterns), marker_filename=marker_filename
+                ),
+            ],
+            mock_gets=[
+                MockGet(
+                    product_type=OptionalSourceRoot,
+                    subject_type=SourceRootRequest,
+                    mock=_do_find_root,
+                ),
+                MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=_mock_fs_check),
+            ],
+        )
+
+    source_root = _do_find_root(SourceRootRequest(PurePath(path))).source_root
+    return None if source_root is None else source_root.path
 
 
 def test_source_root_at_buildroot() -> None:
-    srpm = SourceRootPatternMatcher(("/",))
-    assert PurePath(".") == srpm.find_root("foo/bar.py")
-    assert PurePath(".") == srpm.find_root("foo/")
-    assert PurePath(".") == srpm.find_root("foo")
+    def find_root(path):
+        return _find_root(path, ("/",))
+
+    assert "." == find_root("foo/bar.py")
+    assert "." == find_root("foo/")
+    assert "." == find_root("foo")
     with pytest.raises(NoSourceRootError):
-        srpm.find_root("../foo/bar.py")
+        find_root("../foo/bar.py")
 
 
 def test_fixed_source_roots() -> None:
-    srpm = SourceRootPatternMatcher(("/root1", "/foo/root2", "/root1/root3"))
-    assert PurePath("root1") == srpm.find_root("root1/bar.py")
-    assert PurePath("foo/root2") == srpm.find_root("foo/root2/bar/baz.py")
-    assert PurePath("root1/root3") == srpm.find_root("root1/root3/qux.py")
-    assert PurePath("root1/root3") == srpm.find_root("root1/root3/qux/quux.py")
-    assert PurePath("root1/root3") == srpm.find_root("root1/root3")
-    assert srpm.find_root("blah/blah.py") is None
+    def find_root(path):
+        return _find_root(path, ("/root1", "/foo/root2", "/root1/root3"))
+
+    assert "root1" == find_root("root1/bar.py")
+    assert "foo/root2" == find_root("foo/root2/bar/baz.py")
+    assert "root1/root3" == find_root("root1/root3/qux.py")
+    assert "root1/root3" == find_root("root1/root3/qux/quux.py")
+    assert "root1/root3" == find_root("root1/root3")
+    assert find_root("blah/blah.py") is None
 
 
 def test_source_root_suffixes() -> None:
-    srpm = SourceRootPatternMatcher(("src/python", "/"))
-    assert PurePath("src/python") == srpm.find_root("src/python/foo/bar.py")
-    assert PurePath("src/python/foo/src/python") == srpm.find_root(
-        "src/python/foo/src/python/bar.py"
-    )
-    assert PurePath(".") == srpm.find_root("foo/bar.py")
+    def find_root(path):
+        return _find_root(path, ("src/python", "/"))
+
+    assert "src/python" == find_root("src/python/foo/bar.py")
+    assert "src/python/foo/src/python" == find_root("src/python/foo/src/python/bar.py")
+    assert "." == find_root("foo/bar.py")
 
 
 def test_source_root_patterns() -> None:
-    srpm = SourceRootPatternMatcher(("src/*", "/project/*"))
-    assert PurePath("src/python") == srpm.find_root("src/python/foo/bar.py")
-    assert PurePath("src/python/foo/src/shell") == srpm.find_root("src/python/foo/src/shell/bar.sh")
-    assert PurePath("project/python") == srpm.find_root("project/python/foo/bar.py")
-    assert srpm.find_root("prefix/project/python/foo/bar.py") is None
+    def find_root(path):
+        return _find_root(path, ("src/*", "/project/*"))
+
+    assert "src/python" == find_root("src/python/foo/bar.py")
+    assert "src/python/foo/src/shell" == find_root("src/python/foo/src/shell/bar.sh")
+    assert "project/python" == find_root("project/python/foo/bar.py")
+    assert find_root("prefix/project/python/foo/bar.py") is None
+
+
+def test_marker_file() -> None:
+    def find_root(path):
+        return _find_root(
+            path, tuple(), "SOURCE_ROOT", ("project1/SOURCE_ROOT", "project2/src/SOURCE_ROOT",)
+        )
+
+    assert "project1" == find_root("project1/foo/bar.py")
+    assert "project1" == find_root("project1/foo/")
+    assert "project1" == find_root("project1/foo")
+    assert "project1" == find_root("project1/")
+    assert "project1" == find_root("project1")
+    assert "project2/src" == find_root("project2/src/baz/qux.py")
+    assert "project2/src" == find_root("project2/src/baz/")
+    assert "project2/src" == find_root("project2/src/baz")
+    assert "project2/src" == find_root("project2/src/")
+    assert "project2/src" == find_root("project2/src")
+    assert find_root("project3/qux") is None
+    assert find_root("project3/") is None
+    assert find_root("project3") is None
+
+
+def test_marker_file_nested_source_roots() -> None:
+    def find_root(path):
+        return _find_root(
+            path, tuple(), "SOURCE_ROOT", ("SOURCE_ROOT", "project1/src/SOURCE_ROOT",)
+        )
+
+    assert "project1/src" == find_root("project1/src/foo/bar.py")
+    assert "project1/src" == find_root("project1/src/foo")
+    assert "project1/src" == find_root("project1/src")
+    assert "." == find_root("project1")
+    assert "." == find_root("baz/qux.py")
+    assert "." == find_root("baz")
+    assert "." == find_root(".")
+    assert "." == find_root("")
+
+
+def test_marker_file_and_patterns() -> None:
+    def find_root(path):
+        return _find_root(path, ("src/python",), "setup.py", ("project1/setup.py",))
+
+    assert "project1" == find_root("project1/foo/bar.py")
+    assert "project2/src/python" == find_root("project2/src/python/baz/qux.py")

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -64,7 +64,7 @@ def test_source_root_at_buildroot() -> None:
     assert "." == find_root("foo/bar.py")
     assert "." == find_root("foo/")
     assert "." == find_root("foo")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="cannot contain `..` segment: ../foo/bar.py"):
         find_root("../foo/bar.py")
 
 

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -28,6 +28,7 @@ def _find_root(
         root_patterns=list(patterns),
         marker_filenames=list(marker_filenames or []),
     )
+
     # This inner function is passed as the callable to the mock, to allow recursion in the rule.
     def _mock_fs_check(pathglobs: PathGlobs) -> Snapshot:
         for glob in pathglobs.globs:

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -24,9 +24,7 @@ def _find_root(
     existing_marker_files: Iterable[str] = None,
 ) -> Optional[str]:
     source_root_config = create_subsystem(
-        SourceRootConfig,
-        root_patterns=list(patterns),
-        marker_filenames=marker_filenames
+        SourceRootConfig, root_patterns=list(patterns), marker_filenames=marker_filenames
     )
     # This inner function is passed as the callable to the mock, to allow recursion in the rule.
     def _mock_fs_check(pathglobs: PathGlobs) -> Snapshot:
@@ -61,7 +59,7 @@ def test_source_root_at_buildroot() -> None:
     assert "." == find_root("foo/bar.py")
     assert "." == find_root("foo/")
     assert "." == find_root("foo")
-    with pytest.raises(NoSourceRootError):
+    with pytest.raises(ValueError):
         find_root("../foo/bar.py")
 
 
@@ -136,8 +134,10 @@ def test_marker_file_nested_source_roots() -> None:
 def test_multiple_marker_filenames() -> None:
     def find_root(path):
         return _find_root(
-            path, tuple(), ("SOURCE_ROOT", "setup.py"),
-            ("project1/javasrc/SOURCE_ROOT", "project2/setup.py",)
+            path,
+            tuple(),
+            ("SOURCE_ROOT", "setup.py"),
+            ("project1/javasrc/SOURCE_ROOT", "project2/setup.py",),
         )
 
     assert "project1/javasrc" == find_root("project1/javasrc/foo/bar.java")


### PR DESCRIPTION
In some python repos, existing setup.py files might already
mark source roots, or you can pick your own name, e.g.,
SOURCE_ROOT or .source_root, and use an empty file.

This is useful in large repos containing many small projects,
each with their own source root, if you don't want to enumerate
those in the central config.

[ci skip-rust-tests]
[ci skip-jvm-tests]
