### PR TITLE
Fix busted integration test

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -159,7 +159,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
     def test_uses_correct_python_version(self) -> None:
         py2_args = [
             "--pylint-version=pylint<2",
-            "--pylint-extra-requirements=setuptools<45",
+            "--pylint-extra-requirements=['setuptools<45', 'isort>=4.3.21,<4.4']",
         ]
         py2_target = self.make_target_with_origin(
             [self.py3_only_source], name="py2", interpreter_constraints="CPython==2.7.*"


### PR DESCRIPTION


### Problem

Integration test is busted due to the release of a new version of iSort (5.x) which breaks existing isort APIs
<img width="1200" alt="Screenshot 2020-07-05 12 38 56" src="https://user-images.githubusercontent.com/1268088/86540845-a899c400-bebc-11ea-967c-084bbdeeedb9.png">
This repos locally on current master by running:
`/v2 test src/python/pants/backend/python/lint/pylint:integration`

### Solution

Put a constraint on isort version used in this test


### Result

Fixed tests, passing builds.