### PR TITLE
Expose method to bring down dynamic UI

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -288,8 +288,6 @@ async def run_tests(
 
     exit_code = PANTS_SUCCEEDED_EXIT_CODE
 
-    console.teardown_dynamic_ui()
-
     for result in results:
         if result.test_result.status == Status.FAILURE:
             exit_code = PANTS_FAILED_EXIT_CODE

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -287,6 +287,9 @@ async def run_tests(
     )
 
     exit_code = PANTS_SUCCEEDED_EXIT_CODE
+
+    console.teardown_dynamic_ui()
+
     for result in results:
         if result.test_result.status == Status.FAILURE:
             exit_code = PANTS_FAILED_EXIT_CODE

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -29,6 +29,11 @@ class NativeStdOut(NativeWriter):
     def write(self, payload: str) -> None:
         self.native.write_stdout(self.scheduler_session.session, payload)
 
+    def teardown_dynamic_ui(self) -> None:
+        scheduler = self.scheduler_session.scheduler
+        session = self.scheduler_session.session
+        self.native.teardown_dynamic_ui(scheduler._scheduler, session)
+
 
 class NativeStdErr(NativeWriter):
     def write(self, payload: str) -> None:
@@ -80,6 +85,9 @@ class Console:
 
     def write_stderr(self, payload: str) -> None:
         self.stderr.write(payload)
+
+    def teardown_dynamic_ui(self) -> None:
+        self.stdout.teardown_dynamic_ui()
 
     def print_stdout(self, payload: str, end: str = "\n") -> None:
         self.stdout.write(f"{payload}{end}")

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -27,17 +27,16 @@ class NativeWriter:
 
 class NativeStdOut(NativeWriter):
     def write(self, payload: str) -> None:
-        self.native.write_stdout(self.scheduler_session.session, payload)
-
-    def teardown_dynamic_ui(self) -> None:
-        scheduler = self.scheduler_session.scheduler
+        scheduler = self.scheduler_session.scheduler._scheduler
         session = self.scheduler_session.session
-        self.native.teardown_dynamic_ui(scheduler._scheduler, session)
+        self.native.write_stdout(scheduler, session, payload, teardown_ui=True)
 
 
 class NativeStdErr(NativeWriter):
     def write(self, payload: str) -> None:
-        self.native.write_stderr(self.scheduler_session.session, payload)
+        scheduler = self.scheduler_session.scheduler._scheduler
+        session = self.scheduler_session.session
+        self.native.write_stderr(scheduler, session, payload, teardown_ui=True)
 
 
 @side_effecting
@@ -85,9 +84,6 @@ class Console:
 
     def write_stderr(self, payload: str) -> None:
         self.stderr.write(payload)
-
-    def teardown_dynamic_ui(self) -> None:
-        self.stdout.teardown_dynamic_ui()
 
     def print_stdout(self, payload: str, end: str = "\n") -> None:
         self.stdout.write(f"{payload}{end}")

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -142,6 +142,9 @@ class Native(metaclass=SingletonMetaclass):
     def write_stderr(self, session, msg: str):
         return self.lib.write_stderr(session, msg)
 
+    def teardown_dynamic_ui(self, scheduler, session):
+        self.lib.teardown_dynamic_ui(scheduler, session)
+
     def flush_log(self):
         return self.lib.flush_log()
 

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -136,10 +136,14 @@ class Native(metaclass=SingletonMetaclass):
         """Proxy a log message to the Rust logging faculties."""
         return self.lib.write_log(msg, level, target)
 
-    def write_stdout(self, session, msg: str):
+    def write_stdout(self, scheduler, session, msg: str, teardown_ui: bool):
+        if teardown_ui:
+            self.teardown_dynamic_ui(scheduler, session)
         return self.lib.write_stdout(session, msg)
 
-    def write_stderr(self, session, msg: str):
+    def write_stderr(self, scheduler, session, msg: str, teardown_ui: bool):
+        if teardown_ui:
+            self.teardown_dynamic_ui(scheduler, session)
         return self.lib.write_stderr(session, msg)
 
     def teardown_dynamic_ui(self, scheduler, session):

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -197,7 +197,7 @@ impl Session {
     }
   }
 
-  async fn maybe_display_teardown(&self) {
+  pub async fn maybe_display_teardown(&self) {
     if let Some(display) = &self.0.display {
       let teardown = {
         let mut display = display.lock();
@@ -497,7 +497,6 @@ impl Scheduler {
       .core
       .executor
       .block_on(session.maybe_display_teardown());
-
     result
   }
 


### PR DESCRIPTION
### Problem

In some cases, most notably when pants prints the results of the `test` goal to stderr, we do this printing while the dynamic UI is still active. This means that when the dynamic UI is deactivated, the lines in the terminal corresponding to where the dynamic UI swimlanes were being animated vanish suddenly, which results in the terminal scrolling to some distance beyond where the last output was when a pants run is complete. This is undesirable. We'd like to be able to have a pants rule explicitly disable the dynamic UI when the rule knows it has no more work to do other than printing output.

### Solution

This commit exposes a method on the Python `Console` class `teardown_dynamic_ui()` that proxies to the extant `maybe_teardown_display` method, that will disable the dynamic UI for the remainder of the pants run.

### Result

Fixes https://github.com/pantsbuild/pants/issues/10005