### PR TITLE
Add support for cycle-tolerant "weak" Gets

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -69,14 +69,14 @@ class Externs:
             if isinstance(res, Get):
                 # Get.
                 return PyGeneratorResponseGet(
-                    res.product_type, res.subject_declared_type, res.subject,
+                    res.product_type, res.subject_declared_type, res.subject, res.weak,
                 )
             elif type(res) in (tuple, list):
                 # GetMulti.
                 return PyGeneratorResponseGetMulti(
                     tuple(
                         PyGeneratorResponseGet(
-                            get.product_type, get.subject_declared_type, get.subject,
+                            get.product_type, get.subject_declared_type, get.subject, get.weak,
                         )
                         for get in res
                     )

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -52,33 +52,29 @@ impl Generation {
 ///
 /// A result from running a Node.
 ///
-/// If the value is Dirty, the consumer should check whether the dependencies of the Node have the
-/// same values as they did when this Node was last run; if so, the value can be re-used
-/// (and should be marked "Clean").
-///
-/// If the value is Uncacheable it may only be consumed in the same Run that produced it, and should
-/// be recomputed in a new Run.
-///
-/// A value of type UncacheableDependencies has Uncacheable dependencies, and is treated as
-/// equivalent to Dirty in all cases except when `poll`d: since `poll` requests are waiting for
-/// meaningful work to do, they need to differentiate between a truly invalidated/changed (Dirty)
-/// Node and a Node that would be re-cleaned once per session.
-///
-/// If the value is Clean, the consumer can simply use the value as-is.
-///
 #[derive(Clone, Debug)]
 pub enum EntryResult<N: Node> {
+  // The value is Clean, and the consumer can simply use it as-is.
   Clean(N::Item),
-  UncacheableDependencies(N::Item),
+  // If the value is Dirty, the consumer should check whether the dependencies of the Node have the
+  // same values as they did when this Node was last run; if so, the value can be re-used
+  // (and should be marked "Clean").
   Dirty(N::Item),
-  Uncacheable(N::Item, <<N as Node>::Context as NodeContext>::RunId),
+  // Uncacheable values may only be consumed in the same Session that produced them, and should
+  // be recomputed in a new Session.
+  Uncacheable(N::Item, <<N as Node>::Context as NodeContext>::SessionId),
+  // A value of type UncacheableDependencies has Uncacheable dependencies, and is treated as
+  // equivalent to Dirty in all cases except when `poll`d: since `poll` requests are waiting for
+  // meaningful work to do, they need to differentiate between a truly invalidated/changed (Dirty)
+  // Node and a Node that would be re-cleaned once per session.
+  UncacheableDependencies(N::Item),
 }
 
 impl<N: Node> EntryResult<N> {
   fn is_clean(&self, context: &N::Context) -> bool {
     match self {
       EntryResult::Clean(..) => true,
-      EntryResult::Uncacheable(_, run_id) => context.run_id() == run_id,
+      EntryResult::Uncacheable(_, session_id) => context.session_id() == session_id,
       EntryResult::Dirty(..) => false,
       EntryResult::UncacheableDependencies(..) => false,
     }
@@ -95,7 +91,7 @@ impl<N: Node> EntryResult<N> {
   /// currently to clean it).
   fn poll_should_wait(&self, context: &N::Context) -> bool {
     match self {
-      EntryResult::Uncacheable(_, run_id) => context.run_id() == run_id,
+      EntryResult::Uncacheable(_, session_id) => context.session_id() == session_id,
       EntryResult::Dirty(..) => false,
       EntryResult::UncacheableDependencies(_) | EntryResult::Clean(..) => true,
     }
@@ -287,24 +283,33 @@ impl<N: Node> Entry<N> {
   ) -> EntryState<N> {
     // Increment the RunToken to uniquely identify this work.
     let run_token = run_token.next();
-    let context = context_factory.clone_for(entry_id);
+    let context = context_factory.clone_for(entry_id, run_token);
     let node = node.clone();
     let (abort_handle, abort_registration) = AbortHandle::new_pair();
+    trace!(
+      "Running node {:?} with {:?}. It was: previous_result={:?}",
+      node,
+      run_token,
+      previous_result,
+    );
 
     context_factory.spawn(async move {
       // If we have previous result generations, compare them to all current dependency
       // generations (which, if they are dirty, will cause recursive cleaning). If they
       // match, we can consider the previous result value to be clean for reuse.
       let was_clean = if let Some(previous_dep_generations) = previous_dep_generations {
+        trace!("Getting deps to attempt to clean {}", node);
         match context.graph().dep_generations(entry_id, &context).await {
           Ok(ref dep_generations) if dep_generations == &previous_dep_generations => {
+            trace!("Deps matched: {} is clean.", node);
             // Dependencies have not changed: Node is clean.
             true
           }
           _ => {
-            // If dependency generations mismatched or failed to fetch, clear its
-            // dependencies and indicate that it should re-run.
-            context.graph().clear_deps(entry_id, run_token);
+            // If dependency generations mismatched or failed to fetch, clear stale edges and
+            // indicate that it should re-run.
+            context.graph().clear_stale_edges(entry_id, run_token);
+            trace!("Deps did not match: {} needs to re-run.", node);
             false
           }
         }
@@ -403,11 +408,6 @@ impl<N: Node> Entry<N> {
           result,
           dep_generations,
         } => {
-          trace!(
-            "Re-starting node {:?}. It was: previous_result={:?}",
-            self.node,
-            result,
-          );
           assert!(
             !result.is_clean(context),
             "A clean Node should not reach this point: {:?}",
@@ -454,12 +454,13 @@ impl<N: Node> Entry<N> {
   /// method, and 2) comparing the current/previous results unnecessarily.
   ///
   pub(crate) fn complete(
-    &mut self,
+    &self,
     context: &N::Context,
     result_run_token: RunToken,
     dep_generations: Vec<Generation>,
     result: Option<Result<N::Item, N::Error>>,
     has_uncacheable_deps: bool,
+    has_weak_deps: bool,
   ) {
     let mut state = self.state.lock();
 
@@ -474,7 +475,6 @@ impl<N: Node> Entry<N> {
           "Not completing node {:?} because it was invalidated.",
           self.node
         );
-        return;
       }
     }
 
@@ -499,19 +499,22 @@ impl<N: Node> Entry<N> {
             }
           }
           Some(Ok(result)) => {
-            // If the new result does not match the previous result, the generation increments.
             let next_result: EntryResult<N> = if !self.node.cacheable() {
-              EntryResult::Uncacheable(result, context.run_id().clone())
+              EntryResult::Uncacheable(result, context.session_id().clone())
+            } else if has_weak_deps {
+              EntryResult::Dirty(result)
             } else if has_uncacheable_deps {
               EntryResult::UncacheableDependencies(result)
             } else {
               EntryResult::Clean(result)
             };
+            // If the new result does not match the previous result, the generation increments.
             if Some(next_result.as_ref()) != previous_result.as_ref().map(EntryResult::as_ref) {
               // Node was re-executed (ie not cleaned) and had a different result value.
               generation = generation.next()
             };
             self.notify_waiters(waiters, Ok((next_result.as_ref().clone(), generation)));
+
             EntryState::Completed {
               result: next_result,
               pollers: Vec::new(),
@@ -588,16 +591,23 @@ impl<N: Node> Entry<N> {
   }
 
   ///
-  /// Get the current RunToken of this entry.
-  ///
-  /// TODO: Consider moving the Generation and RunToken out of the EntryState once we decide what
-  /// we want the per-Entry locking strategy to be.
+  /// Get the RunToken of this entry regardless of whether it is running.
   ///
   pub(crate) fn run_token(&self) -> RunToken {
     match *self.state.lock() {
       EntryState::NotStarted { run_token, .. }
       | EntryState::Running { run_token, .. }
       | EntryState::Completed { run_token, .. } => run_token,
+    }
+  }
+
+  ///
+  /// Get the current RunToken of this entry iff it is currently running.
+  ///
+  pub(crate) fn running_run_token(&self) -> Option<RunToken> {
+    match *self.state.lock() {
+      EntryState::Running { run_token, .. } => Some(run_token),
+      _ => None,
     }
   }
 

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -453,12 +453,6 @@ impl<N: Node> Entry<N> {
   /// result should be used. This special case exists to avoid 1) cloning the result to call this
   /// method, and 2) comparing the current/previous results unnecessarily.
   ///
-  /// Takes a &mut InnerGraph to ensure that completing nodes doesn't race with dirtying them.
-  /// The important relationship being guaranteed here is that if the Graph is calling
-  /// invalidate_from_roots, it may mark us, or our dependencies, as dirty. We don't want to
-  /// complete _while_ a batch of nodes are being marked as dirty, and this exclusive access ensures
-  /// that can't happen.
-  ///
   pub(crate) fn complete(
     &mut self,
     context: &N::Context,
@@ -466,7 +460,6 @@ impl<N: Node> Entry<N> {
     dep_generations: Vec<Generation>,
     result: Option<Result<N::Item, N::Error>>,
     has_uncacheable_deps: bool,
-    _graph: &mut super::InnerGraph<N>,
   ) {
     let mut state = self.state.lock();
 

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -500,7 +500,7 @@ async fn cyclic_strong_weak_with_strong_first() {
 #[ignore]
 async fn cyclic_strong_weak_with_weak_first() {
   // A cycle between two nodes with a strong dep from top to bottom and a weak dep from bottom
-  // to top, where we enter from the top first.
+  // to top, where we enter from the bottom first.
   let (graph, context) = cyclic_references(vec![TNode::new(1)]);
   assert_eq!(
     graph.create(TNode::new(0), &context).await,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -17,7 +17,7 @@ use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
 
 use fs::{safe_create_dir_all_ioerror, GitignoreStyleExcludes, PosixFS};
-use graph::{EntryId, Graph, InvalidationResult, NodeContext};
+use graph::{EntryId, Graph, InvalidationResult, NodeContext, RunToken};
 use log::info;
 use process_execution::{
   self, speculate::SpeculatingCommandRunner, BoundedCommandRunner, CommandRunner, NamedCaches,
@@ -320,20 +320,21 @@ impl Deref for InvalidatableGraph {
 
 #[derive(Clone)]
 pub struct Context {
-  entry_id: Option<EntryId>,
+  entry_id_and_run_token: Option<(EntryId, RunToken)>,
   pub core: Arc<Core>,
   pub session: Session,
-  run_id: Uuid,
+  session_run_id: Uuid,
 }
 
 impl Context {
   pub fn new(core: Arc<Core>, session: Session) -> Context {
-    let run_id = session.run_id();
+    // NB: See `impl NodeContext for Context` for more information on this naming.
+    let session_run_id = session.run_id();
     Context {
-      entry_id: None,
+      entry_id_and_run_token: None,
       core,
       session,
-      run_id,
+      session_run_id,
     }
   }
 
@@ -341,11 +342,7 @@ impl Context {
   /// Get the future value for the given Node implementation.
   ///
   pub async fn get<N: WrappedNode>(&self, node: N) -> Result<N::Item, Failure> {
-    let node_result = self
-      .core
-      .graph
-      .get(self.entry_id, self, node.into())
-      .await?;
+    let node_result = self.core.graph.get(self, node.into()).await?;
     Ok(
       node_result
         .try_into()
@@ -357,11 +354,7 @@ impl Context {
   /// Same as for Self::get, but returns None if a cycle would be created.
   ///
   pub async fn get_weak<N: WrappedNode>(&self, node: N) -> Result<Option<N::Item>, Failure> {
-    let node_result = self
-      .core
-      .graph
-      .get_weak(self.entry_id, self, node.into())
-      .await?;
+    let node_result = self.core.graph.get_weak(self, node.into()).await?;
     Ok(node_result.map(|v| {
       v.try_into()
         .unwrap_or_else(|_| panic!("A Node implementation was ambiguous."))
@@ -371,23 +364,30 @@ impl Context {
 
 impl NodeContext for Context {
   type Node = NodeKey;
-  type RunId = Uuid;
+  // NB: The name "Session" is slightly overloaded between the graph crate and the engine: what the
+  // graph crate calls a SessionId we refer to as the "run_id of the Session". See
+  // `scheduler::Session` for more information.
+  type SessionId = Uuid;
 
   ///
-  /// Clones this Context for a new EntryId. Because the Core of the context is an Arc, this
+  /// Clones this Context for a new run of a Node. Because the Core of the context is an Arc, this
   /// is a shallow clone.
   ///
-  fn clone_for(&self, entry_id: EntryId) -> Context {
+  fn clone_for(&self, entry_id: EntryId, run_token: RunToken) -> Context {
     Context {
-      entry_id: Some(entry_id),
+      entry_id_and_run_token: Some((entry_id, run_token)),
       core: self.core.clone(),
       session: self.session.clone(),
-      run_id: self.run_id,
+      session_run_id: self.session_run_id,
     }
   }
 
-  fn run_id(&self) -> &Self::RunId {
-    &self.run_id
+  fn entry_id_and_run_token(&self) -> Option<(EntryId, RunToken)> {
+    self.entry_id_and_run_token
+  }
+
+  fn session_id(&self) -> &Self::SessionId {
+    &self.session_run_id
   }
 
   fn graph(&self) -> &Graph<NodeKey> {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -352,6 +352,21 @@ impl Context {
         .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
     )
   }
+
+  ///
+  /// Same as for Self::get, but returns None if a cycle would be created.
+  ///
+  pub async fn get_weak<N: WrappedNode>(&self, node: N) -> Result<Option<N::Item>, Failure> {
+    let node_result = self
+      .core
+      .graph
+      .get_weak(self.entry_id, self, node.into())
+      .await?;
+    Ok(node_result.map(|v| {
+      v.try_into()
+        .unwrap_or_else(|_| panic!("A Node implementation was ambiguous."))
+    }))
+  }
 }
 
 impl NodeContext for Context {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -431,8 +431,9 @@ py_class!(pub class PyGeneratorResponseGet |py| {
     data product: PyType;
     data declared_subject: PyType;
     data subject: PyObject;
-    def __new__(_cls, product: PyType, declared_subject: PyType, subject: PyObject) -> CPyResult<Self> {
-      Self::create_instance(py, product, declared_subject, subject)
+    data weak: PyBool;
+    def __new__(_cls, product: PyType, declared_subject: PyType, subject: PyObject, weak: PyBool) -> CPyResult<Self> {
+      Self::create_instance(py, product, declared_subject, subject, weak)
     }
 });
 
@@ -448,6 +449,7 @@ pub struct Get {
   pub product: TypeId,
   pub subject: Key,
   pub declared_subject: Option<TypeId>,
+  pub weak: bool,
 }
 
 impl Get {
@@ -458,6 +460,7 @@ impl Get {
         .key_insert(py, get.subject(py).clone_ref(py).into())
         .map_err(|e| Failure::from_py_err(py, e))?,
       declared_subject: Some(interns.type_insert(py, get.declared_subject(py).clone_ref(py))),
+      weak: get.weak(py).is_true(),
     })
   }
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -19,7 +19,7 @@ type IntrinsicFn =
 ///
 /// Native "rule" implementations.
 ///
-/// On a case by case basis, intrinsics might have associated Nodes in the Graph order to memoize
+/// On a case by case basis, intrinsics might have associated Nodes in the Graph in order to memoize
 /// their results. For example: `multi_platform_process_request_to_process_result` and
 /// `path_globs_to_snapshot` take a while to run because they run a process and capture filesystem
 /// state (respectively) and have small in-memory outputs. On the other hand, `digest_to_snapshot`

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -16,6 +16,16 @@ use std::path::PathBuf;
 type IntrinsicFn =
   Box<dyn Fn(Context, Vec<Value>) -> BoxFuture<'static, NodeResult<Value>> + Send + Sync>;
 
+///
+/// Native "rule" implementations.
+///
+/// On a case by case basis, intrinsics might have associated Nodes in the Graph order to memoize
+/// their results. For example: `multi_platform_process_request_to_process_result` and
+/// `path_globs_to_snapshot` take a while to run because they run a process and capture filesystem
+/// state (respectively) and have small in-memory outputs. On the other hand, `digest_to_snapshot`
+/// runs a relatively cheap operation (loading a Snapshot from the mmap'ed database) on a small
+/// input, and produces a larger output: it is thus not memoized.
+///
 pub struct Intrinsics {
   intrinsics: IndexMap<Intrinsic, IntrinsicFn>,
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -66,6 +66,8 @@ struct InnerSession {
   // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
   // same Session while still observing new values for uncacheable rules like Goals.
   //
+  // See `impl NodeContext for Context` for more information.
+  //
   // TODO: Figure out how the `--loop` interplays with metrics. It's possible that for metrics
   // purposes, each iteration of a loop should be considered to be a new Session, but for now the
   // Session/build_id would be stable.


### PR DESCRIPTION
### Problem

As covered in #10059: in order to support fine-grained dependency inference on real world graphs (which very frequently involve file-level dependency cycles), we'd like to very carefully introduce a form of cycle-tolerance.

### Solution

Introduce the concept of "weak" `Get`s (exposed via `await Get(.., weak=True)`) which can return `None` if a cycle would be formed that would cause a `@rule` to depend on its own result. A weak `Get` is intended to be similar in practice to a [weak reference](https://en.wikipedia.org/wiki/Weak_reference), and correspondingly non-weak edges are referred to as "strong" edges.

A few changes were made to the `Graph` to support this, but the most fundamental was that we now allow cycles in the `Graph`, as long as they don't involve any running `Node`s. As described in the docstring for `graph::Graph`, we record dependencies for two reasons: 1) invalidation, and 2) deadlock detection. Invalidation is not concerned by cycles, and a deadlock can only occur in running code and thus does not need to walk non-live edges.

### Result

Tests demonstrate that `@rules` are able to successfully consume "weak-weak" cycles, where a graph like:
```
digraph {
  A -> B [label=weak, style=dashed];
  B -> A [label=weak, style=dashed];
}
```
... produces the set `{A, B}` when entered from either direction. Followup work will additionally allow for "strong-weak" cycles, which "mostly" work right now, but which currently have behavior that depends on where the cycle is entered. See #10229 and the ignored test in this change.