### PR TITLE
Fix the `coverage` field not working with v2

### DIFF
--- a/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
+++ b/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
@@ -23,31 +23,23 @@ class PantsFileTracer(FileTracer):
 
 
 class PantsPythonFileReporter(PythonFileReporter):
-  def __init__(self, stripped_filename, full_filename):
-    # NB: This constructor is not compatible with the superclass. We intentionally do not call
-    # super().
-    self.stripped_filename = stripped_filename
-    self.full_filename = full_filename
-    self.coverage = None
-    self._parser = None
-    self._source = None
-
-  # We override this to handle our source root logic.
-  @property
-  def filename(self):
-    return self.stripped_filename
+  def __init__(self, stripped_filename, unstripped_filename):
+    super(PantsPythonFileReporter, self).__init__(morf=stripped_filename)
+    self.unstripped_filename = unstripped_filename
 
   # This is what gets used in reports.
   def relative_filename(self):
-    return self.full_filename
+    return self.unstripped_filename
 
+  # We override to work around https://github.com/nedbat/coveragepy/issues/646.
   @property
   def parser(self):
     if self._parser is None:
-      self._parser = PythonParser(filename=self.full_filename)
+      self._parser = PythonParser(filename=self.filename)
       self._parser.parse_source()
     return self._parser
 
