### PR TITLE
Remove `pyopenssl`, `parametrized`, and `wheel` dependencies

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -20,7 +20,6 @@ mypy==0.780
 
 Markdown==2.1.1
 packaging==20.3
-parameterized==0.6.1
 pathspec==0.8.0
 pex==2.1.11
 psutil==5.7.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,7 +25,6 @@ pathspec==0.8.0
 pex==2.1.11
 psutil==5.7.0
 Pygments==2.6.1
-pyopenssl==19.1.0
 pystache==0.5.4
 python-Levenshtein==0.12.0
 pywatchman==1.4.1

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -36,5 +36,4 @@ setuptools==44.0.0
 toml==0.10.1
 typed-ast>=1.4.1,<1.5
 typing-extensions==3.7.4.2
-wheel==0.34.2
 www-authenticate==0.9.2

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -4,7 +4,6 @@
 python_library(
   dependencies=[
     '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
     'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/base:workunit',
     'src/python/pants/binaries',

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -95,7 +95,6 @@ python_library(
     ':artifact_cache_stats',
     ':pantsd_stats',
     '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
     'src/python/pants/auth',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:run_info',

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -5,7 +5,6 @@ python_library(
   sources = ['**/*.py'],
   dependencies = [
     '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
     'src/python/pants/util:dirutil',
   ],
   tags = {"partially_type_checked"},

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -5,7 +5,6 @@
 python_tests(
   dependencies = [
     '3rdparty/python:dataclasses',
-    '3rdparty/python:parameterized',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
     'src/python/pants/base:exceptions',

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -4,7 +4,6 @@
 python_tests(
   dependencies = [
     '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
     'src/python/pants/net',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -15,8 +15,7 @@ python_tests(
   name = 'reporting_integration',
   sources = ['test_reporting_integration.py'],
   dependencies = [
-    '3rdparty/python:parameterized',
-    '3rdparty/python:py-zipkin',
+    '3rdparty/python:psutil',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
     'examples/src/java/org/pantsbuild/example:hello_directory',

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -9,7 +9,6 @@ from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 
 import psutil
-from parameterized import parameterized
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.collections import assert_single_element
@@ -194,18 +193,21 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         )
         self.assertIn("", pants_run.stdout_data)
 
-    @parameterized.expand(["--quiet", "--no-quiet"])
-    def test_epilog_to_stderr(self, quiet_flag):
-        command = [
-            "--time",
-            quiet_flag,
-            "bootstrap",
-            "examples/src/java/org/pantsbuild/example/hello::",
-        ]
-        pants_run = self.run_pants(command)
-        self.assert_success(pants_run)
-        self.assertIn("Cumulative Timings", pants_run.stderr_data)
-        self.assertNotIn("Cumulative Timings", pants_run.stdout_data)
+    def test_epilog_to_stderr(self) -> None:
+        def run_test(quiet_flag: str) -> None:
+            command = [
+                "--time",
+                quiet_flag,
+                "bootstrap",
+                "examples/src/java/org/pantsbuild/example/hello::",
+            ]
+            pants_run = self.run_pants(command)
+            self.assert_success(pants_run)
+            self.assertIn("Cumulative Timings", pants_run.stderr_data)
+            self.assertNotIn("Cumulative Timings", pants_run.stdout_data)
+
+        run_test("--quiet")
+        run_test("--no-quiet")
 
     def test_zipkin_reporter(self):
         ZipkinHandler = zipkin_handler()


### PR DESCRIPTION
`pyopenssl` was only being used to pin a transitive dep back in 2017. We don't need to do this anymore because `requests` is more up-to-date. We should also be using a constraints file for this purpose, rather than `requirements.txt`.

`parametrized` is similar to Pytest's parametrization feature. Because we want to encourage tests to use Pytest-style, it's better to use that instead. While Pytest cannot parametrize class-based tests, those can be parametrized through other means like inner helper functions. 

`wheel` was not being used by anything.