### PR TITLE
Fixes to get the process_executor CLI tool working again.

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -74,7 +74,12 @@ impl ByteStore {
       serverset,
       headers: oauth_bearer_token
         .iter()
-        .map(|t| (String::from("authorization"), format!("Bearer {}", t)))
+        .map(|t| {
+          (
+            String::from("authorization"),
+            format!("Bearer {}", t.trim()),
+          )
+        })
         .collect(),
     })
   }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -143,7 +143,7 @@ impl CommandRunner {
     if let Some(oauth_bearer_token) = oauth_bearer_token {
       headers.insert(
         String::from("authorization"),
-        format!("Bearer {}", oauth_bearer_token),
+        format!("Bearer {}", oauth_bearer_token.trim()),
       );
     }
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -43,6 +43,7 @@ use process_execution::{
 };
 use store::{BackoffConfig, Store};
 use tokio::runtime::Handle;
+use workunit_store::WorkunitStore;
 
 /// A binary which takes args of format:
 ///  process_executor --env=FOO=bar --env=SOME=value --input-digest=abc123 --input-digest-length=80
@@ -54,6 +55,8 @@ use tokio::runtime::Handle;
 #[tokio::main]
 async fn main() {
   env_logger::init();
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
 
   let args = App::new("process_executor")
     .arg(


### PR DESCRIPTION
### Problem

The process_executor fails currently with 1) an untrimmed OAuth token, 2) no workunit store.

### Solution

Trim tokens, and create a workunit store.

### Result

The `process_executor` works for connecting to RBE.
