### PR TITLE
fs_util cat-proto has --child-dir arg

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -35,7 +35,7 @@ mod snapshot_ops;
 mod snapshot_ops_tests;
 #[cfg(test)]
 mod snapshot_tests;
-pub use crate::snapshot_ops::{SnapshotOps, StoreWrapper, SubsetParams};
+pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams};
 
 use async_trait::async_trait;
 use bazel_protos::remote_execution as remexec;


### PR DESCRIPTION
This lets it operate on a subtree of a Directory, rather than the whole
thing.