### PR TITLE
Remove --zipkin-trace-v2 option

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -88,15 +88,8 @@ class LocalPantsRunner:
         dynamic_ui = global_scope.dynamic_ui if global_scope.v2 else False
         use_colors = global_scope.get("colors", True)
 
-        zipkin_trace_v2 = options.for_scope("reporting").zipkin_trace_v2
-        # TODO(#8658) This should_report_workunits flag must be set to True for
-        # StreamingWorkunitHandler to receive WorkUnits. It should eventually
-        # be merged with the zipkin_trace_v2 flag, since they both involve most
-        # of the same engine functionality, but for now is separate to avoid
-        # breaking functionality associated with zipkin tracing while iterating on streaming workunit reporting.
         stream_workunits = len(options.for_global_scope().streaming_workunits_handlers) != 0
         return graph_scheduler_helper.new_session(
-            zipkin_trace_v2,
             RunTracker.global_instance().run_id,
             dynamic_ui=dynamic_ui,
             use_colors=use_colors,

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -182,7 +182,7 @@ class Native(metaclass=SingletonMetaclass):
         should_report_workunits: bool,
     ) -> PySession:
         return PySession(
-            scheduler, should_record_zipkin_spans, dynamic_ui, build_id, should_report_workunits,
+            scheduler, dynamic_ui, build_id, should_report_workunits,
         )
 
     def new_scheduler(

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -174,16 +174,9 @@ class Native(metaclass=SingletonMetaclass):
         return PyExecutionRequest()
 
     def new_session(
-        self,
-        scheduler,
-        should_record_zipkin_spans,
-        dynamic_ui: bool,
-        build_id,
-        should_report_workunits: bool,
+        self, scheduler, dynamic_ui: bool, build_id, should_report_workunits: bool,
     ) -> PySession:
-        return PySession(
-            scheduler, dynamic_ui, build_id, should_report_workunits,
-        )
+        return PySession(scheduler, dynamic_ui, build_id, should_report_workunits,)
 
     def new_scheduler(
         self,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -350,17 +350,13 @@ class Scheduler:
         self._native.lib.garbage_collect_store(self._scheduler)
 
     def new_session(
-        self,
-        zipkin_trace_v2: bool,
-        build_id,
-        dynamic_ui: bool = False,
-        should_report_workunits: bool = False,
+        self, build_id, dynamic_ui: bool = False, should_report_workunits: bool = False,
     ) -> "SchedulerSession":
         """Creates a new SchedulerSession for this Scheduler."""
         return SchedulerSession(
             self,
             self._native.new_session(
-                self._scheduler, zipkin_trace_v2, dynamic_ui, build_id, should_report_workunits,
+                self._scheduler, dynamic_ui, build_id, should_report_workunits,
             ),
         )
 

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -76,9 +76,7 @@ class SchedulerTestBase:
             include_trace_on_error=include_trace_on_error,
         )
         return scheduler.new_session(
-            zipkin_trace_v2=False,
-            build_id="buildid_for_test",
-            should_report_workunits=should_report_workunits,
+            build_id="buildid_for_test", should_report_workunits=should_report_workunits,
         )
 
     def context_with_scheduler(self, scheduler, *args, **kwargs):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -174,16 +174,9 @@ class LegacyGraphScheduler:
     goal_map: Any
 
     def new_session(
-        self,
-        zipkin_trace_v2,
-        build_id,
-        dynamic_ui: bool = False,
-        use_colors=True,
-        should_report_workunits=False,
+        self, build_id, dynamic_ui: bool = False, use_colors=True, should_report_workunits=False,
     ) -> "LegacyGraphSession":
-        session = self.scheduler.new_session(
-            zipkin_trace_v2, build_id, dynamic_ui, should_report_workunits
-        )
+        session = self.scheduler.new_session(build_id, dynamic_ui, should_report_workunits)
         console = Console(use_colors=use_colors, session=session if dynamic_ui else None,)
         return LegacyGraphSession(session, console, self.build_file_aliases, self.goal_map)
 

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -49,9 +49,7 @@ class SchedulerService(PantsService):
         self._scheduler = legacy_graph_scheduler.scheduler
         # This session is only used for checking whether any invalidation globs have been invalidated.
         # It is not involved with a build itself; just with deciding when we should restart pantsd.
-        self._scheduler_session = self._scheduler.new_session(
-            zipkin_trace_v2=False, build_id="scheduler_service_session",
-        )
+        self._scheduler_session = self._scheduler.new_session(build_id="scheduler_service_session",)
         self._logger = logging.getLogger(__name__)
 
         # NB: We declare these as a single field so that they can be changed atomically.

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -23,9 +23,7 @@ class StoreGCService(PantsService):
         gc_interval_secs=(4 * 60 * 60),
     ):
         super().__init__()
