### PR TITLE
Retry for filesystem changes more quickly, indefinitely, and with logging

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -340,7 +340,7 @@ async def run_tests(
     return Test(exit_code)
 
 
-@rule
+@rule(desc="Run test target")
 async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> AddressAndTestResult:
     field_set = wrapped_field_set.field_set
     result = await Get[TestResult](TestFieldSet, field_set)

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -801,7 +801,6 @@ impl<N: Node> Graph<N> {
       let mut inner = self.inner.lock();
       entry.complete(
         context,
-        entry_id,
         run_token,
         dep_generations,
         result,

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -41,12 +41,6 @@ pub trait NodeError: Clone + Debug + Eq + Send {
   /// Graph (generally while running).
   ///
   fn invalidated() -> Self;
-  ///
-  /// Creates an instance that represents an uncacheable node failing from
-  /// retrying its dependencies too many times, but never able to resolve them,
-  /// usually because they were invalidated too many times while running.
-  ///
-  fn exhausted() -> Self;
 
   ///
   /// Creates an instance that represents that a Node dependency was cyclic along the given path.

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use rand::{self, Rng};
-use tokio::time::{timeout, Elapsed};
+use tokio::time::{delay_for, timeout, Elapsed};
 
 use crate::{EntryId, Graph, InvalidationResult, Node, NodeContext, NodeError};
 
@@ -356,9 +356,10 @@ async fn uncachable_node_only_runs_once() {
 #[tokio::test]
 async fn retries() {
   let _logger = env_logger::try_init();
-  let graph = Arc::new(Graph::new_with_invalidation_timeout(Duration::from_secs(
-    10,
-  )));
+  let graph = Arc::new(Graph::new_with_invalidation_timeout(
+    Duration::from_secs(10),
+    Duration::from_millis(100),
+  ));
 
   let context = {
     let delay_for_root = Duration::from_millis(100);
@@ -390,7 +391,10 @@ async fn retries() {
 #[tokio::test]
 async fn exhaust_uncacheable_retries() {
   let _logger = env_logger::try_init();
-  let graph = Arc::new(Graph::new_with_invalidation_timeout(Duration::from_secs(2)));
+  let graph = Arc::new(Graph::new_with_invalidation_timeout(
+    Duration::from_secs(2),
+    Duration::from_millis(100),
+  ));
 
   let context = {
     let mut uncacheable = HashSet::new();
@@ -430,25 +434,31 @@ async fn exhaust_uncacheable_retries() {
 #[tokio::test]
 async fn canceled_immediately() {
   let _logger = env_logger::try_init();
-  let graph = Arc::new(Graph::new());
+  let invalidation_delay = Duration::from_millis(10);
+  let graph = Arc::new(Graph::new_with_invalidation_timeout(
+    Duration::from_secs(10),
+    invalidation_delay,
+  ));
 
-  let delay_for_root = Duration::from_millis(2000);
+  let delay_for_mid = Duration::from_millis(2000);
   let start_time = Instant::now();
   let context = {
     let mut delays = HashMap::new();
-    delays.insert(TNode::new(0), delay_for_root);
+    delays.insert(TNode::new(1), delay_for_mid);
     TContext::new(graph.clone()).with_delays(delays)
   };
 
-  // We invalidate three times: the root should only actually run to completion once, because we
-  // should cancel it the other times.
+  // We invalidate three times: the mid should only actually run to completion once, because we
+  // should cancel it the other times. We wait longer than the invalidation_delay for each
+  // invalidation to ensure that work actually starts before being invalidated.
   let iterations = 3;
-  let sleep_per_invalidation = Duration::from_millis(100);
+  let sleep_per_invalidation = invalidation_delay * 10;
+  assert!(delay_for_mid > sleep_per_invalidation * 3);
   let graph2 = graph.clone();
   let _join = thread::spawn(move || {
     for _ in 0..iterations {
       thread::sleep(sleep_per_invalidation);
-      graph2.invalidate_from_roots(|&TNode(n, _)| n == 0);
+      graph2.invalidate_from_roots(|&TNode(n, _)| n == 1);
     }
   });
   assert_eq!(
@@ -457,7 +467,20 @@ async fn canceled_immediately() {
   );
 
   // We should have waited much less than the time it would have taken to complete three times.
-  assert!(Instant::now() < start_time + (delay_for_root * iterations));
+  assert!(Instant::now() < start_time + (delay_for_mid * iterations));
+
+  // And the top nodes should have seen three aborts.
+  assert_eq!(
+    vec![
+      TNode::new(1),
+      TNode::new(2),
+      TNode::new(1),
+      TNode::new(2),
+      TNode::new(1),
+      TNode::new(2)
+    ],
+    context.aborts(),
+  );
 }
 
 #[tokio::test]
@@ -644,16 +667,19 @@ impl Node for TNode {
   type Error = TError;
 
   async fn run(self, context: TContext) -> Result<Vec<T>, TError> {
+    let mut abort_guard = context.abort_guard(self.clone());
     context.ran(self.clone());
     let token = T(self.0, context.salt());
-    context.maybe_delay(&self);
-    if let Some(dep) = context.dependency_of(&self) {
+    context.maybe_delay(&self).await;
+    let res = if let Some(dep) = context.dependency_of(&self) {
       let mut v = context.get(dep).await?;
       v.push(token);
       Ok(v)
     } else {
       Ok(vec![token])
-    }
+    };
+    abort_guard.did_not_abort();
+    res
   }
 
   fn cacheable(&self) -> bool {
@@ -732,6 +758,7 @@ struct TContext {
   delays: Arc<HashMap<TNode, Duration>>,
   uncacheable: Arc<HashSet<TNode>>,
   graph: Arc<Graph<TNode>>,
+  aborts: Arc<Mutex<Vec<TNode>>>,
   runs: Arc<Mutex<Vec<TNode>>>,
   entry_id: Option<EntryId>,
 }
@@ -747,6 +774,7 @@ impl NodeContext for TContext {
       delays: self.delays.clone(),
       uncacheable: self.uncacheable.clone(),
       graph: self.graph.clone(),
+      aborts: self.aborts.clone(),
       runs: self.runs.clone(),
       entry_id: Some(entry_id),
     }
@@ -778,6 +806,7 @@ impl TContext {
       delays: Arc::default(),
       uncacheable: Arc::default(),
       graph,
+      aborts: Arc::new(Mutex::new(Vec::new())),
       runs: Arc::new(Mutex::new(Vec::new())),
       entry_id: None,
     }
@@ -820,14 +849,26 @@ impl TContext {
     self.graph.get(self.entry_id, self, dst).await
   }
 
+  fn abort_guard(&self, node: TNode) -> AbortGuard {
+    AbortGuard {
+      context: self.clone(),
+      node: Some(node),
+    }
+  }
+
+  fn aborted(&self, node: TNode) {
+    let mut aborts = self.aborts.lock();
+    aborts.push(node);
+  }
+
   fn ran(&self, node: TNode) {
     let mut runs = self.runs.lock();
     runs.push(node);
   }
 
-  fn maybe_delay(&self, node: &TNode) {
+  async fn maybe_delay(&self, node: &TNode) {
     if let Some(delay) = self.delays.get(node) {
-      thread::sleep(*delay);
+      delay_for(*delay).await;
     }
   }
 
@@ -849,8 +890,35 @@ impl TContext {
     }
   }
 
+  fn aborts(&self) -> Vec<TNode> {
+    self.aborts.lock().clone()
+  }
+
   fn runs(&self) -> Vec<TNode> {
     self.runs.lock().clone()
+  }
+}
+
+///
+/// A guard that if dropped, records that the given Node was aborted. When a future is canceled, it
+/// is dropped without re-running.
+///
+struct AbortGuard {
+  context: TContext,
+  node: Option<TNode>,
+}
+
+impl AbortGuard {
+  fn did_not_abort(&mut self) {
+    self.node = None;
+  }
+}
+
+impl Drop for AbortGuard {
+  fn drop(&mut self) {
+    if let Some(node) = self.node.take() {
+      self.context.aborted(node);
+    }
   }
 }
 

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -391,11 +391,11 @@ async fn canceled_immediately() {
   let invalidation_delay = Duration::from_millis(10);
   let graph = Arc::new(Graph::new_with_invalidation_delay(invalidation_delay));
 
-  let delay_for_mid = Duration::from_millis(2000);
+  let delay_for_middle = Duration::from_millis(2000);
   let start_time = Instant::now();
   let context = {
     let mut delays = HashMap::new();
-    delays.insert(TNode::new(1), delay_for_mid);
+    delays.insert(TNode::new(1), delay_for_middle);
     TContext::new(graph.clone()).with_delays(delays)
   };
 
@@ -404,7 +404,7 @@ async fn canceled_immediately() {
   // invalidation to ensure that work actually starts before being invalidated.
   let iterations = 3;
   let sleep_per_invalidation = invalidation_delay * 10;
-  assert!(delay_for_mid > sleep_per_invalidation * 3);
+  assert!(delay_for_middle > sleep_per_invalidation * 3);
   let graph2 = graph.clone();
   let _join = thread::spawn(move || {
     for _ in 0..iterations {
@@ -418,7 +418,7 @@ async fn canceled_immediately() {
   );
 
   // We should have waited much less than the time it would have taken to complete three times.
-  assert!(Instant::now() < start_time + (delay_for_mid * iterations));
+  assert!(Instant::now() < start_time + (delay_for_middle * iterations));
 
   // And the top nodes should have seen three aborts.
   assert_eq!(

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -126,10 +126,8 @@ impl StreamedHermeticCommand {
     let mut inner = Command::new(program);
     inner
       // TODO: This will not universally prevent child processes continuing to run in the
-      // background, for a few reasons:
-      //   1) the Graph memoizes runs, and generally completes them rather than cancelling them,
-      //   2) killing a pantsd client with Ctrl+C kills the server with a signal, which won't
-      //      currently result in an orderly dropping of everything in the graph. See #10004.
+      // background, because killing a pantsd client with Ctrl+C kills the server with a signal,
+      // which won't currently result in an orderly dropping of everything in the graph. See #10004.
       .kill_on_drop(true)
       .env_clear()
       // It would be really nice not to have to manually set PATH but this is sadly the only way

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1189,10 +1189,6 @@ impl NodeError for Failure {
     Failure::Invalidated
   }
 
-  fn exhausted() -> Failure {
-    Context::mk_error("Exhausted retries while waiting for the filesystem to stabilize.")
-  }
-
   fn cyclic(mut path: Vec<String>) -> Failure {
     let path_len = path.len();
     if path_len > 1 {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1040,14 +1040,16 @@ impl NodeKey {
   fn user_facing_name(&self) -> Option<String> {
     match self {
       NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
-      NodeKey::Snapshot(_) => Some(format!("{}", self)),
+      NodeKey::Snapshot(ref s) => Some(format!("Snapshotting: {}", s.0)),
       NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.user_facing_name(),
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
-      NodeKey::DownloadedFile(..) => None,
+      NodeKey::DownloadedFile(ref d) => Some(format!("Downloading: {}", d.0)),
       NodeKey::ReadLink(..) => None,
-      NodeKey::Scandir(Scandir(Dir(path))) => Some(format!("Reading {}", path.display())),
+      NodeKey::Scandir(Scandir(Dir(path))) => {
+        Some(format!("Reading directory: {}", path.display()))
+      }
       NodeKey::Select(..) => None,
     }
   }
@@ -1170,16 +1172,22 @@ impl Node for NodeKey {
 impl Display for NodeKey {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
     match self {
-      &NodeKey::DigestFile(ref s) => write!(f, "DigestFile({:?})", s.0),
-      &NodeKey::DownloadedFile(ref s) => write!(f, "DownloadedFile({:?})", s.0),
+      &NodeKey::DigestFile(ref s) => write!(f, "DigestFile({})", s.0.path.display()),
+      &NodeKey::DownloadedFile(ref s) => write!(f, "DownloadedFile({})", s.0),
       &NodeKey::MultiPlatformExecuteProcess(ref s) => {
-        write!(f, "MultiPlatformExecuteProcess({:?}", s.0)
+        if let Some(name) = s.0.user_facing_name() {
+          write!(f, "Process({})", name)
+        } else {
+          write!(f, "Process({:?})", s)
+        }
       }
-      &NodeKey::ReadLink(ref s) => write!(f, "ReadLink({:?})", s.0),
-      &NodeKey::Scandir(ref s) => write!(f, "Scandir({:?})", s.0),
-      &NodeKey::Select(ref s) => write!(f, "Select({}, {})", s.params, s.product,),
-      &NodeKey::Task(ref task) => write!(f, "{:?}", task),
-      &NodeKey::Snapshot(ref s) => write!(f, "Snapshot({})", format!("{}", &s.0)),
+      &NodeKey::ReadLink(ref s) => write!(f, "ReadLink({})", (s.0).0.display()),
+      &NodeKey::Scandir(ref s) => write!(f, "Scandir({})", (s.0).0.display()),
+      &NodeKey::Select(ref s) => write!(f, "{}", s.product),
+      &NodeKey::Task(ref task) => {
+        write!(f, "@rule {}({})", task.task.display_info.name, task.params)
+      }
+      &NodeKey::Snapshot(ref s) => write!(f, "Snapshot({})", s.0),
     }
   }
 }

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -22,7 +22,6 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 def launch_file_toucher(f):
     """Launch a loop to touch the given file, and return a function to call to stop and join it."""
     if not os.path.isfile(f):
-
         raise AssertionError("Refusing to touch a non-file.")
 
     halt = threading.Event()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -22,6 +22,7 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 def launch_file_toucher(f):
     """Launch a loop to touch the given file, and return a function to call to stop and join it."""
     if not os.path.isfile(f):
+
         raise AssertionError("Refusing to touch a non-file.")
 
     halt = threading.Event()


### PR DESCRIPTION
### Problem

As described in #10081, there are a few different concerns around retrying nodes when the filesystem changes:
1. whether we have retried enough times
2. whether we've made it clear to the user that we're retrying
3. whether we retry immediately upon change, or only after something has completed

### Solution

To address each of the above points, we retry:
1. indefinitely
2. with logging
3. immediately upon invalidation of nodes by:
    * removing the `Running::dirty` flag, and moving a `Running` node to `NotStarted` to trigger invalidation
    * "aborting"/dropping ongoing work for a canceled attempt using `futures::Abortable`

Additionally, improve the `Display` and `user_facing_name` implementations for `Node` to allow for better log messages from the `Graph`.

### Result

A message like:
```
12:39:52.93 [INFO] Completed: Building requirements.pex
15:21:58.95 [INFO] Filesystem changed during run: retrying `Test` in 500ms...
15:21:58.96 [INFO] Filesystem changed during run: retrying `@rule coordinator_of_tests((OptionsBootstrapper(args=['--no-v1', '--v2', '--no-process-execution-use-local-cache', 'test', 'tests/python/pants_test/util:'], env={'PANTS_DEV': '1'}, config=ChainedConfig(['/Users/stuhood/src/pants/pants.toml', '/Users/stuhood/.pants.rc'])), WrappedTestFieldSet(field_set=PythonTestFieldSet(address=Address(tests/python/pants_test/util, argutil), origin=SiblingAddresses(directory='tests/python/pants_test/util'), sources=<class 'pants.backend.python.target_types.PythonTestsSources'>(alias='sources', sanitized_raw_value=('test_argutil.py',), default=('test_*.py', '*_test.py', 'tests.py', 'conftest.py')), timeout=pants.backend.python.target_types.PythonTestsTimeout(alias='timeout', value=None, default=None), coverage=pants.backend.python.target_types.PythonCoverage(alias='coverage', value=('pants.util.argutil',), default=None)))))` in 500ms...
12:39:57.17 [INFO] Completed: Building requirements.pex with 1 requirement: dataclasses==0.6
```
...is rendered immediately when a file that a test depends on is invalidated.

Fixes #10081.