### PR TITLE
Remove deprecated v1 functionality

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
@@ -178,7 +178,7 @@ class ProtobufGen(SimpleCodegenTask):
         if files:
             deprecated_conditional(
                 lambda: True,
-                removal_version="1.30.1.dev0",
+                removal_version="1.31.0.dev0",
                 entity_description="Importing from .protos embedded in remote JAR files.",
                 hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
                 "if you need this functionality.",

--- a/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
@@ -178,7 +178,7 @@ class ProtobufGen(SimpleCodegenTask):
         if files:
             deprecated_conditional(
                 lambda: True,
-                removal_version="1.30.0.dev0",
+                removal_version="1.30.1.dev0",
                 entity_description="Importing from .protos embedded in remote JAR files.",
                 hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
                 "if you need this functionality.",

--- a/src/python/pants/backend/jvm/tasks/ivy_outdated.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_outdated.py
@@ -67,7 +67,7 @@ class IvyOutdated(NailgunTask):
     def execute(self):
         deprecated_conditional(
             lambda: True,
-            removal_version="1.30.0.dev0",
+            removal_version="1.30.1.dev0",
             entity_description="The `outdated` goal",
             hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
             "if you need this functionality.",

--- a/src/python/pants/backend/jvm/tasks/ivy_outdated.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_outdated.py
@@ -67,7 +67,7 @@ class IvyOutdated(NailgunTask):
     def execute(self):
         deprecated_conditional(
             lambda: True,
-            removal_version="1.30.1.dev0",
+            removal_version="1.31.0.dev0",
             entity_description="The `outdated` goal",
             hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
             "if you need this functionality.",

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -50,7 +50,7 @@ class UnpackJars(UnpackRemoteSourcesBase):
     def unpack_target(self, unpacked_jars, unpack_dir):
         deprecated_conditional(
             lambda: True,
-            removal_version="1.30.0.dev0",
+            removal_version="1.31.0.dev0",
             entity_description="The `unpack-jars` goal",
             hint_message="Contact the Pants team on Slack or pants-devel@googlegroups.com "
             "if you need this functionality.",

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -9,7 +9,7 @@ from typing import List
 from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
 from pants.engine.fs import Digest, DirectoryToMaterialize, Snapshot, UrlToFetch
-from pants.engine.platform import Platform, PlatformConstraint
+from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -71,19 +71,3 @@ def test_generate_request() -> None:
         create_subsystem(
             FooBar, version="9.9.9", known_versions=FooBar.default_known_versions
         ).get_request(Platform.darwin)
-
-
-# Delete this test after ExternalTool.get_default_versions_and_digests() is removed.
-def test_get_default_versions_and_digests() -> None:
-    assert {
-        "darwin": (
-            "3.4.7",
-            "9d0e18cd74b918c7b3edd0203e75569e0c8caecb1367b3be409b45e28514f5be",
-            123321,
-        ),
-        "linux": (
-            "3.4.7",
-            "a019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
-            134213,
-        ),
-    } == FooBar.get_default_versions_and_digests()


### PR DESCRIPTION
Removes a backwards compatibility mechanism for ExternalTool.

Postpones some ivy-related deprecation.