### PR TITLE
Add `--pytest-coverage-omit-test-sources` option to v2

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -2,12 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import configparser
+import itertools
 import json
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Optional
+from typing import Optional, Tuple, cast
 
 import pkg_resources
 
@@ -19,7 +20,7 @@ from pants.backend.python.rules.pex import (
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
-from pants.backend.python.target_types import PythonSources
+from pants.backend.python.target_types import PythonSources, PythonTestsSources
 from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
@@ -69,6 +70,49 @@ Step 4: `test.py` outputs the final report.
 COVERAGE_PLUGIN_MODULE_NAME = "__pants_coverage_plugin__"
 
 
+class PytestCoverage(PythonToolBase):
+    options_scope = "pytest-coverage"
+    default_version = "coverage>=5.0.3,<5.1"
+    default_entry_point = "coverage"
+    default_interpreter_constraints = ["CPython>=3.6"]
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--report",
+            type=CoverageReportType,
+            default=CoverageReportType.CONSOLE,
+            help="Which coverage report type to emit.",
+        )
+        register(
+            "--report-output-path",
+            type=str,
+            default=PurePath("dist", "coverage", "python").as_posix(),
+            advanced=True,
+            help="Path to write pytest coverage report to. Must be relative to build root.",
+        )
+        register(
+            "--include-test-sources",
+            type=bool,
+            default=False,
+            advanced=True,
+            help="Whether to include the test files in coverage measurement.",
+        )
+
+    @property
+    def report(self) -> CoverageReportType:
+        return cast(CoverageReportType, self.options.report)
+
+    @property
+    def report_output_path(self) -> str:
+        return cast(str, self.options.report_output_path)
+
+    @property
+    def include_test_sources(self) -> bool:
+        return cast(bool, self.options.include_test_sources)
+
+
 @dataclass(frozen=True)
 class CoveragePlugin:
     digest: Digest
@@ -109,13 +153,24 @@ class CoverageConfig:
 
 @rule
 async def create_coverage_config(
-    _: CoverageConfigRequest, transitive_targets: TransitiveTargets, log_level: LogLevel
+    _: CoverageConfigRequest,
+    transitive_targets: TransitiveTargets,
+    coverage_subsystem: PytestCoverage,
+    log_level: LogLevel,
 ) -> CoverageConfig:
     all_stripped_sources = await MultiGet(
         Get(SourceRootStrippedSources, StripSourcesFieldRequest(tgt[PythonSources]))
         for tgt in transitive_targets.closure
         if tgt.has_field(PythonSources)
     )
+    all_stripped_test_sources: Tuple[SourceRootStrippedSources, ...] = ()
+    if not coverage_subsystem.include_test_sources:
+        all_stripped_test_sources = await MultiGet(
+            Get(SourceRootStrippedSources, StripSourcesFieldRequest(tgt[PythonTestsSources]))
+            for tgt in transitive_targets.closure
+            if tgt.has_field(PythonTestsSources)
+        )
+
     # We map stripped file names to their source roots so that we can map back to the actual
     # sources file when generating coverage reports. For example,
     # {'helloworld/project.py': 'src/python'}.
@@ -138,6 +193,13 @@ async def create_coverage_config(
     cp.read_string(default_config)
     cp.set("run", "plugins", COVERAGE_PLUGIN_MODULE_NAME)
 
+    if not coverage_subsystem.include_test_sources:
+        test_files = itertools.chain.from_iterable(
+            stripped_test_sources.snapshot.files
+            for stripped_test_sources in all_stripped_test_sources
+        )
+        cp.set("run", "omit", ",".join(sorted(test_files)))
+
     if log_level in (LogLevel.DEBUG, LogLevel.TRACE):
         # See https://coverage.readthedocs.io/en/coverage-5.1/cmd.html?highlight=debug#diagnostics.
         cp.set("run", "debug", "\n\ttrace\n\tconfig")
@@ -157,29 +219,6 @@ async def create_coverage_config(
         InputFilesContent([FileContent(".coveragerc", config_content.encode())])
     )
     return CoverageConfig(digest)
-
-
-class PytestCoverage(PythonToolBase):
-    options_scope = "pytest-coverage"
-    default_version = "coverage>=5.0.3,<5.1"
-    default_entry_point = "coverage"
-    default_interpreter_constraints = ["CPython>=3.6"]
-
-    @classmethod
-    def register_options(cls, register):
-        super().register_options(register)
-        register(
-            "--report-output-path",
-            type=str,
-            default=PurePath("dist", "coverage", "python").as_posix(),
-            help="Path to write pytest coverage report to. Must be relative to build root.",
-        )
-        register(
-            "--report",
-            type=CoverageReportType,
-            default=CoverageReportType.CONSOLE,
-            help="Which coverage report type to emit.",
-        )
 
 
 @dataclass(frozen=True)
@@ -272,7 +311,7 @@ async def generate_coverage_report(
         ),
     )
 
