### PR TITLE
Prepare notes for lucky #10013 cherrypicks

### DIFF
--- a/src/python/pants/notes/1.21.x.rst
+++ b/src/python/pants/notes/1.21.x.rst
@@ -3,6 +3,19 @@
 
 This document describes releases leading up to the ``1.21.x`` ``stable`` series.
 
+1.21.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.21.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10022)
+  `PR #10022 <https://github.com/pantsbuild/pants/pull/10022>`_
+
 1.21.0 (10/14/2019)
 -------------------
 

--- a/src/python/pants/notes/1.22.x.rst
+++ b/src/python/pants/notes/1.22.x.rst
@@ -3,6 +3,19 @@
 
 This document describes releases leading up to the ``1.22.x`` ``stable`` series.
 
+1.22.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.22.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10021)
+  `PR #10021 <https://github.com/pantsbuild/pants/pull/10021>`_
+
 1.22.0 (11/14/2019)
 ------------------------
 The first stable release of the 1.22.x series, with no changes since the previous rc!

--- a/src/python/pants/notes/1.23.x.rst
+++ b/src/python/pants/notes/1.23.x.rst
@@ -3,6 +3,19 @@
 
 This document describes releases leading up to the ``1.23.x`` ``stable`` series.
 
+1.23.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.23.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10020)
+  `PR #10020 <https://github.com/pantsbuild/pants/pull/10020>`_
+
 1.23.0 (12/10/2019)
 -------------------
 

--- a/src/python/pants/notes/1.24.x.rst
+++ b/src/python/pants/notes/1.24.x.rst
@@ -3,6 +3,19 @@
 
 This document describes releases leading up to the ``1.24.x`` ``stable`` series.
 
+1.24.1rc1 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.24.x`` ``stable`` series. This ``.1rc1``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10019)
+  `PR #10019 <https://github.com/pantsbuild/pants/pull/10019>`_
+
 1.24.1rc0 (02/06/2020)
 ----------------------
 

--- a/src/python/pants/notes/1.25.x.rst
+++ b/src/python/pants/notes/1.25.x.rst
@@ -10,6 +10,19 @@ The ``1.25.x`` series brings two major changes to Pants:
 
 Please see https://groups.google.com/forum/#!topic/pants-devel/3nmdSeyvwU0 for more information.
 
+1.25.1rc1 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.25.x`` ``stable`` series. This ``.1rc1``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10018)
+  `PR #10018 <https://github.com/pantsbuild/pants/pull/10018>`_
+
 1.25.1rc0 (03/20/2020)
 ----------------------
 

--- a/src/python/pants/notes/1.26.x.rst
+++ b/src/python/pants/notes/1.26.x.rst
@@ -9,6 +9,19 @@ Some significant changes in this series:
 
 * Adds support for TOML config files, e.g. ``pants.toml``. INI config files will still be supported for some time, but INI is now legacy. Please see https://groups.google.com/forum/#!topic/pants-devel/N1H03oJONco for more information.
 
+1.26.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.26.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10017)
+  `PR #10017 <https://github.com/pantsbuild/pants/pull/10017>`_
+
 1.26.0 (04/29/2020)
 -------------------
 

--- a/src/python/pants/notes/1.27.x.rst
+++ b/src/python/pants/notes/1.27.x.rst
@@ -7,8 +7,21 @@ The ``1.27.x`` series deprecates several unused backends and plugins. Please
 see https://groups.google.com/forum/#!topic/pants-devel/ngMZRIJvwHM for more
 information.
 
+1.27.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.27.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10016)
+  `PR #10016 <https://github.com/pantsbuild/pants/pull/10016>`_
+
 1.27.0 (5/20/2020)
--------------------
+------------------
 
 The first stable release in the ``1.27.x`` series, with no changes since the previous release candidate!
 

--- a/src/python/pants/notes/1.28.x.rst
+++ b/src/python/pants/notes/1.28.x.rst
@@ -5,6 +5,20 @@ This document describes releases leading up to the ``1.28.x`` ``stable`` series.
 
 See https://pants.readme.io/docs/release-notes-1-28 for an overview of the changes in this release.
 
+1.28.1rc0 (6/16/2020)
+---------------------
+
+N.B.: No further releases are expected in the ``1.28.x`` ``stable`` series. This ``.1rc0``
+release is for those upgrading through stable versions who wish to retain pytest console
+coverage support in Pants "v1".
+
+Bugfixes
+~~~~~~~~
+
+* Restore pytest coverage console report. (#10016)
+  `PR #10016 <https://github.com/pantsbuild/pants/pull/10016>`_
+
+
 1.28.0 (5/22/2020)
 ------------------
 


### PR DESCRIPTION
See #10065: we're going to execute `rc` releases from all stable branches between `1.21.x` and `1.28.x` in order to fix a back-compat break.