### PR TITLE
Attempt to adjust file handle limits and warn if they cannot be adjusted

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlimit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
@@ -2442,6 +2443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rule_graph"
 version = "0.0.1"
 
@@ -3742,6 +3752,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
+"checksum rlimit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6d26e65e82a1e2628c5f209ec12f4508fa50e644bd2f264138e60129d61eae8"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -14,6 +14,7 @@ ignore = "0.4.11"
 lazy_static = "1"
 log = "0.4"
 parking_lot = "0.6"
+rlimit = "0.3"
 task_executor = { path = "../task_executor" }
 
 [dev-dependencies]

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -56,7 +56,7 @@ use futures::future::FutureExt;
 use futures::future::{self as future03, TryFutureExt};
 use futures01::{future, Future};
 use hashing::{Digest, EMPTY_DIGEST};
-use log::{self, error, warn, Log};
+use log::{self, debug, error, warn, Log};
 use logging::logger::LOGGER;
 use logging::{Destination, Logger, PythonLogLevel};
 use rule_graph::{self, RuleGraph};
@@ -730,6 +730,10 @@ fn scheduler_create(
   remote_execution_overall_deadline_secs: u64,
   process_execution_local_enable_nailgun: bool,
 ) -> CPyResult<PyScheduler> {
+  match fs::increase_limits() {
+    Ok(msg) => debug!("{}", msg),
+    Err(e) => warn!("{}", e),
+  }
   let core: Result<Core, String> = with_executor(py, executor_ptr, |executor| {
     let types = types_ptr
       .types(py)


### PR DESCRIPTION
### Problem

A few consecutive versions of macOS had particularly low "soft" `ulimit -n` (`NOFILE`: ie number of file handle) values.

### Solution

The soft/current limit can be raised as high the hard/max limit, and there is likely to be a gap between them. Attempt to raise the current limit to the maximum, and warn if we can't raise above a known-reasonable value.

### Result

In at least some cases, we will successfully, silently adjust the limit. In other cases we will warn the user that they have a value that is likely to cause trouble.

[ci skip-jvm-tests]