### PR TITLE
Use the term 'smoke screen' instead of 'sanity check'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,7 +276,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
-      --githooks --sanity-checks --doc-gen --python-version 3.6
+      --githooks --smoke-screens --doc-gen --python-version 3.6
     - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
       --remote-execution-enabled --lint --python-version 3.6
     stage: Test Pants
@@ -338,7 +338,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
-      --githooks --sanity-checks --doc-gen --python-version 3.7
+      --githooks --smoke-screens --doc-gen --python-version 3.7
     - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
       --remote-execution-enabled --lint --python-version 3.7
     stage: Test Pants (Cron)
@@ -1536,13 +1536,13 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
-    - CACHE_NAME=osx_sanity.10_12.py36
+    - CACHE_NAME=macos_smoke.10_12.py36
     language: generic
-    name: OSX 10.12 sanity check (Python 3.6)
+    name: macOS 10.12 smoke screen (Python 3.6)
     os: osx
     osx_image: xcode9.2
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
+    - MODE=debug ./build-support/bin/ci.py --smoke-screens --python-version 3.6
     stage: Test Pants
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1562,13 +1562,13 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
-    - CACHE_NAME=osx_sanity.10_12.py37
+    - CACHE_NAME=macos_smoke.10_12.py37
     language: generic
-    name: OSX 10.12 sanity check (Python 3.7)
+    name: macOS 10.12 smoke screen (Python 3.7)
     os: osx
     osx_image: xcode9.2
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.7
+    - MODE=debug ./build-support/bin/ci.py --smoke-screens --python-version 3.7
     stage: Test Pants (Cron)
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1588,13 +1588,13 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
-    - CACHE_NAME=osx_sanity.10_13.py36
+    - CACHE_NAME=macos_smoke.10_13.py36
     language: generic
-    name: OSX 10.13 sanity check (Python 3.6)
+    name: macOS 10.13 smoke screen (Python 3.6)
     os: osx
     osx_image: xcode10.1
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
+    - MODE=debug ./build-support/bin/ci.py --smoke-screens --python-version 3.6
     stage: Test Pants
   - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
@@ -1614,13 +1614,13 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
-    - CACHE_NAME=osx_sanity.10_13.py37
+    - CACHE_NAME=macos_smoke.10_13.py37
     language: generic
-    name: OSX 10.13 sanity check (Python 3.7)
+    name: macOS 10.13 smoke screen (Python 3.7)
     os: osx
     osx_image: xcode10.1
     script:
-    - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.7
+    - MODE=debug ./build-support/bin/ci.py --smoke-screens --python-version 3.7
     stage: Test Pants (Cron)
   - addons:
       apt:

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -35,8 +35,8 @@ def main() -> None:
 
         if args.githooks:
             run_githooks()
-        if args.sanity_checks:
-            run_sanity_checks()
+        if args.smoke_screens:
+            run_smoke_screens()
         if args.lint:
             run_lint(oauth_token_path=remote_execution_oauth_token_path)
         if args.doc_gen:
@@ -114,9 +114,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--githooks", action="store_true", help="Run pre-commit githook.")
     parser.add_argument(
-        "--sanity-checks",
+        "--smoke-screens",
         action="store_true",
-        help="Run sanity checks of bootstrapped Pants and repo BUILD files.",
+        help="Run several smoke screens of bootstrapped Pants and repo BUILD files.",
     )
     parser.add_argument("--lint", action="store_true", help="Run lint over whole codebase.")
     parser.add_argument("--doc-gen", action="store_true", help="Run doc generation tests.")
@@ -409,9 +409,9 @@ def run_githooks() -> None:
     )
 
 
-def run_sanity_checks() -> None:
+def run_smoke_screens() -> None:
     def run_check(command: List[str]) -> None:
-        print(f"* Executing `./pants.pex {' '.join(command)}` as a sanity check")
+        print(f"* Executing `./pants.pex {' '.join(command)}` as a smoke screen")
         try:
             subprocess.run(
                 ["./pants.pex", *command],
@@ -430,7 +430,7 @@ def run_sanity_checks() -> None:
         ["roots"],
         ["targets"],
     ]
