### PR TITLE
Internally activate Protobuf, Pylint, and Bandit backends

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -24,8 +24,6 @@ class ReferenceGenerator:
 
     ./pants \
       --backend-packages="-['internal_backend.rules_for_testing', 'internal_backend.utilities']" \
-      --backend-packages="+['pants.backend.python.lint.bandit', \
-        'pants.backend.python.lint.pylint', 'pants.backend.codegen.protobuf.python']" \
       --no-verify-config help-all > /tmp/help_info
 
     to generate the data, and then:

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -145,7 +145,6 @@ function execute_packaged_pants_with_internal_backends() {
     --no-pantsd \
     --pythonpath="['pants-plugins/src/python']" \
       --backend-packages="[\
-        'pants.backend.awslambda.python',\
         'pants.backend.python',\
         'internal_backend.utilities',\
       ]" \

--- a/pants.toml
+++ b/pants.toml
@@ -7,11 +7,14 @@ pythonpath = ["%(buildroot)s/pants-plugins/src/python"]
 
 backend_packages.add = [
   "pants.backend.awslambda.python",
+  "pants.backend.codegen.protobuf.python",
   "pants.backend.python",
+  "pants.backend.python.lint.bandit",
   "pants.backend.python.lint.black",
   "pants.backend.python.lint.docformatter",
   "pants.backend.python.lint.flake8",
   "pants.backend.python.lint.isort",
+  "pants.backend.python.lint.pylint",
   "pants.backend.python.typecheck.mypy",
   "internal_backend.rules_for_testing",
   "internal_backend.utilities",
@@ -58,6 +61,9 @@ root_patterns = [
 #  so we can use --python-setup-resolve-all-constraints (which requires a lockfile).
 requirement_constraints = "3rdparty/python/requirements.txt"
 
+[bandit]
+skip = true
+
 [black]
 config = "pyproject.toml"
 
@@ -76,6 +82,9 @@ config = [".isort.cfg", "examples/.isort.cfg"]
 
 [mypy]
 config = "build-support/mypy/mypy.ini"
+
+[pylint]
+skip = true
 
 [pants-releases]
 branch_notes = """

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -11,4 +11,5 @@ python_tests(
 python_integration_tests(
   name='integration',
   uses_pants_run=True,
+  timeout=90,
 )

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -27,7 +27,7 @@ python_integration_tests(
   tags = ['platform_specific_behavior'],
   # NB: This frequently times out, but due to hanging. So, we want to fail eagerly. See
   # https://github.com/pantsbuild/pants/issues/8127.
-  timeout = 200,
+  timeout = 240,
 )
 
 python_integration_tests(

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -3,4 +3,5 @@
 
 python_integration_tests(
   uses_pants_run=True,
+  timeout=150,
 )


### PR DESCRIPTION
This will help us to ensure that we never introduce issues like rule graph issues. This is a light form of dogfooding.

[ci skip-rust-tests]
