### PR TITLE
Fix generated subtargets not working with `dependees`

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -244,6 +244,15 @@ class Address:
             return self.spec
         return self._spec_path
 
+    def maybe_convert_to_base_target(self) -> "Address":
+        """If this address is a generated subtarget, convert it back into its original base target.
+
+        Otherwise, return itself unmodified.
+        """
+        if not self.generated_base_target_name:
+            return self
+        return self.__class__(self._spec_path, target_name=self.generated_base_target_name)
+
     def __eq__(self, other):
         if not isinstance(other, Address):
             return False
@@ -318,6 +327,11 @@ class BuildFileAddress(Address):
             target_name=self.target_name,
             generated_base_target_name=self.generated_base_target_name,
         )
+
+    def maybe_convert_to_base_target(self) -> "BuildFileAddress":
+        if not self.generated_base_target_name:
+            return self
+        return self.__class__(rel_path=self.rel_path, target_name=self.generated_base_target_name)
 
     def __repr__(self) -> str:
         prefix = f"BuildFileAddress({self.rel_path}, {self.target_name}"

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -204,6 +204,14 @@ def test_address_spec() -> None:
     assert generated_subdirectory_addr.path_safe_spec == "a.b.subdir.c.txt"
 
 
+def test_address_maybe_convert_to_base_target() -> None:
+    generated_addr = Address("a/b", "c.txt", generated_base_target_name="c")
+    assert generated_addr.maybe_convert_to_base_target() == Address("a/b", "c")
+
+    normal_addr = Address("a/b", "c")
+    assert normal_addr.maybe_convert_to_base_target() is normal_addr
+
+
 def test_address_parse_method() -> None:
     def assert_parsed(spec_path: str, target_name: str, address: Address) -> None:
         assert spec_path == address.spec_path
@@ -236,3 +244,6 @@ def test_build_file_address() -> None:
     assert generated_bfa != BuildFileAddress(rel_path="dir/BUILD", target_name="example.txt")
     assert generated_bfa == Address("dir", "example.txt", generated_base_target_name="original")
     assert generated_bfa.spec == "dir/example.txt"
+    assert generated_bfa.maybe_convert_to_base_target() == BuildFileAddress(
+        rel_path="dir/BUILD", target_name="original"
+    )

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -101,11 +101,7 @@ def _raise_did_you_mean(address_family: AddressFamily, name: str, source=None) -
 @rule
 async def find_build_file(address: Address) -> BuildFileAddress:
     address_family = await Get(AddressFamily, Dir(address.spec_path))
-    owning_address = (
-        address
-        if not address.generated_base_target_name
-        else Address(address.spec_path, address.generated_base_target_name)
-    )
+    owning_address = address.maybe_convert_to_base_target()
     if owning_address not in address_family.addressables:
         _raise_did_you_mean(address_family=address_family, name=owning_address.target_name)
     bfa = next(


### PR DESCRIPTION
Because it's tricky to get right and also not critical for Pants to work, we for now punt on `dependees` using generated subtargets and instead convert back to the original base target. https://github.com/pantsbuild/pants/issues/10354 tracks doing the better thing.

[ci skip-rust-tests]
