### PR TITLE
Expose the types consumed to produce a type in a RuleGraph.

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -215,6 +215,16 @@ class Scheduler:
                 for line in fd.readlines():
                     yield line.rstrip()
 
+    def rule_graph_consumed_types(
+        self, root_subject_types: Sequence[Type], product_type: Type
+    ) -> Sequence[Type]:
+        return cast(
+            Sequence[Type],
+            self._native.lib.rule_graph_consumed_types(
+                self._scheduler, root_subject_types, product_type
+            ),
+        )
+
     def invalidate_files(self, direct_filenames):
         # NB: Watchman no longer triggers events when children are created/deleted under a directory,
         # so we always need to invalidate the direct parent as well.

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -210,6 +210,11 @@ class SchedulerTest(TestBase):
         with self.assertDoesNotRaise():
             _ = self.request_single_product(D, Params(c))
 
+    def test_consumed_types(self):
+        assert {A, B, C, str} == set(
+            self.scheduler.scheduler.rule_graph_consumed_types([A, C], str)
+        )
+
     @contextmanager
     def _assert_execution_error(self, expected_msg):
         with assert_execution_error(self, expected_msg):

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -339,6 +339,23 @@ impl<R: Rule> RuleGraph<R> {
   }
 
   ///
+  /// Returns all types consumed by rules within this RuleGraph.
+  ///
+  pub fn consumed_types(&self) -> HashSet<R::TypeId> {
+    self
+      .rule_dependency_edges
+      .iter()
+      .flat_map(|(entry, edges)| {
+        entry
+          .params()
+          .iter()
+          .cloned()
+          .chain(edges.dependencies.keys().map(|k| k.product()))
+      })
+      .collect()
+  }
+
+  ///
   /// Find the entrypoint in this RuleGraph for the given product and params.
   ///
   pub fn find_root<I: IntoIterator<Item = R::TypeId>>(

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -33,14 +33,6 @@ pub fn none() -> PyObject {
   gil.python().None()
 }
 
-pub fn get_value_from_type_id(ty: TypeId) -> Value {
-  with_interns(|interns| {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Value::from(interns.type_get(&ty).clone_ref(py).into_object())
-  })
-}
-
 pub fn get_type_for(val: &Value) -> TypeId {
   with_interns_mut(|interns| {
     let gil = Python::acquire_gil();
@@ -70,6 +62,14 @@ pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
     .cast_as::<PyBool>(gil.python())
     .unwrap()
     .is_true()
+}
+
+pub fn type_for_type_id(ty: TypeId) -> PyType {
+  with_interns(|interns| {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    interns.type_get(&ty).clone_ref(py)
+  })
 }
 
 pub fn type_for(py_type: PyType) -> TypeId {
@@ -240,7 +240,7 @@ pub fn key_to_str(key: &Key) -> String {
 }
 
 pub fn type_to_str(type_id: TypeId) -> String {
-  project_str(&get_value_from_type_id(type_id), "__name__")
+  project_str(&type_for_type_id(type_id).into_object().into(), "__name__")
 }
 
 pub fn val_to_str(val: &Value) -> String {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -23,7 +23,7 @@ use crate::selectors;
 use crate::tasks::{self, Rule};
 use boxfuture::{BoxFuture, Boxable};
 use bytes::{self, BufMut};
-use cpython::Python;
+use cpython::{Python, PythonObject};
 use fs::{
   self, Dir, DirectoryListing, File, FileContent, GlobExpansionConjunction, GlobMatching, Link,
   PathGlobs, PathStat, PreparedPathGlobs, StrictGlobMatching, VFS,
@@ -764,7 +764,7 @@ impl Task {
               .cloned()
               .ok_or_else(|| match get.declared_subject {
                 Some(ty) if externs::is_union(ty) => {
-                  let value = externs::get_value_from_type_id(ty);
+                  let value = externs::type_for_type_id(ty).into_object().into();
                   match externs::call_method(
                     &value,
                     "non_member_error_message",


### PR DESCRIPTION
### Problem

In order to include `Subsystem`s in the help for a `@goal_rule`, we need to know which are relevant to each goal.

### Solution

Expose a method to compute the reachable types from a root of the `RuleGraph`, and add a method to `LegacyGraphSession` to compute the reachable types for a goal.

### Result

A followup change could use `goal_consumed_types` to render help for all `Optionable`s/`Subsystem`s reachable for a goal. Helps to unblock #8884.

[ci skip-jvm-tests]