### PR TITLE
Add a configurable cap on total pantsd memory usage.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -531,6 +531,16 @@ class GlobalOptions(Subsystem):
             "any prior running Pants command must be finished for the current one to start. "
             "To never timeout, use the value -1.",
         )
+        register(
+            "--pantsd-max-memory-usage",
+            advanced=True,
+            type=int,
+            default=2 ** 32,
+            help=(
+                "The maximum memory usage of a pantsd process (in bytes). There is at most one "
+                "pantsd process per workspace."
+            ),
+        )
 
         # These facilitate configuring the native engine.
         register(

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -381,17 +381,17 @@ class PantsDaemon(PantsDaemonProcessManager):
         self.write_metadata_by_name(
             "pantsd", self.FINGERPRINT_KEY, ensure_text(self.options_fingerprint)
         )
-        scheduler_service = next(
-            s for s in self._services.services if isinstance(s, SchedulerService)
-        )
-        scheduler_service.begin_monitoring_memory_usage(pid)
+        scheduler_services = [s for s in self._services.services if isinstance(s, SchedulerService)]
+        for scheduler_service in scheduler_services:
+            scheduler_service.begin_monitoring_memory_usage(pid)
 
         # If we can, add the pidfile to watching via the scheduler.
         pidfile_absolute = self._metadata_file_path("pantsd", "pid")
         if pidfile_absolute.startswith(self._build_root):
-            scheduler_service.add_invalidation_glob(
-                os.path.relpath(pidfile_absolute, self._build_root)
-            )
+            for scheduler_service in scheduler_services:
+                scheduler_service.add_invalidation_glob(
+                    os.path.relpath(pidfile_absolute, self._build_root)
+                )
         else:
             logging.getLogger(__name__).warning(
                 "Not watching pantsd pidfile because subprocessdir is outside of buildroot. Having "

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -15,9 +15,10 @@ from pants.base.exception_sink import ExceptionSink, SignalHandler
 from pants.bin.daemon_pants_runner import DaemonPantsRunner
 from pants.engine.internals.native import Native
 from pants.engine.unions import UnionMembership
-from pants.init.engine_initializer import EngineInitializer
+from pants.init.engine_initializer import EngineInitializer, LegacyGraphScheduler
 from pants.init.logging import clear_logging_handlers, init_rust_logger, setup_logging_to_file
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.process_manager import PantsDaemonProcessManager
@@ -26,6 +27,7 @@ from pants.pantsd.service.pailgun_service import PailgunService
 from pants.pantsd.service.pants_service import PantsServices
 from pants.pantsd.service.scheduler_service import SchedulerService
 from pants.pantsd.service.store_gc_service import StoreGCService
+from pants.pantsd.watchman import Watchman
 from pants.pantsd.watchman_launcher import WatchmanLauncher
 from pants.util.contextutil import stdio_as
 from pants.util.logging import LogLevel
@@ -140,11 +142,11 @@ class PantsDaemon(PantsDaemonProcessManager):
 
     @staticmethod
     def _setup_services(
-        build_root,
-        bootstrap_options,
-        legacy_graph_scheduler,
-        native,
-        watchman,
+        build_root: str,
+        bootstrap_options: OptionValueContainer,
+        legacy_graph_scheduler: LegacyGraphScheduler,
+        native: Native,
+        watchman: Watchman,
         union_membership: UnionMembership,
     ):
         """Initialize pantsd services.
@@ -170,6 +172,7 @@ class PantsDaemon(PantsDaemonProcessManager):
             build_root=build_root,
             invalidation_globs=invalidation_globs,
             union_membership=union_membership,
+            max_memory_usage_in_bytes=bootstrap_options.pantsd_max_memory_usage,
         )
 
         pailgun_service = PailgunService(
@@ -373,17 +376,19 @@ class PantsDaemon(PantsDaemonProcessManager):
         """
 
         # Write the pidfile.
-        self.write_pid()
+        pid = os.getpid()
+        self.write_pid(pid=pid)
         self.write_metadata_by_name(
             "pantsd", self.FINGERPRINT_KEY, ensure_text(self.options_fingerprint)
         )
+        scheduler_service = next(
+            s for s in self._services.services if isinstance(s, SchedulerService)
+        )
+        scheduler_service.begin_monitoring_memory_usage(pid)
 
-        # Add the pidfile to watching via the scheduler.
+        # If we can, add the pidfile to watching via the scheduler.
         pidfile_absolute = self._metadata_file_path("pantsd", "pid")
         if pidfile_absolute.startswith(self._build_root):
-            scheduler_service = next(
-                s for s in self._services.services if isinstance(s, SchedulerService)
-            )
             scheduler_service.add_invalidation_glob(
                 os.path.relpath(pidfile_absolute, self._build_root)
             )

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -40,7 +40,7 @@ class PantsDaemonMonitor(ProcessManager):
     def _log(self):
         print(magenta(f"PantsDaemonMonitor: pid is {self._pid} is_alive={self.is_alive()}"))
 
-    def assert_started_and_stopped(self, timeout=30):
+    def assert_started_and_stopped(self, timeout: int = 30) -> None:
         """Asserts that pantsd was alive (it wrote a pid file), but that it stops afterward."""
         self._process = None
         self._pid = self.await_pid(timeout)

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -40,6 +40,12 @@ class PantsDaemonMonitor(ProcessManager):
     def _log(self):
         print(magenta(f"PantsDaemonMonitor: pid is {self._pid} is_alive={self.is_alive()}"))
 
+    def assert_started_and_stopped(self, timeout=30):
+        """Asserts that pantsd was alive (it wrote a pid file), but that it stops afterward."""
+        self._process = None
+        self._pid = self.await_pid(timeout)
+        self.assert_stopped()
+
     def assert_started(self, timeout=30):
         self._process = None
         self._pid = self.await_pid(timeout)

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -399,6 +399,22 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 ),
             )
 
