### PR TITLE
Add a __run.sh script to reproduce a process execution in a preserved chroot

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2023,6 +2023,7 @@ dependencies = [
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sharded_lmdb 0.0.1",
+ "shell-quote 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "task_executor 0.0.1",
@@ -2677,6 +2678,16 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "shell-quote"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "shlex"
@@ -3781,6 +3792,8 @@ dependencies = [
 "checksum serde_test 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "4a6563891298bffe3306cbd5f058845f406f3ceb505c8cb2e4e103d12807d7ee"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+"checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
+"checksum shell-quote 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fb975283e6af8d3d691ddcefdca3a4dffe369167746d22fd993205e1e0c0de0"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05a3e303ace6adb0a60a9e9e2fbc6a33e1749d1e43587e2125f7efa9c5e107c5"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2680,11 +2680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-escape"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "shell-quote"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,7 +3787,6 @@ dependencies = [
 "checksum serde_test 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "4a6563891298bffe3306cbd5f058845f406f3ceb505c8cb2e4e103d12807d7ee"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
-"checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
 "checksum shell-quote 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fb975283e6af8d3d691ddcefdca3a4dffe369167746d22fd993205e1e0c0de0"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -27,6 +27,7 @@ nails = "0.5.1"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 sha2 = "0.8"
 sharded_lmdb = {  path = "../sharded_lmdb" }
+shell-quote = "0.1.0"
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -34,6 +34,8 @@ use crate::{
 
 use bytes::{Bytes, BytesMut};
 
+pub const USER_EXECUTABLE_MODE: u32 = 0o100755;
+
 #[derive(Clone)]
 pub struct CommandRunner {
   pub store: Store,
@@ -502,7 +504,7 @@ pub trait CapturedWorkdir {
         ::std::fs::OpenOptions::new()
           .create_new(true)
           .write(true)
-          .mode(0o755) // Executable for user, read-only for others.
+          .mode(USER_EXECUTABLE_MODE) // Executable for user, read-only for others.
           .open(&full_file_path)
           .map_err(|e| format!("{:?}", e))?
           .write_all(full_script.as_bytes())

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -479,9 +479,10 @@ pub trait CapturedWorkdir {
           let formatted_assignment = format!("{}={}", key, arg_str);
           env_var_strings.push(formatted_assignment);
         }
+        let stringified_env_vars: String = env_var_strings.join(" ");
 
         // Shell-quote every command-line argument, as necessary.
-        let mut full_command_line: Vec<String> = env_var_strings;
+        let mut full_command_line: Vec<String> = vec![];
         for arg in req.argv.iter() {
           let quoted_arg = bash::escape(&arg);
           let arg_str = str::from_utf8(&quoted_arg)
@@ -494,9 +495,11 @@ pub trait CapturedWorkdir {
         let full_script = format!(
           "#!/bin/bash
 # This command line should execute the same process as pants did internally.
+export {}
+
 {}
 ",
-          stringified_command_line,
+          stringified_env_vars, stringified_command_line,
         );
 
         let full_file_path = workdir_path.join("__run.sh");


### PR DESCRIPTION
### Problem

Fixes #10029.

### Solution

- Add an executable file named `__run.sh` with quoted environment variables and command-line arguments so that process executions can be reproduced within the chroot.
- Add testing.