### PR TITLE
Teach `pants_requirement()` to work with dependency inference

### DIFF
--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -51,8 +51,7 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   fi
 
   echo "* Checking MyPy"
-  ./v2 --changed-since="${MERGE_BASE}" --changed-include-dependees=transitive \
-    --tag='-nolint' typecheck || exit 1
+  ./v2 --changed-since="${MERGE_BASE}" --changed-dependees=transitive --tag='-nolint' typecheck || exit 1
 
   echo "* Checking Flake8, and formatting"
   ./v2 --changed-since="${MERGE_BASE}" --tag='-nolint' lint || \

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import Iterable, Optional
 
 from pants.base.build_environment import pants_version
 from pants.base.exceptions import TargetDefinitionException
@@ -11,13 +12,13 @@ from pants.util.meta import classproperty
 
 
 class PantsRequirement:
-    """Exports a `python_requirement_library` pointing at the active pants' corresponding sdist.
+    """Exports a `python_requirement_library` pointing at the active Pants's corresponding sdist.
 
     This requirement is useful for custom plugin authors who want to build and test their plugin with
-    pants itself.  Using the resulting target as a dependency of their plugin target ensures the
-    dependency stays true to the surrounding repo's version of pants.
+    Pants itself. Using the resulting target as a dependency of their plugin target ensures the
+    dependency stays true to the surrounding repo's version of Pants.
 
-    NB: The requirement generated is for official pants releases on pypi; so may not be appropriate
+    NB: The requirement generated is for official Pants releases on PyPI; so may not be appropriate
     for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants sdists.
 
     :API: public
@@ -30,13 +31,20 @@ class PantsRequirement:
     def __init__(self, parse_context):
         self._parse_context = parse_context
 
-    def __call__(self, name=None, dist=None):
+    def __call__(
+        self,
+        name: Optional[str] = None,
+        dist: Optional[str] = None,
+        *,
+        modules: Optional[Iterable[str]] = None,
+    ):
         """
-        :param string name: The name to use for the target, defaults to the dist name if specified and
-                            otherwise the parent dir name.
-        :param string dist: The pants dist to create a requirement for. This must be a
-                            'pantsbuild.pants*' distribution; eg:
-                            'pantsbuild.pants.testutil'.
+        :param name: The name to use for the target, defaults to the dist name if specified and
+                     otherwise the parent dir name.
+        :param dist: The Pants dist to create a requirement for. This must be a 'pantsbuild.pants*'
+                     distribution; eg: 'pantsbuild.pants.testutil'.
+        :param modules: The modules exposed by this distribution, e.g. `["pants"]` or
+                        `["pants.testutil"]`.
         """
         name = name or dist or os.path.basename(self._parse_context.rel_path)
         dist = dist or "pantsbuild.pants"
@@ -44,14 +52,13 @@ class PantsRequirement:
             target = Address(spec_path=self._parse_context.rel_path, target_name=name)
             raise TargetDefinitionException(
                 target=target,
-                msg="The {} target only works for pantsbuild.pants "
-                "distributions, given {}".format(self.alias, dist),
+                msg=(
+                    f"The {self.alias} target only works for pantsbuild.pants distributions, but "
+                    f"given {dist}"
+                ),
             )
 
-        requirement = PythonRequirement(
-            requirement="{key}=={version}".format(key=dist, version=pants_version())
-        )
-
+        requirement = PythonRequirement(requirement=f"{dist}=={pants_version()}", modules=modules)
         self._parse_context.create_object(
             "python_requirement_library", name=name, requirements=[requirement]
         )

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Iterable, Optional
+from typing import Optional
 
 from pants.base.build_environment import pants_version
 from pants.base.exceptions import TargetDefinitionException
