### PR TITLE
Kill ./pants literals.

### DIFF
--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -5,6 +5,7 @@ import textwrap
 from dataclasses import dataclass
 from typing import Generic, Optional, Sequence, Type, cast, get_type_hints
 
+from pants.core.util_rules.pants_bin import PantsBin
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import goal_rule
@@ -203,6 +204,7 @@ def list_target_types(
     union_membership: UnionMembership,
     target_types_subsystem: TargetTypesSubsystem,
     console: Console,
+    pants_bin: PantsBin,
 ) -> TargetTypes:
     with target_types_subsystem.line_oriented(console) as print_stdout:
         if target_types_subsystem.details:
@@ -231,8 +233,8 @@ def list_target_types(
             lines = [
                 f"\n{title}\n",
                 textwrap.fill(
-                    "Use `./pants target-types --details=$target_type` to get detailed "
-                    "information for a particular target type.",
+                    f"Use `{pants_bin.render_command('target-types', '--details=$target_type')}` "
+                    "to get detailed information for a particular target type.",
                     80,
                 ),
                 "\n",

--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from typing import Optional, cast
 
 from pants.backend.pants_info.list_target_types import TargetTypesSubsystem, list_target_types
+from pants.core.util_rules.pants_bin import PantsBin
 from pants.engine.target import BoolField, IntField, RegisteredTargetTypes, StringField, Target
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, create_goal_subsystem, run_rule
@@ -81,6 +82,7 @@ def run_goal(
                 TargetTypesSubsystem, sep="\\n", output_file=None, details=details_target
             ),
             console,
+            PantsBin(name="./BNF"),
         ],
     )
     return cast(str, console.stdout.getvalue())
@@ -94,8 +96,8 @@ def test_list_all() -> None:
         Target types
         ------------
 
