### PR TITLE
Bump to nails 0.6.0 to lay groundwork for cancelation of pantsd runs

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1603,7 +1603,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "nails 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2008,7 +2008,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
- "nails 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3675,7 +3675,7 @@ dependencies = [
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-"checksum nails 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e878cb7ecafadf84e7f41c9b58b104d522bb3c861340c80364fb56e289f99683"
+"checksum nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "730beff5b62ab70260d375993bc1ed6f23fce54ee4ede3d95e2ac93545443c6b"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum notify 5.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b00c0b65188bffb5598c302e19b062feb94adef02c31f15622a163c95d673c3"

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 bytes = "0.5"
 futures = "0.3"
 log = "0.4"
-nails = "0.5.1"
+nails = "0.6.0"
 os_pipe = "0.9"
 task_executor = { path = "../task_executor" }
 # TODO: See #10291.

--- a/src/rust/engine/nailgun/src/tests.rs
+++ b/src/rust/engine/nailgun/src/tests.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future;
-use nails::client_handle_connection;
 use nails::execution::{child_channel, ChildInput, ChildOutput, Command, ExitCode};
+use nails::{client_handle_connection, Config};
 use task_executor::Executor;
 use tokio::net::TcpStream;
 use tokio::runtime::Handle;
@@ -88,7 +88,7 @@ async fn run_client(port: u16) -> Result<ExitCode, String> {
   let (stdio_write, _stdio_read) = child_channel::<ChildOutput>();
   let (_stdin_write, stdin_read) = child_channel::<ChildInput>();
   let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-  client_handle_connection(stream, cmd, stdio_write, stdin_read)
+  client_handle_connection(Config::default(), stream, cmd, stdio_write, stdin_read)
     .await
     .map_err(|e| e.to_string())
 }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -21,7 +21,7 @@ grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "ed3afa3c24d
 hashing = { path = "../hashing" }
 libc = "0.2.39"
 log = "0.4"
-nails = "0.5.1"
+nails = "0.6.0"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 sha2 = "0.9"
 sharded_lmdb = {  path = "../sharded_lmdb" }

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -268,7 +268,13 @@ impl CapturedWorkdir for CommandRunner {
         debug!("Connecting to server at {}...", addr);
         TcpStream::connect(addr)
           .and_then(move |stream| {
-            nails::client_handle_connection(stream, cmd, stdio_write, stdin_read)
+            nails::client_handle_connection(
+              nails::Config::default(),
+              stream,
+              cmd,
+              stdio_write,
+              stdin_read,
+            )
           })
           .map_err(|e| format!("Error communicating with server: {}", e))
           .map_ok(ChildOutput::Exit)


### PR DESCRIPTION
### Problem

To prepare for #7654, we need to remove dependence on signal handling between the pantsd client and server. Signals do not provide enough information to decide which run to abort, and in general are not particularly subtle.

### Solution

Rather than signals, we will instead rely on nailgun connection liveness via the "Heartbeat" extension to the nailgun protocol (implemented in [nails 0.6.0](https://github.com/stuhood/nails/compare/fb72699d929cbffe80aee18cd539c77699f1f5be...070fe03cdc20996c40c62d1694d6a69459b6faa9)), which allows for requiring regular heartbeats from the client, and aborting a run if they do not arrive.

In addition to heartbeats, `nails` now also makes guarantees about how a `Nail` will be notified that the connection has closed (namely that the input stream will remain open until the connection dies).

### Result

Followup changes (including #10004) will be able to take advantage of these new signals to cancel ongoing work without killing the pantsd server.