### PR TITLE
Add cache_failures option to Process type

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -39,6 +39,7 @@ class Process:
     jdk_home: Optional[str]
     is_nailgunnable: bool
     execution_slot_variable: Optional[str]
+    cache_failures: bool
 
     def __init__(
         self,
@@ -55,6 +56,7 @@ class Process:
         jdk_home: Optional[str] = None,
         is_nailgunnable: bool = False,
         execution_slot_variable: Optional[str] = None,
+        cache_failures: bool = False,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -94,6 +96,7 @@ class Process:
         self.jdk_home = jdk_home
         self.is_nailgunnable = is_nailgunnable
         self.execution_slot_variable = execution_slot_variable
+        self.cache_failures = cache_failures
 
 
 @frozen_after_init

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -644,7 +644,7 @@ impl<N: Node> Graph<N> {
 
         // We can retry the dst Node if the src Node is not cacheable. If the src is not cacheable,
         // it only be allowed to run once, and so Node invalidation does not pass through it.
-        !inner.entry_for_id(src_id).unwrap().node().cacheable()
+        !inner.entry_for_id(src_id).unwrap().node().cacheable(None)
       } else {
         // Otherwise, this is an external request: always retry.
         trace!(
@@ -863,7 +863,11 @@ impl<N: Node> Graph<N> {
             // This is to allow for the behaviour that an uncacheable Node should always have "dirty"
             // (marked as UncacheableDependencies) dependents, transitively.
             let entry = inner.entry_for_id(edge_ref.target()).unwrap();
-            if !entry.node().cacheable() || entry.has_uncacheable_deps() {
+            let result_item = match result {
+              Some(Ok(ref item)) => Some(item),
+              _ => None,
+            };
+            if !entry.node().cacheable(result_item) || entry.has_uncacheable_deps() {
               has_uncacheable_deps = true;
             }
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -644,7 +644,7 @@ impl<N: Node> Graph<N> {
 
         // We can retry the dst Node if the src Node is not cacheable. If the src is not cacheable,
         // it only be allowed to run once, and so Node invalidation does not pass through it.
-        !inner.entry_for_id(src_id).unwrap().node().cacheable(None)
+        !inner.entry_for_id(src_id).unwrap().node().cacheable()
       } else {
         // Otherwise, this is an external request: always retry.
         trace!(
@@ -867,7 +867,7 @@ impl<N: Node> Graph<N> {
               Some(Ok(ref item)) => Some(item),
               _ => None,
             };
-            if !entry.node().cacheable(result_item) || entry.has_uncacheable_deps() {
+            if !entry.cacheable_with_output(result_item) || entry.has_uncacheable_deps() {
               has_uncacheable_deps = true;
             }
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -32,7 +32,7 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   ///
   /// If the node result is cacheable, return true.
   ///
-  fn cacheable(&self) -> bool;
+  fn cacheable(&self, result: Option<&Self::Item>) -> bool;
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -30,9 +30,16 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   async fn run(self, context: Self::Context) -> Result<Self::Item, Self::Error>;
 
   ///
-  /// If the node result is cacheable, return true.
+  /// If a node's output is cacheable based solely on properties of the node, and not the output,
+  /// return true.
   ///
-  fn cacheable(&self, result: Option<&Self::Item>) -> bool;
+  fn cacheable(&self) -> bool;
+
+  /// A Node may want to compute cacheability differently based on properties of the Node's item.
+  /// The output of this method will be and'd with `cacheable` to compute overall cacheability.
+  fn cacheable_item(&self, _item: &Self::Item) -> bool {
+    self.cacheable()
+  }
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -690,7 +690,7 @@ impl Node for TNode {
     res
   }
 
-  fn cacheable(&self, _: Option<&Vec<T>>) -> bool {
+  fn cacheable(&self) -> bool {
     self.1
   }
 }

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -690,7 +690,7 @@ impl Node for TNode {
     res
   }
 
-  fn cacheable(&self) -> bool {
+  fn cacheable(&self, _: Option<&Vec<T>>) -> bool {
     self.1
   }
 }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -77,8 +77,10 @@ impl crate::CommandRunner for CommandRunner {
       }
     }
 
+    let cache_failures = req.0.values().any(|process| process.cache_failures);
+
     let result = command_runner.underlying.run(req, context).await?;
-    if result.exit_code == 0 {
+    if result.exit_code == 0 || cache_failures {
       if let Err(err) = command_runner.store(key, &result).await {
         debug!(
           "Error storing process execution result to local cache: {} - ignoring and continuing",

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -290,7 +290,7 @@ impl Process {
       target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
       execution_slot_variable: None,
-      cache_failures: true,
+      cache_failures: false,
     }
   }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -260,6 +260,8 @@ pub struct Process {
   pub target_platform: PlatformConstraint,
 
   pub is_nailgunnable: bool,
+
+  pub cache_failures: bool,
 }
 
 impl Process {
@@ -288,6 +290,7 @@ impl Process {
       target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
       execution_slot_variable: None,
+      cache_failures: true,
     }
   }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -65,6 +65,7 @@ fn construct_nailgun_server_request(
     target_platform: platform_constraint,
     is_nailgunnable: true,
     execution_slot_variable: None,
+    cache_failures: false,
   }
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -39,21 +39,11 @@ fn unique_temp_dir(base_dir: PathBuf, prefix: Option<String>) -> TempDir {
 }
 
 fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> Process {
-  Process {
-    argv: vec![],
-    env: Default::default(),
-    working_directory: None,
-    input_files: EMPTY_DIGEST,
-    output_files: Default::default(),
-    output_directories: Default::default(),
-    timeout: Default::default(),
-    description: "".to_string(),
-    append_only_caches: Default::default(),
-    jdk_home: jdk_home,
-    target_platform: PlatformConstraint::Darwin,
-    is_nailgunnable: true,
-    execution_slot_variable: None,
-  }
+  let mut process = Process::new(vec![]);
+  process.jdk_home = jdk_home;
+  process.is_nailgunnable = true;
+  process.target_platform = PlatformConstraint::Darwin;
+  process
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -88,7 +88,7 @@ async fn make_execute_request() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
-    cache_failures: true,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -173,7 +173,7 @@ async fn make_execute_request_with_instance_name() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
-    cache_failures: true,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -266,7 +266,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
-    cache_failures: true,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -513,7 +513,7 @@ async fn make_execute_request_with_timeout() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
-    cache_failures: true,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,6 +1,5 @@
-use crate::{PlatformConstraint, Process, RelativePath};
+use crate::{Process, RelativePath};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
@@ -8,20 +7,11 @@ use std::time::Duration;
 fn process_equality() {
   // TODO: Tests like these would be cleaner with the builder pattern for the rust-side Process API.
 
-  let process_generator = |description: String, timeout: Option<Duration>| Process {
-    argv: vec![],
-    env: BTreeMap::new(),
-    working_directory: None,
-    input_files: hashing::EMPTY_DIGEST,
-    output_files: BTreeSet::new(),
-    output_directories: BTreeSet::new(),
-    timeout,
-    description,
-    append_only_caches: BTreeMap::new(),
-    jdk_home: None,
-    target_platform: PlatformConstraint::None,
-    is_nailgunnable: false,
-    execution_slot_variable: None,
+  let process_generator = |description: String, timeout: Option<Duration>| {
+    let mut p = Process::new(vec![]);
+    p.description = description;
+    p.timeout = timeout;
+    p
   };
 
   fn hash<Hashable: Hash>(hashable: &Hashable) -> u64 {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -366,6 +366,7 @@ async fn main() {
     .expect("invalid value for `target-platform"),
     is_nailgunnable,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let runner: Box<dyn process_execution::CommandRunner> = match server_arg {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1253,11 +1253,17 @@ impl Node for NodeKey {
     .0
   }
 
-  fn cacheable(&self, output: Option<&NodeOutput>) -> bool {
+  fn cacheable(&self) -> bool {
     match self {
       &NodeKey::Task(ref s) => s.task.cacheable,
-      &NodeKey::MultiPlatformExecuteProcess(ref mp) => match output {
-        Some(NodeOutput::ProcessResult(ref process_result)) => {
+      _ => true,
+    }
+  }
+
+  fn cacheable_item(&self, output: &NodeOutput) -> bool {
+    match self {
+      NodeKey::MultiPlatformExecuteProcess(ref mp) => match output {
+        NodeOutput::ProcessResult(ref process_result) => {
           let process_succeeded = process_result.0.exit_code == 0;
           if mp.cache_failures {
             true

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -234,7 +234,10 @@ pub fn lift_digest(digest: &Value) -> Result<hashing::Digest, String> {
 /// A Node that represents a set of processes to execute on specific platforms.
 ///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct MultiPlatformExecuteProcess(MultiPlatformProcess);
+pub struct MultiPlatformExecuteProcess {
+  cache_failures: bool,
+  process: MultiPlatformProcess,
+}
 
 impl MultiPlatformExecuteProcess {
   fn lift_execute_process(
@@ -300,6 +303,8 @@ impl MultiPlatformExecuteProcess {
       }
     };
 
+    let cache_failures = externs::project_bool(&value, "cache_failures");
+
     Ok(process_execution::Process {
       argv: externs::project_multi_strs(&value, "argv"),
       env,
@@ -314,6 +319,7 @@ impl MultiPlatformExecuteProcess {
       target_platform,
       is_nailgunnable,
       execution_slot_variable,
+      cache_failures,
     })
   }
 
@@ -340,16 +346,22 @@ impl MultiPlatformExecuteProcess {
       ));
     }
 
+    let mut cache_failures = true;
+
     let mut request_by_constraint: BTreeMap<(PlatformConstraint, PlatformConstraint), Process> =
       BTreeMap::new();
     for (constraint_key, execute_process) in constraint_key_pairs.iter().zip(processes.iter()) {
       let underlying_req =
         MultiPlatformExecuteProcess::lift_execute_process(execute_process, constraint_key.1)?;
+      if !underlying_req.cache_failures {
+        cache_failures = false;
+      }
       request_by_constraint.insert(*constraint_key, underlying_req.clone());
     }
-    Ok(MultiPlatformExecuteProcess(MultiPlatformProcess(
-      request_by_constraint,
-    )))
+    Ok(MultiPlatformExecuteProcess {
+      cache_failures,
+      process: MultiPlatformProcess(request_by_constraint),
+    })
   }
 }
 
@@ -364,7 +376,7 @@ impl WrappedNode for MultiPlatformExecuteProcess {
   type Item = ProcessResult;
 
   async fn run_wrapped_node(self, context: Context) -> NodeResult<ProcessResult> {
-    let request = self.0;
+    let request = self.process;
     let execution_context = process_execution::Context::new(
       context.session.workunit_store(),
       context.session.build_id().to_string(),
@@ -1091,7 +1103,7 @@ impl NodeKey {
   fn workunit_name(&self) -> String {
     match self {
       NodeKey::Task(ref task) => task.task.display_info.name.clone(),
-      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.workunit_name(),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.process.workunit_name(),
       NodeKey::Snapshot(..) => "snapshot".to_string(),
       NodeKey::DigestFile(..) => "digest_file".to_string(),
       NodeKey::DownloadedFile(..) => "downloaded_file".to_string(),
@@ -1112,7 +1124,7 @@ impl NodeKey {
     match self {
       NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
       NodeKey::Snapshot(ref s) => Some(format!("Snapshotting: {}", s.0)),
-      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.user_facing_name(),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.process.user_facing_name(),
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
@@ -1241,9 +1253,20 @@ impl Node for NodeKey {
     .0
   }
 
-  fn cacheable(&self) -> bool {
+  fn cacheable(&self, output: Option<&NodeOutput>) -> bool {
     match self {
       &NodeKey::Task(ref s) => s.task.cacheable,
+      &NodeKey::MultiPlatformExecuteProcess(ref mp) => match output {
+        Some(NodeOutput::ProcessResult(ref process_result)) => {
+          let process_succeeded = process_result.0.exit_code == 0;
+          if mp.cache_failures {
+            true
+          } else {
+            process_succeeded
+          }
+        }
+        _ => true,
+      },
       _ => true,
     }
   }
@@ -1255,7 +1278,7 @@ impl Display for NodeKey {
       &NodeKey::DigestFile(ref s) => write!(f, "DigestFile({})", s.0.path.display()),
       &NodeKey::DownloadedFile(ref s) => write!(f, "DownloadedFile({})", s.0),
       &NodeKey::MultiPlatformExecuteProcess(ref s) => {
-        if let Some(name) = s.0.user_facing_name() {
+        if let Some(name) = s.process.user_facing_name() {
           write!(f, "Process({})", name)
         } else {
           write!(f, "Process({:?})", s)


### PR DESCRIPTION
### Problem

Failed processes are being memoized in pantsd (https://github.com/pantsbuild/pants/issues/10129 )

### Solution

This commit introduces a new flag on the `Process` type `cache_failures`, defaulting to False, which is in turn passed to to the engine's node-execution infrastructure. If this flag is false, the engine will treat a `MultiPlatformExecuteRequest` node as noncacheable rather than cacheable, which will cause such nodes to be re-run in the pantsd case mentioned in the above issue. Note that this involves changing the signature of the `Node::cacheable` method to now take into account the result value of a node.
