### PR TITLE
Fix bug where workunit completion was not reported correctly

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
 name = "concrete_time"
 version = "0.0.1"
 dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 serde_derive = "1.0.98"
 serde = "1.0.98"
+log = "0.4"

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -102,7 +102,14 @@ impl TimeSpan {
     end: &std::time::SystemTime,
   ) -> TimeSpan {
     let start = Self::since_epoch(start);
-    let duration = Self::since_epoch(end) - start;
+    let end = Self::since_epoch(end);
+    let duration = match end.checked_sub(start) {
+      Some(d) => d,
+      None => {
+        log::warn!("Invalid TimeSpan - start: {:?}, end: {:?}", start, end);
+        std::time::Duration::new(0, 0)
+      }
+    };
     TimeSpan {
       start: start.into(),
       duration: duration.into(),

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -26,7 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-#![type_length_limit = "1303884"]
+#![type_length_limit = "1303889"]
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -75,5 +75,6 @@ python_integration_tests(
   name = 'log_output_integration',
   sources = ['log_output_integration_test.py'],
   uses_pants_run=True,
+  timeout = 180,
 )
 

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -70,3 +70,14 @@ python_integration_tests(
   sources = ['test_prelude_integration.py'],
   uses_pants_run=True,
 )
+
+python_tests(
+  name = 'log_output_integration',
+  sources = [ 'log_output_integration_test.py' ],
+  dependencies = [
+    'src/python/pants/engine/internals:tests',
+    'src/python/pants/testutil:int-test',
+  ],
+  tags = ['integration'],
+)
+

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -71,13 +71,9 @@ python_integration_tests(
   uses_pants_run=True,
 )
 
-python_tests(
+python_integration_tests(
   name = 'log_output_integration',
-  sources = [ 'log_output_integration_test.py' ],
-  dependencies = [
-    'src/python/pants/engine/internals:tests',
-    'src/python/pants/testutil:int-test',
-  ],
-  tags = ['integration'],
+  sources = ['log_output_integration_test.py'],
+  uses_pants_run=True,
 )
 

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -40,7 +40,7 @@ class LogOutputIntegrationTest(PantsRunIntegrationTest):
 
         return tmpdir_relative
 
-    def test_completed_log_output(self):
+    def test_completed_log_output(self) -> None:
         build_root = get_buildroot()
         with temporary_dir(root_dir=build_root) as tmpdir:
             tmpdir_relative = self._prepare_sources(tmpdir, build_root)

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import Path
+from textwrap import dedent
+
+from pants.base.build_environment import get_buildroot
+from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+from pants.util.contextutil import temporary_dir
+
+
+class LogOutputIntegrationTest(PantsRunIntegrationTest):
+    def _prepare_sources(self, tmpdir: str, build_root: str) -> Path:
+        tmpdir_relative = Path(tmpdir).relative_to(build_root)
+        src_root = Path(tmpdir, "src", "python", "project")
+        src_root.mkdir(parents=True)
+        (src_root / "__init__.py").touch()
+
+        (src_root / "fake_test.py").write_text(
+            dedent(
+                """\
+
+                def fake_test():
+                    assert 1 == 2
+                """
+            )
+        )
+
+        (src_root / "BUILD").write_text(
+            dedent(
+                """\
+                python_tests(
+                    name="fake",
+                    sources=["fake_test.py"],
+                    dependencies=[],
+                )
+                """
+            )
+        )
+
+        return tmpdir_relative
+
+    def test_completed_log_output(self):
+        build_root = get_buildroot()
+        with temporary_dir(root_dir=build_root) as tmpdir:
+            tmpdir_relative = self._prepare_sources(tmpdir, build_root)
+
+            test_run_result = self.run_pants(
+                ["--no-dynamic-ui", "test", f"{tmpdir_relative}/src/python/project:fake"]
+            )
+
+            assert "[INFO] Starting: Run Pytest for" in test_run_result.stderr_data
+            assert "[INFO] Completed: Run Pytest for" in test_run_result.stderr_data


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/pull/10179 had the effect of changing the architecture of the workunit store so that when workunits were started and completed, the methods responsible for these tasks would push them onto a mpsc queue, and they would only actually be added to the store when one of the methods that handed them pulled the workunits off the queue. This is fine when the dynamic UI is running, because the `heavy_hitters` method will be running constantly, and therefore logging workunit completion messages. However, in the `--no-dynamic-ui` case, `heavy_hitters` doesn't run, and therefore nothing handles the workunits on the queue, 

### Solution

The workunit store is already aware of whether the dynamic UI is running or not, so this commit has the workunit completion method check this flag. If it's set, we send workunits over the mpsc queue, and expect them to be added to the store (a locking operation) by `heavy_hitters`, which needs to grab the lock anyway. When the dynamic UI is not running, the workunit add method doesn't use the heavy hitters mpsc queue at all, and just emits the display message for the workunit completion. Additionally, a new integration test is added to test that these workunit completion log messages get printed.


### Result

Fixes https://github.com/pantsbuild/pants/issues/10274