### PR TITLE
Render local process infrastructure errors more verbosely.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "notify"
 version = "5.0.0-pre.3"
-source = "git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1#0a2d91ca36b5c1162736e87f0b238529374641f1"
+source = "git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc#64880f0662db2b5ecbf25f1cccdca64bb8fac1bc"
 dependencies = [
  "anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3361,7 +3361,7 @@ dependencies = [
  "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
- "notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1)",
+ "notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3635,7 +3635,7 @@ dependencies = [
 "checksum nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "730beff5b62ab70260d375993bc1ed6f23fce54ee4ede3d95e2ac93545443c6b"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
-"checksum notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=0a2d91ca36b5c1162736e87f0b238529374641f1)" = "<none>"
+"checksum notify 5.0.0-pre.3 (git+https://github.com/pantsbuild/notify?rev=64880f0662db2b5ecbf25f1cccdca64bb8fac1bc)" = "<none>"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -127,9 +127,11 @@ async fn env_is_deterministic() {
 
 #[tokio::test]
 async fn binary_not_found() {
-  run_command_locally(Process::new(owned_string_vec(&["echo", "-n", "foo"])))
+  let err_string = run_command_locally(Process::new(owned_string_vec(&["echo", "-n", "foo"])))
     .await
     .expect_err("Want Err");
+  assert!(err_string.contains("Failed to execute"));
+  assert!(err_string.contains("echo"));
 }
 
 #[tokio::test]
@@ -396,7 +398,7 @@ async fn test_directory_preservation() {
   let script_metadata = std::fs::metadata(&run_script_path).unwrap();
 
   // Ensure the script is executable.
-  assert_eq!(USER_EXECUTABLE_MODE, script_metadata.permissions().mode());
+  assert!(USER_EXECUTABLE_MODE & script_metadata.permissions().mode() != 0);
 
   // Ensure the bash command line is provided.
   let bytes_quoted_command_line = bash::escape(&bash_contents);

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -363,7 +363,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
         .command_runner
         .run(request, execution_context)
         .await
-        .map_err(|e| throw(&format!("Failed to execute process: {}", e)))?;
+        .map_err(|e| throw(&e))?;
 
       Ok(ProcessResult(res))
     } else {


### PR DESCRIPTION
### Problem

Currently we do not render a representation of the process when a process fails to start.

### Solution

When processes fail due to infrastructure or implementation errors (ie, they fail to start at all, or we fail to receive output from them or capture their outputs), we should render the relevant process information directly in the error. This should be a relatively rare case.

We do this only for the local process runner, because in the case of remote execution, infrastruture errors are much more common, and should potentially have a different treatment.

### Result

In a sandbox without `echo` defined:
```
Failed to execute: Process {
    argv: [
        "echo",
        "-n",
        "foo",
    ],
    env: {},
    <snip>
}

Error launching process: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
