### PR TITLE
Set default source root patterns.

### DIFF
--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -36,9 +36,14 @@ class StripSourceRootsTest(TestBase):
         args: Optional[List[str]] = None,
     ) -> StrippedResponseData:
         args = args or []
-        args.append("--source-root-patterns=src/python")
-        args.append("--source-root-patterns=src/java")
-        args.append("--source-root-patterns=tests/python")
+        has_source_root_patterns = False
+        for arg in args:
+            if arg.startswith("--source-root-patterns"):
+                has_source_root_patterns = True
+                break
+        if not has_source_root_patterns:
+            source_root_patterns = ["src/python", "src/java", "tests/python"]
+            args.append(f"--source-root-patterns={json.dumps(source_root_patterns)}")
         result = self.request_single_product(
             SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),
         )

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -145,6 +145,8 @@ class SourceRootConfig(Subsystem):
 
     options_scope = "source"
 
+    DEFAULT_ROOT_PATTERNS = ["/", "src", "src/python", "src/py"]
+
     @classmethod
     def register_options(cls, register):
         super().register_options(register)
@@ -164,10 +166,7 @@ class SourceRootConfig(Subsystem):
             metavar='["pattern1", "pattern2", ...]',
             type=list,
             fingerprint=True,
-            # For Python a good default might be the repo root, but that would be a bad default
-            # for other languages, so best to have no default for now, and force users to be
-            # explicit about this when integrating Pants.  It's a fairly trivial thing to do.
-            default=[],
+            default=cls.DEFAULT_ROOT_PATTERNS,
             advanced=True,
             help="A list of source root suffixes. A directory with this suffix will be considered "
             "a potential source root. E.g., `src/python` will match `<buildroot>/src/python`, "

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -100,6 +100,18 @@ def test_source_root_patterns() -> None:
     assert find_root("prefix/project/python/foo/bar.py") is None
 
 
+def test_source_root_default_patterns() -> None:
+    # Test that the default root patterns behave as expected.
+    def find_root(path):
+        return _find_root(path, tuple(SourceRootConfig.DEFAULT_ROOT_PATTERNS))
+
+    assert "src/python" == find_root("src/python/foo/bar.py")
+    assert "src" == find_root("src/baz/qux.py")
+    assert "project1/src/python" == find_root("project1/src/python/foo/bar.py")
+    assert "project2/src" == find_root("project2/src/baz/qux.py")
+    assert "." == find_root("corge/grault.py")
+
+
 def test_marker_file() -> None:
     def find_root(path):
         return _find_root(

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -19,7 +19,9 @@ class MavenLayoutTest(TestBase):
 
     def setUp(self):
         super().setUp()
-        init_subsystems([SourceRootConfig, JUnit])
+        init_subsystems(
+            [SourceRootConfig, JUnit], {"source": {"root_patterns": ["src/main/*", "src/test/*"]}}
+        )
         self.create_file("projectB/src/test/scala/a/source")
         self.add_to_build_file(
             "projectB/src/test/scala", 'junit_tests(name="test", sources=["a/source"])'


### PR DESCRIPTION
These will work in a decent variety of cases, and will help many
users avoid having to think about source roots when they first
onboard.
