### PR TITLE
Display whether a scope is a goal or subsystem in help.

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -37,7 +37,8 @@ class HelpFormatter:
 
         def add_option(ohis, *, category=None):
             lines.append("")
-            display_scope = f"`{oshi.scope}`" if oshi.scope else "Global"
+            goal_or_subsystem = "goal" if oshi.is_goal else "subsystem"
+            display_scope = f"`{oshi.scope}` {goal_or_subsystem}" if oshi.scope else "Global"
             if category:
                 title = f"{display_scope} {category} options"
                 lines.append(self._maybe_green(f"{title}\n{'-' * len(title)}"))
@@ -58,7 +59,7 @@ class HelpFormatter:
             add_option(oshi.advanced, category="advanced")
         if self._show_deprecated:
             add_option(oshi.deprecated, category="deprecated")
-        return [*lines, "\n"]
+        return [*lines, ""]
 
     def format_option(self, ohi: OptionHelpInfo) -> List[str]:
         """Format the help output for a single option.

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -63,7 +63,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         parser.register(*args, **kwargs)
         # Force a parse to generate the derivation history.
         parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainer(), lambda: [], 0, []))
-        oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser)
+        oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False)
         return HelpFormatter(
             show_advanced=show_advanced, show_deprecated=show_deprecated, color=False
         ).format_options(oshi)

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -102,7 +102,9 @@ def test_default() -> None:
             parent_parser=None,
         )
         parser.register(*args, **kwargs)
-        oshi = HelpInfoExtracter(parser.scope).get_option_scope_help_info("description", parser)
+        oshi = HelpInfoExtracter(parser.scope).get_option_scope_help_info(
+            "description", parser, False
+        )
         assert oshi.description == "description"
         assert len(oshi.basic) == 1
         ohi = oshi.basic[0]
@@ -182,7 +184,7 @@ def test_grouping():
             parent_parser=None,
         )
         parser.register("--foo", **kwargs)
-        oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser)
+        oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False)
         assert exp_to_len(expected_basic) == len(oshi.basic)
         assert exp_to_len(expected_advanced) == len(oshi.advanced)
 
@@ -241,6 +243,7 @@ def test_get_all_help_info():
             GLOBAL_SCOPE: {
                 "scope": GLOBAL_SCOPE,
                 "description": "Global options.",
+                "is_goal": False,
                 "basic": (
                     {
                         "display_args": ("-o=<int>", "--opt1=<int>"),
@@ -269,6 +272,7 @@ def test_get_all_help_info():
             "foo": {
                 "scope": "foo",
                 "description": "A foo.",
+                "is_goal": False,
                 "basic": (
                     {
                         "display_args": ("--[no-]foo-opt2",),
@@ -315,6 +319,7 @@ def test_get_all_help_info():
             "bar": {
                 "scope": "bar",
                 "description": "The bar goal.",
+                "is_goal": True,
                 "basic": tuple(),
                 "advanced": tuple(),
                 "deprecated": tuple(),

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -38,8 +38,8 @@ class TestHelpIntegration(PantsRunIntegrationTest):
         pants_run = self.run_pants(command=command)
         self.assert_success(pants_run)
         # Spot check to see that scope headings are printed even for advanced options
-        assert "`pytest` options" in pants_run.stdout_data
-        assert "`pytest` advanced options" in pants_run.stdout_data
+        assert "`pytest` subsystem options" in pants_run.stdout_data
+        assert "`pytest` subsystem advanced options" in pants_run.stdout_data
         # Spot check to see that full args for all options are printed
         assert "--[no-]test-debug" in pants_run.stdout_data
         # Spot check to see that subsystem options are printing

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -27,7 +27,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
         pants_run = self.run_pants(command=command)
         self.assert_success(pants_run)
         # Spot check to see that scope headings are printed
-        assert "`pytest` options" in pants_run.stdout_data
+        assert "`pytest` subsystem options" in pants_run.stdout_data
         # Spot check to see that full args for all options are printed
         assert "--[no-]test-debug" in pants_run.stdout_data
         # Spot check to see that subsystem options are printing

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -112,7 +112,7 @@ class HelpPrinter:
             help_scopes = set(help_request.scopes)
 
         if help_scopes:
-            for scope in help_scopes:
+            for scope in sorted(help_scopes):
                 help_str = self._format_help(scope, help_request.advanced)
                 if help_str:
                     print(help_str)
@@ -137,7 +137,7 @@ class HelpPrinter:
             f"  {self._bin_name} help-advanced [goal/subsystem]             Get help for a goal's or subsystem's advanced options."
         )
         print(
-            f"  {self._bin_name} help-all                                   Get help for all goals."
+            f"  {self._bin_name} help-all                                   Get help for all goals and subsystems."
         )
         print(
             f"  {self._bin_name} goals                                      List all installed goals."
@@ -175,4 +175,5 @@ class HelpPrinter:
                 if self._use_color:
                     related_subsystems_label = green(related_subsystems_label)
                 formatted_lines.append(f"{related_subsystems_label} {', '.join(related_scopes)}")
+                formatted_lines.append("")
         return "\n".join(formatted_lines)


### PR DESCRIPTION
Now help for goal options has headers like:

```
`test` goal options
-------------------
```

And help for subsystem options has headers like:

```
`pytest` subsystem options
--------------------------
```

[ci skip-rust-tests]

