### PR TITLE
Unify accessing options for a `GoalSubsystem` with `Subsystem`

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -7,14 +7,14 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import goal_rule
 
 
-class ListAndDieForTestingOptions(GoalSubsystem):
+class ListAndDieForTestingSubsystem(GoalSubsystem):
     """A fast and deadly variant of `./pants list`."""
 
     name = "list-and-die-for-testing"
 
 
 class ListAndDieForTesting(Goal):
-    subsystem_cls = ListAndDieForTestingOptions
+    subsystem_cls = ListAndDieForTestingSubsystem
 
 
 @goal_rule
@@ -25,6 +25,4 @@ def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> Lis
 
 
 def rules():
-    return [
-        fast_list_and_die_for_testing,
-    ]
+    return [fast_list_and_die_for_testing]

--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -5,7 +5,7 @@ from enum import Enum
 from textwrap import dedent
 from typing import Optional, cast
 
-from pants.backend.pants_info.list_target_types import TargetTypesOptions, list_target_types
+from pants.backend.pants_info.list_target_types import TargetTypesSubsystem, list_target_types
 from pants.engine.target import BoolField, IntField, RegisteredTargetTypes, StringField, Target
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions
@@ -84,7 +84,7 @@ def run_goal(
             RegisteredTargetTypes.create([FortranBinary, FortranLibrary, FortranTests]),
             union_membership or UnionMembership({}),
             create_goal_subsystem(
-                TargetTypesOptions, sep="\\n", output_file=None, details=details_target
+                TargetTypesSubsystem, sep="\\n", output_file=None, details=details_target
             ),
             create_subsystem(GlobalOptions, v1=False),
             console,

--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -8,13 +8,7 @@ from typing import Optional, cast
 from pants.backend.pants_info.list_target_types import TargetTypesSubsystem, list_target_types
 from pants.engine.target import BoolField, IntField, RegisteredTargetTypes, StringField, Target
 from pants.engine.unions import UnionMembership
-from pants.option.global_options import GlobalOptions
-from pants.testutil.engine.util import (
-    MockConsole,
-    create_goal_subsystem,
-    create_subsystem,
-    run_rule,
-)
+from pants.testutil.engine.util import MockConsole, create_goal_subsystem, run_rule
 
 
 # Note no docstring.
@@ -86,7 +80,6 @@ def run_goal(
             create_goal_subsystem(
                 TargetTypesSubsystem, sep="\\n", output_file=None, details=details_target
             ),
-            create_subsystem(GlobalOptions, v1=False),
             console,
         ],
     )

--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import cast
+
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalTool,
@@ -39,7 +41,7 @@ class ClocBinary(ExternalTool):
         return f"https://github.com/AlDanial/cloc/releases/download/{version}/cloc-{version}.pl"
 
 
-class CountLinesOfCodeOptions(GoalSubsystem):
+class CountLinesOfCodeSubsystem(GoalSubsystem):
     """Count lines of code."""
 
     name = "cloc"
@@ -48,18 +50,25 @@ class CountLinesOfCodeOptions(GoalSubsystem):
     def register_options(cls, register) -> None:
         super().register_options(register)
         register(
-            "--ignored", type=bool, help="Show information about files ignored by cloc.",
+            "--ignored",
+            type=bool,
+            default=False,
+            help="Show information about files ignored by cloc.",
         )
+
+    @property
+    def ignored(self) -> bool:
+        return cast(bool, self.options.ignored)
 
 
 class CountLinesOfCode(Goal):
-    subsystem_cls = CountLinesOfCodeOptions
+    subsystem_cls = CountLinesOfCodeSubsystem
 
 
 @goal_rule
 async def run_cloc(
     console: Console,
-    options: CountLinesOfCodeOptions,
+    cloc_subsystem: CountLinesOfCodeSubsystem,
     cloc_binary: ClocBinary,
     sources_snapshot: SourcesSnapshot,
 ) -> CountLinesOfCode:
