### PR TITLE
remoting: make streaming client the default

### DIFF
--- a/pants.remote.toml
+++ b/pants.remote.toml
@@ -23,9 +23,6 @@ remote_execution_extra_platform_properties = [
   "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:ec94526d1aa0604b7f693a0b1fb224ca7822a0d821ce20dff50ec808cad597b6",
 ]
 
-# Enable the REv2 streaming client.
-remote_execution_enable_streaming = true
-
 # This should correspond to the number of workers running in Google RBE. See
 # https://console.cloud.google.com/apis/api/remotebuildexecution.googleapis.com/quotas?project=pants-remoting-beta&folder&organizationId&duration=PT6H.
 process_execution_remote_parallelism = 32

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -138,7 +138,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
-    remote_execution_enable_streaming=False,
+    remote_execution_enable_streaming=True,
     remote_execution_overall_deadline_secs=60 * 60,  # one hour
     process_execution_local_enable_nailgun=False,
 )
@@ -781,9 +781,9 @@ class GlobalOptions(Subsystem):
         register(
             "--remote-execution-enable-streaming",
             type=bool,
-            default=False,
+            default=DEFAULT_EXECUTION_OPTIONS.remote_execution_enable_streaming,
             advanced=True,
-            help="Enable the streaming remote execution client (experimental).",
+            help="Enable the streaming remote execution client.",
         )
         register(
             "--remote-execution-overall-deadline-secs",


### PR DESCRIPTION
### Problem

The streaming RE client is not the default. It has been enabled in CI for a few weeks now. New development is happening in the streaming client and not in the polling client. Time to make the streaming RE client the default.

### Solution

Set the streaming RE client as the default.

### Result

Nothing should break.
