### PR TITLE
Render only leaf rule graph errors, and improve error messages

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -19,11 +19,7 @@ from pants.reporting.streaming_workunit_handler import (
     StreamingWorkunitContext,
     StreamingWorkunitHandler,
 )
-from pants.testutil.engine.util import (
-    assert_equal_with_printing,
-    fmt_rule,
-    remove_locations_from_traceback,
-)
+from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants.testutil.test_base import TestBase
 from pants.util.logging import LogLevel
 
@@ -325,17 +321,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         with self.assertRaises(Exception) as cm:
             list(self.mk_scheduler(rules=rules, include_trace_on_error=False))
 
-        self.assert_equal_with_printing(
-            dedent(
-                f"""
-                Rules with errors: 1
-
-                  {fmt_rule(upcast)}:
-                    No rule was available to compute MyInt. Maybe declare RootRule(MyInt)?
-                """
-            ).strip(),
-            str(cm.exception),
-        )
+        assert "consider declaring RootRule(MyInt)" in str(cm.exception)
 
 
 @dataclass

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -517,7 +517,7 @@ class RuleGraphTest(TestBase):
                 Rules with errors: 1
 
                   {fmt_rule(a_from_b)}:
-                    No rule was available to compute B with parameter type SubA
+                    No rule was able to compute B. No installed rules return the type B: Is the rule that you're expecting to run registered? If that type should be provided from outside the rule graph, consider declaring RootRule(B).
                 """
             ).strip(),
             str(cm.exception),
@@ -585,8 +585,8 @@ class RuleGraphTest(TestBase):
                 Rules with errors: 1
 
                   {fmt_rule(a_from_b_and_c)}:
-                    No rule was available to compute B with parameter type SubA
-                    No rule was available to compute C with parameter type SubA
+                    No rule was able to compute B. No installed rules return the type B: Is the rule that you're expecting to run registered? If that type should be provided from outside the rule graph, consider declaring RootRule(B).
+                    No rule was able to compute C. No installed rules return the type C: Is the rule that you're expecting to run registered? If that type should be provided from outside the rule graph, consider declaring RootRule(C).
                 """
             ).strip(),
             str(cm.exception),
