### PR TITLE
Revert generated subtargets and explicit file dependencies

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -36,8 +36,6 @@ async def map_addresses_to_dependees() -> AddressToDependees:
     address_to_dependees = defaultdict(set)
     for tgt, dependencies in zip(all_explicit_targets, dependencies_per_target):
         for dependency in dependencies:
-            # TODO(#10354): teach dependees how to work with generated subtargets.
-            dependency = dependency.maybe_convert_to_base_target()
             address_to_dependees[dependency].add(tgt.address)
     return AddressToDependees(
         FrozenDict(
@@ -56,7 +54,7 @@ class DependeesRequest:
     def __init__(
         self, addresses: Iterable[Address], *, transitive: bool, include_roots: bool
     ) -> None:
-        self.addresses = FrozenOrderedSet(addr.maybe_convert_to_base_target() for addr in addresses)
+        self.addresses = FrozenOrderedSet(addr for addr in addresses)
         self.transitive = transitive
         self.include_roots = include_roots
 

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -1,6 +1,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  sources=['*.py', '!register.py', '!*_test.py'],
+)
+
+python_library(
+  name='plugin',
+  sources=['register.py'],
+)
 
 python_tests(name="tests")

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -94,7 +94,7 @@ class ModuleMapperTest(TestBase):
         options_bootstrapper = create_options_bootstrapper(
             args=["--source-root-patterns=['src/python', 'tests/python', 'build-support']"]
         )
-        # Two modules belonging to the same target. We should generate subtargets for each file.
+        util_addr = Address.parse("src/python/project/util")
         self.create_files("src/python/project/util", ["dirutil.py", "tarutil.py"])
         self.add_to_build_file("src/python/project/util", "python_library()")
         # A module with two owners, meaning that neither should be resolved.
@@ -102,28 +102,15 @@ class ModuleMapperTest(TestBase):
         self.add_to_build_file("src/python", "python_library()")
         self.create_file("build-support/two_owners.py")
         self.add_to_build_file("build-support", "python_library()")
-        # A package module. Because there's only one source file belonging to the target, we should
-        # not generate subtargets.
+        # A package module.
         self.create_file("tests/python/project_test/demo_test/__init__.py")
         self.add_to_build_file("tests/python/project_test/demo_test", "python_library()")
         result = self.request_single_product(FirstPartyModuleToAddressMapping, options_bootstrapper)
         assert result.mapping == FrozenDict(
             {
-                "project.util.dirutil": Address(
-                    "src/python/project/util",
-                    target_name="dirutil.py",
-                    generated_base_target_name="util",
-                ),
-                "project.util.tarutil": Address(
-                    "src/python/project/util",
-                    target_name="tarutil.py",
-                    generated_base_target_name="util",
-                ),
-                "project_test.demo_test": Address(
-                    "tests/python/project_test/demo_test",
-                    target_name="__init__.py",
-                    generated_base_target_name="demo_test",
-                ),
+                "project.util.dirutil": util_addr,
+                "project.util.tarutil": util_addr,
+                "project_test.demo_test": Address.parse("tests/python/project_test/demo_test"),
             }
         )
 
@@ -192,20 +179,14 @@ class ModuleMapperTest(TestBase):
         self.create_file("source_root1/project/app.py")
         self.create_file("source_root1/project/file2.py")
         self.add_to_build_file("source_root1/project", "python_library()")
-        assert get_owner("project.app") == Address(
-            "source_root1/project", target_name="app.py", generated_base_target_name="project"
-        )
+        assert get_owner("project.app") == Address.parse("source_root1/project")
 
         # Check a package path
         self.create_file("source_root2/project/subdir/__init__.py")
         self.add_to_build_file("source_root2/project/subdir", "python_library()")
-        assert get_owner("project.subdir") == Address(
-            "source_root2/project/subdir",
-            target_name="__init__.py",
-            generated_base_target_name="subdir",
-        )
+        assert get_owner("project.subdir") == Address.parse("source_root2/project/subdir")
 
-        # Test a module with no owner (stdlib). This also sanity checks that we can handle when
+        # Test a module with no owner (stdlib). This also smoke tests that we can handle when
         # there is no parent module.
         assert get_owner("typing") is None
 
@@ -213,6 +194,4 @@ class ModuleMapperTest(TestBase):
         # can handle when the module includes a symbol (like a class name) at the end.
         self.create_file("script.py")
         self.add_to_build_file("", "python_library(name='script')")
-        assert get_owner("script.Demo") == Address(
-            "", target_name="script.py", generated_base_target_name="script"
-        )
+        assert get_owner("script.Demo") == Address.parse("//:script")

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -45,10 +45,7 @@ async def infer_python_dependencies(request: InferPythonDependencies) -> Inferre
     return InferredDependencies(
         owner.address
         for owner in owner_per_import
-        if (
-            owner.address
-            and owner.address.maybe_convert_to_base_target() != request.sources_field.address
-        )
+        if (owner.address and owner.address != request.sources_field.address)
     )
 
 

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -93,19 +93,7 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        # NB: We do not infer `src/python/app.py`, even though it's used by `src/python/f2.py`,
-        # because it is part of the requested address.
         normal_address = Address("src/python", "python")
         assert run_dep_inference(normal_address) == InferredDependencies(
-            [
-                Address("3rdparty/python", "Django"),
-                Address("src/python/util", target_name="dep.py", generated_base_target_name="util"),
-            ]
-        )
-
-        generated_subtarget_address = Address(
-            "src/python", target_name="f2.py", generated_base_target_name="python"
-        )
-        assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
-            [Address("src/python", target_name="app.py", generated_base_target_name="python")]
+            [Address("3rdparty/python", "Django"), Address("src/python/util", "util")]
         )

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -1,6 +1,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  sources=["*.py", "!cmd_line_spec_parser.py", "!specs.py", "!*_test.py"],
+)
+
+python_library(
+  name="specs",
+  sources=["cmd_line_spec_parser.py", "specs.py"],
+)
 
 python_tests(name='tests')

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -2,7 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=["*.py", "!pants_exe.py", "!pants_loader.py"],
+  name="daemon_pants_runner",
+  sources=["daemon_pants_runner.py"],
+)
+
+python_library(
+  name="local_pants_runner",
+  sources=["local_pants_runner.py"],
 )
 
 python_library(
@@ -16,6 +22,16 @@ python_library(
   dependencies=[
     ":pants_exe",  # NB: This is not inferred.
   ],
+)
+
+python_library(
+  name="pants_runner",
+  sources=["pants_runner.py"],
+)
+
+python_library(
+  name="remote_pants_runner",
+  sources=["remote_pants_runner.py"],
 )
 
 # This binary's entry_point is used by the pantsbuild.pants sdist to setup a binary for

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -1,7 +1,14 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  sources=["*.py", "!address.py", "!*_test.py"],
+)
+
+python_library(
+  name="address",
+  sources=["address.py"],
+)
 
 python_tests(
   name="tests",

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -121,10 +121,6 @@ class Address:
     def parse(cls, spec: str, relative_to: str = "", subproject_roots=None) -> "Address":
         """Parses an address from its serialized form.
 
-        Note that this does not work properly with generated subtargets, e.g. the address
-        `helloworld/app.py`. We would not be able to calculate the `generated_base_target_name`, so
-        we treat this like a normal target address.
-
         :param spec: An address in string form <path>:<name>.
         :param relative_to: For sibling specs, ie: ':another_in_same_build_family', interprets
                             the missing spec_path part as `relative_to`.
@@ -167,21 +163,16 @@ class Address:
                 f"name: {name}"
             )
 
-    def __init__(
-        self, spec_path: str, target_name: str, *, generated_base_target_name: Optional[str] = None
-    ) -> None:
+    def __init__(self, spec_path: str, target_name: str) -> None:
         """
         :param spec_path: The path from the root of the repo to this target.
         :param target_name: The name of a target this Address refers to.
-        :param generated_base_target_name: If this Address refers to a generated subtarget, this
-                                           stores the target_name of the original base target.
         """
         self.validate_path(spec_path)
         self.check_target_name(spec_path, target_name)
         self._spec_path = spec_path
         self._target_name = target_name
-        self.generated_base_target_name = generated_base_target_name
-        self._hash = hash((self._spec_path, self._target_name, self.generated_base_target_name))
+        self._hash = hash((self._spec_path, self._target_name))
 
     @property
     def spec_path(self) -> str:
@@ -208,9 +199,6 @@ class Address:
         :API: public
         """
         prefix = "//" if not self._spec_path else ""
-        if self.generated_base_target_name:
-            path = os.path.join(self._spec_path, self._target_name)
-            return f"{prefix}{path}"
         return f"{prefix}{self._spec_path}:{self._target_name}"
 
     @property
@@ -225,8 +213,7 @@ class Address:
         """
         :API: public
         """
-        prefix = ":" if not self.generated_base_target_name else "./"
-        return f"{prefix}{self._target_name}"
+        return f":{self._target_name}"
 
     def reference(self, referencing_path: Optional[str] = None) -> str:
         """How to reference this address in a BUILD file.
@@ -239,44 +226,22 @@ class Address:
             return self.spec
         return self._spec_path
 
-    def maybe_convert_to_base_target(self) -> "Address":
-        """If this address is a generated subtarget, convert it back into its original base target.
-
-        Otherwise, return itself unmodified.
-        """
-        if not self.generated_base_target_name:
-            return self
-        return self.__class__(self._spec_path, target_name=self.generated_base_target_name)
-
     def __eq__(self, other):
         if not isinstance(other, Address):
             return False
-        return (
-            self._spec_path == other._spec_path
-            and self._target_name == other._target_name
-            and self.generated_base_target_name == other.generated_base_target_name
-        )
+        return self._spec_path == other._spec_path and self._target_name == other._target_name
 
     def __hash__(self):
         return self._hash
 
     def __repr__(self) -> str:
-        prefix = f"Address({self.spec_path}, {self.target_name}"
-        return (
-            f"{prefix})"
-            if not self.generated_base_target_name
-            else f"{prefix}, generated_base_target_name={self.generated_base_target_name})"
-        )
+        return f"Address({self.spec_path}, {self.target_name})"
 
     def __str__(self) -> str:
         return self.spec
 
     def __lt__(self, other):
-        return (self._spec_path, self._target_name, self.generated_base_target_name) < (
-            other._spec_path,
-            other._target_name,
-            other.generated_base_target_name,
-        )
+        return (self._spec_path, self._target_name) < (other._spec_path, other._target_name)
 
 
 class BuildFileAddress(Address):
@@ -285,27 +250,17 @@ class BuildFileAddress(Address):
     :API: public
     """
 
-    def __init__(
-        self,
-        *,
-        rel_path: str,
-        target_name: Optional[str] = None,
-        generated_base_target_name: Optional[str] = None,
-    ) -> None:
+    def __init__(self, *, rel_path: str, target_name: Optional[str] = None,) -> None:
         """
         :param rel_path: The BUILD files' path, relative to the root_dir.
         :param target_name: The name of the target within the BUILD file; defaults to the default
                             target, aka the name of the BUILD file parent dir.
-        :param generated_base_target_name: If this Address refers to a generated subtarget, this
-                                           stores the target_name of the original base target.
 
         :API: public
         """
         spec_path = os.path.dirname(rel_path)
         super().__init__(
-            spec_path=spec_path,
-            target_name=target_name or os.path.basename(spec_path),
-            generated_base_target_name=generated_base_target_name,
+            spec_path=spec_path, target_name=target_name or os.path.basename(spec_path),
         )
         self.rel_path = rel_path
 
@@ -317,24 +272,10 @@ class BuildFileAddress(Address):
         #  is weird to subclass `Address` but break Liskov substitution in many places, like the
         #  constructor. The blocker is that this type is used widely by V1 and it can't be cleanly
         #  deprecated.
-        return Address(
-            spec_path=self.spec_path,
-            target_name=self.target_name,
-            generated_base_target_name=self.generated_base_target_name,
-        )
-
-    def maybe_convert_to_base_target(self) -> "BuildFileAddress":
-        if not self.generated_base_target_name:
-            return self
-        return self.__class__(rel_path=self.rel_path, target_name=self.generated_base_target_name)
+        return Address(spec_path=self.spec_path, target_name=self.target_name,)
 
     def __repr__(self) -> str:
-        prefix = f"BuildFileAddress({self.rel_path}, {self.target_name}"
-        return (
-            f"{prefix})"
-            if not self.generated_base_target_name
-            else f"{prefix}, generated_base_target_name={self.generated_base_target_name})"
-        )
+        return f"BuildFileAddress({self.rel_path}, {self.target_name})"
 
 
 def _is_build_file_name(name: str) -> bool:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -158,11 +158,6 @@ def test_address_equality() -> None:
     assert Address("a/b", "c") == Address.parse("a/b:c")
     assert Address.parse("a/b:c") == Address.parse("a/b:c")
 
-    assert Address("a/b", "c") != Address("a/b", "c", generated_base_target_name="original")
-    assert Address("a/b", "c", generated_base_target_name="original") == Address(
-        "a/b", "c", generated_base_target_name="original"
-    )
-
 
 def test_address_spec() -> None:
     normal_addr = Address("a/b", "c")
@@ -174,41 +169,6 @@ def test_address_spec() -> None:
     assert top_level_addr.spec == "//:root" == str(top_level_addr) == top_level_addr.reference()
     assert top_level_addr.relative_spec == ":root"
     assert top_level_addr.path_safe_spec == ".root"
-
-    generated_addr = Address("a/b", "c.txt", generated_base_target_name="c")
-    assert generated_addr.spec == "a/b/c.txt" == str(generated_addr) == generated_addr.reference()
-    assert generated_addr.relative_spec == "./c.txt"
-    assert generated_addr.path_safe_spec == "a.b.c.txt"
-
-    top_level_generated_addr = Address("", "root.txt", generated_base_target_name="root")
-    assert (
-        top_level_generated_addr.spec
-        == "//root.txt"
-        == str(top_level_generated_addr)
-        == top_level_generated_addr.reference()
-    )
-    assert top_level_generated_addr.relative_spec == "./root.txt"
-    assert top_level_generated_addr.path_safe_spec == ".root.txt"
-
-    generated_subdirectory_addr = Address(
-        "a/b", "subdir/c.txt", generated_base_target_name="original"
-    )
-    assert (
-        generated_subdirectory_addr.spec
-        == "a/b/subdir/c.txt"
-        == str(generated_subdirectory_addr)
-        == generated_subdirectory_addr.reference()
-    )
-    assert generated_subdirectory_addr.relative_spec == "./subdir/c.txt"
-    assert generated_subdirectory_addr.path_safe_spec == "a.b.subdir.c.txt"
-
-
-def test_address_maybe_convert_to_base_target() -> None:
-    generated_addr = Address("a/b", "c.txt", generated_base_target_name="c")
-    assert generated_addr.maybe_convert_to_base_target() == Address("a/b", "c")
-
-    normal_addr = Address("a/b", "c")
-    assert normal_addr.maybe_convert_to_base_target() is normal_addr
 
 
 def test_address_parse_method() -> None:
@@ -236,13 +196,3 @@ def test_build_file_address() -> None:
     assert bfa == Address("dir", "example")
     assert type(bfa.to_address()) is Address
     assert bfa.to_address() == Address("dir", "example")
-
-    generated_bfa = BuildFileAddress(
-        rel_path="dir/BUILD", target_name="example.txt", generated_base_target_name="original"
-    )
-    assert generated_bfa != BuildFileAddress(rel_path="dir/BUILD", target_name="example.txt")
-    assert generated_bfa == Address("dir", "example.txt", generated_base_target_name="original")
-    assert generated_bfa.spec == "dir/example.txt"
-    assert generated_bfa.maybe_convert_to_base_target() == BuildFileAddress(
-        rel_path="dir/BUILD", target_name="original"
-    )

--- a/src/python/pants/core/BUILD
+++ b/src/python/pants/core/BUILD
@@ -1,4 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  sources=['*.py', '!register.py', '!*_test.py'],
+)
+
+python_library(
+  name='plugin',
+  sources=['register.py'],
+)

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -1,7 +1,75 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  name="addresses",
+  sources=["addresses.py"],
+)
+
+python_library(
+  name="collection",
+  sources=["collection.py"],
+)
+
+python_library(
+  name="console",
+  sources=["console.py"],
+)
+
+python_library(
+  name="desktop",
+  sources=["desktop.py"],
+)
+
+python_library(
+  name="engine_aware",
+  sources=["engine_aware.py"],
+)
+
+python_library(
+  name="fs",
+  sources=["fs.py"],
+)
+
+python_library(
+  name="goal",
+  sources=["goal.py"],
+)
+
+python_library(
+  name="interactive_process",
+  sources=["interactive_process.py"],
+)
+
+python_library(
+  name="platform",
+  sources=["platform.py"],
+)
+
+python_library(
+  name="process",
+  sources=["process.py"],
+)
+
+python_library(
+  name="rules",
+  sources=["rules.py"],
+)
+
+python_library(
+  name="selectors",
+  sources=["selectors.py"],
+)
+
+python_library(
+  name="target",
+  sources=["target.py"],
+)
+
+python_library(
+  name="unions",
+  sources=["unions.py"],
+)
 
 python_tests(
   name='tests',

--- a/src/python/pants/engine/internals/BUILD
+++ b/src/python/pants/engine/internals/BUILD
@@ -1,10 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
-  sources=['*.py', '!native.py', '!*_test.py']
-)
-
 python_tests(
   name='tests',
   sources=['*_test.py', '!*_integration_test.py'],
@@ -16,6 +12,21 @@ python_integration_tests(
   dependencies=[
     'examples/src/python/example:hello_directory',
   ],
+)
+
+python_library(
+  name='build_files',
+  sources=['build_files.py'],
+)
+
+python_library(
+  name='graph',
+  sources=['graph.py'],
+)
+
+python_library(
+  name="mapper",
+  sources=["mapper.py"],
 )
 
 python_library(
@@ -32,4 +43,39 @@ resources(
     'native_engine.so',
     'native_engine.so.metadata',
   ],
+)
+
+python_library(
+  name='nodes',
+  sources=['nodes.py']
+)
+
+python_library(
+  name='options_parsing',
+  sources=['options_parsing.py'],
+)
+
+python_library(
+  name='parser',
+  sources=['parser.py'],
+)
+
+python_library(
+  name='scheduler',
+  sources=['scheduler.py'],
+)
+
+python_library(
+  name='scheduler_test_base',
+  sources=['scheduler_test_base.py'],
+)
+
+python_library(
+  name='target_adaptor',
+  sources=['target_adaptor.py']
+)
+
+python_library(
+  name='uuid',
+  sources=['uuid.py']
 )

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -101,22 +101,12 @@ def _raise_did_you_mean(address_family: AddressFamily, name: str, source=None) -
 @rule
 async def find_build_file(address: Address) -> BuildFileAddress:
     address_family = await Get(AddressFamily, Dir(address.spec_path))
-    owning_address = address.maybe_convert_to_base_target()
-    if owning_address not in address_family.addressables:
-        _raise_did_you_mean(address_family=address_family, name=owning_address.target_name)
-    bfa = next(
+    if address not in address_family.addressables:
+        _raise_did_you_mean(address_family=address_family, name=address.target_name)
+    return next(
         build_file_address
         for build_file_address in address_family.addressables.keys()
-        if build_file_address == owning_address
-    )
-    return (
-        bfa
-        if not address.generated_base_target_name
-        else BuildFileAddress(
-            rel_path=bfa.rel_path,
-            target_name=address.target_name,
-            generated_base_target_name=address.generated_base_target_name,
-        )
+        if build_file_address == address
     )
 
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -280,19 +280,6 @@ class BuildFileIntegrationTest(TestBase):
         bfas = self.request_single_product(BuildFileAddresses, Addresses([addr]))
         assert bfas == BuildFileAddresses([bfa])
 
-    def test_build_file_address_generated_subtarget(self) -> None:
-        self.create_file("helloworld/BUILD.ext", "mock_tgt(name='original')")
-        addr = Address("helloworld", target_name="generated", generated_base_target_name="original")
-        expected_bfa = BuildFileAddress(
-            rel_path="helloworld/BUILD.ext",
-            target_name="generated",
-            generated_base_target_name="original",
-        )
-        bfa = self.request_single_product(BuildFileAddress, addr)
-        assert bfa == expected_bfa
-        bfas = self.request_single_product(BuildFileAddresses, Addresses([addr]))
-        assert bfas == BuildFileAddresses([bfa])
-
     def test_address_not_found(self) -> None:
         with pytest.raises(ExecutionError) as exc:
             self.request_single_product(TargetAdaptor, Address.parse("helloworld"))

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -33,11 +33,8 @@ from pants.engine.target import (
     StringField,
     StringOrStringSequenceField,
     StringSequenceField,
-    Tags,
     Target,
     TargetWithOrigin,
-    generate_subtarget,
-    generate_subtarget_address,
 )
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockGet, run_rule
@@ -396,66 +393,6 @@ def test_required_field() -> None:
         RequiredTarget({"async": 0}, address=address)
     assert str(address) in str(exc.value)
     assert "primitive" in str(exc.value)
-
-
-# -----------------------------------------------------------------------------------------------
-# Test generated subtargets
-# -----------------------------------------------------------------------------------------------
-
-
-def test_generate_subtarget() -> None:
-    class MockTarget(Target):
-        alias = "mock_target"
-        core_fields = (Tags, Sources)
-
-    # When the target already only has a single source, the result should be the same, except for a
-    # different address.
-    single_source_tgt = MockTarget(
-        {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]},
-        address=Address.parse("src/fortran:demo"),
-    )
-    expected_single_source_address = Address(
-        "src/fortran", target_name="demo.f95", generated_base_target_name="demo"
-    )
-    assert generate_subtarget(
-        single_source_tgt, full_file_name="src/fortran/demo.f95"
-    ) == MockTarget(
-        {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]}, address=expected_single_source_address
-    )
-    assert (
-        generate_subtarget_address(single_source_tgt.address, full_file_name="src/fortran/demo.f95")
-        == expected_single_source_address
-    )
-
-    subdir_tgt = MockTarget(
-        {Sources.alias: ["demo.f95", "subdir/demo.f95"]}, address=Address.parse("src/fortran:demo")
-    )
-    expected_subdir_address = Address(
-        "src/fortran", target_name="subdir/demo.f95", generated_base_target_name="demo"
-    )
-    assert generate_subtarget(
-        subdir_tgt, full_file_name="src/fortran/subdir/demo.f95"
-    ) == MockTarget({Sources.alias: ["subdir/demo.f95"]}, address=expected_subdir_address)
-    assert (
-        generate_subtarget_address(subdir_tgt.address, full_file_name="src/fortran/subdir/demo.f95")
-        == expected_subdir_address
-    )
-
-    class NoSourcesTgt(Target):
-        alias = "no_sources_tgt"
-        core_fields = (Tags,)
-
-    no_sources_tgt = NoSourcesTgt({Tags.alias: ["demo"]}, address=Address.parse("//:no_sources"))
-    expected_no_sources_address = Address(
-        "", target_name="fake.txt", generated_base_target_name="no_sources"
-    )
-    assert generate_subtarget(no_sources_tgt, full_file_name="fake.txt") == NoSourcesTgt(
-        {Tags.alias: ["demo"]}, address=expected_no_sources_address
-    )
-    assert (
-        generate_subtarget_address(no_sources_tgt.address, full_file_name="fake.txt")
-        == expected_no_sources_address
-    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -1,4 +1,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  name='aggregated_timings',
+  sources=['aggregated_timings.py'],
+)
+
+python_library(
+  name='pantsd_stats',
+  sources=['pantsd_stats.py'],
+)
+
+python_library(
+  name='run_tracker',
+  sources=['run_tracker.py'],
+)

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -2,9 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
+  sources=["*.py", "!engine_initializer.py"],
   dependencies=[
     ':plugins',
   ],
