### PR TITLE
Add info_msg field on workunits and use it to replace some explicit logging

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -53,6 +53,7 @@ from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger()
 
@@ -223,7 +224,7 @@ async def setup_pytest_for_target(
     )
 
 
-@rule
+@rule(level=LogLevel.INFO)
 async def run_python_test(
     field_set: PythonTestFieldSet,
     test_setup: TestTargetSetup,
@@ -292,7 +293,10 @@ async def run_python_test(
             logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")
 
     return TestResult.from_fallible_process_result(
-        result, coverage_data=coverage_data, xml_results=xml_results_digest
+        result,
+        coverage_data=coverage_data,
+        xml_results=xml_results_digest,
+        address_ref=field_set.address.reference(),
     )
 
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -87,10 +87,10 @@ class TestResult(EngineAware):
 
     def level(self):
         if self.status == Status.FAILURE:
-            return LogLevel.WARN
+            return LogLevel.ERROR
         return None
 
-    def info_message(self):
+    def message(self):
         result = "succeeded" if self.status == Status.SUCCESS else "failed"
         return f"tests {result}: {self.address_ref}"
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
-import logging
 from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
@@ -22,7 +21,7 @@ from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule, rule
+from pants.engine.rules import EngineAware, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     FieldSetWithOrigin,
@@ -31,10 +30,7 @@ from pants.engine.target import (
     TargetsToValidFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership, union
-
-# TODO: Until we have templating of rule names (#7907) or some other way to affect the level
-# of a workunit for a failed test, we should continue to log tests completing.
-logger = logging.getLogger(__name__)
+from pants.util.logging import LogLevel
 
 
 class Status(Enum):
@@ -61,12 +57,13 @@ class CoverageReportType(Enum):
 
 
 @dataclass(frozen=True)
-class TestResult:
+class TestResult(EngineAware):
     status: Status
     stdout: str
     stderr: str
     coverage_data: Optional["CoverageData"]
     xml_results: Optional[Digest]
+    address_ref: str = ""
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -77,6 +74,7 @@ class TestResult:
         *,
         coverage_data: Optional["CoverageData"] = None,
         xml_results: Optional[Digest] = None,
+        address_ref: str = "",
     ) -> "TestResult":
         return TestResult(
             status=Status.SUCCESS if process_result.exit_code == 0 else Status.FAILURE,
@@ -84,7 +82,17 @@ class TestResult:
             stderr=process_result.stderr.decode(),
             coverage_data=coverage_data,
             xml_results=xml_results,
+            address_ref=address_ref,
         )
+
+    def level(self):
+        if self.status == Status.FAILURE:
+            return LogLevel.WARN
+        return None
+
+    def info_message(self):
+        result = "succeeded" if self.status == Status.SUCCESS else "failed"
+        return f"tests {result}: {self.address_ref}"
 
 
 @dataclass(frozen=True)
@@ -346,10 +354,6 @@ async def run_tests(
 async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> AddressAndTestResult:
     field_set = wrapped_field_set.field_set
     result = await Get(TestResult, TestFieldSet, field_set)
-    logger.info(
-        f"Tests {'succeeded' if result.status == Status.SUCCESS else 'failed'}: "
-        f"{field_set.address.reference()}"
-    )
     return AddressAndTestResult(field_set.address, result)
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -28,9 +28,13 @@ class EngineAware(ABC):
     are expected to be overridden by concrete types implementing EngineAware.
     """
 
-    @abstractmethod
     def level(self) -> Optional[LogLevel]:
         """Overrides the level of the workunit associated with this type."""
+        return None
+
+    def info_message(self) -> Optional[str]:
+        """Sets an info message on the workunit."""
+        return None
 
 
 @decorated_type_checkable

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -32,8 +32,8 @@ class EngineAware(ABC):
         """Overrides the level of the workunit associated with this type."""
         return None
 
-    def info_message(self) -> Optional[str]:
-        """Sets an info message on the workunit."""
+    def message(self) -> Optional[str]:
+        """Sets an optional result message on the workunit."""
         return None
 
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -512,7 +512,7 @@ impl CommandRunner for BoundedCommandRunner {
     let outer_metadata = WorkunitMetadata {
       desc: Some(desc.clone()),
       level: Level::Debug,
-      info_msg: None,
+      message: None,
       blocked: true,
       stdout: None,
       stderr: None,
@@ -526,7 +526,7 @@ impl CommandRunner for BoundedCommandRunner {
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
-          info_msg: None,
+          message: None,
           level: Level::Info,
           blocked: false,
           stdout: None,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -512,6 +512,7 @@ impl CommandRunner for BoundedCommandRunner {
     let outer_metadata = WorkunitMetadata {
       desc: Some(desc.clone()),
       level: Level::Debug,
+      info_msg: None,
       blocked: true,
       stdout: None,
       stderr: None,
@@ -525,6 +526,7 @@ impl CommandRunner for BoundedCommandRunner {
       semaphore.with_acquired(move || {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
+          info_msg: None,
           level: Level::Info,
           blocked: false,
           stdout: None,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1074,6 +1074,7 @@ impl Node for NodeKey {
       let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
       let metadata = WorkunitMetadata {
         desc: user_facing_name.clone(),
+        info_msg: None,
         level: self.workunit_level(),
         blocked: false,
         stdout: None,

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -87,13 +87,13 @@ impl Workunit {
       identifier.to_string()
     };
 
-    let info_str = if let Some(ref s) = self.metadata.info_msg {
+    let message = if let Some(ref s) = self.metadata.message {
       format!(" - {}", s)
     } else {
       "".to_string()
     };
 
-    log!(level, "{} {}{}", state, effective_identifier, info_str);
+    log!(level, "{} {}{}", state, effective_identifier, message);
   }
 }
 
@@ -106,7 +106,7 @@ pub enum WorkunitState {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
-  pub info_msg: Option<String>,
+  pub message: Option<String>,
   pub level: Level,
   pub blocked: bool,
   pub stdout: Option<hashing::Digest>,
@@ -130,7 +130,7 @@ impl Default for WorkunitMetadata {
     Self {
       level: Level::Info,
       desc: None,
-      info_msg: None,
+      message: None,
       blocked: false,
       stdout: None,
       stderr: None,

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -88,7 +88,7 @@ impl Workunit {
     };
 
     let info_str = if let Some(ref s) = self.metadata.info_msg {
-      format!("\n - {}", s)
+      format!(" - {}", s)
     } else {
       "".to_string()
     };

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -101,6 +101,7 @@ pub enum WorkunitState {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
+  pub info_msg: Option<String>,
   pub level: Level,
   pub blocked: bool,
   pub stdout: Option<hashing::Digest>,
@@ -124,6 +125,7 @@ impl Default for WorkunitMetadata {
     Self {
       level: Level::Info,
       desc: None,
+      info_msg: None,
       blocked: false,
       stdout: None,
       stderr: None,

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -76,19 +76,24 @@ impl Workunit {
      * multibyte unicode characters in the string
      */
     let max_len = 200;
-    if identifier.len() > max_len {
+    let effective_identifier = if identifier.len() > max_len {
       let truncated_identifier: String = identifier.chars().take(max_len).collect();
       let trunc = identifier.len() - max_len;
-      log!(
-        level,
-        "{} {}... ({} characters truncated)",
-        state,
-        truncated_identifier,
-        trunc
-      );
+      format!(
+        "{}... ({} characters truncated)",
+        truncated_identifier, trunc
+      )
     } else {
-      log!(level, "{} {}", state, identifier);
-    }
+      identifier.to_string()
+    };
+
+    let info_str = if let Some(ref s) = self.metadata.info_msg {
+      format!("\n - {}", s)
+    } else {
+      "".to_string()
+    };
+
+    log!(level, "{} {}{}", state, effective_identifier, info_str);
   }
 }
 


### PR DESCRIPTION
### Problem

We want pants rules to be able to induce their associated workunits to display additional informational text, in the same way that rules can currently change their workunit levels based on rule-specific business logic with the `EngineAware` class. Specifically, we would like to use this for test rules, so we can print an error message when a test fails (or a different error message when the test succeeds).

### Solution

This commit introduces a new optional text field called `info_msg` on workunits, which is controlled by a new method on `EngineAware` return types, and uses it to display a test result string rather than an explicit call to `logger`.

### Result

Asciinema recording of a test failure (with the log level set to ERROR): https://asciinema.org/a/342834

