### PR TITLE
remoting: use debug level for remoting sub-workunits

### DIFF
--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -609,7 +609,7 @@ impl crate::CommandRunner for StreamingCommandRunner {
     with_workunit(
       context.workunit_store.clone(),
       "ensure_action_uploaded".to_owned(),
-      WorkunitMetadata::new(),
+      WorkunitMetadata::with_level(Level::Debug),
       self.ensure_action_uploaded(&store, &command, &action, request.input_files),
       |_, md| md,
     )
@@ -621,7 +621,7 @@ impl crate::CommandRunner for StreamingCommandRunner {
     let response = with_workunit(
       context.workunit_store.clone(),
       "run_execute_request".to_owned(),
-      WorkunitMetadata::new(),
+      WorkunitMetadata::with_level(Level::Debug),
       timeout_fut,
       |_, mut metadata| {
         metadata.level = Level::Error;

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -623,12 +623,14 @@ impl crate::CommandRunner for StreamingCommandRunner {
       "run_execute_request".to_owned(),
       WorkunitMetadata::with_level(Level::Debug),
       timeout_fut,
-      |_, mut metadata| {
-        metadata.level = Level::Error;
-        metadata.desc = Some(format!(
-          "remote execution timed out after {:?}",
-          deadline_duration
-        ));
+      |result, mut metadata| {
+        if let Err(_) = result {
+          metadata.level = Level::Error;
+          metadata.desc = Some(format!(
+            "remote execution timed out after {:?}",
+            deadline_duration
+          ));
+        }
         metadata
       },
     )

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -624,7 +624,7 @@ impl crate::CommandRunner for StreamingCommandRunner {
       WorkunitMetadata::with_level(Level::Debug),
       timeout_fut,
       |result, mut metadata| {
-        if let Err(_) = result {
+        if result.is_err() {
           metadata.level = Level::Error;
           metadata.desc = Some(format!(
             "remote execution timed out after {:?}",

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -109,7 +109,7 @@ pub struct WorkunitMetadata {
 
 impl WorkunitMetadata {
   pub fn new() -> Self {
-    Default::default()
+    WorkunitMetadata::default()
   }
 
   pub fn with_level(level: Level) -> Self {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -108,8 +108,20 @@ pub struct WorkunitMetadata {
 }
 
 impl WorkunitMetadata {
-  pub fn new() -> WorkunitMetadata {
-    WorkunitMetadata {
+  pub fn new() -> Self {
+    Default::default()
+  }
+
+  pub fn with_level(level: Level) -> Self {
+    let mut metadata = WorkunitMetadata::default();
+    metadata.level = level;
+    metadata
+  }
+}
+
+impl Default for WorkunitMetadata {
+  fn default() -> Self {
+    Self {
       level: Level::Info,
       desc: None,
       blocked: false,


### PR DESCRIPTION
### Problem

The workunits generated by remoting for ensure_action_uploaded and run_execute_request were created with the default info level, which means they get "completed" statuses printed to the console. This is too verbose.

Example:

```
17:57:56.11 [INFO] Completed: ensure_action_uploaded
```

### Solution

Switch those workunits to debug level. This PR also adds a helper to WorkunitMetadata to make it easier to construct a default instance with an alternate level.

Fixes a bug in the final metadata where it always set error.

### Result

Less verbose.
