### PR TITLE
Merge the unit and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -423,9 +423,9 @@ jobs:
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=unit_tests.py36
+    - CACHE_NAME=python_tests.py36
     language: python
-    name: Unit tests (Python 3.6)
+    name: Python tests (Python 3.6)
     os: linux
     python:
     - '2.7'
@@ -433,7 +433,8 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --remote-execution-enabled --python-version 3.6
+      --unit-tests --integration-tests --remote-execution-enabled --python-version
+      3.6
     stage: Test Pants
     sudo: required
   - addons:
@@ -483,9 +484,9 @@ jobs:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=unit_tests.py37
+    - CACHE_NAME=python_tests.py37
     language: python
-    name: Unit tests (Python 3.7)
+    name: Python tests (Python 3.7)
     os: linux
     python:
     - '2.7'
@@ -493,126 +494,8 @@ jobs:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --remote-execution-enabled --python-version 3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    - ./build-support/bin/prune_travis_cache.sh
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
-      | tar -zxvf - travis-wait-enhanced
-    - mv travis-wait-enhanced /home/travis/bin/
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.py36
-    language: python
-    name: Integration tests (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests --remote-execution-enabled --python-version 3.6
-    stage: Test Pants
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    - ./build-support/bin/prune_travis_cache.sh
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
-      | tar -zxvf - travis-wait-enhanced
-    - mv travis-wait-enhanced /home/travis/bin/
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.py37
-    language: python
-    name: Integration tests (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests --remote-execution-enabled --python-version 3.7
+      --unit-tests --integration-tests --remote-execution-enabled --python-version
+      3.7
     stage: Test Pants (Cron)
     sudo: required
   - before_cache:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -547,20 +547,21 @@ def cargo_audit() -> Dict:
 
 
 # -------------------------------------------------------------------------
-# Unit tests
+# Python tests
 # -------------------------------------------------------------------------
 
 
-def unit_tests(python_version: PythonVersion) -> Dict:
+def python_tests(python_version: PythonVersion) -> Dict:
     shard = {
         **linux_shard(python_version=python_version, install_travis_wait=True),
-        "name": f"Unit tests (Python {python_version.decimal})",
+        "name": f"Python tests (Python {python_version.decimal})",
         "script": [
             "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
-            f"--unit-tests --remote-execution-enabled --python-version {python_version.decimal}"
+            "--unit-tests --integration-tests --remote-execution-enabled --python-version "
+            f"{python_version.decimal}"
         ],
     }
-    safe_append(shard, "env", f"CACHE_NAME=unit_tests.py{python_version.number}")
+    safe_append(shard, "env", f"CACHE_NAME=python_tests.py{python_version.number}")
     return shard
 
 
@@ -607,27 +608,6 @@ def build_wheels_osx() -> Dict:
         ),
     }
     safe_extend(shard, "env", _build_wheels_env(platform=Platform.osx))
-    return shard
-
-
-# -------------------------------------------------------------------------
-# Integration tests
-# -------------------------------------------------------------------------
-
-
-def integration_tests(python_version: PythonVersion) -> Dict:
-    shard = {
-        **linux_shard(python_version=python_version, install_travis_wait=True),
-        "name": f"Integration tests (Python {python_version.decimal})",
-        "script": [
-            (
-                "travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py "
-                "--integration-tests --remote-execution-enabled --python-version "
-                f"{python_version.decimal}"
-            ),
-        ],
-    }
-    safe_append(shard, "env", f"CACHE_NAME=integration.py{python_version.number}")
     return shard
 
 
@@ -832,8 +812,7 @@ def main() -> None:
                     clippy(),
                     # TODO: fix Cargo audit. Run `build-support/bin/ci.py --cargo-audit` locally.
                     # cargo_audit(),
-                    *[unit_tests(v) for v in supported_python_versions],
-                    *[integration_tests(v) for v in supported_python_versions],
+                    *[python_tests(v) for v in supported_python_versions],
                     rust_tests_linux(),
                     rust_tests_osx(),
                     build_wheels_linux(),


### PR DESCRIPTION
So long as we have remote execution, there is no reason to have separate shards.

By unifying, we are also able to get one single merged coverage report.