### PR TITLE
Improvements and refactoring of help system.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -17,6 +17,7 @@ from pants.engine.internals.native import Native
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.unions import UnionMembership
 from pants.goal.run_tracker import RunTracker
+from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.help.help_printer import HelpPrinter
 from pants.init.engine_initializer import (
     EngineInitializer,
@@ -275,8 +276,15 @@ class LocalPantsRunner:
             )
 
             if self.options.help_request:
+                all_help_info = HelpInfoExtracter.get_all_help_info(
+                    self.options,
+                    self.union_membership,
+                    self.graph_session.goal_consumed_subsystem_scopes,
+                )
                 help_printer = HelpPrinter(
-                    options=self.options, union_membership=self.union_membership
+                    bin_name=self.options.for_global_scope().pants_bin_name,
+                    help_request=self.options.help_request,
+                    all_help_info=all_help_info,
                 )
                 return help_printer.print_help()
 

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -6,14 +6,11 @@ from typing import List
 
 from colors import cyan, green, magenta, red
 
-from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
+from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo
 
 
 class HelpFormatter:
-    def __init__(
-        self, *, scope: str, show_advanced: bool, show_deprecated: bool, color: bool
-    ) -> None:
-        self._scope = scope
+    def __init__(self, *, show_advanced: bool, show_deprecated: bool, color: bool) -> None:
         self._show_advanced = show_advanced
         self._show_deprecated = show_deprecated
         self._color = color
@@ -33,28 +30,21 @@ class HelpFormatter:
     def _maybe_color(self, color, s):
         return color(s) if self._color else s
 
-    def format_options(self, scope, description, option_registrations_iter):
-        """Return a help message for the specified options.
-
-        :param scope: The options scope.
-        :param description: The description of the scope.
-        :param option_registrations_iter: An iterator over (args, kwargs) pairs, as passed in to
-                                          options registration.
-        """
-        oshi = HelpInfoExtracter(self._scope).get_option_scope_help_info(option_registrations_iter)
+    def format_options(self, oshi: OptionScopeHelpInfo):
+        """Return a help message for the specified options."""
         lines = []
 
         def add_option(ohis, *, category=None):
             lines.append("")
-            display_scope = f"`{scope}`" if scope else "Global"
+            display_scope = f"`{oshi.scope}`" if oshi.scope else "Global"
             if category:
                 title = f"{display_scope} {category} options"
                 lines.append(self._maybe_green(f"{title}\n{'-' * len(title)}"))
             else:
                 title = f"{display_scope} options"
                 lines.append(self._maybe_green(f"{title}\n{'-' * len(title)}"))
-                if description:
-                    lines.append(f"\n{description}")
+                if oshi.description:
+                    lines.append(f"\n{oshi.description}")
             lines.append(" ")
             if not ohis:
                 lines.append("No options available.")

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -5,19 +5,20 @@ import unittest
 from dataclasses import replace
 
 from pants.help.help_formatter import HelpFormatter
-from pants.help.help_info_extracter import OptionHelpInfo
+from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
 
 
 class OptionHelpFormatterTest(unittest.TestCase):
-    def format_help_for_foo(self, **kwargs):
+    @staticmethod
+    def _format_for_single_option(**kwargs):
         ohi = OptionHelpInfo(
-            registering_class=type(None),
-            display_args=["--foo"],
+            display_args=("--foo",),
             comma_separated_display_args="--foo",
-            scoped_cmd_line_args=["--foo"],
-            unscoped_cmd_line_args=["--foo"],
+            scoped_cmd_line_args=tuple("--foo",),
+            unscoped_cmd_line_args=tuple("--foo",),
             typ=bool,
             default=None,
+            default_str="None",
             help="help for foo",
             deprecated_message=None,
             removal_version=None,
@@ -26,44 +27,43 @@ class OptionHelpFormatterTest(unittest.TestCase):
         )
         ohi = replace(ohi, **kwargs)
         lines = HelpFormatter(
-            scope="", show_advanced=False, show_deprecated=False, color=False
+            show_advanced=False, show_deprecated=False, color=False
         ).format_option(ohi)
         assert len(lines) == 3
         assert "help for foo" in lines[2]
         return lines[1]
 
     def test_format_help(self):
