### PR TITLE
Simplify Collection.

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -414,14 +414,12 @@ class FilesystemSpecs(Collection[FilesystemSpec]):
     @memoized_property
     def includes(self) -> Tuple[Union[FilesystemLiteralSpec, FilesystemGlobSpec], ...]:
         return tuple(
-            spec
-            for spec in self.dependencies
-            if isinstance(spec, (FilesystemGlobSpec, FilesystemLiteralSpec))
+            spec for spec in self if isinstance(spec, (FilesystemGlobSpec, FilesystemLiteralSpec))
         )
 
     @memoized_property
     def ignores(self) -> Tuple[FilesystemIgnoreSpec, ...]:
-        return tuple(spec for spec in self.dependencies if isinstance(spec, FilesystemIgnoreSpec))
+        return tuple(spec for spec in self if isinstance(spec, FilesystemIgnoreSpec))
 
     @staticmethod
     def _generate_path_globs(

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -19,6 +19,8 @@ class Collection(Tuple[T, ...]):
 
         class Examples(Collection[Example]):
             pass
+
+    N.B: Collection instances are only considered equal if both their types and contents are equal.
     """
 
     @overload  # noqa: F811
@@ -36,9 +38,7 @@ class Collection(Tuple[T, ...]):
         return self.__class__(cast(Tuple[T, ...], result))
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return super().__eq__(other)
+        return type(self) == type(other) and super().__eq__(other)
 
     def __ne__(self, other: Any) -> bool:
         # We must explicitly override to provide the inverse of _our_ __eq__ and not get the

--- a/src/python/pants/engine/collection_test.py
+++ b/src/python/pants/engine/collection_test.py
@@ -46,6 +46,9 @@ def test_collection_reversed() -> None:
 
 
 def test_collection_equality() -> None:
+    assert () != Collection()
+    assert Collection() != ()
+
     assert Collection([]) == Collection([])
     c1 = Collection([1, 2, 3])
     assert c1 == Collection([1, 2, 3])

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1339,7 +1339,7 @@ fn capture_snapshots(
   session_ptr: PySession,
   path_globs_and_root_tuple_wrapper: PyObject,
 ) -> CPyResult<PyObject> {
-  let values = externs::project_multi(&path_globs_and_root_tuple_wrapper.into(), "dependencies");
+  let values = externs::project_iterable(&path_globs_and_root_tuple_wrapper.into());
   let path_globs_and_roots = values
     .iter()
     .map(|value| {
@@ -1398,7 +1398,7 @@ fn merge_directories(
   session_ptr: PySession,
   directories_value: PyObject,
 ) -> CPyResult<PyObject> {
-  let digests = externs::project_multi(&directories_value.into(), "dependencies")
+  let digests = externs::project_iterable(&directories_value.into())
     .iter()
     .map(|v| nodes::lift_digest(v))
     .collect::<Result<Vec<_>, _>>()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -314,7 +314,7 @@ fn create_digest_to_digest(
   context: Context,
   args: Vec<Value>,
 ) -> BoxFuture<'static, NodeResult<Value>> {
-  let file_values = externs::project_multi(&args[0], "dependencies");
+  let file_values = externs::project_iterable(&args[0]);
   let digests: Vec<_> = file_values
     .iter()
     .map(|file| {


### PR DESCRIPTION
Collection and its subclasses are now just new-types for tuple removing
the previously awkward `dependencies` field exposed for the engine. The
engine is updated to handle these Collections as Iterable Python
objects when attempting to collect their contained values.
