### PR TITLE
use try_into for a fallible conversion to hashing::Digest

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -27,6 +27,13 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+use std::convert::TryInto;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::exit;
+use std::sync::Arc;
+use std::time::Duration;
+
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use clap::{value_t, App, Arg, SubCommand};
@@ -39,11 +46,6 @@ use parking_lot::Mutex;
 use protobuf::Message;
 use rand::seq::SliceRandom;
 use serde_derive::Serialize;
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
-use std::process::exit;
-use std::sync::Arc;
-use std::time::Duration;
 use store::{Snapshot, Store, StoreFileByDigest, UploadSummary};
 use tokio::runtime::Handle;
 
@@ -612,7 +614,7 @@ fn expand_files_helper(
         {
           let mut files_unlocked = files.lock();
           for file in dir.get_files() {
-            let file_digest: Result<Digest, String> = file.get_digest().into();
+            let file_digest: Result<Digest, String> = file.get_digest().try_into();
             files_unlocked.push((format!("{}{}", prefix, file.name), file_digest?));
           }
         }
@@ -620,7 +622,7 @@ fn expand_files_helper(
           .get_directories()
           .iter()
           .map(move |subdir| {
-            let digest: Result<Digest, String> = subdir.get_digest().into();
+            let digest: Result<Digest, String> = subdir.get_digest().try_into();
             digest.map(|digest| (subdir, digest))
           })
           .collect::<Result<Vec<_>, _>>()?;

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -1,4 +1,8 @@
-use super::{BackoffConfig, EntryType};
+use std::cmp::min;
+use std::collections::{BTreeMap, HashSet};
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::time::Duration;
 
 use bazel_protos::{self, call_option};
 use bytes::{Bytes, BytesMut};
@@ -10,10 +14,8 @@ use futures01::{future, Future, Sink, Stream};
 use hashing::{Digest, Fingerprint};
 use serverset::{retry, Serverset};
 use sha2::Sha256;
-use std::cmp::min;
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
-use std::time::Duration;
+
+use super::{BackoffConfig, EntryType};
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -335,7 +337,7 @@ impl ByteStore {
             response
               .get_missing_blob_digests()
               .iter()
-              .map(|digest| digest.into())
+              .map(|digest| digest.try_into())
               .collect::<Result<HashSet<_>, _>>()
           }
         })

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -1,3 +1,7 @@
+use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use hashing::{Digest, Fingerprint};
 use tempfile;
 use testutil::data::TestDirectory;
@@ -9,10 +13,6 @@ use fs::{
   Dir, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching, PathGlobs, PathStat,
   PosixFS, StrictGlobMatching,
 };
-
-use std;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 const STR: &str = "European Burmese";
 
