### PR TITLE
Rename `Workspace.materialize_directory()` to `Workspace.write_digest()`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -101,12 +101,12 @@ async def create_python_awslambda(
         description=f"Setting up handler in {pex_filename}",
     )
     result = await Get(ProcessResult, Process, process)
-    # Note that the AWS-facing handler function is always lambdex_handler.handler, which
-    # is the wrapper injected by lambdex that manages invocation of the actual handler.
     return CreatedAWSLambda(
         digest=result.output_digest,
-        name=pex_filename,
+        zip_file_relpath=pex_filename,
         runtime=field_set.runtime.value,
+        # The AWS-facing handler function is always lambdex_handler.handler, which is the wrapper
+        # injected by lambdex that manages invocation of the actual handler.
         handler="lambdex_handler.handler",
     )
 

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -51,7 +51,7 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
             DigestContents, created_awslambda.digest
         )
         assert len(created_awslambda_digest_contents) == 1
-        return created_awslambda.name, created_awslambda_digest_contents[0].content
+        return created_awslambda.zip_file_relpath, created_awslambda_digest_contents[0].content
 
     def test_create_hello_world_lambda(self) -> None:
         self.create_file(
@@ -83,8 +83,10 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
             ),
         )
 
-        name, content = self.create_python_awslambda("src/python/foo/bar:hello_world_lambda")
-        assert "hello_world_lambda.zip" == name
+        zip_file_relpath, content = self.create_python_awslambda(
+            "src/python/foo/bar:hello_world_lambda"
+        )
+        assert "hello_world_lambda.zip" == zip_file_relpath
         zipfile = ZipFile(BytesIO(content))
         names = set(zipfile.namelist())
         assert "lambdex_handler.py" in names

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -22,7 +22,7 @@ from pants.backend.python.rules.pex import rules as pex_rules
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.target_types import PythonInterpreterCompatibility
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, DirectoryToMaterialize, FileContent
+from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
@@ -225,7 +225,7 @@ class PexTest(ExternalToolTestBase):
                 ),
             ),
         )
