### PR TITLE
Fix when an explicitly provided dependency supersedes an inferred dependency

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -615,7 +615,14 @@ async def resolve_dependencies(
                 inference_request_type(sources_field),
             )
 
-    return Addresses(sorted([*provided, *itertools.chain.from_iterable(injected), *inferred]))
+    # Typically, dep inference will return generated subtargets. We check that their original base
+    # targets were not explicitly provided because it would be redundant to include the generated
+    # subtargets too.
+    explicitly_provided = {*provided, *itertools.chain.from_iterable(injected)}
+    remaining_inferred = {
+        dep for dep in inferred if dep.maybe_convert_to_base_target() not in explicitly_provided
+    }
+    return Addresses(sorted({*explicitly_provided, *remaining_inferred}))
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Before, if we were to add an explicit dep on `util:tests` for `util:util`:
```
▶ ./pants dependencies src/python/pants/util/strutil_test.py
src/python/pants/util/strutil.py
src/python/pants/util:util
```

After:
```
▶ ./pants dependencies src/python/pants/util/strutil_test.py
src/python/pants/util:util
```

This follows a general pattern with generated subtargets: if the original owning target is already being used, it is redundant and confusing to still use the generated subtarget. Generated subtargets should only be used as an optimization when possible, otherwise, we fall back to the original.

[ci skip-rust-tests]
