### PR TITLE
Default to non strict timestamps in zip

### DIFF
--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -298,6 +298,11 @@ def open_zip(path_or_file: Union[str, Any], *args, **kwargs) -> Iterator[zipfile
         raise InvalidZipPath(f"Invalid zip location: {path_or_file}")
     if "allowZip64" not in kwargs:
         kwargs["allowZip64"] = True
+    # When using pants bundle and zinc incremental compilation, zip file may have a modification
+    # timestamp at 0. Zip doesn't allow timestamp < 1980, using strict_timestamp = False will
+    # force timestamp to 1980-01-01 if modification time is before 1980.
+    if "strict_timestamps" not in kwargs:
+        kwargs["strict_timestamps"] = False
     try:
         zf = zipfile.ZipFile(path_or_file, *args, **kwargs)
     except zipfile.BadZipfile as bze:


### PR DESCRIPTION


### Problem
When doing our pants bundle, you may encounter issue with
`PANTS_COMPILE_ZINC_INCREMENTAL=true`, because it will create zips with
modification set to 0.

For example, on our project, we sometimes have a cryptic error about
zips and date: 'ZIP does not support timestamps before 1980'

After adding some `print` we see that jar files have this `stat`
```
$ stat [LONG_PATH_IN_PANTSD]/z.jar
  Size: 10414           Blocks: 24         IO Block: 4096   regular file
Device: fe06h/65030d    Inode: 272633      Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/mgrenonville)   Gid: ( 1000/mgrenonville)
Access: 2020-06-11 16:30:57.212498551 +0200
Modify: 1970-01-01 00:00:00.000000000 +0100
Change: 2020-06-11 16:30:51.468441079 +0200

```
modification time is used by python zipfile.py to get date at `/usr/lib/python3.8/zipfile.py:526` :
```python 
        st = os.stat(filename)
        isdir = stat.S_ISDIR(st.st_mode)
        mtime = time.localtime(st.st_mtime)
        date_time = mtime[0:6]
        if not strict_timestamps and date_time[0] < 1980:
            date_time = (1980, 1, 1, 0, 0, 0)
        elif not strict_timestamps and date_time[0] > 2107:
            date_time = (2107, 12, 31, 23, 59, 59)
```

### Solution
In fact, when digging in code, it is clearly related to
strict_timestamps in python code.


### Result
Defaulting it to `False` doesn't seem a bad idea.