### PR TITLE
Rename argument in streaming workunit callback

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -333,7 +333,7 @@ class WorkunitTracker:
     started_workunit_chunks: List[List[dict]] = field(default_factory=list)
     finished: bool = False
 
-    def add(self, workunits, **kwargs) -> None:
+    def add(self, **kwargs) -> None:
         if kwargs["finished"] is True:
             self.finished = True
 
@@ -341,8 +341,9 @@ class WorkunitTracker:
         if started_workunits:
             self.started_workunit_chunks.append(started_workunits)
 
-        if workunits:
-            self.finished_workunit_chunks.append(workunits)
+        completed_workunits = kwargs.get("completed_workunits")
+        if completed_workunits:
+            self.finished_workunit_chunks.append(completed_workunits)
 
 
 class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
@@ -723,11 +724,12 @@ class StreamingWorkunitProcessTests(TestBase):
     def test_context_object(self):
         scheduler = self.scheduler
 
-        def callback(workunits, **kwargs) -> None:
+        def callback(**kwargs) -> None:
             context = kwargs["context"]
             assert isinstance(context, StreamingWorkunitContext)
 
-            for workunit in workunits:
+            completed_workunits = kwargs["completed_workunits"]
+            for workunit in completed_workunits:
                 if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:
                     digest = workunit["artifacts"]["stdout_digest"]
                     output = context.digests_to_bytes([digest])

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -71,6 +71,7 @@ class StreamingWorkunitHandler:
             callback(
                 workunits=workunits["completed"],
                 started_workunits=workunits["started"],
+                completed_workunits=workunits["completed"],
                 finished=True,
                 context=self._context,
             )
@@ -109,8 +110,8 @@ class _InnerHandler(threading.Thread):
             workunits = self.scheduler.poll_workunits(self.max_workunit_verbosity)
             for callback in self.callbacks:
                 callback(
-                    workunits=workunits["completed"],
                     started_workunits=workunits["started"],
+                    completed_workunits=workunits["completed"],
                     finished=False,
                     context=self._context,
                 )


### PR DESCRIPTION
### Problem

The streaming workunit system invokes the callback with several named keyword arguments, one of which is `workunits`. We later added a `started_workunits` kwarg intended for started workunits, with `workunits` now containing only finished workunits. This is confusing since it implies that the `workunits` argument contains all the workunits rather than only the ones that have completed.

### Solution

Rename the `workunits` kwarg to `completed_workunits`. This breaks any streaming workunit clients not updated to expect a `completed_workunit` argument or that *do* expect a `workunit` argument, but that should be okay in the context of the upcoming 2.0 major release bump. 
