### PR TITLE
Implement cycle detection in transitive_targets, and tolerate cycles in file-addresses.

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -143,7 +143,7 @@ class CycleException(Exception):
 
 
 def _detect_cycles(
-    roots: Tuple[Address, ...], dependencies: Dict[Address, Tuple[Address, ...]]
+    roots: Tuple[Address, ...], dependency_mapping: Dict[Address, Tuple[Address, ...]]
 ) -> None:
     path_stack: OrderedSet[Address] = OrderedSet()
     visited: Set[Address] = set()
@@ -152,12 +152,12 @@ def _detect_cycles(
         if address in visited:
             # NB: File-level dependencies are cycle tolerant.
             if not address.generated_base_target_name and address in path_stack:
-                raise CycleException(address, tuple(path_stack) + (address,))
+                raise CycleException(address, (*path_stack, address))
             return
         path_stack.add(address)
         visited.add(address)
 
-        for dep_address in dependencies[address]:
+        for dep_address in dependency_mapping[address]:
             visit(dep_address)
 
         path_stack.remove(address)

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -153,7 +153,7 @@ class GraphTest(TestBase):
             Address("", target_name="t2.txt", generated_base_target_name="t2"),
         ]
 
-    def do_test_failed_cycle(self, address_str: str, cyclic_address_str: str) -> None:
+    def assert_failed_cycle(self, address_str: str, cyclic_address_str: str) -> None:
         with self.assertRaisesRegex(
             Exception,
             f"(?ms)Dependency graph contained a cycle:.*-> {cyclic_address_str}.*-> {cyclic_address_str}.*",
@@ -172,7 +172,7 @@ class GraphTest(TestBase):
                 """
             ),
         )
-        self.do_test_failed_cycle("//:t1", "//:t1")
+        self.assert_failed_cycle("//:t1", "//:t1")
 
     def test_cycle_direct(self) -> None:
         self.add_to_build_file(
@@ -184,8 +184,8 @@ class GraphTest(TestBase):
                 """
             ),
         )
-        self.do_test_failed_cycle("//:t1", "//:t1")
-        self.do_test_failed_cycle("//:t2", "//:t2")
+        self.assert_failed_cycle("//:t1", "//:t1")
+        self.assert_failed_cycle("//:t2", "//:t2")
 
     def test_cycle_indirect(self) -> None:
         self.add_to_build_file(
@@ -198,8 +198,8 @@ class GraphTest(TestBase):
                 """
             ),
         )
-        self.do_test_failed_cycle("//:t1", "//:t2")
-        self.do_test_failed_cycle("//:t2", "//:t2")
+        self.assert_failed_cycle("//:t1", "//:t2")
+        self.assert_failed_cycle("//:t2", "//:t2")
 
     def test_resolve_generated_subtarget(self) -> None:
         self.add_to_build_file("demo", "target(sources=['f1.txt', 'f2.txt'])")

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -525,14 +525,6 @@ class TargetsWithOrigins(Collection[TargetWithOrigin]):
 
 
 @dataclass(frozen=True)
-class TransitiveTarget:
-    """A recursive structure wrapping a Target root and TransitiveTarget deps."""
-
-    root: Target
-    dependencies: Tuple["TransitiveTarget", ...]
-
-
-@dataclass(frozen=True)
 class TransitiveTargets:
     """A set of Target roots, and their transitive, flattened, de-duped dependencies.
 


### PR DESCRIPTION
### Problem

After more deeply investigating the issues with #10230 (demonstrated in #10393 and its revert), it doesn't seem like the right idea to rely on the engine's cycle detection (which the implementation of #10230 showed should primarily be used for deadlock detection) to expose high level cycle tolerance for the build graph.

### Solution

Move to iterative transitive target expansion (à la #10046), and cycle detect afterward using DFS with a stack of visited entries. 

### Result

Fixes #10059, and closes #10229. A followup will back out portions of #10230 (but not all of it, as there were a number of other improvements mixed in).

[ci skip-rust-tests]