### PR TITLE
Lower the default max-memory usage of pantsd.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -547,7 +547,7 @@ class GlobalOptions(Subsystem):
             "--pantsd-max-memory-usage",
             advanced=True,
             type=int,
-            default=2 ** 32,
+            default=2 ** 30,
             help=(
                 "The maximum memory usage of a pantsd process (in bytes). There is at most one "
                 "pantsd process per workspace."


### PR DESCRIPTION
### Problem

The default max memory usage from #10003 was chosen with larger monorepos in mind, and didn't match the expectation of consumers in smaller repos. 

### Solution

Very large repos will have folks who are able/willing to adjust limits like this to optimize for their repo size, so adjust the default down in favor of having good defaults.  This relates to #7675, but it isn't the time to dive in there.

### Result

Fixes #10264.

[ci skip-rust-tests]