### PR TITLE
Always include types in the engine's definition of equality.

### DIFF
--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -57,6 +57,14 @@ pub fn is_union(ty: TypeId) -> bool {
 
 pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
   let gil = Python::acquire_gil();
+  let py = gil.python();
+  // NB: Although it does not precisely align with Python's definition of equality, we ban matches
+  // between non-equal types to avoid legacy behavior like `assert True == 1`, which is very
+  // surprising in interning, and would likely be surprising anywhere else in the engine where we
+  // compare things.
+  if h1.get_type(py) != h2.get_type(py) {
+    return false;
+  }
   h1.rich_compare(gil.python(), h2, CompareOp::Eq)
     .unwrap()
     .cast_as::<PyBool>(gil.python())


### PR DESCRIPTION
### Problem

I spent a few hours debugging why a boolean param was turning into an integer in some cases in the simple test in #10230, and determined that it was due to the behavior that `1 == True` and `0 == False` in Python. This impacts the engine in strange ways. For example: before the fix, the test in this change that attempts to use both a `bool` and an `int` fails with:
```
Exception: Values used as `Params` must have distinct types, but the following values had the same type (`int`):
  1
  1
``` 

### Solution

Always include types in the engine's definition of equality. Although this affects more than just memoization/interning, my expectation is that in any possible position where the engine will use `equals` the default behavior would be undesirable.