-    with travis_section("SanityCheck", "Sanity checking bootstrapped Pants and repo BUILD files"):
+    with travis_section("SmokeScreen", "Smoke screening bootstrapped Pants and repo BUILD files"):
         check_pants_pex_exists()
         for check in checks:
             run_check(check)

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -504,7 +504,7 @@ def lint(python_version: PythonVersion) -> Dict:
         "script": [
             (
                 "travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py "
-                f"--githooks --sanity-checks --doc-gen --python-version {python_version.decimal}"
+                f"--githooks --smoke-screens --doc-gen --python-version {python_version.decimal}"
             ),
             # NB: We split up `--lint` into its own shard because it uses remote execution. The
             # RBE token expires after 60 minutes, so we don't want to generate the token until all
@@ -728,32 +728,32 @@ def osx_platform_tests(python_version: PythonVersion) -> Dict:
 
 
 # -------------------------------------------------------------------------
-# OSX sanity checks
+# OSX smoke screens
 # -------------------------------------------------------------------------
 
 
-def _osx_sanity_check(
+def _osx_smoke_screen(
     python_version: PythonVersion, *, os_version_number: int, osx_image: str
 ) -> Dict:
     shard = {
         **osx_shard(python_version=python_version, osx_image=osx_image),
-        "name": f"OSX 10.{os_version_number} sanity check (Python {python_version.decimal})",
+        "name": f"macOS 10.{os_version_number} smoke screen (Python {python_version.decimal})",
         "script": [
-            f"MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version {python_version.decimal}"
+            f"MODE=debug ./build-support/bin/ci.py --smoke-screens --python-version {python_version.decimal}"
         ],
     }
     safe_append(
-        shard, "env", f"CACHE_NAME=osx_sanity.10_{os_version_number}.py{python_version.number}"
+        shard, "env", f"CACHE_NAME=macos_smoke.10_{os_version_number}.py{python_version.number}"
     )
     return shard
 
 
-def osx_10_12_sanity_check(python_version: PythonVersion) -> Dict:
-    return _osx_sanity_check(python_version, os_version_number=12, osx_image="xcode9.2")
+def osx_10_12_smoke_screen(python_version: PythonVersion) -> Dict:
+    return _osx_smoke_screen(python_version, os_version_number=12, osx_image="xcode9.2")
 
 
-def osx_10_13_sanity_check(python_version: PythonVersion) -> Dict:
-    return _osx_sanity_check(python_version, os_version_number=13, osx_image="xcode10.1")
+def osx_10_13_smoke_screen(python_version: PythonVersion) -> Dict:
+    return _osx_smoke_screen(python_version, os_version_number=13, osx_image="xcode10.1")
 
 
 # -------------------------------------------------------------------------
@@ -884,8 +884,8 @@ def main() -> None:
                     build_wheels_linux(),
                     build_wheels_osx(),
                     *[osx_platform_tests(v) for v in supported_python_versions],
-                    *[osx_10_12_sanity_check(v) for v in supported_python_versions],
-                    *[osx_10_13_sanity_check(v) for v in supported_python_versions],
+                    *[osx_10_12_smoke_screen(v) for v in supported_python_versions],
+                    *[osx_10_13_smoke_screen(v) for v in supported_python_versions],
                     *[jvm_tests(v) for v in supported_python_versions],
                     deploy_stable(),
                     deploy_unstable(),

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -119,7 +119,7 @@ class CmdLineSpecParserTest(TestBase):
         double_absolute_address = "/" + os.path.join(self.build_root, "a")
         double_absolute_file = "/" + os.path.join(self.build_root, "a.txt")
         for spec in [double_absolute_address, double_absolute_file]:
-            assert "//" == spec[:2], "A sanity check that we have a leading-// absolute spec"
+            assert "//" == spec[:2], "A check that we have a leading-// absolute spec"
         self.assert_address_spec_parsed(
             double_absolute_address, single(double_absolute_address[2:])
         )


### PR DESCRIPTION
A simple change we can make to better comply with our code of conduct's commitment to inclusivity. See [NPR](https://www.npr.org/2019/07/08/739643765/why-people-are-arguing-to-stop-using-the-words-crazy-and-insane) for why to avoid words like 'insanity' and its sibling 'sanity'.