### PR TITLE
Give loaded macros access to registered pants concepts

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD
@@ -1,8 +1,16 @@
 load("//examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS", "dep_on_welcome")
-load("examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS_2", "source_exe_scala")
+# Load statements can use the `:` syntax to keep bazel compatibility. ":"s get translated to "/"
+load("examples/src/scala/org/pantsbuild/example/build_file_macros:BUILD_MACROS_2", "source_exe_scala")
+load("//examples/src/scala/org/pantsbuild/example/build_file_macros/CUSTOM_ARTIFACT_MACRO", "custom_artifact")
 
 jvm_binary(
   main="org.pantsbuild.example.build_file_macros.Exe",
   sources=source_exe_scala(),
   dependencies=dep_on_welcome()
+)
+
+scala_library(
+    name="provides_custom_artifact",
+    sources=source_exe_scala(),
+    provides=custom_artifact("provides_custom_artifact"),
 )

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/BUILD_MACROS
@@ -1,4 +1,3 @@
 def dep_on_welcome():
-
     return ['examples/src/scala/org/pantsbuild/example/hello/welcome:welcome']
 

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/CUSTOM_ARTIFACT_MACRO
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/CUSTOM_ARTIFACT_MACRO
@@ -1,0 +1,6 @@
+def custom_artifact(name):
+  return artifact(
+    org = "org.pantsbuild.custom_artifact",
+    name = name,
+    repo = public,
+  )

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_NON_REGISTERED_MACROS
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_NON_REGISTERED_MACROS
@@ -1,0 +1,2 @@
+load("//this/is/ignored", "non_registered_symbol")
+load("//this/is/ignored", "jar")

--- a/examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_REGISTERED_MACROS
+++ b/examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_REGISTERED_MACROS
@@ -1,0 +1,1 @@
+load("//this/is/ignored", "jar", "artifact")

--- a/tests/python/pants_test/engine/legacy/test_parser_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_parser_integration.py
@@ -21,11 +21,26 @@ class LoadStatementsIntegrationTests(PantsDaemonIntegrationTestBase):
 
     def test_files_with_load_statements_parse(self):
         pants_run = self.do_command(
-            "list", "examples/src/scala/org/pantsbuild/example/build_file_macros", success=True
+            "list",
+            "examples/src/scala/org/pantsbuild/example/build_file_macros:build_file_macros",
+            success=True,
         )
         assert {
             "examples/src/scala/org/pantsbuild/example/build_file_macros:build_file_macros"
         } == set(pants_run.stdout_data.splitlines())
+
+    def test_macro_definitions_have_access_to_registered_concepts(self):
+        # We check that we can use pants concepts in loaded macros.
+        # We run `export` instead of list to force the parsing and understanding of the custom artifact.
+        pants_run = self.do_command(
+            "export",
+            "examples/src/scala/org/pantsbuild/example/build_file_macros:provides_custom_artifact",
+            success=True,
+        )
+        assert (
+            "examples/src/scala/org/pantsbuild/example/build_file_macros:provides_custom_artifact"
+            in pants_run.stdout_data
+        )
 
     def test_only_load_specified_symbols(self):
         fail_to_load_symbols_build_file = dedent(
@@ -95,6 +110,42 @@ class LoadStatementsIntegrationTests(PantsDaemonIntegrationTestBase):
         with self._mock_broken_project_dir(load_non_existing_symbol) as tmpdir:
             pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
             assert 'Tried to load non existing file: "non/existing/file"' in pants_run.stderr_data
+
+    def test_macro_files_ignore_loads_if_loaded_symbols_are_registered(self):
+        ignore_registered_symbols_load_build_file = dedent(
+            """
+            # We try to load a macro file that itself has load() statements,
+            # and all statements load symbols registered with pants.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_REGISTERED_MACROS")
+
+            target(name="dummy")
+            """
+        )
+
+        with self._mock_broken_project_dir(ignore_registered_symbols_load_build_file) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=True,)
+            assert ":dummy" in pants_run.stdout_data
+
+    def test_macro_files_error_if_trying_to_load_non_registered_symbols(self):
+        fail_load_non_registered_sybmols_build_file = dedent(
+            """
+            # We try to load a macro file that itself has load() statements,
+            # Some of which are not registered with pants.
+            load("examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_NON_REGISTERED_MACROS")
+
+            target(name="dummy")
+            """
+        )
+
+        with self._mock_broken_project_dir(fail_load_non_registered_sybmols_build_file) as tmpdir:
+            pants_run = self.do_command("list", f"{tmpdir}:", success=False,)
+            print(f"BL: asdfsdf{pants_run.stderr_data}")
+            assert (
+                "File examples/src/scala/org/pantsbuild/example/build_file_macros/MACRO_THAT_LOADS_NON_REGISTERED_MACROS "
+                "is trying to load() sybmols ['non_registered_symbol'], which are not registered with pants. "
+                "This is not allowed for now, please stick to loading only registered symbols."
+                in pants_run.stderr_data
+            )
 
     def test_loads_dont_pollute_other_files(self):
         fail_to_load_symbols_build_file = dedent(


### PR DESCRIPTION
### Problem

In #9886, we introduced a way to import macros defined outside of a BUILD file into pants. However, these macros don't have access to the pants parsing context, which severely limited their usefulness (they couldn't use `jar` or `artifact`, for instance).

### Solution

Pass pants' parsing context to the loading of a macro file, so that macros outside of BUILD files have access to the same context as regular pants macros have.

### Result

Concepts like `jar` and `artifact` can be used in macros defined outside of BUILD files.

In general, we don't support `load` statements from non-BUILD file. However, for Bazel compatibility, we need the ability to explcitly load symbols from our internal representation of them. Therefore, we reach a middle ground. If a macro file has a `load()` statement:

- If all the symbols loaded are symbols registered in pants, we ignore the load statements (logging to `debug`). Illustrated in [test_macro_files_ignore_loads_if_loaded_symbols_are_registered](https://github.com/pantsbuild/pants/pull/10150/commits/db0c07a9b893fb11269dd1e102ea4f5089fb2d83#diff-5c12b9127758407e0fea8d3702d5ad58R114).
- If any symbols loaded are _not_ symbols registered in pants, we error loudly, marking which symbols are not valid to load. Illustrated in [test_macro_files_error_if_trying_to_load_non_registered_symbols](https://github.com/pantsbuild/pants/pull/10150/commits/db0c07a9b893fb11269dd1e102ea4f5089fb2d83#diff-5c12b9127758407e0fea8d3702d5ad58R129).
