### PR TITLE
Upgrade to Pex 2.1.14

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ mypy==0.782
 
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.13
+pex==2.1.14
 psutil==5.7.0
 pystache==0.5.4
 python-Levenshtein==0.12.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -25,9 +25,9 @@ class PexBin(ExternalTool):
 
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.13"
+    default_version = "v2.1.14"
     default_known_versions = [
-        f"v2.1.13|{plat}|240712c75bb7c7cdfe3dd808ad6e6f186182e6aea3efeea5760683bb0fe89198|2633838"
+        f"v2.1.14|{plat}|12937da9ad5ad2c60564aa35cb4b3992ba3cc5ef7efedd44159332873da6fe46|2637138"
         for plat in ["darwin", "linux "]
     ]
 


### PR DESCRIPTION
This will allow us to use the new `--use-first-matching-interpreter` flag.

[ci skip-rust-tests]