-        self.scheduler.materialize_directory(DirectoryToMaterialize(pex.digest))
+        self.scheduler.write_digest(pex.digest)
         pex_path = os.path.join(self.build_root, "test.pex")
         with zipfile.ZipFile(pex_path, "r") as zipfp:
             with zipfp.open("PEX-INFO", "r") as pex_info:

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -41,7 +41,6 @@ from pants.engine.fs import (
     CreateDigest,
     Digest,
     DigestContents,
-    DirectoryToMaterialize,
     FileContent,
     MergeDigests,
     PathGlobs,
@@ -334,9 +333,7 @@ async def run_setup_pys(
         for exported_target, setup_py_result in zip(exported_targets, setup_py_results):
             addr = exported_target.target.address.reference()
             console.print_stderr(f"Writing dist for {addr} under {distdir.relpath}/.")
-            workspace.materialize_directory(
-                DirectoryToMaterialize(setup_py_result.output, path_prefix=str(distdir.relpath))
-            )
+            workspace.write_digest(setup_py_result.output, path_prefix=str(distdir.relpath))
     else:
         # Just dump the chroot.
         for exported_target, chroot in zip(exported_targets, chroots):
@@ -344,9 +341,7 @@ async def run_setup_pys(
             provides = exported_target.provides
             setup_py_dir = distdir.relpath / f"{provides.name}-{provides.version}"
             console.print_stderr(f"Writing setup.py chroot for {addr} to {setup_py_dir}")
-            workspace.materialize_directory(
-                DirectoryToMaterialize(chroot.digest, path_prefix=str(setup_py_dir))
-            )
+            workspace.write_digest(chroot.digest, path_prefix=str(setup_py_dir))
 
     return SetupPy(0)
 

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Iterable, List, Tuple, Type
 
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.console import Console
-from pants.engine.fs import EMPTY_DIGEST, Digest, DirectoryToMaterialize, MergeDigests, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
 from pants.engine.rules import goal_rule
@@ -205,7 +205,7 @@ async def fmt(
         # than silently having one result override the other. In practicality, this should never
         # happen due to us grouping each language's formatters into a single digest.
         merged_formatted_digest = await Get(Digest, MergeDigests(changed_digests))
-        workspace.materialize_directory(DirectoryToMaterialize(merged_formatted_digest))
+        workspace.write_digest(merged_formatted_digest)
 
     sorted_results = sorted(individual_results, key=lambda res: res.formatter_name)
     for result in sorted_results:

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -13,7 +13,7 @@ from pants.core.util_rules.filter_empty_sources import (
 )
 from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
+from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import goal_rule
@@ -60,11 +60,7 @@ class LintResult:
         if not self.results_file:
             return
         output_path = self.results_file.output_path
-        workspace.materialize_directory(
-            DirectoryToMaterialize(
-                self.results_file.digest, path_prefix=output_path.parent.as_posix(),
-            )
-        )
+        workspace.write_digest(self.results_file.digest, path_prefix=output_path.parent.as_posix())
         console.print_stdout(f"Wrote {self.linter_name} report to: {output_path.as_posix()}")
 
 

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -8,7 +8,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 from pants.base.build_root import BuildRoot
 from pants.core.goals.binary import BinaryFieldSet
 from pants.engine.console import Console
-from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
+from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
 from pants.engine.rules import goal_rule
@@ -95,14 +95,12 @@ async def run(
 
     workdir = global_options.options.pants_workdir
     with temporary_dir(root_dir=workdir, cleanup=True) as tmpdir:
-        path_relative_to_build_root = PurePath(tmpdir).relative_to(build_root.path).as_posix()
-        workspace.materialize_directory(
-            DirectoryToMaterialize(request.digest, path_prefix=path_relative_to_build_root)
-        )
+        tmpdir_relative_path = PurePath(tmpdir).relative_to(build_root.path).as_posix()
+        workspace.write_digest(request.digest, path_prefix=tmpdir_relative_path)
 
-        full_path = PurePath(tmpdir, request.binary_name).as_posix()
+        exe_path = PurePath(tmpdir, request.binary_name).as_posix()
         process = InteractiveProcess(
-            argv=(full_path, *request.prefix_args, *options.values.args),
+            argv=(exe_path, *request.prefix_args, *options.values.args),
             env=request.env,
             run_in_workspace=True,
         )

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -27,7 +27,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
 from pants.engine.target import (
     Sources,
@@ -202,6 +202,10 @@ class TestTest(TestBase):
                     mock=lambda field_sets: FieldSetsWithSources(
                         field_sets if include_sources else ()
                     ),
+                ),
+                # Merge XML results.
+                MockGet(
+                    product_type=Digest, subject_type=MergeDigests, mock=lambda _: EMPTY_DIGEST,
                 ),
                 MockGet(
                     product_type=CoverageReports,

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -20,7 +20,6 @@ from pants.engine.fs import (
     CreateDigest,
     Digest,
     DigestContents,
-    DirectoryToMaterialize,
     FileContent,
     MergeDigests,
     PathGlobs,
@@ -384,10 +383,10 @@ class FSTest(TestBase, SchedulerTestBase):
             )
             assert both_snapshot.digest == both_merged
 
-    def test_materialize_directories(self) -> None:
+    def test_write_digest(self) -> None:
         self.prime_store_with_roland_digest()
         digest = Digest("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80)
-        self.scheduler.materialize_directory(DirectoryToMaterialize(digest, path_prefix="test/"))
+        self.scheduler.write_digest(digest, path_prefix="test/")
         assert Path(self.build_root, "test/roland").read_text() == "European Burmese"
 
     def test_add_prefix(self) -> None:

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -619,20 +619,6 @@ def split_basename_and_dirname(path: str) -> Tuple[str, str]:
     return os.path.dirname(path), os.path.basename(path)
 
 
-def check_no_overlapping_paths(paths: Iterable[str]) -> None:
-    """Given a list of paths, ensure that all are unique and do not have the same prefix."""
-    for path in paths:
-        list_copy_without_path = list(paths)
-        list_copy_without_path.remove(path)
-        if path in list_copy_without_path:
-            raise ValueError(f"{path} appeared more than once. All paths must be unique.")
-        for p in list_copy_without_path:
-            if path in p:
-                raise ValueError(
-                    f"{path} and {p} have the same prefix. All paths must be unique and cannot overlap."
-                )
-
-
 def is_executable(path: str) -> bool:
     """Returns whether a path names an existing executable file."""
     return os.path.isfile(path) and os.access(path, os.X_OK)

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -18,7 +18,6 @@ from pants.util.dirutil import (
     ExistingFileError,
     _mkdtemp_unregister_cleaner,
     absolute_symlink,
-    check_no_overlapping_paths,
     ensure_relative_file_name,
     fast_relpath,
     get_basedir,
@@ -596,18 +595,3 @@ class AbsoluteSymlinkTest(unittest.TestCase):
     def test_overwrite_dir(self) -> None:
         os.makedirs(os.path.join(self.link, "a", "b", "c"))
         self._create_and_check_link(self.source, self.link)
-
-    def test_check_no_overlapping_paths_two_same(self) -> None:
-        paths = ["/path/to/file", "/path/to/file", "/no/path/to/file"]
-        with self.assertRaises(ValueError):
-            check_no_overlapping_paths(paths)
-
-    def test_check_no_overlapping_paths_prefix(self) -> None:
-        paths = ["/path/to", "/path/to/file", "/no/path/to/file"]
-        with self.assertRaises(ValueError):
-            check_no_overlapping_paths(paths)
-
-    def test_check_no_overlapping_paths_unique_paths(self) -> None:
-        paths = ["/he/went/to/the/store", "/she/saw/a/movie", "/no/one/knew/where/to/go"]
-        # This test is successful if nothing happens when calling check_no_overlapping_paths(paths)
-        check_no_overlapping_paths(paths)

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -58,7 +58,7 @@ use cpython::{
 use futures::compat::Future01CompatExt;
 use futures::future::FutureExt;
 use futures::future::{self as future03, TryFutureExt};
-use futures01::{future, Future};
+use futures01::Future;
 use hashing::{Digest, EMPTY_DIGEST};
 use log::{self, debug, error, warn, Log};
 use logging::logger::LOGGER;
@@ -137,10 +137,10 @@ py_module_initializer!(native_engine, |py, m| {
   )?;
   m.add(
     py,
-    "materialize_directories",
+    "write_digest",
     py_fn!(
       py,
-      materialize_directories(a: PyScheduler, b: PySession, c: PyObject)
+      write_digest(a: PyScheduler, b: PySession, c: PyObject, d: String)
     ),
   )?;
   m.add(
@@ -403,8 +403,6 @@ py_class!(class PyTypes |py| {
       snapshot: PyType,
       file_content: PyType,
       digest_contents: PyType,
-      materialize_directories_results: PyType,
-      materialize_directory_result: PyType,
       address: PyType,
       path_globs: PyType,
       merge_digests: PyType,
@@ -432,8 +430,6 @@ py_class!(class PyTypes |py| {
         snapshot: externs::type_for(snapshot),
         file_content: externs::type_for(file_content),
         digest_contents: externs::type_for(digest_contents),
-        materialize_directories_results: externs::type_for(materialize_directories_results),
-        materialize_directory_result: externs::type_for(materialize_directory_result),
         address: externs::type_for(address),
         path_globs: externs::type_for(path_globs),
         merge_digests: externs::type_for(merge_digests),
@@ -1582,83 +1578,33 @@ fn run_local_interactive_process(
   .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
 }
 
-fn materialize_directories(
+fn write_digest(
   py: Python,
   scheduler_ptr: PyScheduler,
   session_ptr: PySession,
-  directories_digests_and_path_prefixes_value: PyObject,
-) -> CPyResult<PyObject> {
-  let digests_and_path_prefixes = externs::project_multi(
-    &directories_digests_and_path_prefixes_value.into(),
-    "dependencies",
-  )
-  .into_iter()
-  .map(|value| {
-    let dir_digest = nodes::lift_digest(&externs::project_ignoring_type(&value, "digest"));
-    let path_prefix = PathBuf::from(externs::project_str(&value, "path_prefix"));
-    dir_digest.map(|dir_digest| (dir_digest, path_prefix))
-  })
-  .collect::<Result<Vec<_>, _>>()
-  .map_err(|e| PyErr::new::<exc::ValueError, _>(py, (e,)))?;
-
+  digest: PyObject,
+  path_prefix: String,
+) -> PyUnitResult {
+  let lifted_digest =
+    nodes::lift_digest(&digest.into()).map_err(|e| PyErr::new::<exc::ValueError, _>(py, (e,)))?;
   with_scheduler(py, scheduler_ptr, |scheduler| {
     with_session(py, session_ptr, |session| {
       // TODO: A parent_id should be an explicit argument.
       session.workunit_store().init_thread_state(None);
-      let types = &scheduler.core.types;
-      let materialize_directories_results = types.materialize_directories_results;
-      let materialize_directory_result = types.materialize_directory_result;
+
+      // Python will have already validated that path_prefix is a relative path.
+      let mut destination = PathBuf::new();
+      destination.push(scheduler.core.build_root.clone());
+      destination.push(path_prefix);
 
       block_in_place_and_wait(py, || {
-        future::join_all(
-          digests_and_path_prefixes
-            .into_iter()
-            .map(|(digest, path_prefix)| {
-              // NB: all DirectoryToMaterialize paths are validated in Python to be relative paths.
-              // Here, we join them with the build root.
-              let mut destination = PathBuf::new();
-              destination.push(scheduler.core.build_root.clone());
-              destination.push(path_prefix);
-              let metadata = scheduler
-                .core
-                .store()
-                .materialize_directory(destination.clone(), digest);
-              metadata.map(|m| (destination, m))
-            })
-            .collect::<Vec<_>>(),
-        )
+        scheduler
+          .core
+          .store()
+          .materialize_directory(destination.clone(), lifted_digest)
       })
-      .map(move |metadata_list| {
-        let entries: Vec<Value> = metadata_list
-          .iter()
-          .map(
-            |(output_dir, metadata): &(PathBuf, store::DirectoryMaterializeMetadata)| {
-              let path_list = metadata.to_path_list();
-              let path_values: Vec<Value> = path_list
-                .into_iter()
-                .map(|rel_path: String| {
-                  let mut path = PathBuf::new();
-                  path.push(output_dir);
-                  path.push(rel_path);
-                  externs::store_utf8(&path.to_string_lossy())
-                })
-                .collect();
-
-              externs::unsafe_call(
-                materialize_directory_result,
-                &[externs::store_tuple(path_values)],
-              )
-            },
-          )
-          .collect();
-
-        externs::unsafe_call(
-          materialize_directories_results,
-          &[externs::store_tuple(entries)],
-        )
-        .into()
-      })
-      .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
+      .map_err(|e| PyErr::new::<exc::ValueError, _>(py, (e,)))?;
+      Ok(None)
     })
   })
 }
@@ -1792,7 +1738,7 @@ fn write_to_file(path: &Path, graph: &RuleGraph<Rule>) -> io::Result<()> {
 ///   see https://github.com/pantsbuild/pants/issues/9476
 ///
 /// TODO: The alternative to blocking the runtime would be to have the Python code `await` special
-/// methods for things like `materialize_directories` and etc.
+/// methods for things like `write_digest` and etc.
 ///
 fn block_in_place_and_wait<T, E, F>(py: Python, f: impl FnOnce() -> F + Sync + Send) -> Result<T, E>
 where

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -8,8 +8,6 @@ pub struct Types {
   pub snapshot: TypeId,
   pub file_content: TypeId,
   pub digest_contents: TypeId,
-  pub materialize_directories_results: TypeId,
-  pub materialize_directory_result: TypeId,
   pub address: TypeId,
   pub path_globs: TypeId,
   pub merge_digests: TypeId,

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -19,7 +19,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.core.util_rules import archive, external_tool
-from pants.engine.fs import CreateDigest, Digest, DirectoryToMaterialize, FileContent, MergeDigests
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
@@ -102,11 +102,10 @@ class PluginResolverTest(TestBase):
             output_directories=("dist/",),
         )
         result = self.request_single_product(ProcessResult, process)
-        output_paths = self.scheduler.materialize_directory(
-            DirectoryToMaterialize(result.output_digest, path_prefix="output")
-        ).output_paths
+        result_snapshot = self.request_single_product(Snapshot, result.output_digest)
+        self.scheduler.write_digest(result.output_digest, path_prefix="output")
         safe_mkdir(install_dir)
-        for path in output_paths:
+        for path in result_snapshot.files:
             shutil.copy(path, install_dir)
 
     @contextmanager

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePath
 from textwrap import dedent
 from typing import Iterable
 
@@ -106,7 +106,7 @@ class PluginResolverTest(TestBase):
         self.scheduler.write_digest(result.output_digest, path_prefix="output")
         safe_mkdir(install_dir)
         for path in result_snapshot.files:
-            shutil.copy(path, install_dir)
+            shutil.copy(PurePath(self.build_root, "output", path), install_dir)
 
     @contextmanager
     def plugin_resolution(self, *, interpreter=None, chroot=None, plugins=None, sdist=True):


### PR DESCRIPTION
We've had several people mention that `materialize_directory` confused them because a) `directory` suggests you can only materialize a directory and not a file, and b) `materialize` isn't very simple. Instead, `write_digest()` fits with the general naming conventions we've established for the file system: https://www.pantsbuild.org/v2.0/docs/rules-api-file-system

This also removes the parallel `Workspace.materialize_directories()`. It required that each distinct digest have zero overlapping contents, which is not very common. We never used this method in production. Instead, users should call `await Get(Digest, MergeDigests)` beforehand.

`write_digest()` no longer returns any result, as the value was redundant with the contents of the input `digest`. If the user needs the names of the files written, they can lift the input Digest into a Snapshot and use `snapshot.files`.

Finally, we remove the intermediate type `WriteDigest`, as there is no need for this and it suggests that you may use the type in rules, when you cannot.

