### PR TITLE
Change StreamingWorkunitHandler default verbosity to DEBUG

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -367,7 +367,10 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
 
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
-            scheduler, callbacks=[tracker.add], report_interval_seconds=0.01
+            scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
         )
         with handler.session():
             scheduler.product_request(Fib, subjects=[0])
@@ -393,7 +396,10 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
         )
         tracker = WorkunitTracker()
         handler = StreamingWorkunitHandler(
-            scheduler, callbacks=[tracker.add], report_interval_seconds=0.01
+            scheduler,
+            callbacks=[tracker.add],
+            report_interval_seconds=0.01,
+            max_workunit_verbosity=LogLevel.INFO,
         )
 
         with handler.session():

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -39,12 +39,13 @@ class StreamingWorkunitHandler:
         scheduler: Any,
         callbacks: Iterable[Callable],
         report_interval_seconds: float,
-        max_workunit_verbosity: LogLevel = LogLevel.INFO,
+        max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
     ):
         self.scheduler = scheduler
         self.report_interval = report_interval_seconds
         self.callbacks = callbacks
         self._thread_runner: Optional[_InnerHandler] = None
+        # TODO(10092) The max verbosity should be a per-client setting, rather than a global setting.
         self.max_workunit_verbosity = max_workunit_verbosity
 
     def start(self) -> None:


### PR DESCRIPTION
### Problem

We were previously limiting the verbosity of streaming workunits to INFO. However, this means that a lot of useful workunit information is pruned away before it gets to streaming workunit clients.

### Solution

Change the default max verbosity to DEBUG.