-        default_line = self.format_help_for_foo(default="MYDEFAULT")
+        default_line = self._format_for_single_option(default="MYDEFAULT")
         assert default_line.lstrip() == "default: MYDEFAULT"
 
     def test_format_help_choices(self):
-        default_line = self.format_help_for_foo(
+        default_line = self._format_for_single_option(
             typ=str, default="kiwi", choices="apple, banana, kiwi"
         )
         assert default_line.lstrip() == "one of: [apple, banana, kiwi]; default: kiwi"
 
+    @staticmethod
+    def _format_for_global_scope(show_advanced, show_deprecated, args, kwargs):
+        oshi = HelpInfoExtracter("").get_option_scope_help_info("", [(args, kwargs)])
+        return HelpFormatter(
+            show_advanced=show_advanced, show_deprecated=show_deprecated, color=False
+        ).format_options(oshi)
+
     def test_suppress_advanced(self):
         args = ["--foo"]
         kwargs = {"advanced": True}
-        lines = HelpFormatter(
-            scope="", show_advanced=False, show_deprecated=False, color=False
-        ).format_options(scope="", description="", option_registrations_iter=[(args, kwargs)])
+        lines = self._format_for_global_scope(False, False, args, kwargs)
         assert len(lines) == 5
         assert not any("--foo" in line for line in lines)
-        lines = HelpFormatter(
-            scope="", show_advanced=True, show_deprecated=False, color=False
-        ).format_options(scope="", description="", option_registrations_iter=[(args, kwargs)])
+        lines = self._format_for_global_scope(True, False, args, kwargs)
         assert len(lines) == 12
 
     def test_suppress_deprecated(self):
         args = ["--foo"]
         kwargs = {"removal_version": "33.44.55"}
-        lines = HelpFormatter(
-            scope="", show_advanced=False, show_deprecated=False, color=False
-        ).format_options(scope="", description="", option_registrations_iter=[(args, kwargs)])
+        lines = self._format_for_global_scope(False, False, args, kwargs)
         assert len(lines) == 5
         assert not any("--foo" in line for line in lines)
-        lines = HelpFormatter(
-            scope="", show_advanced=True, show_deprecated=True, color=False
-        ).format_options(scope="", description="", option_registrations_iter=[(args, kwargs)])
+        lines = self._format_for_global_scope(True, True, args, kwargs)
         assert len(lines) == 17

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -14,8 +14,8 @@ class OptionHelpFormatterTest(unittest.TestCase):
         ohi = OptionHelpInfo(
             display_args=("--foo",),
             comma_separated_display_args="--foo",
-            scoped_cmd_line_args=tuple("--foo",),
-            unscoped_cmd_line_args=tuple("--foo",),
+            scoped_cmd_line_args=("--foo",),
+            unscoped_cmd_line_args=("--foo",),
             typ=bool,
             default=None,
             default_str="None",

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -106,7 +106,7 @@ class HelpInfoExtracter:
             )
             scope_to_help_info[oshi.scope] = oshi
 
-            if issubclass(scope_info.optionable_cls, GoalSubsystem):
+            if scope_info.optionable_cls and issubclass(scope_info.optionable_cls, GoalSubsystem):
                 is_implemented = union_membership.has_members_for_all(
                     scope_info.optionable_cls.required_union_implementations
                 )

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -1,14 +1,20 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-import unittest
+import dataclasses
 from enum import Enum
+from typing import Tuple
 
+from pants.engine.goal import GoalSubsystem
+from pants.engine.unions import UnionMembership
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
 from pants.option.option_tracker import OptionTracker
+from pants.option.options import Options
 from pants.option.parser import Parser
+from pants.option.ranked_value import Rank, RankedValue
+from pants.option.scope import GLOBAL_SCOPE
+from pants.subsystem.subsystem import Subsystem
 
 
 class LogLevel(Enum):
@@ -16,151 +22,292 @@ class LogLevel(Enum):
     DEBUG = "debug"
 
 
-class HelpInfoExtracterTest(unittest.TestCase):
-    def test_global_scope(self):
-        def do_test(args, kwargs, expected_display_args, expected_scoped_cmd_line_args):
-            # The scoped and unscoped args are the same in global scope.
-            expected_unscoped_cmd_line_args = expected_scoped_cmd_line_args
-            ohi = HelpInfoExtracter("").get_option_help_info(args, kwargs)
-            self.assertListEqual(expected_display_args, ohi.display_args)
-            self.assertListEqual(expected_scoped_cmd_line_args, ohi.scoped_cmd_line_args)
-            self.assertListEqual(expected_unscoped_cmd_line_args, ohi.unscoped_cmd_line_args)
+def test_global_scope():
+    def do_test(args, kwargs, expected_display_args, expected_scoped_cmd_line_args):
+        # The scoped and unscoped args are the same in global scope.
+        expected_unscoped_cmd_line_args = expected_scoped_cmd_line_args
+        ohi = HelpInfoExtracter("").get_option_help_info(args, kwargs)
+        assert tuple(expected_display_args) == ohi.display_args
+        assert tuple(expected_scoped_cmd_line_args) == ohi.scoped_cmd_line_args
+        assert tuple(expected_unscoped_cmd_line_args) == ohi.unscoped_cmd_line_args
 
-        do_test(["-f"], {"type": bool}, ["-f"], ["-f"])
-        do_test(["--foo"], {"type": bool}, ["--[no-]foo"], ["--foo", "--no-foo"])
-        do_test(
-            ["--foo"],
-            {"type": bool, "implicit_value": False},
-            ["--[no-]foo"],
-            ["--foo", "--no-foo"],
+    do_test(["-f"], {"type": bool}, ["-f"], ["-f"])
+    do_test(["--foo"], {"type": bool}, ["--[no-]foo"], ["--foo", "--no-foo"])
+    do_test(
+        ["--foo"], {"type": bool, "implicit_value": False}, ["--[no-]foo"], ["--foo", "--no-foo"],
+    )
+    do_test(["-f", "--foo"], {"type": bool}, ["-f", "--[no-]foo"], ["-f", "--foo", "--no-foo"])
+
+    do_test(["--foo"], {}, ["--foo=<str>"], ["--foo"])
+    do_test(["--foo"], {"metavar": "xx"}, ["--foo=xx"], ["--foo"])
+    do_test(["--foo"], {"type": int}, ["--foo=<int>"], ["--foo"])
+    do_test(
+        ["--foo"], {"type": list}, ["--foo=\"['<str>', '<str>', ...]\""], ["--foo"],
+    )
+    do_test(
+        ["--foo"], {"type": list, "member_type": int}, ['--foo="[<int>, <int>, ...]"'], ["--foo"],
+    )
+    do_test(
+        ["--foo"],
+        {"type": list, "member_type": dict},
+        [
+            "--foo=\"[{'key1': val1, 'key2': val2, ...}, "
+            "{'key1': val1, 'key2': val2, ...}, ...]\"",
+        ],
+        ["--foo"],
+    )
+    do_test(["--foo"], {"type": dict}, ["--foo=\"{'key1': val1, 'key2': val2, ...}\""], ["--foo"])
+
+    do_test(["--foo", "--bar"], {}, ["--foo=<str>", "--bar=<str>"], ["--foo", "--bar"])
+
+
+def test_non_global_scope():
+    def do_test(
+        args,
+        kwargs,
+        expected_display_args,
+        expected_scoped_cmd_line_args,
+        expected_unscoped_cmd_line_args,
+    ):
+        ohi = HelpInfoExtracter("bar.baz").get_option_help_info(args, kwargs)
+        assert tuple(expected_display_args) == ohi.display_args
+        assert tuple(expected_scoped_cmd_line_args) == ohi.scoped_cmd_line_args
+        assert tuple(expected_unscoped_cmd_line_args) == ohi.unscoped_cmd_line_args
+
+    do_test(["-f"], {"type": bool}, ["--bar-baz-f"], ["--bar-baz-f"], ["-f"])
+    do_test(
+        ["--foo"],
+        {"type": bool},
+        ["--[no-]bar-baz-foo"],
+        ["--bar-baz-foo", "--no-bar-baz-foo"],
+        ["--foo", "--no-foo"],
+    )
+    do_test(
+        ["--foo"],
+        {"type": bool, "implicit_value": False},
+        ["--[no-]bar-baz-foo"],
+        ["--bar-baz-foo", "--no-bar-baz-foo"],
+        ["--foo", "--no-foo"],
+    )
+
+
+def test_default() -> None:
+    def do_test(args, kwargs, expected_default_str):
+        # Defaults are computed in the parser and added into the kwargs, so we
+        # must jump through this hoop in this test.
+        parser = Parser(
+            env={},
+            config=Config.load([]),
+            scope_info=GlobalOptions.get_scope_info(),
+            parent_parser=None,
+            option_tracker=OptionTracker(),
         )
-        do_test(["-f", "--foo"], {"type": bool}, ["-f", "--[no-]foo"], ["-f", "--foo", "--no-foo"])
+        parser.register(*args, **kwargs)
+        oshi = HelpInfoExtracter(parser.scope).get_option_scope_help_info(
+            "description", parser.option_registrations_iter(),
+        )
+        assert oshi.description == "description"
+        assert len(oshi.basic) == 1
+        ohi = oshi.basic[0]
+        assert ohi.default_str == expected_default_str
 
-        do_test(["--foo"], {}, ["--foo=<str>"], ["--foo"])
-        do_test(["--foo"], {"metavar": "xx"}, ["--foo=xx"], ["--foo"])
-        do_test(["--foo"], {"type": int}, ["--foo=<int>"], ["--foo"])
-        do_test(
-            ["--foo"], {"type": list}, ["--foo=\"['<str>', '<str>', ...]\""], ["--foo"],
-        )
-        do_test(
-            ["--foo"],
-            {"type": list, "member_type": int},
-            ['--foo="[<int>, <int>, ...]"'],
-            ["--foo"],
-        )
-        do_test(
-            ["--foo"],
-            {"type": list, "member_type": dict},
-            [
-                "--foo=\"[{'key1': val1, 'key2': val2, ...}, "
-                "{'key1': val1, 'key2': val2, ...}, ...]\"",
-            ],
-            ["--foo"],
-        )
-        do_test(
-            ["--foo"], {"type": dict}, ["--foo=\"{'key1': val1, 'key2': val2, ...}\""], ["--foo"]
-        )
+    do_test(["--foo"], {"type": bool}, "False")
+    do_test(["--foo"], {"type": bool, "default": True}, "True")
+    do_test(["--foo"], {"type": bool, "implicit_value": False}, "True")
+    do_test(["--foo"], {"type": bool, "implicit_value": False, "default": False}, "False")
+    do_test(["--foo"], {}, "None")
+    do_test(["--foo"], {"type": int}, "None")
+    do_test(["--foo"], {"type": int, "default": 42}, "42")
+    do_test(["--foo"], {"type": list}, "[]")
+    do_test(["--foo"], {"type": dict}, "{}")
+    do_test(["--foo"], {"type": LogLevel}, "None")
+    do_test(["--foo"], {"type": LogLevel, "default": LogLevel.DEBUG}, "debug")
 
-        do_test(["--foo", "--bar"], {}, ["--foo=<str>", "--bar=<str>"], ["--foo", "--bar"])
 
-    def test_non_global_scope(self):
-        def do_test(
-            args,
-            kwargs,
-            expected_display_args,
-            expected_scoped_cmd_line_args,
-            expected_unscoped_cmd_line_args,
-        ):
-            ohi = HelpInfoExtracter("bar.baz").get_option_help_info(args, kwargs)
-            self.assertListEqual(expected_display_args, ohi.display_args)
-            self.assertListEqual(expected_scoped_cmd_line_args, ohi.scoped_cmd_line_args)
-            self.assertListEqual(expected_unscoped_cmd_line_args, ohi.unscoped_cmd_line_args)
-
-        do_test(["-f"], {"type": bool}, ["--bar-baz-f"], ["--bar-baz-f"], ["-f"])
-        do_test(
-            ["--foo"],
-            {"type": bool},
-            ["--[no-]bar-baz-foo"],
-            ["--bar-baz-foo", "--no-bar-baz-foo"],
-            ["--foo", "--no-foo"],
-        )
-        do_test(
-            ["--foo"],
-            {"type": bool, "implicit_value": False},
-            ["--[no-]bar-baz-foo"],
-            ["--bar-baz-foo", "--no-bar-baz-foo"],
-            ["--foo", "--no-foo"],
+def test_compute_default():
+    def do_test(expected_default, expected_default_str, **kwargs):
+        kwargs["default"] = RankedValue(Rank.HARDCODED, kwargs["default"])
+        assert (expected_default, expected_default_str) == HelpInfoExtracter.compute_default(
+            **kwargs
         )
 
-    def test_default(self) -> None:
-        def do_test(args, kwargs, expected_default):
-            # Defaults are computed in the parser and added into the kwargs, so we
-            # must jump through this hoop in this test.
-            parser = Parser(
-                env={},
-                config=Config.load([]),
-                scope_info=GlobalOptions.get_scope_info(),
-                parent_parser=None,
-                option_tracker=OptionTracker(),
-            )
-            parser.register(*args, **kwargs)
-            oshi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser).basic
-            assert len(oshi) == 1
-            ohi = oshi[0]
-            assert ohi.default == expected_default
+    do_test(False, "False", type=bool, default=False)
+    do_test(42, "42", type=int, default=42)
+    do_test("foo", "foo", type=str, default="foo")
+    do_test(None, "None", type=str, default=None)
+    do_test([1, 2, 3], '"[1, 2, 3]"', type=list, member_type=int, default=[1, 2, 3])
+    do_test(LogLevel.INFO, "info", type=LogLevel, default=LogLevel.INFO)
 
-        do_test(["--foo"], {"type": bool}, "False")
-        do_test(["--foo"], {"type": bool, "default": True}, "True")
-        do_test(["--foo"], {"type": bool, "implicit_value": False}, "True")
-        do_test(["--foo"], {"type": bool, "implicit_value": False, "default": False}, "False")
-        do_test(["--foo"], {}, "None")
-        do_test(["--foo"], {"type": int}, "None")
-        do_test(["--foo"], {"type": int, "default": 42}, "42")
-        do_test(["--foo"], {"type": list}, "[]")
-        do_test(["--foo"], {"type": dict}, "{}")
-        do_test(["--foo"], {"type": LogLevel}, "None")
-        do_test(["--foo"], {"type": LogLevel, "default": LogLevel.DEBUG}, "debug")
 
-    def test_deprecated(self):
-        kwargs = {"removal_version": "999.99.9", "removal_hint": "do not use this"}
-        ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
-        self.assertEqual("999.99.9", ohi.removal_version)
-        self.assertEqual("do not use this", ohi.removal_hint)
-        self.assertIsNotNone(ohi.deprecated_message)
+def test_deprecated():
+    kwargs = {"removal_version": "999.99.9", "removal_hint": "do not use this"}
+    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    assert "999.99.9" == ohi.removal_version
+    assert "do not use this" == ohi.removal_hint
+    assert ohi.deprecated_message is not None
 
-    def test_passthrough(self):
-        kwargs = {"passthrough": True, "type": list, "member_type": str}
-        ohi = HelpInfoExtracter("").get_option_help_info(["--thing"], kwargs)
-        assert 2 == len(ohi.display_args)
-        assert any(args.startswith("--thing") for args in ohi.display_args)
-        assert any(args.startswith("... -- ") for args in ohi.display_args)
 
-    def test_choices(self) -> None:
-        kwargs = {"choices": ["info", "debug"]}
-        ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
-        assert ohi.choices == "info, debug"
+def test_passthrough():
+    kwargs = {"passthrough": True, "type": list, "member_type": str}
+    ohi = HelpInfoExtracter("").get_option_help_info(["--thing"], kwargs)
+    assert 2 == len(ohi.display_args)
+    assert any(args.startswith("--thing") for args in ohi.display_args)
+    assert any(args.startswith("... -- ") for args in ohi.display_args)
 
-    def test_choices_enum(self) -> None:
-        kwargs = {"type": LogLevel}
-        ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
-        assert ohi.choices == "info, debug"
 
-    def test_list_of_enum(self) -> None:
-        kwargs = {"type": list, "member_type": LogLevel}
-        ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
-        assert ohi.choices == "info, debug"
+def test_choices() -> None:
+    kwargs = {"choices": ["info", "debug"]}
+    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    assert ohi.choices == "info, debug"
 
-    def test_grouping(self):
-        def do_test(kwargs, expected_basic=False, expected_advanced=False):
-            def exp_to_len(exp):
-                return int(exp)  # True -> 1, False -> 0.
 
-            oshi = HelpInfoExtracter("").get_option_scope_help_info([([], kwargs)])
-            self.assertEqual(exp_to_len(expected_basic), len(oshi.basic))
-            self.assertEqual(exp_to_len(expected_advanced), len(oshi.advanced))
+def test_choices_enum() -> None:
+    kwargs = {"type": LogLevel}
+    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    assert ohi.choices == "info, debug"
 
-        do_test({}, expected_basic=True)
-        do_test({"advanced": False}, expected_basic=True)
-        do_test({"advanced": True}, expected_advanced=True)
-        do_test({"recursive_root": True}, expected_basic=True)
-        do_test({"advanced": True, "recursive_root": True}, expected_advanced=True)
+
+def test_list_of_enum() -> None:
+    kwargs = {"type": list, "member_type": LogLevel}
+    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    assert ohi.choices == "info, debug"
+
+
+def test_grouping():
+    def do_test(kwargs, expected_basic=False, expected_advanced=False):
+        def exp_to_len(exp):
+            return int(exp)  # True -> 1, False -> 0.
+
+        oshi = HelpInfoExtracter("").get_option_scope_help_info("", [([], kwargs)])
+        assert exp_to_len(expected_basic) == len(oshi.basic)
+        assert exp_to_len(expected_advanced) == len(oshi.advanced)
+
+    do_test({}, expected_basic=True)
+    do_test({"advanced": False}, expected_basic=True)
+    do_test({"advanced": True}, expected_advanced=True)
+    do_test({"recursive_root": True}, expected_basic=True)
+    do_test({"advanced": True, "recursive_root": True}, expected_advanced=True)
+
+
+def test_get_all_help_info():
+    class Global(Subsystem):
+        """Global options."""
+
+        options_scope = GLOBAL_SCOPE
+
+        @classmethod
+        def register_options(cls, register):
+            register("-o", "--opt1", type=int, default=42, help="Option 1")
+
+    class Foo(Subsystem):
+        """A foo."""
+
+        options_scope = "foo"
+
+        @classmethod
+        def register_options(cls, register):
+            register("--opt2", type=bool, default=True, help="Option 2")
+            register("--opt3", advanced=True, choices=["a", "b", "c"])
+
+    class Bar(GoalSubsystem):
+        """The bar goal."""
+
+        name = "bar"
+
+    options = Options.create(
+        env={},
+        config=Config.load_file_contents(""),
+        known_scope_infos=[Global.get_scope_info(), Foo.get_scope_info(), Bar.get_scope_info()],
+        args=[],
+        bootstrap_option_values=None,
+    )
+    Global.register_options_on_scope(options)
+    Foo.register_options_on_scope(options)
+    Bar.register_options_on_scope(options)
+
+    def fake_consumed_scopes_mapper(scope: str) -> Tuple[str, ...]:
+        return ("somescope", f"used_by_{scope or 'GLOBAL_SCOPE'}")
+
+    all_help_info = HelpInfoExtracter.get_all_help_info(
+        options, UnionMembership({}), fake_consumed_scopes_mapper
+    )
+    all_help_info_dict = dataclasses.asdict(all_help_info)
+    expected_all_help_info_dict = {
+        "scope_to_help_info": {
+            GLOBAL_SCOPE: {
+                "scope": GLOBAL_SCOPE,
+                "description": "Global options.",
+                "basic": (
+                    {
+                        "display_args": ("-o=<int>", "--opt1=<int>"),
+                        "comma_separated_display_args": "-o=<int>, --opt1=<int>",
+                        "scoped_cmd_line_args": ("-o", "--opt1"),
+                        "unscoped_cmd_line_args": ("-o", "--opt1"),
+                        "typ": int,
+                        "default": 42,
+                        "default_str": "42",
+                        "help": "Option 1",
+                        "deprecated_message": None,
+                        "removal_version": None,
+                        "removal_hint": None,
+                        "choices": None,
+                    },
+                ),
+                "advanced": tuple(),
+                "deprecated": tuple(),
+            },
+            "foo": {
+                "scope": "foo",
+                "description": "A foo.",
+                "basic": (
+                    {
+                        "display_args": ("--[no-]foo-opt2",),
+                        "comma_separated_display_args": "--[no-]foo-opt2",
+                        "scoped_cmd_line_args": ("--foo-opt2", "--no-foo-opt2"),
+                        "unscoped_cmd_line_args": ("--opt2", "--no-opt2"),
+                        "typ": bool,
+                        "default": True,
+                        "default_str": "True",
+                        "help": "Option 2",
+                        "deprecated_message": None,
+                        "removal_version": None,
+                        "removal_hint": None,
+                        "choices": None,
+                    },
+                ),
+                "advanced": (
+                    {
+                        "display_args": ("--foo-opt3=<str>",),
+                        "comma_separated_display_args": "--foo-opt3=<str>",
+                        "scoped_cmd_line_args": ("--foo-opt3",),
+                        "unscoped_cmd_line_args": ("--opt3",),
+                        "typ": str,
+                        "default": None,
+                        "default_str": "None",
+                        "help": "No help available.",
+                        "deprecated_message": None,
+                        "removal_version": None,
+                        "removal_hint": None,
+                        "choices": "a, b, c",
+                    },
+                ),
+                "deprecated": tuple(),
+            },
+            "bar": {
+                "scope": "bar",
+                "description": "The bar goal.",
+                "basic": tuple(),
+                "advanced": tuple(),
+                "deprecated": tuple(),
+            },
+        },
+        "name_to_goal_info": {
+            "bar": {
+                "name": "bar",
+                "description": "The bar goal.",
+                "consumed_scopes": ("somescope", "used_by_bar"),
+                "is_implemented": True,
+            }
+        },
+    }
+    assert expected_all_help_info_dict == all_help_info_dict

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -1,5 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import dataclasses
 from enum import Enum
 from typing import Tuple

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -89,7 +89,7 @@ class LegacyGraphSession:
             return tuple()
         consumed_types = self.goal_consumed_types(goal_product)
         return tuple(
-            sorted({typ.options_scope for typ in consumed_types if issubclass(typ, Subsystem)})
+            sorted({typ.options_scope for typ in consumed_types if issubclass(typ, Subsystem)})  # type: ignore[misc]
         )
 
     def goal_consumed_types(self, goal_product: Type) -> Set[Type]:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -36,6 +36,7 @@ from pants.option.global_options import (
 )
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.scm.subsystems.changed import rules as changed_rules
+from pants.subsystem.subsystem import Subsystem
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +82,18 @@ class LegacyGraphSession:
             )
             self.invalid_goals = invalid_goals
 
+    def goal_consumed_subsystem_scopes(self, goal_name: str) -> Tuple[str, ...]:
+        """Return the scopes of subsystems that could be consumed while running the given goal."""
+        goal_product = self.goal_map.get(goal_name)
+        if not goal_product:
+            return tuple()
+        consumed_types = self.goal_consumed_types(goal_product)
+        return tuple(
+            sorted({typ.options_scope for typ in consumed_types if issubclass(typ, Subsystem)})
+        )
+
     def goal_consumed_types(self, goal_product: Type) -> Set[Type]:
-        """Return the set of types that could possibly by consumed while running the given goal."""
+        """Return the set of types that could possibly be consumed while running the given goal."""
         # TODO: This needs to be kept in sync with the Params injected in run_goal_rules, with a
         # subtle difference that prevents automating validation that they are kept in sync:
         #

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -36,7 +36,7 @@ class HelpRequest(ABC):
 class OptionsHelp(HelpRequest):
     advanced: bool = False
     all_scopes: bool = False
-    scopes: Tuple[str, ...] = tuple()
+    scopes: Tuple[str, ...] = ()
 
 
 class GoalsHelp(HelpRequest):

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -1,5 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import dataclasses
 import os.path
 import sys

--- a/src/python/pants/option/option_tracker.py
+++ b/src/python/pants/option/option_tracker.py
@@ -8,22 +8,23 @@ from typing import DefaultDict, Iterator, List, Optional
 from pants.option.ranked_value import Rank
 
 
+@dataclass(frozen=True)
+class OptionHistoryRecord:
+    value: str
+    rank: Rank
+    deprecation_version: Optional[str]
+    details: Optional[str]
+
+
 # TODO: Get rid of this? The parser should be able to lazily track.
 class OptionTracker:
     """Records a history of what options are set and where they came from."""
-
-    @dataclass(frozen=True)
-    class OptionHistoryRecord:
-        value: str
-        rank: Rank
-        deprecation_version: Optional[str]
-        details: Optional[str]
 
     class OptionHistory:
         """Tracks the history of an individual option."""
 
         def __init__(self) -> None:
-            self.values: List["OptionTracker.OptionHistoryRecord"] = []
+            self.values: List[OptionHistoryRecord] = []
 
         def record_value(
             self,
@@ -55,9 +56,7 @@ class OptionTracker:
                     )
 
             self.values.append(
-                OptionTracker.OptionHistoryRecord(
-                    value, rank, deprecation_version_to_write, details
-                )
+                OptionHistoryRecord(value, rank, deprecation_version_to_write, details)
             )
 
         @property
@@ -68,11 +67,11 @@ class OptionTracker:
             return self.latest.rank > Rank.HARDCODED and self.values[-2].rank > Rank.NONE
 
         @property
-        def latest(self) -> Optional["OptionTracker.OptionHistoryRecord"]:
+        def latest(self) -> Optional[OptionHistoryRecord]:
             """The most recent value this option was set to, or None if it was never set."""
             return self.values[-1] if self.values else None
 
-        def __iter__(self) -> Iterator["OptionTracker.OptionHistoryRecord"]:
+        def __iter__(self) -> Iterator[OptionHistoryRecord]:
             for record in self.values:
                 yield record
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -326,7 +326,6 @@ class Options:
         # TODO(benjy): Make this an instance of a class that implements __call__, so we can
         # docstring it, and so it's less weird than attaching properties to a function.
         def register(*args, **kwargs):
-            kwargs["registering_class"] = optionable_class
             self.register(optionable_class.options_scope, *args, **kwargs)
 
         # Clients can access the bootstrap option values as register.bootstrap.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -568,7 +568,6 @@ class Parser:
         "advanced",
         "recursive",
         "recursive_root",
-        "registering_class",
         "fingerprint",
         "removal_version",
         "removal_hint",


### PR DESCRIPTION
Previously the HelpFormatter, HelpPrinter and HelpInfoExtracter were rather 
entangled. This change:

- Fully detaches these concepts: The HelpInfoExtracter now produces an
  instance of a new AllHelpInfo class, containing all help information, 
  including scope descriptions. The HelpPrinter/HelpFormatter operate
  exclusively on this data. They no longer need access to an Options instance,
  let alone a HelpInfoExtractor.
- Displays related subsystems in the help output for a goal.
- Distinguishes the stringified option default from the original typed default value.
- Switches some help-related dataclass fields to be tuples instead of lists.
- Various other improvements.

[ci skip-rust-tests]

