### PR TITLE
Use with_workunit everywhere

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
+#![type_length_limit = "1303884"]
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
+#![type_length_limit = "1076739"]
 
 use clap::{value_t, App, AppSettings, Arg};
 use futures::compat::Future01CompatExt;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -35,7 +35,7 @@ use process_execution::{
 
 use graph::{Entry, Node, NodeError, NodeVisualizer};
 use store::{self, StoreFileByDigest};
-use workunit_store::{new_span_id, scope_task_workunit_state, Level, WorkunitMetadata};
+use workunit_store::{with_workunit, Level, WorkunitMetadata};
 
 pub type NodeResult<T> = Result<T, Failure>;
 
@@ -1086,34 +1086,22 @@ impl Node for NodeKey {
   type Error = Failure;
 
   async fn run(self, context: Context) -> Result<NodeOutput, Failure> {
-    let mut workunit_state = workunit_store::expect_workunit_state();
+    let workunit_state = workunit_store::expect_workunit_state();
 
-    let (started_workunit_id, user_facing_name, metadata) = {
-      let user_facing_name = self.user_facing_name();
-      let name = self.workunit_name();
-      let span_id = new_span_id();
-
-      // We're starting a new workunit: record our parent, and set the current parent to our span.
-      let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
-      let metadata = WorkunitMetadata {
-        desc: user_facing_name.clone(),
-        message: None,
-        level: self.workunit_level(),
-        blocked: false,
-        stdout: None,
-        stderr: None,
-      };
-
-      let started_workunit_id =
-        context
-          .session
-          .workunit_store()
-          .start_workunit(span_id, name, parent_id, metadata.clone());
-      (started_workunit_id, user_facing_name, metadata)
+    let user_facing_name = self.user_facing_name();
+    let workunit_name = self.workunit_name();
+    let metadata = WorkunitMetadata {
+      desc: user_facing_name.clone(),
+      message: None,
+      level: self.workunit_level(),
+      blocked: false,
+      stdout: None,
+      stderr: None,
     };
+    let metadata2 = metadata.clone();
 
-    scope_task_workunit_state(Some(workunit_state), async move {
-      let context2 = context.clone();
+    let result_future = async move {
+      let metadata = metadata2;
       let maybe_watch = if let Some(path) = self.fs_subject() {
         let abs_path = context.core.build_root.join(path);
         context
@@ -1181,13 +1169,18 @@ impl Node for NodeKey {
         message,
         ..metadata
       };
-      context2
-        .session
-        .workunit_store()
-        .complete_workunit_with_new_metadata(started_workunit_id, final_metadata);
-      result
-    })
+      (result, final_metadata)
+    };
+
+    with_workunit(
+      workunit_state.store,
+      workunit_name,
+      metadata,
+      result_future,
+      |result, _| result.1.clone(),
+    )
     .await
+    .0
   }
 
   fn cacheable(&self) -> bool {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -434,7 +434,7 @@ impl WorkunitStore {
     self.heavy_hitters_data.heavy_hitters(k)
   }
 
-  pub fn start_workunit(
+  fn start_workunit(
     &self,
     span_id: SpanId,
     name: String,


### PR DESCRIPTION
This commit changes all call sites that were previously using the public `start_workunit`/`complete_workunit` method pair to use the `with_workunit` method, so that the former two methods can be made private.