### PR TITLE
Tweak `DescendantAddresses` so that call sites can no-op when no matches

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -189,6 +189,7 @@ class DescendantAddresses(AddressSpec):
     """An AddressSpec representing all addresses located recursively under the given directory."""
 
     directory: str
+    error_if_no_matches: bool = True
 
     def to_spec_string(self) -> str:
         return f"{self.directory}::"
@@ -205,7 +206,12 @@ class DescendantAddresses(AddressSpec):
     def address_target_pairs_from_address_families(
         self, address_families: Sequence["AddressFamily"]
     ):
-        return self.all_address_target_pairs(address_families)
+        addr_tgt_pairs = self.all_address_target_pairs(address_families)
+        if self.error_if_no_matches and len(addr_tgt_pairs) == 0:
+            raise self.AddressResolutionError(
+                f"Address spec {repr(self.to_spec_string())} does not match any targets."
+            )
+        return addr_tgt_pairs
 
     def make_glob_patterns(self, address_mapper: "AddressMapper") -> List[str]:
         return [os.path.join(self.directory, "**", pat) for pat in address_mapper.build_patterns]

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -205,12 +205,7 @@ class DescendantAddresses(AddressSpec):
     def address_target_pairs_from_address_families(
         self, address_families: Sequence["AddressFamily"]
     ):
-        addr_tgt_pairs = self.all_address_target_pairs(address_families)
-        if len(addr_tgt_pairs) == 0:
-            raise self.AddressResolutionError(
-                "AddressSpec {} does not match any targets.".format(self)
-            )
-        return addr_tgt_pairs
+        return self.all_address_target_pairs(address_families)
 
     def make_glob_patterns(self, address_mapper: "AddressMapper") -> List[str]:
         return [os.path.join(self.directory, "**", pat) for pat in address_mapper.build_patterns]


### PR DESCRIPTION
For dep inference, we need to use `DescendantAddress(src_root)` for every source root, but this will sometimes fail. For example, Pants has a source root `3rdparty/protobuf`, but doesn't have any BUILD files in it.

We may end up wanting to change the overall CI behavior so that `./pants list ::` would stop failing when no targets exist, but we do not yet want to change the CI behavior until further discussion.

So, this adds an optional field to `DescendantAddresses` so that call sites can determine the behavior they want.

[ci skip-rust-tests]
[ci skip-jvm-tests]