### PR TITLE
A flag to force rerunning tests, bypassing the cache.

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -225,6 +225,12 @@ class TestOptions(GoalSubsystem):
             ),
         )
         register(
+            "--force",
+            type=bool,
+            default=False,
+            help="Force the tests to run, even if they could be satisfied from cache.",
+        )
+        register(
             "--use-coverage",
             type=bool,
             default=False,

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -4,7 +4,7 @@
 import uuid
 from dataclasses import dataclass
 
-from pants.engine.rules import uncacheable_rule
+from pants.engine.rules import RootRule, uncacheable_rule
 
 
 @dataclass(frozen=True)
@@ -23,4 +23,4 @@ async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
 
 
 def rules():
-    return [generate_uuid]
+    return [generate_uuid, RootRule(UUIDRequest)]

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -1,23 +1,28 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import random
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from pants.engine.rules import RootRule, uncacheable_rule
+from pants.engine.rules import RootRule, _uncacheable_rule
 
 
 @dataclass(frozen=True)
 class UUIDRequest:
-    pass
+    randomizer: float = field(default_factory=random.random)
 
 
-@uncacheable_rule
+@_uncacheable_rule
 async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
     """A rule to generate a UUID.
 
     Useful primarily to force a rule to re-run: a rule that `await Get`s on a UUIDRequest will be
     uncacheable, because this rule is itself uncacheable.
+
+    Note that this will return a new UUID each time if request multiple times in a single session.
+    If you want two requests to return the same UUID, set the `randomizer` field in both
+    requests to some fixed value.
     """
     return uuid.uuid4()
 

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -1,0 +1,26 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import uuid
+from dataclasses import dataclass
+
+from pants.engine.rules import uncacheable_rule
+
+
+@dataclass(frozen=True)
+class UUIDRequest:
+    pass
+
+
+@uncacheable_rule
+async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
+    """A rule to generate a UUID.
+
+    Useful primarily to force a rule to re-run: a rule that `await Get`s on a UUIDRequest will be
+    uncacheable, because this rule is itself uncacheable.
+    """
+    return uuid.uuid4()
+
+
+def rules():
+    return [generate_uuid]

--- a/src/python/pants/engine/internals/uuid_test.py
+++ b/src/python/pants/engine/internals/uuid_test.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from uuid import UUID
+
+from pants.engine.internals.uuid import UUIDRequest
+from pants.engine.internals.uuid import rules as uuid_rules
+from pants.engine.rules import RootRule
+from pants.testutil.test_base import TestBase
+
+
+class UUIDTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            *uuid_rules(),
+            RootRule(UUIDRequest),
+        )
+
+    def test_distinct_uuids(self):
+        uuid1 = self.request_single_product(UUID, UUIDRequest())
+        uuid2 = self.request_single_product(UUID, UUIDRequest())
+        assert uuid1 != uuid2
+
+    def test_identical_uuids(self):
+        uuid1 = self.request_single_product(UUID, UUIDRequest(randomizer=0.0))
+        uuid2 = self.request_single_product(UUID, UUIDRequest(randomizer=0.0))
+        assert uuid1 == uuid2

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -7,6 +7,7 @@ import itertools
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union, get_type_hints
 
 from pants.engine.goal import Goal
@@ -152,7 +153,14 @@ def _get_starting_indent(source):
     return 0
 
 
