### PR TITLE
Add option for specifying environment variable with concurrency slot

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -63,6 +63,7 @@ class TestTargetSetup:
     timeout_seconds: Optional[int]
     xml_dir: Optional[str]
     junit_family: str
+    execution_slot_variable: str
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -201,6 +202,7 @@ async def setup_pytest_for_target(
         timeout_seconds=field_set.timeout.calculate_from_global_options(pytest),
         xml_dir=pytest.options.junit_xml_dir,
         junit_family=pytest.options.junit_family,
+        execution_slot_variable=pytest.options.execution_slot_var,
     )
 
 
@@ -247,6 +249,7 @@ async def run_python_test(
         description=f"Run Pytest for {field_set.address.reference()}",
         timeout_seconds=test_setup.timeout_seconds,
         env=env,
+        execution_slot_variable=test_setup.execution_slot_variable,
     )
     result = await Get(FallibleProcessResult, Process, process)
 

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 from pathlib import Path, PurePath
 from textwrap import dedent
 from typing import List, Optional
@@ -140,6 +141,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         origin: Optional[OriginSpec] = None,
         junit_xml_dir: Optional[str] = None,
         use_coverage: bool = False,
+        execution_slot_var: Optional[str] = None,
     ) -> TestResult:
         args = [
             "--backend-packages=pants.backend.python",
@@ -154,6 +156,9 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             args.append(f"--pytest-junit-xml-dir={junit_xml_dir}")
         if use_coverage:
             args.append("--test-use-coverage")
+        if execution_slot_var:
+            args.append(f"--pytest-execution-slot-var={execution_slot_var}")
+
         options_bootstrapper = create_options_bootstrapper(args=args)
         address = Address(self.package, "target")
         if origin is None:
@@ -371,3 +376,22 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert result.status == Status.SUCCESS
         assert f"{self.package}/test_good.py ." in result.stdout
         assert result.coverage_data is not None
+
+    def test_execution_slot_variable(self) -> None:
+        source = FileContent(
+            path="test_concurrency_slot.py",
+            content=dedent(
+                """\
+                import os
+
+                def test_fail_printing_slot_env_var():
+                    slot = os.getenv("SLOT")
+                    print(f"Value of slot is {slot}")
+                    # Deliberately fail the test so the SLOT output gets printed to stdout
+                    assert 1 == 2
+                """
+            ).encode(),
+        )
+        self.create_python_test_target([source])
+        result = self.run_pytest(execution_slot_var="SLOT")
+        assert re.search(r"Value of slot is \d+", result.stdout)

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -79,9 +79,10 @@ class PyTest(Subsystem):
         register(
             "--execution-slot-var",
             type=str,
-            default="",
+            default=None,
             advanced=True,
-            help="If a non-empty string, the process execution slot id (an integer) will be exposed to tests under this environment variable name.",
+            help="If a non-empty string, the process execution slot id (an integer) will be exposed to tests under this "
+            "environment variable name.",
         )
 
     def get_requirement_strings(self) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -76,6 +76,13 @@ class PyTest(Subsystem):
             advanced=True,
             help="The format of the generated XML file. See https://docs.pytest.org/en/latest/reference.html#confval-junit_family.",
         )
