### PR TITLE
Remove unused `SingleFileExecutable`

### DIFF
--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -1,8 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from dataclasses import dataclass
-
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalTool,
@@ -15,7 +13,6 @@ from pants.engine.fs import (
     DigestContents,
     FileContent,
     MergeDigests,
-    SingleFileExecutable,
     SourcesSnapshot,
 )
 from pants.engine.goal import Goal, GoalSubsystem
@@ -40,21 +37,6 @@ class ClocBinary(ExternalTool):
     def generate_url(self, plat: Platform) -> str:
         version = self.get_options().version
         return f"https://github.com/AlDanial/cloc/releases/download/{version}/cloc-{version}.pl"
-
-
-@dataclass(frozen=True)
-class DownloadedClocScript:
-    """Cloc script as downloaded from the pantsbuild binaries repo."""
-
-    exe: SingleFileExecutable
-
-    @property
-    def script_path(self) -> str:
-        return self.exe.exe_filename
-
-    @property
-    def digest(self) -> Digest:
-        return self.exe.digest
 
 
 class CountLinesOfCodeOptions(GoalSubsystem):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -10,12 +10,7 @@ from pants.engine.collection import Collection
 from pants.engine.rules import RootRule, side_effecting
 from pants.option.custom_types import GlobExpansionConjunction as GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior as GlobMatchErrorBehavior
-from pants.util.dirutil import (
-    ensure_relative_file_name,
-    maybe_read_file,
-    safe_delete,
-    safe_file_dump,
-)
+from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
 from pants.util.meta import frozen_after_init
 
 
@@ -306,35 +301,6 @@ _EMPTY_FINGERPRINT = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b78
 
 EMPTY_DIGEST = Digest(fingerprint=_EMPTY_FINGERPRINT, serialized_bytes_length=0)
 EMPTY_SNAPSHOT = Snapshot(EMPTY_DIGEST, files=(), dirs=())
-
-
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class SingleFileExecutable:
-    """Wraps a `Snapshot` and ensures that it only contains a single file."""
-
-    _exe_filename: Path
-    digest: Digest
-
-    @property
-    def exe_filename(self) -> str:
-        return ensure_relative_file_name(self._exe_filename)
-
-    class ValidationError(ValueError):
-        pass
-
-    @classmethod
-    def _raise_validation_error(cls, snapshot: Snapshot, should_message: str) -> None:
-        raise cls.ValidationError(f"snapshot {snapshot} used for {cls} should {should_message}")
-
-    def __init__(self, snapshot: Snapshot) -> None:
-        if len(snapshot.files) != 1:
-            self._raise_validation_error(snapshot, "have exactly 1 file!")
-        if snapshot.digest == EMPTY_DIGEST:
-            self._raise_validation_error(snapshot, "have a non-empty digest!")
-
-        self._exe_filename = Path(snapshot.files[0])
-        self.digest = snapshot.digest
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -6,15 +6,12 @@ from pathlib import Path
 
 from pants.engine.console import Console
 from pants.engine.fs import (
-    EMPTY_DIGEST,
     CreateDigest,
     Digest,
     DirectoryToMaterialize,
     FileContent,
     MaterializeDirectoriesResult,
     MaterializeDirectoryResult,
-    SingleFileExecutable,
-    Snapshot,
     Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
@@ -115,44 +112,3 @@ class IsChildOfTest(TestBase):
 
         assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
         assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)
-
-
-class SingleFileExecutableTest(TestBase):
-    def test_raises_with_multiple_files(self):
-        snapshot = self.request_single_product(
-            Snapshot,
-            CreateDigest(
-                [
-                    FileContent(path="a.txt", content=b"test file contents"),
-                    FileContent(path="b.txt", content=b"more test file contents"),
-                ]
-            ),
-        )
-
-        with self.assertRaisesWithMessage(
-            SingleFileExecutable.ValidationError,
-            f"snapshot {snapshot} used for {SingleFileExecutable} should have exactly 1 file!",
-        ):
-            SingleFileExecutable(snapshot)
-
-    def test_raises_empty_digest(self):
-        snapshot = Snapshot(EMPTY_DIGEST, files=("a.txt",), dirs=())
-
-        with self.assertRaisesWithMessage(
-            SingleFileExecutable.ValidationError,
-            f"snapshot {snapshot} used for {SingleFileExecutable} should have a non-empty digest!",
-        ):
-            SingleFileExecutable(snapshot)
-
-    def test_accepts_single_file_snapshot(self):
-        snapshot = self.request_single_product(
-            Snapshot,
-            CreateDigest([FileContent(path="subdir/a.txt", content=b"test file contents")]),
-        )
-        assert SingleFileExecutable(snapshot).exe_filename == "./subdir/a.txt"
-
-        snapshot = self.request_single_product(
-            Snapshot,
-            CreateDigest([FileContent(path="some_silly_file_name", content=b"test file contents")]),
-        )
-        assert SingleFileExecutable(snapshot).exe_filename == "./some_silly_file_name"


### PR DESCRIPTION
This was superseded by `ExternalTool`, which is how you now download binaries like `protoc` and `shellcheck`. From there, you `await Get(DownloadedExternalTool, ExternalToolRequest)`. The `DownloadedExternalTool` has a property called `.exe`, which is similar in spirit to `SingleFileExecutable`.

[ci skip-rust-tests]