### PR TITLE
Get rid of double-workunit-completion print

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -505,7 +505,6 @@ impl WorkunitStore {
             if let Some(metadata) = new_metadata {
               workunit.metadata = metadata;
             }
-            workunit.log_workunit_state();
             workunit_records.insert(span_id.clone(), workunit.clone());
 
             if should_emit(&workunit) {


### PR DESCRIPTION
### Problem

After the refactoring of `WorkunitStore` in https://github.com/pantsbuild/pants/pull/10179 , there was an accidental duplication of the line of code that prints the workunit completion message, resulting in the completion message getting printed twice.

### Solution

Remove the superfluous call.
