### PR TITLE
Reduce time spend grabbing locks in workunit code

### DIFF
--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -96,6 +96,19 @@ impl TimeSpan {
     }
   }
 
+  /// Construct a TimeSpan that started at `start` and ends at `end`.
+  pub fn from_start_and_end_systemtime(
+    start: &std::time::SystemTime,
+    end: &std::time::SystemTime,
+  ) -> TimeSpan {
+    let start = Self::since_epoch(start);
+    let duration = Self::since_epoch(end) - start;
+    TimeSpan {
+      start: start.into(),
+      duration: duration.into(),
+    }
+  }
+
   fn std_duration_from_protobuf_timestamp(
     t: &protobuf::well_known_types::Timestamp,
   ) -> std::time::Duration {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -7,12 +7,12 @@ use std::time::Duration;
 
 use bazel_protos::{self, call_option};
 use bytes::{Bytes, BytesMut};
-use concrete_time::TimeSpan;
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, Future, Sink, Stream};
 use hashing::Digest;
 use serverset::{retry, Serverset};
+use workunit_store::new_span_id;
 
 use super::{BackoffConfig, EntryType};
 
@@ -108,8 +108,6 @@ impl ByteStore {
   }
 
   pub async fn store_bytes(&self, bytes: &[u8]) -> Result<Digest, String> {
-    let start_time = std::time::SystemTime::now();
-
     let len = bytes.len();
     let digest = Digest::of_bytes(&bytes);
     let resource_name = format!(
@@ -120,6 +118,14 @@ impl ByteStore {
       digest.1,
     );
     let workunit_name = format!("store_bytes({})", resource_name.clone());
+    let span_id = new_span_id();
+    if let Some(workunit_state) = workunit_store::get_workunit_state() {
+      let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
+      workunit_state
+        .store
+        .start_workunit(span_id.clone(), workunit_name, parent_id, metadata);
+    }
     let store = self.clone();
 
     let result = self
@@ -209,14 +215,7 @@ impl ByteStore {
       .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let parent_id = workunit_state.parent_id;
-      let metadata = workunit_store::WorkunitMetadata::new();
-      workunit_state.store.add_completed_workunit(
-        workunit_name.clone(),
-        TimeSpan::since(&start_time),
-        parent_id,
-        metadata,
-      );
+      workunit_state.store.complete_workunit(span_id)
     }
 
     result
@@ -231,8 +230,6 @@ impl ByteStore {
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {
-    let start_time = std::time::SystemTime::now();
-
     let store = self.clone();
     let resource_name = format!(
       "{}/blobs/{}/{}",
@@ -241,6 +238,14 @@ impl ByteStore {
       digest.1
     );
     let workunit_name = format!("load_bytes_with({})", resource_name.clone());
+    let span_id = new_span_id();
+    if let Some(workunit_state) = workunit_store::get_workunit_state() {
+      let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
+      workunit_state
+        .store
+        .start_workunit(span_id.clone(), workunit_name, parent_id, metadata);
+    }
 
     let result = self
       .with_byte_stream_client(move |client| {
@@ -294,13 +299,7 @@ impl ByteStore {
       .await;
 
     if let Some(workunit_state) = workunit_store::get_workunit_state() {
-      let name = workunit_name.clone();
-      let time_span = TimeSpan::since(&start_time);
-      let parent_id = workunit_state.parent_id;
-      let metadata = workunit_store::WorkunitMetadata::new();
-      workunit_state
-        .store
-        .add_completed_workunit(name, time_span, parent_id, metadata);
+      workunit_state.store.complete_workunit(span_id);
     }
 
     result
@@ -314,13 +313,20 @@ impl ByteStore {
     &self,
     request: bazel_protos::remote_execution::FindMissingBlobsRequest,
   ) -> impl Future<Item = HashSet<Digest>, Error = String> {
-    let start_time = std::time::SystemTime::now();
-
     let store = self.clone();
     let workunit_name = format!(
       "list_missing_digests({})",
       store.instance_name.clone().unwrap_or_default()
     );
+    let span_id = new_span_id();
+    if let Some(workunit_state) = workunit_store::get_workunit_state() {
+      let parent_id = workunit_state.parent_id;
+      let metadata = workunit_store::WorkunitMetadata::new();
+      workunit_state
+        .store
+        .start_workunit(span_id.clone(), workunit_name, parent_id, metadata);
+    }
+
     async move {
       let store2 = store.clone();
       let res = store2
@@ -345,13 +351,7 @@ impl ByteStore {
         })
         .await;
       if let Some(workunit_state) = workunit_store::get_workunit_state() {
-        let name = workunit_name.clone();
-        let time_span = TimeSpan::since(&start_time);
-        let parent_id = workunit_state.parent_id;
-        let metadata = workunit_store::WorkunitMetadata::new();
-        workunit_state
-          .store
-          .add_completed_workunit(name, time_span, parent_id, metadata);
+        workunit_state.store.complete_workunit(span_id);
       }
       res
     }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -418,10 +418,19 @@ impl AddAssign<UploadSummary> for ExecutionStats {
   }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Context {
   workunit_store: WorkunitStore,
   build_id: String,
+}
+
+impl Default for Context {
+  fn default() -> Self {
+    Context {
+      workunit_store: WorkunitStore::new(false),
+      build_id: String::default(),
+    }
+  }
 }
 
 impl Context {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -18,6 +18,7 @@ use futures01::{future, Future, Stream};
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
+use std::time::SystemTime;
 use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use tokio::time::delay_for;
 
@@ -775,8 +776,16 @@ fn maybe_add_workunit(
   workunit_store: &WorkunitStore,
 ) {
   if !result_cached {
+    let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
+    let end_time: SystemTime = start_time + time_span.duration.into();
     let metadata = workunit_store::WorkunitMetadata::new();
-    workunit_store.add_completed_workunit(name.to_string(), time_span, parent_id, metadata);
+    workunit_store.add_completed_workunit(
+      name.to_string(),
+      start_time,
+      end_time,
+      parent_id,
+      metadata,
+    );
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote/streaming_tests.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming_tests.rs
@@ -381,7 +381,7 @@ async fn sends_headers() {
   )
   .unwrap();
   let context = Context {
-    workunit_store: WorkunitStore::default(),
+    workunit_store: WorkunitStore::new(false),
     build_id: String::from("marmosets"),
   };
   command_runner

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -867,7 +867,7 @@ async fn sends_headers() {
   )
   .unwrap();
   let context = Context {
-    workunit_store: WorkunitStore::default(),
+    workunit_store: WorkunitStore::new(false),
     build_id: String::from("marmosets"),
   };
   command_runner

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1184,8 +1184,7 @@ impl Node for NodeKey {
       context2
         .session
         .workunit_store()
-        .complete_workunit_with_new_metadata(started_workunit_id, final_metadata)
-        .unwrap();
+        .complete_workunit_with_new_metadata(started_workunit_id, final_metadata);
       result
     })
     .await

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -138,7 +138,7 @@ impl Default for WorkunitMetadata {
   }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct WorkunitStore {
   rendering_dynamic_ui: bool,
   inner: Arc<Mutex<WorkUnitInnerStore>>,


### PR DESCRIPTION
### Problem

This is an attempt to alleviate console UI glitches such as https://github.com/pantsbuild/pants/issues/9962 by reducing the amount of time that other code spends grabbing the same locks in `WorkunitStore` that the UI code needs to grab to figure out what workunits need to be rendered.

### Solution

This commit splits the `WorkunitStore` struct into two structs containing different data structures under different locks, one responsible for handling the heavy hitters calculation, the other for handling streaming workunits. Additionally, the methods that actually add started and complete workunits to the store have been modified to push those workunits onto a Rust `mpsc::Sender`/`Receiver` queue, so the only locks they need to grab are the ones associated with the sender side of those queues. `heavy_hitters` and `with_latest_workunits` will pop workunits off these queues each time they are called, and then process them separately under different locks, so it is now possible for both of them to be running at the same time.
