### PR TITLE
remoting: check action cache for cached result before submitting a request

### DIFF
--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -9,6 +9,15 @@ impl<'a> From<&'a hashing::Digest> for crate::remote_execution::Digest {
   }
 }
 
+impl From<hashing::Digest> for crate::remote_execution::Digest {
+  fn from(d: hashing::Digest) -> Self {
+    let mut digest = super::remote_execution::Digest::new();
+    digest.set_hash(d.0.to_hex());
+    digest.set_size_bytes(d.1 as i64);
+    digest
+  }
+}
+
 impl<'a> From<&'a hashing::Digest> for crate::build::bazel::remote::execution::v2::Digest {
   fn from(d: &hashing::Digest) -> Self {
     Self {

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -117,7 +117,7 @@ impl CommandRunner {
     if let Some((execute_response, platform)) = maybe_execute_response {
       crate::remote::populate_fallible_execution_result(
         self.file_store.clone(),
-        execute_response,
+        execute_response.get_result(),
         vec![],
         platform,
       )

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -167,6 +167,12 @@ impl StreamingCommandRunner {
       .await
   }
 
+  /// Check the remote Action Cache for a cached result of running the given `action_digest`.
+  ///
+  /// This check is necessary because some RE servers do not short-circuit the Execute method
+  /// by checking the Action Cache (e.g., BuildBarn). Thus, this client must check the cache
+  /// explicitly in order to avoid duplicating already-cached work. This behavior matches
+  /// the Bazel RE client.
   async fn check_action_cache(
     &self,
     action_digest: Digest,

--- a/src/rust/engine/process_execution/src/remote/streaming.rs
+++ b/src/rust/engine/process_execution/src/remote/streaming.rs
@@ -24,6 +24,7 @@ use super::{
   format_error, maybe_add_workunit, populate_fallible_execution_result,
   populate_fallible_execution_result_for_timeout, ExecutionError, OperationOrStatus,
 };
+use crate::remote::rpcerror_to_string;
 use crate::{
   Context, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform, PlatformConstraint,
   Process, ProcessMetadata,
@@ -54,6 +55,7 @@ pub struct StreamingCommandRunner {
   channel: grpcio::Channel,
   env: Arc<grpcio::Environment>,
   execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
+  action_cache_client: Arc<bazel_protos::remote_execution_grpc::ActionCacheClient>,
   overall_deadline: Duration,
   capabilities_cell: Arc<DoubleCheckedCell<bazel_protos::remote_execution::ServerCapabilities>>,
   capabilities_client: Arc<bazel_protos::remote_execution_grpc::CapabilitiesClient>,
@@ -91,6 +93,9 @@ impl StreamingCommandRunner {
     let execution_client = Arc::new(bazel_protos::remote_execution_grpc::ExecutionClient::new(
       channel.clone(),
     ));
+    let action_cache_client = Arc::new(
+      bazel_protos::remote_execution_grpc::ActionCacheClient::new(channel.clone()),
+    );
 
     let mut headers = headers;
     if let Some(oauth_bearer_token) = oauth_bearer_token {
@@ -112,6 +117,7 @@ impl StreamingCommandRunner {
       channel,
       env,
       execution_client,
+      action_cache_client,
       store,
       platform,
       overall_deadline,
@@ -161,24 +167,75 @@ impl StreamingCommandRunner {
       .await
   }
 
-  async fn ensure_action_uploaded(
+  async fn check_action_cache(
     &self,
-    store: &Store,
+    action_digest: Digest,
+    metadata: &ProcessMetadata,
+    context: &Context,
+  ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
+    let mut request = bazel_protos::remote_execution::GetActionResultRequest::new();
+    if let Some(ref instance_name) = metadata.instance_name {
+      request.set_instance_name(instance_name.clone());
+    }
+    request.set_action_digest(action_digest.into());
+
+    let call_opt = call_option(&self.headers, Some(context.build_id.clone()))?;
+
+    let action_result_response = self
+      .action_cache_client
+      .get_action_result_async_opt(&request, call_opt)
+      .unwrap()
+      .compat()
+      .await;
+
+    match action_result_response {
+      Ok(action_result) => {
+        let response = populate_fallible_execution_result(
+          self.store.clone(),
+          &action_result,
+          vec![],
+          self.platform,
+        )
+        .compat()
+        .await?;
+        Ok(Some(response))
+      }
+      Err(err) => match err {
+        grpcio::Error::RpcFailure(rpc_status)
+          if rpc_status.status == grpcio::RpcStatusCode::NOT_FOUND =>
+        {
+          Ok(None)
+        }
+        _ => Err(rpcerror_to_string(err)),
+      },
+    }
+  }
+
+  async fn ensure_action_stored_locally(
+    &self,
     command: &Command,
     action: &Action,
-    input_files: Digest,
-  ) -> Result<(), String> {
+  ) -> Result<(Digest, Digest), String> {
     let (command_digest, action_digest) = future03::try_join(
       self.store_proto_locally(command),
       self.store_proto_locally(action),
     )
     .await?;
 
+    Ok((command_digest, action_digest))
+  }
+
+  async fn ensure_action_uploaded(
+    &self,
+    store: &Store,
+    command_digest: Digest,
+    action_digest: Digest,
+    input_files: Digest,
+  ) -> Result<(), String> {
     let _ = store
       .ensure_remote_has_recursive(vec![command_digest, action_digest, input_files])
       .compat()
       .await?;
-
     Ok(())
   }
 
@@ -410,7 +467,7 @@ impl StreamingCommandRunner {
           return Ok(
             populate_fallible_execution_result(
               self.store.clone(),
-              execute_response,
+              execute_response.get_result(),
               vec![],
               self.platform,
             )
@@ -641,12 +698,36 @@ impl crate::CommandRunner for StreamingCommandRunner {
     // deadline for execution of this request.
     let deadline_duration = self.overall_deadline + request.timeout.unwrap_or_default();
 
+    // Ensure the action and command are stored locally.
+    let (command_digest, action_digest) = with_workunit(
+      context.workunit_store.clone(),
+      "ensure_action_stored_locally".to_owned(),
+      WorkunitMetadata::with_level(Level::Debug),
+      self.ensure_action_stored_locally(&command, &action),
+      |_, md| md,
+    )
+    .await?;
+
+    // Check the remote Action Cache to see if this request was already computed.
+    // If so, return immediately with the result.
+    let cached_response_opt = with_workunit(
+      context.workunit_store.clone(),
+      "check_action_cache".to_owned(),
+      WorkunitMetadata::with_level(Level::Debug),
+      self.check_action_cache(action_digest, &self.metadata, &context),
+      |_, md| md,
+    )
+    .await?;
+    if let Some(cached_response) = cached_response_opt {
+      return Ok(cached_response);
+    }
+
     // Upload the action (and related data, i.e. the embedded command and input files).
     with_workunit(
       context.workunit_store.clone(),
       "ensure_action_uploaded".to_owned(),
       WorkunitMetadata::with_level(Level::Debug),
-      self.ensure_action_uploaded(&store, &command, &action, request.input_files),
+      self.ensure_action_uploaded(&store, command_digest, action_digest, request.input_files),
       |_, md| md,
     )
     .await?;

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -12,8 +12,8 @@ use futures::compat::{Future01CompatExt, Sink01CompatExt};
 use futures::future::{FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use grpcio::RpcStatus;
-use parking_lot::Mutex;
 use hashing::Digest;
+use parking_lot::Mutex;
 
 ///
 /// Represents an expected API call from the REv2 client. The data carried by each enum
@@ -36,7 +36,7 @@ pub enum ExpectedAPICall {
   GetActionResult {
     action_digest: Digest,
     response: Result<bazel_protos::remote_execution::ActionResult, grpcio::RpcStatus>,
-  }
+  },
 }
 
 ///
@@ -484,16 +484,19 @@ impl bazel_protos::remote_execution_grpc::ActionCache for MockResponder {
       Some(ExpectedAPICall::GetActionResult {
         action_digest,
         response,
-         }) => {
+      }) => {
         let action_digest_from_request: Digest = match req.get_action_digest().try_into() {
           Ok(d) => d,
           Err(e) => {
             sink.fail(grpcio::RpcStatus::new(
               grpcio::RpcStatusCode::INVALID_ARGUMENT,
-              Some(format!("GetActionResult endpoint called with bad digest: {:?}", e,)),
+              Some(format!(
+                "GetActionResult endpoint called with bad digest: {:?}",
+                e,
+              )),
             ));
             return;
-          },
+          }
         };
 
         if action_digest_from_request == action_digest {
@@ -507,7 +510,8 @@ impl bazel_protos::remote_execution_grpc::ActionCache for MockResponder {
             grpcio::RpcStatusCode::INVALID_ARGUMENT,
             Some(format!(
               "Did not expect request with this action digest. Expected: {:?}, Got: {:?}",
-              action_digest, req.get_action_digest()
+              action_digest,
+              req.get_action_digest()
             )),
           ));
         }
@@ -516,7 +520,10 @@ impl bazel_protos::remote_execution_grpc::ActionCache for MockResponder {
       Some(api_call) => {
         error_to_send = Some(grpcio::RpcStatus::new(
           grpcio::RpcStatusCode::INVALID_ARGUMENT,
-          Some(format!("GetActionResult endpoint called. Expected: {:?}", api_call,)),
+          Some(format!(
+            "GetActionResult endpoint called. Expected: {:?}",
+            api_call,
+          )),
         ));
       }
 


### PR DESCRIPTION
### Problem

The REv2 specification does not explicitly require servers to return cached results from the [`Execute` method of the `Execution` service](https://github.com/bazelbuild/remote-apis/blob/0afc3700d177bb37ed48438fb50d8bc7f4872874/build/bazel/remote/execution/v2/remote_execution.proto#L107). The specification hints that servers might do so, but stops short of actually mandating it, [stating that](https://github.com/bazelbuild/remote-apis/blob/0afc3700d177bb37ed48438fb50d8bc7f4872874/build/bazel/remote/execution/v2/remote_execution.proto#L377-L387): 

> When a server completes execution of an Action, it MAY choose to cache the result in the ActionCache unless `do_not_cache` is `true`. Clients SHOULD expect the server to do so. By default, future calls to Execute the same `Action` will also serve their results from the cache. Clients must take care to understand the caching behaviour.

The RE client in Pants does not currently call `GetActionResult` to check for cached results before submitting an execution request. This is not problematic if the server checks the cache and short-circuits `Execute` calls with any cached results. This may be the case for RBE, but is intentionally not the case for BuildBarn. Bazel always calls `GetActionResult`, and so the BuildBarn team determined it to be duplicative to have `Execute` also check the cache a second time (which would negatively impact performance). (I have not audited what Buildgrid and Buildfarm do.) See discussion at https://buildteamworld.slack.com/archives/CD6HZC750/p1593720268111500.

Thus, at least when submitting work to BuildBarn, Pants will not take advantage of the Action Cache and the server will redo work that has already been performed and stored in the Action Cache.

### Solution

Pants should call `GetActionResult` to check for a cached result before it attempts to upload and submit the `Action` and `Command` protos for execution.

Testing: The test framework's mock server now answers `GetActionResult` requests. The new test `successful_served_from_action_cache` tests that Pants checks the Action Cache first. (The other unit tests handle the fact that GetActionResult calls are made, but assume nothing was cached.)

### Result

I used an early iteration of this PR to run tests of Toolchain's internal repo against BuildBarn. With this PR, the second run is cached and completes in about a minute. Without this PR, that run actually submits execution requests and duplicates work with a significant impact on build performance.
