### PR TITLE
Push down process timeouts in remote execution

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -34,5 +34,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
   ],
   tags={'integration', 'partially_type_checked'},
-  timeout=480,
+  timeout=600,
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
@@ -19,5 +19,5 @@ python_tests(
     'contrib/mypy:examples_directory',
   ],
   tags={'integration', 'partially_type_checked'},
-  timeout = 120,
+  timeout = 300,
 )

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -39,7 +39,7 @@ python_tests(
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
   ],
-  timeout=540,
+  timeout=720,
   tags={'integration', 'partially_type_checked'},
 )
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -79,5 +79,5 @@ python_tests(
     'testprojects/src/python:plugins_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout=120,
+  timeout=300,
 )

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -38,6 +38,17 @@ pub(crate) struct RemoteTestResult {
   pub(crate) stderr_bytes: Vec<u8>,
 }
 
+impl RemoteTestResult {
+  pub fn stdout(&self) -> &str {
+    std::str::from_utf8(&self.stdout_bytes).unwrap()
+  }
+
+  #[allow(dead_code)]
+  pub fn stderr(&self) -> &str {
+    std::str::from_utf8(&self.stderr_bytes).unwrap()
+  }
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) enum StdoutType {
   Raw(String),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -211,7 +211,9 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
-            std::time::Duration::from_secs(320),
+            // The queue buffer time is added to the server-side enforced timeout to ensure that we
+            // tend to see an error from the server before the client gives up.
+            std::time::Duration::from_secs(900),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?)

--- a/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
@@ -29,5 +29,5 @@ python_tests(
     'testprojects/src/protobuf/org/pantsbuild/testproject:import_from_buildroot_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 330,
+  timeout = 480,
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -76,7 +76,7 @@ python_tests(
     'testprojects/3rdparty:managed_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 370,
+  timeout = 480,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -88,7 +88,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:deployexcludes_directory',
     'testprojects/src/java/org/pantsbuild/testproject:manifest_directory',
   ],
-  timeout=420,
+  timeout=600,
   tags = {'integration', 'partially_type_checked'},
 )
 
@@ -150,7 +150,7 @@ python_tests(
     'testprojects/3rdparty:checkstyle_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 240,
+  timeout = 360,
 )
 
 python_tests(
@@ -417,7 +417,7 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
   ],
   tags = {'partially_type_checked'},
-  timeout = 150,
+  timeout = 300,
 )
 
 python_tests(
@@ -574,7 +574,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:jvmprepcommand_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 250,
+  timeout = 480,
 )
 
 python_tests(
@@ -714,7 +714,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:procedure_syntax_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:rsc_compat_directory',
   ],
-  timeout=370,
+  timeout=480,
   tags = {'integration', 'partially_type_checked'},
 )
 
@@ -768,7 +768,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:runtime_directory',
   ],
-  timeout=600,
+  timeout=900,
   tags = {'integration', 'partially_type_checked'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -47,7 +47,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:missingjardepswhitelist_directory',
   ],
   tags={'integration', 'partially_type_checked'},
-  timeout=570,
+  timeout=720,
 )
 
 python_tests(
@@ -62,7 +62,7 @@ python_tests(
     'testprojects/src/thrift/org/pantsbuild:thrift_exports_directory',
   ],
   tags={'integration', 'partially_type_checked'},
-  timeout=600,
+  timeout=720,
 )
 
 python_tests(
@@ -84,5 +84,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:missingjardepswhitelist_directory',
   ],
   tags={'integration', 'partially_type_checked'},
-  timeout = 240,
+  timeout = 360,
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -18,6 +18,6 @@ python_tests(
   dependencies=[
     ':base_compile_integration_test'
   ],
-  timeout = 640,
+  timeout = 900,
   tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -107,7 +107,7 @@ python_tests(
         "testprojects/tests/python/pants:timeout_directory",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=240,
+    timeout=420,
 )
 
 python_tests(
@@ -151,7 +151,7 @@ python_tests(
         "testprojects/src/python:python_distribution_directory",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=420,
+    timeout=600,
 )
 
 python_tests(
@@ -176,7 +176,7 @@ python_tests(
         "testprojects/src/python:interpreter_selection_directory",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=120,
+    timeout=240,
 )
 
 python_tests(
@@ -192,7 +192,7 @@ python_tests(
         "testprojects/src/python:print_env_directory",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=240,
+    timeout=360,
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -114,5 +114,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 600,
+  timeout = 720,
 )

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -47,5 +47,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 240,
+  timeout = 360,
 )

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -49,7 +49,7 @@ python_tests(
         "testprojects/src/protobuf/org/pantsbuild/testproject:all_directories",
     ],
     tags={"integration", "partially_type_checked"},
-    timeout=200,
+    timeout=300,
 )
 
 python_tests(
@@ -68,7 +68,7 @@ python_tests(
     sources=["test_python_testprojects_src_integration.py"],
     dependencies=[":projects_test_base", "testprojects/src/python:all_directories",],
     tags={"integration", "partially_type_checked"},
-    timeout=150,
+    timeout=300,
 )
 
 python_tests(
@@ -76,7 +76,7 @@ python_tests(
     sources=["test_python_testprojects_tests_integration.py"],
     dependencies=[":projects_test_base", "testprojects/tests/python:all_directories",],
     tags={"integration", "partially_type_checked"},
-    timeout=120,
+    timeout=180,
 )
 
 python_tests(


### PR DESCRIPTION
### Problem

The remote execution API supports pushing down a server-enforced timeout, but we currently do not set this parameter.

### Solution

Set the timeout for remote execution using the optional user-specified timeout from `Process`. Add support to the two remote execution clients for handling `DEADLINE_EXCEEDED`.

### Result

The server should enforce process timeouts in general. Both remote execution implementations have a much longer backstop timeout that is fatal.

It's likely that timeouts will now trigger more accurately (ie, that we will have fewer false-positive timeouts caused by setting the "queue time" incorrectly), but because we have removed the queue time as a buffer, many of our existing tests need their timeouts adjusted.