### PR TITLE
call instance method on instance rather than class

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -105,7 +105,7 @@ class JvmTask(Task):
             if isinstance(target, JvmTarget)
         ]
         if not target_platforms:
-            return [JvmPlatform.default_runtime_platform]
+            return [JvmPlatform.global_instance().default_runtime_platform]
         else:
             return target_platforms
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
@@ -111,7 +111,8 @@ class JvmTaskTest(JvmTaskTestBase):
             )
 
             self.assertEqual(
-                [JvmPlatform.default_runtime_platform], self.task.runtime_platforms_for_targets([])
+                [JvmPlatform.global_instance().default_runtime_platform],
+                self.task.runtime_platforms_for_targets([]),
             )
 
     def java8_platform(self):


### PR DESCRIPTION
### Problem

`'property' object has no attribute 'strict` in `.../jvm_platform.py`, line 147

### Solution

Get the default runtime platform off of the global instance instead of the class.

### Result

The issue should be fixed.