### PR TITLE
Wait for ongoing runs to complete before shutting down pantsd

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -189,13 +189,12 @@ class Native(metaclass=SingletonMetaclass):
     def match_path_globs(self, path_globs: PathGlobs, paths: Iterable[str]) -> bool:
         return cast(bool, self.lib.match_path_globs(path_globs, tuple(paths)))
 
-    def nailgun_server_await_bound(self, nailgun_server) -> int:
-        """Blocks until the server has bound a port, and then returns the port.
+    def nailgun_server_await_shutdown(self, nailgun_server) -> None:
+        """Blocks until the server has shut down.
 
-        Returns the actual port the server has successfully bound to, or raises an exception if the
-        server has exited.
+        Raises an exception if the server exited abnormally
         """
-        return cast(int, self.lib.nailgun_server_await_bound(self._executor, nailgun_server))
+        self.lib.nailgun_server_await_shutdown(self._executor, nailgun_server)
 
     def new_nailgun_server(self, port: int, runner: RawFdRunner):
         """Creates a nailgun server with a requested port.

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -255,7 +255,7 @@ class PantsDaemon(PantsDaemonProcessManager):
 
     def _write_nailgun_port(self):
         """Write the nailgun port to a well known file."""
-        self.write_socket(self._native.nailgun_server_await_bound(self._server))
+        self.write_socket(self._server.port())
 
     def _initialize_pid(self):
         """Writes out our pid and metadata.
@@ -325,7 +325,9 @@ class PantsDaemon(PantsDaemonProcessManager):
                 time.sleep(self.JOIN_TIMEOUT_SECONDS)
 
             # We're exiting: join the server to avoid interrupting ongoing runs.
-            # TODO: This will happen via #8200.
+            self._logger.info("waiting for ongoing runs to complete before exiting...")
+            self._native.nailgun_server_await_shutdown(self._server)
+            self._logger.info("exiting.")
 
 
 def launch():

--- a/src/rust/engine/nailgun/src/lib.rs
+++ b/src/rust/engine/nailgun/src/lib.rs
@@ -32,7 +32,6 @@
 mod tests;
 
 use std::collections::HashMap;
-use std::future::Future;
 use std::io;
 use std::net::Ipv4Addr;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -48,22 +47,21 @@ use nails::execution::{self, send_to_io, sink_for, stream_for, ChildInput, Child
 use nails::Nail;
 use tokio::fs::File;
 use tokio::net::TcpListener;
-use tokio::sync::watch;
 
 use task_executor::Executor;
 
 pub struct Server {
   exit_sender: oneshot::Sender<()>,
-  state: watch::Receiver<ServerState>,
+  exited_receiver: oneshot::Receiver<Result<(), String>>,
+  port: u16,
 }
 
 impl Server {
   ///
   /// Spawn the server on a background Task.
   ///
-  /// The port provided here may be `0` in order to request a random port. A caller should call
-  /// `await_bound` to wait for the server to have bound a port to determine what port was actually
-  /// selected.
+  /// The port provided here may be `0` in order to request a random port. A caller can use
+  /// `Server.port()` to determine what port was actually selected.
   ///
   pub async fn new(
     executor: Executor,
@@ -87,20 +85,21 @@ impl Server {
     .noisy_stdin(false);
 
     // TODO: No longer necessary to differentiate starting from Bound.
-    let (state_sender, state_receiver) = watch::channel(ServerState::Bound(port_actual));
+    let (exited_sender, exited_receiver) = oneshot::channel();
     let (exit_sender, exit_receiver) = oneshot::channel();
 
     let _join = executor.spawn(Self::serve(
       executor.clone(),
       config,
       exit_receiver,
-      state_sender,
+      exited_sender,
       listener,
     ));
 
     Ok(Server {
       exit_sender,
-      state: state_receiver,
+      exited_receiver,
+      port: port_actual,
     })
   }
 
@@ -111,25 +110,32 @@ impl Server {
     executor: Executor,
     config: nails::Config<N>,
     should_exit: oneshot::Receiver<()>,
-    state: watch::Sender<ServerState>,
+    exited: oneshot::Sender<Result<(), String>>,
     listener: TcpListener,
   ) {
     let exit_result = Self::accept_loop(executor, config, should_exit, listener).await;
     info!("Server exiting with {:?}", exit_result);
-    let _ = state.broadcast(ServerState::Exited(exit_result));
+    let _ = exited.send(exit_result);
   }
 
   async fn accept_loop<N: Nail>(
     executor: Executor,
     config: nails::Config<N>,
-    _should_exit: oneshot::Receiver<()>,
+    mut should_exit: oneshot::Receiver<()>,
     mut listener: TcpListener,
   ) -> Result<(), String> {
     loop {
-      let tcp_stream = match listener.accept().await {
-        Ok((tcp_stream, _addr)) => tcp_stream,
-        Err(e) => {
+      let tcp_stream = match future::select(listener.accept().boxed(), should_exit).await {
+        future::Either::Left((Ok((tcp_stream, _addr)), s_e)) => {
+          // Got a connection.
+          should_exit = s_e;
+          tcp_stream
+        }
+        future::Either::Left((Err(e), _)) => {
           break Err(format!("Server failed to accept connections: {}", e));
+        }
+        future::Either::Right((_, _)) => {
+          break Ok(());
         }
       };
 
@@ -139,25 +145,22 @@ impl Server {
   }
 
   ///
-  /// Returns a Future that will wait for the server to have bound its port and then return it, or
-  /// return an error if the server has exited.
+  /// The port that the server is listening on.
   ///
-  pub fn await_bound(&self) -> impl Future<Output = Result<u16, String>> {
-    let state_receiver = self.state.clone();
-    async move {
-      match *state_receiver.borrow() {
-        ServerState::Bound(port) => return Ok(port),
-        ServerState::Exited(ref e) => return Err(format!("Server exited with {:?}", e)),
-      };
-    }
+  pub fn port(&self) -> u16 {
+    self.port
   }
 
   ///
-  /// Signal to the server that it should shut down, but do not wait for it to have shut down.
+  /// Returns a Future that will wait for the server to have shut down.
   ///
-  pub fn shutdown(self) {
+  pub async fn shutdown(self) -> Result<(), String> {
     // If we fail to send the exit signal, it's because the task is already shut down.
     let _ = self.exit_sender.send(());
+    self
+      .exited_receiver
+      .await
+      .or_else(|_| Err("Server exited uncleanly.".to_owned()))?
   }
 }
 

--- a/src/rust/engine/nailgun/src/lib.rs
+++ b/src/rust/engine/nailgun/src/lib.rs
@@ -125,7 +125,7 @@ impl Server {
     mut should_exit: oneshot::Receiver<()>,
     mut listener: TcpListener,
   ) -> Result<(), String> {
-    // While connections are ongoing, they acquire `read`: before shutting down, the server
+    // While connections are ongoing, they acquire `read`; before shutting down, the server
     // acquires `write`.
     let ongoing_connections = Arc::new(RwLock::new(()));
 

--- a/src/rust/engine/nailgun/src/tests.rs
+++ b/src/rust/engine/nailgun/src/tests.rs
@@ -1,12 +1,17 @@
 use crate::Server;
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
+use futures::future;
 use nails::client_handle_connection;
 use nails::execution::{child_channel, ChildInput, ChildOutput, Command, ExitCode};
 use task_executor::Executor;
 use tokio::net::TcpStream;
 use tokio::runtime::Handle;
+use tokio::sync::Notify;
+use tokio::time::delay_for;
 
 #[tokio::test]
 async fn spawn_and_bind() {
@@ -27,6 +32,53 @@ async fn accept() {
 
   // And connect with a client. This Nail will ignore the content of the command, so we're
   // only validating the exit code.
+  let actual_exit_code = run_client(server.port()).await.unwrap();
+  assert_eq!(exit_code, actual_exit_code);
+  server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn shutdown_awaits_ongoing() {
+  // A server that waits for a signal to complete a connection.
+  let connection_accepted = Arc::new(Notify::new());
+  let should_complete_connection = Arc::new(Notify::new());
+  let exit_code = ExitCode(42);
+  let server = Server::new(Executor::new(Handle::current()), 0, {
+    let connection_accepted = connection_accepted.clone();
+    let should_complete_connection = should_complete_connection.clone();
+    move |_| {
+      connection_accepted.notify();
+      Handle::current().block_on(should_complete_connection.notified());
+      exit_code
+    }
+  })
+  .await
+  .unwrap();
+
+  // Spawn a connection in the background, and once it has been established, kick off shutdown of
+  // the server.
+  let mut client_completed = tokio::spawn(run_client(server.port()));
+  connection_accepted.notified().await;
+  let mut server_shutdown = tokio::spawn(server.shutdown());
+
+  // Confirm that the client doesn't return, and that the server doesn't shutdown.
+  match future::select(client_completed, delay_for(Duration::from_millis(500))).await {
+    future::Either::Right((_, c_c)) => client_completed = c_c,
+    x => panic!("Client should not have completed: {:?}", x),
+  }
+  match future::select(server_shutdown, delay_for(Duration::from_millis(500))).await {
+    future::Either::Right((_, s_s)) => server_shutdown = s_s,
+    x => panic!("Server should not have shut down: {:?}", x),
+  }
+
+  // Then signal completion of the connection, and confirm that both the client and server exit
+  // cleanly.
+  should_complete_connection.notify();
+  assert_eq!(exit_code, client_completed.await.unwrap().unwrap());
+  server_shutdown.await.unwrap().unwrap();
+}
+
+async fn run_client(port: u16) -> Result<ExitCode, String> {
   let cmd = Command {
     command: "nothing".to_owned(),
     args: vec![],
@@ -35,12 +87,8 @@ async fn accept() {
   };
   let (stdio_write, _stdio_read) = child_channel::<ChildOutput>();
   let (_stdin_write, stdin_read) = child_channel::<ChildInput>();
-  let stream = TcpStream::connect(("127.0.0.1", server.port()))
+  let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+  client_handle_connection(stream, cmd, stdio_write, stdin_read)
     .await
-    .unwrap();
-  let actual_exit_code = client_handle_connection(stream, cmd, stdio_write, stdin_read)
-    .await
-    .unwrap();
-  assert_eq!(exit_code, actual_exit_code);
-  server.shutdown().await.unwrap();
+    .map_err(|e| e.to_string())
 }


### PR DESCRIPTION
### Problem

As described in #8200, the errors when pantsd shuts down during a run are not particularly helpful.

### Solution

When pantsd has chosen to exit (due to either of the `PantsService` instances exiting: generally the `SchedulerService` which watches the pythonpath and other invalidation globs for changes), wait for any ongoing connections to complete before exiting.

### Result

The server will wait for ongoing runs to complete before exiting. Fixes #8200.
