### PR TITLE
Simplify `ci.py` now that we have no v1 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -433,7 +433,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --plugin-tests --remote-execution-enabled --python-version 3.6
+      --unit-tests --remote-execution-enabled --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -493,7 +493,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --plugin-tests --remote-execution-enabled --python-version 3.7
+      --unit-tests --remote-execution-enabled --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - addons:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -556,8 +556,8 @@ def unit_tests(python_version: PythonVersion) -> Dict:
         **linux_shard(python_version=python_version, install_travis_wait=True),
         "name": f"Unit tests (Python {python_version.decimal})",
         "script": [
-            "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py --unit-tests --plugin-tests "
-            f"--remote-execution-enabled --python-version {python_version.decimal}"
+            "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
+            f"--unit-tests --remote-execution-enabled --python-version {python_version.decimal}"
         ],
     }
     safe_append(shard, "env", f"CACHE_NAME=unit_tests.py{python_version.number}")
@@ -621,8 +621,9 @@ def integration_tests(python_version: PythonVersion) -> Dict:
         "name": f"Integration tests - V2 (Python {python_version.decimal})",
         "script": [
             (
-                "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py --integration-tests "
-                f"--remote-execution-enabled --python-version {python_version.decimal}"
+                "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
+                "--integration-tests --remote-execution-enabled --python-version "
+                f"{python_version.decimal}"
             ),
         ],
     }

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -119,7 +119,7 @@ class CmdLineSpecParserTest(TestBase):
         double_absolute_address = "/" + os.path.join(self.build_root, "a")
         double_absolute_file = "/" + os.path.join(self.build_root, "a.txt")
         for spec in [double_absolute_address, double_absolute_file]:
-            assert "//" == spec[:2], "A sanity check that we have a leading-// absolute spec"
+            assert "//" == spec[:2]
         self.assert_address_spec_parsed(
             double_absolute_address, single(double_absolute_address[2:])
         )


### PR DESCRIPTION
We can remove the block list mechanism now.