-        self._scheduler_session = scheduler.new_session(
-            zipkin_trace_v2=False, build_id="store_gc_service_session"
-        )
+        self._scheduler_session = scheduler.new_session(build_id="store_gc_service_session")
         self._logger = logging.getLogger(__name__)
 
         self._period_secs = period_secs

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -95,13 +95,6 @@ class Reporting(Subsystem):
             help="Rate at which to sample Zipkin traces. Value 0.0 - 100.0.",
         )
         register(
-            "--zipkin-trace-v2",
-            advanced=True,
-            type=bool,
-            default=False,
-            help="If enabled, the zipkin spans are tracked for v2 engine execution progress.",
-        )
-        register(
             "--zipkin-service-name-prefix",
             advanced=True,
             default="pants",

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -429,9 +429,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             build_configuration=self.build_config(),
             build_ignore_patterns=None,
             execution_options=ExecutionOptions.from_bootstrap_options(global_options),
-        ).new_session(
-            zipkin_trace_v2=False, build_id="buildid_for_test", should_report_workunits=True
-        )
+        ).new_session(build_id="buildid_for_test", should_report_workunits=True)
         self._scheduler = graph_session.scheduler_session
         self._build_graph, self._address_mapper = graph_session.create_build_graph(
             Specs(address_specs=AddressSpecs([]), filesystem_specs=FilesystemSpecs([])),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -58,8 +58,6 @@ struct InnerSession {
   // If enabled, the display that will render the progress of the V2 engine. This is only
   // Some(_) if the --dynamic-ui option is enabled.
   display: Option<Mutex<ConsoleUI>>,
-  // If enabled, Zipkin spans for v2 engine will be collected.
-  should_record_zipkin_spans: bool,
   // A place to store info about workunits in rust part
   workunit_store: WorkunitStore,
   // The unique id for this Session: used for metrics gathering purposes.
@@ -81,7 +79,6 @@ pub struct Session(Arc<InnerSession>);
 impl Session {
   pub fn new(
     scheduler: &Scheduler,
-    should_record_zipkin_spans: bool,
     should_render_ui: bool,
     build_id: String,
     should_report_workunits: bool,
@@ -97,7 +94,6 @@ impl Session {
       preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashMap::new()),
       display,
-      should_record_zipkin_spans,
       workunit_store,
       build_id,
       run_id: Mutex::new(Uuid::new_v4()),
@@ -129,10 +125,6 @@ impl Session {
 
   pub fn preceding_graph_size(&self) -> usize {
     self.0.preceding_graph_size
-  }
-
-  pub fn should_record_zipkin_spans(&self) -> bool {
-    self.0.should_record_zipkin_spans
   }
 
   pub fn should_report_workunits(&self) -> bool {
@@ -183,10 +175,6 @@ impl Session {
     } else {
       f()
     }
-  }
-
-  pub fn should_handle_workunits(&self) -> bool {
-    self.should_report_workunits() || self.should_record_zipkin_spans()
   }
 
   fn maybe_display_initialize(&self, executor: &Executor, sender: &mpsc::Sender<ExecutionEvent>) {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -201,21 +201,6 @@ impl WorkunitStore {
     }))
   }
 
-  pub fn get_workunits(&self) -> Vec<Workunit> {
-    let mut inner_guard = (*self.inner).lock();
-    let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
-    let workunit_records = &inner_store.workunit_records;
-    inner_store
-      .completed_ids
-      .iter()
-      .flat_map(|id| workunit_records.get(id))
-      .flat_map(|workunit| match workunit.state {
-        WorkunitState::Started { .. } => None,
-        WorkunitState::Completed { .. } => Some(workunit.clone()),
-      })
-      .collect()
-  }
-
   ///
   /// Find the longest running leaf workunits, and render their first visible parents.
   ///

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -22,7 +22,6 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
                     "test",
                     f"--run-tracker-stats-local-json-file={tmpfile}",
                     "--run-tracker-stats-version=2",
-                    "--reporting-zipkin-trace-v2",
                     "testprojects/src/java/org/pantsbuild/testproject/unicode/main",
                 ]
             )

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -9,7 +9,6 @@ from http.server import BaseHTTPRequestHandler
 import psutil
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
-from pants.util.collections import assert_single_element
 from pants.util.contextutil import http_server
 
 
@@ -50,68 +49,6 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
             num_of_traces = len(ZipkinHandler.traces)
             self.assertEqual(num_of_traces, 0)
-
-    def test_zipkin_reporter_for_v2_engine(self):
-        ZipkinHandler = zipkin_handler()
-        with http_server(ZipkinHandler) as port:
-            endpoint = f"http://localhost:{port}"
-            command = [
-                "-ldebug",
-                f"--reporting-zipkin-endpoint={endpoint}",
-                "--reporting-zipkin-trace-v2",
-                "list",
-                "examples/src/python/example/hello/greet",
-            ]
-
-            pants_run = self.run_pants(command)
-            self.assert_success(pants_run)
-
-            child_processes = self.find_child_processes_that_send_spans(pants_run.stderr_data)
-            self.assertTrue(child_processes)
-
-            self.wait_spans_to_be_sent(child_processes)
-
-            trace = assert_single_element(ZipkinHandler.traces.values())
-
-            v2_span_name_part = "snapshot"
-            self.assertTrue(
-                any(v2_span_name_part in span["name"] for span in trace),
-                "There is no span that contains '{}' in it's name. The trace:{}".format(
-                    v2_span_name_part, trace
-                ),
-            )
-
-    def test_zipkin_reports_for_pure_v2_goals(self):
-        ZipkinHandler = zipkin_handler()
-        with http_server(ZipkinHandler) as port:
-            endpoint = f"http://localhost:{port}"
-            command = [
-                "-ldebug",
-                "--no-v1",
-                "--v2",
-                f"--reporting-zipkin-endpoint={endpoint}",
-                "--reporting-zipkin-trace-v2",
-                "list",
-                "3rdparty:",
-            ]
-
-            pants_run = self.run_pants(command)
-            self.assert_success(pants_run)
-
-            child_processes = self.find_child_processes_that_send_spans(pants_run.stderr_data)
-            self.assertTrue(child_processes)
-
-            self.wait_spans_to_be_sent(child_processes)
-
-            trace = assert_single_element(ZipkinHandler.traces.values())
-
-            v2_span_name_part = "snapshot"
-            self.assertTrue(
-                any(v2_span_name_part in span["name"] for span in trace),
-                "There is no span that contains '{}' in it's name. The trace:{}".format(
-                    v2_span_name_part, trace
-                ),
-            )
 
     @staticmethod
     def find_spans_by_name_and_service_name(trace, name, service_name):


### PR DESCRIPTION
This commit removes the --zipkin-trace-v2 option and tests using it. In the v2 world, we will implement zipkin tracing (if necessary) with a plugin that consumes streaming workunits. This also allows us to remove the `get_workunits` rust FFI function, which was only used to implement this functionality, and no longer have to pass around the zipkin tracing boolean in rust code.