### PR TITLE
refactor execution strategy options into separate struct

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -12,6 +12,7 @@ from pants.engine.fs import PathGlobs
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import (
     PyExecutionRequest,
+    PyExecutionStrategyOptions,
     PyExecutor,
     PyGeneratorResponseBreak,
     PyGeneratorResponseGet,
@@ -225,6 +226,16 @@ class Native(metaclass=SingletonMetaclass):
             execution_overall_deadline_secs=execution_options.remote_execution_overall_deadline_secs,
         )
 
+        exec_stategy_opts = PyExecutionStrategyOptions(
+            local_parallelism=execution_options.process_execution_local_parallelism,
+            remote_parallelism=execution_options.process_execution_remote_parallelism,
+            cleanup_local_dirs=execution_options.process_execution_cleanup_local_dirs,
+            speculation_delay=execution_options.process_execution_speculation_delay,
+            speculation_strategy=execution_options.process_execution_speculation_strategy,
+            use_local_cache=execution_options.process_execution_use_local_cache,
+            local_enable_nailgun=execution_options.process_execution_local_enable_nailgun,
+        )
+
         return self.lib.scheduler_create(
             self._executor,
             tasks,
@@ -238,13 +249,7 @@ class Native(metaclass=SingletonMetaclass):
             use_gitignore,
             root_subject_types,
             remoting_options,
-            execution_options.process_execution_local_parallelism,
-            execution_options.process_execution_remote_parallelism,
-            execution_options.process_execution_cleanup_local_dirs,
-            execution_options.process_execution_speculation_delay,
-            execution_options.process_execution_speculation_strategy,
-            execution_options.process_execution_use_local_cache,
-            execution_options.process_execution_local_enable_nailgun,
+            exec_stategy_opts,
         )
 
     def set_panic_handler(self):

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -43,7 +43,7 @@ mod selectors;
 mod tasks;
 mod types;
 
-pub use crate::context::{Core, RemotingOptions};
+pub use crate::context::{Core, ExecutionStrategyOptions, RemotingOptions};
 pub use crate::core::{Failure, Function, Key, Params, TypeId, Value};
 pub use crate::intrinsics::Intrinsics;
 pub use crate::scheduler::{ExecutionRequest, ExecutionTermination, Scheduler, Session};


### PR DESCRIPTION
### Problem

The large number of execution strategy-related options passed into the engine's `Core::new` function is unwieldy. Adding a new option is a chore.

### Solution

Introduce `ExecutionStrategyOptions` struct and a `PyExecutionStrategyOptions` wrapper. Use both.

### Result

The execution strategy-related options are now grouped into a single `ExecutionStrategyOptions` that can be passed around. It is clear where to add new execution strategy-related options.

Implements https://github.com/pantsbuild/pants/issues/10273
