### PR TITLE
Set --dynamic-ui default based on CI environment variable

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -875,8 +875,10 @@ class GlobalOptions(Subsystem):
         register(
             "--dynamic-ui",
             type=bool,
-            default=sys.stderr.isatty(),
-            help="Display a dynamically-updating console UI as pants runs.",
+            default=(("CI" not in os.environ) and sys.stderr.isatty()),
+            help="Display a dynamically-updating console UI as Pants runs. This is true by default "
+            "if Pants detects a TTY and there is no 'CI' environment variable indicating that "
+            "Pants is running in a continuous integration environment; and false otherwise.",
         )
 
         register(


### PR DESCRIPTION
### Problem

Several different continuous integration systems (including Travis and CircleCI) expose a tty to programs that execute within them, but doesn't correctly handle the dynamic UI screen updating, resulting in garbage being printed to the console in CI contexts.

### Solution

Pants now sets the default value of the `--dynamic-ui` option to False if there is an environment variable called `CI` with a value of `true`, which several popular CI systems do (including Travis and CircleCI), so the dynamic UI will be turned off by default in CI without requiring manual disabling. The dynamic UI can still be explicitly enabled in CI if this is wanted.