-        Use `./pants target-types --details=$target_type` to get detailed information
-        for a particular target type.
+        Use `./BNF target-types --details=$target_type` to get detailed information for
+        a particular target type.
 
 
         fortran_binary   <no description>

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -20,14 +20,19 @@ class Bandit(PythonToolBase):
     def register_options(cls, register):
         super().register_options(register)
         register(
-            "--skip", type=bool, default=False, help="Don't use Bandit when running `./pants lint`"
+            "--skip",
+            type=bool,
+            default=False,
+            help=f"Don't use Bandit when running `{register.bootstrap.pants_bin_name} lint`",
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to Bandit, e.g. "
-            '`--bandit-args="--skip B101,B308 --confidence"`',
+            help=(
+                f"Arguments to pass directly to Bandit, e.g. "
+                f'`--{cls.options_scope}-args="--skip B101,B308 --confidence"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -21,14 +21,19 @@ class Black(PythonToolBase):
             "--skip",
             type=bool,
             default=False,
-            help="Don't use Black when running `./pants fmt` and `./pants lint`",
+            help=(
+                f"Don't use Black when running `{register.bootstrap.pants_bin_name} fmt` and "
+                f"`{register.bootstrap.pants_bin_name} lint`"
+            ),
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to Black, e.g. "
-            '`--black-args="--target-version=py37 --quiet"`',
+            help=(
+                "Arguments to pass directly to Black, e.g. "
+                f'`--{cls.options_scope}-args="--target-version=py37 --quiet"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -19,12 +19,17 @@ class Docformatter(PythonToolBase):
             "--skip",
             type=bool,
             default=False,
-            help="Don't use docformatter when running `./pants fmt` and `./pants lint`.",
+            help=(
+                f"Don't use docformatter when running `{register.bootstrap.pants_bin_name} fmt` "
+                f"and `{register.bootstrap.pants_bin_name} lint`."
+            ),
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to docformatter, e.g. "
-            '`--docformatter-args="--wrap-summaries=100 --pre-summary-newline"`.',
+            help=(
+                "Arguments to pass directly to docformatter, e.g. "
+                f'`--{cls.options_scope}-args="--wrap-summaries=100 --pre-summary-newline"`.'
+            ),
         )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -18,14 +18,19 @@ class Flake8(PythonToolBase):
     def register_options(cls, register):
         super().register_options(register)
         register(
-            "--skip", type=bool, default=False, help="Don't use Flake8 when running `./pants lint`"
+            "--skip",
+            type=bool,
+            default=False,
+            help=f"Don't use Flake8 when running `{register.bootstrap.pants_bin_name} lint`",
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to Flake8, e.g. "
-            '`--flake8-args="--ignore E123,W456 --enable-extensions H111"`',
+            help=(
+                "Arguments to pass directly to Flake8, e.g. "
+                f'`--{cls.options_scope}-args="--ignore E123,W456 --enable-extensions H111"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -20,14 +20,19 @@ class Isort(PythonToolBase):
             "--skip",
             type=bool,
             default=False,
-            help="Don't use isort when running `./pants fmt` and `./pants lint`",
+            help=(
+                f"Don't use isort when running `{register.bootstrap.pants_bin_name} fmt` and "
+                f"`{register.bootstrap.pants_bin_name} lint`"
+            ),
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to isort, e.g. "
-            '`--isort-args="--case-sensitive --trailing-comma"`',
+            help=(
+                "Arguments to pass directly to isort, e.g. "
+                f'`--{cls.options_scope}-args="--case-sensitive --trailing-comma"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -19,14 +19,19 @@ class Pylint(PythonToolBase):
     def register_options(cls, register):
         super().register_options(register)
         register(
-            "--skip", type=bool, default=False, help="Don't use Pylint when running `./pants lint`"
+            "--skip",
+            type=bool,
+            default=False,
+            help=f"Don't use Pylint when running `{register.bootstrap.pants_bin_name} lint`",
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to Pylint, e.g. "
-            '`--pylint-args="--ignore=foo.py,bar.py --disable=C0330,W0311"`',
+            help=(
+                "Arguments to pass directly to Pylint, e.g. "
+                f'`--{cls.options_scope}-args="--ignore=foo.py,bar.py --disable=C0330,W0311"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -21,7 +21,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
-from pants.core.util_rules import determine_source_files, strip_source_roots
+from pants.core.util_rules import determine_source_files, pants_bin, strip_source_roots
 from pants.engine.addresses import Addresses
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, Process
@@ -137,6 +137,7 @@ def rules():
         *determine_source_files.rules(),
         *inject_ancestor_files.rules(),
         *inject_init.rules(),
+        *pants_bin.rules(),
         *pex.rules(),
         *python_native_code.rules(),
         *strip_source_roots.rules(),

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -19,14 +19,19 @@ class MyPy(PythonToolBase):
     def register_options(cls, register):
         super().register_options(register)
         register(
-            "--skip", type=bool, default=False, help="Don't use MyPy when running `./pants lint`."
+            "--skip",
+            type=bool,
+            default=False,
+            help=f"Don't use MyPy when running `{register.bootstrap.pants_bin_name} lint`.",
         )
         register(
             "--args",
             type=list,
             member_type=shell_str,
-            help="Arguments to pass directly to mypy, e.g. "
-            '`--mypy-args="--python-version 3.7 --disallow-any-expr"`',
+            help=(
+                "Arguments to pass directly to mypy, e.g. "
+                f'`--{cls.options_scope}-args="--python-version 3.7 --disallow-any-expr"`'
+            ),
         )
         register(
             "--config",

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -14,6 +14,7 @@ from pants.core.util_rules import (
     distdir,
     external_tool,
     filter_empty_sources,
+    pants_bin,
     strip_source_roots,
 )
 from pants.source import source_root
@@ -33,6 +34,7 @@ def rules():
         *determine_source_files.rules(),
         *distdir.rules(),
         *filter_empty_sources.rules(),
+        *pants_bin.rules(),
         *strip_source_roots.rules(),
         *archive.rules(),
         *external_tool.rules(),

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -152,7 +152,7 @@ class ExternalTool(Subsystem):
                 ver, plat_val, sha256, length = (x.strip() for x in known_version.split("|"))
             except ValueError:
                 raise ExternalToolError(
-                    f"Bad value for --known-versions (see ./pants "
+                    f"Bad value for --known-versions (see {self.get_options().pants_bin_name} "
                     f"help-advanced {self.options_scope}): {known_version}"
                 )
             if plat_val == plat.value and ver == version:

--- a/src/python/pants/core/util_rules/pants_bin.py
+++ b/src/python/pants/core/util_rules/pants_bin.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import cast
+
+from pants.engine.rules import rule
+from pants.option.global_options import GlobalOptions
+
+
+@dataclass(frozen=True)
+class PantsBin:
+    name: str
+
+    def render_command(
+        self, *args: str, format_vertical: bool = False, continuation_indent: str = "\t"
+    ) -> str:
+        """Renders the given args as a valid Pants command line for the current Pants executable.
+
+        The `continuation_indent` will only be used for folded continuation line if
+        `format_vertical` is chosen.
+        """
+        cmd = [self.name, *args]
+        joined_by = f" \\\n{continuation_indent}" if format_vertical else " "
+        return joined_by.join(cmd)
+
+
+@rule
+def pants_bin(global_options: GlobalOptions) -> PantsBin:
+    pants_bin_name = cast(str, global_options.get_options().pants_bin_name)
+    return PantsBin(name=pants_bin_name)
+
+
+def rules():
+    return [pants_bin]


### PR DESCRIPTION
We now use the --pants-bin-name option wherever possible so that help
messages reflect the actual name of the Pants binary in use. A PantsBin
type is introduced to allow rules to emit help suggesting valid Pants
command lines to run.

[ci skip-rust-tests]