### PR TITLE
Fix `--changed-dependees` to work when v1 is disabled

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -3,16 +3,86 @@
 
 import json
 from collections import defaultdict
+from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Mapping, Set
+from typing import Iterable, Set
 
 from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.engine.addresses import Address, Addresses
+from pants.engine.collection import DeduplicatedCollection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies, DependenciesRequest, Targets
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+@dataclass(frozen=True)
+class AddressToDependees:
+    mapping: FrozenDict[Address, FrozenOrderedSet[Address]]
+
+
+@rule
+async def map_addresses_to_dependees() -> AddressToDependees:
+    # Get every target in the project so that we can iterate over them to find their dependencies.
+    all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    dependencies_per_target = await MultiGet(
+        Get(Addresses, DependenciesRequest(tgt.get(Dependencies))) for tgt in all_targets
+    )
+
+    address_to_dependees = defaultdict(set)
+    for tgt, dependencies in zip(all_targets, dependencies_per_target):
+        for dependency in dependencies:
+            address_to_dependees[dependency].add(tgt.address)
+    return AddressToDependees(
+        FrozenDict(
+            {addr: FrozenOrderedSet(dependees) for addr, dependees in address_to_dependees.items()}
+        )
+    )
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class DependeesRequest:
+    addresses: FrozenOrderedSet[Address]
+    transitive: bool
+    include_roots: bool
+
+    def __init__(
+        self, addresses: Iterable[Address], *, transitive: bool, include_roots: bool
+    ) -> None:
+        self.addresses = FrozenOrderedSet(addresses)
+        self.transitive = transitive
+        self.include_roots = include_roots
+
+
+class Dependees(DeduplicatedCollection[Address]):
+    sort_input = True
+
+
+@rule
+def find_dependees(
+    request: DependeesRequest, address_to_dependees: AddressToDependees
+) -> Dependees:
+    check = set(request.addresses)
+    known_dependents: Set[Address] = set()
+    while True:
+        dependents = set(known_dependents)
+        for target in check:
+            target_dependees = address_to_dependees.mapping.get(target, FrozenOrderedSet())
+            dependents.update(target_dependees)
+        check = dependents - known_dependents
+        if not check or not request.transitive:
+            result = (
+                dependents | set(request.addresses)
+                if request.include_roots
+                else dependents - set(request.addresses)
+            )
+            return Dependees(result)
+        known_dependents = dependents
 
 
 class DependeesOutputFormat(Enum):
@@ -55,71 +125,44 @@ class DependeesOptions(LineOriented, GoalSubsystem):
         )
 
 
-class Dependees(Goal):
+class DependeesGoal(Goal):
     subsystem_cls = DependeesOptions
-
-
-def calculate_dependees(
-    address_to_dependees: Mapping[Address, Set[Address]],
-    roots: Iterable[Address],
-    *,
-    transitive: bool
-) -> Set[Address]:
-    check = set(roots)
-    known_dependents: Set[Address] = set()
-    while True:
-        dependents = set(known_dependents)
-        for target in check:
-            dependents.update(address_to_dependees[target])
-        check = dependents - known_dependents
-        if not check or not transitive:
-            return dependents - set(roots)
-        known_dependents = dependents
 
 
 @goal_rule
 async def dependees_goal(
     specified_addresses: Addresses, options: DependeesOptions, console: Console
-) -> Dependees:
-    # Get every target in the project so that we can iterate over them to find their dependencies.
-    all_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    dependencies_per_target = await MultiGet(
-        Get(Addresses, DependenciesRequest(tgt.get(Dependencies))) for tgt in all_targets
-    )
+) -> DependeesGoal:
+    transitive = options.values.transitive
+    include_roots = options.values.closed
 
-    address_to_dependees = defaultdict(set)
-    for tgt, dependencies in zip(all_targets, dependencies_per_target):
-        for dependency in dependencies:
-            address_to_dependees[dependency].add(tgt.address)
-
-    # JSON should output each distinct specified target with its dependees, unlike the `text`
-    # format flattening into a single set.
     if options.values.output_format == DependeesOutputFormat.json:
