### PR TITLE
remoting: add workunits for upload and execution

### DIFF
--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -27,7 +27,7 @@ use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, PlatformConstraint,
   Process, ProcessMetadata,
 };
-use workunit_store::{expect_workunit_state, new_span_id, WorkunitMetadata};
+use workunit_store::{with_workunit, WorkunitMetadata};
 
 /// Implementation of CommandRunner that runs a command via the Bazel Remote Execution API
 /// (https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvroblTZ_6s/edit).
@@ -585,8 +585,6 @@ impl crate::CommandRunner for StreamingCommandRunner {
     request: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    let workunit_state = expect_workunit_state();
-
     // Construct the REv2 ExecuteRequest and related data for this execution request.
     let request = self.extract_compatible_request(&request).unwrap();
     let store = self.store.clone();
@@ -608,44 +606,44 @@ impl crate::CommandRunner for StreamingCommandRunner {
     let deadline_duration = self.overall_deadline + request.timeout.unwrap_or_default();
 
     // Upload the action (and related data, i.e. the embedded command and input files).
-    let upload_span_id = context.workunit_store.start_workunit(
-      new_span_id(),
+    with_workunit(
+      context.workunit_store.clone(),
       "ensure_action_uploaded".to_owned(),
-      workunit_state.parent_id.clone(),
       WorkunitMetadata::new(),
-    );
-    self
-      .ensure_action_uploaded(&store, &command, &action, request.input_files)
-      .await?;
-    context.workunit_store.complete_workunit(upload_span_id)?;
+      self.ensure_action_uploaded(&store, &command, &action, request.input_files),
+      |_, md| md,
+    )
+    .await?;
 
     // Submit the execution request to the RE server for execution.
-    let execute_span_id = context.workunit_store.start_workunit(
-      new_span_id(),
-      "run_execute_request".to_owned(),
-      workunit_state.parent_id.clone(),
-      WorkunitMetadata::new(),
-    );
     let result_fut = self.run_execute_request(execute_request, request, &context);
     let timeout_fut = tokio::time::timeout(deadline_duration, result_fut);
-    match timeout_fut.await {
-      Ok(r) => {
-        context.workunit_store.complete_workunit(execute_span_id)?;
-        r
-      }
+    let response = with_workunit(
+      context.workunit_store.clone(),
+      "run_execute_request".to_owned(),
+      WorkunitMetadata::new(),
+      timeout_fut,
+      |_, mut metadata| {
+        metadata.level = Level::Error;
+        metadata.desc = Some(format!(
+          "remote execution timed out after {:?}",
+          deadline_duration
+        ));
+        metadata
+      },
+    )
+    .await;
+    match response {
+      Ok(r) => r,
       Err(_) => {
         debug!(
           "remote execution for build_id={} timed out after {:?}",
           &build_id, deadline_duration
         );
-        let msg = format!("remote execution timed out after {:?}", deadline_duration);
-        let mut metadata = WorkunitMetadata::new();
-        metadata.level = Level::Error;
-        metadata.desc = Some(msg.clone());
-        context
-          .workunit_store
-          .complete_workunit_with_new_metadata(execute_span_id, metadata)?;
-        Err(msg)
+        Err(format!(
+          "remote execution timed out after {:?}",
+          deadline_duration
+        ))
       }
     }
   }

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -118,6 +118,8 @@ async fn extract_execute_response(
 
 #[tokio::test]
 async fn successful_with_only_call_to_execute() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
   let execute_request = echo_foo_request();
   let op_name = "gimme-foo".to_string();
 
@@ -157,6 +159,8 @@ async fn successful_with_only_call_to_execute() {
 
 #[tokio::test]
 async fn successful_after_reconnect_with_wait_execution() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
   let execute_request = echo_foo_request();
   let op_name = "gimme-foo".to_string();
 
@@ -199,6 +203,8 @@ async fn successful_after_reconnect_with_wait_execution() {
 
 #[tokio::test]
 async fn successful_after_reconnect_from_retryable_error() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
   let execute_request = echo_foo_request();
   let op_name_1 = "gimme-foo".to_string();
   let op_name_2 = "gimme-bar".to_string();
@@ -253,6 +259,9 @@ async fn successful_after_reconnect_from_retryable_error() {
 
 #[tokio::test]
 async fn server_rejecting_execute_request_gives_error() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
 
   let mock_server = mock::execution_server::TestServer::new(
@@ -280,6 +289,9 @@ async fn server_rejecting_execute_request_gives_error() {
 
 #[tokio::test]
 async fn server_sending_triggering_timeout_with_deadline_exceeded() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
 
   let mock_server = {
@@ -308,6 +320,9 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
 
 #[tokio::test]
 async fn sends_headers() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
   let op_name = "gimme-foo".to_string();
 
@@ -409,6 +424,9 @@ async fn sends_headers() {
 
 #[tokio::test]
 async fn extract_response_with_digest_stdout() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let op_name = "gimme-foo".to_string();
   let testdata = TestData::roland();
   let testdata_empty = TestData::empty();
@@ -490,6 +508,9 @@ async fn extract_response_with_digest_stdout_osx_remote() {
 
 #[tokio::test]
 async fn ensure_inline_stdio_is_stored() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let runtime = task_executor::Executor::new(Handle::current());
 
   let test_stdout = TestData::roland();
@@ -587,6 +608,9 @@ async fn ensure_inline_stdio_is_stored() {
 
 #[tokio::test]
 async fn bad_result_bytes() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
 
   let mock_server = {
@@ -632,6 +656,9 @@ async fn bad_result_bytes() {
 
 #[tokio::test]
 async fn initial_response_error() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
 
   let mock_server = {
@@ -671,6 +698,9 @@ async fn initial_response_error() {
 
 #[tokio::test]
 async fn initial_response_missing_response_and_error() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let execute_request = echo_foo_request();
 
   let mock_server = {
@@ -704,6 +734,9 @@ async fn initial_response_missing_response_and_error() {
 
 #[tokio::test]
 async fn execute_missing_file_uploads_if_known() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let runtime = task_executor::Executor::new(Handle::current());
 
   let roland = TestData::roland();
@@ -805,6 +838,9 @@ async fn execute_missing_file_uploads_if_known() {
 
 #[tokio::test]
 async fn execute_missing_file_errors_if_unknown() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
   let missing_digest = TestDirectory::containing_roland().digest();
 
   let mock_server = {

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -499,7 +499,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration', 'partially_type_checked'},
-  timeout = 320,
+  timeout = 420,
 )
 
 python_tests(

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -8,7 +8,7 @@ python_tests(
     'src/python/pants/reporting',
   ],
   tags = {"partially_type_checked"},
-  timeout = 10,
+  timeout = 30,
 )
 
 python_tests(


### PR DESCRIPTION
### Problem

The REv2 client does not capture workunits for upload and execution.

### Solution

Capture workunits for upload and execution.

### Result

More data is captured.