### PR TITLE
Fix Protobuf when using source roots

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -6,14 +6,16 @@ from pants.backend.codegen.protobuf.target_types import ProtobufSources
 from pants.backend.python.target_types import PythonSources
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.core.util_rules.strip_source_roots import representative_path_from_address
 from pants.engine.addresses import Addresses
-from pants.engine.fs import Digest, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import AddPrefix, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
+from pants.source.source_root import SourceRoot, SourceRootRequest
 
 
 class GeneratePythonFromProtobufRequest(GenerateSourcesRequest):
@@ -91,8 +93,22 @@ async def generate_python_from_protobuf(
             output_directories=(output_dir,),
         )
     )
-    normalized_snapshot = await Get[Snapshot](RemovePrefix(result.output_digest, output_dir))
-    return GeneratedSources(normalized_snapshot)
+
+    # We must do some path manipulation on the output digest for it to look like normal sources,
+    # including adding back the original source root.
+    normalized_digest = await Get[Digest](RemovePrefix(result.output_digest, output_dir))
+    source_root = await Get[SourceRoot](
+        SourceRootRequest,
+        SourceRootRequest.for_file(
+            representative_path_from_address(request.protocol_target.address)
+        ),
+    )
+    source_root_restored = (
+        await Get(Snapshot, AddPrefix(normalized_digest, source_root.path))
+        if source_root.path != "."
+        else await Get(Snapshot, Digest, normalized_digest)
+    )
+    return GeneratedSources(source_root_restored)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -37,12 +37,34 @@ class ProtobufPythonIntegrationTest(TestBase):
             RootRule(GeneratePythonFromProtobufRequest),
         )
 
+    def assert_files_generated(
+        self, spec: str, *, expected_files: List[str], source_roots: List[str]
+    ) -> None:
+        tgt = self.request_single_product(WrappedTarget, Address.parse(spec)).target
+        protocol_sources = self.request_single_product(
+            HydratedSources,
+            Params(HydrateSourcesRequest(tgt[ProtobufSources]), create_options_bootstrapper()),
+        )
+        generated_sources = self.request_single_product(
+            GeneratedSources,
+            Params(
+                GeneratePythonFromProtobufRequest(protocol_sources.snapshot, tgt),
+                create_options_bootstrapper(
+                    args=[
+                        "--backend-packages=pants.backend.codegen.protobuf.python",
+                        f"--source-root-patterns={repr(source_roots)}",
+                    ]
+                ),
+            ),
+        )
+        assert set(generated_sources.snapshot.files) == set(expected_files)
+
     def test_generates_python(self) -> None:
         # This tests a few things:
         #  * We generate the correct file names.
         #  * Protobuf files can import other protobuf files, and those can import others
         #    (transitive dependencies). We'll only generate the requested target, though.
-        #  * We can handle multiple source roots, which need to be stripped in the final output.
+        #  * We can handle multiple source roots, which need to be preserved in the final output.
 
         self.create_file(
             "src/protobuf/dir1/f.proto",
@@ -105,30 +127,35 @@ class ProtobufPythonIntegrationTest(TestBase):
             "tests/protobuf/test_protos", "protobuf_library(dependencies=['src/protobuf/dir2'])"
         )
 
-        def assert_files_generated(spec: str, *, expected_files: List[str]) -> None:
-            tgt = self.request_single_product(WrappedTarget, Address.parse(spec)).target
-            protocol_sources = self.request_single_product(
-                HydratedSources,
-                Params(HydrateSourcesRequest(tgt[ProtobufSources]), create_options_bootstrapper()),
-            )
-            generated_sources = self.request_single_product(
-                GeneratedSources,
-                Params(
-                    GeneratePythonFromProtobufRequest(protocol_sources.snapshot, tgt),
-                    create_options_bootstrapper(
-                        args=[
-                            "--source-root-patterns=src/protobuf",
-                            "--source-root-patterns=tests/protobuf",
-                        ]
-                    ),
-                ),
-            )
-            assert set(generated_sources.snapshot.files) == set(expected_files)
-
-        assert_files_generated(
-            "src/protobuf/dir1", expected_files=["dir1/f_pb2.py", "dir1/f2_pb2.py"]
+        source_roots = ["/src/protobuf", "/tests/protobuf"]
+        self.assert_files_generated(
+            "src/protobuf/dir1",
+            source_roots=source_roots,
+            expected_files=["src/protobuf/dir1/f_pb2.py", "src/protobuf/dir1/f2_pb2.py"],
         )
-        assert_files_generated("src/protobuf/dir2", expected_files=["dir2/f_pb2.py"])
-        assert_files_generated(
-            "tests/protobuf/test_protos", expected_files=["test_protos/f_pb2.py"]
+        self.assert_files_generated(
+            "src/protobuf/dir2",
+            source_roots=source_roots,
+            expected_files=["src/protobuf/dir2/f_pb2.py"],
+        )
+        self.assert_files_generated(
+            "tests/protobuf/test_protos",
+            source_roots=source_roots,
+            expected_files=["tests/protobuf/test_protos/f_pb2.py"],
+        )
+
+    def test_top_level_source_root(self) -> None:
+        self.create_file(
+            "protos/f.proto",
+            dedent(
+                """\
+                syntax = "proto2";
+
+                package protos;
+                """
+            ),
+        )
+        self.add_to_build_file("protos", "protobuf_library()")
+        self.assert_files_generated(
+            "protos", source_roots=["/"], expected_files=["protos/f_pb2.py"]
         )


### PR DESCRIPTION
Cherry-pick of 2a4559bb9. 

We do not need to include changes to `python_sources.py` because 1.30.x always strips the source roots, so we don't ever need to set `PEX_EXTRA_SYS_PATH`. The Python pipeline should work without further changes.

[ci skip-jvm-tests
[ci skip-rust-tests]