### PR TITLE
scrooge plugin: scala compiler_option_sets parameter passthrough

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -351,4 +351,4 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
     @property
     def _copy_target_attributes(self):
-        return super()._copy_target_attributes + ["strict_deps"]
+        return super()._copy_target_attributes + ["strict_deps", "compiler_option_sets"]


### PR DESCRIPTION
### Problem

`compiler_option_sets` parameter is not propogated from scrooge source definition to syntetic targets making it impossible to override flags.
more details in #9867 

### Solution

copy parameters over

### Result

compiler flags applied to generated sources correctly
