### PR TITLE
Remove unused `--fmt-only` option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Please see [pants.readme.io/docs/contributor-overview](https://pants.readme.io/docs/contributor-overview).
+Please see [pantsbuild.org/docs/contributor-overview](https://www.pantsbuild.org/docs/contributor-overview).

--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ Some noteworthy features include:
 * Unified interface for multiple tools and languages.
 * Extensibility and customizability via a plugin API.
 
-Documentation:
-
- * V2 version of Pants (Python only, for now): https://pants.readme.io/docs/welcome-to-pants
- * V1 version of Pants: http://www.pantsbuild.org/
+Documentation: [pantsbuild.org](http://www.pantsbuild.org/).
 
 We release to [PyPI](https://pypi.org/pypi)
 [![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
@@ -35,7 +32,3 @@ To run Pants, you need:
 * A C compiler, system headers, Python headers (to compile native Python modules) and the `libffi`
  library and headers (to compile and link modules that use CFFI to access native code).
 * Internet access (so that Pants can fully bootstrap itself).
-
-Additionally, if you use the JVM backend to work with Java or Scala code:
-
-* OpenJDK or Oracle JDK version 8 or greater.

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -43,7 +43,7 @@ class DependenciesOptions(LineOriented, GoalSubsystem):
             default=DependencyType.SOURCE,
             help=(
                 "Which types of dependencies to list, where `source` means source code "
-                "dependencies and `3rdparty` means third-party requirements and JARs."
+                "dependencies and `3rdparty` means third-party requirements."
             ),
         )
 

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -104,17 +104,6 @@ class FmtOptions(GoalSubsystem):
     def register_options(cls, register) -> None:
         super().register_options(register)
         register(
-            "--only",
-            type=str,
-            default=None,
-            fingerprint=True,
-            advanced=True,
-            help=(
-                "Only run the specified formatter. Currently the only accepted values are "
-                "`scalafix` or not setting any value."
-            ),
-        )
-        register(
             "--per-target-caching",
             advanced=True,
             type=bool,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -902,9 +902,7 @@ class GlobalOptions(Subsystem):
 
         loop_flag = "--loop"
         register(
-            loop_flag,
-            type=bool,
-            help="Run goals continuously as file changes are detected.",
+            loop_flag, type=bool, help="Run goals continuously as file changes are detected.",
         )
         register(
             "--loop-max",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -177,7 +177,7 @@ class GlobalOptions(Subsystem):
             type=bool,
             default=False,
             advanced=True,
-            help="Whether to show/hide logging done by 3rdparty rust crates used by the pants "
+            help="Whether to show/hide logging done by 3rdparty Rust crates used by the Pants "
             "engine.",
         )
 
@@ -185,7 +185,10 @@ class GlobalOptions(Subsystem):
             "--colors",
             type=bool,
             default=sys.stdout.isatty(),
-            help="Set whether log messages are displayed in color.",
+            help=(
+                "Whether Pants should use colors in output or not. This may also impact whether "
+                "some tools Pants run use color."
+            ),
         )
 
         register(
@@ -239,15 +242,16 @@ class GlobalOptions(Subsystem):
             "is using once the program is already running. This option is useful to set in "
             "your pants.toml, however, and then you can grep the value to select which "
             "version to use for setup scripts (e.g. `./pants`), runner scripts, IDE plugins, "
-            "etc. For example, the setup script we distribute at https://www.pantsbuild.org/install.html#recommended-installation "
-            "uses this value to determine which Python version to run with. You may find the "
-            "version of the pants instance you are running using -v, -V, or --version.",
+            "etc. For example, the setup script we distribute at "
+            "https://www.pantsbuild.org/docs/installation uses this value to determine which Python"
+            "version to run with. You may find the version of the Pants instance you are running "
+            "by using -v, -V, or --version.",
         )
         register(
             "--pants-bin-name",
             advanced=True,
             default="./pants",
-            help="The name of the script or binary used to invoke pants. "
+            help="The name of the script or binary used to invoke Pants. "
             "Useful when printing help messages.",
         )
         register(
@@ -359,7 +363,7 @@ class GlobalOptions(Subsystem):
             daemon=True,
             help="The directory to use for tracking subprocess metadata, if any. This should "
             "live outside of the dir used by `--pants-workdir` to allow for tracking "
-            "subprocesses that outlive the workdir data (e.g. `./pants server`).",
+            "subprocesses that outlive the workdir data.",
         )
         register(
             "--pants-config-files",
@@ -436,7 +440,7 @@ class GlobalOptions(Subsystem):
             help="Paths to ignore for all filesystem operations performed by pants "
             "(e.g. BUILD file scanning, glob matching, etc). "
             "Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). "
-            "The `--pants-distdir` and `--pants-workdir` locations are inherently ignored."
+            "The `--pants-distdir` and `--pants-workdir` locations are inherently ignored. "
             "--pants-ignore can be used in tandem with --pants-ignore-use-gitignore, and any rules "
             "specified here apply after rules specified in a .gitignore file.",
         )
@@ -446,7 +450,7 @@ class GlobalOptions(Subsystem):
             type=bool,
             default=True,
             help="Make use of a root .gitignore file when determining whether to ignore filesystem "
-            "operations performed by pants. If used together with `--pants-ignore`, any exclude/include "
+            "operations performed by Pants. If used together with `--pants-ignore`, any exclude/include "
             "patterns specified there apply after .gitignore rules.",
         )
         register(
@@ -503,9 +507,9 @@ class GlobalOptions(Subsystem):
             default=True,
             daemon=True,
             help=(
-                "Enables use of the pants daemon (pantsd). pantsd can significantly improve "
+                "Enables use of the Pants daemon (pantsd). pantsd can significantly improve "
                 "runtime performance by lowering per-run startup cost, and by caching filesystem "
-                "operations and @rule execution."
+                "operations and rule execution."
             ),
         )
 
@@ -517,9 +521,9 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=False,
-            help="Enable concurrent runs of pants. Without this enabled, pants will "
+            help="Enable concurrent runs of Pants. Without this enabled, Pants will "
             "start up all concurrent invocations (e.g. in other terminals) without pantsd. "
-            "Enabling this option requires parallel pants invocations to block on the first",
+            "Enabling this option requires parallel Pants invocations to block on the first",
         )
 
         # Calling pants command (inner run) from other pants command is unusual behaviour,
@@ -532,7 +536,7 @@ class GlobalOptions(Subsystem):
             "--parent-build-id",
             advanced=True,
             default=None,
-            help="The build ID of the other pants run which spawned this one, if any.",
+            help="The build ID of the other Pants run which spawned this one, if any.",
         )
 
         # NB: We really don't want this option to invalidate the daemon, because different clients might have
@@ -624,7 +628,7 @@ class GlobalOptions(Subsystem):
             type=int,
             default=0,
             daemon=True,
-            help="The port to bind the pants nailgun server to. Defaults to a random port.",
+            help="The port to bind the Pants nailgun server to. Defaults to a random port.",
         )
         # TODO(#7514): Make this default to 1.0 seconds if stdin is a tty!
         register(
@@ -649,7 +653,7 @@ class GlobalOptions(Subsystem):
             default=[],
             daemon=True,
             help="Filesystem events matching any of these globs will trigger a daemon restart. "
-            "Pants' own code, plugins, and `--pants-config-files` are inherently invalidated.",
+            "Pants's own code, plugins, and `--pants-config-files` are inherently invalidated.",
         )
 
         register(
@@ -872,8 +876,7 @@ class GlobalOptions(Subsystem):
             type=list,
             metavar="[+-]tag1,tag2,...",
             help="Include only targets with these tags (optional '+' prefix) or without these "
-            "tags ('-' prefix).  Useful with ::, to find subsets of targets "
-            "(e.g., integration tests.)",
+            "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection.",
         )
         register(
             "--dynamic-ui",
@@ -901,7 +904,7 @@ class GlobalOptions(Subsystem):
         register(
             loop_flag,
             type=bool,
-            help="Run v2 @goal_rules continuously as file changes are detected.",
+            help="Run goals continuously as file changes are detected.",
         )
         register(
             "--loop-max",
@@ -915,7 +918,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=True,
-            help="Use a global lock to exclude other versions of pants from running during "
+            help="Use a global lock to exclude other versions of Pants from running during "
             "critical operations.",
         )
         register(


### PR DESCRIPTION
We do want to add this feature, but it doesn't do anything for now, so it's confusing to keep.

[ci skip-rust-tests]