### PR TITLE
Rename ReportType to CoverageReportType and move it to test.py

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -4,7 +4,6 @@
 import configparser
 import json
 from dataclasses import dataclass
-from enum import Enum
 from io import StringIO
 from pathlib import PurePath
 from textwrap import dedent
@@ -27,6 +26,7 @@ from pants.core.goals.test import (
     CoverageData,
     CoverageDataCollection,
     CoverageReport,
+    CoverageReportType,
     FilesystemCoverageReport,
 )
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
@@ -197,24 +197,6 @@ async def create_coverage_config(coverage_config_request: CoverageConfigRequest)
     return CoverageConfig(digest)
 
 
-class ReportType(Enum):
-    CONSOLE = ("console", "report")
-    XML = ("xml", None)
-    HTML = ("html", None)
-
-    _report_name: str
-
-    def __new__(cls, value: str, report_name: Optional[str] = None) -> "ReportType":
-        member: "ReportType" = object.__new__(cls)
-        member._value_ = value
-        member._report_name = report_name if report_name is not None else value
-        return member
-
-    @property
-    def report_name(self) -> str:
-        return self._report_name
-
-
 class PytestCoverage(PythonToolBase):
     options_scope = "pytest-coverage"
     default_version = "coverage>=5.0.3,<5.1"
@@ -232,8 +214,8 @@ class PytestCoverage(PythonToolBase):
         )
         register(
             "--report",
-            type=ReportType,
-            default=ReportType.CONSOLE,
+            type=CoverageReportType,
+            default=CoverageReportType.CONSOLE,
             help="Which coverage report type to emit.",
         )
 
@@ -370,15 +352,15 @@ async def generate_coverage_report(
     )
     result = await Get[ProcessResult](Process, process)
 
-    if report_type == ReportType.CONSOLE:
+    if report_type == CoverageReportType.CONSOLE:
         return ConsoleCoverageReport(result.stdout.decode())
 
     report_dir = PurePath(coverage_subsystem.options.report_output_path)
 
     report_file: Optional[PurePath] = None
-    if report_type == ReportType.HTML:
+    if report_type == CoverageReportType.HTML:
         report_file = report_dir / "htmlcov" / "index.html"
-    elif report_type == ReportType.XML:
+    elif report_type == CoverageReportType.XML:
         report_file = report_dir / "coverage.xml"
 
     return FilesystemCoverageReport(

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -42,6 +42,24 @@ class Status(Enum):
     FAILURE = "FAILURE"
 
 
+class CoverageReportType(Enum):
+    CONSOLE = ("console", "report")
+    XML = ("xml", None)
+    HTML = ("html", None)
+
+    _report_name: str
+
+    def __new__(cls, value: str, report_name: Optional[str] = None) -> "CoverageReportType":
+        member: "CoverageReportType" = object.__new__(cls)
+        member._value_ = value
+        member._report_name = report_name if report_name is not None else value
+        return member
+
+    @property
+    def report_name(self) -> str:
+        return self._report_name
+
+
 @dataclass(frozen=True)
 class TestResult:
     status: Status


### PR DESCRIPTION
Some context: this is part of work I am doing to allow multiple report types to be request (i.e. html & xml reports) and also add support for materializing the "raw" coverage data file.
See https://github.com/pantsbuild/pants/issues/9968

### Problem

Other languages will eventually will want to have code coverage for their tests, and the notion of XML and HTML coverage reports is not specific to python.

### Solution

Move & rename the Coverage report type enum into test.py