### PR TITLE
close write stream for CAS writes via ByteStream API

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -177,6 +177,9 @@ impl ByteStore {
           }
         })?;
 
+        // The gRPC library cancels streams on drop; closes must be explicit. Not closing
+        // the stream caused the BuildGrid CAS server to generate errors on writes
+        // when the stream was cancelled.
         sender
           .close()
           .map_err(|e| {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -184,7 +184,7 @@ impl ByteStore {
           .close()
           .map_err(|e| {
             format!(
-              "Error from server when uploading digest {:?}: {:?}",
+              "Error from server when uploading digest during close {:?}: {:?}",
               digest, e
             )
           })
@@ -193,7 +193,7 @@ impl ByteStore {
         let received = receiver
           .map_err(move |e| {
             format!(
-              "Error from server when uploading digest {:?}: {:?}",
+              "Error from server when uploading digest while receiving response {:?}: {:?}",
               digest, e
             )
           })


### PR DESCRIPTION
### Problem

The gRPC library used by the Rust engine cancels streams on drop; close must be called explicitly. BuildGrid's CAS daemon was [generating errors on writes](https://gitlab.com/BuildGrid/buildgrid/-/blob/master/buildgrid/server/cas/instance.py#L392)  via the ByteStream API due to the stream being cancelled. 

### Solution

Explicitly close the stream to the ByteStream Write RPC.

### Result

With this PR, I did not see the CAS write errors any more in the log of the BuildGrid CAS server.