-        json_result = {}
-        for specified_address in specified_addresses:
-            dependees = calculate_dependees(
-                address_to_dependees, [specified_address], transitive=options.values.transitive
+        dependees_per_target = await MultiGet(
+            Get(
+                Dependees,
+                DependeesRequest(
+                    [specified_address], transitive=transitive, include_roots=include_roots
+                ),
             )
-            if options.values.closed:
-                dependees.add(specified_address)
-            json_result[specified_address.spec] = sorted(addr.spec for addr in dependees)
+            for specified_address in specified_addresses
+        )
+        json_result = {
+            specified_address.spec: [dependee.spec for dependee in dependees]
+            for specified_address, dependees in zip(specified_addresses, dependees_per_target)
+        }
         with options.line_oriented(console) as print_stdout:
             print_stdout(json.dumps(json_result, indent=4, separators=(",", ": "), sort_keys=True))
-        return Dependees(exit_code=0)
+        return DependeesGoal(exit_code=0)
 
-    # Filter `address_to_dependees` based on the specified addresses, and flatten it into a
-    # single set.
-    result_addresses = calculate_dependees(
-        address_to_dependees, specified_addresses, transitive=options.values.transitive
+    dependees = await Get(
+        Dependees,
+        DependeesRequest(specified_addresses, transitive=transitive, include_roots=include_roots),
     )
-    if options.values.closed:
-        result_addresses |= set(specified_addresses)
-
     with options.line_oriented(console) as print_stdout:
-        for address in sorted(result_addresses):
-            print_stdout(address)
-    return Dependees(exit_code=0)
+        for address in dependees:
+            print_stdout(address.spec)
+    return DependeesGoal(exit_code=0)
 
 
 def rules():
-    return [dependees_goal]
+    return [find_dependees, map_addresses_to_dependees, dependees_goal]

--- a/src/python/pants/backend/project_info/dependees_test.py
+++ b/src/python/pants/backend/project_info/dependees_test.py
@@ -4,9 +4,9 @@
 from textwrap import dedent
 from typing import List
 
-from pants.backend.project_info.dependees import Dependees
+from pants.backend.project_info.dependees import DependeesGoal
 from pants.backend.project_info.dependees import DependeesOutputFormat as OutputFormat
-from pants.backend.project_info.dependees import dependees_goal
+from pants.backend.project_info.dependees import rules as dependee_rules
 from pants.engine.target import Dependencies, Target
 from pants.testutil.goal_rule_test_base import GoalRuleTestBase
 
@@ -17,7 +17,7 @@ class MockTarget(Target):
 
 
 class DependeesTest(GoalRuleTestBase):
-    goal_cls = Dependees
+    goal_cls = DependeesGoal
 
     @classmethod
     def target_types(cls):
@@ -25,7 +25,7 @@ class DependeesTest(GoalRuleTestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), dependees_goal)
+        return (*super().rules(), *dependee_rules())
 
     def setUp(self) -> None:
         self.add_to_build_file("base", "tgt()")

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -133,6 +133,7 @@ class LocalPantsRunner:
 
         global_options = options.for_global_scope()
         specs = SpecsCalculator.create(
+            options_bootstrapper=options_bootstrapper,
             options=options,
             build_root=build_root,
             session=graph_session.scheduler_session,

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -15,7 +15,9 @@ from pants.base.specs import (
     Specs,
 )
 from pants.engine.internals.scheduler import SchedulerSession
+from pants.engine.selectors import Params
 from pants.option.options import Options
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.scm.subsystems.changed import ChangedAddresses, ChangedOptions, ChangedRequest
 from pants.util.ordered_set import OrderedSet
 
@@ -63,6 +65,7 @@ class SpecsCalculator:
     @classmethod
     def create(
         cls,
+        options_bootstrapper: OptionsBootstrapper,
         options: Options,
         session: SchedulerSession,
         build_root: Optional[str] = None,
@@ -98,10 +101,12 @@ class SpecsCalculator:
                 sources=tuple(changed_options.changed_files(scm=scm)),
                 dependees=changed_options.dependees,
             )
-            (changed_addresses,) = session.product_request(ChangedAddresses, [changed_request])
-            logger.debug("changed addresses: %s", changed_addresses.addresses)
+            (changed_addresses,) = session.product_request(
+                ChangedAddresses, [Params(changed_request, options_bootstrapper)]
+            )
+            logger.debug("changed addresses: %s", changed_addresses)
             dependencies = tuple(
-                SingleAddress(a.spec_path, a.target_name) for a in changed_addresses.addresses
+                SingleAddress(a.spec_path, a.target_name) for a in changed_addresses
             )
             return Specs(
                 address_specs=AddressSpecs(

--- a/src/python/pants/scm/subsystems/BUILD
+++ b/src/python/pants/scm/subsystems/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources = ['changed.py'],
   dependencies = [
     '3rdparty/python:dataclasses',
+    'src/python/pants/backend/project_info',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/engine:addresses',

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, cast
 
-from pants.backend.project_info.dependees import Dependees, DependeesRequest
+from pants.backend.project_info.dependees import (
+    Dependees,
+    DependeesRequest,
+    find_dependees,
+    map_addresses_to_dependees,
+)
 from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
@@ -153,4 +158,9 @@ class Changed(Subsystem):
 
 
 def rules():
-    return [find_changed_owners, RootRule(ChangedRequest)]
+    return [
+        map_addresses_to_dependees,
+        find_dependees,
+        find_changed_owners,
+        RootRule(ChangedRequest),
+    ]

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -5,16 +5,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, cast
 
+from pants.backend.project_info.dependees import Dependees, DependeesRequest
 from pants.base.deprecated import resolve_conflicting_options
-from pants.base.specs import AddressSpecs, DescendantAddresses
-from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.addresses import Address, Addresses
+from pants.engine.addresses import Address
+from pants.engine.collection import Collection
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.internals.mapper import AddressMapper
-from pants.engine.internals.parser import HydratedStruct
-from pants.engine.legacy.graph import _DependentGraph, target_types_from_build_file_aliases
 from pants.engine.rules import RootRule, rule
-from pants.engine.selectors import Get, MultiGet
+from pants.engine.selectors import Get
 from pants.goal.workspace import ScmWorkspace
 from pants.option.option_value_container import OptionValueContainer
 from pants.scm.scm import Scm
@@ -33,38 +30,24 @@ class ChangedRequest:
     dependees: DependeesOption
 
 
-@dataclass(frozen=True)
-class ChangedAddresses:
-    """Light wrapper around the addresses referring to the changed targets."""
-
-    addresses: Addresses
+class ChangedAddresses(Collection[Address]):
+    pass
 
 
 @rule
-async def find_owners(
-    build_configuration: BuildConfiguration,
-    address_mapper: AddressMapper,
-    changed_request: ChangedRequest,
-) -> ChangedAddresses:
-    owners = await Get(Owners, OwnersRequest(sources=changed_request.sources))
-
-    # If the ChangedRequest does not require dependees, then we're done.
-    if changed_request.dependees == DependeesOption.NONE:
+async def find_changed_owners(request: ChangedRequest) -> ChangedAddresses:
+    owners = await Get(Owners, OwnersRequest(request.sources))
+    if request.dependees == DependeesOption.NONE:
         return ChangedAddresses(owners.addresses)
-
-    # Otherwise: find dependees.
-    all_addresses = await Get(Addresses, AddressSpecs((DescendantAddresses(""),)))
-    all_structs = [
-        s.value for s in await MultiGet(Get(HydratedStruct, Address, a) for a in all_addresses)
-    ]
-
-    bfa = build_configuration.registered_aliases()
-    graph = _DependentGraph.from_iterable(
-        target_types_from_build_file_aliases(bfa), address_mapper, all_structs
+    address_to_dependees = await Get(
+        Dependees,
+        DependeesRequest(
+            owners.addresses,
+            transitive=request.dependees == DependeesOption.TRANSITIVE,
+            include_roots=True,
+        ),
     )
-    if changed_request.dependees == DependeesOption.DIRECT:
-        return ChangedAddresses(Addresses(graph.dependents_of_addresses(owners.addresses)))
-    return ChangedAddresses(Addresses(graph.transitive_dependents_of_addresses(owners.addresses)))
+    return ChangedAddresses(address_to_dependees)
 
 
 @dataclass(frozen=True)
@@ -156,7 +139,7 @@ class Changed(Subsystem):
             type=DependeesOption,
             default=DependeesOption.NONE,
             help="Include direct or transitive dependees of changed targets.",
-            removal_version="2.0.1.dev0",
+            removal_version="2.1.0.dev0",
             removal_hint="Use `--changed-dependees` instead of `--changed-include-dependees`.",
         )
         register(
@@ -164,10 +147,10 @@ class Changed(Subsystem):
             type=bool,
             default=False,
             help="Stop searching for owners once a source is mapped to at least one owning target.",
-            removal_version="2.0.1.dev0",
+            removal_version="2.1.0.dev0",
             removal_hint="The option `--changed-fast` no longer does anything.",
         )
 
 
 def rules():
-    return [find_owners, RootRule(ChangedRequest)]
+    return [find_changed_owners, RootRule(ChangedRequest)]


### PR DESCRIPTION
While we were using a rule to calculate the dependees, it was using a v1 code path based on TargetAdaptor. This means that `--changed-dependees` caused a crash when v1 is disabled.

To land this, we refactor `dependees` into two helper rules so that any rule can now `await Get(Dependees, DependeesRequest)`. 

[ci skip-rust-tests]