@@ -32,19 +32,13 @@ class PantsRequirement:
         self._parse_context = parse_context
 
     def __call__(
-        self,
-        name: Optional[str] = None,
-        dist: Optional[str] = None,
-        *,
-        modules: Optional[Iterable[str]] = None,
+        self, name: Optional[str] = None, dist: Optional[str] = None,
     ):
         """
         :param name: The name to use for the target, defaults to the dist name if specified and
                      otherwise the parent dir name.
         :param dist: The Pants dist to create a requirement for. This must be a 'pantsbuild.pants*'
                      distribution; eg: 'pantsbuild.pants.testutil'.
-        :param modules: The modules exposed by this distribution, e.g. `["pants"]` or
-                        `["pants.testutil"]`.
         """
         name = name or dist or os.path.basename(self._parse_context.rel_path)
         dist = dist or "pantsbuild.pants"
@@ -58,7 +52,10 @@ class PantsRequirement:
                 ),
             )
 
-        requirement = PythonRequirement(requirement=f"{dist}=={pants_version()}", modules=modules)
+        module_name = dist.replace("pantsbuild.", "")
+        requirement = PythonRequirement(
+            requirement=f"{dist}=={pants_version()}", modules=[module_name]
+        )
         self._parse_context.create_object(
             "python_requirement_library", name=name, requirements=[requirement]
         )

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -12,14 +12,14 @@ from pants.util.meta import classproperty
 
 
 class PantsRequirement:
-    """Exports a `python_requirement_library` pointing at the active Pants's corresponding sdist.
+    """Exports a `python_requirement_library` pointing at the active Pants's corresponding dist.
 
     This requirement is useful for custom plugin authors who want to build and test their plugin with
     Pants itself. Using the resulting target as a dependency of their plugin target ensures the
     dependency stays true to the surrounding repo's version of Pants.
 
     NB: The requirement generated is for official Pants releases on PyPI; so may not be appropriate
