### PR TITLE
Improve performance of Python dependency inference

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/BUILD
+++ b/src/python/pants/backend/python/dependency_inference/BUILD
@@ -27,7 +27,6 @@ python_tests(
   name="tests",
   dependencies=[
     ":dependency_inference",
-    "src/python/pants/backend/project_info",
     "src/python/pants/testutil:test_base",
   ],
   tags = {"type_checked"},

--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -8,11 +8,11 @@ from pkg_resources import Requirement
 
 
 class PythonRequirements:
-    """Translates a Pip requirements file into an equivalent set of `python_requirement_library`
+    """Translates a pip requirements file into an equivalent set of `python_requirement_library`
     targets.
 
     If the `requirements.txt` file has lines `foo>=3.14` and `bar>=2.7`,
-    then then will translate to:
+    then this will translate to:
 
       python_requirement_library(
         name="foo",


### PR DESCRIPTION
We get dramatically better performance by pre-computing a mapping of module -> address once at the beginning of a Pants run. Every single target can then reuse this mapping. Thanks to Pantsd, future runs will also benefit from this mapping.

This redesign also allows us to better formalize that only one target should own a module. If >1 owns a module, then we don't record the module to avoid the ambiguity. Users will need to explicitly specify that target.

### Result

Running `./v2 --dependency-inference --no-enable-pantsd dependencies2 src/python/pants/util:` 10 times each:

Before:
```
            Mean        Std.Dev.    Min         Median      Max
real        10.175      0.225       9.918       10.132      10.725
user        16.552      0.758       15.290      16.395      17.871
sys         4.694       0.277       4.335       4.713       5.158
```

After:
```
            Mean        Std.Dev.    Min         Median      Max
real        7.332       0.714       6.854       6.996       9.274
user        7.877       0.657       7.444       7.570       9.613
sys         5.530       0.201       5.327       5.485       6.066
```