+)
+
+python_library(
+  name="engine_initializer",
+  sources=["engine_initializer.py"],
 )
 
 target(
@@ -23,6 +29,6 @@ target(
     'src/python/pants/backend/python/lint/pylint',
     'src/python/pants/backend/python/typecheck/mypy',
     'src/python/pants/backend/native',
-    'src/python/pants/core',
+    'src/python/pants/core:plugin',
   ],
 )

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -2,15 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from pathlib import PurePath
-from typing import Iterable, Optional, cast
+from typing import Iterable, Optional
 
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.specs import (
     AddressSpec,
     AddressSpecs,
-    FilesystemLiteralSpec,
     FilesystemSpec,
     FilesystemSpecs,
     SingleAddress,
@@ -117,17 +115,10 @@ class SpecsCalculator:
         )
         logger.debug("changed addresses: %s", changed_addresses)
 
-        address_specs = []
-        filesystem_specs = []
-        for address in cast(ChangedAddresses, changed_addresses):
-            if address.generated_base_target_name:
-                file_name = PurePath(address.spec_path, address.target_name).as_posix()
-                filesystem_specs.append(FilesystemLiteralSpec(file_name))
-            else:
-                address_specs.append(SingleAddress(address.spec_path, address.target_name))
+        address_specs = tuple(
+            SingleAddress(address.spec_path, address.target_name) for address in changed_addresses
+        )
         return Specs(
-            address_specs=AddressSpecs(
-                address_specs, exclude_patterns=exclude_patterns, tags=tags,
-            ),
-            filesystem_specs=FilesystemSpecs(filesystem_specs),
+            address_specs=AddressSpecs(address_specs, exclude_patterns=exclude_patterns, tags=tags),
+            filesystem_specs=FilesystemSpecs(),
         )

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -1,7 +1,19 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  sources=["*.py", "!global_options.py", "!options_bootstrapper.py", "!*_test.py"],
+)
+
+python_library(
+  name="global_options",
+  sources=["global_options.py"],
+)
+
+python_library(
+  name="options_bootstrapper",
+  sources=["options_bootstrapper.py"],
+)
 
 python_tests(
   name="tests",

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -1,4 +1,22 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library()
+python_library(
+  name='pants_daemon_client',
+  sources=['pants_daemon_client.py'],
+)
+
+python_library(
+  name='pants_daemon_core',
+  sources=['pants_daemon_core.py'],
+)
+
+python_library(
+  name='pants_daemon',
+  sources=['pants_daemon.py'],
+)
+
+python_library(
+  name='process_manager',
+  sources=['process_manager.py'],
+)


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/issues/10423, generated subtargets were not a very good implementation for the ultimate feature we care about: file-level dependencies. Generated subtargets leaked much more than we hoped to end-users and were very complex to get right.

Instead, in https://github.com/pantsbuild/pants/issues/10423, we will achieve the same feature through a change that is better encapsulated from end-users.

We still keep `!` dependency ignores, but only via explicit addresses, as this is what dep inference again uses. We can add back explicit file dependencies once we have the new implementation working.

[ci skip-rust-tests]