### PR TITLE
Add `UnionMembership.from_rules()`

### DIFF
--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -8,7 +8,7 @@ from typing import Optional, cast
 from pants.backend.pants_info.list_target_types import TargetTypesSubsystem, list_target_types
 from pants.core.util_rules.pants_bin import PantsBin
 from pants.engine.target import BoolField, IntField, RegisteredTargetTypes, StringField, Target
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.testutil.engine.util import MockConsole, create_goal_subsystem, run_rule
 
 
@@ -120,7 +120,9 @@ def test_list_single() -> None:
         required = True
 
     tests_target_stdout = run_goal(
-        union_membership=UnionMembership({FortranTests.PluginField: [CustomField]}),
+        union_membership=UnionMembership.from_rules(
+            [UnionRule(FortranTests.PluginField, CustomField)]
+        ),
         details_target=FortranTests.alias,
     )
     assert tests_target_stdout == dedent(

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -120,7 +120,7 @@ class LocalPantsRunner:
         if global_bootstrap_options.verify_config:
             options.verify_configs(options_bootstrapper.config)
 
-        union_membership = UnionMembership(build_config.union_rules())
+        union_membership = UnionMembership.from_rules(build_config.union_rules)
 
         # If we're running with the daemon, we'll be handed a warmed Scheduler, which we use
         # to initialize a session here.

--- a/src/python/pants/build_graph/build_configuration_test.py
+++ b/src/python/pants/build_graph/build_configuration_test.py
@@ -23,9 +23,9 @@ class BuildConfigurationTest(unittest.TestCase):
 
     def test_register_exposed_object(self):
         self._register_aliases(objects={"jane": 42})
-        aliases = self.bc_builder.create().registered_aliases()
-        self.assertEqual(FrozenDict(), aliases.context_aware_object_factories)
-        self.assertEqual(FrozenDict(jane=42), aliases.objects)
+        aliases = self.bc_builder.create().registered_aliases
+        assert FrozenDict() == aliases.context_aware_object_factories
+        assert FrozenDict(jane=42) == aliases.objects
 
     def test_register_exposed_context_aware_object_factory(self):
         def caof_function(parse_context):
@@ -41,15 +41,14 @@ class BuildConfigurationTest(unittest.TestCase):
         self._register_aliases(
             context_aware_object_factories={"func": caof_function, "cls": CaofClass}
         )
-        aliases = self.bc_builder.create().registered_aliases()
-        self.assertEqual(FrozenDict(), aliases.objects)
-        self.assertEqual(
-            FrozenDict({"func": caof_function, "cls": CaofClass}),
-            aliases.context_aware_object_factories,
+        aliases = self.bc_builder.create().registered_aliases
+        assert FrozenDict() == aliases.objects
+        assert (
+            FrozenDict({"func": caof_function, "cls": CaofClass})
+            == aliases.context_aware_object_factories
         )
 
     def test_register_union_rules(self) -> None:
-        # Two calls to register_rules should merge relevant unions.
         @union
         class Base:
             pass
@@ -60,6 +59,8 @@ class BuildConfigurationTest(unittest.TestCase):
         class B:
             pass
 
-        self.bc_builder.register_rules([UnionRule(Base, A)])
-        self.bc_builder.register_rules([UnionRule(Base, B)])
-        self.assertEqual(self.bc_builder.create().union_rules()[Base], FrozenOrderedSet([A, B]))
+        union_a = UnionRule(Base, A)
+        union_b = UnionRule(Base, B)
+        self.bc_builder.register_rules([union_a])
+        self.bc_builder.register_rules([union_b])
+        assert self.bc_builder.create().union_rules == FrozenOrderedSet([union_a, union_b])

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -813,7 +813,7 @@ class TestCodegen(TestBase):
         self.address = Address.parse("src/avro:lib")
         self.create_files("src/avro", files=["f.avro"])
         self.add_to_build_file("src/avro", "avro_library(name='lib', sources=['*.avro'])")
-        self.union_membership = UnionMembership.from_rules(self.rules())
+        self.union_membership = self.request_single_product(UnionMembership, Params())
 
     def test_generate_sources(self) -> None:
         protocol_sources = AvroSources(["*.avro"], address=self.address)

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -813,7 +813,7 @@ class TestCodegen(TestBase):
         self.address = Address.parse("src/avro:lib")
         self.create_files("src/avro", files=["f.avro"])
         self.add_to_build_file("src/avro", "avro_library(name='lib', sources=['*.avro'])")
-        self.union_membership = self.request_single_product(UnionMembership, Params())
+        self.union_membership = UnionMembership.from_rules(self.rules())
 
     def test_generate_sources(self) -> None:
         protocol_sources = AvroSources(["*.avro"], address=self.address)

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -37,12 +37,10 @@ from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResultWithPlatform, MultiPlatformProcess
 from pants.engine.rules import Rule, RuleIndex, TaskRule
 from pants.engine.selectors import Params
-from pants.engine.unions import union
+from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import ExecutionOptions
 from pants.util.contextutil import temporary_file_path
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
@@ -92,7 +90,7 @@ class Scheduler:
         local_execution_root_dir: str,
         named_caches_dir: str,
         rules: Tuple[Rule, ...],
-        union_rules: FrozenDict[Type, FrozenOrderedSet[Type]],
+        union_membership: UnionMembership,
         execution_options: ExecutionOptions,
         include_trace_on_error: bool = True,
         visualize_to_dir: Optional[str] = None,
@@ -108,8 +106,7 @@ class Scheduler:
         :param local_execution_root_dir: The directory to use for local execution sandboxes.
         :param named_caches_dir: The directory to use as the root for named mutable caches.
         :param rules: A set of Rules which is used to compute values in the graph.
-        :param union_rules: A dict mapping union base types to member types so that rules can be written
-                            against abstract union types without knowledge of downstream rulesets.
+        :param union_membership: All the registered and normalized union rules.
         :param execution_options: Execution options for (remote) processes.
         :param include_trace_on_error: Include the trace through the graph upon encountering errors.
         :type include_trace_on_error: bool
@@ -119,11 +116,11 @@ class Scheduler:
         self.include_trace_on_error = include_trace_on_error
         self._visualize_to_dir = visualize_to_dir
         # Validate and register all provided and intrinsic tasks.
-        rule_index = RuleIndex.create(list(rules), union_rules)
+        rule_index = RuleIndex.create(rules)
         self._root_subject_types = [r.output_type for r in rule_index.roots]
 
         # Create the native Scheduler and Session.
-        tasks = self._register_rules(rule_index)
+        tasks = self._register_rules(rule_index, union_membership)
 
         types = PyTypes(
             directory_digest=Digest,
@@ -187,21 +184,21 @@ class Scheduler:
             return subject_or_params.params
         return [subject_or_params]
 
-    def _register_rules(self, rule_index: RuleIndex):
+    def _register_rules(self, rule_index: RuleIndex, union_membership: UnionMembership):
         """Create a native Tasks object, and record the given RuleIndex on it."""
 
         tasks = self._native.new_tasks()
 
         for output_type, rules in rule_index.rules.items():
             for rule in rules:
-                if type(rule) is TaskRule:
-                    self._register_task(tasks, output_type, rule, rule_index.union_rules)
+                if isinstance(rule, TaskRule):
+                    self._register_task(tasks, output_type, rule, union_membership)
                 else:
-                    raise ValueError("Unexpected Rule type: {}".format(rule))
+                    raise ValueError(f"Unexpected Rule type: {rule}")
         return tasks
 
     def _register_task(
-        self, tasks, output_type: Type, rule: TaskRule, union_rules: Dict[Type, OrderedSet[Type]]
+        self, tasks, output_type: Type, rule: TaskRule, union_membership: UnionMembership
     ) -> None:
         """Register the given TaskRule with the native scheduler."""
         self._native.lib.tasks_task_begin(
@@ -222,8 +219,9 @@ class Scheduler:
 
         for the_get in rule.input_gets:
             if union.is_instance(the_get.subject_declared_type):
-                # If the registered subject type is a union, add Get edges to all registered union members.
-                for union_member in union_rules.get(the_get.subject_declared_type, []):
+                # If the registered subject type is a union, add Get edges to all registered
+                # union members.
+                for union_member in union_membership.get(the_get.subject_declared_type):
                     add_get_edge(the_get.product_type, union_member)
             else:
                 # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -8,8 +8,8 @@ from dataclasses import asdict
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.internals.nodes import Throw
 from pants.engine.internals.scheduler import Scheduler
-from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.engine.unions import UnionMembership
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.testutil.engine.util import init_native
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -9,6 +9,7 @@ from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.internals.nodes import Throw
 from pants.engine.internals.scheduler import Scheduler
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
+from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import init_native
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
@@ -44,7 +45,6 @@ class SchedulerTestBase:
     def mk_scheduler(
         self,
         rules=None,
-        union_rules=None,
         project_tree=None,
         work_dir=None,
         include_trace_on_error=True,
@@ -71,7 +71,7 @@ class SchedulerTestBase:
             local_execution_root_dir=local_execution_root_dir,
             named_caches_dir=named_caches_dir,
             rules=rules,
-            union_rules=union_rules,
+            union_membership=UnionMembership({}),
             execution_options=execution_options or DEFAULT_EXECUTION_OPTIONS,
             include_trace_on_error=include_trace_on_error,
         )

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -14,6 +14,8 @@ import pytest
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.internals.native import Native
+from pants.engine.internals.scheduler import Scheduler
 from pants.engine.rules import (
     MissingParameterTypeAnnotation,
     MissingReturnTypeAnnotation,
@@ -26,17 +28,10 @@ from pants.engine.rules import (
 )
 from pants.engine.selectors import Get, GetConstraints
 from pants.engine.unions import UnionMembership
-from pants.testutil.engine.util import (
-    MockGet,
-    assert_equal_with_printing,
-    fmt_rule,
-    run_rule,
-)
-from pants.engine.internals.native import Native
-from pants.engine.internals.scheduler import Scheduler
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
+from pants.testutil.engine.util import MockGet, assert_equal_with_printing, fmt_rule, run_rule
 from pants.testutil.test_base import TestBase
 from pants.util.enums import match
-from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -6,6 +6,7 @@ import re
 import unittest
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from textwrap import dedent
 from typing import Callable, List, Optional, Tuple, Type, Union
 
@@ -24,16 +25,37 @@ from pants.engine.rules import (
     rule,
 )
 from pants.engine.selectors import Get, GetConstraints
+from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import (
     MockGet,
     assert_equal_with_printing,
-    create_scheduler,
     fmt_rule,
     run_rule,
 )
+from pants.engine.internals.native import Native
+from pants.engine.internals.scheduler import Scheduler
 from pants.testutil.test_base import TestBase
 from pants.util.enums import match
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.logging import LogLevel
+
+
+def create_scheduler(rules, validate=True, native=None):
+    """Create a Scheduler."""
+    native = native or Native()
+    return Scheduler(
+        native=native,
+        ignore_patterns=[],
+        use_gitignore=False,
+        build_root=str(Path.cwd()),
+        local_store_dir="./.pants.d/lmdb_store",
+        local_execution_root_dir="./.pants.d",
+        named_caches_dir="./.pants.d/named_caches",
+        rules=rules,
+        union_membership=UnionMembership({}),
+        execution_options=DEFAULT_EXECUTION_OPTIONS,
+        validate=validate,
+    )
 
 
 class RuleVisitorTest(unittest.TestCase):

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -39,7 +39,7 @@ from pants.engine.target import (
     generate_subtarget,
     generate_subtarget_address,
 )
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.testutil.engine.util import MockGet, run_rule
 from pants.util.collections import ensure_str_list
 from pants.util.frozendict import FrozenDict
@@ -262,7 +262,9 @@ def test_add_custom_fields() -> None:
         alias = "custom_field"
         default = False
 
-    union_membership = UnionMembership({FortranTarget.PluginField: [CustomField]})
+    union_membership = UnionMembership.from_rules(
+        [UnionRule(FortranTarget.PluginField, CustomField)]
+    )
     tgt_values = {CustomField.alias: True}
     tgt = FortranTarget(
         tgt_values, address=Address.parse(":lib"), union_membership=union_membership

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.unions import UnionMembership, UnionRule, union
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+def test_union_membership_from_rules() -> None:
+    @union
+    class Base:
+        pass
+
+    class A:
+        pass
+
+    class B:
+        pass
+
+    assert UnionMembership.from_rules([UnionRule(Base, A), UnionRule(Base, B)]) == UnionMembership(
+        {Base: FrozenOrderedSet([A, B])}
+    )

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -79,7 +79,7 @@ class OptionsInitializer:
 
         :returns: An Options object representing the full set of runtime options.
         """
-        optionables = {GlobalOptions, *GlobalSubsystems.get(), *build_configuration.optionables()}
+        optionables = {GlobalOptions, *GlobalSubsystems.get(), *build_configuration.optionables}
         known_scope_infos = [
             si for optionable in optionables for si in optionable.known_scope_infos()
         ]

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -24,10 +24,9 @@ from colors import blue, cyan, green, magenta, red
 
 from pants.engine.goal import GoalSubsystem
 from pants.engine.internals.native import Native
-from pants.engine.internals.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionMembership
-from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
+
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.ranked_value import Rank, RankedValue, Value
 from pants.subsystem.subsystem import Subsystem
@@ -196,24 +195,6 @@ def run_rule(
 def init_native():
     """Return the `Native` instance."""
     return Native()
-
-
-def create_scheduler(rules, union_rules=None, validate=True, native=None):
-    """Create a Scheduler."""
-    native = native or init_native()
-    return Scheduler(
-        native=native,
-        ignore_patterns=[],
-        use_gitignore=False,
-        build_root=str(Path.cwd()),
-        local_store_dir="./.pants.d/lmdb_store",
-        local_execution_root_dir="./.pants.d",
-        named_caches_dir="./.pants.d/named_caches",
-        rules=rules,
-        union_rules=union_rules,
-        execution_options=DEFAULT_EXECUTION_OPTIONS,
-        validate=validate,
-    )
 
 
 def assert_equal_with_printing(

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -4,7 +4,6 @@
 import re
 from dataclasses import dataclass
 from io import StringIO
-from pathlib import Path
 from types import CoroutineType, GeneratorType
 from typing import (
     Any,
@@ -26,7 +25,6 @@ from pants.engine.goal import GoalSubsystem
 from pants.engine.internals.native import Native
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionMembership
-
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.ranked_value import Rank, RankedValue, Value
 from pants.subsystem.subsystem import Subsystem

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -142,12 +142,12 @@ class LoaderTest(unittest.TestCase):
 
     def assert_empty(self):
         build_configuration = self.bc_builder.create()
-        registered_aliases = build_configuration.registered_aliases()
+        registered_aliases = build_configuration.registered_aliases
         self.assertEqual(0, len(registered_aliases.objects))
         self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
-        self.assertEqual(build_configuration.optionables(), FrozenOrderedSet())
-        self.assertEqual(0, len(build_configuration.rules()))
-        self.assertEqual(0, len(build_configuration.target_types()))
+        self.assertEqual(build_configuration.optionables, FrozenOrderedSet())
+        self.assertEqual(0, len(build_configuration.rules))
+        self.assertEqual(0, len(build_configuration.target_types))
 
     def test_load_valid_empty(self):
         with self.create_register() as backend_package:
@@ -159,11 +159,11 @@ class LoaderTest(unittest.TestCase):
         with self.create_register(build_file_aliases=lambda: aliases) as backend_package:
             load_backend(self.bc_builder, backend_package)
             build_configuration = self.bc_builder.create()
-            registered_aliases = build_configuration.registered_aliases()
+            registered_aliases = build_configuration.registered_aliases
             self.assertEqual(DummyObject1, registered_aliases.objects["obj1"])
             self.assertEqual(DummyObject2, registered_aliases.objects["obj2"])
             self.assertEqual(
-                build_configuration.optionables(), FrozenOrderedSet([DummySubsystem]),
+                build_configuration.optionables, FrozenOrderedSet([DummySubsystem]),
             )
 
     def test_load_invalid_entrypoint(self):
@@ -283,10 +283,10 @@ class LoaderTest(unittest.TestCase):
 
         # Aliases now exist.
         build_configuration = self.bc_builder.create()
-        registered_aliases = build_configuration.registered_aliases()
+        registered_aliases = build_configuration.registered_aliases
         self.assertEqual(DummyObject1, registered_aliases.objects["FROMPLUGIN1"])
         self.assertEqual(DummyObject2, registered_aliases.objects["FROMPLUGIN2"])
-        self.assertEqual(build_configuration.optionables(), FrozenOrderedSet([DummySubsystem]))
+        self.assertEqual(build_configuration.optionables, FrozenOrderedSet([DummySubsystem]))
 
     def test_rules(self):
         def backend_rules():
@@ -295,7 +295,7 @@ class LoaderTest(unittest.TestCase):
         with self.create_register(rules=backend_rules) as backend_package:
             load_backend(self.bc_builder, backend_package)
             self.assertEqual(
-                self.bc_builder.create().rules(),
+                self.bc_builder.create().rules,
                 FrozenOrderedSet([example_rule.rule, RootRule(RootType)]),
             )
 
@@ -305,7 +305,7 @@ class LoaderTest(unittest.TestCase):
         self.working_set.add(self.get_mock_plugin("this-plugin-rules", "0.0.1", rules=plugin_rules))
         self.load_plugins(["this-plugin-rules"])
         self.assertEqual(
-            self.bc_builder.create().rules(),
+            self.bc_builder.create().rules,
             FrozenOrderedSet([example_rule.rule, RootRule(RootType), example_plugin_rule.rule]),
         )
 
@@ -315,7 +315,7 @@ class LoaderTest(unittest.TestCase):
 
         with self.create_register(target_types=target_types) as backend_package:
             load_backend(self.bc_builder, backend_package)
-            assert self.bc_builder.create().target_types() == FrozenOrderedSet(
+            assert self.bc_builder.create().target_types == FrozenOrderedSet(
                 [DummyTarget, DummyTarget2]
             )
 
@@ -330,7 +330,7 @@ class LoaderTest(unittest.TestCase):
             self.get_mock_plugin("new-targets", "0.0.1", target_types=plugin_targets)
         )
         self.load_plugins(["new-targets"])
-        assert self.bc_builder.create().target_types() == FrozenOrderedSet(
+        assert self.bc_builder.create().target_types == FrozenOrderedSet(
             [DummyTarget, DummyTarget2, PluginTarget]
         )
 
@@ -348,5 +348,5 @@ class LoaderTest(unittest.TestCase):
             )
         # The backend should load first, then the plugins, therefore the alias registered in
         # the plugin will override the alias registered by the backend
-        registered_aliases = build_configuration.registered_aliases()
+        registered_aliases = build_configuration.registered_aliases
         self.assertEqual(DummyObject2, registered_aliases.objects["override-alias"])


### PR DESCRIPTION
We now only convert `UnionRules` into a `Mapping[Type, Iterable[Type]]` in one place, whereas we previously had the logic duplicated across multiple places.

This also allows tests to use `UnionRule` if they want so that they look more like an actual `register.py` file, rather than having to use the explicit `UnionMembership` constructor.

[ci skip-rust-tests]