+  # We override to work around https://github.com/nedbat/coveragepy/issues/646.
   def no_branch_lines(self):
     return self.parser.lines_matching(
       join_regex(DEFAULT_PARTIAL[:]),
@@ -75,7 +67,7 @@ class SourceRootRemappingPlugin(CoveragePlugin):
     source_root = self.stripped_files_to_source_roots[stripped_file]
     return PantsPythonFileReporter(
       stripped_filename=stripped_file,
-      full_filename=os.path.join(source_root, stripped_file),
+      unstripped_filename=os.path.join(source_root, stripped_file),
     )
 
 

--- a/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
+++ b/src/python/pants/backend/python/rules/coverage_plugin/plugin.py
@@ -12,66 +12,65 @@ from coverage.python import PythonFileReporter
 
 
 class PantsFileTracer(FileTracer):
-  """This tells Coverage which files Pants 'owns'."""
+    """This tells Coverage which files Pants 'owns'."""
 
-  def __init__(self, filename):
-    super(PantsFileTracer, self).__init__()
-    self.filename = filename
+    def __init__(self, filename):
+        super(PantsFileTracer, self).__init__()
+        self.filename = filename
 
-  def source_filename(self):
-    return self.filename
+    def source_filename(self):
+        return self.filename
 
 
 class PantsPythonFileReporter(PythonFileReporter):
-  def __init__(self, stripped_filename, unstripped_filename):
-    super(PantsPythonFileReporter, self).__init__(morf=stripped_filename)
-    self.unstripped_filename = unstripped_filename
+    def __init__(self, stripped_filename, unstripped_filename):
+        super(PantsPythonFileReporter, self).__init__(morf=stripped_filename)
+        self.unstripped_filename = unstripped_filename
 
-  # This is what gets used in reports.
-  def relative_filename(self):
-    return self.unstripped_filename
+    # This is what gets used in reports.
+    def relative_filename(self):
+        return self.unstripped_filename
 
-  # We override to work around https://github.com/nedbat/coveragepy/issues/646.
-  @property
-  def parser(self):
-    if self._parser is None:
-      self._parser = PythonParser(filename=self.filename)
-      self._parser.parse_source()
-    return self._parser
+    # We override to work around https://github.com/nedbat/coveragepy/issues/646.
+    @property
+    def parser(self):
+        if self._parser is None:
+            self._parser = PythonParser(filename=self.filename)
+            self._parser.parse_source()
+        return self._parser
 
-  # We override to work around https://github.com/nedbat/coveragepy/issues/646.
-  def no_branch_lines(self):
-    return self.parser.lines_matching(
-      join_regex(DEFAULT_PARTIAL[:]),
-      join_regex(DEFAULT_PARTIAL_ALWAYS[:]),
-    )
+    # We override to work around https://github.com/nedbat/coveragepy/issues/646.
+    def no_branch_lines(self):
+        return self.parser.lines_matching(
+            join_regex(DEFAULT_PARTIAL[:]), join_regex(DEFAULT_PARTIAL_ALWAYS[:])
+        )
 
 
 class SourceRootRemappingPlugin(CoveragePlugin):
-  """A plugin that knows how to restore source roots from stripped files in Coverage reports."""
+    """A plugin that knows how to restore source roots from stripped files in Coverage reports."""
 
-  def __init__(self, chroot_path, stripped_files_to_source_roots):
-    super(SourceRootRemappingPlugin, self).__init__()
-    self.chroot_path = chroot_path
-    self.stripped_files_to_source_roots = stripped_files_to_source_roots
+    def __init__(self, chroot_path, stripped_files_to_source_roots):
+        super(SourceRootRemappingPlugin, self).__init__()
+        self.chroot_path = chroot_path
+        self.stripped_files_to_source_roots = stripped_files_to_source_roots
 
-  def file_tracer(self, filename):
-    if not filename.startswith(self.chroot_path):
-      return None
-    stripped_file = os.path.relpath(filename, self.chroot_path)
-    if stripped_file in self.stripped_files_to_source_roots:
-      return PantsFileTracer(filename)
+    def file_tracer(self, filename):
+        if not filename.startswith(self.chroot_path):
+            return None
+        stripped_file = os.path.relpath(filename, self.chroot_path)
+        if stripped_file in self.stripped_files_to_source_roots:
+            return PantsFileTracer(filename)
 
-  def file_reporter(self, filename):
-    stripped_file = os.path.relpath(filename, self.chroot_path)
-    source_root = self.stripped_files_to_source_roots[stripped_file]
-    return PantsPythonFileReporter(
-      stripped_filename=stripped_file,
-      unstripped_filename=os.path.join(source_root, stripped_file),
-    )
+    def file_reporter(self, filename):
+        stripped_file = os.path.relpath(filename, self.chroot_path)
+        source_root = self.stripped_files_to_source_roots[stripped_file]
+        return PantsPythonFileReporter(
+            stripped_filename=stripped_file,
+            unstripped_filename=os.path.join(source_root, stripped_file),
+        )
 
 
 def coverage_init(reg, options):
-  chroot_path = os.getcwd()
-  stripped_files_to_source_roots = json.loads(options['stripped_files_to_source_roots'])
-  reg.add_file_tracer(SourceRootRemappingPlugin(chroot_path, stripped_files_to_source_roots))
+    chroot_path = os.getcwd()
+    stripped_files_to_source_roots = json.loads(options["stripped_files_to_source_roots"])
+    reg.add_file_tracer(SourceRootRemappingPlugin(chroot_path, stripped_files_to_source_roots))

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -215,6 +215,8 @@ async def merge_coverage_data(
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> MergedCoverageData:
+    if len(data_collection) == 1:
+        return MergedCoverageData(data_collection[0].digest)
     # We prefix each .coverage file with its corresponding address to avoid collisions.
     coverage_digests = await MultiGet(
         Get[Digest](AddPrefix(data.digest, prefix=data.address.path_safe_spec))
@@ -232,7 +234,7 @@ async def merge_coverage_data(
         subprocess_encoding_environment=subprocess_encoding_environment,
     )
     result = await Get[ProcessResult](Process, process)
-    return MergedCoverageData(coverage_data=result.output_digest)
+    return MergedCoverageData(result.output_digest)
 
 
 @rule(desc="Generate Pytest coverage report")

--- a/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
@@ -98,12 +98,12 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
         assert (
             dedent(
                 f"""\
-                Name                                                Stmts   Miss Branch BrPart  Cover
-                -------------------------------------------------------------------------------------
-                {tmpdir_relative}/src/python/project/lib.py                   4      1      0      0    100%
-                {tmpdir_relative}/src/python/project/lib_test.py              3      0      0      0   100%
-                -------------------------------------------------------------------------------------
-                TOTAL                                                  10      1      0      0    100%
+                Name                                         Stmts   Miss Branch BrPart  Cover
+                ------------------------------------------------------------------------------
+                {tmpdir_relative}/src/python/project/lib.py            4      0      0      0   100%
+                {tmpdir_relative}/src/python/project/lib_test.py       3      0      0      0   100%
+                ------------------------------------------------------------------------------
+                TOTAL                                            7      0      0      0   100%
                 """
             )
             in result.stderr_data

--- a/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
@@ -95,13 +95,16 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
         # generate reports. This was showing up at test-time, even though the final merged report
         # would work properly.
         assert "Failed to generate report" not in result.stderr_data
-        assert dedent(
-            f"""\
-            Name                                                Stmts   Miss Branch BrPart  Cover
-            -------------------------------------------------------------------------------------
-            {tmpdir_relative}/src/python/project/lib.py                   4      1      0      0    100%
-            {tmpdir_relative}/src/python/project/lib_test.py              3      0      0      0   100%
-            -------------------------------------------------------------------------------------
-            TOTAL                                                  10      1      0      0    100%
-            """
-        ) in result.stderr_data
+        assert (
+            dedent(
+                f"""\
+                Name                                                Stmts   Miss Branch BrPart  Cover
+                -------------------------------------------------------------------------------------
+                {tmpdir_relative}/src/python/project/lib.py                   4      1      0      0    100%
+                {tmpdir_relative}/src/python/project/lib_test.py              3      0      0      0   100%
+                -------------------------------------------------------------------------------------
+                TOTAL                                                  10      1      0      0    100%
+                """
+            )
+            in result.stderr_data
+        )


### PR DESCRIPTION
Previously, the `coverage` field would not work if the specified module lived in a different folder than the test. 

The issue is that we weren't using the `FileTracer` mechanism, which is necessary for Coverage to know which files Pants "owns". We were using `find_executable_files`, but we need `FileTracer` too. (We still need `find_executable_files` so that files which are not encountered during test execution still count as "owned" by this plugin.)

This PR also makes two small improvements:
* Don't merge data if there's only one test result. This avoids unnecessary work.
* If `-ldebug`, turn on some Coverage debug output. This is how v1 behaved, and it seems useful to preserve.