### PR TITLE
pytest: use output_files for junit XML generation option

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -234,8 +234,7 @@ async def run_python_test(
 
     use_coverage = test_options.values.use_coverage
     output_dirs = [".coverage"] if use_coverage else []
-    if test_setup.xml_dir:
-        output_dirs.append(test_results_file)
+    output_files = [test_results_file] if test_setup.xml_dir else []
     process = test_setup.test_runner_pex.create_process(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
@@ -243,6 +242,7 @@ async def run_python_test(
         pex_args=test_setup.args,
         input_digest=test_setup.input_digest,
         output_directories=tuple(output_dirs) if output_dirs else None,
+        output_files=tuple(output_files) if output_files else None,
         description=f"Run Pytest for {field_set.address.reference()}",
         timeout_seconds=test_setup.timeout_seconds,
         env=env,

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -222,26 +222,34 @@ async def run_python_test(
     test_options: TestOptions,
 ) -> TestResult:
     """Runs pytest for one target."""
+    output_files = []
+
     add_opts = [f"--color={'yes' if global_options.options.colors else 'no'}"]
+
+    # Configure generation of JUnit-compatible test report.
+    test_results_file = None
     if test_setup.xml_dir:
         test_results_file = f"{field_set.address.path_safe_spec}.xml"
         add_opts.extend(
             (f"--junitxml={test_results_file}", f"-o junit_family={test_setup.junit_family}",)
         )
+        output_files.append(test_results_file)
+
+    # Configure generation of a coverage report.
+    use_coverage = test_options.values.use_coverage
+    if use_coverage:
+        output_files.append(".coverage")
+
     # We explicitly add the CWD to the PEX runtime sys.path. Some pytest plugins
     # (e.g., pytest-django)  need this so that their dynamic import logic works properly.
     env = {"PYTEST_ADDOPTS": " ".join(add_opts), "PEX_EXTRA_SYS_PATH": "."}
 
-    use_coverage = test_options.values.use_coverage
-    output_dirs = [".coverage"] if use_coverage else []
-    output_files = [test_results_file] if test_setup.xml_dir else []
     process = test_setup.test_runner_pex.create_process(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path=f"./{test_setup.test_runner_pex.output_filename}",
         pex_args=test_setup.args,
         input_digest=test_setup.input_digest,
-        output_directories=tuple(output_dirs) if output_dirs else None,
         output_files=tuple(output_files) if output_files else None,
         description=f"Run Pytest for {field_set.address.reference()}",
         timeout_seconds=test_setup.timeout_seconds,
@@ -260,7 +268,7 @@ async def run_python_test(
             logger.warning(f"Failed to generate coverage data for {field_set.address}.")
 
     xml_results_digest = None
-    if test_setup.xml_dir:
+    if test_results_file:
         xml_results_snapshot = await Get(
             Snapshot, SnapshotSubset(result.output_digest, PathGlobs([test_results_file]))
         )

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -274,7 +274,8 @@ async def run_python_test(
         )
         if xml_results_snapshot.files == (test_results_file,):
             xml_results_digest = await Get(
-                Digest, AddPrefix(xml_results_snapshot.digest, test_setup.xml_dir)
+                Digest,
+                AddPrefix(xml_results_snapshot.digest, test_setup.xml_dir),  # type: ignore[arg-type]
             )
         else:
             logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -373,7 +373,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert file.path.startswith("dist/test-results")
         assert b"pants_test.test_good" in file.content
 
-    @pytest.mark.skip(reason="TODO")
+    @pytest.mark.skip(reason="https://github.com/pantsbuild/pants/issues/10141")
     def test_single_passing_test_with_coverage(self) -> None:
         self.create_python_test_target([self.good_source])
         result = self.run_pytest(use_coverage=True)


### PR DESCRIPTION
### Problem

When running pytest with JUnit XML generation enabled, the Pants pytest_runner [uses `output_directories` instead of `output_files` to make the output file known to the process executor](https://github.com/pantsbuild/pants/blob/master/src/python/pants/backend/python/rules/pytest_runner.py#L237-L245). This works fine with local execution but breaks with remote execution because RE servers can skip `output_directories` that are not in fact directories. 

This issue manifests as errors like this:

```
$ ./pants --pytest-junit-xml-dir=dist/test-results [remote-config options] test XXX
05:07:26.01 [INFO] Completed: Run Pytest for XXX
05:07:26.02 [WARN] Failed to generate JUnit XML data for XXX.
05:07:26.02 [INFO] Tests failed: XXX
𐄂 XXX
ERROR: --junitxml must be a filename, given: XXX.xml
```

### Solution

Use `output_files` instead for the JUnit XML generation file.

### Result

The test runs and JUnit XML is properly generated and written to the local filesystem.
