### PR TITLE
Fix `dependencies --transitive` to include target roots that are also dependencies

### DIFF
--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -13,7 +13,6 @@ from pants.engine.rules import goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies as DependenciesField
 from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 class DependencyType(Enum):
@@ -59,7 +58,7 @@ async def dependencies(
 ) -> Dependencies:
     if options.values.transitive:
         transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
-        targets = Targets(transitive_targets.closure - FrozenOrderedSet(transitive_targets.roots))
+        targets = Targets(transitive_targets.dependencies)
     else:
         target_roots = await Get(Targets, Addresses, addresses)
         dependencies_per_target_root = await MultiGet(

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -77,4 +77,6 @@ class GraphTest(TestBase):
             Params(Addresses([root.address, d2.address]), create_options_bootstrapper()),
         )
         assert transitive_targets.roots == (root, d2)
+        # NB: `//:d2` is both a target root and a dependency of `//:root`.
+        assert transitive_targets.dependencies == FrozenOrderedSet([d1, d2, d3, t2, t1])
         assert transitive_targets.closure == FrozenOrderedSet([root, d2, d1, d3, t2, t1])

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -547,10 +547,19 @@ class TransitiveTarget:
 
 @dataclass(frozen=True)
 class TransitiveTargets:
-    """A set of Target roots, and their transitive, flattened, de-duped closure."""
+    """A set of Target roots, and their transitive, flattened, de-duped dependencies.
+
+    If a target root is a dependency of another target root, then it will show up both in `roots`
+    and in `dependencies`.
+    """
 
     roots: Tuple[Target, ...]
-    closure: FrozenOrderedSet[Target]
+    dependencies: FrozenOrderedSet[Target]
+
+    @memoized_property
+    def closure(self) -> FrozenOrderedSet[Target]:
+        """The roots and the dependencies combined."""
+        return FrozenOrderedSet([*self.roots, *self.dependencies])
 
 
 @frozen_after_init


### PR DESCRIPTION
Before, `./pants dependencies --transitive ::` would return empty input. This is surprising because many of the target roots are in fact dependencies of other target roots.

We change `TransitiveTargets` to have the field `dependencies`, which is any of the transitive dependencies of the target roots. The dependencies may include values from the target roots.

`TransitiveTargets` keeps a `closure` property to combine the roots with the dependencies.

[ci skip-rust-tests]
