### PR TITLE
Refactor some code around nodes.rs

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::{BTreeMap, HashSet};
-use std::convert::{Into, TryInto};
+use std::convert::Into;
 use std::future::Future;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::{Failure, TypeId};
+use crate::core::TypeId;
 use crate::intrinsics::Intrinsics;
-use crate::nodes::{NodeKey, WrappedNode};
+use crate::nodes::NodeKey;
 use crate::scheduler::Session;
 use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
@@ -357,22 +357,6 @@ impl Context {
       session,
       run_id,
     }
-  }
-
-  ///
-  /// Get the future value for the given Node implementation.
-  ///
-  pub async fn get<N: WrappedNode>(&self, node: N) -> Result<N::Item, Failure> {
-    let node_result = self
-      .core
-      .graph
-      .get(self.entry_id, self, node.into())
-      .await?;
-    Ok(
-      node_result
-        .try_into()
-        .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
-    )
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -81,7 +81,7 @@ impl StoreFileByDigest<Failure> for Context {
 ///
 #[async_trait]
 pub trait WrappedNode: Into<NodeKey> {
-  type Item: TryFrom<NodeOutput>;
+  type Item;
 
   async fn run_wrapped_node(self, context: Context) -> NodeResult<Self::Item>;
 }
@@ -1180,61 +1180,6 @@ impl TryFrom<NodeOutput> for Value {
   fn try_from(nr: NodeOutput) -> Result<Self, ()> {
     match nr {
       NodeOutput::Value(v) => Ok(v),
-      _ => Err(()),
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for Arc<store::Snapshot> {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::Snapshot(v) => Ok(v),
-      _ => Err(()),
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for hashing::Digest {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::Digest(v) => Ok(v),
-      _ => Err(()),
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for ProcessResult {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::ProcessResult(v) => Ok(*v),
-      _ => Err(()),
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for LinkDest {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::LinkDest(v) => Ok(v),
-      _ => Err(()),
-    }
-  }
-}
-
-impl TryFrom<NodeOutput> for Arc<DirectoryListing> {
-  type Error = ();
-
-  fn try_from(nr: NodeOutput) -> Result<Self, ()> {
-    match nr {
-      NodeOutput::DirectoryListing(v) => Ok(v),
       _ => Err(()),
     }
   }


### PR DESCRIPTION
I noticed that some of the code pertaining to the `WrappedNode` trait in `nodes.rs` was needlessly verbose, and this commit tries to clean that up by:

- removing the `From<T> for NodeOutput` implementations for various types. These were only used in the body of the `Node::run` trait implementation on `NodeKey`, and it's less verbose to just do the mapping of those types to `NodeOutput` variants there, than to have all the `From` implementations and call `NodeOutput::from` repeatedly

- renaming `WrappedNode::run` to `run_wrapped_node`. There are other methods called `run`, and this just makes it easier to grep in the codebase for instances of the method one might care about

- removing the `Context::get` method. This did functionally the same thing as `WrappedNode::run_wrapped_node` and can be replaced with it at every call sight. Also it's confusing that there are multiple separate methods in the codebase called `get`, and removing this makes that incrementally less confusing.

- removing the constraint that the `Item` of a `WrappedNode` must implement `TryFrom<NodeOutput>`, and remove this implementation for all the types that implemented it save `Value` (since another bit of code uses that implementation)