### PR TITLE
Fix awslambda configuration of Pex.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -18,7 +18,7 @@ mypy==0.781
 
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.12
+pex==2.1.13
 psutil==5.7.0
 pystache==0.5.4
 python-Levenshtein==0.12.0

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -63,7 +63,7 @@ async def create_python_awslambda(
     # (Running the "hello world" lambda in the example code will report the platform, and can be
     # used to verify correctness of these platform strings.)
     py_major, py_minor = field_set.runtime.to_interpreter_version()
-    platform = f"manylinux2014_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
+    platform = f"linux_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
     # set pymalloc ABI flag - this was removed in python 3.8 https://bugs.python.org/issue36707
     if py_major <= 3 and py_minor < 8:
         platform += "m"
@@ -75,6 +75,13 @@ async def create_python_awslambda(
             entry_point=None,
             output_filename=pex_filename,
             platforms=PexPlatforms([platform]),
+            additional_args=[
+                # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
+                "--manylinux=manylinux2014",
+                # When we're executing Pex on Linux, allow a local interpreter to be resolved if
+                # available and matching the AMI platform.
+                "--resolve-local-platforms",
+            ],
         )
     )
 

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -23,9 +23,9 @@ from pants.python.python_setup import PythonSetup
 class PexBin(ExternalTool):
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.12"
+    default_version = "v2.1.13"
     default_known_versions = [
-        f"v2.1.12|{plat}|98cee30e00bfad8279159390139844f9154d9505f98cdbf35733f92412e26910|2631935"
+        f"v2.1.13|{plat}|240712c75bb7c7cdfe3dd808ad6e6f186182e6aea3efeea5760683bb0fe89198|2633838"
         for plat in ["darwin", "linux"]
     ]
 


### PR DESCRIPTION
With an upgrade of Pex to support resolution of `--platform` arguments
to matching local interpreters, awslambda now supports building sdists
when possible. Additionally, awslambda now allows for AMI-specific
non-manylinux wheels if needed.

Fixes #10286.

[ci skip-rust-tests]