### PR TITLE
Remove the passthrough-arguments-with-multiple-goals deprecation.

### DIFF
--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -50,7 +50,6 @@ class ArgSplitterTest(unittest.TestCase):
         expected_scope_to_flags: Dict[str, List[str]],
         expected_specs: List[str],
         expected_passthru: Optional[List[str]] = None,
-        expected_passthru_owner: Optional[str] = None,
         expected_is_help: bool = False,
         expected_help_advanced: bool = False,
         expected_help_all: bool = False,
@@ -65,7 +64,6 @@ class ArgSplitterTest(unittest.TestCase):
         assert expected_scope_to_flags == split_args.scope_to_flags
         assert expected_specs == split_args.specs
         assert expected_passthru == split_args.passthru
-        assert expected_passthru_owner == split_args.passthru_owner
         assert expected_is_help == (splitter.help_request is not None)
         assert expected_help_advanced == (
             isinstance(splitter.help_request, OptionsHelp) and splitter.help_request.advanced
@@ -237,7 +235,6 @@ class ArgSplitterTest(unittest.TestCase):
             expected_scope_to_flags={"": [], "test": []},
             expected_specs=["foo/bar"],
             expected_passthru=["-t", "arg"],
-            expected_passthru_owner="test",
         )
         self.assert_valid_split(
             "./pants -farg --fff=arg compile --gg-gg=arg-arg -g test.junit --iii "
@@ -252,7 +249,6 @@ class ArgSplitterTest(unittest.TestCase):
             },
             expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
             expected_passthru=["passthru1", "passthru2"],
-            expected_passthru_owner="test.junit",
         )
 
     def test_subsystem_flags(self) -> None:
@@ -299,10 +295,7 @@ class ArgSplitterTest(unittest.TestCase):
 
     def test_help_detection(self) -> None:
         assert_help = partial(
-            self.assert_valid_split,
-            expected_passthru=None,
-            expected_passthru_owner=None,
-            expected_is_help=True,
+            self.assert_valid_split, expected_passthru=None, expected_is_help=True,
         )
         assert_help_no_arguments = partial(
             assert_help, expected_goals=[], expected_scope_to_flags={"": []}, expected_specs=[],

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1252,7 +1252,7 @@ class OptionsTest(TestBase):
         # NB: Passthrough args end up on our `--modifypassthrough` arg.
         pairs = options.get_fingerprintable_for_scope("compile.scala")
         self.assertEqual(
-            [(str, "blah blah blah"), (bool, True), (int, 77), (str, ["-d", "-v"])], pairs
+            [(str, "blah blah blah"), (str, ["-d", "-v"]), (bool, True), (int, 77)], pairs
         )
 
     def test_fingerprintable(self) -> None:
@@ -1410,6 +1410,8 @@ class OptionsTest(TestBase):
         self.assertEqual(4, options.for_scope("compile.java").c)
 
     def test_invalid_option_errors(self) -> None:
+        self.maxDiff = None
+
         def parse_joined_command_line(*args):
             bootstrap_options = create_options(
                 {
@@ -1452,7 +1454,7 @@ class OptionsTest(TestBase):
                 Suggestions:
                 -v: [--v2, --verbose, --a, --b, --y, -n, -z, --compile-c]
                 --config-overridden: [--config-override]
-                --c: [--compile-c, --compile-scala-modifycompile, --compile-scala-modifylogs, --config-override, --a, --b, --y, -n, -z, --v2]
+                --c: [--compile-c, --compile-scala-modifycompile, --compile-scala-modifylogs, --compile-scala-modifypassthrough, --config-override, --a, --b, --y, -n, -z, --v2]
 
                 (Run `./pants help-advanced` for all available options.)"""
             ),

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -331,10 +331,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
         options_hasher = sha1()
         options_hasher.update(scope.encode())
         options_fp = OptionsFingerprinter.combined_options_fingerprint_for_scope(
-            scope,
-            self.context.options,
-            build_graph=self.context.build_graph,
-            include_passthru=self.supports_passthru_args(),
+            scope, self.context.options, build_graph=self.context.build_graph,
         )
         options_hasher.update(options_fp.encode())
         return options_hasher.hexdigest()

--- a/src/python/pants/testutil/option/fakes.py
+++ b/src/python/pants/testutil/option/fakes.py
@@ -98,6 +98,10 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
                 options_for_this_scope = options_for_this_scope.option_values
 
             if passthru_args:
+                # TODO: This is _very_ partial support for passthrough args: this should be
+                # inspecting the kwargs of option registrations to decide which arguments to
+                # extend: this explicit `passthrough_args` argument is only passthrough because
+                # it is marked as such.
                 pa = options_for_this_scope.get("passthrough_args", [])
                 if isinstance(pa, RankedValue):
                     pa = pa.value
@@ -112,9 +116,6 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
         def for_global_scope(self):
             return self.for_scope(GLOBAL_SCOPE)
 
-        def passthru_args_for_scope(self, scope):
-            return passthru_args or []
-
         def items(self):
             return list(options.items())
 
@@ -122,7 +123,7 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
         def scope_to_flags(self):
             return {}
 
-        def get_fingerprintable_for_scope(self, bottom_scope, include_passthru=False):
+        def get_fingerprintable_for_scope(self, bottom_scope):
             """Returns a list of fingerprintable (option type, option value) pairs for the given
             scope.
 
@@ -130,14 +131,8 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
             all enclosing scopes as in the Options class!
 
             :param str bottom_scope: The scope to gather fingerprintable options for.
-            :param bool include_passthru: Whether to include passthru args captured by `bottom_scope` in the
-                                          fingerprintable options.
             """
             pairs = []
-            if include_passthru:
-                pu_args = self.passthru_args_for_scope(bottom_scope)
-                pairs.extend((str, arg) for arg in pu_args)
-
             option_values = self.for_scope(bottom_scope)
             for option_name, option_type in fingerprintable[bottom_scope].items():
                 pairs.append((option_type, option_values[option_name]))


### PR DESCRIPTION
### Problem

When multiple goals were specified, using passthrough arguments required special handling that was challenging to explain, and was thus deprecated.  

### Solution

Remove the deprecation.

### Result

Only one goal may be specified when passthrough args are in use.

[ci skip-rust-tests]
[ci skip-jvm-tests]