### PR TITLE
Expose new StreamingWorkunitContext on streaming workunits callback

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -604,7 +604,7 @@ class StreamingWorkunitProcessTests(TestBase):
                 if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:
                     digest = workunit["artifacts"]["stdout_digest"]
                     output = context.digests_to_bytes([digest])
-                    assert output == [b"stdout output\n"]
+                    assert output == (b"stdout output\n",)
 
         handler = StreamingWorkunitHandler(
             scheduler,

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -14,7 +14,10 @@ from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
+from pants.reporting.streaming_workunit_handler import (
+    StreamingWorkunitContext,
+    StreamingWorkunitHandler,
+)
 from pants.testutil.engine.util import (
     assert_equal_with_printing,
     fmt_rule,
@@ -589,3 +592,30 @@ class StreamingWorkunitProcessTests(TestBase):
         byte_outputs = self._scheduler.digests_to_bytes([stdout_digest, stderr_digest])
         assert byte_outputs[0] == result.stdout
         assert byte_outputs[1] == result.stderr
+
+    def test_context_object(self):
+        self._init_engine()  # need to call this so that self._scheduler is not None when we pass it to StreamingWorkunitHandler
+
+        def callback(workunits, **kwargs) -> None:
+            context = kwargs["context"]
+            assert type(context) == StreamingWorkunitContext
+
+            for workunit in workunits:
+                if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:
+                    digest = workunit["artifacts"]["stdout_digest"]
+                    output = context.digests_to_bytes([digest])
+                    assert output == [b"stdout output\n"]
+
+        handler = StreamingWorkunitHandler(
+            self._scheduler,
+            callbacks=[callback],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
+        )
+
+        stdout_process = Process(
+            argv=("/bin/bash", "-c", "/bin/echo 'stdout output'"), description="Stdout process"
+        )
+
+        with handler.session():
+            self.request_single_product(ProcessResult, stdout_process)

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -522,11 +522,11 @@ class StreamingWorkunitProcessTests(TestBase):
     additional_options = ["--no-process-execution-use-local-cache"]
 
     def test_process_digests_on_workunits(self):
-        self._init_engine()  # need to call this so that self._scheduler is not None when we pass it to StreamingWorkunitHandler
+        scheduler = self.scheduler
 
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
-            self._scheduler,
+            scheduler,
             callbacks=[tracker.add],
             report_interval_seconds=0.01,
             max_workunit_verbosity=LogLevel.INFO,
@@ -594,7 +594,7 @@ class StreamingWorkunitProcessTests(TestBase):
         assert byte_outputs[1] == result.stderr
 
     def test_context_object(self):
-        self._init_engine()  # need to call this so that self._scheduler is not None when we pass it to StreamingWorkunitHandler
+        scheduler = self.scheduler
 
         def callback(workunits, **kwargs) -> None:
             context = kwargs["context"]
@@ -607,7 +607,7 @@ class StreamingWorkunitProcessTests(TestBase):
                     assert output == [b"stdout output\n"]
 
         handler = StreamingWorkunitHandler(
-            self._scheduler,
+            scheduler,
             callbacks=[callback],
             report_interval_seconds=0.01,
             max_workunit_verbosity=LogLevel.INFO,

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -598,7 +598,7 @@ class StreamingWorkunitProcessTests(TestBase):
 
         def callback(workunits, **kwargs) -> None:
             context = kwargs["context"]
-            assert type(context) == StreamingWorkunitContext
+            assert isinstance(context, StreamingWorkunitContext)
 
             for workunit in workunits:
                 if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -578,15 +578,16 @@ class SchedulerSession:
             self._scheduler._scheduler, self._session, _DirectoryDigests(digests)
         )
 
-    def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
+    def digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
         sched_pointer = self._scheduler._scheduler
         return cast(
-            List[bytes], self._scheduler._native.lib.digests_to_bytes(sched_pointer, digests)
+            Tuple[bytes],
+            tuple(self._scheduler._native.lib.digests_to_bytes(sched_pointer, list(digests))),
         )
 
-    def ensure_remote_has_recursive(self, digests: List[Digest]) -> None:
+    def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:
         sched_pointer = self._scheduler._scheduler
-        self._scheduler._native.lib.ensure_remote_has_recursive(sched_pointer, digests)
+        self._scheduler._native.lib.ensure_remote_has_recursive(sched_pointer, list(digests))
 
     def run_local_interactive_process(
         self, request: "InteractiveProcessRequest"

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -3,9 +3,23 @@
 
 import threading
 from contextlib import contextmanager
-from typing import Any, Callable, Iterable, Iterator, Optional
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Iterator, List, Optional
 
+from pants.engine.fs import Digest
+from pants.engine.internals.scheduler import SchedulerSession
 from pants.util.logging import LogLevel
+
+
+@dataclass(frozen=True)
+class StreamingWorkunitContext:
+    _scheduler: SchedulerSession
+
+    def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
+        return self._scheduler.digests_to_bytes(digests)
+
+    def ensure_remote_has_recursive(self, digests: List[Digest]) -> None:
+        return self._scheduler.ensure_remote_has_recursive(digests)
 
 
 class StreamingWorkunitHandler:
@@ -48,6 +62,7 @@ class StreamingWorkunitHandler:
                 workunits=workunits["completed"],
                 started_workunits=workunits["started"],
                 finished=True,
+                context=StreamingWorkunitContext(_scheduler=self.scheduler),
             )
 
     @contextmanager

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -4,7 +4,7 @@
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Iterator, List, Optional
+from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Tuple
 
 from pants.engine.fs import Digest
 from pants.engine.internals.scheduler import SchedulerSession
@@ -15,12 +15,12 @@ from pants.util.logging import LogLevel
 class StreamingWorkunitContext:
     _scheduler: SchedulerSession
 
-    def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
+    def digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
         """Given a list of Digest objects, return a list of the bytes corresponding to each of those
         Digests in sequence."""
         return self._scheduler.digests_to_bytes(digests)
 
-    def ensure_remote_has_recursive(self, digests: List[Digest]) -> None:
+    def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:
         """Invoke the internal ensure_remote_has_recursive function, which ensures that a remote
         ByteStore, if it exists, has a copy of the files fingerprinted by each Digest."""
         return self._scheduler.ensure_remote_has_recursive(digests)

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -16,9 +16,13 @@ class StreamingWorkunitContext:
     _scheduler: SchedulerSession
 
     def digests_to_bytes(self, digests: List[Digest]) -> List[bytes]:
+        """Given a list of Digest objects, return a list of the bytes corresponding to each of those
+        Digests in sequence."""
         return self._scheduler.digests_to_bytes(digests)
 
     def ensure_remote_has_recursive(self, digests: List[Digest]) -> None:
+        """Invoke the internal ensure_remote_has_recursive function, which ensures that a remote
+        ByteStore, if it exists, has a copy of the files fingerprinted by each Digest."""
         return self._scheduler.ensure_remote_has_recursive(digests)
 
 


### PR DESCRIPTION
### Problem

In order for streaming workunit clients to call the `digests_to_bytes` and `ensure_remote_has_recursive` methods with `Digest` arguments, they need a reference to the scheduler. However, we don't want to just expose a direct reference to the scheduler.

### Solution

Create a new type `StreamingWorkunitContext` that contains a reference to the scheduler, and pass it as an additional kwarg. This type exposes those two methods on the Scheduler, allowing streaming workunit clients to access them.
