### PR TITLE
Generate JUNIT XML test results when running tests.

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -242,11 +242,19 @@ class TestStrategy(Enum):
                 *PYTEST_PASSTHRU_ARGS,
             ],
             self.v1_chroot: ["./pants.pex", "test.pytest", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
-            self.v2_local: ["./pants.pex", "--no-v1", "--v2", "test", *sorted(targets)],
+            self.v2_local: [
+                "./pants.pex",
+                "--no-v1",
+                "--v2",
+                "test",
+                "--pytest-junit-xml-dir=dist/test-results/",
+                *sorted(targets),
+            ],
             self.v2_remote: [
                 "./pants.pex",
                 *_use_remote_execution(oauth_token_path or ""),
                 "test",
+                "--pytest-junit-xml-dir=dist/test-results/",
                 *sorted(targets),
             ],
         }[


### PR DESCRIPTION
### Problem

We don't have very good test coverage for all the pytest features we currently support, including this creating XML test results file.

### Solution

Long term, we should probably have tests for those, but for now, just running those in CI will expose any issues that we have especially when running with RE.
See: https://github.com/pantsbuild/pants/pull/10136