@@ -113,7 +122,7 @@ async def run_cloc(
     for line in reports[report_filename].splitlines():
         console.print_stdout(line)
 
-    if options.values.ignored:
+    if cloc_subsystem.ignored:
         console.print_stderr("\nIgnored the following files:")
         for line in reports[ignore_filename].splitlines():
             console.print_stderr(line)

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -3,7 +3,7 @@
 
 import itertools
 from enum import Enum
-from typing import Set
+from typing import Set, cast
 
 from pants.backend.python.target_types import PythonRequirementsField
 from pants.engine.addresses import Addresses
@@ -21,7 +21,7 @@ class DependencyType(Enum):
     SOURCE_AND_THIRD_PARTY = "source-and-3rdparty"
 
 
-class DependenciesOptions(LineOriented, GoalSubsystem):
+class DependenciesSubsystem(LineOriented, GoalSubsystem):
     """List the dependencies of the input targets."""
 
     name = "dependencies"
@@ -47,16 +47,24 @@ class DependenciesOptions(LineOriented, GoalSubsystem):
             ),
         )
 
+    @property
+    def transitive(self) -> bool:
+        return cast(bool, self.options.transitive)
+
+    @property
+    def type(self) -> DependencyType:
+        return cast(DependencyType, self.options.type)
+
 
 class Dependencies(Goal):
-    subsystem_cls = DependenciesOptions
+    subsystem_cls = DependenciesSubsystem
 
 
 @goal_rule
 async def dependencies(
-    console: Console, addresses: Addresses, options: DependenciesOptions,
+    console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem,
 ) -> Dependencies:
-    if options.values.transitive:
+    if dependencies_subsystem.transitive:
         transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
         targets = Targets(transitive_targets.dependencies)
     else:
@@ -66,12 +74,12 @@ async def dependencies(
         )
         targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
 
