### PR TITLE
A script to create an index.html for pants wheels on S3.

### DIFF
--- a/build-support/bin/create_s3_index_file.sh
+++ b/build-support/bin/create_s3_index_file.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Creates an index file for an existing S3 pantsbuild.pants wheel set.
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 SHA"
+  exit 1
+fi
+
+set -euo pipefail
+
+SHA=$1
+WHEEL_DIR=binaries.pantsbuild.org/wheels/pantsbuild.pants
+
+VERSION=$(aws s3 ls "s3://${WHEEL_DIR}/${SHA}/" | awk '{print $2}' | tr -d "/")
+
+VERSION_DIR="${WHEEL_DIR}/${SHA}/${VERSION}"
+
+for obj in $(aws s3 ls "s3://${VERSION_DIR}/" | grep "\.whl" | awk '{print $4}'); do
+  URL="https://${VERSION_DIR}/${obj}"
+  # Note that we replace the + with its escape sequence, as a raw + in a URL is
+  # interpreted as a space.
+  # Note also that we disable the shellcheck "echo may not expand escape sequences"
+  # check, since in this case we don't want to expand escape sequences.
+  # shellcheck disable=SC2028
+  echo "<br><a href=\"${URL//+/%2B}\">${obj}</a>\n";
+done | aws s3 cp --acl=public-read --content-type=text/html - "s3://${VERSION_DIR}/index.html"

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -49,6 +49,11 @@ def deploy() -> None:
         check=True,
     )
 
+    # Create/update the index file in S3.  After running on both the MacOS and Linux shards
+    # the index file will contain the wheels for both.
+    for sha in os.listdir("dist/deploy/wheels/pantsbuild.pants/"):
+        subprocess.run(["./build-support/bin/create_s3_index_file.sh", sha])
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The index file URL can be passed to pip/pex --find-links (or pants
--python-repos-repos) in order to resolve unreleased pants wheels
by sha.

[ci skip-rust-tests]
