### PR TITLE
remoting: add --remote-execution-overall-deadline-secs option

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -298,6 +298,7 @@ class Native(metaclass=SingletonMetaclass):
             execution_options.process_execution_use_local_cache,
             tuple((k, v) for (k, v) in execution_options.remote_execution_headers.items()),
             execution_options.remote_execution_enable_streaming,
+            execution_options.remote_execution_overall_deadline_secs,
             execution_options.process_execution_local_enable_nailgun,
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -85,6 +85,7 @@ class ExecutionOptions:
     remote_execution_extra_platform_properties: Any
     remote_execution_headers: Any
     remote_execution_enable_streaming: bool
+    remote_execution_overall_deadline_secs: int
     process_execution_local_enable_nailgun: bool
 
     @classmethod
@@ -111,6 +112,7 @@ class ExecutionOptions:
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
             remote_execution_headers=bootstrap_options.remote_execution_headers,
             remote_execution_enable_streaming=bootstrap_options.remote_execution_enable_streaming,
+            remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
         )
 
@@ -137,6 +139,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     remote_execution_enable_streaming=False,
+    remote_execution_overall_deadline_secs=10 * 60,
     process_execution_local_enable_nailgun=False,
 )
 
@@ -835,6 +838,13 @@ class GlobalOptions(Subsystem):
             default=False,
             advanced=True,
             help="Enable the streaming remote execution client (experimental).",