+    def test_pantsd_max_memory_usage(self):
+        """Validates that the max_memory_usage setting is respected."""
+        # We set a very, very low max memory usage, which forces pantsd to restart immediately.
+        max_memory_usage_bytes = 130
+        with self.pantsd_successful_run_context() as ctx:
+            # TODO: We run the command, but we expect it to race pantsd shutting down, so we don't
+            # assert success. https://github.com/pantsbuild/pants/issues/8200 will address waiting
+            # until after the current command completes to invalidate the scheduler, at which point
+            # we can assert success here.
+            ctx.runner(
+                [f"--pantsd-max-memory-usage={max_memory_usage_bytes}", "list", "testprojects::"]
+            )
+
+            # Assert that a pid file is written, but that the server stops afterward.
+            ctx.checker.assert_started_and_stopped()
+
     def test_pantsd_invalidation_stale_sources(self):
         test_path = "tests/python/pants_test/daemon_correctness_test_0001"
         test_build_file = os.path.join(test_path, "BUILD")


### PR DESCRIPTION
### Problem

`pantsd` does not implement garbage collection of the `Graph` (see #7675), but additionally, there are likely a few Python-level reference cycles beyond those that we have already discovered.

### Solution

We will eventually implement #7675, and it will need a config value to control how much it collects. But in the meantime, having a configurable built-in cap on total memory usage is generally useful, and can consume the same flag that our eventual collection will.

### Result

`pantsd` will restart itself when it uses more than the configured amount of memory (defaulting to 4GB). As mentioned in the test comment, until #8200 is fixed, the message rendered when we restart will not be particularly friendly, so we should likely not cherry-pick this to 1.29.x, which will not receive #8200.

This is not a complete fix for #9999, but I'm going to resolve it in favor of tracking followup in #7675.

[ci skip-rust-tests]
[ci skip-jvm-tests]