### PR TITLE
allow MergeDigests to have overlapping contents

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -36,7 +36,7 @@ mod snapshot_ops_tests;
 #[cfg(test)]
 mod snapshot_tests;
 pub use crate::snapshot_ops::{
-  MergeBehavior, SnapshotOps, SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams,
+  MergeBehavior, SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams,
 };
 
 use async_trait::async_trait;

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -35,7 +35,9 @@ mod snapshot_ops;
 mod snapshot_ops_tests;
 #[cfg(test)]
 mod snapshot_tests;
-pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams};
+pub use crate::snapshot_ops::{
+  MergeBehavior, SnapshotOps, SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams,
+};
 
 use async_trait::async_trait;
 use bazel_protos::remote_execution as remexec;

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -14,7 +14,7 @@ use futures::compat::Future01CompatExt;
 use futures::future::{self as future03, TryFutureExt};
 use futures01::future::{self, Future};
 use glob::Pattern;
-use hashing::{Digest, Fingerprint};
+use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use indexmap::{self, IndexMap, IndexSet};
 
 use std::convert::From;

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -9,7 +9,9 @@ use tempfile;
 use testutil::data::TestDirectory;
 use testutil::make_file;
 
-use crate::{MergeBehavior, OneOffStoreFileByDigest, Snapshot, SnapshotOps, RelativePath, Store, SubsetParams};
+use crate::{
+  MergeBehavior, OneOffStoreFileByDigest, RelativePath, Snapshot, SnapshotOps, Store, SubsetParams,
+};
 use fs::{
   Dir, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching, PathGlobs, PathStat,
   PosixFS, PreparedPathGlobs, StrictGlobMatching,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -31,6 +31,7 @@ use store::{MergeBehavior, Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use tokio::time::delay_for;
 use workunit_store::{with_workunit, Metric, SpanId, WorkunitMetadata, WorkunitStore};
+use store::{MergeBehavior, Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
 
 use crate::{

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -28,6 +28,10 @@ use protobuf::{self, Message, ProtobufEnum};
 use rand::{thread_rng, Rng};
 use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use workunit_store::{with_workunit, Metric, SpanId, WorkunitMetadata, WorkunitStore};
+use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
+use sha2::Sha256;
+use store::{MergeBehavior, Snapshot, SnapshotOps, Store, StoreFileByDigest};
+use tokio::time::delay_for;
 
 use crate::{
   Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
@@ -1231,7 +1235,7 @@ pub fn extract_output_files(
     directory_digests.push(files_digest);
 
     store
-      .merge(directory_digests)
+      .merge(directory_digests, MergeBehavior::NoDuplicates)
       .map_err(|err| format!("Error when merging output files and directories: {:?}", err))
       .await
   })

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -26,12 +26,12 @@ use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn, Level};
 use protobuf::{self, Message, ProtobufEnum};
 use rand::{thread_rng, Rng};
-use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
-use workunit_store::{with_workunit, Metric, SpanId, WorkunitMetadata, WorkunitStore};
-use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
 use sha2::Sha256;
 use store::{MergeBehavior, Snapshot, SnapshotOps, Store, StoreFileByDigest};
+use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use tokio::time::delay_for;
+use workunit_store::{with_workunit, Metric, SpanId, WorkunitMetadata, WorkunitStore};
+use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
 
 use crate::{
   Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -391,13 +391,15 @@ fn create_digest_to_digest(
 
   let store = context.core.store();
   async move {
-    let digests = future::try_join_all(digests).await?;
+    let digests = future::try_join_all(digests)
+      .await
+      .map_err(|e| throw(&format!("{:?}", e)))?;
     let digest = store
       .merge(digests, MergeBehavior::NoDuplicates)
       .await
-      .map_err(|e| format!("{:?}", e))?;
-    let res: Result<_, String> = Ok(Snapshot::store_directory(&context.core, &digest));
-    res
+      .map_err(|e| throw(&format!("{:?}", e)))?;
+    let res = Snapshot::store_directory_digest(&digest).map_err(|e| throw(&format!("{:?}", e)))?;
+    Ok(res)
   }
   .boxed()
 }


### PR DESCRIPTION
### Problem

This blocks #9781.

Currently, snapshots are not allowed to have overlapping file or directory paths when merged. We currently unconditionally raise an error when:
1. a file has the same path as a directory.
2. two files have the same path and different contents.

We currently do *not*, but we probably *want* to:

3. only *lazily* remove files with colliding paths.

It's possible to work around possible file collisions when merging by performing a `subset()` operation on one of your digests beforehand, but that *unconditionally* removes files from a digest -- even when another digest might not have those files! That's where this PR comes in.

### Solution

- Add a `MergeBehavior` enum argument to `merge()` which describes how to respond when the digests to be merged have colliding file and directory paths.
  - `MergeBehavior` can use `SubsetParams` to describe which files can have colliding paths.
- Extract the logic of the `merge()` operation into a helper struct `DigestMergeContext`.
- Add a criterion benchmark that measures the performance of a merge operation that allows every single file path to freely collide in the digests to be merged.
- Expose the `merge_behavior` field on `MergeDigests` in python.

### Result

`MergeDirectories` is faster, and we can avoid pre-emptively `subset()`ing snapshots to avoid duplicate file paths!

Compared to master:
```
materialize_directory/materialize_directory
                        time:   [44.406 ms 46.136 ms 47.658 ms]
                        change: [-13.473% -8.3598% -2.8386%] (p = 0.01 < 0.05)
                        Performance has improved.

snapshot_subset/wildcard
                        time:   [1.1803 ms 1.2564 ms 1.3164 ms]
                        change: [+4.4522% +9.8348% +15.800%] (p = 0.00 < 0.05)
                        Performance has regressed.

snapshot_merge/snapshot_merge
                        time:   [10.913 ms 11.107 ms 11.398 ms]
                        change: [-99.199% -99.138% -99.060%] (p = 0.00 < 0.05)
                        Performance has improved.

snapshot_merge/snapshot_merge_overlapping_subset
                        time:   [10.762 ms 11.172 ms 11.573 ms]
```
