### PR TITLE
remoting: use debug level for RE client workunits saved from remote

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -359,6 +359,7 @@ impl CommandRunner {
           time_span,
           parent_id.clone(),
           &workunit_store,
+          WorkunitMetadata::with_level(Level::Debug),
         );
       }
       Err(s) => warn!("{}", s),
@@ -376,6 +377,7 @@ impl CommandRunner {
           time_span,
           parent_id.clone(),
           &workunit_store,
+          WorkunitMetadata::with_level(Level::Debug),
         );
       }
       Err(s) => warn!("{}", s),
@@ -393,6 +395,7 @@ impl CommandRunner {
           time_span,
           parent_id.clone(),
           &workunit_store,
+          WorkunitMetadata::with_level(Level::Debug),
         );
       }
       Err(s) => warn!("{}", s),
@@ -410,6 +413,7 @@ impl CommandRunner {
           time_span,
           parent_id,
           &workunit_store,
+          WorkunitMetadata::with_level(Level::Debug),
         );
       }
       Err(s) => warn!("{}", s),
@@ -823,11 +827,11 @@ fn maybe_add_workunit(
   time_span: concrete_time::TimeSpan,
   parent_id: Option<String>,
   workunit_store: &WorkunitStore,
+  metadata: WorkunitMetadata,
 ) {
   if !result_cached {
     let start_time: SystemTime = SystemTime::UNIX_EPOCH + time_span.start.into();
     let end_time: SystemTime = start_time + time_span.duration.into();
-    let metadata = workunit_store::WorkunitMetadata::new();
     workunit_store.add_completed_workunit(
       name.to_string(),
       start_time,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::runtime::Handle;
-use workunit_store::{Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
+use workunit_store::{Level, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
 
@@ -1726,7 +1726,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::new(),
+      metadata: WorkunitMetadata::with_level(Level::Debug),
     },
     Workunit {
       name: String::from("remote execution worker input fetching"),
@@ -1738,7 +1738,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::new(),
+      metadata: WorkunitMetadata::with_level(Level::Debug),
     },
     Workunit {
       name: String::from("remote execution worker command executing"),
@@ -1750,7 +1750,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::new(),
+      metadata: WorkunitMetadata::with_level(Level::Debug),
     },
     Workunit {
       name: String::from("remote execution worker output uploading"),
@@ -1762,7 +1762,7 @@ async fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      metadata: WorkunitMetadata::new(),
+      metadata: WorkunitMetadata::with_level(Level::Debug),
     }
   };
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1,3 +1,8 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
 use bazel_protos;
 use bazel_protos::operations::Operation;
 use bazel_protos::remote_execution::ExecutedActionMetadata;
@@ -5,29 +10,25 @@ use bytes::Bytes;
 use futures::compat::Future01CompatExt;
 use grpcio;
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
+use maplit::{btreemap, hashset};
 use mock;
+use mock::execution_server::{ExpectedAPICall, MockOperation};
+use protobuf::well_known_types::Timestamp;
 use protobuf::{self, Message, ProtobufEnum};
+use spectral::prelude::*;
 use spectral::{assert_that, string::StrAssertions};
-use std::convert::TryInto;
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 use testutil::owned_string_vec;
+use tokio::runtime::Handle;
+use workunit_store::{Level, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 use crate::remote::{digest, CommandRunner, ExecutionError, OperationOrStatus};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
   MultiPlatformProcess, Platform, PlatformConstraint, Process, ProcessMetadata,
 };
-use maplit::{btreemap, hashset};
-use mock::execution_server::{ExpectedAPICall, MockOperation};
-use protobuf::well_known_types::Timestamp;
-use spectral::prelude::*;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::path::{Path, PathBuf};
-use std::time::Duration;
-use tokio::runtime::Handle;
-use workunit_store::{Level, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
 


### PR DESCRIPTION
### Problem

A recent bug fix causes Pants to print out INFO level messages even if the parent is DEBUG level. This now causes the workunits generated from remote execution timings to print out and spam the console with lots of messages like these: 

```
18:41:46.01 [INFO] Completed: remote execution worker output uploading
18:41:46.22 [INFO] Completed: remote execution action scheduling
18:41:46.22 [INFO] Completed: remote execution worker input fetching
18:41:46.22 [INFO] Completed: remote execution worker command executing
18:41:46.22 [INFO] Completed: remote execution worker output uploading
18:41:46.32 [INFO] Completed: remote execution action scheduling
18:41:46.32 [INFO] Completed: remote execution worker input fetching
```

### Solution

Set the workunits to DEBUG level.

### Result

Log should not be spammed.