### PR TITLE
Move SubprocessProcessHandler near its single use.

### DIFF
--- a/src/python/pants/console/BUILD
+++ b/src/python/pants/console/BUILD
@@ -4,7 +4,4 @@
 python_library(
   name = 'stty_utils',
   sources = ['stty_utils.py'],
-  dependencies = [
-    'src/python/pants/util:process_handler',  # NB: only for a bug with setup-py. Remove when fixed.
-  ],
 )

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -29,6 +29,7 @@ python_library(
   sources = ['pants_run_integration_test.py'],
   dependencies = [
     '//:build_root',
+    ':process_handler',
     'src/python/pants:entry_point'
   ],
 )
@@ -46,6 +47,7 @@ target(
   ],
 )
 
+python_tests(name='tests')
 
 python_library(
   name = 'test_base',
@@ -56,7 +58,6 @@ python_library(
   name = 'external_tool_test_base',
   sources = ['external_tool_test_base.py'],
 )
-
 
 python_library(
   name = 'goal_rule_test_base',
@@ -81,6 +82,11 @@ python_library(
 python_library(
   name='pexrc_util',
   sources=['pexrc_util.py'],
+)
+
+python_library(
+  name='process_handler',
+  sources=['process_handler.py'],
 )
 
 python_library(

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -46,7 +46,10 @@ target(
   ],
 )
 
-python_tests(name='tests')
+python_tests(
+  name='tests',
+  sources=['*_test.py', '!pants_run_integration_test.py']
+)
 
 python_library(
   name = 'test_base',

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -29,7 +29,6 @@ python_library(
   sources = ['pants_run_integration_test.py'],
   dependencies = [
     '//:build_root',
-    ':process_handler',
     'src/python/pants:entry_point'
   ],
 )

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -20,10 +20,10 @@ from pants.option.config import TomlSerializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon_client import PantsDaemonClient
 from pants.subsystem.subsystem import Subsystem
+from pants.testutil.process_handler import SubprocessProcessHandler
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import fast_relpath, safe_mkdir, safe_open
 from pants.util.osutil import Pid
-from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.strutil import ensure_binary
 
 # NB: If `shell=True`, it's a single `str`.

--- a/src/python/pants/testutil/process_handler.py
+++ b/src/python/pants/testutil/process_handler.py
@@ -5,40 +5,10 @@ import io
 import multiprocessing
 import subprocess
 import sys
-from abc import ABC, abstractmethod
 from typing import Optional
 
 
-class ProcessHandler(ABC):
-    """An abstraction of process handling calls using the same interface as subprocess.Popen.
-
-    See SubprocessProcessHandler below for an example.
-    """
-
-    @abstractmethod
-    def wait(self, timeout: Optional[float] = None) -> int:
-        """Wait for the underlying process to terminate.
-
-        :param timeout: The time to wait for the process to terminate in fractional seconds. Wait
-                        forever by default.
-        :returns: The process exit code is it has terminated.
-        :raises: :class:`subprocess.TimeoutExpired`
-        """
-
-    @abstractmethod
-    def kill(self) -> None:
-        pass
-
-    @abstractmethod
-    def terminate(self) -> None:
-        pass
-
-    @abstractmethod
-    def poll(self) -> Optional[int]:
-        pass
-
-
-class SubprocessProcessHandler(ProcessHandler):
+class SubprocessProcessHandler:
     """A `ProcessHandler` that delegates directly to a subprocess.Popen object."""
 
     def __init__(self, process: subprocess.Popen) -> None:

--- a/src/python/pants/testutil/process_handler_test.py
+++ b/src/python/pants/testutil/process_handler_test.py
@@ -5,7 +5,7 @@ import subprocess
 import unittest
 from textwrap import dedent
 
-from pants.util.process_handler import SubprocessProcessHandler
+from pants.testutil.process_handler import SubprocessProcessHandler
 
 
 class TestSubprocessProcessHandler(unittest.TestCase):

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -89,11 +89,6 @@ python_library(
 )
 
 python_library(
-  name = 'process_handler',
-  sources = ['process_handler.py'],
-)
-
-python_library(
   name = 'retry',
   sources = ['retry.py'],
 )


### PR DESCRIPTION
The setup-py goal discovered that process_handler.py was no longer used
by production code. Move it where its used and kill the unused
abstraction.

[ci skip-rust-tests]