### PR TITLE
Use colors in log messages

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -124,8 +124,8 @@ class Native(metaclass=SingletonMetaclass):
     def decompress_tarball(self, tarfile_path, dest_dir):
         return self.lib.decompress_tarball(tarfile_path, dest_dir)
 
-    def init_rust_logging(self, level, log_show_rust_3rdparty):
-        return self.lib.init_logging(level, log_show_rust_3rdparty)
+    def init_rust_logging(self, level, log_show_rust_3rdparty: bool, use_color: bool):
+        return self.lib.init_logging(level, log_show_rust_3rdparty, use_color)
 
     def setup_pantsd_logger(self, log_file_path, level):
         return self.lib.setup_pantsd_logger(log_file_path, level)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -22,8 +22,8 @@ logging.addLevelName(logging.WARNING, "WARN")
 logging.addLevelName(pants_logging.TRACE, "TRACE")
 
 
-def init_rust_logger(log_level: LogLevel, log_show_rust_3rdparty: bool) -> None:
-    Native().init_rust_logging(log_level.level, log_show_rust_3rdparty)
+def init_rust_logger(log_level: LogLevel, log_show_rust_3rdparty: bool, use_color: bool) -> None:
+    Native().init_rust_logging(log_level.level, log_show_rust_3rdparty, use_color)
 
 
 class NativeHandler(StreamHandler):
@@ -131,7 +131,10 @@ def setup_logging(global_bootstrap_options):
     level = LogLevel.ERROR if getattr(global_bootstrap_options, "quiet", False) else global_level
     log_dir = global_bootstrap_options.logdir
 
-    Native().init_rust_logging(level.level, global_bootstrap_options.log_show_rust_3rdparty)
+    log_show_rust_3rdparty = global_bootstrap_options.log_show_rust_3rdparty
+    use_color = global_bootstrap_options.colors
+
+    init_rust_logger(level, log_show_rust_3rdparty, use_color)
     setup_logging_to_stderr(level, warnings_filter_regexes=ignores)
     if log_dir:
         setup_logging_to_file(global_level, log_dir=log_dir, warnings_filter_regexes=ignores)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -182,6 +182,13 @@ class GlobalOptions(Subsystem):
         )
 
         register(
+            "--colors",
+            type=bool,
+            default=sys.stdout.isatty(),
+            help="Set whether log messages are displayed in color.",
+        )
+
+        register(
             "--v1",
             advanced=True,
             type=bool,
@@ -859,13 +866,6 @@ class GlobalOptions(Subsystem):
         # won't choke on them on the command line, and also so we can access their values as regular
         # global-scope options, for convenience.
         cls.register_bootstrap_options(register)
-
-        register(
-            "--colors",
-            type=bool,
-            default=sys.stdout.isatty(),
-            help="Set whether log messages are displayed in color.",
-        )
 
         register(
             "--tag",

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -210,7 +210,8 @@ class PantsDaemon(PantsDaemonProcessManager):
         # for further forks.
         with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
             # Reinitialize logging for the daemon context.
-            init_rust_logger(self._log_level, self._log_show_rust_3rdparty)
+            use_color = self._bootstrap_options.for_global_scope().colors
+            init_rust_logger(self._log_level, self._log_show_rust_3rdparty, use_color=use_color)
 
             level = self._log_level
             ignores = self._bootstrap_options.for_global_scope().ignore_pants_warnings

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -367,6 +367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "concrete_time"
 version = "0.0.1"
 dependencies = [
@@ -1430,6 +1440,7 @@ version = "0.0.1"
 dependencies = [
  "cargo_metadata 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1636,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "notify"
 version = "5.0.0-pre.3"
-source = "git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1#0a2d91ca36b5c1162736e87f0b238529374641f1"
+source = "git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc#64880f0662db2b5ecbf25f1cccdca64bb8fac1bc"
 dependencies = [
  "anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3361,7 +3372,7 @@ dependencies = [
  "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
- "notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1)",
+ "notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3517,6 +3528,7 @@ dependencies = [
 "checksum cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf02acd61125952ee148207cd411f9b73c9e218eab4b901375a82e1a443b6238"
+"checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 "checksum console 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
@@ -3635,7 +3647,7 @@ dependencies = [
 "checksum nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "730beff5b62ab70260d375993bc1ed6f23fce54ee4ede3d95e2ac93545443c6b"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
-"checksum notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1)" = "<none>"
+"checksum notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc)" = "<none>"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+colored = "1.9.0"
 chrono = "0.4.10"
 lazy_static = "1"
 log = "0.4"

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -83,7 +83,7 @@ py_module_initializer!(native_engine, |py, m| {
   m.add(
     py,
     "init_logging",
-    py_fn!(py, init_logging(a: u64, b: bool)),
+    py_fn!(py, init_logging(a: u64, b: bool, c: bool)),
   )?;
   m.add(
     py,
@@ -1659,8 +1659,13 @@ fn materialize_directories(
   })
 }
 
-fn init_logging(_: Python, level: u64, show_rust_3rdparty_logs: bool) -> PyUnitResult {
-  Logger::init(level, show_rust_3rdparty_logs);
+fn init_logging(
+  _: Python,
+  level: u64,
+  show_rust_3rdparty_logs: bool,
+  use_color: bool,
+) -> PyUnitResult {
+  Logger::init(level, show_rust_3rdparty_logs, use_color);
   Ok(None)
 }
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -26,6 +26,7 @@ class LoggingTest(TestBase):
             # verbosity as necessary.
             level=LogLevel.ERROR.level,
             log_show_rust_3rdparty=False,
+            use_color=False,
         )
 
     @contextmanager


### PR DESCRIPTION
### Problem

We would like the logging output of pants to be friendlier by using color judiciously.

### Solution

This commit adds text coloring and styling to the output of log messages if the `--colors` global option is set. To avoid overwhelming the screen with color, we only apply color to the bracketed log level signifier (e.g. `[INFO]`, `[DEBUG]`), except in the case of ERROR-level log messages, where we display all the text in red. The color scheme used is:

TRACE - magenta
DEBUG - green
INFO - default color,
WARN - red
ERROR - red