### PR TITLE
Hotfix Bandit breaking from stevedore 3.0 release

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -10,9 +10,9 @@ class Bandit(PythonToolBase):
     options_scope = "bandit"
     default_version = "bandit>=1.6.2,<1.7"
     # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
-    default_extra_requirements = ["setuptools<45", "stevedore>=2.0.1,<3"]
+    default_extra_requirements = ["setuptools<45", "stevedore<3"]
     default_entry_point = "bandit"
-    default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.0"]
+    default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.5"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -9,7 +9,8 @@ from pants.option.custom_types import file_option, shell_str
 class Bandit(PythonToolBase):
     options_scope = "bandit"
     default_version = "bandit>=1.6.2,<1.7"
-    default_extra_requirements = ["setuptools<45"]  # `<45` is for Python 2 support
+    # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
+    default_extra_requirements = ["setuptools<45", "stevedore>=2.0.1,<3"]
     default_entry_point = "bandit"
     default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.0"]
 


### PR DESCRIPTION
CI starting breaking about 4 hours ago, when a transitive dep of `Bandit` called [Stevedore had its 3.0 release](https://pypi.org/project/stevedore/#history).
 
The failure was:

```
  File "/Users/eric/.pex/installed_wheels/00819186ecdcbd98d3ccae67a09c673ec7165d77/stevedore-3.0.0-py3-none-any.whl/stevedore/_cache.py", line 62, in _get_mtime
    s = os.stat(name)
NotADirectoryError: [Errno 20] Not a directory: '/private/tmp/process-execution4QrCGY/bandit.pex/.bootstrap'
```

Closes https://github.com/pantsbuild/pants/issues/10316.

[ci skip-rust-tests]