### PR TITLE
Normalize paths before determining whether we can watch them.

### DIFF
--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -147,13 +147,15 @@ class OptionsInitializer:
             *bootstrap_options.pants_config_files,
         )
         for glob in potentially_absolute_globs:
-            glob_relpath = fast_relpath_optional(glob, buildroot) if os.path.isabs(glob) else glob
-            if glob_relpath:
-                invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
-            else:
+            # NB: We use `relpath` here because these paths are untrusted, and might need to be
+            # normalized in addition to being relativized.
+            glob_relpath = os.path.relpath(glob, buildroot)
+            if glob_relpath.startswith(".."):
                 logger.debug(
                     f"Changes to {glob}, outside of the buildroot, will not be invalidated."
                 )
+            else:
+                invalidation_globs.update([glob_relpath, glob_relpath + "/**"])
 
         # Explicitly specified globs are already relative, and are added verbatim.
         invalidation_globs.update(

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -150,7 +150,7 @@ class OptionsInitializer:
             # NB: We use `relpath` here because these paths are untrusted, and might need to be
             # normalized in addition to being relativized.
             glob_relpath = os.path.relpath(glob, buildroot)
-            if glob_relpath.startswith(".."):
+            if glob_relpath == "." or glob_relpath.startswith(".."):
                 logger.debug(
                     f"Changes to {glob}, outside of the buildroot, will not be invalidated."
                 )

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -30,7 +30,7 @@ class OptionsInitializerTest(unittest.TestCase):
             OptionsInitializer.create(ob, build_config)
         self.assertIn("The `--remote-execution` option requires", str(exc.exception))
 
-    def test_invalidation_globs(self):
+    def test_invalidation_globs(self) -> None:
         # Confirm that an un-normalized relative path in the pythonpath is filtered out.
         suffix = "something-ridiculous"
         ob = OptionsBootstrapper.create(args=[f"--pythonpath=../{suffix}"])


### PR DESCRIPTION
### Problem

Pythonpath entries may not be normalized (ie, may contain relative path operations that escape the root), and this can mean that globs are not valid. An example is trying to load a plugin as a source from a directory "next to" your buildroot.

### Solution

Normalize paths while relativizing them, so that we properly ignore a relative path that escapes the buildroot.

[ci skip-rust-tests]
[ci skip-jvm-tests]