### PR TITLE
Tweak `any_matches_filespec` to return which paths matched

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -47,7 +47,7 @@ from pants.engine.target import (
     generate_subtarget,
 )
 from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
-from pants.source.filespec import any_matches_filespec
+from pants.source.filespec import matches_filespec
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 logger = logging.getLogger(__name__)
@@ -185,8 +185,8 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
         for tgt, bfa in zip(candidate_targets, build_file_addresses)
         if bfa.rel_path in sources_set
         # NB: Deleted files can only be matched against the 'filespec' (i.e. `PathGlobs`) for a
-        # target, which is why we use `any_matches_filespec`.
-        or any_matches_filespec(tgt.get(Sources).filespec, paths=sources_set)
+        # target, which is why we use `matches_filespec`.
+        or bool(matches_filespec(tgt.get(Sources).filespec, paths=sources_set))
     )
     return Owners(owners)
 

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -159,8 +159,9 @@ class Native(metaclass=SingletonMetaclass):
     def override_thread_logging_destination_to_just_stderr(self):
         self.lib.override_thread_logging_destination("stderr")
 
-    def match_path_globs(self, path_globs: PathGlobs, paths: Iterable[str]) -> bool:
-        return cast(bool, self.lib.match_path_globs(path_globs, tuple(paths)))
+    def match_path_globs(self, path_globs: PathGlobs, paths: Iterable[str]) -> Tuple[str, ...]:
+        """Return all paths that match the PathGlobs."""
+        return tuple(self.lib.match_path_globs(path_globs, tuple(paths)))
 
     def nailgun_server_await_shutdown(self, nailgun_server) -> None:
         """Blocks until the server has shut down.

--- a/src/python/pants/source/filespec.py
+++ b/src/python/pants/source/filespec.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 from typing_extensions import TypedDict
 
@@ -24,18 +24,7 @@ class Filespec(_IncludesDict, total=False):
     excludes: List[str]
 
 
-def globs_matches(
-    *, paths: Iterable[str], include_patterns: Iterable[str], exclude_patterns: Iterable[str],
-) -> bool:
-    path_globs = PathGlobs(globs=(*include_patterns, *(f"!{e}" for e in exclude_patterns)))
-    return Native().match_path_globs(path_globs, paths)
-
-
-def matches_filespec(spec: Filespec, *, path: str) -> bool:
-    return any_matches_filespec(spec, paths=[path])
-
-
-def any_matches_filespec(spec: Filespec, *, paths: Iterable[str]) -> bool:
-    return globs_matches(
-        paths=paths, include_patterns=spec["includes"], exclude_patterns=spec.get("excludes", [])
-    )
+def matches_filespec(spec: Filespec, *, paths: Iterable[str]) -> Tuple[str, ...]:
+    include_patterns = spec["includes"]
+    exclude_patterns = [f"!{e}" for e in spec.get("excludes", [])]
+    return Native().match_path_globs(PathGlobs(globs=(*include_patterns, *exclude_patterns)), paths)

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -9,21 +9,33 @@ from pants.testutil.test_base import TestBase
 
 
 class FilespecTest(TestBase):
-    def assert_rule_match(self, glob: str, expected_matches: Tuple[str, ...]) -> None:
+    def assert_rule_match(
+        self, glob: str, paths: Tuple[str, ...], *, should_match: bool = True
+    ) -> None:
         # Confirm in-memory behavior.
-        assert matches_filespec({"includes": [glob]}, paths=expected_matches) == expected_matches
+        matched_filespec = matches_filespec({"includes": [glob]}, paths=paths)
+        if should_match:
+            assert matched_filespec == paths
+        else:
+            assert not matched_filespec
 
         # Confirm on-disk behavior.
-        for expected_match in expected_matches:
+        for expected_match in paths:
             if expected_match.endswith("/"):
                 self.create_dir(expected_match)
             else:
                 self.create_file(expected_match)
         snapshot = self.request_single_product(Snapshot, PathGlobs([glob]))
-        assert sorted(expected_matches) == sorted(snapshot.files)
+        if should_match:
+            assert sorted(paths) == sorted(snapshot.files)
+        else:
+            assert not snapshot.files
 
     def test_matches_single_star_0(self) -> None:
         self.assert_rule_match("a/b/*/f.py", ("a/b/c/f.py", "a/b/q/f.py"))
+
+    def test_matches_single_star_0_neg(self) -> None:
+        self.assert_rule_match("a/b/*/f.py", ("a/b/c/d/f.py", "a/b/f.py"), should_match=False)
 
     def test_matches_single_star_1(self) -> None:
         self.assert_rule_match("foo/bar/*", ("foo/bar/baz", "foo/bar/bar"))
@@ -31,11 +43,19 @@ class FilespecTest(TestBase):
     def test_matches_single_star_2(self) -> None:
         self.assert_rule_match("*/bar/b*", ("foo/bar/baz", "foo/bar/bar"))
 
+    def test_matches_single_star_2_neg(self) -> None:
+        self.assert_rule_match(
+            "*/bar/b*", ("foo/koo/bar/baz", "foo/bar/bar/zoo"), should_match=False
+        )
+
     def test_matches_single_star_3(self) -> None:
         self.assert_rule_match("*/[be]*/b*", ("foo/bar/baz", "foo/bar/bar"))
 
     def test_matches_single_star_4(self) -> None:
         self.assert_rule_match("foo*/bar", ("foofighters/bar", "foofighters.venv/bar"))
+
+    def test_matches_single_star_4_neg(self) -> None:
+        self.assert_rule_match("foo*/bar", ("foofighters/baz/bar",), should_match=False)
 
     def test_matches_double_star_0(self) -> None:
         self.assert_rule_match("**", ("a/b/c", "b"))
@@ -46,18 +66,46 @@ class FilespecTest(TestBase):
     def test_matches_double_star_2(self) -> None:
         self.assert_rule_match("a/b/**", ("a/b/d", "a/b/c/d/e/f"))
 
+    def test_matches_double_star_2_neg(self) -> None:
+        self.assert_rule_match("a/b/**", ("a/b",), should_match=False)
+
     def test_matches_dots(self) -> None:
         self.assert_rule_match(".*", (".dots", ".dips"))
 
     def test_matches_dots_relative(self) -> None:
         self.assert_rule_match("./*.py", ("f.py", "g.py"))
 
+    def test_matches_dots_neg(self) -> None:
+        self.assert_rule_match(
+            ".*",
+            (
+                "b",
+                "a/non/dot/dir/file.py",
+                "dist",
+                "all/nested/.dot",
+                ".some/hidden/nested/dir/file.py",
+            ),
+            should_not_match=True,
+        )
+
     def test_matches_dirs(self) -> None:
         self.assert_rule_match("dist/", ("dist",))
+
+    def test_matches_dirs_neg(self) -> None:
+        self.assert_rule_match(
+            "dist/", ("not_dist", "cdist", "dist.py", "dist/dist"), should_match=False
+        )
 
     def test_matches_dirs_dots(self) -> None:
         self.assert_rule_match(
             "build-support/*.venv/", ("build-support/blah.venv", "build-support/rbt.venv")
+        )
+
+    def test_matches_dirs_dots_neg(self) -> None:
+        self.assert_rule_match(
+            "build-support/*.venv/",
+            ("build-support/rbt.venv.but_actually_a_file",),
+            should_match=False,
         )
 
     def test_matches_literals(self) -> None:

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -9,13 +9,9 @@ from pants.testutil.test_base import TestBase
 
 
 class FilespecTest(TestBase):
-    def assert_rule_match(
-        self, glob: str, expected_matches: Tuple[str, ...], negate: bool = False,
-    ) -> None:
+    def assert_rule_match(self, glob: str, expected_matches: Tuple[str, ...]) -> None:
         # Confirm in-memory behavior.
-        for path in expected_matches:
-            expected = False if negate else True
-            assert matches_filespec({"includes": [glob]}, path=path) is expected
+        assert matches_filespec({"includes": [glob]}, paths=expected_matches) == expected_matches
 
         # Confirm on-disk behavior.
         for expected_match in expected_matches:
@@ -24,17 +20,10 @@ class FilespecTest(TestBase):
             else:
                 self.create_file(expected_match)
         snapshot = self.request_single_product(Snapshot, PathGlobs([glob]))
-        if negate:
-            subset = set(expected_matches).intersection(set(snapshot.files))
-            assert subset == set()
-        else:
-            assert sorted(expected_matches) == sorted(snapshot.files)
+        assert sorted(expected_matches) == sorted(snapshot.files)
 
     def test_matches_single_star_0(self) -> None:
         self.assert_rule_match("a/b/*/f.py", ("a/b/c/f.py", "a/b/q/f.py"))
-
-    def test_matches_single_star_0_neg(self) -> None:
-        self.assert_rule_match("a/b/*/f.py", ("a/b/c/d/f.py", "a/b/f.py"), negate=True)
 
     def test_matches_single_star_1(self) -> None:
         self.assert_rule_match("foo/bar/*", ("foo/bar/baz", "foo/bar/bar"))
@@ -42,17 +31,11 @@ class FilespecTest(TestBase):
     def test_matches_single_star_2(self) -> None:
         self.assert_rule_match("*/bar/b*", ("foo/bar/baz", "foo/bar/bar"))
 
-    def test_matches_single_star_2_neg(self) -> None:
-        self.assert_rule_match("*/bar/b*", ("foo/koo/bar/baz", "foo/bar/bar/zoo"), negate=True)
-
     def test_matches_single_star_3(self) -> None:
         self.assert_rule_match("*/[be]*/b*", ("foo/bar/baz", "foo/bar/bar"))
 
     def test_matches_single_star_4(self) -> None:
         self.assert_rule_match("foo*/bar", ("foofighters/bar", "foofighters.venv/bar"))
-
-    def test_matches_single_star_4_neg(self) -> None:
-        self.assert_rule_match("foo*/bar", ("foofighters/baz/bar",), negate=True)
 
     def test_matches_double_star_0(self) -> None:
         self.assert_rule_match("**", ("a/b/c", "b"))
@@ -63,42 +46,18 @@ class FilespecTest(TestBase):
     def test_matches_double_star_2(self) -> None:
         self.assert_rule_match("a/b/**", ("a/b/d", "a/b/c/d/e/f"))
 
-    def test_matches_double_star_2_neg(self) -> None:
-        self.assert_rule_match("a/b/**", ("a/b",), negate=True)
-
     def test_matches_dots(self) -> None:
         self.assert_rule_match(".*", (".dots", ".dips"))
 
     def test_matches_dots_relative(self) -> None:
         self.assert_rule_match("./*.py", ("f.py", "g.py"))
 
-    def test_matches_dots_neg(self) -> None:
-        self.assert_rule_match(
-            ".*",
-            (
-                "b",
-                "a/non/dot/dir/file.py",
-                "dist",
-                "all/nested/.dot",
-                ".some/hidden/nested/dir/file.py",
-            ),
-            negate=True,
-        )
-
     def test_matches_dirs(self) -> None:
         self.assert_rule_match("dist/", ("dist",))
-
-    def test_matches_dirs_neg(self) -> None:
-        self.assert_rule_match("dist/", ("not_dist", "cdist", "dist.py", "dist/dist"), negate=True)
 
     def test_matches_dirs_dots(self) -> None:
         self.assert_rule_match(
             "build-support/*.venv/", ("build-support/blah.venv", "build-support/rbt.venv")
-        )
-
-    def test_matches_dirs_dots_neg(self) -> None:
-        self.assert_rule_match(
-            "build-support/*.venv/", ("build-support/rbt.venv.but_actually_a_file",), negate=True
         )
 
     def test_matches_literals(self) -> None:

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -85,7 +85,7 @@ class FilespecTest(TestBase):
                 "all/nested/.dot",
                 ".some/hidden/nested/dir/file.py",
             ),
-            should_not_match=True,
+            should_match=False,
         )
 
     def test_matches_dirs(self) -> None:


### PR DESCRIPTION
We need this extra detail to be able to know when calculating the owners of files whether to use the original owning target or a generated subtarget (https://github.com/pantsbuild/pants/pull/10356). This will allow us to determine if, for a particular target, we are matching deleted files vs. concrete files.