### PR TITLE
Display multiline help nicely.

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -28,7 +28,7 @@ class PexBin(ExternalTool):
     default_version = "v2.1.13"
     default_known_versions = [
         f"v2.1.13|{plat}|240712c75bb7c7cdfe3dd808ad6e6f186182e6aea3efeea5760683bb0fe89198|2633838"
-        for plat in ["darwin", "linux"]
+        for plat in ["darwin", "linux "]
     ]
 
     def generate_url(self, plat: Platform) -> str:

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import textwrap
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List
@@ -97,22 +98,32 @@ class ExternalTool(Subsystem):
             fingerprint=True,
             help=f"Use this version of {cls.name}.",
         )
+
+        help_str = textwrap.dedent(
+            f"""
+        Known versions to verify downloads against.
+        Each element is a pipe-separated string of `version|platform|sha256|length`, where:
+
+            - `version` is the version string
+            - `platform` is one of [{','.join(Platform.__members__.keys())}],
+            - `sha256` is the 64-character hex representation of the expected sha256
+              digest of the download file, as emitted by `shasum -a 256`
+            - `length` is the expected length of the download file in bytes
+
+            E.g., '3.1.2|darwin|6d0f18cd84b918c7b3edd0203e75569e0c7caecb1367bbbe409b44e28514f5be|42813'.
+
+            Values are space-stripped, so pipes can be indented for readability if necessary.
+            You can compute the length and sha256 easily with:
+            `curl -L $URL | tee >(wc -c) >(shasum -a 256) >/dev/null`
+        """
+        )
         register(
             "--known-versions",
             type=list,
             member_type=str,
             default=cls.default_known_versions,
             advanced=True,
-            help=f"Known versions to verify downloads against. Each element is a "
-            f"pipe-separated string of version|platform|sha256|length, where `version` is the "
-            f"version string, `platform` is one of [{','.join(Platform.__members__.keys())}], "
-            f"`sha256` is the 64-character hex representation of the expected sha256 digest of the "
-            f"download file, as emitted by `shasum -a 256`, and `length` is the expected length of "
-            f"the download file in bytes. E.g., '3.1.2|darwin|"
-            f"6d0f18cd84b918c7b3edd0203e75569e0c7caecb1367bbbe409b44e28514f5be|42813'. "
-            f"Values are space-stripped, so pipes can be indented for readability if necessary."
-            f"You can compute the length and sha256 easily with:  "
-            f"curl -L $URL | tee >(wc -c) >(shasum -a 256) >/dev/null",
+            help=help_str,
         )
 
     @abstractmethod

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -77,7 +77,7 @@ class OptionValueHistory:
     ranked_values: Tuple[RankedValue]
 
     @property
-    def final_value(self):
+    def final_value(self) -> RankedValue:
         return self.ranked_values[-1]
 
 


### PR DESCRIPTION
This includes:

- Respecting any embedded newlines in the option help string.
- Formatting option values (defaults, current value) nicely
  when they are large lists and dicts.

[ci skip-rust-tests]
