### PR TITLE
Cleanup `fs.py`

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,13 +22,12 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import Digest, MergeDigests, PathGlobs
+from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -26,13 +26,12 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests, PathGlobs
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -28,13 +28,19 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
+from pants.engine.fs import (
+    Digest,
+    DigestSubset,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+    Snapshot,
+)
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -24,14 +24,19 @@ from pants.core.util_rules.determine_source_files import (
     SourceFiles,
     SpecifiedSourceFilesRequest,
 )
-from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    EMPTY_SNAPSHOT,
+    Digest,
+    GlobExpansionConjunction,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
-from pants.option.custom_types import GlobExpansionConjunction
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -31,7 +31,14 @@ from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.core.util_rules.determine_source_files import SourceFiles, SpecifiedSourceFilesRequest
 from pants.engine.addresses import Address, Addresses
-from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    EMPTY_DIGEST,
+    AddPrefix,
+    Digest,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
@@ -44,7 +51,6 @@ from pants.engine.target import (
     TransitiveTargets,
 )
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize

--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -35,6 +35,7 @@ from pants.engine.fs import (
     Digest,
     DigestContents,
     FileContent,
+    GlobMatchErrorBehavior,
     MergeDigests,
     PathGlobs,
 )
@@ -44,7 +45,6 @@ from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 
 

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -24,12 +24,17 @@ from pants.backend.python.target_types import (
     PythonRequirementsField,
 )
 from pants.engine.addresses import Address, Addresses
-from pants.engine.fs import Digest, DigestContents, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    Digest,
+    DigestContents,
+    GlobExpansionConjunction,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.engine.target import TransitiveTargets
-from pants.option.custom_types import GlobExpansionConjunction
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.meta import frozen_after_init
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -23,13 +23,19 @@ from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
 from pants.core.util_rules import determine_source_files, pants_bin, strip_source_roots
 from pants.engine.addresses import Addresses
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, PathGlobs
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    FileContent,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin, TransitiveTargets
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -8,9 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union, cast
 
 from pants.engine.collection import Collection
-from pants.engine.fs import PathGlobs
-from pants.option.custom_types import GlobExpansionConjunction
-from pants.option.global_options import GlobMatchErrorBehavior
+from pants.engine.fs import GlobExpansionConjunction, GlobMatchErrorBehavior, PathGlobs
 from pants.util.collections import assert_single_element
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
 from pants.util.filtering import and_filters, create_filters

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -24,16 +24,16 @@ from pants.engine.fs import (
     DigestSubset,
     DownloadFile,
     FileContent,
+    GlobMatchErrorBehavior,
     MergeDigests,
     PathGlobs,
     PathGlobsAndRoot,
     RemovePrefix,
     Snapshot,
-    create_fs_rules,
 )
