### PR TITLE
Fix pants.toml contents appearing in engine error messages

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -345,7 +345,7 @@ class InlinedGraphTest(GraphTestBase):
         self.do_test_trace_message(
             scheduler,
             parsed_address,
-            f"(?ms)Dep graph contained a cycle:.*{cyclic_address_str}.* <-.*{cyclic_address_str}.* <-",
+            f"(?ms)Dependency graph contained a cycle:.*{cyclic_address_str}.* <-.*{cyclic_address_str}.* <-",
         )
 
     def test_cycle_self(self) -> None:

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -574,6 +574,9 @@ class _EmptyConfig(Config):
     def get_source_for_option(self, section: str, option: str) -> None:
         return None
 
+    def __repr__(self) -> str:
+        return "EmptyConfig()"
+
 
 @dataclass(frozen=True, eq=False)
 class _SingleFileConfig(Config):
@@ -605,6 +608,9 @@ class _SingleFileConfig(Config):
         if self.has_option(section, option):
             return self.sources()[0]
         return None
+
+    def __repr__(self) -> str:
+        return f"SingleFileConfig({self.config_path})"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, _SingleFileConfig):
@@ -669,6 +675,9 @@ class _ChainedConfig(Config):
             if cfg.has_option(section, option):
                 return cfg.get_source_for_option(section, option)
         return None
+
+    def __repr__(self) -> str:
+        return f"ChainedConfig({self.sources()})"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -50,6 +50,13 @@ class OptionsBootstrapper:
     args: Tuple[str, ...]
     config: Config
 
