### PR TITLE
Preserve source roots in MyPy and Pylint output

### DIFF
--- a/src/python/pants/backend/python/lint/mypy/rules.py
+++ b/src/python/pants/backend/python/lint/mypy/rules.py
@@ -86,9 +86,11 @@ async def mypy_lint(
         PexRequest(
             output_filename="mypy.pex",
             requirements=PexRequirements(mypy.get_requirement_specs()),
-            # TODO(#10131): figure out how to robustly handle interpreter constraints. Unlike other
-            #  linters, the version of Python used to run MyPy can be different than the version of
-            #  the code.
+            # NB: This only determines what MyPy is run with. The user can specify what version
+            # their code is with `--python-version`. See
+            # https://mypy.readthedocs.io/en/stable/config_file.html#platform-configuration. We do
+            # not auto-configure this for simplicity and to avoid Pants magically setting values for
+            # users.
             interpreter_constraints=PexInterpreterConstraints(mypy.default_interpreter_constraints),
             entry_point=mypy.get_entry_point(),
         ),

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -128,15 +128,15 @@ class PylintIntegrationTest(ExternalToolTestBase):
         result = self.run_pylint([target])
         assert len(result) == 1
         assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "bad.py:2:0: C0103" in result[0].stdout
+        assert f"{self.source_root}/bad.py:2:0: C0103" in result[0].stdout
 
     def test_mixed_sources(self) -> None:
         target = self.make_target_with_origin([self.good_source, self.bad_source])
         result = self.run_pylint([target])
         assert len(result) == 1
         assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "good.py" not in result[0].stdout
-        assert "bad.py:2:0: C0103" in result[0].stdout
+        assert f"{self.source_root}/good.py" not in result[0].stdout
+        assert f"{self.source_root}/bad.py:2:0: C0103" in result[0].stdout
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -146,8 +146,8 @@ class PylintIntegrationTest(ExternalToolTestBase):
         result = self.run_pylint(targets)
         assert len(result) == 1
         assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "good.py" not in result[0].stdout
-        assert "bad.py:2:0: C0103" in result[0].stdout
+        assert f"{self.source_root}/good.py" not in result[0].stdout
+        assert f"{self.source_root}/bad.py:2:0: C0103" in result[0].stdout
 
     def test_precise_file_args(self) -> None:
         target = self.make_target_with_origin(
@@ -298,7 +298,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
         )
         assert len(result) == 1
         assert result[0].exit_code == 4
-        assert "thirdparty_plugin.py:10:8: W5301" in result[0].stdout
+        assert f"{self.source_root}/thirdparty_plugin.py:10:8: W5301" in result[0].stdout
 
     def test_source_plugin(self) -> None:
         # NB: We make this source plugin fairly complex by having it use transitive dependencies.
@@ -390,4 +390,4 @@ class PylintIntegrationTest(ExternalToolTestBase):
         )
         assert len(result) == 1
         assert result[0].exit_code == PYLINT_FAILURE_RETURN_CODE
-        assert "source_plugin.py:2:0: C9871" in result[0].stdout
+        assert f"{self.source_root}/source_plugin.py:2:0: C9871" in result[0].stdout


### PR DESCRIPTION
Before (Pylint):

```
bad.py:2:0: C0103
```

After (Pylint):

```
src/python/bad.py:2:0: C0103
```