### PR TITLE
Improvements to help output.

### DIFF
--- a/build-support/bin/docs_templates/options_scope_reference.md.mustache
+++ b/build-support/bin/docs_templates/options_scope_reference.md.mustache
@@ -3,6 +3,8 @@
 ```{{/is_goal}}
 {{description}}
 
+Config section: <span style="color: purple"><code>{{scope}}{{^scope}}GLOBAL{{/scope}}</code></span>
+
 ## Basic options
 
 {{#basic}}
@@ -20,6 +22,16 @@ None
 {{^advanced}}
 None
 {{/advanced}}
+
+## Deprecated options
+
+{{#deprecated}}
+{{> single_option}}
+{{/deprecated}}
+{{^deprecated}}
+None
+{{/deprecated}}
+
 
 {{#comma_separated_consumed_scopes}}
 ## Related subsystems

--- a/build-support/bin/docs_templates/options_scope_reference.md.mustache
+++ b/build-support/bin/docs_templates/options_scope_reference.md.mustache
@@ -3,7 +3,7 @@
 ```{{/is_goal}}
 {{description}}
 
-Config section: <span style="color: purple"><code>{{scope}}{{^scope}}GLOBAL{{/scope}}</code></span>
+Config section: <span style="color: purple"><code>[{{scope}}{{^scope}}GLOBAL{{/scope}}]</code></span>
 
 ## Basic options
 

--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -1,9 +1,16 @@
-<div style="color: purple"><code>{{comma_separated_display_args}}</code></div>
+<div style="color: purple">
+<code>{{comma_separated_display_args}}</code><br>
+<code>{{env_var}}</code><br>
+<code>{{config_key}}</code>
+</div>
 <div style="padding-left: 2em;">