@@ -286,7 +286,7 @@ async fn snapshot_merge_two_files() {
 
   let merged_child_dirnode = merged_root_directory.directories[0].clone();
   let merged_child_dirnode_digest: Result<Digest, String> =
-    merged_child_dirnode.get_digest().into();
+    merged_child_dirnode.get_digest().try_into();
   let merged_child_directory = store
     .load_directory(merged_child_dirnode_digest.unwrap())
     .await

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 impl<'a> From<&'a hashing::Digest> for crate::remote_execution::Digest {
   fn from(d: &hashing::Digest) -> Self {
     let mut digest = super::remote_execution::Digest::new();
@@ -16,8 +18,10 @@ impl<'a> From<&'a hashing::Digest> for crate::build::bazel::remote::execution::v
   }
 }
 
-impl<'a> From<&'a super::remote_execution::Digest> for Result<hashing::Digest, String> {
-  fn from(d: &super::remote_execution::Digest) -> Self {
+impl<'a> TryFrom<&'a super::remote_execution::Digest> for hashing::Digest {
+  type Error = String;
+
+  fn try_from(d: &super::remote_execution::Digest) -> Result<Self, Self::Error> {
     hashing::Fingerprint::from_hex_string(d.get_hash())
       .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", d.get_hash(), err))
       .map(|fingerprint| hashing::Digest(fingerprint, d.get_size_bytes() as usize))

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions_tests.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions_tests.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use hashing;
 
 #[test]
@@ -22,7 +24,7 @@ fn from_bazel_digest() {
   bazel_digest
     .set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
   bazel_digest.set_size_bytes(10);
-  let converted: Result<hashing::Digest, String> = (&bazel_digest).into();
+  let converted: Result<hashing::Digest, String> = (&bazel_digest).try_into();
   let want = hashing::Digest(
     hashing::Fingerprint::from_hex_string(
       "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
@@ -38,7 +40,7 @@ fn from_bad_bazel_digest() {
   let mut bazel_digest = crate::remote_execution::Digest::new();
   bazel_digest.set_hash("0".to_owned());
   bazel_digest.set_size_bytes(10);
-  let converted: Result<hashing::Digest, String> = (&bazel_digest).into();
+  let converted: Result<hashing::Digest, String> = (&bazel_digest).try_into();
   let err = converted.expect_err("Want Err converting bad digest");
   assert!(
     err.starts_with("Bad fingerprint in Digest \"0\":"),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
+use std::convert::TryInto;
 use std::mem::drop;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -944,7 +945,7 @@ fn extract_stdout(
 ) -> BoxFuture<Digest, String> {
   if execute_response.get_result().has_stdout_digest() {
     let stdout_digest_result: Result<Digest, String> =
-      execute_response.get_result().get_stdout_digest().into();
+      execute_response.get_result().get_stdout_digest().try_into();
     let stdout_digest =
       try_future!(stdout_digest_result.map_err(|err| format!("Error extracting stdout: {}", err)));
     Box::pin(async move { Ok(stdout_digest) })
@@ -971,7 +972,7 @@ fn extract_stderr(
 ) -> BoxFuture<Digest, String> {
   if execute_response.get_result().has_stderr_digest() {
     let stderr_digest_result: Result<Digest, String> =
-      execute_response.get_result().get_stderr_digest().into();
+      execute_response.get_result().get_stderr_digest().try_into();
     let stderr_digest =
       try_future!(stderr_digest_result.map_err(|err| format!("Error extracting stderr: {}", err)));
     Box::pin(async move { Ok(stderr_digest) })
@@ -1009,7 +1010,7 @@ pub fn extract_output_files(
     let store = store.clone();
     directory_digests.push(
       (async move {
-        let digest_result: Result<Digest, String> = dir.get_tree_digest().into();
+        let digest_result: Result<Digest, String> = dir.get_tree_digest().try_into();
         let mut digest = digest_result?;
         if !dir.get_path().is_empty() {
           for component in dir.get_path().rsplit('/') {
@@ -1039,7 +1040,7 @@ pub fn extract_output_files(
     .iter()
     .map(|output_file| {
       let output_file_path_buf = PathBuf::from(output_file.get_path());
-      let digest: Result<Digest, String> = output_file.get_digest().into();
+      let digest: Result<Digest, String> = output_file.get_digest().try_into();
       path_map.insert(output_file_path_buf.clone(), digest?);
       Ok(PathStat::file(
         output_file_path_buf.clone(),

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -500,7 +501,7 @@ impl bazel_protos::remote_execution_grpc::ContentAddressableStorage for StubCASR
     let blobs = self.blobs.lock();
     let mut response = bazel_protos::remote_execution::FindMissingBlobsResponse::new();
     for digest in req.get_blob_digests() {
-      let hashing_digest_result: Result<Digest, String> = digest.into();
+      let hashing_digest_result: Result<Digest, String> = digest.try_into();
       let hashing_digest = hashing_digest_result.expect("Bad digest");
       if !blobs.contains_key(&hashing_digest.0) {
         response.mut_missing_blob_digests().push(digest.clone())


### PR DESCRIPTION
### Problem

There is a conversion using the `From` trait from the protobuf Digest to a `Result<hashing::Digest, String>`. This conversion is failable so should use TryFrom instead.

Motivation:  I was modifying the `fs` crate to switch away from futures 0.1 and this change seemed to help some of the type inference, but mainly improved my understanding of the code since it was more clear where a `Result` type was appearing.

I've pulled it out here for ease of review.

### Solution

Use try_into for these conversions.

### Result

Tests pass.