### PR TITLE
Remove indentation in process errors.

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -178,7 +178,8 @@ class ProcessExecutionFailure(Exception):
         super().__init__(
             "\n".join(
                 [
-                    f"Process '{process_description}' failed with exit code {exit_code}.\nstdout:",
+                    f"Process '{process_description}' failed with exit code {exit_code}.",
+                    "stdout:",
                     stdout.decode(),
                     "stderr:",
                     stderr.decode(),

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -4,7 +4,6 @@
 import itertools
 import logging
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIGEST, Digest
@@ -174,16 +173,16 @@ class ProcessExecutionFailure(Exception):
         self.exit_code = exit_code
         self.stdout = stdout
         self.stderr = stderr
+        # NB: We don't use dedent on a single format string here because it would attempt to
+        # interpret the stdio content.
         super().__init__(
-            dedent(
-                f"""\
-                Process '{process_description}' failed with exit code {exit_code}.
-                stdout:
-                {stdout.decode()}
-
-                stderr:
-                {stderr.decode()}
-                """
+            "\n".join(
+                [
+                    f"Process '{process_description}' failed with exit code {exit_code}.\nstdout:",
+                    stdout.decode(),
+                    "stderr:",
+                    stderr.decode(),
+                ]
             )
         )
 


### PR DESCRIPTION
### Problem

`dedent` was failing due to interpreting the stdio content of the failed process, leading to deeply indented output:
```
23:45:13 [ERROR] 1 Exception encountered:

Engine traceback:
  in `lint` goal
  in Lint using Flake8
Traceback (most recent call last):
  File "/Users/stuhood/src/pants/src/python/pants/engine/process.py", line 215, in fallible_to_exec_result_or_raise
    description.value,
pants.engine.process.ProcessExecutionFailure:                 Process 'Building flake8.pex with 4 requirements: flake8-2020>=1.6.0,<1.7.0, flake8-pantsbuild>=2.0,<3, flake8>=3.7.9,<3.9, setuptools<45' failed with exit code 1.
                stdout:


                stderr:
                ERROR: Could not find a version that satisfies the requirement flake8-2020<1.7.0,>=1.6.0 (from versions: none)
ERROR: No matching distribution found for flake8-2020<1.7.0,>=1.6.0
```

### Solution

Switch to using join on unformatted strings.

### Result

```
23:57:18 [ERROR] 1 Exception encountered:

Engine traceback:
  in `lint` goal
  in Lint using Flake8
Traceback (most recent call last):
  File "/Users/stuhood/src/pants/src/python/pants/engine/process.py", line 215, in fallible_to_exec_result_or_raise
    description.value,
pants.engine.process.ProcessExecutionFailure: Process 'Building flake8.pex with 4 requirements: flake8-2020>=1.6.0,<1.7.0, flake8-pantsbuild>=2.0,<3, flake8>=3.7.9,<3.9, setuptools<45' failed with exit code 1.
stdout:

stderr:
ERROR: Could not find a version that satisfies the requirement flake8-2020<1.7.0,>=1.6.0 (from versions: none)
ERROR: No matching distribution found for flake8-2020<1.7.0,>=1.6.0
```

[ci skip-rust-tests]