+        )
+        register(
+            "--remote-execution-overall-deadline-secs",
+            type=int,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_execution_overall_deadline_secs,
+            advanced=True,
+            help="Overall timeout in seconds for each remote execution request from time of submission",
         )
         register(
             "--process-execution-local-parallelism",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -139,7 +139,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     remote_execution_enable_streaming=False,
-    remote_execution_overall_deadline_secs=10 * 60,
+    remote_execution_overall_deadline_secs=60 * 60,  # one hour
     process_execution_local_enable_nailgun=False,
 )
 

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ops::Add;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -579,6 +580,7 @@ impl crate::CommandRunner for StreamingCommandRunner {
     let Process {
       description,
       input_files,
+      timeout,
       ..
     } = compatible_underlying_request;
     let build_id = context.build_id.clone();
@@ -594,7 +596,8 @@ impl crate::CommandRunner for StreamingCommandRunner {
 
     // Record the time that we started to process this request, then compute the ultimate
     // deadline for execution of this request.
-    let deadline_duration = Duration::from_secs(self.overall_deadline_secs);
+    let deadline_duration =
+      Duration::from_secs(self.overall_deadline_secs).add(timeout.unwrap_or(Duration::default()));
 
     // Upload the action (and related data, i.e. the embedded command and input files).
     self

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -29,6 +29,8 @@ use crate::remote_tests::{
 };
 use crate::{CommandRunner, Context, MultiPlatformProcess, Platform, Process};
 
+const OVERALL_DEADLINE_SECS: u64 = 10 * 60;
+
 fn create_command_runner(
   address: String,
   cas: &mock::StubCAS,
@@ -45,6 +47,7 @@ fn create_command_runner(
     BTreeMap::new(),
     store.clone(),
     platform,
+    OVERALL_DEADLINE_SECS,
   )
   .expect("Failed to make command runner");
   (command_runner, store)
@@ -331,6 +334,7 @@ async fn sends_headers() {
     },
     store,
     Platform::Linux,
+    OVERALL_DEADLINE_SECS,
   )
   .unwrap();
   let context = Context {
@@ -516,6 +520,7 @@ async fn ensure_inline_stdio_is_stored() {
     BTreeMap::new(),
     store.clone(),
     Platform::Linux,
+    OVERALL_DEADLINE_SECS,
   )
   .unwrap();
 
@@ -751,6 +756,7 @@ async fn execute_missing_file_uploads_if_known() {
     BTreeMap::new(),
     store.clone(),
     Platform::Linux,
+    OVERALL_DEADLINE_SECS,
   )
   .unwrap();
 
@@ -810,6 +816,7 @@ async fn execute_missing_file_errors_if_unknown() {
     BTreeMap::new(),
     store,
     Platform::Linux,
+    OVERALL_DEADLINE_SECS,
   )
   .unwrap();
 

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -29,7 +29,7 @@ use crate::remote_tests::{
 };
 use crate::{CommandRunner, Context, MultiPlatformProcess, Platform, Process};
 
-const OVERALL_DEADLINE_SECS: u64 = 10 * 60;
+const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
 
 fn create_command_runner(
   address: String,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -402,7 +402,7 @@ async fn main() {
             headers,
             store.clone(),
             Platform::Linux,
-            overall_deadline_secs,
+            Duration::from_secs(overall_deadline_secs),
           )
           .expect("Failed to make command runner"),
         )

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -204,6 +204,14 @@ async fn main() {
             .default_value("false")
             .help("Enable the experimental streaming remote execution client.")
       )
+      .arg(
+        Arg::with_name("overall-deadline-secs")
+            .long("overall-deadline-secs")
+            .takes_value(true)
+            .required(false)
+            .default_value("600")
+            .help("Overall timeout in seconds for each request from time of submission")
+      )
       .setting(AppSettings::TrailingVarArg)
     .arg(
       Arg::with_name("argv")
@@ -287,6 +295,7 @@ async fn main() {
     .map(collection_from_keyvalues::<_, BTreeMap<_, _>>)
     .unwrap_or_default();
   let enable_streaming_client = args.is_present("enable-streaming-client");
+  let overall_deadline_secs = value_t!(args.value_of("overall-deadline-secs"), u64).unwrap_or(600);
 
   let executor = task_executor::Executor::new(Handle::current());
 
@@ -393,6 +402,7 @@ async fn main() {
             headers,
             store.clone(),
             Platform::Linux,
+            overall_deadline_secs,
           )
           .expect("Failed to make command runner"),
         )

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -295,7 +295,7 @@ async fn main() {
     .map(collection_from_keyvalues::<_, BTreeMap<_, _>>)
     .unwrap_or_default();
   let enable_streaming_client = args.is_present("enable-streaming-client");
-  let overall_deadline_secs = value_t!(args.value_of("overall-deadline-secs"), u64).unwrap_or(600);
+  let overall_deadline_secs = value_t!(args.value_of("overall-deadline-secs"), u64).unwrap_or(3600);
 
   let executor = task_executor::Executor::new(Handle::current());
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -86,6 +86,7 @@ impl Core {
     process_execution_use_local_cache: bool,
     remote_execution_headers: BTreeMap<String, String>,
     remote_execution_enable_streaming: bool,
+    remote_execution_overall_deadline_secs: u64,
     process_execution_local_enable_nailgun: bool,
   ) -> Result<Core, String> {
     // Randomize CAS address order to avoid thundering herds from common config.
@@ -207,6 +208,7 @@ impl Core {
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
+            remote_execution_overall_deadline_secs,
           )?)
         } else {
           Box::new(process_execution::remote::CommandRunner::new(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -208,7 +208,7 @@ impl Core {
             // TODO if we ever want to configure the remote platform to be something else we
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
-            remote_execution_overall_deadline_secs,
+            Duration::from_secs(remote_execution_overall_deadline_secs),
           )?)
         } else {
           Box::new(process_execution::remote::CommandRunner::new(

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -353,6 +353,7 @@ py_module_initializer!(native_engine, |py, m| {
         process_execution_use_local_cache: bool,
         remote_execution_headers: Vec<(String, String)>,
         remote_execution_enable_streaming: bool,
+        remote_execution_overall_deadline_secs: u64,
         process_execution_local_enable_nailgun: bool
       )
     ),
@@ -682,6 +683,7 @@ fn scheduler_create(
   process_execution_use_local_cache: bool,
   remote_execution_headers: Vec<(String, String)>,
   remote_execution_enable_streaming: bool,
+  remote_execution_overall_deadline_secs: u64,
   process_execution_local_enable_nailgun: bool,
 ) -> CPyResult<PyScheduler> {
   let core: Result<Core, String> = Ok(()).and_then(move |()| {
@@ -728,6 +730,7 @@ fn scheduler_create(
       process_execution_use_local_cache,
       remote_execution_headers.into_iter().collect(),
       remote_execution_enable_streaming,
+      remote_execution_overall_deadline_secs,
       process_execution_local_enable_nailgun,
     )
   });


### PR DESCRIPTION
### Problem

The streaming REv2 client was using the per-process execution timeout as the deadline timeout from the time of submission. This does not account for queuing time. REv2 supports passing a deadline timeout to the server. We should do that, but should also have a generous overall timeout as well. This PR makes the overall timeout configurable and raises it to 10 minutes.

### Solution

Adds a `--remote-execution-overall-deadline-secs` option to configure the overall timeout used for remote execution requests.

### Result

Should not see timeouts from the timeout being too low.