### PR TITLE
Don't register any options as recursive.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -164,11 +164,7 @@ class GlobalOptions(Subsystem):
         default_rel_distdir = f"/{default_distdir_name}/"
 
         register(
-            "-l",
-            "--level",
-            type=LogLevel,
-            default=LogLevel.INFO,
-            help="Set the logging level.",
+            "-l", "--level", type=LogLevel, default=LogLevel.INFO, help="Set the logging level.",
         )
 
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -168,7 +168,6 @@ class GlobalOptions(Subsystem):
             "--level",
             type=LogLevel,
             default=LogLevel.INFO,
-            recursive=True,
             help="Set the logging level.",
         )
 


### PR DESCRIPTION
This will remove the --level option from the
advanced options help of every single scope...

Note that this doesn't remove the recursive options
machinery - that is used under the covers to support
subsystems scoped to other subsystems, and we're
not yet sure what we want to do with those.

[ci skip-rust-tests]
