### PR TITLE
Add support for returning multiple coverage reports for each MergedCoverageData.

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -26,7 +26,7 @@ from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
     CoverageDataCollection,
-    CoverageReport,
+    CoverageReports,
     FilesystemCoverageReport,
 )
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
@@ -324,7 +324,7 @@ async def generate_coverage_report(
     transitive_targets: TransitiveTargets,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> CoverageReport:
+) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
     requirements_pex = coverage_setup.requirements_pex
 
@@ -371,7 +371,7 @@ async def generate_coverage_report(
     result = await Get[ProcessResult](Process, process)
 
     if report_type == ReportType.CONSOLE:
-        return ConsoleCoverageReport(result.stdout.decode())
+        return CoverageReports(reports=(ConsoleCoverageReport(result.stdout.decode()),))
 
     report_dir = PurePath(coverage_subsystem.options.report_output_path)
 
@@ -380,12 +380,12 @@ async def generate_coverage_report(
         report_file = report_dir / "htmlcov" / "index.html"
     elif report_type == ReportType.XML:
         report_file = report_dir / "coverage.xml"
-
-    return FilesystemCoverageReport(
+    fs_report = FilesystemCoverageReport(
         result_digest=result.output_digest,
         directory_to_materialize_to=report_dir,
         report_file=report_file,
     )
+    return CoverageReports(reports=(fs_report,))
 
 
 def rules():

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -7,7 +7,7 @@ from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import Dict, Iterable, List, Optional, Type, TypeVar
+from typing import Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.core.util_rules.filter_empty_sources import (
@@ -158,6 +158,19 @@ class FilesystemCoverageReport(CoverageReport):
         return self.report_file
 
 
+@dataclass(frozen=True)
+class CoverageReports:
+    reports: Tuple[CoverageReport, ...]
+
+    def materialize(self, console: Console, workspace: Workspace) -> Tuple[PurePath, ...]:
+        report_paths = []
+        for report in self.reports:
+            report_path = report.materialize(console, workspace)
+            if report_path:
+                report_paths.append(report_path)
+        return tuple(report_paths)
+
+
 class TestOptions(GoalSubsystem):
     """Runs tests."""
 
@@ -291,17 +304,16 @@ async def run_tests(
         for data_cls, data in itertools.groupby(all_coverage_data, lambda data: type(data)):
             collection_cls = coverage_types_to_collection_types[data_cls]
             coverage_collections.append(collection_cls(data))
-
-        coverage_reports = await MultiGet(
-            Get[CoverageReport](CoverageDataCollection, coverage_collection)
+        # We can create multiple reports for each coverage data (console, xml and html)
+        coverage_reports_collections = await MultiGet(
+            Get[CoverageReports](CoverageDataCollection, coverage_collection)
             for coverage_collection in coverage_collections
         )
 
-        coverage_report_files = []
-        for report in coverage_reports:
-            report_file = report.materialize(console, workspace)
-            if report_file is not None:
-                coverage_report_files.append(report_file)
+        coverage_report_files: List[PurePath] = []
+        for coverage_reports in coverage_reports_collections:
+            report_files = coverage_reports.materialize(console, workspace)
+            coverage_report_files.extend(report_files)
 
         if coverage_report_files and options.values.open_coverage:
             desktop.ui_open(console, interactive_runner, coverage_report_files)

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -12,7 +12,7 @@ from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
     CoverageDataCollection,
-    CoverageReport,
+    CoverageReports,
     Status,
     Test,
     TestDebugRequest,
@@ -173,11 +173,12 @@ class TestTest(TestBase):
 
         def mock_coverage_report_generation(
             coverage_data_collection: MockCoverageDataCollection,
-        ) -> CoverageReport:
+        ) -> CoverageReports:
             addresses = ", ".join(
                 coverage_data.address.spec for coverage_data in coverage_data_collection
             )
-            return ConsoleCoverageReport(f"Ran coverage on {addresses}")
+            console_report = ConsoleCoverageReport(f"Ran coverage on {addresses}")
+            return CoverageReports(reports=(console_report,))
 
         result: Test = run_rule(
             run_tests,
@@ -206,7 +207,7 @@ class TestTest(TestBase):
                     ),
                 ),
                 MockGet(
-                    product_type=CoverageReport,
+                    product_type=CoverageReports,
                     subject_type=CoverageDataCollection,
                     mock=mock_coverage_report_generation,
                 ),


### PR DESCRIPTION
Part of working towrds: https://github.com/pantsbuild/pants/issues/9968

### Problem

We allow the user to only specify one coverage report type, we should allow specifying multiple report types.

### Solution

This is part of the solution, it introduces a CoverageReports wrapper that holds CoverageReport instances.
Instead of returning a returing CoverageReport we return CoverageReports and allow the run_tests rule to act on multiple reports thru that wrapper