### PR TITLE
access store server for action cache

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -122,14 +122,17 @@ impl CommandRunner {
     ));
 
     let store_channel = {
+      let store_server = store_servers
+        .get(0)
+        .ok_or_else(|| "At least one store_server must be specified".to_owned())?;
       let builder = grpcio::ChannelBuilder::new(env.clone());
       if let Some(ref root_ca_certs) = root_ca_certs {
         let creds = grpcio::ChannelCredentialsBuilder::new()
           .root_cert(root_ca_certs.clone())
           .build();
-        builder.secure_connect(&store_servers[0], creds)
+        builder.secure_connect(&store_server, creds)
       } else {
-        builder.connect(&store_servers[0])
+        builder.connect(&store_server)
       }
     };
     let action_cache_client = Arc::new(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -96,6 +96,7 @@ impl CommandRunner {
   /// Construct a new CommandRunner
   pub fn new(
     address: &str,
+    store_servers: Vec<String>,
     metadata: ProcessMetadata,
     root_ca_certs: Option<Vec<u8>>,
     oauth_bearer_token: Option<String>,
@@ -107,9 +108,9 @@ impl CommandRunner {
     let env = Arc::new(grpcio::EnvBuilder::new().build());
     let channel = {
       let builder = grpcio::ChannelBuilder::new(env.clone());
-      if let Some(root_ca_certs) = root_ca_certs {
+      if let Some(ref root_ca_certs) = root_ca_certs {
         let creds = grpcio::ChannelCredentialsBuilder::new()
-          .root_cert(root_ca_certs)
+          .root_cert(root_ca_certs.clone())
           .build();
         builder.secure_connect(address, creds)
       } else {
@@ -119,8 +120,20 @@ impl CommandRunner {
     let execution_client = Arc::new(bazel_protos::remote_execution_grpc::ExecutionClient::new(
       channel.clone(),
     ));
+
+    let store_channel = {
+      let builder = grpcio::ChannelBuilder::new(env.clone());
+      if let Some(ref root_ca_certs) = root_ca_certs {
+        let creds = grpcio::ChannelCredentialsBuilder::new()
+          .root_cert(root_ca_certs.clone())
+          .build();
+        builder.secure_connect(&store_servers[0], creds)
+      } else {
+        builder.connect(&store_servers[0])
+      }
+    };
     let action_cache_client = Arc::new(
-      bazel_protos::remote_execution_grpc::ActionCacheClient::new(channel.clone()),
+      bazel_protos::remote_execution_grpc::ActionCacheClient::new(store_channel),
     );
 
     let mut headers = headers;

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -943,6 +943,7 @@ async fn sends_headers() {
 
   let command_runner = CommandRunner::new(
     &mock_server.address(),
+    vec![mock_server.address().clone()],
     empty_request_metadata(),
     None,
     Some(String::from("catnip-will-get-you-anywhere")),
@@ -1149,6 +1150,7 @@ async fn ensure_inline_stdio_is_stored() {
 
   let cmd_runner = CommandRunner::new(
     &mock_server.address(),
+    vec![mock_server.address().clone()],
     empty_request_metadata(),
     None,
     None,
@@ -1431,6 +1433,7 @@ async fn execute_missing_file_uploads_if_known() {
     .expect("Saving directory bytes to store");
   let command_runner = CommandRunner::new(
     &mock_server.address(),
+    vec![mock_server.address().clone()],
     empty_request_metadata(),
     None,
     None,
@@ -1506,6 +1509,7 @@ async fn execute_missing_file_errors_if_unknown() {
 
   let runner = CommandRunner::new(
     &mock_server.address(),
+    vec![mock_server.address().clone()],
     empty_request_metadata(),
     None,
     None,
@@ -2209,6 +2213,7 @@ fn create_command_runner(
   let store = make_store(store_dir.path(), cas, runtime.clone());
   let command_runner = CommandRunner::new(
     &address,
+    vec![address.clone()],
     empty_request_metadata(),
     None,
     None,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -384,6 +384,7 @@ async fn main() {
         Box::new(
           process_execution::remote::CommandRunner::new(
             address,
+            vec![address.to_owned()],
             ProcessMetadata {
               instance_name: remote_instance_arg,
               cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -197,6 +197,7 @@ impl Core {
             // requires the remoting_opts.execution_server be present when
             // remoting_opts.execution_enable is set.
             &remoting_opts.execution_server.unwrap(),
+            remoting_opts.store_servers.clone(),
             process_execution_metadata.clone(),
             root_ca_certs,
             oauth_bearer_token,


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/10317 describes a bug where Pants looks for the Action Cache at the address of the remote execution servers instead of remote store servers, which causes Pants to not find the Action Cache when it is hosted on the store servers.

### Solution

Use the store server for the Action Cache location.

### Result

Pants is able to retrieve action results from the Action Cache in situations where the execution and store servers are different.
