### PR TITLE
Do not render pytest at info, and give it a description.

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -53,7 +53,6 @@ from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
-from pants.util.logging import LogLevel
 
 logger = logging.getLogger()
 
@@ -224,7 +223,7 @@ async def setup_pytest_for_target(
     )
 
 
-@rule(level=LogLevel.INFO)
+@rule(desc="Run Pytest")
 async def run_python_test(
     field_set: PythonTestFieldSet,
     test_setup: TestTargetSetup,
@@ -300,7 +299,7 @@ async def run_python_test(
     )
 
 
-@rule(desc="Run pytest in an interactive process")
+@rule(desc="Run Pytest in an interactive process")
 async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
     process = InteractiveProcess(
         argv=(test_setup.test_runner_pex.output_filename, *test_setup.args),


### PR DESCRIPTION
### Problem

Marking this `@rule` `INFO` caused it to start rendering both startup and shutdown even in the healthy case. In CI that looks like:
```
...
05:37:09 [INFO] Starting: run_python_test
05:37:09 [INFO] Starting: run_python_test
05:37:09 [INFO] Starting: run_python_test
...
```

### Solution

Remove `level=INFO` to default to `DEBUG`, but add a description so that when a test fails, you get human readable output.

### Result

```
$ ./v2 test tests/python/pants_test/util/test_strutil.py
10:59:46.38 [INFO] Completed: Run Pytest for tests/python/pants_test/util:strutil
10:59:46.38 [ERROR] Completed: Run Pytest - tests failed: tests/python/pants_test/util:strutil
𐄂 tests/python/pants_test/util:strutil
...
```
and without the UI:
```
$ ./v2 --no-dynamic-ui test tests/python/pants_test/util/test_strutil.py
18:01:24 [INFO] Starting: Run Pytest for tests/python/pants_test/util:strutil
18:01:26 [INFO] Completed: Run Pytest for tests/python/pants_test/util:strutil
18:01:26 [ERROR] Completed: Run Pytest - tests failed: tests/python/pants_test/util:strutil
𐄂 tests/python/pants_test/util:strutil
...
```

[ci skip-rust-tests]
[ci skip-jvm-tests]