### PR TITLE
Fix MyPy to include `resources`, but still not `files`

### DIFF
--- a/src/python/pants/backend/python/lint/mypy/rules.py
+++ b/src/python/pants/backend/python/lint/mypy/rules.py
@@ -78,8 +78,7 @@ async def mypy_lint(
     )
 
     prepared_sources_request = Get(
-        UnstrippedPythonSources,
-        UnstrippedPythonSourcesRequest(transitive_targets.closure, include_resources=False),
+        UnstrippedPythonSources, UnstrippedPythonSourcesRequest(transitive_targets.closure),
     )
     pex_request = Get(
         Pex,

--- a/src/python/pants/backend/python/lint/mypy/rules.py
+++ b/src/python/pants/backend/python/lint/mypy/rules.py
@@ -107,11 +107,9 @@ async def mypy_lint(
     )
 
     file_list_path = "__files.txt"
+    python_files = "\n".join(f for f in prepared_sources.snapshot.files if f.endswith(".py"))
     file_list = await Get(
-        Digest,
-        InputFilesContent(
-            [FileContent(file_list_path, "\n".join(prepared_sources.snapshot.files).encode())]
-        ),
+        Digest, InputFilesContent([FileContent(file_list_path, python_files.encode())]),
     )
 
     merged_input_files = await Get(

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -162,14 +162,11 @@ async def pylint_lint_partition(
     )
 
     prepare_plugin_sources_request = Get(
-        StrippedPythonSources,
-        StrippedPythonSourcesRequest(partition.plugin_targets, include_resources=True),
+        StrippedPythonSources, StrippedPythonSourcesRequest(partition.plugin_targets),
     )
     prepare_python_sources_request = Get(
         UnstrippedPythonSources,
-        UnstrippedPythonSourcesRequest(
-            partition.targets_with_dependencies, include_resources=False
-        ),
+        UnstrippedPythonSourcesRequest(partition.targets_with_dependencies),
     )
     specified_source_files_request = Get(
         SourceFiles,

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -98,7 +98,7 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         input_digests.append(request.additional_sources)
     if request.include_source_files:
         prepared_sources = await Get(
-            StrippedPythonSources, StrippedPythonSourcesRequest(all_targets, include_resources=True)
+            StrippedPythonSources, StrippedPythonSourcesRequest(all_targets)
         )
         input_digests.append(prepared_sources.snapshot.digest)
     merged_input_digest = await Get(Digest, MergeDigests(input_digests))

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -162,7 +162,7 @@ async def setup_pytest_for_target(
     )
 
     prepared_sources_request = Get(
-        StrippedPythonSources, StrippedPythonSourcesRequest(all_targets, include_resources=True)
+        StrippedPythonSources, StrippedPythonSourcesRequest(all_targets, include_files=True)
     )
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -19,6 +19,34 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.meta import frozen_after_init
 
 
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class _BasePythonSourcesRequest:
+    targets: Tuple[Target, ...]
+    include_resources: bool
+    include_files: bool
+
+    def __init__(
+        self,
+        targets: Iterable[Target],
+        *,
+        include_resources: bool = True,
+        include_files: bool = False
+    ) -> None:
+        self.targets = tuple(targets)
+        self.include_resources = include_resources
+        self.include_files = include_files
+
+    @property
+    def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
+        types = [PythonSources]
+        if self.include_resources:
+            types.append(ResourcesSources)
+        if self.include_files:
+            types.append(FilesSources)
+        return tuple(types)
+
+
 @dataclass(frozen=True)
 class StrippedPythonSources:
     """Sources that can be imported and used by Python, relative to the root.
@@ -35,23 +63,8 @@ class StrippedPythonSources:
     snapshot: Snapshot
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class StrippedPythonSourcesRequest:
-    targets: Tuple[Target, ...]
-    include_resources: bool
-
-    def __init__(self, targets: Iterable[Target], *, include_resources: bool) -> None:
-        self.targets = tuple(targets)
-        self.include_resources = include_resources
-
-    @property
-    def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
-        return (
-            (PythonSources,)
-            if not self.include_resources
-            else (PythonSources, FilesSources, ResourcesSources)
-        )
+class StrippedPythonSourcesRequest(_BasePythonSourcesRequest):
+    pass
 
 
 @dataclass(frozen=True)
@@ -74,23 +87,8 @@ class UnstrippedPythonSources:
     source_roots: Tuple[str, ...]
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class UnstrippedPythonSourcesRequest:
-    targets: Tuple[Target, ...]
-    include_resources: bool
-
-    def __init__(self, targets: Iterable[Target], *, include_resources: bool) -> None:
-        self.targets = tuple(targets)
-        self.include_resources = include_resources
-
-    @property
-    def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
-        return (
-            (PythonSources,)
-            if not self.include_resources
-            else (PythonSources, FilesSources, ResourcesSources)
-        )
+class UnstrippedPythonSourcesRequest(_BasePythonSourcesRequest):
+    pass
 
 
 @rule

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Iterable, Tuple, Type
+from typing import Iterable, List, Tuple, Type
 
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
@@ -39,7 +39,7 @@ class _BasePythonSourcesRequest:
 
     @property
     def valid_sources_types(self) -> Tuple[Type[Sources], ...]:
-        types = [PythonSources]
+        types: List[Type[Sources]] = [PythonSources]
         if self.include_resources:
             types.append(ResourcesSources)
         if self.include_files:


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/pull/10154. Turns out, there are many cases where we want to include `resources`, but exclude `files`. Stu explained that we only want `files` for tests and for apps. Likewise, we almost always want `resources` to be included.

[ci skip-rust-tests]
[ci skip-jvm-tests]
