### PR TITLE
Control workunit levels at `@rule` execution time

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -12,7 +12,7 @@ from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import CanModifyWorkunit, RootRule, rule
+from pants.engine.rules import EngineAware, RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import (
     StreamingWorkunitContext,
@@ -518,7 +518,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
 
     def test_can_modify_workunit(self):
         @dataclass(frozen=True)
-        class ModifiedOutput(CanModifyWorkunit):
+        class ModifiedOutput(EngineAware):
             _level: LogLevel
             val: int
 
@@ -547,7 +547,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
 
     def test_no_can_modify_workunit(self):
         @dataclass(frozen=True)
-        # Without the CanModifyWorkunit class, the engine shouldn't try to interpret
+        # Without the EngineAware class, the engine shouldn't try to interpret
         # _level as a LogLevel at all.
         class ModifiedOutput:
             _level: str
@@ -578,9 +578,9 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
 
     def test_can_modify_workunit_no_level_attr(self):
         @dataclass(frozen=True)
-        # If _level is None, even with the CanModifyWorkunit class, the engine shouldn't try to set
+        # If _level is None, even with the EngineAware class, the engine shouldn't try to set
         # a new workunit level.
-        class ModifiedOutput(CanModifyWorkunit):
+        class ModifiedOutput(EngineAware):
             _level: Optional[LogLevel]
             val: int
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -20,7 +20,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.internals.nodes import Return, Throw
-from pants.engine.rules import Rule, RuleIndex, TaskRule
+from pants.engine.rules import CanModifyWorkunit, Rule, RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.engine.unions import union
 from pants.option.global_options import ExecutionOptions
@@ -160,13 +160,14 @@ class Scheduler:
         return tasks
 
     def _register_task(
-        self, tasks, output_type, rule: TaskRule, union_rules: Dict[Type, OrderedSet[Type]]
+        self, tasks, output_type: Type, rule: TaskRule, union_rules: Dict[Type, OrderedSet[Type]]
     ) -> None:
         """Register the given TaskRule with the native scheduler."""
         self._native.lib.tasks_task_begin(
             tasks,
             rule.func,
             output_type,
+            issubclass(output_type, CanModifyWorkunit),
             rule.cacheable,
             rule.canonical_name,
             rule.desc or "",

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -20,7 +20,7 @@ from pants.engine.fs import (
 )
 from pants.engine.interactive_process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.internals.nodes import Return, Throw
-from pants.engine.rules import CanModifyWorkunit, Rule, RuleIndex, TaskRule
+from pants.engine.rules import EngineAware, Rule, RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.engine.unions import union
 from pants.option.global_options import ExecutionOptions
@@ -167,7 +167,7 @@ class Scheduler:
             tasks,
             rule.func,
             output_type,
-            issubclass(output_type, CanModifyWorkunit),
+            issubclass(output_type, EngineAware),
             rule.cacheable,
             rule.canonical_name,
             rule.desc or "",

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -25,7 +25,7 @@ class CanModifyWorkunit:
     """This is a marker class used to indicate that an `@rule` can modify its own workunit.
 
     If a rule's return type is a subclass of CanModifyWorkunit, then the level of that workunit will
-    be set to the level of the attribute `_level`, if it exists.
+    be set to the value of an attribute _level: LogLevel, if it exists and is not None.
     """
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -558,24 +558,18 @@ class RuleIndex:
         serializable_roots: OrderedSet = OrderedSet()
         union_rules = dict(union_rules or ())
 
-        def add_task(product_type, rule):
-            # TODO(#7311): make a defaultdict-like wrapper for OrderedDict if more widely used.
-            if product_type not in serializable_rules:
-                serializable_rules[product_type] = OrderedSet()
-            serializable_rules[product_type].add(rule)
-
-        def add_root_rule(root_rule):
-            serializable_roots.add(root_rule)
-
-        def add_rule(rule):
+        def add_rule(rule: Rule) -> None:
             if isinstance(rule, RootRule):
-                add_root_rule(rule)
+                serializable_roots.add(rule)
             else:
-                add_task(rule.output_type, rule)
+                output_type = rule.output_type
+                if output_type not in serializable_rules:
+                    serializable_rules[output_type] = OrderedSet()
+                serializable_rules[output_type].add(rule)
             for dep_rule in rule.dependency_rules:
                 add_rule(dep_rule)
 
-        def add_type_transition_rule(union_rule):
+        def add_type_transition_rule(union_rule: UnionRule) -> None:
             # NB: This does not require that union bases be supplied to `def rules():`, as the union type
             # is never instantiated!
             union_base = union_rule.union_base
@@ -606,7 +600,11 @@ functions decorated with @rule.""".format(
                     )
                 )
 
-        return cls(serializable_rules, FrozenOrderedSet(serializable_roots), union_rules)
+        return RuleIndex(
+            rules=serializable_rules,
+            roots=FrozenOrderedSet(serializable_roots),
+            union_rules=union_rules,
+        )
 
     def normalized_rules(self) -> NormalizedRules:
         rules = FrozenOrderedSet(

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -21,13 +21,17 @@ from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
-class EngineAware:
+class EngineAware(ABC):
     """This is a marker class used to indicate that the output of an `@rule` can send metadata about
     the rule's output to the engine.
 
-    If a rule's return type is a subclass of EngineAware, then the level of that workunit will be
-    set to the value of an attribute _level: LogLevel, if it exists and is not None.
+    EngineAware defines abstract methods on the class, all of which return an Optional[T], and which
+    are expected to be overridden by concrete types implementing EngineAware.
     """
+
+    @abstractmethod
+    def level(self) -> Optional[LogLevel]:
+        """Overrides the level of the workunit associated with this type."""
 
 
 @decorated_type_checkable

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -21,11 +21,12 @@ from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
-class CanModifyWorkunit:
-    """This is a marker class used to indicate that an `@rule` can modify its own workunit.
+class EngineAware:
+    """This is a marker class used to indicate that the output of an `@rule` can send metadata about
+    the rule's output to the engine.
 
-    If a rule's return type is a subclass of CanModifyWorkunit, then the level of that workunit will
-    be set to the value of an attribute _level: LogLevel, if it exists and is not None.
+    If a rule's return type is a subclass of EngineAware, then the level of that workunit will be
+    set to the value of an attribute _level: LogLevel, if it exists and is not None.
     """
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -21,6 +21,14 @@ from pants.util.meta import decorated_type_checkable, frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
+class CanModifyWorkunit:
+    """This is a marker class used to indicate that an `@rule` can modify its own workunit.
+
+    If a rule's return type is a subclass of CanModifyWorkunit, then the level of that workunit will
+    be set to the level of the attribute `_level`, if it exists.
+    """
+
+
 @decorated_type_checkable
 def side_effecting(cls):
     """Annotates a class to indicate that it is a side-effecting type, which needs to be handled

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -249,10 +249,6 @@ impl Value {
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
   }
-
-  pub fn as_py_object(&self) -> Arc<PyObject> {
-    self.0.clone()
-  }
 }
 
 impl PartialEq for Value {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -249,6 +249,10 @@ impl Value {
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
   }
+
+  pub fn as_py_object(&self) -> Arc<PyObject> {
+    self.0.clone()
+  }
 }
 
 impl PartialEq for Value {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -287,9 +287,10 @@ py_module_initializer!(native_engine, |py, m| {
         b: PyObject,
         c: PyType,
         d: bool,
-        e: String,
+        e: bool,
         f: String,
-        g: u64
+        g: String,
+        h: u64
       )
     ),
   )?;
@@ -1019,6 +1020,7 @@ fn tasks_task_begin(
   tasks_ptr: PyTasks,
   func: PyObject,
   output_type: PyType,
+  can_modify_workunit: bool,
   cacheable: bool,
   name: String,
   desc: String,
@@ -1033,6 +1035,7 @@ fn tasks_task_begin(
     tasks.task_begin(
       func,
       output_type,
+      can_modify_workunit,
       cacheable,
       name,
       if desc.is_empty() { None } else { Some(desc) },

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -221,6 +221,10 @@ pub fn project_u64(value: &Value, field: &str) -> u64 {
   getattr(value, field).unwrap()
 }
 
+pub fn project_maybe_u64(value: &Value, field: &str) -> Result<u64, String> {
+  getattr(value, field)
+}
+
 pub fn project_f64(value: &Value, field: &str) -> f64 {
   getattr(value, field).unwrap()
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -810,7 +810,7 @@ impl Task {
       return None;
     }
 
-    let new_level_val: Value = externs::getattr(&result_val, "_level").ok()?;
+    let new_level_val: Value = externs::call_method(&result_val, "level", &[]).ok()?;
 
     {
       let gil = Python::acquire_gil();

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -206,6 +206,7 @@ impl fmt::Display for Rule {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
   pub product: TypeId,
+  pub can_modify_workunit: bool,
   pub clause: Vec<TypeId>,
   pub gets: Vec<Get>,
   pub func: Function,
@@ -272,6 +273,7 @@ impl Tasks {
     &mut self,
     func: Function,
     product: TypeId,
+    can_modify_workunit: bool,
     cacheable: bool,
     name: String,
     desc: Option<String>,
@@ -285,6 +287,7 @@ impl Tasks {
     self.preparing = Some(Task {
       cacheable,
       product,
+      can_modify_workunit,
       clause: Vec::new(),
       gets: Vec::new(),
       func,


### PR DESCRIPTION
### Problem

We want `@rule`s to be able to potentially modify the level of a workunit they are associated with at rule execution time.

### Solution

This commit introduces a new Python class called `EngineAware`, which defines an abstract method `level()` returning an Optional LogLevel. If the type returned by a rule subclasses `EngineAware`, the engine will use the output of that method to potentially override the level set on the workunit associated with running the rule. 

For now this API is only used to allow rules to override their own workunit level, but we expect that in the future this class will be used to implement more pieces of rule metadata.

