### PR TITLE
remoting: more unit tests and fix an edge case

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -31,7 +31,7 @@ use workunit_store::WorkunitStore;
 
 // Streaming client module. Intended as an eventual repalcement for the CommandRunner in this
 // module.
-mod streaming;
+pub(crate) mod streaming;
 pub use streaming::StreamingCommandRunner;
 #[cfg(test)]
 mod streaming_tests;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -132,6 +132,7 @@ pub enum ExecutionError {
   // Digests are Files and Directories which have been reported to be missing. May be incomplete.
   MissingDigests(Vec<Digest>),
   // String is the operation name which can be used to poll the GetOperation gRPC API.
+  // Note: Unused by the streaming client.
   NotFinished(String),
   // String is the error message.
   Retryable(String),

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -339,7 +339,8 @@ impl StreamingCommandRunner {
     ExecutionError::MissingDigests(missing_digests)
   }
 
-  async fn extract_execute_response(
+  // pub(crate) for testing
+  pub(crate) async fn extract_execute_response(
     &self,
     operation_or_status: OperationOrStatus,
   ) -> Result<FallibleProcessResultWithPlatform, ExecutionError> {

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -54,6 +54,11 @@ pub struct StreamingCommandRunner {
   execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
 }
 
+enum StreamOutcome {
+  Complete(OperationOrStatus),
+  StreamClosed(Option<String>),
+}
+
 impl StreamingCommandRunner {
   /// Construct a new StreamingCommandRunner
   pub fn new(
@@ -145,11 +150,7 @@ impl StreamingCommandRunner {
   // Outputs progress reported by the server and returns the next actionable operation
   // or gRPC status back to the main loop (plus the operation name so the main loop can
   // reconnect).
-  async fn wait_on_operation_stream<S>(
-    &self,
-    mut stream: S,
-    build_id: &str,
-  ) -> (Option<String>, OperationOrStatus)
+  async fn wait_on_operation_stream<S>(&self, mut stream: S, build_id: &str) -> StreamOutcome
   where
     S: Stream<Item = Result<bazel_protos::operations::Operation, grpcio::Error>> + Unpin,
   {
@@ -181,13 +182,13 @@ impl StreamingCommandRunner {
           }
 
           // Otherwise, return to the main loop with the operation as the result.
-          return (operation_name_opt, OperationOrStatus::Operation(operation));
+          return StreamOutcome::Complete(OperationOrStatus::Operation(operation));
         }
 
         Some(Err(err)) => {
           debug!("wait_on_operation_stream: got error: {:?}", err);
           match super::rpcerror_to_status_or_string(&err) {
-            Ok(status) => return (None, OperationOrStatus::Status(status)),
+            Ok(status) => return StreamOutcome::Complete(OperationOrStatus::Status(status)),
             Err(message) => {
               let code = match err {
                 grpcio::Error::RpcFailure(rpc_status) => rpc_status.status,
@@ -196,19 +197,15 @@ impl StreamingCommandRunner {
               let mut status = bazel_protos::status::Status::new();
               status.set_code(code.into());
               status.set_message(format!("gRPC error: {}", message));
-              return (operation_name_opt, OperationOrStatus::Status(status));
+              return StreamOutcome::Complete(OperationOrStatus::Status(status));
             }
           }
         }
 
         None => {
-          // Stream disconnected unexpectedly. Return a synthetic UNAVAILABLE status so that the
-          // main loop will reconnect with the WaitExecution method.
+          // Stream disconnected unexpectedly.
           debug!("wait_on_operation_stream: unexpected disconnect from RE server");
-          let mut status = bazel_protos::status::Status::new();
-          status.set_code(grpcio::RpcStatusCode::UNAVAILABLE.into());
-          status.set_message("stream disconnected unexpectedly".to_owned());
-          return (operation_name_opt, OperationOrStatus::Status(status));
+          return StreamOutcome::StreamClosed(operation_name_opt);
         }
       }
     }
@@ -504,17 +501,25 @@ impl StreamingCommandRunner {
           // Monitor the operation stream until there is an actionable operation
           // or status to interpret.
           let compat_stream = operation_stream.compat();
-          let (operation_name_opt, actionable_result) = self
+          let stream_outcome = self
             .wait_on_operation_stream(compat_stream, &context.build_id)
             .await;
-          trace!("wait_on_operation_stream (build_id={}) returned: operation_name_opt={:?}; actionable_result={:?}", context.build_id, operation_name_opt, actionable_result);
 
-          // Save the operation name in case we need to reconnect via WaitExecution.
-          if let Some(name) = operation_name_opt {
-            current_operation_name = Some(name);
+          match stream_outcome {
+            StreamOutcome::Complete(status) => {
+              trace!(
+                "wait_on_operation_stream (build_id={}) returned completion={:?}",
+                context.build_id,
+                status
+              );
+              status
+            }
+            StreamOutcome::StreamClosed(operation_name_opt) => {
+              trace!("wait_on_operation_stream (build_id={}) returned stream close, will retry operation_name={:?}", context.build_id, operation_name_opt);
+              current_operation_name = operation_name_opt;
+              continue;
+            }
           }
-
-          actionable_result
         }
         Err(err) => match err {
           grpcio::Error::RpcFailure(rpc_status) => {

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -2,20 +2,28 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use hashing::EMPTY_DIGEST;
+use maplit::btreemap;
 use mock::execution_server::ExpectedAPICall;
+use protobuf::Message;
+use spectral::assert_that;
+use spectral::hashmap::HashMapAssertions;
+use spectral::string::StrAssertions;
+use spectral::vec::VecAssertions;
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
+use testutil::owned_string_vec;
 use tokio::runtime::Handle;
 
-use crate::remote::StreamingCommandRunner;
+use crate::remote::{ExecutionError, OperationOrStatus, StreamingCommandRunner};
 use crate::remote_tests::{
   assert_cancellation_requests, echo_foo_request, empty_request_metadata,
   make_incomplete_operation, make_retryable_operation_failure, make_store,
   make_successful_operation, RemoteTestResult, StderrType, StdoutType,
 };
-use crate::CommandRunner;
-use crate::{Context, MultiPlatformProcess, Platform};
+use crate::{CommandRunner, Context, MultiPlatformProcess, Platform, Process};
+use std::time::Duration;
+use workunit_store::WorkunitStore;
 
 fn create_command_runner(
   address: String,
@@ -59,6 +67,41 @@ async fn run_command_remote(
     .await?
     .unwrap()
     .0;
+  Ok(RemoteTestResult {
+    original,
+    stdout_bytes,
+    stderr_bytes,
+  })
+}
+
+async fn extract_execute_response(
+  operation: bazel_protos::operations::Operation,
+  remote_platform: Platform,
+) -> Result<RemoteTestResult, ExecutionError> {
+  let cas = mock::StubCAS::builder()
+    .file(&TestData::roland())
+    .directory(&TestDirectory::containing_roland())
+    .build();
+  let (command_runner, store) = create_command_runner("".to_owned(), &cas, remote_platform);
+
+  let original = command_runner
+    .extract_execute_response(OperationOrStatus::Operation(operation))
+    .await?;
+
+  let stdout_bytes: Vec<u8> = store
+    .load_file_bytes_with(original.stdout_digest, |bytes| bytes.into())
+    .await
+    .unwrap()
+    .unwrap()
+    .0;
+
+  let stderr_bytes: Vec<u8> = store
+    .load_file_bytes_with(original.stderr_digest, |bytes| bytes.into())
+    .await
+    .unwrap()
+    .unwrap()
+    .0;
+
   Ok(RemoteTestResult {
     original,
     stdout_bytes,
@@ -199,4 +242,185 @@ async fn successful_after_reconnect_from_retryable_error() {
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, EMPTY_DIGEST);
   assert_cancellation_requests(&mock_server, vec![]);
+}
+
+#[tokio::test]
+async fn server_rejecting_execute_request_gives_error() {
+  let execute_request = echo_foo_request();
+
+  let mock_server = mock::execution_server::TestServer::new(
+    mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
+      execute_request: crate::remote::make_execute_request(
+        &Process::new(owned_string_vec(&["/bin/echo", "-n", "bar"])),
+        empty_request_metadata(),
+      )
+      .unwrap()
+      .2,
+      stream_responses: Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::INVALID_ARGUMENT,
+        None,
+      )),
+    }]),
+    None,
+  );
+
+  let error = run_command_remote(mock_server.address(), execute_request)
+    .await
+    .expect_err("Want Err");
+  assert_that(&error).contains("INVALID_ARGUMENT");
+  assert_that(&error).contains("Did not expect this request");
+}
+
+#[tokio::test]
+async fn sends_headers() {
+  let execute_request = echo_foo_request();
+  let op_name = "gimme-foo".to_string();
+
+  let mock_server = {
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
+        execute_request: crate::remote::make_execute_request(
+          &execute_request.clone().try_into().unwrap(),
+          empty_request_metadata(),
+        )
+        .unwrap()
+        .2,
+        stream_responses: Ok(vec![
+          make_incomplete_operation(&op_name),
+          make_successful_operation(
+            &op_name,
+            StdoutType::Raw("foo".to_owned()),
+            StderrType::Raw("".to_owned()),
+            0,
+          ),
+        ]),
+      }]),
+      None,
+    )
+  };
+  let cas = mock::StubCAS::empty();
+  let runtime = task_executor::Executor::new(Handle::current());
+  let store_dir = TempDir::new().unwrap();
+  let store = Store::with_remote(
+    runtime.clone(),
+    store_dir,
+    vec![cas.address()],
+    None,
+    None,
+    None,
+    1,
+    10 * 1024 * 1024,
+    Duration::from_secs(1),
+    store::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
+    1,
+    1,
+  )
+  .expect("Failed to make store");
+
+  let command_runner = StreamingCommandRunner::new(
+    &mock_server.address(),
+    empty_request_metadata(),
+    None,
+    Some(String::from("catnip-will-get-you-anywhere")),
+    btreemap! {
+      String::from("cat") => String::from("roland"),
+    },
+    store,
+    Platform::Linux,
+  )
+  .unwrap();
+  let context = Context {
+    workunit_store: WorkunitStore::default(),
+    build_id: String::from("marmosets"),
+  };
+  command_runner
+    .run(execute_request, context)
+    .await
+    .expect("Execution failed");
+
+  let received_messages = mock_server.mock_responder.received_messages.lock();
+  let message_headers: Vec<_> = received_messages
+    .iter()
+    .map(|received_message| received_message.headers.clone())
+    .collect();
+  assert_that!(message_headers).has_length(1);
+  for headers in message_headers {
+    {
+      let want_key = String::from("google.devtools.remoteexecution.v1test.requestmetadata-bin");
+      assert_that!(headers).contains_key(&want_key);
+      let mut proto = bazel_protos::remote_execution::RequestMetadata::new();
+      proto
+        .merge_from_bytes(&headers[&want_key])
+        .expect("Failed to parse metadata proto");
+      assert_eq!(proto.get_tool_details().get_tool_name(), "pants");
+      assert_eq!(proto.get_tool_invocation_id(), "marmosets");
+    }
+    {
+      let want_key = String::from("cat");
+      assert_that!(headers).contains_key(&want_key);
+      assert_eq!(headers[&want_key], "roland".as_bytes());
+    }
+    {
+      let want_key = String::from("authorization");
+      assert_that!(headers).contains_key(&want_key);
+      assert_eq!(
+        headers[&want_key],
+        "Bearer catnip-will-get-you-anywhere".as_bytes()
+      );
+    }
+  }
+}
+
+#[tokio::test]
+async fn extract_response_with_digest_stdout() {
+  let op_name = "gimme-foo".to_string();
+  let testdata = TestData::roland();
+  let testdata_empty = TestData::empty();
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Digest(testdata.digest()),
+      StderrType::Raw(testdata_empty.string()),
+      0,
+    )
+    .op
+    .unwrap()
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout_bytes, testdata.bytes());
+  assert_eq!(result.stderr_bytes, testdata_empty.bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(result.original.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.original.platform, Platform::Linux);
+}
+
+#[tokio::test]
+async fn extract_response_with_digest_stderr() {
+  let op_name = "gimme-foo".to_string();
+  let testdata = TestData::roland();
+  let testdata_empty = TestData::empty();
+  let result = extract_execute_response(
+    make_successful_operation(
+      &op_name,
+      StdoutType::Raw(testdata_empty.string()),
+      StderrType::Digest(testdata.digest()),
+      0,
+    )
+    .op
+    .unwrap()
+    .unwrap(),
+    Platform::Linux,
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout_bytes, testdata_empty.bytes());
+  assert_eq!(result.stderr_bytes, testdata.bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(result.original.output_directory, EMPTY_DIGEST);
+  assert_eq!(result.original.platform, Platform::Linux);
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2477,7 +2477,7 @@ fn timestamp_only_secs(v: i64) -> Timestamp {
   dummy_timestamp
 }
 
-fn make_precondition_failure_operation(
+pub(crate) fn make_precondition_failure_operation(
   violations: Vec<bazel_protos::error_details::PreconditionFailure_Violation>,
 ) -> MockOperation {
   let mut operation = bazel_protos::operations::Operation::new();
@@ -2682,7 +2682,7 @@ fn make_any_proto(message: &dyn Message) -> protobuf::well_known_types::Any {
   any
 }
 
-fn missing_preconditionfailure_violation(
+pub(crate) fn missing_preconditionfailure_violation(
   digest: &Digest,
 ) -> bazel_protos::error_details::PreconditionFailure_Violation {
   {
@@ -2702,7 +2702,7 @@ fn assert_contains(haystack: &str, needle: &str) {
   )
 }
 
-fn cat_roland_request() -> MultiPlatformProcess {
+pub(crate) fn cat_roland_request() -> MultiPlatformProcess {
   let req = Process {
     argv: owned_string_vec(&["/bin/cat", "roland"]),
     env: BTreeMap::new(),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2506,9 +2506,9 @@ fn make_precondition_failure_status(
   status
 }
 
-async fn run_cmd_runner(
+pub(crate) async fn run_cmd_runner<R: crate::CommandRunner>(
   request: MultiPlatformProcess,
-  command_runner: CommandRunner,
+  command_runner: R,
   store: Store,
 ) -> Result<RemoteTestResult, String> {
   let original = command_runner.run(request, Context::default()).await?;
@@ -2720,7 +2720,7 @@ fn cat_roland_request() -> MultiPlatformProcess {
   req.into()
 }
 
-fn echo_roland_request() -> MultiPlatformProcess {
+pub(crate) fn echo_roland_request() -> MultiPlatformProcess {
   let req = Process {
     argv: owned_string_vec(&["/bin/echo", "meoooow"]),
     env: BTreeMap::new(),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2218,7 +2218,9 @@ async fn extract_output_files_from_response_no_prefix() {
   )
 }
 
-fn workunits_with_constant_span_id(workunit_store: &mut WorkunitStore) -> HashSet<Workunit> {
+pub(crate) fn workunits_with_constant_span_id(
+  workunit_store: &mut WorkunitStore,
+) -> HashSet<Workunit> {
   workunit_store.with_latest_workunits(log::Level::Trace, |_, completed_workunits| {
     completed_workunits
       .iter()
@@ -2445,7 +2447,7 @@ pub(crate) fn make_successful_operation(
   MockOperation::new(op)
 }
 
-fn make_successful_operation_with_metadata(
+pub(crate) fn make_successful_operation_with_metadata(
   operation_name: &str,
   stdout: StdoutType,
   stderr: StderrType,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2672,7 +2672,7 @@ async fn extract_output_files_from_response(
     .await
 }
 
-fn make_any_proto(message: &dyn Message) -> protobuf::well_known_types::Any {
+pub(crate) fn make_any_proto(message: &dyn Message) -> protobuf::well_known_types::Any {
   let mut any = protobuf::well_known_types::Any::new();
   any.set_type_url(format!(
     "type.googleapis.com/{}",
@@ -2693,7 +2693,7 @@ pub(crate) fn missing_preconditionfailure_violation(
   }
 }
 
-fn assert_contains(haystack: &str, needle: &str) {
+pub(crate) fn assert_contains(haystack: &str, needle: &str) {
   assert!(
     haystack.contains(needle),
     "{:?} should contain {:?}",


### PR DESCRIPTION
### Problem

Need more unit test coverage for the streaming REv2 client.

### Solution

Port more of the unit tests from the polling REv2 client to the streaming client.

Fix an edge case with detecting when to reconnect to a stream with WaitExecution. Triggered after missing digests upload. Found by running the ported unit tests.

### Result

Unit test pass. The bug is fixed.
