### PR TITLE
Downgrade to tokio 0.2.20.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -57,7 +57,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -690,7 +690,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -797,7 +797,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -820,7 +820,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -1022,7 +1022,7 @@ dependencies = [
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ dependencies = [
  "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1188,7 +1188,7 @@ dependencies = [
  "net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1205,7 +1205,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-native-certs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1443,7 +1443,7 @@ dependencies = [
  "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1588,7 +1588,7 @@ dependencies = [
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1606,7 +1606,7 @@ dependencies = [
  "nails 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1618,7 +1618,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2021,7 +2021,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2040,7 +2040,7 @@ dependencies = [
  "process_execution 0.0.1",
  "store 0.1.0",
  "task_executor 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2416,7 +2416,7 @@ dependencies = [
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2635,7 +2635,7 @@ dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2772,7 +2772,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -2880,7 +2880,7 @@ dependencies = [
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3040,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3054,7 +3054,7 @@ dependencies = [
  "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3408,7 +3408,7 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3501,7 +3501,7 @@ dependencies = [
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3811,7 +3811,7 @@ dependencies = [
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "45e4bc5ac99433e0dcb8b9f309dd271a165ae37dde129b9e0ce1bfdd8bfe4891"
-"checksum tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+"checksum tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 "checksum tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)" = "<none>"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 "checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -127,7 +127,8 @@ tar_api = { path = "tar_api" }
 task_executor = { path = "task_executor" }
 tempfile = "3"
 time = "0.1.40"
-tokio = { version = "0.2", features = ["rt-threaded"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-threaded"] }
 ui = { path = "ui" }
 url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }

--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -10,4 +10,5 @@ parking_lot = "0.11"
 
 [dev-dependencies]
 futures = "0.3"
-tokio = { version = "0.2", features = ["rt-core", "macros", "time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-core", "macros", "time"] }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -20,4 +20,5 @@ task_executor = { path = "../task_executor" }
 [dev-dependencies]
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-core", "macros"] }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -22,7 +22,8 @@ serverset = { path = "../../serverset" }
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.1.39"
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "signal", "stream"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-threaded", "macros", "signal", "stream"] }
 workunit_store = { path = "../../workunit_store" }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -22,5 +22,6 @@ serde_json = "1.0"
 serde_derive = "1.0"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
-tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-threaded", "macros"] }
 workunit_store = { path = "../../workunit_store" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -37,7 +37,8 @@ workunit_store = {path = "../../workunit_store" }
 maplit = "*"
 mock = { path = "../../testutil/mock" }
 testutil = { path = "../../testutil" }
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-core", "macros"] }
 walkdir = "2"
 criterion = "0.3"
 

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -12,9 +12,11 @@ futures = "0.3"
 log = "0.4"
 parking_lot = "0.11"
 petgraph = "0.4.5"
-tokio = { version = "0.2", features = ["time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["time"] }
 
 [dev-dependencies]
 rand = "0.6"
 env_logger = "0.5.4"
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["macros", "rt-threaded", "time"] }

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -12,7 +12,8 @@ log = "0.4"
 num_enum = "0.4"
 parking_lot = "0.11"
 simplelog = "0.7.4"
-tokio = { version = "0.2", features = ["rt-util"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-util"] }
 uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -12,7 +12,9 @@ log = "0.4"
 nails = "0.5.1"
 os_pipe = "0.9"
 task_executor = { path = "../task_executor" }
-tokio = { version = "0.2", features = ["tcp", "fs", "sync"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["tcp", "fs", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["dns", "rt-threaded", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["dns", "rt-threaded", "macros"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -30,7 +30,8 @@ store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"
 concrete_time = { path = "../concrete_time" }
-tokio = { version = "0.2", features = ["process", "rt-threaded", "sync", "tcp", "time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["process", "rt-threaded", "sync", "tcp", "time"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 uname = "0.1.1"
 workunit_store = { path = "../workunit_store" }
@@ -49,4 +50,5 @@ parking_lot = "0.11"
 spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "0.2", features = ["macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["macros"] }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -14,5 +14,6 @@ hashing = { path = "../hashing" }
 process_execution = { path = "../process_execution" }
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
-tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-threaded", "macros"] }
 workunit_store = { path = "../workunit_store"}

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -8,9 +8,11 @@ publish = false
 [dependencies]
 futures = "0.3"
 parking_lot = "0.11"
-tokio = { version = "0.2", features = ["time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["time"] }
 
 [dev-dependencies]
 maplit = "1"
 testutil = { path = "../testutil" }
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-core", "macros"] }

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -9,5 +9,6 @@ publish = false
 futures = "0.3"
 logging = { path = "../logging" }
 num_cpus = "1"
-tokio = { version = "0.2", features = ["blocking", "rt-threaded"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["blocking", "rt-threaded"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -16,4 +16,5 @@ hashing = { path = "../../hashing" }
 parking_lot = "0.11"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 testutil = { path = ".." }
-tokio = { version = "0.2", features = ["time"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["time"] }

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -19,4 +19,5 @@ task_executor = { path = "../task_executor" }
 [dev-dependencies]
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-core", "macros"] }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -10,6 +10,7 @@ concrete_time = { path = "../concrete_time" }
 hashing = { path = "../hashing" }
 parking_lot = "0.11"
 rand = "0.6"
-tokio = { version = "0.2", features = ["rt-util"] }
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["rt-util"] }
 petgraph = "0.4.5"
 log = "0.4"


### PR DESCRIPTION
### Problem

See #10291 (and previously #9476 and its "fix" in #9703).

### Solution

Pin to `0.2.20` to work around the issue. As mentioned in #10291, we'll need to find a better solution than our current contortions, but this gives us breathing room.