-    report_type = coverage_subsystem.options.report
+    report_type = coverage_subsystem.report
     process = coverage_setup.pex.create_process(
         pex_path=f"./{coverage_setup.pex.output_filename}",
         # We pass `--ignore-errors` because Pants dynamically injects missing `__init__.py` files
@@ -290,7 +329,7 @@ async def generate_coverage_report(
     if report_type == CoverageReportType.CONSOLE:
         return CoverageReports((ConsoleCoverageReport(result.stdout.decode()),))
 
-    report_dir = PurePath(coverage_subsystem.options.report_output_path)
+    report_dir = PurePath(coverage_subsystem.report_output_path)
 
     report_file: Optional[PurePath] = None
     if report_type == CoverageReportType.HTML:

--- a/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
@@ -133,30 +133,15 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
                 f"{tmpdir_relative}/tests/python/project_test:arithmetic",
                 f"{tmpdir_relative}/tests/python/project_test/no_src",
             ]
-            exclude_tests_result = self.run_pants(command)
-            include_tests_result = self.run_pants(
-                [*command, "--pytest-coverage-include-test-sources"]
-            )
+            include_tests_result = self.run_pants(command)
+            exclude_tests_result = self.run_pants([*command, "--pytest-coverage-omit-test-sources"])
 
-        assert exclude_tests_result.returncode == include_tests_result.returncode == 0
+        assert include_tests_result.returncode == exclude_tests_result.returncode == 0
         # Regression test: make sure that individual tests do not complain about failing to
         # generate reports. This was showing up at test-time, even though the final merged report
         # would work properly.
-        assert "Failed to generate report" not in exclude_tests_result.stderr_data
         assert "Failed to generate report" not in include_tests_result.stderr_data
-        assert (
-            dedent(
-                f"""\
-                Name                                       Stmts   Miss Branch BrPart  Cover
-                ----------------------------------------------------------------------------
-                {tmpdir_relative}/src/python/project/lib.py          6      0      0      0   100%
-                {tmpdir_relative}/src/python/project/random.py       2      2      0      0     0%
-                ----------------------------------------------------------------------------
-                TOTAL                                          8      2      0      0    75%
-                """
-            )
-            in exclude_tests_result.stderr_data
-        )
+        assert "Failed to generate report" not in exclude_tests_result.stderr_data
         assert (
             dedent(
                 f"""\
@@ -171,4 +156,17 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
                 """
             )
             in include_tests_result.stderr_data
+        )
+        assert (
+            dedent(
+                f"""\
+                Name                                       Stmts   Miss Branch BrPart  Cover
+                ----------------------------------------------------------------------------
+                {tmpdir_relative}/src/python/project/lib.py          6      0      0      0   100%
+                {tmpdir_relative}/src/python/project/random.py       2      2      0      0     0%
+                ----------------------------------------------------------------------------
+                TOTAL                                          8      2      0      0    75%
+                """
+            )
+            in exclude_tests_result.stderr_data
         )

--- a/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage_integration_test.py
@@ -115,7 +115,7 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
             # Test a file that does not cover any src code. While this is unlikely to happen, this
             # tests that we can properly handle the edge case. In particular, we want to make sure
             # that coverage still works when we omit this test file through the option
-            # `--include-test-sources=false`.
+            # `--omit-test-sources`.
             no_src_folder = Path(tmpdir, "tests", "python", "project_test", "no_src")
             no_src_folder.mkdir()
             (no_src_folder / "test_no_src.py").write_text(
@@ -133,15 +133,15 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
                 f"{tmpdir_relative}/tests/python/project_test:arithmetic",
                 f"{tmpdir_relative}/tests/python/project_test/no_src",
             ]
-            include_tests_result = self.run_pants(command)
-            exclude_tests_result = self.run_pants([*command, "--pytest-coverage-omit-test-sources"])
+            result = self.run_pants(command)
+            omit_test_result = self.run_pants([*command, "--pytest-coverage-omit-test-sources"])
 
-        assert include_tests_result.returncode == exclude_tests_result.returncode == 0
+        assert result.returncode == omit_test_result.returncode == 0
         # Regression test: make sure that individual tests do not complain about failing to
         # generate reports. This was showing up at test-time, even though the final merged report
         # would work properly.
-        assert "Failed to generate report" not in include_tests_result.stderr_data
-        assert "Failed to generate report" not in exclude_tests_result.stderr_data
+        assert "Failed to generate report" not in result.stderr_data
+        assert "Failed to generate report" not in omit_test_result.stderr_data
         assert (
             dedent(
                 f"""\
@@ -155,7 +155,7 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
                 TOTAL                                                            13      2      0      0    85%
                 """
             )
-            in include_tests_result.stderr_data
+            in result.stderr_data
         )
         assert (
             dedent(
@@ -168,5 +168,5 @@ class PytestCoverageIntegrationTest(PantsRunIntegrationTest):
                 TOTAL                                          8      2      0      0    75%
                 """
             )
-            in exclude_tests_result.stderr_data
+            in omit_test_result.stderr_data
         )

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -15,6 +15,7 @@ from pants.backend.python.rules import (
     pytest_runner,
 )
 from pants.backend.python.rules.pytest_coverage import (
+    PytestCoverage,
     create_coverage_config,
     prepare_coverage_plugin,
 )
@@ -133,6 +134,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
             SubsystemRule(TestOptions),
+            SubsystemRule(PytestCoverage),
             RootRule(PythonTestFieldSet),
         )
 


### PR DESCRIPTION
It's often noisy to include the test files in the report. 

Unlike v1, we default to not filtering out to mirror how Coverage works normally. But we offer the option `--omit-test-sources` as a nicety to users.

[ci skip-rust-tests]
[ci skip-jvm-tests]
