### PR TITLE
Minor wording change in help message

### DIFF
--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -149,7 +149,7 @@ class HelpPrinter:
         print("  [target] accepts two special forms:")
         print("    dir:  to include all targets in the specified directory.")
         print("    dir:: to include all targets found recursively under the directory.\n")
-        print("More documentation is available on the official website:\n  http://pantsbuild.org/")
+        print("More documentation is available at https://pantsbuild.org")
 
         print(self._format_help(GLOBAL_SCOPE, advanced))
 

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -148,8 +148,8 @@ class HelpPrinter:
         print("     A path glob, such as '**/*.ext', in quotes to prevent shell expansion.")
         print("  [target] accepts two special forms:")
         print("    dir:  to include all targets in the specified directory.")
-        print("    dir:: to include all targets found recursively under the directory.")
-        print("\nFriendly docs:\n  http://pantsbuild.org/")
+        print("    dir:: to include all targets found recursively under the directory.\n")
+        print("More documentation is available on the official website:\n  http://pantsbuild.org/")
 
         print(self._format_help(GLOBAL_SCOPE, advanced))
 


### PR DESCRIPTION
"Friendly docs" as the description for the link to the official pants docs site in the help seems a tad abrupt (and also implies that the pants inline help is not friendly, which we shouldn't be aiming for). This PR changes the string to "More documentation is available at:"