### PR TITLE
Support for injecting ancestor conftest.py files.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -14,6 +14,7 @@ from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
     coverage,
     download_pex_bin,
+    inject_ancestor_files,
     inject_init,
     pex,
     pex_from_targets,
@@ -53,6 +54,7 @@ def rules():
     return (
         *coverage.rules(),
         *download_pex_bin.rules(),
+        *inject_ancestor_files.rules(),
         *inject_init.rules(),
         *python_sources.rules(),
         *dependency_inference_rules.rules(),

--- a/src/python/pants/backend/python/rules/inject_ancestor_files.py
+++ b/src/python/pants/backend/python/rules/inject_ancestor_files.py
@@ -29,7 +29,7 @@ class AncestorFilesRequest:
     dependencies on them.
     """
 
-    name: str  # A glob to match the name component of a file.
+    name: str
     snapshot: Snapshot
     sources_stripped: bool  # True iff snapshot has already had source roots stripped.
 

--- a/src/python/pants/backend/python/rules/inject_ancestor_files.py
+++ b/src/python/pants/backend/python/rules/inject_ancestor_files.py
@@ -1,0 +1,75 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import itertools
+from dataclasses import dataclass
+from pathlib import PurePath
+
+from pants.core.util_rules.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
+from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
+from pants.engine.rules import rule
+from pants.engine.selectors import Get
+from pants.python.pex_build_util import identify_missing_ancestor_files
+from pants.source.source_root import AllSourceRoots
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+@dataclass(frozen=True)
+class AncestorFilesRequest:
+    """A request for ancestor files of a given name.
+
+    "Ancestor files" for name foobar means all files of that name that are siblings of,
+    or in parent directories of, a .py file in the snapshot.
+
+    This is useful when the presence of such ancestor files has semantic meaning.
+    For example, ancestor __init__.py files denote packages, and ancestor conftest.py
+    files denote pytest configuration.
+
+    This allows us to pull in these files without requiring explicit or implicit
+    dependencies on them.
+    """
+
+    name: str  # A glob to match the name component of a file.
+    snapshot: Snapshot
+    sources_stripped: bool  # True iff snapshot has already had source roots stripped.
+
+
+@dataclass(frozen=True)
+class AncestorFiles:
+    """Any ancestor files found."""
+
+    snapshot: Snapshot
+
+
+@rule
+async def find_missing_ancestor_files(
+    request: AncestorFilesRequest, all_source_roots: AllSourceRoots
+) -> AncestorFiles:
+    """Find any named ancestor files that exist on the filesystem but are not in the snapshot."""
+    missing_ancestor_files = identify_missing_ancestor_files(request.name, request.snapshot.files)
+    if not missing_ancestor_files:
+        return AncestorFiles(EMPTY_SNAPSHOT)
+
+    if request.sources_stripped:
+        # If files are stripped, we don't know what source root they might live in, so we look
+        # up every source root.
+        roots = tuple(root.path for root in all_source_roots)
+        missing_ancestor_files = FrozenOrderedSet(
+            PurePath(root, f).as_posix()
+            for root, f in itertools.product(roots, missing_ancestor_files)
+        )
+
+    # NB: This will intentionally _not_ error on any unmatched globs.
+    discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(missing_ancestor_files))
+    if request.sources_stripped:
+        # We must now strip all discovered paths.
+        stripped_snapshot = await Get(
+            SourceRootStrippedSources, StripSnapshotRequest(discovered_ancestors_snapshot)
+        )
+        discovered_ancestors_snapshot = stripped_snapshot.snapshot
+
+    return AncestorFiles(discovered_ancestors_snapshot)
+
+
+def rules():
+    return [find_missing_ancestor_files]

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -1,17 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
 from dataclasses import dataclass
-from pathlib import PurePath
 
-from pants.core.util_rules.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
-from pants.engine.fs import MergeDigests, PathGlobs, Snapshot
+from pants.backend.python.rules.inject_ancestor_files import AncestorFiles, AncestorFilesRequest
+from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
-from pants.python.pex_build_util import identify_missing_init_files
-from pants.source.source_root import AllSourceRoots
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 @dataclass(frozen=True)
@@ -26,33 +21,13 @@ class InitInjectedSnapshot:
 
 
 @rule
-async def inject_missing_init_files(
-    request: InjectInitRequest, all_source_roots: AllSourceRoots
-) -> InitInjectedSnapshot:
-    """Add any `__init__.py` files that exist on the filesystem but are not yet in the snapshot."""
-    missing_init_files = identify_missing_init_files(request.snapshot.files)
-    if not missing_init_files:
-        return InitInjectedSnapshot(request.snapshot)
-
-    if request.sources_stripped:
-        # If files are stripped, we don't know what source root they might live in, so we look
-        # up every source root.
-        roots = tuple(root.path for root in all_source_roots)
-        missing_init_files = FrozenOrderedSet(
-            PurePath(root, f).as_posix() for root, f in itertools.product(roots, missing_init_files)
-        )
-
-    # NB: This will intentionally _not_ error on any unmatched globs.
-    discovered_inits_snapshot = await Get(Snapshot, PathGlobs(missing_init_files))
-    if request.sources_stripped:
-        # We must now strip all discovered paths.
-        stripped_snapshot = await Get(
-            SourceRootStrippedSources, StripSnapshotRequest(discovered_inits_snapshot)
-        )
-        discovered_inits_snapshot = stripped_snapshot.snapshot
-
+async def inject_missing_init_files(request: InjectInitRequest) -> InitInjectedSnapshot:
+    extra_init_files = await Get(
+        AncestorFiles,
+        AncestorFilesRequest("__init__.py", request.snapshot, request.sources_stripped),
+    )
     result = await Get(
-        Snapshot, MergeDigests((request.snapshot.digest, discovered_inits_snapshot.digest)),
+        Snapshot, MergeDigests((request.snapshot.digest, extra_init_files.snapshot.digest)),
     )
     return InitInjectedSnapshot(result)
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -12,6 +12,7 @@ from pants.backend.python.rules.coverage import (
     CoverageSubsystem,
     PytestCoverageData,
 )
+from pants.backend.python.rules.inject_ancestor_files import AncestorFiles, AncestorFilesRequest
 from pants.backend.python.rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -173,12 +174,18 @@ async def setup_pytest_for_target(
         specified_source_files_request,
     )
 
+    conftest_files = await Get(
+        AncestorFiles,
+        AncestorFilesRequest("conftest.py", prepared_sources.snapshot, sources_stripped=False),
+    )
+
     input_digest = await Get(
         Digest,
         MergeDigests(
             (
                 coverage_config.digest,
                 prepared_sources.snapshot.digest,
+                conftest_files.snapshot.digest,
                 requirements_pex.digest,
                 pytest_pex.digest,
                 test_runner_pex.digest,

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple, Type
 
+from pants.backend.python.rules.inject_ancestor_files import rules as inject_ancestor_rules
 from pants.backend.python.rules.inject_init import InitInjectedSnapshot, InjectInitRequest
 from pants.backend.python.rules.inject_init import rules as inject_init_rules
 from pants.backend.python.target_types import PythonSources
@@ -105,7 +106,7 @@ async def prepare_stripped_python_sources(
         ),
     )
     init_injected = await Get(
-        InitInjectedSnapshot, InjectInitRequest(stripped_sources.snapshot, sources_stripped=True)
+        InitInjectedSnapshot, InjectInitRequest(stripped_sources.snapshot, sources_stripped=True),
     )
     return StrippedPythonSources(init_injected.snapshot)
 
@@ -145,6 +146,7 @@ def rules():
         prepare_stripped_python_sources,
         prepare_unstripped_python_sources,
         *determine_source_files.rules(),
+        *inject_ancestor_rules(),
         *inject_init_rules(),
         # TODO: remove this as soon as we have a usage of it.
         RootRule(UnstrippedPythonSourcesRequest),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.python.rules import download_pex_bin, inject_init, pex
+from pants.backend.python.rules import download_pex_bin, inject_ancestor_files, inject_init, pex
 from pants.backend.python.rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -135,6 +135,7 @@ def rules():
         UnionRule(TypecheckRequest, MyPyRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),
+        *inject_ancestor_files.rules(),
         *inject_init.rules(),
         *pex.rules(),
         *python_native_code.rules(),

--- a/src/python/pants/python/pex_build_util_test.py
+++ b/src/python/pants/python/pex_build_util_test.py
@@ -1,13 +1,13 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.python.pex_build_util import identify_missing_init_files
+from pants.python.pex_build_util import identify_missing_ancestor_files
 
 
-def test_identify_missing_init_files() -> None:
+def test_identify_missing_ancestor_files() -> None:
     assert {"a/__init__.py", "a/b/__init__.py", "a/b/c/d/__init__.py"} == set(
-        identify_missing_init_files(
-            ["a/b/foo.py", "a/b/c/__init__.py", "a/b/c/d/bar.py", "a/e/__init__.py"]
+        identify_missing_ancestor_files(
+            "__init__.py", ["a/b/foo.py", "a/b/c/__init__.py", "a/b/c/d/bar.py", "a/e/__init__.py"]
         )
     )
 
@@ -18,12 +18,13 @@ def test_identify_missing_init_files() -> None:
         "src/python/a/b/__init__.py",
         "src/python/a/b/c/d/__init__.py",
     } == set(
-        identify_missing_init_files(
+        identify_missing_ancestor_files(
+            "__init__.py",
             [
                 "src/python/a/b/foo.py",
                 "src/python/a/b/c/__init__.py",
                 "src/python/a/b/c/d/bar.py",
                 "src/python/a/e/__init__.py",
-            ]
+            ],
         )
     )


### PR DESCRIPTION
Refactors our existing ancestor `__init__.py` file
functionality to be more general: Now there's
a rule to find ancestor files with a given name,
and a rule that applies this to `__init__.py` and
merges the results into the snapshot.

This change then uses this refactored functionality
 for conftest.py.

[ci skip-rust-tests]