+    def __repr__(self) -> str:
+        env = {pair[0]: pair[1] for pair in self.env_tuples}
+        # Bootstrap args are included in `args`. We also drop the first argument, which is the path
+        # to `pants_loader.py`.
+        args = list(self.args[1:])
+        return f"OptionsBootstrapper(args={args}, env={env}, config={self.config})"
+
     @staticmethod
     def get_config_file_paths(env, args) -> List[str]:
         """Get the location of the config files.

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1122,7 +1122,7 @@ impl NodeError for Failure {
       path[path_len - 1] += " <-"
     }
     throw(&format!(
-      "Dep graph contained a cycle:\n  {}",
+      "Dependency graph contained a cycle:\n  {}",
       path.join("\n  ")
     ))
   }


### PR DESCRIPTION
Before:
```
Engine traceback:
  in `dependencies2` goal
Traceback (no traceback):
  <pants native internals>
Exception: Dep graph contained a cycle:
  Task(pants.engine.internals.graph:125:transitive_target(), (OptionsBootstrapper(env_tuples=(('PANTS_DEV', '1'),), bootstrap_args=('--no-v1', '--v2'), args=('/Users/eric/DocsLocal/code/projects/pants/src/python/pants/bin/pants_loader.py', '--no-v1', '--v2', 'dependencies2', '--transitive', 'src/python/pants/util:meta'), config=_ChainedConfig(chained_configs=(_SingleFileConfig(config_path='/Users/eric/DocsLocal/code/projects/pants/pants.toml', content_digest='37c222457604d6e6685061208af099266ddad1e7', values=_TomlValues(values={'DEFAULT': {'buildroot': '/Users/eric/DocsLocal/code/projects/pants', 'homedir': '/Users/eric', 'user': 'eric', 'pants_bootstrapdir': '/Users/eric/.cache/pants', 'pants_configdir': '/Users/eric/.config/pants', 'pants_workdir': '/Users/eric/DocsLocal/code/projects/pants/.pants.d', 'pants_supportdir': '/Users/eric/DocsLocal/code/projects/pants/build-support', 'pants_distdir': '/Users/eric/DocsLocal/code/projects/pants/dist', 'jvm_options': ['-Xmx1g'], 'local_artifact_cache': '%(pants_bootstrapdir)s/artifact_cache'}, 'GLOBAL': {'print_exception_stacktrace': True, 'v2': False, 'pythonpath': ['%(buildroot)s/contrib/confluence/src/python', '%(buildroot)s/contrib/go/src/python', '%(buildroot)s/contrib/mypy/src/python', '%(buildroot)s/contrib/node/src/python', '%(buildroot)s/contrib/scrooge/src/python', '%(buildroot)s/pants-plugins/src/python'], 'backend_packages': {'add': ['pants.backend.docgen', 'pants.contrib.confluence', 'pants.contrib.go', 'pants.contrib.node', 'pants.contrib.scrooge', 'internal_backend.repositories', 'internal_backend.sitegen', 'internal_backend.utilities']}, 'backend_packages2': {'add': ['pants.backend.awslambda.python', 'pants.backend.native', 'pants.backend.python', 'pants.backend.python.lint.black', 'pants.backend.python.lint.docformatter', 'pants.backend.python.lint.flake8', 'pants.backend.python.lint.isort', 'internal_backend.rules_for_testing']}, 'pantsd_invalidation_globs': {'add': ['!*_test.py', 'src/rust/engine/**/*.rs', 'src/rust/engine/**/*.toml']}, 'pants_ignore': {'add': ['/build-support/virtualenvs/', '/build-support/*.venv/', '/build-support/bin/native/src', '/src/rust/engine/target', '!*.class', '!/pants.pex']}}, 'source': {'root_patterns': ['src/*', 'src/main/*', 'src/test/*', '/src/go/src', 'test/*', 'tests/*', '3rdparty/*', '/build-support/bin', '/build-support/migration-support']}, 'cache': {'read_from': [], 'write_to': [], 'bootstrap': {'read_from': ['%(local_artifact_cache)s'], 'write_to': ['%(local_artifact_cache)s']}, 'resolve': {'coursier': {'read_from': ['%(local_artifact_cache)s'], 'write_to': ['%(local_artifact_cache)s']}}}, 'ivy': {'ivy_settings': '%(pants_supportdir)s/ivy/ivysettings.xml', 'ivy_profile': '%(pants_supportdir)s/ivy/ivy.xml'}, 'gen': {'scrooge': {'service_deps': "{\n  'java': [\n    '3rdparty:slf4j-api',\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'structs_deps': "{\n  'java': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'service_exports': "{\n  'java': [\n    '3rdparty:thrift',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'structs_exports': "{\n  'java': [\n    '3rdparty:thrift',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n"}, 'thrift-java': {'deps': ['3rdparty:thrift']}, 'thrift-py': {'deps': ['examples/3rdparty/python:thrift']}, 'go-protobuf': {'import_target': 'contrib/go/examples/src/protobuf/org/pantsbuild/example:protobuf-deps'}}, 'compile': {'rsc': {'jvm_options': ['-Xmx4g', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4'], 'args': ['-C-encoding', '-CUTF-8', '-S-encoding', '-SUTF-8', '-S-g:vars', '-S-target:jvm-1.8'], 'warning_args': ['-S-deprecation', '-S-unchecked', '-S-feature'], 'no_warning_args': ['-S-nowarn']}, 'javac': {'args': ['-encoding', 'UTF-8', '-J-Xmx2g'], 'warning_args': ['-Xlint:deprecation', '-Xlint:empty', '-Xlint:finally', '-Xlint:overrides', '-Xlint:static', '-Xlint:unchecked', '-Xlint:try'], 'no_warning_args': ['-Xlint:none']}}, 'black': {'config': 'pyproject.toml'}, 'checkstyle': {'config': '%(pants_supportdir)s/checkstyle/coding_style.xml'}, 'docformatter': {'args': ['--wrap-summaries=100', '--wrap-descriptions=100']}, 'eslint': {'setupdir': '%(pants_supportdir)s/eslint', 'config': '%(pants_supportdir)s/eslint/.eslintrc', 'ignore': '%(pants_supportdir)s/eslint/.eslintignore'}, 'flake8': {'config': 'build-support/flake8/.flake8', 'extra_requirements': {'add': ['flake8-pantsbuild>=2.0,<3', 'flake8-2020>=1.6.0,<1.7.0']}}, 'isort': {'config': ['.isort.cfg', 'contrib/.isort.cfg', 'examples/.isort.cfg']}, 'scalafmt': {'skip': True}, 'scalafix': {'skip': True}, 'scalastyle': {'config': '%(buildroot)s/build-support/scalastyle/scalastyle_config.xml'}, 'lint': {'scalastyle': {'excludes': '%(buildroot)s/build-support/scalastyle/excludes.txt'}}, 'protoc': {'version': '2.4.1', 'gen': {'go-protobuf': {'version': '3.11.4'}}}, 'scala': {'version': 2.12}, 'java': {'strict_deps': True}, 'jvm': {'options': ['-Xmx1g'], 'bench': {'options': ['-Xmx1g']}, 'run': {'jvm': {'options': ['-Xmx1g']}}, 'test': {'junit': {'options': ['-Djava.awt.headless=true', '-Xmx1g']}}}, 'jvm-platform': {'default_platform': 'java8', 'platforms': "{\n  'java7': {'source': '7', 'target': '7', 'args': [] },\n  'java8': {'source': '8', 'target': '8', 'args': [] },\n  'java9': {'source': '9', 'target': '9', 'args': [] },\n}\n"}, 'pants-releases': {'branch_notes': "{\n  'master': 'src/python/pants/notes/master.rst',\n  '1.0.x': 'src/python/pants/notes/1.0.x.rst',\n  '1.1.x': 'src/python/pants/notes/1.1.x.rst',\n  '1.2.x': 'src/python/pants/notes/1.2.x.rst',\n  '1.3.x': 'src/python/pants/notes/1.3.x.rst',\n  '1.4.x': 'src/python/pants/notes/1.4.x.rst',\n  '1.5.x': 'src/python/pants/notes/1.5.x.rst',\n  '1.6.x': 'src/python/pants/notes/1.6.x.rst',\n  '1.7.x': 'src/python/pants/notes/1.7.x.rst',\n  '1.8.x': 'src/python/pants/notes/1.8.x.rst',\n  '1.9.x': 'src/python/pants/notes/1.9.x.rst',\n  '1.10.x': 'src/python/pants/notes/1.10.x.rst',\n  '1.11.x': 'src/python/pants/notes/1.11.x.rst',\n  '1.12.x': 'src/python/pants/notes/1.12.x.rst',\n  '1.13.x': 'src/python/pants/notes/1.13.x.rst',\n  '1.14.x': 'src/python/pants/notes/1.14.x.rst',\n  '1.15.x': 'src/python/pants/notes/1.15.x.rst',\n  '1.16.x': 'src/python/pants/notes/1.16.x.rst',\n  '1.17.x': 'src/python/pants/notes/1.17.x.rst',\n  '1.18.x': 'src/python/pants/notes/1.18.x.rst',\n  '1.19.x': 'src/python/pants/notes/1.19.x.rst',\n  '1.20.x': 'src/python/pants/notes/1.20.x.rst',\n  '1.21.x': 'src/python/pants/notes/1.21.x.rst',\n  '1.22.x': 'src/python/pants/notes/1.22.x.rst',\n  '1.23.x': 'src/python/pants/notes/1.23.x.rst',\n  '1.24.x': 'src/python/pants/notes/1.24.x.rst',\n  '1.25.x': 'src/python/pants/notes/1.25.x.rst',\n  '1.26.x': 'src/python/pants/notes/1.26.x.rst',\n  '1.27.x': 'src/python/pants/notes/1.27.x.rst',\n  '1.28.x': 'src/python/pants/notes/1.28.x.rst',\n  '1.29.x': 'src/python/pants/notes/1.29.x.rst',\n  '1.30.x': 'src/python/pants/notes/1.30.x.rst',\n}\n"}, 'publish': {'jar': {'ivy_settings': '%(pants_supportdir)s/ivy/publish.ivysettings.xml', 'push_postscript': '# Prevent Travis CI from running for this automated JAR publish commit:\n#  https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build\n[ci skip]\n', 'repos': "{\n  'public': {  # must match the name of the `Repository` object that you defined in your plugin.\n    'resolver': 'oss.sonatype.org', # must match hostname in ~/.netrc and the <url> parameter\n                                    # in your custom ivysettings.xml.\n    'auth': 'build-support/ivy:netrc',  # Pants spec to a 'credentials()' object.\n    'help': 'Configure your ~/.netrc for oss.sonatype.org access.'\n  }\n}\n", 'restrict_push_branches': ['master'], 'restrict_push_urls': ['git@github.com:pantsbuild/pants.git', 'https://github.com/pantsbuild/pants.git'], 'verify_commit': False}}, 'python-setup': {'interpreter_cache_dir': '%(pants_bootstrapdir)s/python_cache/interpreters', 'resolver_cache_dir': '%(pants_bootstrapdir)s/python_cache/requirements'}, 'pytest': {'pytest_plugins': {'add': ['setuptools==44.0.0', 'ipdb', 'pytest-icdiff', 'pygments']}}, 'test': {'pytest': {'timeouts': True, 'timeout_default': 60}, 'junit': {'timeouts': True, 'timeout_default': 60}}, 'buildgen': {'go': {'materialize': True, 'remote': True, 'fail_floating': True}}, 'reference': {'pants_reference_template': 'reference/pants_reference_body.html', 'build_dictionary_template': 'reference/build_dictionary_body.html'}, 'markdown': {'fragment': True}, 'sitegen': {'config_path': 'src/docs/docsite.json'}, 'native-build-step': {'cpp-compile-settings': {'default_compiler_option_sets': ['glibcxx_use_old_abi'], 'compiler_option_sets_enabled_args': "{'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0']}", 'compiler_option_sets_disabled_args': "{'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1']}"}}, 'libc': {'enable_libc_search': True}, 'sourcefile-validation': {'config': '@build-support/regexes/config.yaml'}, 'coursier': {'repos': ['https://maven-central.storage-download.googleapis.com/maven2', 'https://repo1.maven.org/maven2', 'https://raw.githubusercontent.com/toolchainlabs/binhost/master/', 'file://%(homedir)s/.m2/repository'], 'fetch_options': {'add': ['--retry-count', '3', '--no-default']}}})),))), src/python/pants/util:meta), TransitiveTarget, true) <-
  Task(pants.engine.internals.graph:125:transitive_target(), (OptionsBootstrapper(env_tuples=(('PANTS_DEV', '1'),), bootstrap_args=('--no-v1', '--v2'), args=('/Users/eric/DocsLocal/code/projects/pants/src/python/pants/bin/pants_loader.py', '--no-v1', '--v2', 'dependencies2', '--transitive', 'src/python/pants/util:meta'), config=_ChainedConfig(chained_configs=(_SingleFileConfig(config_path='/Users/eric/DocsLocal/code/projects/pants/pants.toml', content_digest='37c222457604d6e6685061208af099266ddad1e7', values=_TomlValues(values={'DEFAULT': {'buildroot': '/Users/eric/DocsLocal/code/projects/pants', 'homedir': '/Users/eric', 'user': 'eric', 'pants_bootstrapdir': '/Users/eric/.cache/pants', 'pants_configdir': '/Users/eric/.config/pants', 'pants_workdir': '/Users/eric/DocsLocal/code/projects/pants/.pants.d', 'pants_supportdir': '/Users/eric/DocsLocal/code/projects/pants/build-support', 'pants_distdir': '/Users/eric/DocsLocal/code/projects/pants/dist', 'jvm_options': ['-Xmx1g'], 'local_artifact_cache': '%(pants_bootstrapdir)s/artifact_cache'}, 'GLOBAL': {'print_exception_stacktrace': True, 'v2': False, 'pythonpath': ['%(buildroot)s/contrib/confluence/src/python', '%(buildroot)s/contrib/go/src/python', '%(buildroot)s/contrib/mypy/src/python', '%(buildroot)s/contrib/node/src/python', '%(buildroot)s/contrib/scrooge/src/python', '%(buildroot)s/pants-plugins/src/python'], 'backend_packages': {'add': ['pants.backend.docgen', 'pants.contrib.confluence', 'pants.contrib.go', 'pants.contrib.node', 'pants.contrib.scrooge', 'internal_backend.repositories', 'internal_backend.sitegen', 'internal_backend.utilities']}, 'backend_packages2': {'add': ['pants.backend.awslambda.python', 'pants.backend.native', 'pants.backend.python', 'pants.backend.python.lint.black', 'pants.backend.python.lint.docformatter', 'pants.backend.python.lint.flake8', 'pants.backend.python.lint.isort', 'internal_backend.rules_for_testing']}, 'pantsd_invalidation_globs': {'add': ['!*_test.py', 'src/rust/engine/**/*.rs', 'src/rust/engine/**/*.toml']}, 'pants_ignore': {'add': ['/build-support/virtualenvs/', '/build-support/*.venv/', '/build-support/bin/native/src', '/src/rust/engine/target', '!*.class', '!/pants.pex']}}, 'source': {'root_patterns': ['src/*', 'src/main/*', 'src/test/*', '/src/go/src', 'test/*', 'tests/*', '3rdparty/*', '/build-support/bin', '/build-support/migration-support']}, 'cache': {'read_from': [], 'write_to': [], 'bootstrap': {'read_from': ['%(local_artifact_cache)s'], 'write_to': ['%(local_artifact_cache)s']}, 'resolve': {'coursier': {'read_from': ['%(local_artifact_cache)s'], 'write_to': ['%(local_artifact_cache)s']}}}, 'ivy': {'ivy_settings': '%(pants_supportdir)s/ivy/ivysettings.xml', 'ivy_profile': '%(pants_supportdir)s/ivy/ivy.xml'}, 'gen': {'scrooge': {'service_deps': "{\n  'java': [\n    '3rdparty:slf4j-api',\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'structs_deps': "{\n  'java': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'service_exports': "{\n  'java': [\n    '3rdparty:thrift',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:finagle-thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n", 'structs_exports': "{\n  'java': [\n    '3rdparty:thrift',\n  ],\n  'scala': [\n    '3rdparty:thrift',\n    '3rdparty/jvm/com/twitter:scrooge-core',\n  ],\n}\n"}, 'thrift-java': {'deps': ['3rdparty:thrift']}, 'thrift-py': {'deps': ['examples/3rdparty/python:thrift']}, 'go-protobuf': {'import_target': 'contrib/go/examples/src/protobuf/org/pantsbuild/example:protobuf-deps'}}, 'compile': {'rsc': {'jvm_options': ['-Xmx4g', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4'], 'args': ['-C-encoding', '-CUTF-8', '-S-encoding', '-SUTF-8', '-S-g:vars', '-S-target:jvm-1.8'], 'warning_args': ['-S-deprecation', '-S-unchecked', '-S-feature'], 'no_warning_args': ['-S-nowarn']}, 'javac': {'args': ['-encoding', 'UTF-8', '-J-Xmx2g'], 'warning_args': ['-Xlint:deprecation', '-Xlint:empty', '-Xlint:finally', '-Xlint:overrides', '-Xlint:static', '-Xlint:unchecked', '-Xlint:try'], 'no_warning_args': ['-Xlint:none']}}, 'black': {'config': 'pyproject.toml'}, 'checkstyle': {'config': '%(pants_supportdir)s/checkstyle/coding_style.xml'}, 'docformatter': {'args': ['--wrap-summaries=100', '--wrap-descriptions=100']}, 'eslint': {'setupdir': '%(pants_supportdir)s/eslint', 'config': '%(pants_supportdir)s/eslint/.eslintrc', 'ignore': '%(pants_supportdir)s/eslint/.eslintignore'}, 'flake8': {'config': 'build-support/flake8/.flake8', 'extra_requirements': {'add': ['flake8-pantsbuild>=2.0,<3', 'flake8-2020>=1.6.0,<1.7.0']}}, 'isort': {'config': ['.isort.cfg', 'contrib/.isort.cfg', 'examples/.isort.cfg']}, 'scalafmt': {'skip': True}, 'scalafix': {'skip': True}, 'scalastyle': {'config': '%(buildroot)s/build-support/scalastyle/scalastyle_config.xml'}, 'lint': {'scalastyle': {'excludes': '%(buildroot)s/build-support/scalastyle/excludes.txt'}}, 'protoc': {'version': '2.4.1', 'gen': {'go-protobuf': {'version': '3.11.4'}}}, 'scala': {'version': 2.12}, 'java': {'strict_deps': True}, 'jvm': {'options': ['-Xmx1g'], 'bench': {'options': ['-Xmx1g']}, 'run': {'jvm': {'options': ['-Xmx1g']}}, 'test': {'junit': {'options': ['-Djava.awt.headless=true', '-Xmx1g']}}}, 'jvm-platform': {'default_platform': 'java8', 'platforms': "{\n  'java7': {'source': '7', 'target': '7', 'args': [] },\n  'java8': {'source': '8', 'target': '8', 'args': [] },\n  'java9': {'source': '9', 'target': '9', 'args': [] },\n}\n"}, 'pants-releases': {'branch_notes': "{\n  'master': 'src/python/pants/notes/master.rst',\n  '1.0.x': 'src/python/pants/notes/1.0.x.rst',\n  '1.1.x': 'src/python/pants/notes/1.1.x.rst',\n  '1.2.x': 'src/python/pants/notes/1.2.x.rst',\n  '1.3.x': 'src/python/pants/notes/1.3.x.rst',\n  '1.4.x': 'src/python/pants/notes/1.4.x.rst',\n  '1.5.x': 'src/python/pants/notes/1.5.x.rst',\n  '1.6.x': 'src/python/pants/notes/1.6.x.rst',\n  '1.7.x': 'src/python/pants/notes/1.7.x.rst',\n  '1.8.x': 'src/python/pants/notes/1.8.x.rst',\n  '1.9.x': 'src/python/pants/notes/1.9.x.rst',\n  '1.10.x': 'src/python/pants/notes/1.10.x.rst',\n  '1.11.x': 'src/python/pants/notes/1.11.x.rst',\n  '1.12.x': 'src/python/pants/notes/1.12.x.rst',\n  '1.13.x': 'src/python/pants/notes/1.13.x.rst',\n  '1.14.x': 'src/python/pants/notes/1.14.x.rst',\n  '1.15.x': 'src/python/pants/notes/1.15.x.rst',\n  '1.16.x': 'src/python/pants/notes/1.16.x.rst',\n  '1.17.x': 'src/python/pants/notes/1.17.x.rst',\n  '1.18.x': 'src/python/pants/notes/1.18.x.rst',\n  '1.19.x': 'src/python/pants/notes/1.19.x.rst',\n  '1.20.x': 'src/python/pants/notes/1.20.x.rst',\n  '1.21.x': 'src/python/pants/notes/1.21.x.rst',\n  '1.22.x': 'src/python/pants/notes/1.22.x.rst',\n  '1.23.x': 'src/python/pants/notes/1.23.x.rst',\n  '1.24.x': 'src/python/pants/notes/1.24.x.rst',\n  '1.25.x': 'src/python/pants/notes/1.25.x.rst',\n  '1.26.x': 'src/python/pants/notes/1.26.x.rst',\n  '1.27.x': 'src/python/pants/notes/1.27.x.rst',\n  '1.28.x': 'src/python/pants/notes/1.28.x.rst',\n  '1.29.x': 'src/python/pants/notes/1.29.x.rst',\n  '1.30.x': 'src/python/pants/notes/1.30.x.rst',\n}\n"}, 'publish': {'jar': {'ivy_settings': '%(pants_supportdir)s/ivy/publish.ivysettings.xml', 'push_postscript': '# Prevent Travis CI from running for this automated JAR publish commit:\n#  https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build\n[ci skip]\n', 'repos': "{\n  'public': {  # must match the name of the `Repository` object that you defined in your plugin.\n    'resolver': 'oss.sonatype.org', # must match hostname in ~/.netrc and the <url> parameter\n                                    # in your custom ivysettings.xml.\n    'auth': 'build-support/ivy:netrc',  # Pants spec to a 'credentials()' object.\n    'help': 'Configure your ~/.netrc for oss.sonatype.org access.'\n  }\n}\n", 'restrict_push_branches': ['master'], 'restrict_push_urls': ['git@github.com:pantsbuild/pants.git', 'https://github.com/pantsbuild/pants.git'], 'verify_commit': False}}, 'python-setup': {'interpreter_cache_dir': '%(pants_bootstrapdir)s/python_cache/interpreters', 'resolver_cache_dir': '%(pants_bootstrapdir)s/python_cache/requirements'}, 'pytest': {'pytest_plugins': {'add': ['setuptools==44.0.0', 'ipdb', 'pytest-icdiff', 'pygments']}}, 'test': {'pytest': {'timeouts': True, 'timeout_default': 60}, 'junit': {'timeouts': True, 'timeout_default': 60}}, 'buildgen': {'go': {'materialize': True, 'remote': True, 'fail_floating': True}}, 'reference': {'pants_reference_template': 'reference/pants_reference_body.html', 'build_dictionary_template': 'reference/build_dictionary_body.html'}, 'markdown': {'fragment': True}, 'sitegen': {'config_path': 'src/docs/docsite.json'}, 'native-build-step': {'cpp-compile-settings': {'default_compiler_option_sets': ['glibcxx_use_old_abi'], 'compiler_option_sets_enabled_args': "{'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0']}", 'compiler_option_sets_disabled_args': "{'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1']}"}}, 'libc': {'enable_libc_search': True}, 'sourcefile-validation': {'config': '@build-support/regexes/config.yaml'}, 'coursier': {'repos': ['https://maven-central.storage-download.googleapis.com/maven2', 'https://repo1.maven.org/maven2', 'https://raw.githubusercontent.com/toolchainlabs/binhost/master/', 'file://%(homedir)s/.m2/repository'], 'fetch_options': {'add': ['--retry-count', '3', '--no-default']}}})),))), src/python/pants/util:meta), TransitiveTarget, true) <-
```

After:
```
Engine traceback:
  in `dependencies2` goal
Traceback (no traceback):
  <pants native internals>
Exception: Dependancy graph contained a cycle:
  Task(pants.engine.internals.graph:125:transitive_target(), (OptionsBootstrapper(args=['--no-v1', '--v2', '--no-enable-pantsd', 'dependencies2', '--transitive', 'src/python/pants/util:meta'], env={'PANTS_DEV': '1'}, config=ChainedConfig(['/Users/eric/DocsLocal/code/projects/pants/pants.toml'])), src/python/pants/util:meta), TransitiveTarget, true) <-
  Task(pants.engine.internals.graph:125:transitive_target(), (OptionsBootstrapper(args=['--no-v1', '--v2', '--no-enable-pantsd', 'dependencies2', '--transitive', 'src/python/pants/util:meta'], env={'PANTS_DEV': '1'}, config=ChainedConfig(['/Users/eric/DocsLocal/code/projects/pants/pants.toml'])), src/python/pants/util:meta), TransitiveTarget, true) <-
```

When debugging, we can always ask users to send us the contents of their config files if we need them.

[ci skip-jvm-tests]