### PR TITLE
Upgrade setuptools from 49.1.0 to 49.2.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,7 +24,7 @@ python-Levenshtein==0.12.0
 PyYAML>=5.3.1,<5.4
 requests[security]>=2.20.1
 setproctitle==1.1.10
-setuptools==49.1.0
+setuptools==49.2.0
 toml==0.10.1
 typed-ast>=1.4.1,<1.5
 typing-extensions==3.7.4.2

--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -9,5 +9,5 @@ class Lambdex(PythonToolBase):
     default_version = "lambdex==0.1.3"
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.
-    default_extra_requirements = ["setuptools==49.1.0"]
+    default_extra_requirements = ["setuptools==49.2.0"]
     default_entry_point = "lambdex.bin.lambdex"

--- a/src/python/pants/backend/python/rules/setuptools.py
+++ b/src/python/pants/backend/python/rules/setuptools.py
@@ -8,5 +8,5 @@ class Setuptools(PythonToolBase):
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
     options_scope = "setuptools"
-    default_version = "setuptools==49.1.0"
+    default_version = "setuptools==49.2.0"
     default_extra_requirements = ["wheel==0.31.1"]


### PR DESCRIPTION
v49.2.0
-------

* #2230: Now warn the user when setuptools is imported after distutils modules have been loaded (exempting PyPy for 3.6), directing the users of packages to import setuptools first.

v49.1.3
-------

* #2212: (Distutils) Allow spawn to accept environment. Avoid monkey-patching global state.
* #2249: Fix extension loading technique in stubs.

v49.1.2
-------

* #2232: In preparation for re-enabling a local copy of distutils, Setuptools now honors an environment variable, SETUPTOOLS_USE_DISTUTILS. If set to 'stdlib' (current default), distutils will be used from the standard library. If set to 'local' (default in a imminent backward-incompatible release), the local copy of distutils will be used.

v49.1.1
-------

* #2094: Removed pkg_resources.py2_warn module, which is no longer reachable.

v49.0.1
-------

* #2228: Applied fix for pypa/distutils#3, restoring expectation that spawn will raise a DistutilsExecError when attempting to execute a missing file.