### PR TITLE
Fix validation of dependencies ignores breaking with generated subtargets

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -769,7 +769,11 @@ async def resolve_dependencies(
         *used_ignored_addresses,
         *used_ignored_file_deps,
     }
-    if unused_ignores:
+    # If there are unused ignores and this is not a generated subtarget, we eagerly error so that
+    # the user isn't falsely led to believe the ignore is working. We do not do this for generated
+    # subtargets because we cannot guarantee that the ignore specified in the original owning
+    # target would be used for all generated subtargets.
+    if unused_ignores and not request.field.address.generated_base_target_name:
         raise UnusedDependencyIgnoresException(
             request.field.address, unused_ignores=unused_ignores, result=result
         )

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1198,3 +1198,27 @@ class TestDependencies(TestBase):
                 Address.parse("//:inferred_and_provided2"),
             ],
         )
+
+        self.assert_dependencies_resolved(
+            requested_address=Address(
+                "demo", target_name="f1.st", generated_base_target_name="demo"
+            ),
+            enable_dep_inference=True,
+            expected=[
+                Address.parse("//:inferred1"),
+                Address("", target_name="inferred2.st", generated_base_target_name="inferred2"),
+                Address.parse("//:inferred_and_provided1"),
+                Address.parse("//:inferred_and_provided2"),
+            ],
+        )
+
+        self.assert_dependencies_resolved(
+            requested_address=Address(
+                "demo", target_name="f2.st", generated_base_target_name="demo"
+            ),
+            enable_dep_inference=True,
+            expected=[
+                Address.parse("//:inferred_and_provided1"),
+                Address.parse("//:inferred_and_provided2"),
+            ],
+        )


### PR DESCRIPTION
### Problem
We eagerly validate that every `!` is used in the `dependencies` field as a matter of good UX, because it's confusing how all the different pieces fit together.

However, imagine this: you have a target that owns 5 files. You set on that target `!./bad.py`. However, only one of those 5 files actually uses `bad.py`. This means that the 4 other generated subtargets would now all complain that the ignore `!./bad.py` is unused.

[ci skip-rust-tests]