+from pants.engine.fs import rules as fs_rules
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.testutil.test_base import TestBase
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import http_server, temporary_dir
@@ -79,7 +79,7 @@ class FSTest(TestBase, SchedulerTestBase):
         self, field, filespecs_or_globs, paths, ignore_patterns=None, prepare=None
     ):
         with self.mk_project_tree(ignore_patterns=ignore_patterns) as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
             if prepare:
                 prepare(project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
@@ -87,13 +87,13 @@ class FSTest(TestBase, SchedulerTestBase):
 
     def assert_content(self, filespecs_or_globs, expected_content):
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
             actual_content = self.read_digest_contents(scheduler, filespecs_or_globs)
             assert expected_content == actual_content
 
     def assert_digest(self, filespecs_or_globs, expected_files):
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
             # Confirm all expected files were digested.
             assert set(expected_files) == set(result.files)
@@ -283,7 +283,7 @@ class FSTest(TestBase, SchedulerTestBase):
         with temporary_dir() as temp_dir:
             Path(temp_dir, "roland").write_text("European Burmese")
             Path(temp_dir, "susannah").write_text("I don't know")
-            scheduler = self.mk_scheduler(rules=create_fs_rules())
+            scheduler = self.mk_scheduler(rules=fs_rules())
             snapshots = scheduler.capture_snapshots(
                 (
                     PathGlobsAndRoot(PathGlobs(["roland"]), temp_dir),
@@ -743,7 +743,7 @@ class FSTest(TestBase, SchedulerTestBase):
         on those files."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
             fname = "4.txt"
             new_data = "rouf"
             # read the original file so we have a cached value.
@@ -769,7 +769,7 @@ class FSTest(TestBase, SchedulerTestBase):
         """Test that FileContent is invalidated after deleting parent directory."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
             fname = "a/b/1.txt"
             # read the original file so we have nodes to invalidate.
             original_content = self.read_digest_contents(scheduler, [fname])
@@ -792,7 +792,7 @@ class FSTest(TestBase, SchedulerTestBase):
         self, mutation_function: Callable[[FileSystemProjectTree, str], Exception]
     ) -> None:
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
             dir_path = "a/"
             dir_glob = f"{dir_path}/*"
             initial_snapshot = self.execute_expecting_one_result(

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -17,13 +17,12 @@ from pants.engine.addresses import (
     BuildFileAddress,
     BuildFileAddresses,
 )
-from pants.engine.fs import DigestContents, PathGlobs, Snapshot
+from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Snapshot
 from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressMapper
 from pants.engine.internals.parser import BuildFilePreludeSymbols, error_on_imports
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -11,9 +11,9 @@ from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine import interactive_process, process
+from pants.engine import fs, interactive_process, process
 from pants.engine.console import Console
-from pants.engine.fs import Workspace, create_fs_rules
+from pants.engine.fs import GlobMatchErrorBehavior, Workspace
 from pants.engine.goal import Goal
 from pants.engine.interactive_process import InteractiveRunner
 from pants.engine.internals import graph, options_parsing, uuid
@@ -29,11 +29,7 @@ from pants.engine.selectors import Params
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.global_options import (
-    DEFAULT_EXECUTION_OPTIONS,
-    ExecutionOptions,
-    GlobMatchErrorBehavior,
-)
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.scm.subsystems.changed import rules as changed_rules
 from pants.subsystem.subsystem import Subsystem
@@ -294,12 +290,12 @@ class EngineInitializer:
             registered_target_types_singleton,
             union_membership_singleton,
             build_root_singleton,
+            *fs.rules(),
             *interactive_process.rules(),
             *graph.rules(),
             *uuid.rules(),
             *options_parsing.rules(),
             *process.rules(),
-            *create_fs_rules(),
             *create_platform_rules(),
             *create_graph_rules(address_mapper),
             *changed_rules(),

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -307,14 +307,3 @@ class DictValueComponent:
 
     def __repr__(self) -> str:
         return f"{self.action} {self.val}"
-
-
-class GlobExpansionConjunction(Enum):
-    """Describe whether to require that only some or all glob strings match in a target's sources.
-
-    NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
-    be aware of any changes to this object's definition.
-    """
-
-    any_match = "any_match"
-    all_match = "all_match"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,23 +16,12 @@ from pants.base.build_environment import (
     get_pants_configdir,
     pants_version,
 )
+from pants.engine.fs import GlobMatchErrorBehavior
 from pants.option.custom_types import dir_option
 from pants.option.errors import OptionsError
 from pants.option.scope import GLOBAL_SCOPE
 from pants.subsystem.subsystem import Subsystem
 from pants.util.logging import LogLevel
-
-
-class GlobMatchErrorBehavior(Enum):
-    """Describe the action to perform when matching globs in BUILD files to source files.
-
-    NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
-    be aware of any changes to this object's definition.
-    """
-
-    ignore = "ignore"
-    warn = "warn"
-    error = "error"
 
 
 class FileNotFoundBehavior(Enum):


### PR DESCRIPTION
* Removes unused methods on `Digest`
* Updates docstring.
* Moves `GlobMatchErrorBehavior` and `GlobExpansionConjunction` types to `fs.py`.

[ci skip-rust-tests]