### PR TITLE
Temporarily disable remote execution in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -278,7 +278,7 @@ jobs:
     - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
       --githooks --smoke-tests --python-version 3.6
     - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
-      --remote-execution-enabled --lint --python-version 3.6
+      --lint --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -340,7 +340,7 @@ jobs:
     - travis-wait-enhanced --timeout 50m --interval 9m -- ./build-support/bin/ci.py
       --githooks --smoke-tests --python-version 3.7
     - travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py
-      --remote-execution-enabled --lint --python-version 3.7
+      --lint --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - before_cache:
@@ -433,7 +433,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --remote-execution-enabled --python-version 3.6
+      --unit-tests --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -493,7 +493,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --remote-execution-enabled --python-version 3.7
+      --unit-tests --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -542,9 +542,9 @@ jobs:
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v2.py36
+    - CACHE_NAME=integration.py36
     language: python
-    name: Integration tests - V2 (Python 3.6)
+    name: Integration tests (Python 3.6)
     os: linux
     python:
     - '2.7'
@@ -552,7 +552,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests --remote-execution-enabled --python-version 3.6
+      --integration-tests --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -602,9 +602,9 @@ jobs:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.v2.py37
+    - CACHE_NAME=integration.py37
     language: python
-    name: Integration tests - V2 (Python 3.7)
+    name: Integration tests (Python 3.7)
     os: linux
     python:
     - '2.7'
@@ -612,7 +612,7 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests --remote-execution-enabled --python-version 3.7
+      --integration-tests --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - before_cache:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -510,7 +510,7 @@ def lint(python_version: PythonVersion) -> Dict:
             # local execution has finished.
             (
                 "travis-wait-enhanced --timeout 40m --interval 9m -- ./build-support/bin/ci.py "
-                f"--remote-execution-enabled --lint --python-version {python_version.decimal}"
+                f"--lint --python-version {python_version.decimal}"
             ),
         ],
     }
@@ -557,7 +557,7 @@ def unit_tests(python_version: PythonVersion) -> Dict:
         "name": f"Unit tests (Python {python_version.decimal})",
         "script": [
             "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
-            f"--unit-tests --remote-execution-enabled --python-version {python_version.decimal}"
+            f"--unit-tests --python-version {python_version.decimal}"
         ],
     }
     safe_append(shard, "env", f"CACHE_NAME=unit_tests.py{python_version.number}")
@@ -618,16 +618,15 @@ def build_wheels_osx() -> Dict:
 def integration_tests(python_version: PythonVersion) -> Dict:
     shard = {
         **linux_shard(python_version=python_version, install_travis_wait=True),
-        "name": f"Integration tests - V2 (Python {python_version.decimal})",
+        "name": f"Integration tests (Python {python_version.decimal})",
         "script": [
             (
                 "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
-                "--integration-tests --remote-execution-enabled --python-version "
-                f"{python_version.decimal}"
+                f"--integration-tests --python-version {python_version.decimal}"
             ),
         ],
     }
-    safe_append(shard, "env", f"CACHE_NAME=integration.v2.py{python_version.number}")
+    safe_append(shard, "env", f"CACHE_NAME=integration.py{python_version.number}")
     return shard
 
 

--- a/pants.travis-ci.toml
+++ b/pants.travis-ci.toml
@@ -15,5 +15,8 @@ dynamic_ui = false
 # now in order to smooth off rough edges locally.
 pantsd = false
 
+process_execution_local_parallelism = "%(travis_parallelism)s"
+
 [python-setup]
-resolver_jobs = "%(travis_parallelism)s"
+# TODO: See https://github.com/pantsbuild/pants/issues/9964
+resolver_jobs = 2

--- a/src/python/pants/backend/project_info/BUILD
+++ b/src/python/pants/backend/project_info/BUILD
@@ -41,4 +41,5 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/util:ordered_set',
   ],
+  timeout = 90,
 )

--- a/src/python/pants/backend/python/lint/bandit/BUILD
+++ b/src/python/pants/backend/python/lint/bandit/BUILD
@@ -38,5 +38,5 @@ python_tests(
     'src/python/pants/testutil/subsystem',
   ],
   tags = ['integration'],
-  timeout = 180,
+  timeout = 240,
 )

--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -38,4 +38,5 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = ['integration'],
+  timeout = 120,
 )

--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -37,5 +37,5 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = ['integration'],
-  timeout = 120,
+  timeout = 180,
 )

--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -38,4 +38,5 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = ['integration'],
+  timeout = 120,
 )

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -56,6 +56,7 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
   ],
+  timeout = 90,
 )
 
 

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -56,7 +56,7 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
   ],
-  timeout = 90,
+  timeout = 180,
 )
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -37,5 +37,5 @@ python_tests(
     'src/python/pants/testutil/option',
   ],
   tags = ['integration'],
-  timeout = 120,
+  timeout = 180,
 )

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -26,7 +26,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:logging',
   ],
-  timeout = 180,
+  timeout = 240,
 )
 
 python_tests(


### PR DESCRIPTION
Our Google Cloud credentials stopped working. We will want to re-enable this either once we get RBE working again or we switch to using Toolchain's remote execution service.

Additionally, delete an aspect of `pantsd` testing that was not properly isolated, and was thus racey when run locally. Fixes #7621.

[ci skip-rust-tests]