### PR TITLE
Upgrade setuptools from 47.3.1 to 49.1.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -27,7 +27,7 @@ py_zipkin==0.20.0
 requests[security]>=2.20.1
 responses==0.10.15
 setproctitle==1.1.10
-setuptools==47.3.1
+setuptools==49.1.0
 toml==0.10.1
 typed-ast>=1.4.1,<1.5
 typing-extensions==3.7.4.2

--- a/pants.toml
+++ b/pants.toml
@@ -112,9 +112,6 @@ branch_notes = """
 
 [pytest]
 pytest_plugins.add = [
-  # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
-  #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
-  "setuptools==49.1.0",
   "ipdb",
   "pytest-icdiff",
   "pygments",

--- a/pants.toml
+++ b/pants.toml
@@ -114,7 +114,7 @@ branch_notes = """
 pytest_plugins.add = [
   # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
   #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
-  "setuptools==47.3.1",
+  "setuptools==49.1.0",
   "ipdb",
   "pytest-icdiff",
   "pygments",

--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -9,5 +9,5 @@ class Lambdex(PythonToolBase):
     default_version = "lambdex==0.1.3"
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.
-    default_extra_requirements = ["setuptools==47.3.1"]
+    default_extra_requirements = ["setuptools==49.1.0"]
     default_entry_point = "lambdex.bin.lambdex"

--- a/src/python/pants/backend/python/rules/setuptools.py
+++ b/src/python/pants/backend/python/rules/setuptools.py
@@ -8,5 +8,5 @@ class Setuptools(PythonToolBase):
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
     options_scope = "setuptools"
-    default_version = "setuptools==42.0.2"
+    default_version = "setuptools==49.1.0"
     default_extra_requirements = ["wheel==0.31.1"]


### PR DESCRIPTION
https://github.com/pypa/setuptools/blob/master/CHANGES.rst


v49.1.0
-------

* #2228: Disabled distutils adoption for now while emergent issues are addressed.


v49.0.0
-------

* #2165: Setuptools no longer installs a site.py file during easy_install or develop installs. As a result, .eggs on PYTHONPATH will no longer take precedence over other packages on sys.path. If this issue affects your production environment, please reach out to the maintainers at #2165.
* #2137: Removed (private) pkg_resources.RequirementParseError, now replaced by packaging.requirements.InvalidRequirement. Kept the name for compatibility, but users should catch InvalidRequirement instead.
* #2180: Update vendored packaging in pkg_resources to 19.2.
* #2199: Fix exception causes all over the codebase by using ``raise new_exception from old_exception``


v48.0.0
-------

* #2143: Setuptools adopts distutils from the Python 3.9 standard library and no longer depends on distutils in the standard library. When importing ``setuptools`` or ``setuptools.distutils_patch``, Setuptools will expose its bundled version as a top-level ``distutils`` package (and unload any previously-imported top-level distutils package), retaining the expectation that ``distutils``' objects are actually Setuptools objects.
  To avoid getting any legacy behavior from the standard library, projects are advised to always "import setuptools" prior to importing anything from distutils. This behavior happens by default when using ``pip install`` or ``pep517.build``. Workflows that rely on ``setup.py (anything)`` will need to first ensure setuptools is imported. One way to achieve this behavior without modifying code is to invoke Python thus: ``python -c "import setuptools; exec(open('setup.py').read())" (anything)``.


v47.3.2
-------

* #2071: Replaced references to the deprecated imp package with references to importlib