### PR TITLE
fixes in async_semaphore for concurrency ID calculation

### DIFF
--- a/src/rust/engine/async_semaphore/src/tests.rs
+++ b/src/rust/engine/async_semaphore/src/tests.rs
@@ -16,7 +16,7 @@ async fn acquire_and_release() {
 }
 
 #[tokio::test]
-async fn correct_semaphor_slot_ids() {
+async fn correct_semaphore_slot_ids() {
   let sema = AsyncSemaphore::new(2);
   let (tx1, rx1) = oneshot::channel();
   let (tx2, rx2) = oneshot::channel();
@@ -66,7 +66,7 @@ async fn correct_semaphor_slot_ids() {
 }
 
 #[tokio::test]
-async fn correct_semaphor_slot_ids_2() {
+async fn correct_semaphore_slot_ids_2() {
   let sema = AsyncSemaphore::new(4);
   let (tx1, rx1) = oneshot::channel();
   let (tx2, rx2) = oneshot::channel();

--- a/src/rust/engine/async_semaphore/src/tests.rs
+++ b/src/rust/engine/async_semaphore/src/tests.rs
@@ -56,13 +56,91 @@ async fn correct_semaphor_slot_ids() {
   let id3 = rx3.await.unwrap();
   let id4 = rx4.await.unwrap();
 
-  // Process 1 should get ID 2, then process 2 should run with id 1 and complete, then process 3
-  // should run in the same "slot" as process 2 and get the same id. Process 4 is scheduled
-  // later and gets put into "slot" 2.
-  assert_eq!(id1, 2);
-  assert_eq!(id2, 1);
-  assert_eq!(id3, 1);
-  assert_eq!(id4, 2);
+  // Process 1 should get ID 1, then process 2 should run with id 2 and complete, then process 3
+  // should run in the same "slot" as process 2 and get the same id (2). Process 4 is scheduled
+  // later and gets put into "slot" 1.
+  assert_eq!(id1, 1);
+  assert_eq!(id2, 2);
+  assert_eq!(id3, 2);
+  assert_eq!(id4, 1);
+}
+
+#[tokio::test]
+async fn correct_semaphor_slot_ids_2() {
+  let sema = AsyncSemaphore::new(4);
+  let (tx1, rx1) = oneshot::channel();
+  let (tx2, rx2) = oneshot::channel();
+  let (tx3, rx3) = oneshot::channel();
+  let (tx4, rx4) = oneshot::channel();
+  let (tx5, rx5) = oneshot::channel();
+  let (tx6, rx6) = oneshot::channel();
+  let (tx7, rx7) = oneshot::channel();
+
+  println!("Spawning process 1");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 1");
+    tx1.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 2");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 2");
+    tx2.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 3");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 3");
+    tx3.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 4");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 4");
+    tx4.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 5");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 5");
+    tx5.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 6");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 6");
+    tx6.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+  println!("Spawning process 7");
+  tokio::spawn(sema.clone().with_acquired(move |id| async move {
+    println!("Exec process 7");
+    tx7.send(id).unwrap();
+    delay_for(Duration::from_millis(20)).await;
+    future::ready(())
+  }));
+
+  let id1 = rx1.await.unwrap();
+  let id2 = rx2.await.unwrap();
+  let id3 = rx3.await.unwrap();
+  let id4 = rx4.await.unwrap();
+  let id5 = rx5.await.unwrap();
+  let id6 = rx6.await.unwrap();
+  let id7 = rx7.await.unwrap();
+
+  assert_eq!(id1, 1);
+  assert_eq!(id2, 2);
+  assert_eq!(id3, 3);
+  assert_eq!(id4, 4);
+  assert_eq!(id5, 1);
+  assert_eq!(id6, 2);
+  assert_eq!(id7, 3);
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -532,7 +532,7 @@ impl CommandRunner for BoundedCommandRunner {
 
       semaphore.with_acquired(move |concurrency_id| {
         log::debug!(
-          "Running {} under semaphor with concurrency id: {}",
+          "Running {} under semaphore with concurrency id: {}",
           desc,
           concurrency_id
         );

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -531,6 +531,11 @@ impl CommandRunner for BoundedCommandRunner {
       let name = format!("{}-running", req.workunit_name());
 
       semaphore.with_acquired(move |concurrency_id| {
+        log::debug!(
+          "Running {} under semaphor with concurrency id: {}",
+          desc,
+          concurrency_id
+        );
         let mut metadata = WorkunitMetadata::with_level(Level::Info);
         metadata.desc = Some(desc);
 


### PR DESCRIPTION
### Problem

This is an attempt to fix an issue where the concurrency ID passed into processes executed under the `BoundedCommandRunner` is being limited to a smaller set of IDs than the limit of the `BoundedCommandRunner`.

We were previously using the (`usize`) value of `available_permits` on the inner, locked portion of the `AsyncSemaphor` data structure that `BoundedCommandRunner` uses internally, as the value for the concurrency ID. However, this resulted in undesirable behavior where IDs passed to processes would count down from the local concurrency limit value (e.g. 16) to 1, and then never rise above 1 again. Every time a task finished, it would increment `available_permits` from 0 to 1, and then wake up the next process waiting on the queue, which would decrement `available_permits` again when it began to run and use `1` as its ID.

There was also an issue with always waking up the task in the `front` position in the queue. In the case where a large number of processes were all scheduled at once, they might all call `wake_by_id` on the same waiting task, meaning that any other waiting tasks after the first would wouldn't get awoken until either the first task, or a newly-scheduled task, completed and woke up tasks in the queue beyond the first.

### Solution

To solve the  concurrency ID issue, we add a new queue data structure to `Inner`, that keeps track of discrete IDs. When a permit to run is issued (in `PermitFuture::poll`), an ID is popped from the front of this queue, and when a task completes (in `Permit::drop`) that ID is pushed onto the back of the queue. So, a limited number of IDs will always be cycling through the `AsyncSemaphor` as long as it is running, and we won't see the behavior. This change also has the effect of causing IDs to count up from 1 rather than down from the local concurrency limit, which is only an implementation detail, since these IDs are meant to be opaque identifiers.

When an asynchronous task completes, instead of calling `wake_by_ref()` on the waiter at the front of the queue, use `available_permits` to index into the `waiters` queue and wake up a task. This ensures that each completing task will wake up at least one yet-unwoken waiting task (if there are any such waiting tasks), which will cause those waiting tasks to get scheduled immediately and take up a concurrency slot.

Also, a debug logger with the concurrency ID is added in this commit, to facilitate debugging any further concurrency-ID-related issues we may run into.