### PR TITLE
disable append-only cache in remoting

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -24,8 +24,8 @@ use store::{Snapshot, Store, StoreFileByDigest};
 use tokio::time::delay_for;
 
 use crate::{
-  Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, NamedCaches,
-  Platform, PlatformConstraint, Process, ProcessMetadata,
+  Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
+  PlatformConstraint, Process, ProcessMetadata,
 };
 use std::cmp::min;
 use workunit_store::WorkunitStore;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -814,12 +814,14 @@ pub fn make_execute_request(
     mut platform_properties,
   } = metadata;
 
-  if !req.append_only_caches.is_empty() {
-    platform_properties.extend(NamedCaches::platform_properties(
-      &req.append_only_caches,
-      &cache_key_gen_version,
-    ));
-  }
+  // TODO: Disabling append-only caches in remoting until server support exists due to
+  //       interaction with how servers match platform properties.
+  // if !req.append_only_caches.is_empty() {
+  //   platform_properties.extend(NamedCaches::platform_properties(
+  //     &req.append_only_caches,
+  //     &cache_key_gen_version,
+  //   ));
+  // }
 
   if let Some(cache_key_gen_version) = cache_key_gen_version {
     let mut env = bazel_protos::remote_execution::Command_EnvironmentVariable::new();


### PR DESCRIPTION
### Problem

The append-only cache code currently adds a platform property to RE requests to specify that an append-only cache should be mounted when executing the request (if supported).

We discovered that this does not interact well with REv2 servers that require that workers match on **all** platform properties (e.g. Buildbarn) or that require values (and not just keys) be known ahead of time even if they can match on a subset of properties (e.g. Buildfarm). Adding a platform property requires server configuration to either add additional workers (Buildbarn) or specify all possible values (Buildfarm, for example container-image).

### Solution

Disable the append-only caching in remoting by not setting the platform property.

### Result

Should prevent the need to hack around on the server-side for now to allow Pants to remote with Buildbarn.