@@ -620,13 +620,10 @@ class RuleGraphTest(TestBase):
         self.assert_equal_with_printing(
             dedent(
                 f"""\
-                Rules with errors: 2
-
-                  {fmt_rule(a_from_b)}:
-                    No rule was available to compute B with parameter type C
+                Rules with errors: 1
 
                   {fmt_rule(b_from_suba)}:
-                    No rule was available to compute SubA with parameter type C
+                    No rule was able to compute SubA. No installed rules return the type SubA: Is the rule that you're expecting to run registered? If that type should be provided from outside the rule graph, consider declaring RootRule(SubA).
                 """
             ).strip(),
             str(cm.exception),
@@ -657,7 +654,7 @@ class RuleGraphTest(TestBase):
                 Rules with errors: 1
 
                   {fmt_rule(d_from_c)}:
-                    No rule was available to compute C with parameter type A
+                    No rule was able to compute C. No installed rules return the type C: Is the rule that you're expecting to run registered? If that type should be provided from outside the rule graph, consider declaring RootRule(C).
                 """
             ).strip(),
             str(cm.exception),
@@ -692,16 +689,16 @@ class RuleGraphTest(TestBase):
             self,
             dedent(
                 f"""\
-                Rules with errors: 3
+                Rules with errors: 2
 
                   {fmt_rule(a_from_c)}:
                     Was not reachable, either because no rules could produce the params or because it was shadowed by another @rule.
-                  {fmt_rule(b_from_d)}:
 
-                    No rule was available to compute D with parameter type SubA
                   {fmt_rule(d_from_a_and_suba, gets=[("A", "C")])}:
-
-                    No rule was available to compute A with parameter type SubA
+                    No rule was able to compute A.:
+                      @rule(C) -> A
+                pants.engine.rules_test:667:a_from_c
+                for SubA: Was unfulfillable.
                 """
             ).strip(),
             str(cm.exception),

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -31,8 +31,10 @@
 use std::collections::{hash_map, BTreeSet, HashMap, HashSet};
 
 use crate::rules::{DependencyKey, Rule};
+// TODO: The Builder should likely not be using `params_str`: we should be able to build a graph
+// without ever rendering a string representation, and deferring that for when/if we have errored.
 use crate::{
-  entry_str, params_str, Diagnostic, Entry, EntryWithDeps, InnerEntry, ParamTypes, RootEntry,
+  params_str, Diagnostic, Entry, EntryWithDeps, InnerEntry, ParamTypes, RootEntry,
   RuleDependencyEdges, RuleEdges, RuleGraph, UnfulfillableRuleMap, UnreachableError,
 };
 
@@ -43,7 +45,7 @@ enum ConstructGraphResult<R: Rule> {
   // contains copies of the input Entry for each set subset of the parameters that satisfy it.
   Fulfilled(Vec<EntryWithDeps<R>>),
   // The Entry was not satisfiable with installed rules.
-  Unfulfillable,
+  Unfulfillable(EntryWithDeps<R>),
   // The dependencies of an Entry might be satisfiable, but is currently blocked waiting for the
   // results of the given entries.
   //
@@ -173,7 +175,7 @@ impl<'t, R: Rule> Builder<'t, R> {
       return ConstructGraphResult::Fulfilled(simplified.clone());
     } else if unfulfillable_rules.get(&entry).is_some() {
       // The rule is unfulfillable.
-      return ConstructGraphResult::Unfulfillable;
+      return ConstructGraphResult::Unfulfillable(entry);
     }
 
     // Otherwise, store a placeholder in the rule_dependency_edges map and then visit its
@@ -258,6 +260,7 @@ impl<'t, R: Rule> Builder<'t, R> {
       let fulfillable_candidates = fulfillable_candidates_by_key
         .entry(dependency_key)
         .or_insert_with(Vec::new);
+      let mut unfulfillable_candidates = Vec::new();
       for candidate in self.rhs(&params, product) {
         match candidate {
           Entry::WithDeps(c) => match self.construct_graph_helper(
@@ -266,7 +269,9 @@ impl<'t, R: Rule> Builder<'t, R> {
             unfulfillable_rules,
             c,
           ) {
-            ConstructGraphResult::Unfulfillable => {}
+            ConstructGraphResult::Unfulfillable(c) => {
+              unfulfillable_candidates.push((Entry::WithDeps(c), Some("Was unfulfillable.")));
+            }
             ConstructGraphResult::Fulfilled(simplified_entries) => {
               fulfillable_candidates.push(
                 simplified_entries
@@ -305,6 +310,11 @@ impl<'t, R: Rule> Builder<'t, R> {
             // be consumed.
             if provided_param.is_none() {
               fulfillable_candidates.push(vec![Entry::Param(param)]);
+            } else {
+              unfulfillable_candidates.push((
+                Entry::Param(param),
+                Some("Cannot consume a Param to fulfill a Get."),
+              ));
             }
           }
         };
@@ -333,7 +343,7 @@ impl<'t, R: Rule> Builder<'t, R> {
               params_str(&params),
             )
           },
-          details: vec![],
+          details: unfulfillable_candidates,
         });
       }
     }
@@ -348,7 +358,7 @@ impl<'t, R: Rule> Builder<'t, R> {
         .or_insert_with(Vec::new)
         .extend(unfulfillable_diagnostics);
       rule_dependency_edges.remove(&entry);
-      return Ok(ConstructGraphResult::Unfulfillable);
+      return Ok(ConstructGraphResult::Unfulfillable(entry));
     }
 
     // No dependencies were completely unfulfillable (although some may have been cyclic).
@@ -368,7 +378,7 @@ impl<'t, R: Rule> Builder<'t, R> {
             .or_insert_with(Vec::new)
             .extend(ambiguous_diagnostics);
           rule_dependency_edges.remove(&entry);
-          return Ok(ConstructGraphResult::Unfulfillable);
+          return Ok(ConstructGraphResult::Unfulfillable(entry));
         }
       };
     let simplified_entries_only: Vec<_> = simplified_entries.keys().cloned().collect();
@@ -418,7 +428,7 @@ impl<'t, R: Rule> Builder<'t, R> {
   fn monomorphize(
     entry: &EntryWithDeps<R>,
     deps: &[(R::DependencyKey, Vec<Entry<R>>)],
-  ) -> Result<RuleDependencyEdges<R>, Vec<Diagnostic<R::TypeId>>> {
+  ) -> Result<RuleDependencyEdges<R>, Vec<Diagnostic<R>>> {
     // Collect the powerset of the union of used parameters, ordered by set size.
     let params_powerset: Vec<Vec<R::TypeId>> = {
       let mut all_used_params = BTreeSet::new();
@@ -488,7 +498,7 @@ impl<'t, R: Rule> Builder<'t, R> {
   fn choose_dependencies<'a>(
     available_params: &ParamTypes<R::TypeId>,
     deps: &'a [(R::DependencyKey, Vec<Entry<R>>)],
-  ) -> Result<Option<Vec<ChosenDependency<'a, R>>>, Diagnostic<R::TypeId>> {
+  ) -> Result<Option<Vec<ChosenDependency<'a, R>>>, Diagnostic<R>> {
     let mut combination = Vec::new();
     for (key, input_entries) in deps {
       let provided_param = key.provided_param();
@@ -525,7 +535,10 @@ impl<'t, R: Rule> Builder<'t, R> {
               params_clause,
               params_str(&available_params),
             ),
-            details: chosen_entries.into_iter().map(entry_str).collect(),
+            details: chosen_entries
+              .into_iter()
+              .map(|e| (e.clone(), None))
+              .collect(),
           });
         }
       }

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -330,18 +330,25 @@ impl<'t, R: Rule> Builder<'t, R> {
         // If no candidates were fulfillable, this rule is not fulfillable.
         unfulfillable_diagnostics.push(Diagnostic {
           params: params.clone(),
-          reason: if params.is_empty() {
-            format!(
-              "No rule was available to compute {}. Maybe declare RootRule({})?",
-              dependency_key, product,
-            )
-          } else {
-            format!(
-              "No rule was available to compute {} with parameter type{} {}",
-              dependency_key,
-              if params.len() > 1 { "s" } else { "" },
-              params_str(&params),
-            )
+          reason: {
+            let hint = if unfulfillable_candidates.is_empty() {
+              let root_hint = if provided_param.is_none() {
+                format!(
+                    " If that type should be provided from outside the rule graph, consider declaring RootRule({}).",
+                    product
+                )
+              } else {
+                "".to_string()
+              };
+              format!(
+                  " No installed rules return the type {}: Is the rule that you're expecting to run registered?{}",
+                  product,
+                  root_hint
+              )
+            } else {
+              "".to_string()
+            };
+            format!("No rule was able to compute {}.{}", dependency_key, hint)
           },
           details: unfulfillable_candidates,
         });

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -39,7 +39,33 @@ pub trait DisplayForGraph {
   ///
   /// Return a pretty-printed representation of this Rule's graph node, suitable for graphviz.
   ///
-  fn fmt_for_graph(&self) -> String;
+  fn fmt_for_graph(&self, display_args: DisplayForGraphArgs) -> String;
+}
+
+///
+/// A struct to contain display options consumed by DisplayForGraph.
+///
+#[derive(Clone, Copy)]
+pub struct DisplayForGraphArgs {
+  pub multiline: bool,
+}
+
+impl DisplayForGraphArgs {
+  pub fn line_separator(&self) -> &'static str {
+    if self.multiline {
+      "\n"
+    } else {
+      " "
+    }
+  }
+
+  pub fn optional_line_separator(&self) -> &'static str {
+    if self.multiline {
+      "\n"
+    } else {
+      ""
+    }
+  }
 }
 
 pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + DisplayForGraph + 'static {

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -113,7 +113,7 @@ impl super::Rule for Rule {
 }
 
 impl super::DisplayForGraph for Rule {
-  fn fmt_for_graph(&self) -> String {
+  fn fmt_for_graph(&self, _: super::DisplayForGraphArgs) -> String {
     self.to_string()
   }
 }

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -24,7 +24,7 @@ fn no_root() {
     .validate()
     .err()
     .unwrap()
-    .contains("No rule was available to compute DependencyKey(\"b\", None)."));
+    .contains("No rule was able to compute DependencyKey(\"b\", None)."));
 }
 
 #[test]


### PR DESCRIPTION
### Problem

As further described in #8808, `@rule` graph errors are currently effectively unusable for larger graphs because we render all failed entries rather than only the "root causes".

### Solution

Render the failed "leaves" of the graph, which are (most likely) to be the root causes of any failed nodes that depend on them.

Additionally, improve diagnostics by differentiating between:
1. Not having any installed rules that provide a type
    a. for a "Select", which could potentially be satisfied by installing a `RootRule`
    b. for a `Get`, which can only be satisfied by installing an additional rule
2. Having installed rules to provide a type, but none satisfiable.

### Result

Breaking an existing rule very deep in the graph (by attempting to `Get(DigestContents, PathGlobs)`, which we should fix, but I digress), goes from (note "snipped" lines):
#### Before:
```
Exception: Rules with errors: 82

<snip 266 lines>

  @rule(pants.engine.internals.build_files:61:parse_address_family(AddressMapper, BuildFilePreludeSymbols, Dir) -> AddressFamily, gets=[Get(Snapshot, PathGlobs), Get(DigestContents, Digest)]):
    No rule was available to compute BuildFilePreludeSymbols with parameter types (AddPrefix, Address, AddressSpecs, AddressWithOrigin, Addresses, AllSourceFilesRequest, ChangedRequest, Console, CreateDigest, DependenciesRequest, Digest, Dir, ExternalToolRequest, FieldSetsWithSourcesRequest, FilesystemSpecs, HydrateSourcesRequest, InferDependenciesRequest, InferPythonDependencies, InjectDependenciesRequest, InteractiveRunner, IsortRequest, MaybeExtractable, MergeDigests, MultiPlatformProcess, OptionsBootstrapper, OwnersRequest, PathGlobs, PexFromTargetsRequest, PexRequest, Process, PythonFmtTargets, RemovePrefix, Scope, SetupRequest, SnapshotSubset, SourceRootRequest, SpecifiedSourceFilesRequest, StripSnapshotRequest, StripSourcesFieldRequest, TargetsToValidFieldSetsRequest, TargetsWithSourcesRequest, TwoStepPexFromTargetsRequest, TwoStepPexRequest, UnstrippedPythonSourcesRequest, UrlToFetch, Workspace)

<snip 48 lines>
```
#### After:
```
Exception: Rules with errors: 8

<snip 20 lines>

  @rule(pants.engine.internals.build_files:61:parse_address_family(AddressMapper, BuildFilePreludeSymbols, Dir) -> AddressFamily, gets=[Get(Snapshot, PathGlobs), Get(DigestContents, Digest)]):
    No rule was able to compute BuildFilePreludeSymbols.:
      @rule(pants.engine.internals.build_files:35:evaluate_preludes(AddressMapper) -> BuildFilePreludeSymbols, gets=[Get(DigestContents, PathGlobs)]) for (AddPrefix, Address, AddressSpecs, Addresses, AllSourceFilesRequest, ChangedRequest, Console, CreateDigest, DependenciesRequest, Digest, Dir, ExternalToolRequest, FieldSetsWithSourcesRequest, HydrateSourcesRequest, InferDependenciesRequest, InferPythonDependencies, InjectDependenciesRequest, InteractiveRunner, MaybeExtractable, MergeDigests, MultiPlatformProcess, OptionsBootstrapper, OwnersRequest, PathGlobs, PexFromTargetsRequest, PexRequest, Process, PythonModule, PythonTestFieldSet, RemovePrefix, Scope, SnapshotSubset, SourceRootRequest, SpecifiedSourceFilesRequest, Specs, StripSnapshotRequest, StripSourcesFieldRequest, TargetsToValidFieldSetsRequest, TargetsWithSourcesRequest, TwoStepPexFromTargetsRequest, TwoStepPexRequest, UnstrippedPythonSourcesRequest, UrlToFetch, Workspace, WrappedTestFieldSet): Was unfulfillable.
```

Fixes #8808.
