### PR TITLE
Have `pants help` pay attention to `--colors` option

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -275,9 +275,10 @@ class LocalPantsRunner:
                     self.graph_session.goal_consumed_subsystem_scopes,
                 )
                 help_printer = HelpPrinter(
-                    bin_name=self.options.for_global_scope().pants_bin_name,
+                    bin_name=global_options.pants_bin_name,
                     help_request=self.options.help_request,
                     all_help_info=all_help_info,
+                    use_color=global_options.colors,
                 )
                 return help_printer.print_help()
 

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -3,7 +3,6 @@
 
 import dataclasses
 import json
-import sys
 import textwrap
 from enum import Enum
 from typing import Dict, cast
@@ -30,12 +29,17 @@ class HelpPrinter:
     """Prints help to the console."""
 
     def __init__(
-        self, *, bin_name: str, help_request: HelpRequest, all_help_info: AllHelpInfo
+        self,
+        *,
+        bin_name: str,
+        help_request: HelpRequest,
+        all_help_info: AllHelpInfo,
+        use_color: bool,
     ) -> None:
         self._bin_name = bin_name
         self._help_request = help_request
         self._all_help_info = all_help_info
-        self._use_color = sys.stdout.isatty()
+        self._use_color = use_color
 
     def print_help(self) -> Literal[0, 1]:
         """Print help to the console."""


### PR DESCRIPTION
### Problem

The `./pants help` command prints color output regardless of the state of the `--colors` global option.

### Solution

Hook up the help printing functionality to this option
