### PR TITLE
Revert "Use isort v5.x as the default version (#10258)"

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,4 @@ use_parentheses=True
 
 known_first_party=internal_backend,pants,pants_test
 default_section=THIRDPARTY
+not_skip=__init__.py

--- a/examples/.isort.cfg
+++ b/examples/.isort.cfg
@@ -10,3 +10,4 @@ use_parentheses=True
 
 known_first_party=example
 default_section=THIRDPARTY
+not_skip=__init__.py

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -9,7 +9,7 @@ class Isort(PythonToolBase):
     """The Python import sorter tool (https://timothycrosley.github.io/isort/)."""
 
     options_scope = "isort"
-    default_version = "isort>=5.0.0,<6.0"
+    default_version = "isort>=4.3.21,<4.4"
     default_extra_requirements = ["setuptools<45"]  # NB: `<45` is for Python 2 support
     default_entry_point = "isort.main"
 

--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -48,6 +48,7 @@ from pants.option.custom_types import file_option
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 
+
 """
 An overview:
 


### PR DESCRIPTION
This reverts commit c8274167b73c028600b6156304dc4236f09aa910.

Between isort 4 and isort 5, the requirement on which files are present in the sandbox has changed, and this can result in unstable sort orders. See https://github.com/timothycrosley/isort/issues/1147 for the likely cause. Under isort 5, the following set of roots (via `./pants --changed-parent=master list` can result in an order that does not align with `./pants list ::`: https://gist.github.com/stuhood/ec04e86b8a1f44d8b11dcb79a1732a8f

In order to use isort 5 stably in a sandbox, we will need to include the necessary transitive dependencies for it to execute its new first-party-detection algorithm, or disable it.

[ci skip-rust-tests]