### PR TITLE
Refactor WorkunitStore struct

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -176,8 +176,6 @@ impl StreamingWorkunitData {
     let should_emit = |workunit: &Workunit| -> bool { workunit.metadata.level <= max_verbosity };
 
     let (started_workunits, completed_workunits) = {
-      let mut workunit_records = self.workunit_records.lock();
-
       let mut started_messages = vec![];
       let mut completed_messages = vec![];
 
@@ -193,6 +191,7 @@ impl StreamingWorkunitData {
         }
       }
 
+      let mut workunit_records = self.workunit_records.lock();
       let mut started_workunits: Vec<Workunit> = vec![];
       for mut started in started_messages.into_iter() {
         let span_id = started.span_id.clone();

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -167,291 +167,22 @@ impl StreamingWorkunitData {
       workunit_records: Arc::new(Mutex::new(HashMap::new())),
     }
   }
-}
-
-#[derive(Clone)]
-struct HeavyHittersData {
-  inner: Arc<Mutex<HeavyHittersInnerStore>>,
-  msg_tx: Arc<Mutex<Sender<StoreMsg>>>,
-  msg_rx: Arc<Mutex<Receiver<StoreMsg>>>,
-}
-
-impl HeavyHittersData {
-  fn new() -> HeavyHittersData {
-    let (msg_tx, msg_rx) = channel();
-    HeavyHittersData {
-      inner: Arc::new(Mutex::new(HeavyHittersInnerStore {
-        graph: DiGraph::new(),
-        span_id_to_graph: HashMap::new(),
-        workunit_records: HashMap::new(),
-      })),
-      msg_rx: Arc::new(Mutex::new(msg_rx)),
-      msg_tx: Arc::new(Mutex::new(msg_tx)),
-    }
-  }
-}
-
-#[derive(Default)]
-pub struct HeavyHittersInnerStore {
-  graph: WorkunitGraph,
-  span_id_to_graph: HashMap<SpanId, NodeIndex<u32>>,
-  workunit_records: HashMap<SpanId, Workunit>,
-}
-
-fn first_matched_parent(
-  workunit_records: &HashMap<SpanId, Workunit>,
-  mut span_id: Option<SpanId>,
-  is_visible: impl Fn(&Workunit) -> bool,
-) -> Option<SpanId> {
-  while let Some(current_span_id) = span_id {
-    let workunit = workunit_records.get(&current_span_id);
-
-    // Is the current workunit visible?
-    if let Some(ref workunit) = workunit {
-      if is_visible(workunit) {
-        return Some(current_span_id);
-      }
-    }
-
-    // If not, try its parent.
-    span_id = workunit.and_then(|workunit| workunit.parent_id.clone());
-  }
-  None
-}
-
-impl WorkunitStore {
-  pub fn new(rendering_dynamic_ui: bool) -> WorkunitStore {
-    WorkunitStore {
-      streaming_workunit_data: StreamingWorkunitData::new(),
-      heavy_hitters_data: HeavyHittersData::new(),
-      rendering_dynamic_ui,
-    }
-  }
-
-  pub fn init_thread_state(&self, parent_id: Option<String>) {
-    set_thread_workunit_state(Some(WorkUnitState {
-      store: self.clone(),
-      parent_id,
-    }))
-  }
-
-  ///
-  /// Find the longest running leaf workunits, and render their first visible parents.
-  ///
-  pub fn heavy_hitters(&self, k: usize) -> HashMap<String, Option<Duration>> {
-    use petgraph::Direction;
-    let now = SystemTime::now();
-    let mut inner = self.heavy_hitters_data.inner.lock();
-
-    {
-      let receiver = self.heavy_hitters_data.msg_rx.lock();
-      while let Ok(msg) = receiver.try_recv() {
-        match msg {
-          StoreMsg::Started(started) => Self::add_started_workunit_to_store(started, &mut inner),
-          StoreMsg::Completed(span_id, new_metadata, time) => {
-            Self::add_completed_workunit_to_store(span_id, new_metadata, time, &mut inner)
-          }
-        }
-      }
-    }
-
-    let workunit_graph = &inner.graph;
-
-    let duration_for = |workunit: &Workunit| -> Option<Duration> {
-      match workunit.state {
-        WorkunitState::Started { ref start_time, .. } => now.duration_since(*start_time).ok(),
-        _ => None,
-      }
-    };
-
-    let is_visible = |workunit: &Workunit| -> bool {
-      workunit.metadata.level >= Level::Info && workunit.metadata.desc.is_some()
-    };
-
-    // Initialize the heap with the leaves of the workunit graph.
-    let mut queue: BinaryHeap<(Duration, SpanId)> = workunit_graph
-      .externals(Direction::Outgoing)
-      .map(|entry| workunit_graph[entry].clone())
-      .flat_map(|span_id: SpanId| {
-        let workunit: Option<&Workunit> = inner.workunit_records.get(&span_id);
-        match workunit {
-          Some(workunit) if !workunit.metadata.blocked => {
-            duration_for(workunit).map(|d| (d, span_id.clone()))
-          }
-          _ => None,
-        }
-      })
-      .collect();
-
-    // Output the visible parents of the longest running leaves.
-    let mut res = HashMap::new();
-    while let Some((_dur, span_id)) = queue.pop() {
-      // If the leaf is visible or has a visible parent, emit it.
-      if let Some(span_id) =
-        first_matched_parent(&inner.workunit_records, Some(span_id), is_visible)
-      {
-        let workunit = inner.workunit_records.get(&span_id).unwrap();
-        if let Some(effective_name) = workunit.metadata.desc.as_ref() {
-          let maybe_duration = duration_for(&workunit);
-
-          res.insert(effective_name.to_string(), maybe_duration);
-          if res.len() >= k {
-            break;
-          }
-        }
-      }
-    }
-    res
-  }
-
-  pub fn start_workunit(
-    &self,
-    span_id: SpanId,
-    name: String,
-    parent_id: Option<SpanId>,
-    metadata: WorkunitMetadata,
-  ) -> SpanId {
-    let started = Workunit {
-      name,
-      span_id: span_id.clone(),
-      parent_id,
-      state: WorkunitState::Started {
-        start_time: std::time::SystemTime::now(),
-      },
-      metadata,
-    };
-    if !self.rendering_dynamic_ui {
-      started.log_workunit_state()
-    }
-
-    let sender = self.heavy_hitters_data.msg_tx.lock();
-    sender.send(StoreMsg::Started(started.clone())).unwrap();
-    let sender = self.streaming_workunit_data.msg_tx.lock();
-    sender.send(StoreMsg::Started(started)).unwrap();
-    span_id
-  }
-
-  fn add_started_workunit_to_store(started: Workunit, inner_store: &mut HeavyHittersInnerStore) {
-    let span_id = started.span_id.clone();
-    let parent_id = started.parent_id.clone();
-
-    inner_store
-      .workunit_records
-      .insert(span_id.clone(), started);
-
-    let child = inner_store.graph.add_node(span_id.clone());
-    inner_store.span_id_to_graph.insert(span_id, child);
-    if let Some(parent_id) = parent_id {
-      if let Some(parent) = inner_store.span_id_to_graph.get(&parent_id).cloned() {
-        inner_store.graph.add_edge(parent, child, ());
-      }
-    }
-  }
-
-  pub fn complete_workunit_with_new_metadata(&self, span_id: SpanId, metadata: WorkunitMetadata) {
-    self.complete_workunit_impl(span_id, Some(metadata))
-  }
-
-  pub fn complete_workunit(&self, span_id: SpanId) {
-    self.complete_workunit_impl(span_id, None)
-  }
-
-  fn complete_workunit_impl(&self, span_id: SpanId, new_metadata: Option<WorkunitMetadata>) {
-    let time = std::time::SystemTime::now();
-    let tx = self.heavy_hitters_data.msg_tx.lock();
-    tx.send(StoreMsg::Completed(
-      span_id.clone(),
-      new_metadata.clone(),
-      time,
-    ))
-    .unwrap();
-
-    let tx = self.streaming_workunit_data.msg_tx.lock();
-    tx.send(StoreMsg::Completed(span_id, new_metadata, time))
-      .unwrap();
-  }
-
-  fn add_completed_workunit_to_store(
-    span_id: SpanId,
-    new_metadata: Option<WorkunitMetadata>,
-    end_time: SystemTime,
-    inner_store: &mut HeavyHittersInnerStore,
-  ) {
-    use std::collections::hash_map::Entry;
-
-    match inner_store.workunit_records.entry(span_id.clone()) {
-      Entry::Vacant(_) => {
-        log::warn!("No previously-started workunit found for id: {}", span_id);
-      }
-      Entry::Occupied(o) => {
-        let (span_id, mut workunit) = o.remove_entry();
-        let time_span = match workunit.state {
-          WorkunitState::Completed { .. } => {
-            log::warn!("Workunit {} was already completed", span_id);
-            return;
-          }
-          WorkunitState::Started { start_time } => {
-            TimeSpan::from_start_and_end_systemtime(&start_time, &end_time)
-          }
-        };
-        let new_state = WorkunitState::Completed { time_span };
-        workunit.state = new_state;
-        if let Some(metadata) = new_metadata {
-          workunit.metadata = metadata;
-        }
-        workunit.log_workunit_state();
-        inner_store.workunit_records.insert(span_id, workunit);
-      }
-    }
-  }
-
-  pub fn add_completed_workunit(
-    &self,
-    name: String,
-    start_time: SystemTime,
-    end_time: SystemTime,
-    parent_id: Option<SpanId>,
-    metadata: WorkunitMetadata,
-  ) {
-    let span_id = new_span_id();
-
-    let workunit = Workunit {
-      name,
-      span_id: span_id.clone(),
-      parent_id,
-      state: WorkunitState::Started { start_time },
-      metadata,
-    };
-
-    let sender = self.heavy_hitters_data.msg_tx.lock();
-    sender.send(StoreMsg::Started(workunit.clone())).unwrap();
-    sender
-      .send(StoreMsg::Completed(span_id.clone(), None, end_time))
-      .unwrap();
-
-    let sender = self.streaming_workunit_data.msg_tx.lock();
-    sender.send(StoreMsg::Started(workunit)).unwrap();
-    sender
-      .send(StoreMsg::Completed(span_id, None, end_time))
-      .unwrap();
-  }
 
   pub fn with_latest_workunits<F, T>(&mut self, max_verbosity: log::Level, f: F) -> T
   where
     F: FnOnce(&[Workunit], &[Workunit]) -> T,
   {
     use std::collections::hash_map::Entry;
-
     let should_emit = |workunit: &Workunit| -> bool { workunit.metadata.level <= max_verbosity };
 
     let (started_workunits, completed_workunits) = {
-      let mut workunit_records = self.streaming_workunit_data.workunit_records.lock();
+      let mut workunit_records = self.workunit_records.lock();
 
       let mut started_messages = vec![];
       let mut completed_messages = vec![];
 
       {
-        let receiver = self.streaming_workunit_data.msg_rx.lock();
+        let receiver = self.msg_rx.lock();
         while let Ok(msg) = receiver.try_recv() {
           match msg {
             StoreMsg::Started(started) => started_messages.push(started),
@@ -511,6 +242,287 @@ impl WorkunitStore {
     };
 
     f(&started_workunits, &completed_workunits)
+  }
+}
+
+#[derive(Clone)]
+struct HeavyHittersData {
+  inner: Arc<Mutex<HeavyHittersInnerStore>>,
+  msg_tx: Arc<Mutex<Sender<StoreMsg>>>,
+  msg_rx: Arc<Mutex<Receiver<StoreMsg>>>,
+}
+
+impl HeavyHittersData {
+  fn new() -> HeavyHittersData {
+    let (msg_tx, msg_rx) = channel();
+    HeavyHittersData {
+      inner: Arc::new(Mutex::new(HeavyHittersInnerStore {
+        graph: DiGraph::new(),
+        span_id_to_graph: HashMap::new(),
+        workunit_records: HashMap::new(),
+      })),
+      msg_rx: Arc::new(Mutex::new(msg_rx)),
+      msg_tx: Arc::new(Mutex::new(msg_tx)),
+    }
+  }
+
+  fn add_started_workunit_to_store(started: Workunit, inner_store: &mut HeavyHittersInnerStore) {
+    let span_id = started.span_id.clone();
+    let parent_id = started.parent_id.clone();
+
+    inner_store
+      .workunit_records
+      .insert(span_id.clone(), started);
+
+    let child = inner_store.graph.add_node(span_id.clone());
+    inner_store.span_id_to_graph.insert(span_id, child);
+    if let Some(parent_id) = parent_id {
+      if let Some(parent) = inner_store.span_id_to_graph.get(&parent_id).cloned() {
+        inner_store.graph.add_edge(parent, child, ());
+      }
+    }
+  }
+
+  fn add_completed_workunit_to_store(
+    span_id: SpanId,
+    new_metadata: Option<WorkunitMetadata>,
+    end_time: SystemTime,
+    inner_store: &mut HeavyHittersInnerStore,
+  ) {
+    use std::collections::hash_map::Entry;
+
+    match inner_store.workunit_records.entry(span_id.clone()) {
+      Entry::Vacant(_) => {
+        log::warn!("No previously-started workunit found for id: {}", span_id);
+      }
+      Entry::Occupied(o) => {
+        let (span_id, mut workunit) = o.remove_entry();
+        let time_span = match workunit.state {
+          WorkunitState::Completed { .. } => {
+            log::warn!("Workunit {} was already completed", span_id);
+            return;
+          }
+          WorkunitState::Started { start_time } => {
+            TimeSpan::from_start_and_end_systemtime(&start_time, &end_time)
+          }
+        };
+        let new_state = WorkunitState::Completed { time_span };
+        workunit.state = new_state;
+        if let Some(metadata) = new_metadata {
+          workunit.metadata = metadata;
+        }
+        workunit.log_workunit_state();
+        inner_store.workunit_records.insert(span_id, workunit);
+      }
+    }
+  }
+
+  fn heavy_hitters(&self, k: usize) -> HashMap<String, Option<Duration>> {
+    use petgraph::Direction;
+    let now = SystemTime::now();
+    let mut inner = self.inner.lock();
+
+    {
+      let receiver = self.msg_rx.lock();
+      while let Ok(msg) = receiver.try_recv() {
+        match msg {
+          StoreMsg::Started(started) => Self::add_started_workunit_to_store(started, &mut inner),
+          StoreMsg::Completed(span_id, new_metadata, time) => {
+            Self::add_completed_workunit_to_store(span_id, new_metadata, time, &mut inner)
+          }
+        }
+      }
+    }
+
+    let workunit_graph = &inner.graph;
+
+    let duration_for = |workunit: &Workunit| -> Option<Duration> {
+      match workunit.state {
+        WorkunitState::Started { ref start_time, .. } => now.duration_since(*start_time).ok(),
+        _ => None,
+      }
+    };
+
+    let is_visible = |workunit: &Workunit| -> bool {
+      workunit.metadata.level >= Level::Info && workunit.metadata.desc.is_some()
+    };
+
+    // Initialize the heap with the leaves of the workunit graph.
+    let mut queue: BinaryHeap<(Duration, SpanId)> = workunit_graph
+      .externals(Direction::Outgoing)
+      .map(|entry| workunit_graph[entry].clone())
+      .flat_map(|span_id: SpanId| {
+        let workunit: Option<&Workunit> = inner.workunit_records.get(&span_id);
+        match workunit {
+          Some(workunit) if !workunit.metadata.blocked => {
+            duration_for(workunit).map(|d| (d, span_id.clone()))
+          }
+          _ => None,
+        }
+      })
+      .collect();
+
+    // Output the visible parents of the longest running leaves.
+    let mut res = HashMap::new();
+    while let Some((_dur, span_id)) = queue.pop() {
+      // If the leaf is visible or has a visible parent, emit it.
+      if let Some(span_id) =
+        first_matched_parent(&inner.workunit_records, Some(span_id), is_visible)
+      {
+        let workunit = inner.workunit_records.get(&span_id).unwrap();
+        if let Some(effective_name) = workunit.metadata.desc.as_ref() {
+          let maybe_duration = duration_for(&workunit);
+
+          res.insert(effective_name.to_string(), maybe_duration);
+          if res.len() >= k {
+            break;
+          }
+        }
+      }
+    }
+    res
+  }
+}
+
+#[derive(Default)]
+pub struct HeavyHittersInnerStore {
+  graph: WorkunitGraph,
+  span_id_to_graph: HashMap<SpanId, NodeIndex<u32>>,
+  workunit_records: HashMap<SpanId, Workunit>,
+}
+
+fn first_matched_parent(
+  workunit_records: &HashMap<SpanId, Workunit>,
+  mut span_id: Option<SpanId>,
+  is_visible: impl Fn(&Workunit) -> bool,
+) -> Option<SpanId> {
+  while let Some(current_span_id) = span_id {
+    let workunit = workunit_records.get(&current_span_id);
+
+    // Is the current workunit visible?
+    if let Some(ref workunit) = workunit {
+      if is_visible(workunit) {
+        return Some(current_span_id);
+      }
+    }
+
+    // If not, try its parent.
+    span_id = workunit.and_then(|workunit| workunit.parent_id.clone());
+  }
+  None
+}
+
+impl WorkunitStore {
+  pub fn new(rendering_dynamic_ui: bool) -> WorkunitStore {
+    WorkunitStore {
+      streaming_workunit_data: StreamingWorkunitData::new(),
+      heavy_hitters_data: HeavyHittersData::new(),
+      rendering_dynamic_ui,
+    }
+  }
+
+  pub fn init_thread_state(&self, parent_id: Option<String>) {
+    set_thread_workunit_state(Some(WorkUnitState {
+      store: self.clone(),
+      parent_id,
+    }))
+  }
+
+  ///
+  /// Find the longest running leaf workunits, and render their first visible parents.
+  ///
+  pub fn heavy_hitters(&self, k: usize) -> HashMap<String, Option<Duration>> {
+    self.heavy_hitters_data.heavy_hitters(k)
+  }
+
+  pub fn start_workunit(
+    &self,
+    span_id: SpanId,
+    name: String,
+    parent_id: Option<SpanId>,
+    metadata: WorkunitMetadata,
+  ) -> SpanId {
+    let started = Workunit {
+      name,
+      span_id: span_id.clone(),
+      parent_id,
+      state: WorkunitState::Started {
+        start_time: std::time::SystemTime::now(),
+      },
+      metadata,
+    };
+    if !self.rendering_dynamic_ui {
+      started.log_workunit_state()
+    }
+
+    let sender = self.heavy_hitters_data.msg_tx.lock();
+    sender.send(StoreMsg::Started(started.clone())).unwrap();
+    let sender = self.streaming_workunit_data.msg_tx.lock();
+    sender.send(StoreMsg::Started(started)).unwrap();
+    span_id
+  }
+
+  pub fn complete_workunit_with_new_metadata(&self, span_id: SpanId, metadata: WorkunitMetadata) {
+    self.complete_workunit_impl(span_id, Some(metadata))
+  }
+
+  pub fn complete_workunit(&self, span_id: SpanId) {
+    self.complete_workunit_impl(span_id, None)
+  }
+
+  fn complete_workunit_impl(&self, span_id: SpanId, new_metadata: Option<WorkunitMetadata>) {
+    let time = std::time::SystemTime::now();
+    let tx = self.heavy_hitters_data.msg_tx.lock();
+    tx.send(StoreMsg::Completed(
+      span_id.clone(),
+      new_metadata.clone(),
+      time,
+    ))
+    .unwrap();
+
+    let tx = self.streaming_workunit_data.msg_tx.lock();
+    tx.send(StoreMsg::Completed(span_id, new_metadata, time))
+      .unwrap();
+  }
+
+  pub fn add_completed_workunit(
+    &self,
+    name: String,
+    start_time: SystemTime,
+    end_time: SystemTime,
+    parent_id: Option<SpanId>,
+    metadata: WorkunitMetadata,
+  ) {
+    let span_id = new_span_id();
+
+    let workunit = Workunit {
+      name,
+      span_id: span_id.clone(),
+      parent_id,
+      state: WorkunitState::Started { start_time },
+      metadata,
+    };
+
+    let sender = self.heavy_hitters_data.msg_tx.lock();
+    sender.send(StoreMsg::Started(workunit.clone())).unwrap();
+    sender
+      .send(StoreMsg::Completed(span_id.clone(), None, end_time))
+      .unwrap();
+
+    let sender = self.streaming_workunit_data.msg_tx.lock();
+    sender.send(StoreMsg::Started(workunit)).unwrap();
+    sender
+      .send(StoreMsg::Completed(span_id, None, end_time))
+      .unwrap();
+  }
+
+  pub fn with_latest_workunits<F, T>(&mut self, max_verbosity: log::Level, f: F) -> T
+  where
+    F: FnOnce(&[Workunit], &[Workunit]) -> T,
+  {
+    self
+      .streaming_workunit_data
+      .with_latest_workunits(max_verbosity, f)
   }
 }
 


### PR DESCRIPTION
This commit introduces a number of refactoring changes on the `WorkunitStore` struct:

- rename `WorkUnitInnerStore` to `HeavyHittersInnerStore`
- reduce the scope of a number of locks
- eliminate the separate started/completed workunit mpsc sender/receiver pairs by wrapping the data in an enum
- move some methods to structs with reduced scope