+class RuleType(Enum):
+    rule = "rule"
+    goal_rule = "goal_rule"
+    uncacheable_rule = "uncacheable_rule"
+
+
 def _make_rule(
+    rule_type: RuleType,
     return_type: Type,
     parameter_types: Iterable[Type],
     *,
@@ -166,6 +174,7 @@ def _make_rule(
     As a special case, if the output_type is a subclass of `Goal`, the `Goal.Options` for the `Goal`
     are registered as dependency Optionables.
 
+    :param rule_type: The specific decorator used to declare the rule.
     :param return_type: The return/output type for the Rule. This must be a concrete Python type.
     :param parameter_types: A sequence of types that matches the number and order of arguments to the
                             decorated function.
@@ -174,11 +183,11 @@ def _make_rule(
     """
 
     is_goal_cls = issubclass(return_type, Goal)
-    if cacheable and is_goal_cls:
+    if rule_type == RuleType.rule and is_goal_cls:
         raise TypeError(
             "An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`."
         )
-    if not cacheable and not is_goal_cls:
+    if rule_type == RuleType.goal_rule and not is_goal_cls:
         raise TypeError("An `@goal_rule` must return a subclass of `engine.goal.Goal`.")
 
     def wrapper(func):
@@ -282,10 +291,10 @@ def _ensure_type_annotation(
 
 
 PUBLIC_RULE_DECORATOR_ARGUMENTS = {"canonical_name", "desc", "level"}
-# We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
-# set it implicitly based on whether the rule annotation is @rule or @goal_rule.
+# We don't want @rule-writers to use 'rule_type' or 'cacheable' as kwargs directly,
+# but rather set them implicitly based on the rule annotation.
 # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
-IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"cacheable"}
+IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"rule_type", "cacheable"}
 
 
 def rule_decorator(func, **kwargs) -> Callable:
@@ -304,6 +313,7 @@ def rule_decorator(func, **kwargs) -> Callable:
             f"`@rule`s and `@goal_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
         )
 
+    rule_type: RuleType = kwargs["rule_type"]
     cacheable: bool = kwargs["cacheable"]
 
     func_id = f"@rule {func.__module__}:{func.__name__}"
@@ -343,6 +353,7 @@ def rule_decorator(func, **kwargs) -> Callable:
         )
 
     return _make_rule(
+        rule_type,
         return_type,
         parameter_types,
         cacheable=cacheable,
@@ -358,6 +369,8 @@ def validate_parameter_types(
     if cacheable:
         for ty in parameter_types:
             if side_effecting.is_instance(ty):
+                # TODO: Technically this will also fire for an @uncacheable_rule, but we don't
+                #  expose those as part of the API, so it's OK for this error not to mention them.
                 raise ValueError(
                     f"A `@rule` that was not a @goal_rule ({func_id}) has a side-effecting parameter: {ty}"
                 )
@@ -375,11 +388,15 @@ def inner_rule(*args, **kwargs) -> Callable:
 
 
 def rule(*args, **kwargs) -> Callable:
-    return inner_rule(*args, **kwargs, cacheable=True)
+    return inner_rule(*args, **kwargs, rule_type=RuleType.rule, cacheable=True)
 
 
 def goal_rule(*args, **kwargs) -> Callable:
-    return inner_rule(*args, **kwargs, cacheable=False)
+    return inner_rule(*args, **kwargs, rule_type=RuleType.goal_rule, cacheable=False)
+
+
+def uncacheable_rule(*args, **kwargs) -> Callable:
+    return inner_rule(*args, **kwargs, rule_type=RuleType.uncacheable_rule, cacheable=False)
 
 
 class Rule(ABC):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -156,7 +156,7 @@ def _get_starting_indent(source):
 class RuleType(Enum):
     rule = "rule"
     goal_rule = "goal_rule"
-    uncacheable_rule = "uncacheable_rule"
+    uncacheable_rule = "_uncacheable_rule"
 
 
 def _make_rule(
@@ -369,7 +369,7 @@ def validate_parameter_types(
     if cacheable:
         for ty in parameter_types:
             if side_effecting.is_instance(ty):
-                # TODO: Technically this will also fire for an @uncacheable_rule, but we don't
+                # TODO: Technically this will also fire for an @_uncacheable_rule, but we don't
                 #  expose those as part of the API, so it's OK for this error not to mention them.
                 raise ValueError(
                     f"A `@rule` that was not a @goal_rule ({func_id}) has a side-effecting parameter: {ty}"
@@ -395,7 +395,9 @@ def goal_rule(*args, **kwargs) -> Callable:
     return inner_rule(*args, **kwargs, rule_type=RuleType.goal_rule, cacheable=False)
 
 
-def uncacheable_rule(*args, **kwargs) -> Callable:
+# This has a "private" name, as we don't (yet?) want it to be part of the rule API, at least
+# until we figure out the implications, and have a handle on the semantics and use-cases.
+def _uncacheable_rule(*args, **kwargs) -> Callable:
     return inner_rule(*args, **kwargs, rule_type=RuleType.uncacheable_rule, cacheable=False)
 
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -15,7 +15,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
 from pants.engine.goal import Goal
 from pants.engine.interactive_process import InteractiveRunner
-from pants.engine.internals import graph, options_parsing
+from pants.engine.internals import graph, options_parsing, uuid
 from pants.engine.internals.build_files import create_graph_rules
 from pants.engine.internals.mapper import AddressMapper
 from pants.engine.internals.native import Native
@@ -295,6 +295,7 @@ class EngineInitializer:
             build_root_singleton,
             *interactive_process.rules(),
             *graph.rules(),
+            *uuid.rules(),
             *options_parsing.rules(),
             *process.rules(),
             *create_fs_rules(),


### PR DESCRIPTION
- Introduces an @uncacheable_rule annotation.
- Uses it to create a rule that provides a uuid.
- The pytest runner rule optionally requests a uuid,
  which causes it to be uncacheable (since it now
  depends on an uncacheable rule), thus forcing it
  to run.
- The pytest runner injects the uuid into the pytest
  process's environment, to force it in turn to rerun.

TBD: Do we want @uncacheable_rule to be internal-only? 
  How would we enforce that if so? We can just not
  document it, or give it an internal name (@_uncacheable_rule),
  or just not worry about it - users aren't children, and if 
  they have a strong reason to prevent a rule from being
  cached, maybe we just let them, as long as we explain
  the consequences. 

[ci skip-rust-tests]
