### PR TITLE
Simplify Get implementation post deprecations.

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -64,7 +64,7 @@ class Externs:
         try:
             res = func.send(arg)
 
-            if Get.isinstance(res):
+            if isinstance(res, Get):
                 # Get.
                 return PyGeneratorResponseGet(
                     res.product_type, res.subject_declared_type, res.subject,

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -192,7 +192,7 @@ def run_rule(
     while True:
         try:
             res = rule_coroutine.send(rule_input)
-            if Get.isinstance(res):
+            if isinstance(res, Get):
                 rule_input = get(res.product_type, res.subject)
             elif type(res) in (tuple, list):
                 rule_input = [get(g.product_type, g.subject) for g in res]


### PR DESCRIPTION
### Problem

After the removal of deprecated `Get` syntax there were some other simplifications available for the implementation.

### Solution

Remove a few levels of indirection in `Get` construction. In particular: the `SubjectDeclaredType` is always equal to `Type[SubjectType]`, and so doesn't need a separate type variable. Additionally, the `GetMaker` and `GetFactory` classes could be inlined into `Get`'s constructor.

### Result

Simpler implementation, equivalent API and typecheckability.

[ci skip-jvm-tests]