### PR TITLE
Allow dependencies on files

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-from pathlib import PurePath
 from typing import Optional, Sequence, Tuple
 
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
@@ -226,11 +225,7 @@ class Address:
         """
         :API: public
         """
-        # NB: It's possible for the target name of a generated subtarget to be in a subdirectory,
-        # e.g. 'subdir/f.txt'. When this happens, the relative spec is not safe.
-        if self.generated_base_target_name and PurePath(self.target_name).parent.as_posix() != ".":
-            return self.spec
-        prefix = ":" if not self.generated_base_target_name else ""
+        prefix = ":" if not self.generated_base_target_name else "./"
         return f"{prefix}{self._target_name}"
 
     def reference(self, referencing_path: Optional[str] = None) -> str:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -177,7 +177,7 @@ def test_address_spec() -> None:
 
     generated_addr = Address("a/b", "c.txt", generated_base_target_name="c")
     assert generated_addr.spec == "a/b/c.txt" == str(generated_addr) == generated_addr.reference()
-    assert generated_addr.relative_spec == "c.txt"
+    assert generated_addr.relative_spec == "./c.txt"
     assert generated_addr.path_safe_spec == "a.b.c.txt"
 
     top_level_generated_addr = Address("", "root.txt", generated_base_target_name="root")
@@ -187,7 +187,7 @@ def test_address_spec() -> None:
         == str(top_level_generated_addr)
         == top_level_generated_addr.reference()
     )
-    assert top_level_generated_addr.relative_spec == "root.txt"
+    assert top_level_generated_addr.relative_spec == "./root.txt"
     assert top_level_generated_addr.path_safe_spec == ".root.txt"
 
     generated_subdirectory_addr = Address(
@@ -198,9 +198,8 @@ def test_address_spec() -> None:
         == "a/b/subdir/c.txt"
         == str(generated_subdirectory_addr)
         == generated_subdirectory_addr.reference()
-        # NB: A relative spec is not safe, so we use the full spec.
-        == generated_subdirectory_addr.relative_spec
     )
+    assert generated_subdirectory_addr.relative_spec == "./subdir/c.txt"
     assert generated_subdirectory_addr.path_safe_spec == "a.b.subdir.c.txt"
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1350,7 +1350,13 @@ class GeneratedSources:
 #   await Get(Targets, DependenciesRequest(tgt[Dependencies])
 #   await Get(TransitiveTargets, DependenciesRequest(tgt[Dependencies])
 class Dependencies(AsyncField):
-    """Addresses to other targets that this target depends on, e.g. `['helloworld/subdir:lib']`."""
+    """Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib'].
+
+    Alternatively, you may include file names. Pants will find which target owns that file, and
+    create a new target from that which only includes the file in its `sources` field. For files
+    relative to the current BUILD file, prefix with `./`; otherwise, put the full path, e.g.
+    ['./sibling.txt', 'resources/demo.json'].
+    """
 
     alias = "dependencies"
     sanitized_raw_value: Optional[Tuple[str, ...]]
@@ -1449,6 +1455,10 @@ class InferDependenciesRequest:
                 infer_fortran_dependencies,
                 UnionRule(InferDependenciesRequest, InferFortranDependencies),
             ]
+
+    Generally, dependency inference should return generated subtargets created from the original
+    owning targets. If there are multiple owning targets for a file, dependency inference should
+    no-op because the user would need to explicitly disambiguate.
     """
 
     sources_field: Sources


### PR DESCRIPTION
Like with dep inference inferring file-level dependencies via generated subtargets, users can now do this explicitly in BUILD files. Users simply put the file name, and Pants finds the owning target(s). For relative files, you start with `./`, e.g. `./sibling.py`.

If there is not exactly 1 owner for the file, then we will error, whereas dep inference no-ops. This is to follow the principle of least surprise; we require users to disambiguate.

While we do not expect this to be used frequently, this is an important unification. Now, anything outputted by `./pants dependencies` can be explicitly put in a BUILD file and will work.

[ci skip-rust-tests]