### PR TITLE
No longer special case the `dependencies` field with TargetAdaptor

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -237,8 +237,10 @@ class BuildFileIntegrationTest(TestBase):
                 mock_tgt(
                     fake_field=42,
                     dependencies=[
-                        # Because we don't follow dependencies, this self-cycle should be fine.
+                        # Because we don't follow dependencies or even parse dependencies, this
+                        # self-cycle should be fine.
                         "helloworld",
+                        ":sibling",
                         "helloworld/util",
                         "helloworld/util:tests",
                     ],
@@ -252,9 +254,10 @@ class BuildFileIntegrationTest(TestBase):
         assert target_adaptor.name == "helloworld"
         assert target_adaptor.type_alias == "mock_tgt"
         assert target_adaptor.dependencies == (
-            addr,
-            Address.parse("helloworld/util"),
-            Address.parse("helloworld/util:tests"),
+            "helloworld",
+            ":sibling",
+            "helloworld/util",
+            "helloworld/util:tests",
         )
         # NB: TargetAdaptors do not validate what fields are valid. The Target API should error
         # when encountering this, but it's fine at this stage.

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -35,16 +35,6 @@ class GraphTest(TestBase):
         return (MockTarget,)
 
     def test_transitive_targets(self) -> None:
-        t1 = MockTarget({}, address=Address.parse(":t1"))
-        t2 = MockTarget({Dependencies.alias: [t1.address]}, address=Address.parse(":t2"))
-        d1 = MockTarget({Dependencies.alias: [t1.address]}, address=Address.parse(":d1"))
-        d2 = MockTarget({Dependencies.alias: [t2.address]}, address=Address.parse(":d2"))
-        d3 = MockTarget({}, address=Address.parse(":d3"))
-        root = MockTarget(
-            {Dependencies.alias: [d1.address, d2.address, d3.address]},
-            address=Address.parse(":root"),
-        )
-
         self.add_to_build_file(
             "",
             dedent(
@@ -58,6 +48,16 @@ class GraphTest(TestBase):
                 """
             ),
         )
+
+        def get_target(name: str) -> Target:
+            return self.request_single_product(WrappedTarget, Address.parse(f"//:{name}")).target
+
+        t1 = get_target("t1")
+        t2 = get_target("t2")
+        d1 = get_target("d1")
+        d2 = get_target("d2")
+        d3 = get_target("d3")
+        root = get_target("root")
 
         direct_deps = self.request_single_product(
             Targets, Params(DependenciesRequest(root[Dependencies]), create_options_bootstrapper())


### PR DESCRIPTION
Now, `Dependencies` is a normal `StringSequenceField` like anything else. (Although, a little different because it's `AsyncField` like `Sources`).

This unblocks us from adding the `!` ignore syntax to the `dependencies` field, along with adding explicit file dependencies.

[ci skip-rust-tests]