### PR TITLE
Fix `--print-exception-stacktrace` not invalidating pantsd

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -585,7 +585,11 @@ class GlobalOptions(Subsystem):
             "--print-exception-stacktrace",
             advanced=True,
             type=bool,
-            fingerprint=False,
+            default=False,
+            # TODO: We must restart the daemon because of global mutable state in `init/logging.py`
+            #  from `ExceptionSink.should_print_exception_stacktrace`. Fix this and only use
+            #  `fingerprint=True` instead.
+            daemon=True,
             help="Print to console the full exception stack trace if encountered.",
         )
 


### PR DESCRIPTION
Cherry-pick of d63b29cfd.

[ci skip-rust-tests]
[ci skip-jvm-tests]