### PR TITLE
Do not include resource targets in v2 MyPy chroot

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -14,7 +14,10 @@ from pants.backend.python.rules.pex import (
     PexRequest,
     PexRequirements,
 )
-from pants.backend.python.rules.python_sources import StrippedPythonSources
+from pants.backend.python.rules.python_sources import (
+    StrippedPythonSources,
+    StrippedPythonSourcesRequest,
+)
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import (
@@ -156,9 +159,13 @@ async def pylint_lint_partition(
         ),
     )
 
-    prepare_plugin_sources_request = Get(StrippedPythonSources, Targets, partition.plugin_targets)
+    prepare_plugin_sources_request = Get(
+        StrippedPythonSources,
+        StrippedPythonSourcesRequest(partition.plugin_targets, include_resources=True),
+    )
     prepare_python_sources_request = Get(
-        StrippedPythonSources, Targets, partition.targets_with_dependencies
+        StrippedPythonSources,
+        StrippedPythonSourcesRequest(partition.targets_with_dependencies, include_resources=False),
     )
     specified_source_files_request = Get(
         SourceFiles,

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -12,7 +12,10 @@ from pants.backend.python.rules.pex import (
     PexRequirements,
     TwoStepPexRequest,
 )
-from pants.backend.python.rules.python_sources import StrippedPythonSources
+from pants.backend.python.rules.python_sources import (
+    StrippedPythonSources,
+    StrippedPythonSourcesRequest,
+)
 from pants.backend.python.target_types import (
     PythonInterpreterCompatibility,
     PythonRequirementsField,
@@ -21,7 +24,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
-from pants.engine.target import Targets, TransitiveTargets
+from pants.engine.target import TransitiveTargets
 from pants.python.python_setup import PythonSetup
 from pants.util.meta import frozen_after_init
 
@@ -94,7 +97,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
     if request.additional_sources:
         input_digests.append(request.additional_sources)
     if request.include_source_files:
-        prepared_sources = await Get(StrippedPythonSources, Targets(all_targets))
+        prepared_sources = await Get(
+            StrippedPythonSources, StrippedPythonSourcesRequest(all_targets, include_resources=True)
+        )
         input_digests.append(prepared_sources.snapshot.digest)
     merged_input_digest = await Get(Digest, MergeDigests(input_digests))
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -21,7 +21,10 @@ from pants.backend.python.rules.pex import (
     PexRequirements,
 )
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.rules.python_sources import StrippedPythonSources
+from pants.backend.python.rules.python_sources import (
+    StrippedPythonSources,
+    StrippedPythonSourcesRequest,
+)
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import (
@@ -46,7 +49,7 @@ from pants.engine.interactive_process import InteractiveProcess
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.engine.target import Targets, TransitiveTargets
+from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
@@ -158,7 +161,9 @@ async def setup_pytest_for_target(
         ),
     )
 
-    prepared_sources_request = Get(StrippedPythonSources, Targets(all_targets))
+    prepared_sources_request = Get(
+        StrippedPythonSources, StrippedPythonSourcesRequest(all_targets, include_resources=True)
+    )
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
     # to test, rather than using auto-discovery.

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable, Tuple, Type
 
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
@@ -14,16 +14,17 @@ from pants.core.util_rules.strip_source_roots import representative_path_from_ad
 from pants.engine.fs import Snapshot
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
-from pants.engine.target import Sources, Targets
+from pants.engine.target import Sources, Target
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.meta import frozen_after_init
 
 
 @dataclass(frozen=True)
 class StrippedPythonSources:
     """Sources that can be imported and used by Python, relative to the root.
 
-    Specifically, this will filter out to only have Python, resources(), and files() targets;
-    strip source roots, e.g. `src/python/f.py` -> `f.py`; and will add any missing
+    Specifically, this will filter out to only have Python, and, optionally, resources() and files()
+    targets; strip source roots, e.g. `src/python/f.py` -> `f.py`; and will add any missing
     `__init__.py` files to ensure that modules are recognized correctly.
 
     Use-cases that execute the Python source code (e.g., the `run`, `binary` and `repl` goals) can
@@ -34,12 +35,32 @@ class StrippedPythonSources:
     snapshot: Snapshot
 
 
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class StrippedPythonSourcesRequest:
+    targets: Tuple[Target, ...]
+    include_resources: bool
+
+    def __init__(self, targets: Iterable[Target], *, include_resources: bool) -> None:
+        self.targets = tuple(targets)
+        self.include_resources = include_resources
+
+    @property
+    def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
+        return (
+            (PythonSources,)
+            if not self.include_resources
+            else (PythonSources, FilesSources, ResourcesSources)
+        )
+
+
 @dataclass(frozen=True)
 class UnstrippedPythonSources:
     """Sources that can be introspected by Python, relative to a set of source roots.
 
-    Specifically, this will filter out to only have Python, resources(), and files() targets;
-    and will add any missing `__init__.py` files to ensure that modules are recognized correctly.
+    Specifically, this will filter out to only have Python, and, optionally, resources() and
+    files() targets; and will add any missing `__init__.py` files to ensure that modules are
+    recognized correctly.
 
     Use-cases that introspect Python source code (e.g., the `test, `lint`, `fmt` goals) can
     request this type to get relevant sources that are still relative to their source roots.
@@ -53,13 +74,34 @@ class UnstrippedPythonSources:
     source_roots: Tuple[str, ...]
 
 
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class UnstrippedPythonSourcesRequest:
+    targets: Tuple[Target, ...]
+    include_resources: bool
+
+    def __init__(self, targets: Iterable[Target], *, include_resources: bool) -> None:
+        self.targets = tuple(targets)
+        self.include_resources = include_resources
+
+    @property
+    def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
+        return (
+            (PythonSources,)
+            if not self.include_resources
+            else (PythonSources, FilesSources, ResourcesSources)
+        )
+
+
 @rule
-async def prepare_stripped_python_sources(targets: Targets) -> StrippedPythonSources:
+async def prepare_stripped_python_sources(
+    request: StrippedPythonSourcesRequest,
+) -> StrippedPythonSources:
     stripped_sources = await Get(
         SourceFiles,
         AllSourceFilesRequest(
-            (tgt.get(Sources) for tgt in targets),
-            for_sources_types=(PythonSources, ResourcesSources, FilesSources),
+            (tgt.get(Sources) for tgt in request.targets),
+            for_sources_types=request.valid_sources_types,
             enable_codegen=True,
             strip_source_roots=True,
         ),
@@ -72,12 +114,14 @@ async def prepare_stripped_python_sources(targets: Targets) -> StrippedPythonSou
 
 
 @rule
-async def prepare_unstripped_python_sources(targets: Targets) -> UnstrippedPythonSources:
+async def prepare_unstripped_python_sources(
+    request: UnstrippedPythonSourcesRequest,
+) -> UnstrippedPythonSources:
     sources = await Get(
         SourceFiles,
         AllSourceFilesRequest(
-            (tgt.get(Sources) for tgt in targets),
-            for_sources_types=(PythonSources, ResourcesSources, FilesSources),
+            (tgt.get(Sources) for tgt in request.targets),
+            for_sources_types=request.valid_sources_types,
             enable_codegen=True,
             strip_source_roots=False,
         ),
@@ -89,7 +133,7 @@ async def prepare_unstripped_python_sources(targets: Targets) -> UnstrippedPytho
             SourceRootRequest,
             SourceRootRequest.for_file(representative_path_from_address(tgt.address)),
         )
-        for tgt in targets
+        for tgt in request.targets
         if tgt.has_field(PythonSources) or tgt.has_field(ResourcesSources)
     )
     source_root_paths = {source_root_obj.path for source_root_obj in source_root_objs}
@@ -106,5 +150,6 @@ def rules():
         prepare_unstripped_python_sources,
         *determine_source_files.rules(),
         *inject_init_rules(),
-        RootRule(Targets),
+        # TODO: remove this as soon as we have a usage of it.
+        RootRule(UnstrippedPythonSourcesRequest),
     ]


### PR DESCRIPTION
### Problem
We tell MyPy to run over all the files in `prepared_sources.snapshot.files`. Before, this would include `files` and `resources` targets. 

In the Pants codebase, this is an issue because we have some `files()` targets that own Python files - so, we were telling MyPy to run over `build-support/bin/f.py`, and MyPy would complain that `build-support` is invalid.

### Solution
Add Request types for `StrippedPythonSources` and `UnstrippedPythonSources`.

`pex_from_targets.py` and Pytest continue to include resources. Pylint and MyPy no longer include them.

[ci skip-rust-tests]
[ci skip-jvm-tests]
