### PR TITLE
Speed up `repl` to no longer rebuild a Pex on source file changes

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -28,7 +28,6 @@ from pants.backend.python.rules.pex_from_targets import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.core.util_rules import strip_source_roots
-from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import SubsystemRule, rule
@@ -71,7 +70,7 @@ async def create_python_awslambda(
         platform += "u"
     pex_request = TwoStepPexFromTargetsRequest(
         PexFromTargetsRequest(
-            addresses=Addresses([field_set.address]),
+            addresses=[field_set.address],
             entry_point=None,
             output_filename=pex_filename,
             platforms=PexPlatforms([platform]),

--- a/src/python/pants/backend/python/rules/create_python_binary.py
+++ b/src/python/pants/backend/python/rules/create_python_binary.py
@@ -23,7 +23,6 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types import PythonPlatforms as PythonPlatformsField
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
-from pants.engine.addresses import Addresses
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
@@ -79,7 +78,7 @@ async def create_python_binary(
         TwoStepPex,
         TwoStepPexFromTargetsRequest(
             PexFromTargetsRequest(
-                addresses=Addresses([field_set.address]),
+                addresses=[field_set.address],
                 entry_point=entry_point,
                 platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
                 output_filename=output_filename,

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -23,7 +23,7 @@ from pants.backend.python.target_types import (
     PythonInterpreterCompatibility,
     PythonRequirementsField,
 )
-from pants.engine.addresses import Addresses
+from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import Digest, DigestContents, MergeDigests, PathGlobs, Snapshot
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
@@ -56,7 +56,7 @@ class PexFromTargetsRequest:
 
     def __init__(
         self,
-        addresses: Addresses,
+        addresses: Iterable[Address],
         *,
         output_filename: str,
         entry_point: Optional[str] = None,
@@ -68,7 +68,7 @@ class PexFromTargetsRequest:
         additional_inputs: Optional[Digest] = None,
         description: Optional[str] = None,
     ) -> None:
-        self.addresses = addresses
+        self.addresses = Addresses(addresses)
         self.output_filename = output_filename
         self.entry_point = entry_point
         self.platforms = platforms

--- a/src/python/pants/backend/python/rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets_test.py
@@ -11,7 +11,6 @@ from pants.backend.python.rules.python_sources import StrippedPythonSourcesReque
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.addresses import Addresses
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import RootRule, SubsystemRule
 from pants.engine.selectors import Params
@@ -79,9 +78,7 @@ class PexTest(TestBase):
             ),
         )
 
-        request = PexFromTargetsRequest(
-            Addresses((Address.parse("//:tgt"),)), output_filename="dummy.pex"
-        )
+        request = PexFromTargetsRequest([Address.parse("//:tgt")], output_filename="dummy.pex")
 
         def get_pex_request(constraints_file: Optional[str], resolve_all: bool) -> PexRequest:
             args = [

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -10,7 +10,6 @@ from pants.backend.python.rules.python_sources import (
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.repl import ReplImplementation, ReplRequest
-from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -24,11 +23,12 @@ class PythonRepl(ReplImplementation):
 
 @rule
 async def create_python_repl_request(repl: PythonRepl) -> ReplRequest:
-    addresses = Addresses(tgt.address for tgt in repl.targets)
     pex_request = Get(
         Pex,
         PexFromTargetsRequest(
-            addresses=addresses, output_filename="python.pex", include_source_files=False
+            (tgt.address for tgt in repl.targets),
+            output_filename="python.pex",
+            include_source_files=False,
         ),
     )
     source_files_request = Get(
@@ -50,11 +50,10 @@ class IPythonRepl(ReplImplementation):
 
 @rule
 async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> ReplRequest:
-    addresses = Addresses(tgt.address for tgt in repl.targets)
     pex_request = Get(
         Pex,
         PexFromTargetsRequest(
-            addresses=addresses,
+            (tgt.address for tgt in repl.targets),
             output_filename="ipython.pex",
             entry_point=ipython.get_entry_point(),
             additional_requirements=ipython.get_requirement_specs(),

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -21,7 +21,7 @@ from pants.engine.unions import UnionRule
 
 
 @rule
-async def run_python_binary(
+async def create_python_binary_run_request(
     field_set: PythonBinaryFieldSet, python_binary_defaults: PythonBinaryDefaults
 ) -> RunRequest:
     entry_point = field_set.entry_point.value
@@ -32,7 +32,7 @@ async def run_python_binary(
         entry_point = PythonBinarySources.translate_source_file_to_entry_point(binary_sources.files)
     if entry_point is None:
         raise InvalidFieldException(
-            "You must either specify `sources` or `entry_point` for the `python_binary` target "
+            "You must either specify `sources` or `entry_point` for the target "
             f"{repr(field_set.address)} in order to run it, but both fields were undefined."
         )
 
@@ -59,14 +59,14 @@ async def run_python_binary(
     return RunRequest(
         digest=merged_digest,
         binary_name=pex.output_filename,
-        extra_args=("-m", entry_point),
+        prefix_args=("-m", entry_point),
         env={"PEX_EXTRA_SYS_PATH": ":".join(source_files.source_roots)},
     )
 
 
 def rules():
     return [
-        run_python_binary,
+        create_python_binary_run_request,
         UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
         SubsystemRule(PythonBinaryDefaults),
     ]

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -4,7 +4,7 @@
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Dict, Tuple, Type, cast
+from typing import ClassVar, Dict, Mapping, Optional, Tuple, Type, cast
 
 from pants.base.build_root import BuildRoot
 from pants.engine.console import Console
@@ -17,6 +17,8 @@ from pants.engine.target import Field, Target, Targets, TransitiveTargets
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.util.contextutil import temporary_dir
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
 
 
 @union
@@ -56,10 +58,19 @@ class Repl(Goal):
     subsystem_cls = ReplOptions
 
 
-@dataclass(frozen=True)
-class ReplBinary:
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class ReplRequest:
     digest: Digest
     binary_name: str
+    env: FrozenDict[str, str]
+
+    def __init__(
+        self, *, digest: Digest, binary_name: str, env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.digest = digest
+        self.binary_name = binary_name
+        self.env = FrozenDict(env or {})
 
 
 @goal_rule
@@ -93,16 +104,16 @@ async def run_repl(
             tgt for tgt in transitive_targets.closure if repl_implementation_cls.is_valid(tgt)
         )
     )
-    repl_binary = await Get(ReplBinary, ReplImplementation, repl_impl)
+    request = await Get(ReplRequest, ReplImplementation, repl_impl)
 
     with temporary_dir(root_dir=global_options.options.pants_workdir, cleanup=False) as tmpdir:
         path_relative_to_build_root = PurePath(tmpdir).relative_to(build_root.path).as_posix()
         workspace.materialize_directory(
-            DirectoryToMaterialize(repl_binary.digest, path_prefix=path_relative_to_build_root)
+            DirectoryToMaterialize(request.digest, path_prefix=path_relative_to_build_root)
         )
 
-        full_path = PurePath(tmpdir, repl_binary.binary_name).as_posix()
-        process = InteractiveProcess(argv=[full_path], run_in_workspace=True)
+        full_path = PurePath(tmpdir, request.binary_name).as_posix()
+        process = InteractiveProcess(argv=(full_path,), env=request.env, run_in_workspace=True)
 
     result = interactive_runner.run_process(process)
     return Repl(result.exit_code)

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -26,7 +26,7 @@ from pants.util.meta import frozen_after_init
 class RunRequest:
     digest: Digest
     binary_name: str
-    extra_args: Tuple[str, ...]
+    prefix_args: Tuple[str, ...]
     env: FrozenDict[str, str]
 
     def __init__(
@@ -34,12 +34,12 @@ class RunRequest:
         *,
         digest: Digest,
         binary_name: str,
-        extra_args: Optional[Iterable[str]] = None,
+        prefix_args: Optional[Iterable[str]] = None,
         env: Optional[Mapping[str, str]] = None,
     ) -> None:
         self.digest = digest
         self.binary_name = binary_name
-        self.extra_args = tuple(extra_args or ())
+        self.prefix_args = tuple(prefix_args or ())
         self.env = FrozenDict(env or {})
 
 
@@ -102,7 +102,7 @@ async def run(
 
         full_path = PurePath(tmpdir, request.binary_name).as_posix()
         process = InteractiveProcess(
-            argv=(full_path, *request.extra_args, *options.values.args),
+            argv=(full_path, *request.prefix_args, *options.values.args),
             env=request.env,
             run_in_workspace=True,
         )


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/10410. Closes https://github.com/pantsbuild/pants/issues/10406.

[ci skip-rust-tests]