### PR TITLE
Add report type to FilesystemCoverageReport

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -298,6 +298,7 @@ async def generate_coverage_report(
     elif report_type == CoverageReportType.XML:
         report_file = report_dir / "coverage.xml"
     fs_report = FilesystemCoverageReport(
+        report_type=report_type,
         result_digest=result.output_digest,
         directory_to_materialize_to=report_dir,
         report_file=report_file,

--- a/src/python/pants/backend/python/rules/pytest_coverage.py
+++ b/src/python/pants/backend/python/rules/pytest_coverage.py
@@ -281,7 +281,7 @@ async def generate_coverage_report(
         input_digest=input_digest,
         output_directories=("htmlcov",),
         output_files=("coverage.xml",),
-        description="Generate Pytest coverage report.",
+        description=f"Generate Pytest {report_type.report_name} coverage report.",
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
     )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -165,6 +165,7 @@ class FilesystemCoverageReport(CoverageReport):
     result_digest: Digest
     directory_to_materialize_to: PurePath
     report_file: Optional[PurePath]
+    report_type: CoverageReportType
 
     def materialize(self, console: Console, workspace: Workspace) -> Optional[PurePath]:
         workspace.materialize_directory(


### PR DESCRIPTION
Work towards: https://github.com/pantsbuild/pants/issues/9968



### Problem

Currently, looking at FilesystemCoverageReport the type of report (xml, html and in the future raw) is not specified.
Attaching that information is useful if we want to have rules and other mechansims (work units) that handle rule artifacts to run logic against this data type.

### Solution

Add and populate a report type attribute on FilesystemCoverageReport