-    {{#comma_separated_choices}}
-        <span style="color: green">one of: <code>{{comma_separated_choices}}</code></span><br>
-    {{/comma_separated_choices}}
-    <span style="color: green">default: {{{marked_up_default}}}</span>
+{{#comma_separated_choices}}
+<span style="color: green">one of: <code>{{comma_separated_choices}}</code></span><br>
+{{/comma_separated_choices}}
+<span style="color: green">default: {{{marked_up_default}}}
+</span>{{#deprecated_message}}<br><span style="color: darkred">{{deprecated_message}}
+</span>{{/deprecated_message}}{{#removal_hint}}<br><span style="color: darkred">{{removal_hint}}
+</span>{{/removal_hint}}
 <br>{{help}}
 </div>
 <br>

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -240,7 +240,7 @@ class ReferenceGenerator:
     def _render_parent_page_body(cls, items: Iterable[str], sync: bool) -> str:
         """Returns the body of a parent page for the given items."""
         # The page just lists the items, with links to the page for each one.
-        lines = [f"**[{item}]({cls._link(item, sync)})**\n" for item in items]
+        lines = [f"- [{item}]({cls._link(item, sync)})\n" for item in items]
         return "\n".join(lines)
 
     def render(self):

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -44,13 +44,18 @@ class HelpFormatter:
                 title = f"{display_scope} {category} options"
                 lines.append(self._maybe_green(f"{title}\n{'-' * len(title)}"))
             else:
+                # The basic options section gets the description and options scope info.
+                # No need to repeat those in the advanced section.
                 title = f"{display_scope} options"
                 lines.append(self._maybe_green(f"{title}\n{'-' * len(title)}"))
                 if oshi.description:
                     lines.append(f"\n{oshi.description}")
+                lines.append(" ")
+                config_section = f"[{oshi.scope or 'GLOBAL'}]"
+                lines.append(f"Config section: {self._maybe_magenta(config_section)}")
             lines.append(" ")
             if not ohis:
-                lines.append("No options available.")
+                lines.append("None available.")
                 return
             for ohi in ohis:
                 lines.extend([*self.format_option(ohi), ""])
@@ -84,6 +89,8 @@ class HelpFormatter:
 
         indent = "      "
         arg_lines = [f"  {self._maybe_magenta(args)}" for args in ohi.display_args]
+        arg_lines.append(self._maybe_magenta(f"  {ohi.env_var}"))
+        arg_lines.append(self._maybe_magenta(f"  {ohi.config_key}"))
         choices = "" if ohi.choices is None else f"one of: [{', '.join(ohi.choices)}]"
         choices_lines = [
             f"{indent}{'  ' if i != 0 else ''}{self._maybe_cyan(s)}"

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -21,6 +21,8 @@ class OptionHelpFormatterTest(unittest.TestCase):
             comma_separated_display_args="--foo",
             scoped_cmd_line_args=("--foo",),
             unscoped_cmd_line_args=("--foo",),
+            env_var="PANTS_FOO",
+            config_key="foo",
             typ=bool,
             default=None,
             default_str="None",
@@ -37,11 +39,11 @@ class OptionHelpFormatterTest(unittest.TestCase):
             show_advanced=False, show_deprecated=False, color=False
         ).format_option(ohi)
         choices = kwargs.get("choices")
-        assert len(lines) == 5 if choices else 4
+        assert len(lines) == 7 if choices else 6
         if choices:
-            assert f"one of: [{', '.join(choices)}]" == lines[1].strip()
-        assert "help for foo" in lines[4 if choices else 3]
-        return lines[2] if choices else lines[1]
+            assert f"one of: [{', '.join(choices)}]" == lines[3].strip()
+        assert "help for foo" in lines[6 if choices else 5]
+        return lines[4] if choices else lines[3]
 
     def test_format_help(self):
         default_line = self._format_for_single_option(default="MYDEFAULT")
@@ -73,16 +75,16 @@ class OptionHelpFormatterTest(unittest.TestCase):
         args = ["--foo"]
         kwargs = {"advanced": True}
         lines = self._format_for_global_scope(False, False, args, kwargs)
-        assert len(lines) == 5
+        assert len(lines) == 7
         assert not any("--foo" in line for line in lines)
         lines = self._format_for_global_scope(True, False, args, kwargs)
-        assert len(lines) == 13
+        assert len(lines) == 17
 
     def test_suppress_deprecated(self):
         args = ["--foo"]
         kwargs = {"removal_version": "33.44.55.dev0"}
         lines = self._format_for_global_scope(False, False, args, kwargs)
-        assert len(lines) == 5
+        assert len(lines) == 7
         assert not any("--foo" in line for line in lines)
         lines = self._format_for_global_scope(True, True, args, kwargs)
-        assert len(lines) == 18
+        assert len(lines) == 22

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -54,6 +54,9 @@ class OptionHelpInfo:
                           (e.g., [--scope-baz, --no-scope-baz, --scope-qux])
     unscoped_cmd_line_args: The unscoped raw flag names allowed on the cmd line in this option's
                             scope context (e.g., [--baz, --no-baz, --qux])
+    env_var: The environment variable that set's the option.
+    config_key: The config key for this option (in the section named for its scope).
+
     typ: The type of the option.
     default: The value of this option if no flags are specified (derived from config and env vars).
     help: The help message registered for this option.
@@ -68,6 +71,8 @@ class OptionHelpInfo:
     comma_separated_display_args: str
     scoped_cmd_line_args: Tuple[str, ...]
     unscoped_cmd_line_args: Tuple[str, ...]
+    env_var: str
+    config_key: str
     typ: Type
     default: Any
     default_str: str
@@ -311,11 +316,17 @@ class HelpInfoExtracter:
         removal_hint = kwargs.get("removal_hint")
         choices = self.compute_choices(kwargs)
 
+        dest = Parser.parse_dest(*args, **kwargs)
+        # Global options have three env var variants. The last one is the most human-friendly.
+        env_var = Parser.get_env_var_names(self._scope, dest)[-1]
+
         ret = OptionHelpInfo(
             display_args=tuple(display_args),
             comma_separated_display_args=", ".join(display_args),
             scoped_cmd_line_args=tuple(scoped_cmd_line_args),
             unscoped_cmd_line_args=tuple(unscoped_cmd_line_args),
+            env_var=env_var,
+            config_key=dest,
             typ=typ,
             default=default,
             default_str=default_str,

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -311,7 +311,7 @@ class HelpInfoExtracter:
         if removal_version:
             deprecated_tense = deprecated.get_deprecated_tense(removal_version)
             deprecated_message = (
-                f"DEPRECATED. {deprecated_tense} removed in version: {removal_version}"
+                f"Deprecated, {deprecated_tense} removed in version: {removal_version}."
             )
         removal_hint = kwargs.get("removal_hint")
         choices = self.compute_choices(kwargs)

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -140,7 +140,7 @@ def test_compute_default():
 
 def test_deprecated():
     kwargs = {"removal_version": "999.99.9", "removal_hint": "do not use this"}
-    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert "999.99.9" == ohi.removal_version
     assert "do not use this" == ohi.removal_hint
     assert ohi.deprecated_message is not None
@@ -156,19 +156,19 @@ def test_passthrough():
 
 def test_choices() -> None:
     kwargs = {"choices": ["info", "debug"]}
-    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert ohi.choices == ("info", "debug")
 
 
 def test_choices_enum() -> None:
     kwargs = {"type": LogLevel}
-    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert ohi.choices == ("info", "debug")
 
 
 def test_list_of_enum() -> None:
     kwargs = {"type": list, "member_type": LogLevel}
-    ohi = HelpInfoExtracter("").get_option_help_info([], kwargs)
+    ohi = HelpInfoExtracter("").get_option_help_info(["--foo"], kwargs)
     assert ohi.choices == ("info", "debug")
 
 
@@ -250,6 +250,8 @@ def test_get_all_help_info():
                         "comma_separated_display_args": "-o=<int>, --opt1=<int>",
                         "scoped_cmd_line_args": ("-o", "--opt1"),
                         "unscoped_cmd_line_args": ("-o", "--opt1"),
+                        "config_key": "opt1",
+                        "env_var": "PANTS_OPT1",
                         "value_history": {
                             "ranked_values": (
                                 {"rank": Rank.NONE, "value": None, "details": None},
@@ -280,6 +282,8 @@ def test_get_all_help_info():
                         "comma_separated_display_args": "--[no-]foo-opt2",
                         "scoped_cmd_line_args": ("--foo-opt2", "--no-foo-opt2"),
                         "unscoped_cmd_line_args": ("--opt2", "--no-opt2"),
+                        "config_key": "opt2",
+                        "env_var": "PANTS_FOO_OPT2",
                         "value_history": {
                             "ranked_values": (
                                 {"rank": Rank.NONE, "value": None, "details": None},
@@ -303,6 +307,8 @@ def test_get_all_help_info():
                         "comma_separated_display_args": "--foo-opt3=<str>",
                         "scoped_cmd_line_args": ("--foo-opt3",),
                         "unscoped_cmd_line_args": ("--opt3",),
+                        "config_key": "opt3",
+                        "env_var": "PANTS_FOO_OPT3",
                         "value_history": {
                             "ranked_values": ({"rank": Rank.NONE, "value": None, "details": None},),
                         },

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -744,11 +744,9 @@ class OptionsTest(TestBase):
         options = self._parse(flags="--int-choices=42 --int-choices=99")
         self.assertEqual([42, 99], options.for_global_scope().int_choices)
 
-    def test_parse_name_and_dest(self) -> None:
-        self.assertEqual(("thing", "thing"), Parser.parse_name_and_dest("--thing"))
-        self.assertEqual(
-            ("thing", "other_thing"), Parser.parse_name_and_dest("--thing", dest="other_thing")
-        )
+    def test_parse_dest(self) -> None:
+        self.assertEqual("thing", Parser.parse_dest("--thing"))
+        self.assertEqual("other_thing", Parser.parse_dest("--thing", dest="other_thing"))
 
     def test_validation(self) -> None:
         def assertError(expected_error, *args, **kwargs):

--- a/src/python/pants/testutil/option/fakes.py
+++ b/src/python/pants/testutil/option/fakes.py
@@ -51,7 +51,7 @@ class _FakeOptionValues(object):
 
 def _options_registration_function(defaults, fingerprintables):
     def register(*args, **kwargs):
-        _, option_dest = Parser.parse_name_and_dest(*args, **kwargs)
+        option_dest = Parser.parse_dest(*args, **kwargs)
 
         default = kwargs.get("default")
         if default is None:


### PR DESCRIPTION
- Show env var and config info in help.
- Show deprecated options in online docs.
- Show a list of goals/subsystems in the
  relevant parent docs, instead of an
  empty page.

Also cleans up a nit in the options parser -
we used to distinguish between option "name" and "dest".
But in reality the name wasn't used for anything except,
erroneously, in error messages. Now we just use dest
everywhere.

[ci skip-rust-tests]
