### PR TITLE
Kill child processes on drop.

### DIFF
--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -117,6 +117,11 @@ impl StreamedHermeticCommand {
   fn new<S: AsRef<OsStr>>(program: S) -> StreamedHermeticCommand {
     let mut inner = Command::new(program);
     inner
+      // TODO: This will not universally prevent child processes continuing to run in the
+      // background, for a few reasons:
+      //   1) the Graph memoizes runs, and generally completes them rather than cancelling them,
+      //   2) killing a pantsd client with Ctrl+C kills the server with a signal, which won't
+      //      currently result in an orderly dropping of everything in the graph. See #10004.
       .kill_on_drop(true)
       .env_clear()
       // It would be really nice not to have to manually set PATH but this is sadly the only way

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -117,6 +117,7 @@ impl StreamedHermeticCommand {
   fn new<S: AsRef<OsStr>>(program: S) -> StreamedHermeticCommand {
     let mut inner = Command::new(program);
     inner
+      .kill_on_drop(true)
       .env_clear()
       // It would be really nice not to have to manually set PATH but this is sadly the only way
       // to stop automatic PATH searching.


### PR DESCRIPTION
### Problem

Tokio supports killing child processes on drop, but it is not enabled by default.

### Solution

Kill on drop.

### Result

This will not universally handle child processes continuing to run in the background, for a few reasons: 1) the `Graph` memoizes runs, and generally completes them rather than cancelling them, 2) killing a pantsd client with Ctrl+C kills the server with a signal, which won't result in an orderly dropping of everything in the graph. But, worth doing this before we forget.

[ci skip-jvm-tests]