-    for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants sdists.
+    for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants dists.
 
     :API: public
     """

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Iterable, Optional
+
 from pants.backend.python.register import build_file_aliases
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.build_environment import pants_version
@@ -16,10 +18,15 @@ class PantsRequirementTest(TestBase):
         return build_file_aliases()
 
     def assert_pants_requirement(
-        self, python_requirement_library, expected_dist="pantsbuild.pants"
-    ):
-        self.assertIsInstance(python_requirement_library, PythonRequirementLibrary)
-        expected = PythonRequirement(f"{expected_dist}=={pants_version()}")
+        self,
+        python_requirement_library: PythonRequirementLibrary,
+        expected_dist: str = "pantsbuild.pants",
+        expected_modules: Optional[Iterable[str]] = None,
+    ) -> None:
+        assert isinstance(python_requirement_library, PythonRequirementLibrary)
+        expected = PythonRequirement(
+            f"{expected_dist}=={pants_version()}", modules=expected_modules
+        )
 
         def key(python_requirement):
             return (
@@ -28,35 +35,31 @@ class PantsRequirementTest(TestBase):
                 python_requirement.requirement.extras,
             )
 
-        self.assertEqual(
-            [key(expected)], [key(pr) for pr in python_requirement_library.payload.requirements]
-        )
+        assert [key(expected)] == [
+            key(pr) for pr in python_requirement_library.payload.requirements
+        ]
 
-    def test_default_name(self):
+    def test_default_name(self) -> None:
         self.add_to_build_file("3rdparty/python/pants", "pants_requirement()")
-
         python_requirement_library = self.target("3rdparty/python/pants")
         self.assert_pants_requirement(python_requirement_library)
 
-    def test_custom_name(self):
+    def test_custom_name(self) -> None:
         self.add_to_build_file("3rdparty/python/pants", "pants_requirement('pantsbuild.pants')")
-
         python_requirement_library = self.target("3rdparty/python/pants:pantsbuild.pants")
         self.assert_pants_requirement(python_requirement_library)
 
-    def test_dist(self):
+    def test_dist(self) -> None:
         self.add_to_build_file(
             "3rdparty/python/pants", "pants_requirement(dist='pantsbuild.pants')"
         )
-
         python_requirement_library = self.target("3rdparty/python/pants:pantsbuild.pants")
         self.assert_pants_requirement(python_requirement_library)
 
-    def test_contrib(self):
+    def test_contrib(self) -> None:
         self.add_to_build_file(
             "3rdparty/python/pants", "pants_requirement(dist='pantsbuild.pants.contrib.bob')"
         )
-
         python_requirement_library = self.target(
             "3rdparty/python/pants:pantsbuild.pants.contrib.bob"
         )
@@ -64,22 +67,30 @@ class PantsRequirementTest(TestBase):
             python_requirement_library, expected_dist="pantsbuild.pants.contrib.bob"
         )
 
-    def test_custom_name_contrib(self):
+    def test_custom_name_contrib(self) -> None:
         self.add_to_build_file(
             "3rdparty/python/pants",
             "pants_requirement(name='bob', dist='pantsbuild.pants.contrib.bob')",
         )
-
         python_requirement_library = self.target("3rdparty/python/pants:bob")
         self.assert_pants_requirement(
             python_requirement_library, expected_dist="pantsbuild.pants.contrib.bob"
         )
 
-    def test_bad_dist(self):
+    def test_modules(self) -> None:
+        self.add_to_build_file(
+            "3rdparty/python/pants",
+            "pants_requirement(modules=['pants.mod1', 'pants.mod2.subdir'])",
+        )
+        python_requirement_library = self.target("3rdparty/python/pants")
+        self.assert_pants_requirement(
+            python_requirement_library, expected_modules=["pants.mod1", "pants.mod2.subdir"]
+        )
+
+    def test_bad_dist(self) -> None:
         self.add_to_build_file(
             "3rdparty/python/pants", "pants_requirement(name='jane', dist='pantsbuild.pantsish')"
         )
-
         with self.assertRaises(AddressLookupError):
             # The pants_requirement should raise on the invalid dist name of pantsbuild.pantsish making
             # the target at 3rdparty/python/pants:jane fail to exist.

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -1,8 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Iterable, Optional
-
 from pants.backend.python.register import build_file_aliases
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.build_environment import pants_version
@@ -21,11 +19,11 @@ class PantsRequirementTest(TestBase):
         self,
         python_requirement_library: PythonRequirementLibrary,
         expected_dist: str = "pantsbuild.pants",
-        expected_modules: Optional[Iterable[str]] = None,
+        expected_module: str = "pants",
     ) -> None:
         assert isinstance(python_requirement_library, PythonRequirementLibrary)
         expected = PythonRequirement(
-            f"{expected_dist}=={pants_version()}", modules=expected_modules
+            f"{expected_dist}=={pants_version()}", modules=[expected_module]
         )
 
         def key(python_requirement):
@@ -64,7 +62,9 @@ class PantsRequirementTest(TestBase):
             "3rdparty/python/pants:pantsbuild.pants.contrib.bob"
         )
         self.assert_pants_requirement(
-            python_requirement_library, expected_dist="pantsbuild.pants.contrib.bob"
+            python_requirement_library,
+            expected_dist="pantsbuild.pants.contrib.bob",
+            expected_module="pants.contrib.bob",
         )
 
     def test_custom_name_contrib(self) -> None:
@@ -74,17 +74,9 @@ class PantsRequirementTest(TestBase):
         )
         python_requirement_library = self.target("3rdparty/python/pants:bob")
         self.assert_pants_requirement(
-            python_requirement_library, expected_dist="pantsbuild.pants.contrib.bob"
-        )
-
-    def test_modules(self) -> None:
-        self.add_to_build_file(
-            "3rdparty/python/pants",
-            "pants_requirement(modules=['pants.mod1', 'pants.mod2.subdir'])",
-        )
-        python_requirement_library = self.target("3rdparty/python/pants")
-        self.assert_pants_requirement(
-            python_requirement_library, expected_modules=["pants.mod1", "pants.mod2.subdir"]
+            python_requirement_library,
+            expected_dist="pantsbuild.pants.contrib.bob",
+            expected_module="pants.contrib.bob",
         )
 
     def test_bad_dist(self) -> None:


### PR DESCRIPTION
For third-party requirements, we must tell Pants what modules they export, e.g. `pantsbuild.pants` exporting `pants`. Our heuristic of using the dist's name does not work because every Pants dist starts with `pantsbuild.`.

[ci skip-rust-tests]