### PR TITLE
Reuse report_type

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -376,9 +376,9 @@ async def generate_coverage_report(
     report_dir = PurePath(coverage_subsystem.options.report_output_path)
 
     report_file: Optional[PurePath] = None
-    if coverage_subsystem.options.report == ReportType.HTML:
+    if report_type == ReportType.HTML:
         report_file = report_dir / "htmlcov" / "index.html"
-    elif coverage_subsystem.options.report == ReportType.XML:
+    elif report_type == ReportType.XML:
         report_file = report_dir / "coverage.xml"
 
     return FilesystemCoverageReport(


### PR DESCRIPTION
### Problem

We extract coverage_subsystem.options.report into a local variable earlier in the function/rule.
<img width="799" alt="Screen Shot 2020-06-05 at 1 28 23 PM" src="https://user-images.githubusercontent.com/1268088/83919892-7156bc80-a730-11ea-8aa2-84676ffe5cca.png">
### Solution

Reuse existing variable.

### Result

Readable code/less code