-    include_3rdparty = options.values.type in [
-        DependencyType.THIRD_PARTY,
+    include_source = dependencies_subsystem.type in [
+        DependencyType.SOURCE,
         DependencyType.SOURCE_AND_THIRD_PARTY,
     ]
-    include_source = options.values.type in [
-        DependencyType.SOURCE,
+    include_3rdparty = dependencies_subsystem.type in [
+        DependencyType.THIRD_PARTY,
         DependencyType.SOURCE_AND_THIRD_PARTY,
     ]
 
@@ -86,7 +94,7 @@ async def dependencies(
                     str(python_req.requirement) for python_req in tgt[PythonRequirementsField].value
                 )
 
-    with options.line_oriented(console) as print_stdout:
+    with dependencies_subsystem.line_oriented(console) as print_stdout:
         for address in sorted(address_strings):
             print_stdout(address)
         for requirement_string in sorted(third_party_requirements):

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Sequence, cast
 
 import pytest
 
-from pants.backend.project_info.filter_targets import FilterOptions, filter_targets
+from pants.backend.project_info.filter_targets import FilterSubsystem, filter_targets
 from pants.engine.addresses import Address
 from pants.engine.target import (
     RegisteredTargetTypes,
@@ -37,7 +37,7 @@ def run_goal(
         rule_args=[
             Targets(targets),
             create_goal_subsystem(
-                FilterOptions,
+                FilterSubsystem,
                 sep="\\n",
                 output_file=None,
                 target_type=target_type or [],

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -7,19 +7,21 @@ from pants.engine.rules import goal_rule
 from pants.source.source_root import AllSourceRoots
 
 
-class RootsOptions(LineOriented, GoalSubsystem):
+class RootsSubsystem(LineOriented, GoalSubsystem):
     """List the repo's registered source roots."""
 
     name = "roots"
 
 
 class Roots(Goal):
-    subsystem_cls = RootsOptions
+    subsystem_cls = RootsSubsystem
 
 
 @goal_rule
-async def list_roots(console: Console, options: RootsOptions, asr: AllSourceRoots) -> Roots:
-    with options.line_oriented(console) as print_stdout:
+async def list_roots(
+    console: Console, roots_subsystem: RootsSubsystem, asr: AllSourceRoots
+) -> Roots:
+    with roots_subsystem.line_oriented(console) as print_stdout:
         for src_root in asr:
             print_stdout(src_root.path or ".")
     return Roots(exit_code=0)

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -11,7 +11,7 @@ from pants.engine.selectors import Get
 from pants.engine.target import DescriptionField, ProvidesField, Targets
 
 
-class ListOptions(LineOriented, GoalSubsystem):
+class ListSubsystem(LineOriented, GoalSubsystem):
     """Lists all targets matching the file or target arguments."""
 
     name = "list"
@@ -22,6 +22,7 @@ class ListOptions(LineOriented, GoalSubsystem):
         register(
             "--provides",
             type=bool,
+            default=False,
             help=(
                 "List only targets that provide an artifact, displaying the columns specified by "
                 "--provides-columns."
@@ -44,41 +45,50 @@ class ListOptions(LineOriented, GoalSubsystem):
         register(
             "--documented",
             type=bool,
+            default=False,
             help="Print only targets that are documented with a description.",
         )
 
+    @property
+    def provides(self) -> bool:
+        return cast(bool, self.options.provides)
+
+    @property
+    def documented(self) -> bool:
+        return cast(bool, self.options.documented)
+
 
 class List(Goal):
-    subsystem_cls = ListOptions
+    subsystem_cls = ListSubsystem
 
 
 @goal_rule
-async def list_targets(addresses: Addresses, options: ListOptions, console: Console) -> List:
+async def list_targets(
+    addresses: Addresses, list_subsystem: ListSubsystem, console: Console
+) -> List:
     if not addresses:
-        console.print_stderr(f"WARNING: No targets were matched in goal `{options.name}`.")
+        console.print_stderr(f"WARNING: No targets were matched in goal `{list_subsystem.name}`.")
         return List(exit_code=0)
 
-    provides_enabled = options.values.provides
-    documented_enabled = options.values.documented
-    if provides_enabled and documented_enabled:
+    if list_subsystem.provides and list_subsystem.documented:
         raise ValueError(
             "Cannot specify both `--list-documented` and `--list-provides` at the same time. "
             "Please choose one."
         )
 
-    if provides_enabled:
+    if list_subsystem.provides:
         targets = await Get(Targets, Addresses, addresses)
         addresses_with_provide_artifacts = {
             tgt.address: tgt[ProvidesField].value
             for tgt in targets
             if tgt.get(ProvidesField).value is not None
         }
-        with options.line_oriented(console) as print_stdout:
+        with list_subsystem.line_oriented(console) as print_stdout:
             for address, artifact in addresses_with_provide_artifacts.items():
                 print_stdout(f"{address.spec} {artifact}")
         return List(exit_code=0)
 
-    if documented_enabled:
+    if list_subsystem.documented:
         targets = await Get(Targets, Addresses, addresses)
         addresses_with_descriptions = cast(
             Dict[Address, str],
@@ -88,15 +98,15 @@ async def list_targets(addresses: Addresses, options: ListOptions, console: Cons
                 if tgt.get(DescriptionField).value is not None
             },
         )
-        with options.line_oriented(console) as print_stdout:
+        with list_subsystem.line_oriented(console) as print_stdout:
             for address, description in addresses_with_descriptions.items():
                 formatted_description = "\n  ".join(description.strip().split("\n"))
                 print_stdout(f"{address.spec}\n  {formatted_description}")
         return List(exit_code=0)
 
-    with options.line_oriented(console) as print_stdout:
+    with list_subsystem.line_oriented(console) as print_stdout:
         for address in sorted(addresses):
-            print_stdout(address)
+            print_stdout(address.spec)
     return List(exit_code=0)
 
 

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -4,7 +4,7 @@
 from textwrap import dedent
 from typing import List, Optional, Tuple, cast
 
-from pants.backend.project_info.list_targets import ListOptions, list_targets
+from pants.backend.project_info.list_targets import ListSubsystem, list_targets
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.engine.addresses import Address, Addresses
 from pants.engine.target import DescriptionField, ProvidesField, Target, Targets
@@ -29,7 +29,7 @@ def run_goal(
         rule_args=[
             Addresses(tgt.address for tgt in targets),
             create_goal_subsystem(
-                ListOptions,
+                ListSubsystem,
                 sep="\\n",
                 output_file=None,
                 documented=show_documented,

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -128,34 +128,35 @@ async def flake8_lint_partition(
     address_references = ", ".join(
         sorted(field_set.address.reference() for field_set in partition.field_sets)
     )
-    output_dir = lint_subsystem.output_dir
-    output_path = output_dir / "flake8_report.txt" if output_dir else None
+    report_path = (
+        lint_subsystem.reports_dir / "flake8_report.txt" if lint_subsystem.reports_dir else None
+    )
     flake8_args = generate_args(
         specified_source_files=specified_source_files,
         flake8=flake8,
-        output_file=output_path.name if output_path else None,
+        output_file=report_path.name if report_path else None,
     )
     process = requirements_pex.create_process(
         python_setup=python_setup,
         subprocess_encoding_environment=subprocess_encoding_environment,
         pex_path="./flake8.pex",
         pex_args=flake8_args,
-        output_files=(output_path.name,) if output_path else None,
+        output_files=(report_path.name,) if report_path else None,
         input_digest=input_digest,
         description=(
             f"Run Flake8 on {pluralize(len(partition.field_sets), 'target')}: {address_references}."
         ),
     )
     result = await Get(FallibleProcessResult, Process, process)
-    results_file = None
 
-    if output_path:
+    results_file = None
+    if report_path:
         report_file_snapshot = await Get(
-            Snapshot, SnapshotSubset(result.output_digest, PathGlobs([output_path.name]))
+            Snapshot, SnapshotSubset(result.output_digest, PathGlobs([report_path.name]))
         )
         if report_file_snapshot.is_empty or len(report_file_snapshot.files) != 1:
             raise Exception(f"Unexpected report file snapshot: {report_file_snapshot}")
-        results_file = LintResultFile(output_path=output_path, digest=report_file_snapshot.digest)
+        results_file = LintResultFile(output_path=report_path, digest=report_file_snapshot.digest)
 
     return LintResult.from_fallible_process_result(
         result, linter_name="Flake8", results_file=results_file

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -15,7 +15,13 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
-from pants.core.goals.lint import LintOptions, LintRequest, LintResult, LintResultFile, LintResults
+from pants.core.goals.lint import (
+    LintRequest,
+    LintResult,
+    LintResultFile,
+    LintResults,
+    LintSubsystem,
+)
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import (
     AllSourceFilesRequest,
@@ -68,7 +74,7 @@ def generate_args(
 async def flake8_lint_partition(
     partition: Flake8Partition,
     flake8: Flake8,
-    lint_options: LintOptions,
+    lint_subsystem: LintSubsystem,
     python_setup: PythonSetup,
     subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> LintResult:
@@ -122,7 +128,7 @@ async def flake8_lint_partition(
     address_references = ", ".join(
         sorted(field_set.address.reference() for field_set in partition.field_sets)
     )
-    output_dir = lint_options.output_dir
+    output_dir = lint_subsystem.output_dir
     output_path = output_dir / "flake8_report.txt" if output_dir else None
     flake8_args = generate_args(
         specified_source_files=specified_source_files,

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -7,7 +7,7 @@ from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
-from pants.core.goals.lint import LintOptions, LintResults
+from pants.core.goals.lint import LintResults, LintSubsystem
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.rules import RootRule, SubsystemRule
@@ -30,7 +30,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             *super().rules(),
             *flake8_rules(),
             RootRule(Flake8Request),
-            SubsystemRule(LintOptions),
+            SubsystemRule(LintSubsystem),
         )
 
     def make_target_with_origin(

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -20,7 +20,7 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.goals.test import Status, TestDebugRequest, TestOptions, TestResult
+from pants.core.goals.test import Status, TestDebugRequest, TestResult, TestSubsystem
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
@@ -134,7 +134,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             *python_native_code.rules(),
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
-            SubsystemRule(TestOptions),
+            SubsystemRule(TestSubsystem),
             RootRule(PythonTestFieldSet),
         )
 

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -28,7 +28,7 @@ class CreatedBinary:
     binary_name: str
 
 
-class BinaryOptions(GoalSubsystem):
+class BinarySubsystem(GoalSubsystem):
     """Create a runnable binary."""
 
     name = "binary"
@@ -37,7 +37,7 @@ class BinaryOptions(GoalSubsystem):
 
 
 class Binary(Goal):
-    subsystem_cls = BinaryOptions
+    subsystem_cls = BinarySubsystem
 
 
 @goal_rule

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -9,8 +9,8 @@ from typing import ClassVar, Iterable, List, Optional, Type, cast
 from pants.base.specs import SingleAddress
 from pants.core.goals.fmt import (
     Fmt,
-    FmtOptions,
     FmtResult,
+    FmtSubsystem,
     LanguageFmtResults,
     LanguageFmtTargets,
     fmt,
@@ -139,7 +139,7 @@ class FmtTest(TestBase):
             rule_args=[
                 console,
                 TargetsWithOrigins(targets),
-                create_goal_subsystem(FmtOptions, per_target_caching=per_target_caching),
+                create_goal_subsystem(FmtSubsystem, per_target_caching=per_target_caching),
                 Workspace(self.scheduler),
                 union_membership,
             ],

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -3,7 +3,7 @@
 
 import itertools
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import PurePath
 from typing import Iterable, Optional, cast
 
 from pants.core.goals.style_request import StyleRequest
@@ -25,7 +25,7 @@ from pants.util.strutil import strip_v2_chroot_path
 
 @dataclass(frozen=True)
 class LintResultFile:
-    output_path: Path
+    output_path: PurePath
     digest: Digest
 
 
@@ -120,9 +120,9 @@ class LintSubsystem(GoalSubsystem):
         return cast(bool, self.options.per_target_caching)
 
     @property
-    def output_dir(self) -> Optional[Path]:
-        reports_dir = self.options.reports_dir
-        return Path(reports_dir) if reports_dir else None
+    def reports_dir(self) -> Optional[PurePath]:
+        v = self.options.reports_dir
+        return PurePath(v) if v else None
 
 
 class Lint(Goal):

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -4,7 +4,7 @@
 import itertools
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, Optional, cast
 
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.filter_empty_sources import (
@@ -81,7 +81,7 @@ class LintRequest(StyleRequest):
     """
 
 
-class LintOptions(GoalSubsystem):
+class LintSubsystem(GoalSubsystem):
     """Lint source code."""
 
     name = "lint"
@@ -116,13 +116,17 @@ class LintOptions(GoalSubsystem):
         )
 
     @property
+    def per_target_caching(self) -> bool:
+        return cast(bool, self.options.per_target_caching)
+
+    @property
     def output_dir(self) -> Optional[Path]:
-        reports_dir = self.values.reports_dir
+        reports_dir = self.options.reports_dir
         return Path(reports_dir) if reports_dir else None
 
 
 class Lint(Goal):
-    subsystem_cls = LintOptions
+    subsystem_cls = LintSubsystem
 
 
 @goal_rule
@@ -130,7 +134,7 @@ async def lint(
     console: Console,
     workspace: Workspace,
     targets_with_origins: TargetsWithOrigins,
-    options: LintOptions,
+    lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,
 ) -> Lint:
     request_types = union_membership[LintRequest]
@@ -152,7 +156,7 @@ async def lint(
         if request
     )
 
-    if options.values.per_target_caching:
+    if lint_subsystem.per_target_caching:
         results = await MultiGet(
             Get(LintResults, LintRequest, request.__class__([field_set]))
             for request in valid_requests

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type
 
 from pants.base.specs import SingleAddress
-from pants.core.goals.lint import Lint, LintOptions, LintRequest, LintResult, LintResults, lint
+from pants.core.goals.lint import Lint, LintRequest, LintResult, LintResults, LintSubsystem, lint
 from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
@@ -150,7 +150,7 @@ class LintTest(TestBase):
                 console,
                 workspace,
                 TargetsWithOrigins(targets),
-                create_goal_subsystem(LintOptions, per_target_caching=per_target_caching),
+                create_goal_subsystem(LintSubsystem, per_target_caching=per_target_caching),
                 union_membership,
             ],
             mock_gets=[

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -37,7 +37,7 @@ class ReplImplementation(ABC):
         return tgt.has_fields(cls.required_fields)
 
 
-class ReplOptions(GoalSubsystem):
+class ReplSubsystem(GoalSubsystem):
     """Opens a REPL."""
 
     name = "repl"
@@ -53,9 +53,13 @@ class ReplOptions(GoalSubsystem):
             help="Override the automatically-detected REPL program for the target(s) specified. ",
         )
 
+    @property
+    def shell(self) -> Optional[str]:
+        return cast(Optional[str], self.options.shell)
+
 
 class Repl(Goal):
-    subsystem_cls = ReplOptions
+    subsystem_cls = ReplSubsystem
 
 
 @frozen_after_init
@@ -78,14 +82,13 @@ async def run_repl(
     console: Console,
     workspace: Workspace,
     interactive_runner: InteractiveRunner,
-    options: ReplOptions,
+    repl_subsystem: ReplSubsystem,
     transitive_targets: TransitiveTargets,
     build_root: BuildRoot,
     union_membership: UnionMembership,
     global_options: GlobalOptions,
 ) -> Repl:
-    default_repl = "python"
-    repl_shell_name = cast(str, options.values.shell) or default_repl
+    repl_shell_name = repl_subsystem.shell or "python"
 
     implementations: Dict[str, Type[ReplImplementation]] = {
         impl.name: impl for impl in union_membership[ReplImplementation]

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -6,7 +6,7 @@ from typing import cast
 from pants.base.build_root import BuildRoot
 from pants.base.specs import SingleAddress
 from pants.core.goals.binary import BinaryFieldSet
-from pants.core.goals.run import Run, RunOptions, RunRequest, run
+from pants.core.goals.run import Run, RunRequest, RunSubsystem, run
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
@@ -60,7 +60,7 @@ class RunTest(TestBase):
         res = run_rule(
             run,
             rule_args=[
-                create_goal_subsystem(RunOptions, args=[]),
+                create_goal_subsystem(RunSubsystem, args=[]),
                 create_subsystem(GlobalOptions, pants_workdir=self.pants_workdir),
                 console,
                 interactive_runner,

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -17,8 +17,8 @@ from pants.core.goals.test import (
     Test,
     TestDebugRequest,
     TestFieldSet,
-    TestOptions,
     TestResult,
+    TestSubsystem,
     WrappedTestFieldSet,
     run_tests,
 )
@@ -141,7 +141,9 @@ class TestTest(TestBase):
         valid_targets: bool = True,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
-        options = create_goal_subsystem(TestOptions, debug=debug, use_coverage=use_coverage)
+        test_subsystem = create_goal_subsystem(
+            TestSubsystem, debug=debug, use_coverage=use_coverage
+        )
         interactive_runner = InteractiveRunner(self.scheduler)
         workspace = Workspace(self.scheduler)
         union_membership = UnionMembership(
@@ -179,7 +181,7 @@ class TestTest(TestBase):
 
         result: Test = run_rule(
             run_tests,
-            rule_args=[console, options, interactive_runner, workspace, union_membership],
+            rule_args=[console, test_subsystem, interactive_runner, workspace, union_membership],
             mock_gets=[
                 MockGet(
                     product_type=TargetsToValidFieldSets,

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -63,7 +63,7 @@ class TypecheckRequest(StyleRequest):
     """
 
 
-class TypecheckOptions(GoalSubsystem):
+class TypecheckSubsystem(GoalSubsystem):
     """Run type checkers."""
 
     name = "typecheck"
@@ -72,7 +72,7 @@ class TypecheckOptions(GoalSubsystem):
 
 
 class Typecheck(Goal):
-    subsystem_cls = TypecheckOptions
+    subsystem_cls = TypecheckSubsystem
 
 
 @goal_rule

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -325,14 +325,14 @@ class SubA(A):
 _suba_root_rules = [RootRule(SubA)]
 
 
-class ExampleOptions(GoalSubsystem):
+class ExampleSubsystem(GoalSubsystem):
     """An example."""
 
     name = "example"
 
 
 class Example(Goal):
-    subsystem_cls = ExampleOptions
+    subsystem_cls = ExampleSubsystem
 
 
 @goal_rule

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -19,12 +19,12 @@ class MessageToGoalRule:
     create_digest: CreateDigest
 
 
-class MockWorkspaceGoalOptions(GoalSubsystem):
+class MockWorkspaceGoalSubsystem(GoalSubsystem):
     name = "mock-workspace-goal"
 
 
 class MockWorkspaceGoal(Goal):
-    subsystem_cls = MockWorkspaceGoalOptions
+    subsystem_cls = MockWorkspaceGoalSubsystem
 
 
 @goal_rule

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -10,14 +10,14 @@ from pants.engine.rules import goal_rule
 from pants.option.custom_types import file_option
 
 
-class DeprecationWarningOptions(GoalSubsystem):
+class DeprecationWarningSubsystem(GoalSubsystem):
     """Make a deprecation warning so that warning filters can be integration tested."""
 
     name = "deprecation-warning"
 
 
 class DeprecationWarningGoal(Goal):
-    subsystem_cls = DeprecationWarningOptions
+    subsystem_cls = DeprecationWarningSubsystem
 
 
 @goal_rule
@@ -28,7 +28,7 @@ async def show_warning() -> DeprecationWarningGoal:
     return DeprecationWarningGoal(0)
 
 
-class LifecycleStubsOptions(GoalSubsystem):
+class LifecycleStubsSubsystem(GoalSubsystem):
     """Configure workflows for lifecycle tests (Pants stopping and starting)."""
 
     name = "lifecycle-stub-goal"
@@ -45,12 +45,12 @@ class LifecycleStubsOptions(GoalSubsystem):
 
 
 class LifecycleStubsGoal(Goal):
-    subsystem_cls = LifecycleStubsOptions
+    subsystem_cls = LifecycleStubsSubsystem
 
 
 @goal_rule
-async def run_lifecycle_stubs(opts: LifecycleStubsOptions) -> LifecycleStubsGoal:
-    output_file = opts.values.new_interactive_stream_output_file
+async def run_lifecycle_stubs(opts: LifecycleStubsSubsystem) -> LifecycleStubsGoal:
+    output_file = opts.options.new_interactive_stream_output_file
     if output_file:
         file_stream = open(output_file, "wb")
         ExceptionSink.reset_interactive_output_stream(file_stream, output_file)


### PR DESCRIPTION
With a normal `Subsystem`, you use `self.options.foo` to access an option value. But with a `GoalSubsystem`, you use `self.values.foo`. This difference is confusing and requires unnecessary context switching.

Instead, we rename `.values` to `.options`. 

We also stop using the naming convention of calling the class `MyGoalOptions` and instead use `MyGoalSubsystem`. This makes things more consistent.

In a later followup, it would be good to remove the intermediate types of `OptionableFactory` and `SubsystemClientMixin` to have `GoalSubsystem` instead directly subclass `Subsystem`.

[ci skip-rust-tests]