### PR TITLE
Log report name as part of the console message.

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -181,7 +181,9 @@ class FilesystemCoverageReport(CoverageReport):
                 self.result_digest, path_prefix=str(self.directory_to_materialize_to),
             )
         )
-        console.print_stderr(f"\nWrote coverage report to `{self.directory_to_materialize_to}`")
+        console.print_stderr(
+            f"\nWrote {self.report_type.report_name} coverage report to `{self.directory_to_materialize_to}`"
+        )
         return self.report_file
 
 


### PR DESCRIPTION
With upcoming addition of more report types that can be genarated during a single run, it make sense for this message to show the type/name of report being written.
See: https://github.com/pantsbuild/pants/pull/9997   https://github.com/pantsbuild/pants/issues/9968