### PR TITLE
Restore pytest coverage console report.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -137,7 +137,7 @@ class PytestRun(ChrootedTestRunnerTaskMixin, Task):
         register(
             "--coverage-reports",
             fingerprint=True,
-            choices=("xml", "html"),
+            choices=("xml", "html", "console"),
             type=list,
             member_type=str,
             default=("xml", "html"),
@@ -432,6 +432,8 @@ class PytestRun(ChrootedTestRunnerTaskMixin, Task):
                     else:
                         coverage_workdir = workdirs.coverage_path
                         coverage_reports = self.get_options().coverage_reports
+                        if "console" in coverage_reports:
+                            coverage_run("report", ["-i", "--rcfile", coverage_rc])
                         if "html" in coverage_reports:
                             coverage_run(
                                 "html", ["-i", "--rcfile", coverage_rc, "-d", coverage_workdir]


### PR DESCRIPTION
This feature was dropped in #8208 without a deprecation cycle. Restore
the feature, but do not restore its default on status prior to removal
since not having the console report generated is the new defacto norm
established by #8208.

Cherry-Picks: #10013

[ci skip-rust-tests]
[ci skip-jvm-tests]