### PR TITLE
Upgrade packaging from 20.3 to 20.4

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ fasteners==0.15.0
 #
 mypy==0.781
 
-packaging==20.3
+packaging==20.4
 pathspec==0.8.0
 pex==2.1.12
 psutil==5.7.0


### PR DESCRIPTION
https://github.com/pypa/packaging/blob/master/CHANGELOG.rst


20.4 - 2020-05-19
~~~~~~~~~~~~~~~~~

* Canonicalize version before comparing specifiers. (:issue:`282`)
* Change type hint for ``canonicalize_name`` to return
  ``packaging.utils.NormalizedName``.
  This enables the use of static typing tools (like mypy) to detect mixing of
  normalized and un-normalized names.