### PR TITLE
Fix `--print-exception-stacktrace` not invalidating pantsd

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -572,7 +572,8 @@ class GlobalOptions(Subsystem):
             "--print-exception-stacktrace",
             advanced=True,
             type=bool,
-            fingerprint=False,
+            default=False,
+            daemon=True,
             help="Print to console the full exception stack trace if encountered.",
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -500,6 +500,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=True,
+            daemon=True,
             help=(
                 "Enables use of the Pants daemon (pantsd). pantsd can significantly improve "
                 "runtime performance by lowering per-run startup cost, and by caching filesystem "
@@ -572,6 +573,9 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=False,
+            # TODO: We must restart the daemon because of global mutable state in `init/logging.py`
+            #  from `ExceptionSink.should_print_exception_stacktrace`. Fix this and only use
+            #  `fingerprint=True` instead.
             daemon=True,
             help="Print to console the full exception stack trace if encountered.",
         )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -500,7 +500,6 @@ class GlobalOptions(Subsystem):
             advanced=True,
             type=bool,
             default=True,
-            daemon=True,
             help=(
                 "Enables use of the Pants daemon (pantsd). pantsd can significantly improve "
                 "runtime performance by lowering per-run startup cost, and by caching filesystem "


### PR DESCRIPTION
Before, if a command failed and you run it again with `--print-exception-stacktrace`, it would make no difference because the daemon's cache was being used.

Now, we force pantsd to restart so that the option works properly.

[ci skip-rust-tests]