### PR TITLE
Fix AddPrefix to correctly add arbitrarily many parent components

### DIFF
--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -396,8 +396,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         assert digest == output_digest
 
         # Illegal.
-        with self.assertRaisesWithMessageContaining(
-            Exception, "Cannot add path prefix `../something`: in particular, component "
+        with self.assertRaisesRegex(
+            Exception, r"Cannot add component .*ParentDir.* of path prefix `../something`."
         ):
             self.request_single_product(Digest, AddPrefix(digest, "../something"))
 

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -671,9 +671,9 @@ pub trait SnapshotOps: StoreWrapper + 'static {
         x => {
           return Err(
             format!(
-              "Cannot add path prefix `{}`: in particular, component \"{:?}\".",
+              "Cannot add component \"{:?}\" of path prefix `{}`.",
+              x,
               prefix.display(),
-              x
             )
             .into(),
           )

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -20,7 +20,7 @@ use log::log_enabled;
 use std::collections::HashSet;
 use std::convert::From;
 use std::iter::Iterator;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -659,15 +659,37 @@ pub trait SnapshotOps: StoreWrapper + 'static {
       .map_err(|e| e.into())
   }
 
-  async fn add_prefix(&self, digest: Digest, prefix: PathBuf) -> Result<Digest, SnapshotOpsError> {
-    let mut dir_node = remexec::DirectoryNode::new();
-    dir_node.set_name(osstring_as_utf8(prefix.into_os_string())?);
-    dir_node.set_digest((&digest).into());
+  async fn add_prefix(
+    &self,
+    mut digest: Digest,
+    prefix: PathBuf,
+  ) -> Result<Digest, SnapshotOpsError> {
+    let mut components = prefix.components();
+    while let Some(parent) = components.next_back() {
+      let parent = match &parent {
+        Component::Normal(p) => p,
+        x => {
+          return Err(
+            format!(
+              "Cannot add path prefix `{}`: in particular, component \"{:?}\".",
+              prefix.display(),
+              x
+            )
+            .into(),
+          )
+        }
+      };
+      let mut dir_node = remexec::DirectoryNode::new();
+      dir_node.set_name(osstring_as_utf8(parent.to_os_string())?);
+      dir_node.set_digest((&digest).into());
 
-    let mut out_dir = remexec::Directory::new();
-    out_dir.set_directories(protobuf::RepeatedField::from_vec(vec![dir_node]));
+      let mut out_dir = remexec::Directory::new();
+      out_dir.set_directories(protobuf::RepeatedField::from_vec(vec![dir_node]));
 
-    Ok(self.record_directory(&out_dir).await?)
+      digest = self.record_directory(&out_dir).await?;
+    }
+
+    Ok(digest)
   }
 
   async fn strip_prefix(


### PR DESCRIPTION
### Problem

`AddPrefix` was always adding a single component, even in cases where a prefix had greater or fewer than one parent component.

### Solution

Fix `AddPrefix` to add a parent directory per component.

### Result

Fixes #10180.