### PR TITLE
Fix dependency inference handling of dependencies on self

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -45,7 +45,10 @@ async def infer_python_dependencies(request: InferPythonDependencies) -> Inferre
     return InferredDependencies(
         owner.address
         for owner in owner_per_import
-        if owner.address and owner.address != request.sources_field.address
+        if (
+            owner.address
+            and owner.address.maybe_convert_to_base_target() != request.sources_field.address
+        )
     )
 
 


### PR DESCRIPTION
Before:
```
▶ ./pants dependencies src/python/pants/util:util
3rdparty/python:ansicolors
3rdparty/python:dataclasses
3rdparty/python:typing-extensions
src/python/pants/util/contextutil.py
src/python/pants/util/dirutil.py
src/python/pants/util/meta.py
src/python/pants/util/osutil.py
src/python/pants/util/strutil.py
src/python/pants/util/tarutil.py
```

After:
```
▶ ./pants dependencies src/python/pants/util:util
3rdparty/python:ansicolors
3rdparty/python:dataclasses
3rdparty/python:typing-extensions
```

We always intended for this behavior, but this regressed once we added generated subtargets.

[ci skip-rust-tests]