### PR TITLE
Upgrade responses from 0.10.14 to  0.10.15

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,7 +25,7 @@ python-Levenshtein==0.12.0
 PyYAML>=5.3.1,<5.4
 py_zipkin==0.20.0
 requests[security]>=2.20.1
-responses==0.10.14
+responses==0.10.15
 setproctitle==1.1.10
 setuptools==47.3.1
 toml==0.10.1


### PR DESCRIPTION
https://github.com/getsentry/responses/blob/master/CHANGES

0.10.15
-------

- Added `assert_call_count` to improve ergonomics around ensuring a mock was called.
- Fix incorrect handling of paths with query strings.
- Add Python 3.9 support to CI matrix.