### PR TITLE
Remove `--coverage-py-omit-test-sources`

### DIFF
--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import configparser
-import itertools
 import json
 from dataclasses import dataclass
 from io import StringIO
@@ -20,7 +19,7 @@ from pants.backend.python.rules.pex import (
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
-from pants.backend.python.target_types import PythonSources, PythonTestsSources
+from pants.backend.python.target_types import PythonSources
 from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
@@ -42,7 +41,6 @@ from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Target, TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
-from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
 """
@@ -107,13 +105,6 @@ class CoverageSubsystem(PythonToolBase):
             advanced=True,
             help="Path to write the Pytest Coverage report to. Must be relative to build root.",
         )
-        register(
-            "--omit-test-sources",
-            type=bool,
-            default=False,
-            advanced=True,
-            help="Whether to exclude the test files in coverage measurement.",
-        )
 
     @property
     def filter(self) -> Tuple[str, ...]:
@@ -126,10 +117,6 @@ class CoverageSubsystem(PythonToolBase):
     @property
     def output_dir(self) -> PurePath:
         return PurePath(self.options.output_dir)
-
-    @property
-    def omit_test_sources(self) -> bool:
-        return cast(bool, self.options.omit_test_sources)
 
 
 @dataclass(frozen=True)
@@ -168,21 +155,12 @@ class CoverageConfig:
 
 
 @rule
-async def create_coverage_config(
-    request: CoverageConfigRequest, coverage_subsystem: CoverageSubsystem, log_level: LogLevel
-) -> CoverageConfig:
+async def create_coverage_config(request: CoverageConfigRequest) -> CoverageConfig:
     all_stripped_sources = await MultiGet(
         Get(SourceRootStrippedSources, StripSourcesFieldRequest(tgt[PythonSources]))
         for tgt in request.targets
         if tgt.has_field(PythonSources)
     )
-    all_stripped_test_sources: Tuple[SourceRootStrippedSources, ...] = ()
-    if coverage_subsystem.omit_test_sources:
-        all_stripped_test_sources = await MultiGet(
-            Get(SourceRootStrippedSources, StripSourcesFieldRequest(tgt[PythonTestsSources]))
-            for tgt in request.targets
-            if tgt.has_field(PythonTestsSources)
-        )
 
     # We map stripped file names to their source roots so that we can map back to the actual
     # sources file when generating coverage reports. For example,
@@ -202,17 +180,6 @@ async def create_coverage_config(
     )
     cp = configparser.ConfigParser()
     cp.read_string(default_config)
-
-    if coverage_subsystem.omit_test_sources:
-        test_files = itertools.chain.from_iterable(
-            stripped_test_sources.snapshot.files
-            for stripped_test_sources in all_stripped_test_sources
-        )
-        cp.set("run", "omit", ",".join(sorted(test_files)))
-
-    if log_level in (LogLevel.DEBUG, LogLevel.TRACE):
-        # See https://coverage.readthedocs.io/en/coverage-5.1/cmd.html?highlight=debug#diagnostics.
-        cp.set("run", "debug", "\n\ttrace\n\tconfig")
 
     cp.set("run", "plugins", COVERAGE_PLUGIN_MODULE_NAME)
     cp.add_section(COVERAGE_PLUGIN_MODULE_NAME)

--- a/src/python/pants/backend/python/rules/coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/coverage_integration_test.py
@@ -129,12 +129,11 @@ class CoverageIntegrationTest(PantsRunIntegrationTest):
                 f"{tmpdir_relative}/tests/python/project_test/no_src",
             ]
             default_result = self.run_pants(command)
-            omit_test_result = self.run_pants([*command, "--coverage-py-omit-test-sources"])
             filter_result = self.run_pants(
                 [*command, "--coverage-py-filter=['project.lib', 'project_test.no_src']"]
             )
 
-        for result in (default_result, omit_test_result, filter_result):
+        for result in (default_result, filter_result):
             assert result.returncode == 0
             # Regression test: make sure that individual tests do not complain about failing to
             # generate reports. This was showing up at test-time, even though the final merged
@@ -157,19 +156,6 @@ class CoverageIntegrationTest(PantsRunIntegrationTest):
                 """
             )
             in default_result.stderr_data
-        )
-        assert (
-            dedent(
-                f"""\
-                Name                                       Stmts   Miss Branch BrPart  Cover
-                ----------------------------------------------------------------------------
-                {tmpdir_relative}/src/python/project/lib.py          6      0      0      0   100%
-                {tmpdir_relative}/src/python/project/random.py       2      2      0      0     0%
-                ----------------------------------------------------------------------------
-                TOTAL                                          8      2      0      0    75%
-                """
-            )
-            in omit_test_result.stderr_data
         )
         assert (
             dedent(

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -616,7 +616,7 @@ name = "double-checked-cell-async"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
While this is a nice option to provider users, we are moving in the direction of no longer having a hardcoded `.coveragerc` file and instead allowing users to optionally provide their own. So, this option is no longer pulling its weight.

Users will be able to instead manually configure their own `.coveragerc` to use a value like:

```ini
[run]
omit: test_*
```