+        register(
+            "--execution-slot-var",
+            type=str,
+            default="",
+            advanced=True,
+            help="If a non-empty string, the process execution slot id (an integer) will be exposed to tests under this environment variable name.",
+        )
 
     def get_requirement_strings(self) -> Tuple[str, ...]:
         """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -33,7 +33,7 @@ class Process:
     timeout_seconds: Union[int, float]
     jdk_home: Optional[str]
     is_nailgunnable: bool
-    execution_slot_variable: str = ""
+    execution_slot_variable: str
 
     def __init__(
         self,
@@ -49,6 +49,7 @@ class Process:
         timeout_seconds: Optional[Union[int, float]] = None,
         jdk_home: Optional[str] = None,
         is_nailgunnable: bool = False,
+        execution_slot_variable: str = "",
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -87,6 +88,7 @@ class Process:
         self.timeout_seconds = timeout_seconds if timeout_seconds and timeout_seconds > 0 else -1
         self.jdk_home = jdk_home
         self.is_nailgunnable = is_nailgunnable
+        self.execution_slot_variable = execution_slot_variable
 
 
 @frozen_after_init

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -33,7 +33,7 @@ class Process:
     timeout_seconds: Union[int, float]
     jdk_home: Optional[str]
     is_nailgunnable: bool
-    execution_slot_variable: str
+    execution_slot_variable: Optional[str]
 
     def __init__(
         self,
@@ -49,7 +49,7 @@ class Process:
         timeout_seconds: Optional[Union[int, float]] = None,
         jdk_home: Optional[str] = None,
         is_nailgunnable: bool = False,
-        execution_slot_variable: str = "",
+        execution_slot_variable: Optional[str] = None,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -33,6 +33,7 @@ class Process:
     timeout_seconds: Union[int, float]
     jdk_home: Optional[str]
     is_nailgunnable: bool
+    execution_slot_variable: str = ""
 
     def __init__(
         self,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -532,7 +532,7 @@ impl CommandRunner for BoundedCommandRunner {
       let context = context.clone();
       let name = format!("{}-running", req.workunit_name());
 
-      semaphore.with_acquired(move || {
+      semaphore.with_acquired(move |_id| {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
           message: None,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -227,6 +227,9 @@ pub struct Process {
 
   pub timeout: Option<std::time::Duration>,
 
+  /// If not None, then if a BoundedCommandRunner executes this Process
+  pub execution_slot_variable: Option<String>,
+
   #[derivative(PartialEq = "ignore", Hash = "ignore")]
   pub description: String,
 
@@ -284,6 +287,7 @@ impl Process {
       jdk_home: None,
       target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
+      execution_slot_variable: None,
     }
   }
 
@@ -511,7 +515,7 @@ impl CommandRunner for BoundedCommandRunner {
 
   async fn run(
     &self,
-    req: MultiPlatformProcess,
+    mut req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let name = format!("{}-waiting", req.workunit_name());
@@ -532,7 +536,7 @@ impl CommandRunner for BoundedCommandRunner {
       let context = context.clone();
       let name = format!("{}-running", req.workunit_name());
 
-      semaphore.with_acquired(move |_id| {
+      semaphore.with_acquired(move |concurrency_id| {
         let metadata = WorkunitMetadata {
           desc: Some(desc),
           message: None,
@@ -555,6 +559,15 @@ impl CommandRunner for BoundedCommandRunner {
             ..old_metadata
           },
         };
+
+        for (_, process) in req.0.iter_mut() {
+          if let Some(ref execution_slot_env_var) = process.execution_slot_variable {
+            let execution_slot = format!("{}", concurrency_id);
+            process
+              .env
+              .insert(execution_slot_env_var.clone(), execution_slot);
+          }
+        }
 
         with_workunit(
           context.workunit_store.clone(),

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -349,6 +349,7 @@ async fn jdk_symlink() {
     jdk_home: Some(preserved_work_tmpdir.path().to_path_buf()),
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   })
   .await
   .unwrap();
@@ -500,6 +501,7 @@ async fn timeout() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   })
   .await
   .unwrap();
@@ -546,6 +548,7 @@ async fn working_directory() {
       jdk_home: None,
       target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
+      execution_slot_variable: None,
     },
     work_dir.path().to_owned(),
     true,

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -64,6 +64,7 @@ fn construct_nailgun_server_request(
     jdk_home: Some(jdk),
     target_platform: platform_constraint,
     is_nailgunnable: true,
+    execution_slot_variable: None,
   }
 }
 
@@ -72,34 +73,11 @@ fn construct_nailgun_client_request(
   client_main_class: String,
   mut client_args: Vec<String>,
 ) -> Process {
-  let Process {
-    argv: _argv,
-    input_files,
-    description,
-    append_only_caches,
-    env: original_request_env,
-    working_directory,
-    output_files,
-    output_directories,
-    timeout,
-    jdk_home: _jdk_home,
-    target_platform,
-    is_nailgunnable,
-  } = original_req;
   client_args.insert(0, client_main_class);
   Process {
     argv: client_args,
-    input_files,
-    description,
-    append_only_caches,
-    env: original_request_env,
-    working_directory,
-    output_files,
-    output_directories,
-    timeout,
     jdk_home: None,
-    target_platform,
-    is_nailgunnable,
+    ..original_req
   }
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -255,7 +255,7 @@ impl CapturedWorkdir for CommandRunner {
     let nails_command = self
       .async_semaphore
       .clone()
-      .with_acquired(move || {
+      .with_acquired(move |_id| {
         // Get the port of a running nailgun server (or a new nailgun server if it doesn't exist)
         nailgun_pool
           .connect(

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -52,6 +52,7 @@ fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> Process {
     jdk_home: jdk_home,
     target_platform: PlatformConstraint::Darwin,
     is_nailgunnable: true,
+    execution_slot_variable: None,
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -86,6 +86,7 @@ async fn make_execute_request() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -169,6 +170,7 @@ async fn make_execute_request_with_instance_name() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -260,6 +262,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -337,20 +340,10 @@ async fn make_execute_request_with_cache_key_gen_version() {
 #[tokio::test]
 async fn make_execute_request_with_jdk() {
   let input_directory = TestDirectory::containing_roland();
-  let req = Process {
-    argv: owned_string_vec(&["/bin/echo", "yo"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: input_directory.digest(),
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: None,
-    description: "some description".to_owned(),
-    append_only_caches: BTreeMap::new(),
-    jdk_home: Some(PathBuf::from("/tmp")),
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
+  let mut req = Process::new(owned_string_vec(&["/bin/echo", "yo"]));
+  req.jdk_home = Some(PathBuf::from("/tmp"));
+  req.description = "some description".to_owned();
+  req.input_files = input_directory.digest();
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
   want_command.mut_arguments().push("/bin/echo".to_owned());
@@ -415,6 +408,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
     jdk_home: Some(PathBuf::from("/tmp")),
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -525,6 +519,7 @@ async fn make_execute_request_with_timeout() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -1161,20 +1156,10 @@ async fn timeout_after_sufficiently_delayed_getoperations() {
   // 1 due to the request_timeout.
   let delayed_operation_time = Duration::new(2, 500);
 
-  let execute_request = Process {
-    argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: Some(request_timeout),
-    description: "echo-a-foo".to_string(),
-    append_only_caches: BTreeMap::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
+  let argv = owned_string_vec(&["/bin/echo", "-n", "foo"]);
+  let mut execute_request = Process::new(argv);
+  execute_request.timeout = Some(request_timeout);
+  execute_request.description = "echo-a-foo".to_string();
 
   let op_name = "gimme-foo".to_string();
 
@@ -1220,20 +1205,9 @@ async fn dropped_request_cancels() {
   let request_timeout = Duration::new(10, 0);
   let delayed_operation_time = Duration::new(5, 0);
 
-  let execute_request = Process {
-    argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: Some(request_timeout),
-    description: "echo-a-foo".to_string(),
-    append_only_caches: BTreeMap::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
+  let mut execute_request = Process::new(owned_string_vec(&["/bin/echo", "-n", "foo"]));
+  execute_request.description = "echo-a-foo".to_string();
+  execute_request.timeout = Some(request_timeout);
 
   let op_name = "gimme-foo".to_string();
 
@@ -2459,6 +2433,7 @@ pub fn echo_foo_request() -> MultiPlatformProcess {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
   req.into()
 }
@@ -2846,25 +2821,15 @@ pub(crate) fn cat_roland_request() -> MultiPlatformProcess {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
   req.into()
 }
 
 pub(crate) fn echo_roland_request() -> MultiPlatformProcess {
-  let req = Process {
-    argv: owned_string_vec(&["/bin/echo", "meoooow"]),
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout: one_second(),
-    description: "unleash a roaring meow".to_string(),
-    append_only_caches: BTreeMap::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-  };
+  let mut req = Process::new(owned_string_vec(&["/bin/echo", "meoooow"]));
+  req.timeout = one_second();
+  req.description = "unleash a roaring meow".to_string();
   req.into()
 }
 

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -21,6 +21,7 @@ fn process_equality() {
     jdk_home: None,
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
+    execution_slot_variable: None,
   };
 
   fn hash<Hashable: Hash>(hashable: &Hashable) -> u64 {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -371,6 +371,7 @@ async fn main() {
     )
     .expect("invalid value for `target-platform"),
     is_nailgunnable,
+    execution_slot_variable: None,
   };
 
   let runner: Box<dyn process_execution::CommandRunner> = match server_arg {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -274,6 +274,15 @@ impl MultiPlatformExecuteProcess {
 
     let is_nailgunnable = externs::project_bool(&value, "is_nailgunnable");
 
+    let execution_slot_variable = {
+      let s = externs::project_str(&value, "execution_slot_variable");
+      if s.is_empty() {
+        None
+      } else {
+        Some(s)
+      }
+    };
+
     Ok(process_execution::Process {
       argv: externs::project_multi_strs(&value, "argv"),
       env,
@@ -287,6 +296,7 @@ impl MultiPlatformExecuteProcess {
       jdk_home,
       target_platform,
       is_nailgunnable,
+      execution_slot_variable,
     })
   }
 


### PR DESCRIPTION
### Problem

In some scenarios, pants users might want their tests to be aware of the amount of concurrency those tests are being run with. For instance, database-heavy Django tests might want to be able to reuse a limited number of databases, instead of spawning and destroying a new test database instance for every single concurrent test, which is resource-intensive.

### Solution

This PR introduces the ability to optionally create a variable in the environment of a `Process` that has a numerical ID corresponding to the "slot" that this `Process` is run under by the `BoundedCommandRunner` system. The name of this environment variable is controlled by a new pants option `--process-execution-slot-environment-variable`, and will not be present if this option is the empty string. 

The ID presented to processes via this variable comes from the `BoundedCommandRunner`, and will always be a small numerical value greater than 0 and less than or equal to the maximum amount of concurrency allowed by that `BoundedCommandRunner` instance (which in turn is set by the `--process-execution-{local,remote}-parallelism` options).