### PR TITLE
Eliminate most rule registration boilerplate.

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -4,7 +4,7 @@
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 
 
 class ListAndDieForTestingSubsystem(GoalSubsystem):
@@ -25,4 +25,4 @@ def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> Lis
 
 
 def rules():
-    return [fast_list_and_die_for_testing]
+    return register_rules()

--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -4,7 +4,7 @@
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 
 
 class ListAndDieForTestingSubsystem(GoalSubsystem):
@@ -25,4 +25,4 @@ def fast_list_and_die_for_testing(console: Console, addresses: Addresses) -> Lis
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -9,7 +9,7 @@ from pants.core.util_rules.distdir import DistDir
 from pants.engine.console import Console
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
@@ -79,4 +79,4 @@ async def create_awslambda(
 
 
 def rules():
-    return [create_awslambda]
+    return register_rules()

--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -9,7 +9,7 @@ from pants.core.util_rules.distdir import DistDir
 from pants.engine.console import Console
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
@@ -79,4 +79,4 @@ async def create_awslambda(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -30,7 +30,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.core.util_rules import strip_source_roots
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -129,10 +129,8 @@ async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
 
 def rules():
     return [
-        create_python_awslambda,
-        setup_lambdex,
+        *register_rules(),
         UnionRule(AWSLambdaFieldSet, PythonAwsLambdaFieldSet),
-        SubsystemRule(Lambdex),
         *download_pex_bin.rules(),
         *python_sources.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -30,7 +30,7 @@ from pants.backend.python.subsystems.subprocess_environment import SubprocessEnc
 from pants.core.util_rules import strip_source_roots
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -129,7 +129,7 @@ async def setup_lambdex(lambdex: Lambdex) -> LambdexSetup:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(AWSLambdaFieldSet, PythonAwsLambdaFieldSet),
         *download_pex_bin.rules(),
         *python_sources.rules(),

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -11,7 +11,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -121,6 +121,6 @@ async def generate_python_from_protobuf(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(GenerateSourcesRequest, GeneratePythonFromProtobufRequest),
     ]

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -11,7 +11,7 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -121,7 +121,6 @@ async def generate_python_from_protobuf(
 
 def rules():
     return [
-        generate_python_from_protobuf,
+        *register_rules(),
         UnionRule(GenerateSourcesRequest, GeneratePythonFromProtobufRequest),
-        SubsystemRule(Protoc),
     ]

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -3,7 +3,7 @@
 
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.engine.addresses import Address
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -51,7 +51,6 @@ def inject_dependencies(_: InjectProtobufDependencies, protoc: Protoc) -> Inject
 
 def rules():
     return [
-        inject_dependencies,
+        *register_rules(),
         UnionRule(InjectDependenciesRequest, InjectProtobufDependencies),
-        SubsystemRule(Protoc),
     ]

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -3,7 +3,7 @@
 
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.engine.addresses import Address
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -51,6 +51,6 @@ def inject_dependencies(_: InjectProtobufDependencies, protoc: Protoc) -> Inject
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(InjectDependenciesRequest, InjectProtobufDependencies),
     ]

--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -8,7 +8,7 @@ from typing import Generic, Optional, Sequence, Type, cast, get_type_hints
 from pants.core.util_rules.pants_bin import PantsBin
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.target import (
     AsyncField,
     BoolField,
@@ -249,4 +249,4 @@ def list_target_types(
 
 
 def rules():
-    return [list_target_types]
+    return register_rules()

--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -8,7 +8,7 @@ from typing import Generic, Optional, Sequence, Type, cast, get_type_hints
 from pants.core.util_rules.pants_bin import PantsBin
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import (
     AsyncField,
     BoolField,
@@ -249,4 +249,4 @@ def list_target_types(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -20,7 +20,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get
 from pants.util.strutil import pluralize
 
@@ -131,7 +131,4 @@ async def run_cloc(
 
 
 def rules():
-    return [
-        run_cloc,
-        SubsystemRule(ClocBinary),
-    ]
+    return register_rules()

--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -20,7 +20,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get
 from pants.util.strutil import pluralize
 
@@ -131,4 +131,4 @@ async def run_cloc(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -12,7 +12,7 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules, rule
+from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies, DependenciesRequest, Targets
 from pants.util.frozendict import FrozenDict
@@ -182,4 +182,4 @@ async def dependees_goal(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -12,7 +12,7 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, rule
+from pants.engine.rules import goal_rule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies, DependenciesRequest, Targets
 from pants.util.frozendict import FrozenDict
@@ -182,4 +182,4 @@ async def dependees_goal(
 
 
 def rules():
-    return [find_dependees, map_addresses_to_dependees, dependees_goal]
+    return register_rules()

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonRequirementsField
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies as DependenciesField
 from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets
@@ -104,4 +104,4 @@ async def dependencies(
 
 
 def rules():
-    return [dependencies]
+    return register_rules()

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonRequirementsField
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Dependencies as DependenciesField
 from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets
@@ -104,4 +104,4 @@ async def dependencies(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -9,7 +9,7 @@ from pants.base.build_root import BuildRoot
 from pants.engine.addresses import Address, Addresses, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -120,4 +120,4 @@ async def file_deps(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -9,7 +9,7 @@ from pants.base.build_root import BuildRoot
 from pants.engine.addresses import Address, Addresses, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -120,4 +120,4 @@ async def file_deps(
 
 
 def rules():
-    return [file_deps]
+    return register_rules()

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -8,7 +8,7 @@ from typing import Callable, Pattern
 from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.target import (
     RegisteredTargetTypes,
     Tags,
@@ -162,4 +162,4 @@ def filter_targets(
 
 
 def rules():
-    return [filter_targets]
+    return register_rules()

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -8,7 +8,7 @@ from typing import Callable, Pattern
 from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import (
     RegisteredTargetTypes,
     Tags,
@@ -162,4 +162,4 @@ def filter_targets(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -3,7 +3,7 @@
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.source.source_root import AllSourceRoots
 
 
@@ -28,4 +28,4 @@ async def list_roots(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -3,7 +3,7 @@
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.source.source_root import AllSourceRoots
 
 
@@ -28,4 +28,4 @@ async def list_roots(
 
 
 def rules():
-    return [list_roots]
+    return register_rules()

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -6,7 +6,7 @@ from typing import Dict, cast
 from pants.engine.addresses import Address, Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get
 from pants.engine.target import DescriptionField, ProvidesField, Targets
 
@@ -111,4 +111,4 @@ async def list_targets(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -6,7 +6,7 @@ from typing import Dict, cast
 from pants.engine.addresses import Address, Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get
 from pants.engine.target import DescriptionField, ProvidesField, Targets
 
@@ -111,4 +111,4 @@ async def list_targets(
 
 
 def rules():
-    return [list_targets]
+    return register_rules()

--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -12,7 +12,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DigestContents, SourcesSnapshot
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
@@ -334,4 +334,4 @@ async def validate(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/project_info/source_file_validator.py
+++ b/src/python/pants/backend/project_info/source_file_validator.py
@@ -12,7 +12,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DigestContents, SourcesSnapshot
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import SubsystemRule, goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
@@ -334,4 +334,4 @@ async def validate(
 
 
 def rules():
-    return [validate, SubsystemRule(SourceFileValidation)]
+    return register_rules()

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.strip_source_roots import (
     StripSourcesFieldRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.rules import rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -166,8 +166,4 @@ async def map_module_to_address(
 
 
 def rules():
-    return [
-        map_first_party_modules_to_addresses,
-        map_third_party_modules_to_addresses,
-        map_module_to_address,
-    ]
+    return register_rules()

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.strip_source_roots import (
     StripSourcesFieldRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -166,4 +166,4 @@ async def map_module_to_address(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -16,7 +16,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -158,13 +158,10 @@ async def infer_python_conftest_dependencies(
 
 def rules():
     return [
+        *register_rules(),
         *inject_ancestor_files.rules(),
         *module_mapper.rules(),
-        infer_python_dependencies,
-        infer_python_init_dependencies,
-        infer_python_conftest_dependencies,
         UnionRule(InferDependenciesRequest, InferPythonDependencies),
         UnionRule(InferDependenciesRequest, InferInitDependencies),
         UnionRule(InferDependenciesRequest, InferConftestDependencies),
-        SubsystemRule(PythonInference),
     ]

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -16,7 +16,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     HydratedSources,
@@ -158,7 +158,7 @@ async def infer_python_conftest_dependencies(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         *inject_ancestor_files.rules(),
         *module_mapper.rules(),
         UnionRule(InferDependenciesRequest, InferPythonDependencies),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -152,7 +152,7 @@ async def bandit_lint(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(LintRequest, BanditRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -24,7 +24,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -152,9 +152,7 @@ async def bandit_lint(
 
 def rules():
     return [
-        bandit_lint,
-        bandit_lint_partition,
-        SubsystemRule(Bandit),
+        *register_rules(),
         UnionRule(LintRequest, BanditRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -188,7 +188,7 @@ async def black_lint(field_sets: BlackRequest, black: Black) -> LintResults:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(PythonFmtRequest, BlackRequest),
         UnionRule(LintRequest, BlackRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -188,10 +188,7 @@ async def black_lint(field_sets: BlackRequest, black: Black) -> LintResults:
 
 def rules():
     return [
-        setup,
-        black_fmt,
-        black_lint,
-        SubsystemRule(Black),
+        *register_rules(),
         UnionRule(PythonFmtRequest, BlackRequest),
         UnionRule(LintRequest, BlackRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -162,10 +162,7 @@ async def docformatter_lint(
 
 def rules():
     return [
-        setup,
-        docformatter_fmt,
-        docformatter_lint,
-        SubsystemRule(Docformatter),
+        *register_rules(),
         UnionRule(PythonFmtRequest, DocformatterRequest),
         UnionRule(LintRequest, DocformatterRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -26,7 +26,7 @@ from pants.core.util_rules.determine_source_files import (
 )
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -162,7 +162,7 @@ async def docformatter_lint(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(PythonFmtRequest, DocformatterRequest),
         UnionRule(LintRequest, DocformatterRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -37,7 +37,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -190,9 +190,7 @@ async def flake8_lint(
 
 def rules():
     return [
-        flake8_lint,
-        flake8_lint_partition,
-        SubsystemRule(Flake8),
+        *register_rules(),
         UnionRule(LintRequest, Flake8Request),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -37,7 +37,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -190,7 +190,7 @@ async def flake8_lint(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(LintRequest, Flake8Request),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -7,10 +7,10 @@ from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
-from pants.core.goals.lint import LintResults, LintSubsystem
+from pants.core.goals.lint import LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
-from pants.engine.rules import RootRule, SubsystemRule
+from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.engine.target import TargetWithOrigin
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
@@ -30,7 +30,6 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             *super().rules(),
             *flake8_rules(),
             RootRule(Flake8Request),
-            SubsystemRule(LintSubsystem),
         )
 
     def make_target_with_origin(

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -33,7 +33,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -192,7 +192,7 @@ async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(PythonFmtRequest, IsortRequest),
         UnionRule(LintRequest, IsortRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -33,7 +33,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin
 from pants.engine.unions import UnionRule
@@ -192,10 +192,7 @@ async def isort_lint(request: IsortRequest, isort: Isort) -> LintResults:
 
 def rules():
     return [
-        setup,
-        isort_fmt,
-        isort_lint,
-        SubsystemRule(Isort),
+        *register_rules(),
         UnionRule(PythonFmtRequest, IsortRequest),
         UnionRule(LintRequest, IsortRequest),
         *download_pex_bin.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -310,7 +310,7 @@ async def pylint_lint(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(LintRequest, PylintRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -310,9 +310,7 @@ async def pylint_lint(
 
 def rules():
     return [
-        pylint_lint,
-        pylint_lint_partition,
-        SubsystemRule(Pylint),
+        *register_rules(),
         UnionRule(LintRequest, PylintRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -9,7 +9,7 @@ from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTarge
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Digest, Snapshot
-from pants.engine.rules import rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionMembership, UnionRule, union
 
@@ -66,4 +66,4 @@ async def format_python_target(
 
 
 def rules():
-    return [format_python_target, UnionRule(LanguageFmtTargets, PythonFmtTargets)]
+    return [*register_rules(), UnionRule(LanguageFmtTargets, PythonFmtTargets)]

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -9,7 +9,7 @@ from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTarge
 from pants.core.goals.style_request import StyleRequest
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.fs import Digest, Snapshot
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionMembership, UnionRule, union
 
@@ -66,4 +66,4 @@ async def format_python_target(
 
 
 def rules():
-    return [*register_rules(), UnionRule(LanguageFmtTargets, PythonFmtTargets)]
+    return [*collect_rules(), UnionRule(LanguageFmtTargets, PythonFmtTargets)]

--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -335,10 +335,6 @@ def _get_coverage_reports(
 
 def rules():
     return [
-        create_coverage_config,
-        generate_coverage_reports,
-        merge_coverage_data,
-        setup_coverage,
-        SubsystemRule(CoverageSubsystem),
+        *register_rules(),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
     ]

--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -40,7 +40,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -335,6 +335,6 @@ def _get_coverage_reports(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
     ]

--- a/src/python/pants/backend/python/rules/create_python_binary.py
+++ b/src/python/pants/backend/python/rules/create_python_binary.py
@@ -23,7 +23,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types import PythonPlatforms as PythonPlatformsField
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 
@@ -92,7 +92,6 @@ async def create_python_binary(
 
 def rules():
     return [
-        create_python_binary,
+        *register_rules(),
         UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
-        SubsystemRule(PythonBinaryDefaults),
     ]

--- a/src/python/pants/backend/python/rules/create_python_binary.py
+++ b/src/python/pants/backend/python/rules/create_python_binary.py
@@ -23,7 +23,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types import PythonPlatforms as PythonPlatformsField
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.unions import UnionRule
 
@@ -92,6 +92,6 @@ async def create_python_binary(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
     ]

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -15,7 +15,7 @@ from pants.core.util_rules.external_tool import (
 from pants.engine.fs import Digest
 from pants.engine.platform import Platform
 from pants.engine.process import Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
 
@@ -106,4 +106,4 @@ async def download_pex_bin(pex_binary_tool: PexBin) -> DownloadedPexBin:
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -15,7 +15,7 @@ from pants.core.util_rules.external_tool import (
 from pants.engine.fs import Digest
 from pants.engine.platform import Platform
 from pants.engine.process import Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get
 from pants.python.python_setup import PythonSetup
 
@@ -106,4 +106,4 @@ async def download_pex_bin(pex_binary_tool: PexBin) -> DownloadedPexBin:
 
 
 def rules():
-    return [download_pex_bin, SubsystemRule(PexBin)]
+    return register_rules()

--- a/src/python/pants/backend/python/rules/inject_ancestor_files.py
+++ b/src/python/pants/backend/python/rules/inject_ancestor_files.py
@@ -9,7 +9,7 @@ from typing import Sequence, Set
 
 from pants.core.util_rules.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
-from pants.engine.rules import rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get
 from pants.source.source_root import AllSourceRoots
 from pants.util.ordered_set import FrozenOrderedSet
@@ -99,6 +99,4 @@ async def find_missing_ancestor_files(
 
 
 def rules():
-    return [
-        find_missing_ancestor_files,
-    ]
+    return register_rules()

--- a/src/python/pants/backend/python/rules/inject_ancestor_files.py
+++ b/src/python/pants/backend/python/rules/inject_ancestor_files.py
@@ -9,7 +9,7 @@ from typing import Sequence, Set
 
 from pants.core.util_rules.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get
 from pants.source.source_root import AllSourceRoots
 from pants.util.ordered_set import FrozenOrderedSet
@@ -99,4 +99,4 @@ async def find_missing_ancestor_files(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -41,7 +41,7 @@ from pants.engine.fs import (
 )
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.process import MultiPlatformProcess, ProcessResult
-from pants.engine.rules import RootRule, SubsystemRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -482,10 +482,7 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
 
 def rules():
     return [
-        create_pex,
-        two_step_create_pex,
+        *register_rules(),
         RootRule(PexRequest),
         RootRule(TwoStepPexRequest),
-        SubsystemRule(PythonSetup),
-        SubsystemRule(PythonRepos),
     ]

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -41,7 +41,7 @@ from pants.engine.fs import (
 )
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.process import MultiPlatformProcess, ProcessResult
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -482,7 +482,7 @@ async def two_step_create_pex(two_step_pex_request: TwoStepPexRequest) -> TwoSte
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(PexRequest),
         RootRule(TwoStepPexRequest),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -32,7 +32,7 @@ from pants.engine.fs import (
     MergeDigests,
     PathGlobs,
 )
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.target import TransitiveTargets
 from pants.python.python_setup import PythonSetup
@@ -192,7 +192,7 @@ async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoSte
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(PexFromTargetsRequest),
         RootRule(TwoStepPexFromTargetsRequest),
     ]

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -32,7 +32,7 @@ from pants.engine.fs import (
     MergeDigests,
     PathGlobs,
 )
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get
 from pants.engine.target import TransitiveTargets
 from pants.python.python_setup import PythonSetup
@@ -192,8 +192,7 @@ async def two_step_pex_from_targets(req: TwoStepPexFromTargetsRequest) -> TwoSte
 
 def rules():
     return [
-        pex_from_targets,
-        two_step_pex_from_targets,
+        *register_rules(),
         RootRule(PexFromTargetsRequest),
         RootRule(TwoStepPexFromTargetsRequest),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -38,7 +38,7 @@ from pants.engine.fs import AddPrefix, Digest, DigestSubset, MergeDigests, PathG
 from pants.engine.interactive_process import InteractiveProcess
 from pants.engine.internals.uuid import UUIDRequest
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -306,6 +306,6 @@ async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(TestFieldSet, PythonTestFieldSet),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -38,7 +38,7 @@ from pants.engine.fs import AddPrefix, Digest, DigestSubset, MergeDigests, PathG
 from pants.engine.interactive_process import InteractiveProcess
 from pants.engine.internals.uuid import UUIDRequest
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -306,11 +306,6 @@ async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
 
 def rules():
     return [
-        run_python_test,
-        debug_python_test,
-        setup_pytest_for_target,
+        *register_rules(),
         UnionRule(TestFieldSet, PythonTestFieldSet),
-        SubsystemRule(PyTest),
-        SubsystemRule(PythonSetup),
-        SubsystemRule(CoverageSubsystem),
     ]

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -21,12 +21,12 @@ from pants.backend.python.subsystems import python_native_code, subprocess_envir
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.goals.test import Status, TestDebugRequest, TestResult, TestSubsystem
+from pants.core.goals.test import Status, TestDebugRequest, TestResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.interactive_process import InteractiveRunner
-from pants.engine.rules import RootRule, SubsystemRule
+from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.engine.target import TargetWithOrigin
 from pants.python.python_requirement import PythonRequirement
@@ -137,7 +137,6 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             *python_native_code.rules(),
             *strip_source_roots.rules(),
             *subprocess_environment.rules(),
-            SubsystemRule(TestSubsystem),
             RootRule(PythonTestFieldSet),
             # For conftest detection.
             *dependency_inference_rules.rules(),

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -142,5 +142,6 @@ def rules():
     return [
         *collect_rules(),
         *determine_source_files.rules(),
+        RootRule(StrippedPythonSourcesRequest),
         RootRule(UnstrippedPythonSourcesRequest),
     ]

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -10,7 +10,7 @@ from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.core.util_rules.strip_source_roots import representative_path_from_address
 from pants.engine.fs import Snapshot
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Sources, Target
 from pants.engine.unions import UnionMembership
@@ -140,8 +140,7 @@ async def prepare_unstripped_python_sources(
 
 def rules():
     return [
-        prepare_stripped_python_sources,
-        prepare_unstripped_python_sources,
+        *register_rules(),
         *determine_source_files.rules(),
         RootRule(UnstrippedPythonSourcesRequest),
     ]

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -10,7 +10,7 @@ from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.core.util_rules.strip_source_roots import representative_path_from_address
 from pants.engine.fs import Snapshot
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Sources, Target
 from pants.engine.unions import UnionMembership
@@ -140,7 +140,7 @@ async def prepare_unstripped_python_sources(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         *determine_source_files.rules(),
         RootRule(UnstrippedPythonSourcesRequest),
     ]

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -11,7 +11,7 @@ from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.repl import ReplImplementation, ReplRequest
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 
@@ -74,7 +74,7 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(ReplImplementation, PythonRepl),
         UnionRule(ReplImplementation, IPythonRepl),
     ]

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -11,7 +11,7 @@ from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.repl import ReplImplementation, ReplRequest
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.unions import UnionRule
 
@@ -74,9 +74,7 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
 
 def rules():
     return [
-        SubsystemRule(IPython),
+        *register_rules(),
         UnionRule(ReplImplementation, PythonRepl),
         UnionRule(ReplImplementation, IPythonRepl),
-        create_python_repl_request,
-        create_ipython_repl_request,
     ]

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -14,7 +14,7 @@ from pants.core.goals.run import RunRequest
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import InvalidFieldException, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -66,6 +66,6 @@ async def create_python_binary_run_request(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
     ]

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -14,7 +14,7 @@ from pants.core.goals.run import RunRequest
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import InvalidFieldException, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -66,7 +66,6 @@ async def create_python_binary_run_request(
 
 def rules():
     return [
-        create_python_binary_run_request,
+        *register_rules(),
         UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
-        SubsystemRule(PythonBinaryDefaults),
     ]

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -50,7 +50,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import SubsystemRule, goal_rule, rule
+from pants.engine.rules import goal_rule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -705,15 +705,4 @@ def is_ownable_target(tgt: Target, union_membership: UnionMembership) -> bool:
 
 
 def rules():
-    return [
-        run_setup_pys,
-        run_setup_py,
-        generate_chroot,
-        get_sources,
-        get_requirements,
-        get_ancestor_init_py,
-        get_owned_dependencies,
-        get_exporting_owner,
-        setup_setuptools,
-        SubsystemRule(Setuptools),
-    ]
+    return register_rules()

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -50,7 +50,7 @@ from pants.engine.fs import (
 )
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import goal_rule, register_rules, rule
+from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -705,4 +705,4 @@ def is_ownable_target(tgt: Target, union_membership: UnionMembership) -> bool:
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Tuple
 
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
@@ -59,4 +59,4 @@ def create_pex_native_build_environment(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Tuple
 
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
@@ -59,4 +59,4 @@ def create_pex_native_build_environment(
 
 
 def rules():
-    return [SubsystemRule(PythonNativeCode), create_pex_native_build_environment]
+    return register_rules()

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -57,7 +57,4 @@ def create_subprocess_encoding_environment(
 
 
 def rules():
-    return [
-        SubsystemRule(SubprocessEnvironment),
-        create_subprocess_encoding_environment,
-    ]
+    return register_rules()

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -57,4 +57,4 @@ def create_subprocess_encoding_environment(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -14,7 +14,6 @@ from pants.backend.python.rules.pex import (
 from pants.backend.python.rules.python_sources import (
     UnstrippedPythonSources,
     UnstrippedPythonSourcesRequest,
-    prepare_unstripped_python_sources,
 )
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -32,7 +31,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import SubsystemRule, rule
+from pants.engine.rules import register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -135,9 +134,7 @@ async def mypy_lint(
 
 def rules():
     return [
-        mypy_lint,
-        prepare_unstripped_python_sources,
-        SubsystemRule(MyPy),
+        *register_rules(),
         UnionRule(TypecheckRequest, MyPyRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules import download_pex_bin, pex, python_sources
 from pants.backend.python.rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -140,6 +140,7 @@ def rules():
         *determine_source_files.rules(),
         *pants_bin.rules(),
         *pex.rules(),
+        *python_sources.rules(),
         *python_native_code.rules(),
         *strip_source_roots.rules(),
         *subprocess_environment.rules(),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -31,7 +31,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSetWithOrigin, TransitiveTargets
 from pants.engine.unions import UnionRule
@@ -134,7 +134,7 @@ async def mypy_lint(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         UnionRule(TypecheckRequest, MyPyRequest),
         *download_pex_bin.rules(),
         *determine_source_files.rules(),

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -14,7 +14,7 @@ from functools import reduce
 from typing import Any, List, Optional, Tuple, cast
 
 from pants.base.build_environment import get_buildroot
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.fs.archive import archiver_for_path
 from pants.net.http.fetcher import Fetcher
 from pants.option.global_options import GlobalOptions
@@ -579,4 +579,4 @@ def provide_binary_util() -> BinaryUtil:
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -14,7 +14,7 @@ from functools import reduce
 from typing import Any, List, Optional, Tuple, cast
 
 from pants.base.build_environment import get_buildroot
-from pants.engine.rules import rule
+from pants.engine.rules import register_rules, rule
 from pants.fs.archive import archiver_for_path
 from pants.net.http.fetcher import Fetcher
 from pants.option.global_options import GlobalOptions
@@ -579,6 +579,4 @@ def provide_binary_util() -> BinaryUtil:
 
 
 def rules():
-    return [
-        provide_binary_util,
-    ]
+    return register_rules()

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -5,7 +5,7 @@ import logging
 import typing
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Type, Union
+from typing import Any, Dict, Type, Union
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.rules import Rule, RuleIndex
@@ -23,7 +23,7 @@ class BuildConfiguration:
 
     registered_aliases: BuildFileAliases
     optionables: FrozenOrderedSet[Optionable]
-    rules: FrozenOrderedSet[Union[Rule, Callable]]
+    rules: FrozenOrderedSet[Rule]
     union_rules: FrozenOrderedSet[UnionRule]
     target_types: FrozenOrderedSet[Type[Target]]
 
@@ -133,12 +133,7 @@ class BuildConfiguration:
             self._rules.update(rules)
             self._union_rules.update(union_rules)
             self.register_optionables(
-                {
-                    do
-                    for rule in rules
-                    for do in rule.dependency_optionables
-                    if rule.dependency_optionables
-                }
+                rule.output_type for rule in self._rules if issubclass(rule.output_type, Optionable)
             )
 
         # NB: We expect the parameter to be Iterable[Type[Target]], but we can't be confident in this

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
@@ -60,4 +60,4 @@ async def create_binary(workspace: Workspace, dist_dir: DistDir) -> Binary:
 
 
 def rules():
-    return [create_binary]
+    return register_rules()

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
@@ -60,4 +60,4 @@ async def create_binary(workspace: Workspace, dist_dir: DistDir) -> Binary:
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -10,7 +10,7 @@ from pants.engine.console import Console
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Field, Target, TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -231,4 +231,4 @@ async def fmt(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -10,7 +10,7 @@ from pants.engine.console import Console
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import Field, Target, TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -231,4 +231,4 @@ async def fmt(
 
 
 def rules():
-    return [fmt]
+    return register_rules()

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -16,7 +16,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -192,4 +192,4 @@ async def lint(
 
 
 def rules():
-    return [lint]
+    return register_rules()

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -16,7 +16,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -192,4 +192,4 @@ async def lint(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get
 from pants.engine.target import Field, Target, Targets, TransitiveTargets
 from pants.engine.unions import UnionMembership, union
@@ -121,4 +121,4 @@ async def run_repl(
 
 
 def rules():
-    return [run_repl]
+    return register_rules()

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get
 from pants.engine.target import Field, Target, Targets, TransitiveTargets
 from pants.engine.unions import UnionMembership, union
@@ -121,4 +121,4 @@ async def run_repl(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get
 from pants.engine.target import TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.option.custom_types import shell_str
@@ -118,4 +118,4 @@ async def run(
 
 
 def rules():
-    return [run]
+    return register_rules()

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get
 from pants.engine.target import TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.option.custom_types import shell_str
@@ -118,4 +118,4 @@ async def run(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -22,7 +22,7 @@ from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule, register_rules, rule
+from pants.engine.rules import collect_rules, goal_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     FieldSetWithOrigin,
@@ -385,4 +385,4 @@ async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> Addres
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -22,7 +22,7 @@ from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.interactive_process import InteractiveProcess, InteractiveRunner
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule, rule
+from pants.engine.rules import goal_rule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     FieldSetWithOrigin,
@@ -385,4 +385,4 @@ async def coordinator_of_tests(wrapped_field_set: WrappedTestFieldSet) -> Addres
 
 
 def rules():
-    return [coordinator_of_tests, run_tests]
+    return register_rules()

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -14,7 +14,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -127,4 +127,4 @@ async def typecheck(
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -14,7 +14,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import TargetsWithOrigins
 from pants.engine.unions import UnionMembership, union
@@ -127,4 +127,4 @@ async def typecheck(
 
 
 def rules():
-    return [typecheck]
+    return register_rules()

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 from pants.engine.fs import Digest, RemovePrefix, Snapshot
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get
 
 
@@ -62,4 +62,4 @@ async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
 
 
 def rules():
-    return [*register_rules(), RootRule(MaybeExtractable)]
+    return [*collect_rules(), RootRule(MaybeExtractable)]

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 from pants.engine.fs import Digest, RemovePrefix, Snapshot
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get
 
 
@@ -62,4 +62,4 @@ async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
 
 
 def rules():
-    return [maybe_extract, RootRule(MaybeExtractable)]
+    return [*register_rules(), RootRule(MaybeExtractable)]

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, Snapshot
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -187,7 +187,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(AllSourceFilesRequest),
         RootRule(SpecifiedSourceFilesRequest),
         *strip_source_roots.rules(),

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.strip_source_roots import (
 )
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, Snapshot
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -187,8 +187,7 @@ async def determine_specified_source_files(request: SpecifiedSourceFilesRequest)
 
 def rules():
     return [
-        determine_all_source_files,
-        determine_specified_source_files,
+        *register_rules(),
         RootRule(AllSourceFilesRequest),
         RootRule(SpecifiedSourceFilesRequest),
         *strip_source_roots.rules(),

--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pants.base.build_root import BuildRoot
-from pants.engine.rules import rule
+from pants.engine.rules import register_rules, rule
 from pants.fs.fs import is_child_of
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -39,6 +39,4 @@ def validate_distdir(distdir: Path, buildroot: Path) -> DistDir:
 
 
 def rules():
-    return [
-        get_distdir,
-    ]
+    return register_rules()

--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pants.base.build_root import BuildRoot
-from pants.engine.rules import register_rules, rule
+from pants.engine.rules import collect_rules, rule
 from pants.fs.fs import is_child_of
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -39,4 +39,4 @@ def validate_distdir(distdir: Path, buildroot: Path) -> DistDir:
 
 
 def rules():
-    return register_rules()
+    return collect_rules()

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -9,7 +9,7 @@ from typing import List
 from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
 from pants.engine.fs import Digest, DownloadFile
 from pants.engine.platform import Platform
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.meta import classproperty
@@ -178,4 +178,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return [download_external_tool, RootRule(ExternalToolRequest)]
+    return [*register_rules(), RootRule(ExternalToolRequest)]

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -9,7 +9,7 @@ from typing import List
 from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
 from pants.engine.fs import Digest, DownloadFile
 from pants.engine.platform import Platform
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.meta import classproperty
@@ -178,4 +178,4 @@ async def download_external_tool(request: ExternalToolRequest) -> DownloadedExte
 
 
 def rules():
-    return [*register_rules(), RootRule(ExternalToolRequest)]
+    return [*collect_rules(), RootRule(ExternalToolRequest)]

--- a/src/python/pants/core/util_rules/filter_empty_sources.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 from typing_extensions import Protocol
 
 from pants.engine.collection import Collection
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -67,8 +67,7 @@ async def determine_targets_with_sources(request: TargetsWithSourcesRequest) -> 
 
 def rules():
     return [
-        determine_field_sets_with_sources,
-        determine_targets_with_sources,
+        *register_rules(),
         RootRule(FieldSetsWithSourcesRequest),
         RootRule(TargetsWithSourcesRequest),
     ]

--- a/src/python/pants/core/util_rules/filter_empty_sources.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 from typing_extensions import Protocol
 
 from pants.engine.collection import Collection
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -67,7 +67,7 @@ async def determine_targets_with_sources(request: TargetsWithSourcesRequest) -> 
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(FieldSetsWithSourcesRequest),
         RootRule(TargetsWithSourcesRequest),
     ]

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -18,7 +18,7 @@ from pants.engine.fs import (
     RemovePrefix,
     Snapshot,
 )
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -206,7 +206,7 @@ async def strip_source_roots_from_sources_field(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(StripSnapshotRequest),
         RootRule(StripSourcesFieldRequest),
     ]

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -18,7 +18,7 @@ from pants.engine.fs import (
     RemovePrefix,
     Snapshot,
 )
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -206,8 +206,7 @@ async def strip_source_roots_from_sources_field(
 
 def rules():
     return [
-        strip_source_roots_from_snapshot,
-        strip_source_roots_from_sources_field,
+        *register_rules(),
         RootRule(StripSnapshotRequest),
         RootRule(StripSourcesFieldRequest),
     ]

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -987,16 +987,11 @@ def find_valid_field_sets(
 def rules():
     return [
         *register_rules(),
-        # Owners
-        RootRule(OwnersRequest),
-        # Specs -> AddressesWithOrigins
-        RootRule(Specs),
-        # Sources field
-        RootRule(HydrateSourcesRequest),
-        # Dependencies field
         RootRule(DependenciesRequest),
-        RootRule(InjectDependenciesRequest),
+        RootRule(HydrateSourcesRequest),
         RootRule(InferDependenciesRequest),
-        # FieldSets
+        RootRule(InjectDependenciesRequest),
+        RootRule(OwnersRequest),
+        RootRule(Specs),
         RootRule(TargetsToValidFieldSetsRequest),
     ]

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -51,7 +51,7 @@ from pants.engine.fs import (
     SourcesSnapshot,
 )
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -986,32 +986,17 @@ def find_valid_field_sets(
 
 def rules():
     return [
-        # Address -> Target
-        resolve_target,
-        resolve_targets,
-        # AddressWithOrigin -> TargetWithOrigin
-        resolve_target_with_origin,
-        resolve_targets_with_origins,
-        # TransitiveTargets
-        transitive_targets,
+        *register_rules(),
         # Owners
-        find_owners,
         RootRule(OwnersRequest),
         # Specs -> AddressesWithOrigins
-        addresses_with_origins_from_filesystem_specs,
-        resolve_addresses_with_origins,
         RootRule(Specs),
-        # SourcesSnapshot
-        resolve_sources_snapshot,
         # Sources field
-        hydrate_sources,
         RootRule(HydrateSourcesRequest),
         # Dependencies field
-        resolve_dependencies,
         RootRule(DependenciesRequest),
         RootRule(InjectDependenciesRequest),
         RootRule(InferDependenciesRequest),
         # FieldSets
-        find_valid_field_sets,
         RootRule(TargetsToValidFieldSetsRequest),
     ]

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -51,7 +51,7 @@ from pants.engine.fs import (
     SourcesSnapshot,
 )
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.target import (
     Dependencies,
@@ -986,7 +986,7 @@ def find_valid_field_sets(
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(DependenciesRequest),
         RootRule(HydrateSourcesRequest),
         RootRule(InferDependenciesRequest),

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
@@ -43,7 +43,7 @@ def log_level(global_options: GlobalOptions) -> LogLevel:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(Scope),
         RootRule(OptionsBootstrapper),
     ]

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from pants.engine.rules import RootRule, SubsystemRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
@@ -43,10 +43,7 @@ def log_level(global_options: GlobalOptions) -> LogLevel:
 
 def rules():
     return [
-        scope_options,
-        parse_options,
-        SubsystemRule(GlobalOptions),
-        log_level,
+        *register_rules(),
         RootRule(Scope),
         RootRule(OptionsBootstrapper),
     ]

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -41,6 +41,7 @@ from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import ExecutionOptions
 from pants.util.contextutil import temporary_file_path
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
@@ -89,7 +90,7 @@ class Scheduler:
         local_store_dir: str,
         local_execution_root_dir: str,
         named_caches_dir: str,
-        rules: Tuple[Rule, ...],
+        rules: FrozenOrderedSet[Rule],
         union_membership: UnionMembership,
         execution_options: ExecutionOptions,
         include_trace_on_error: bool = True,

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -5,7 +5,7 @@ import random
 import uuid
 from dataclasses import dataclass, field
 
-from pants.engine.rules import RootRule, _uncacheable_rule, register_rules
+from pants.engine.rules import RootRule, _uncacheable_rule, collect_rules
 
 
 @dataclass(frozen=True)
@@ -28,4 +28,4 @@ async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
 
 
 def rules():
-    return [*register_rules(), RootRule(UUIDRequest)]
+    return [*collect_rules(), RootRule(UUIDRequest)]

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -5,7 +5,7 @@ import random
 import uuid
 from dataclasses import dataclass, field
 
-from pants.engine.rules import RootRule, _uncacheable_rule
+from pants.engine.rules import RootRule, _uncacheable_rule, register_rules
 
 
 @dataclass(frozen=True)
@@ -28,4 +28,4 @@ async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
 
 
 def rules():
-    return [generate_uuid, RootRule(UUIDRequest)]
+    return [*register_rules(), RootRule(UUIDRequest)]

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
@@ -233,7 +233,7 @@ def remove_platform_information(res: FallibleProcessResultWithPlatform,) -> Fall
 def rules():
     """Creates rules that consume the intrinsic filesystem types."""
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(Process),
         RootRule(MultiPlatformProcess),
     ]

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
 
 from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
@@ -233,10 +233,7 @@ def remove_platform_information(res: FallibleProcessResultWithPlatform,) -> Fall
 def rules():
     """Creates rules that consume the intrinsic filesystem types."""
     return [
+        *register_rules(),
         RootRule(Process),
         RootRule(MultiPlatformProcess),
-        upcast_process,
-        fallible_to_exec_result_or_raise,
-        remove_platform_information,
-        get_multi_platform_request_description,
     ]

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -423,10 +423,10 @@ class Rule(ABC):
         """An output `type` for the rule."""
 
 
-def register_rules(*namespaces: Union[ModuleType, Mapping[str, Any]]) -> Iterable[Rule]:
-    """Registers all @rules in the given namespaces.
+def collect_rules(*namespaces: Union[ModuleType, Mapping[str, Any]]) -> Iterable[Rule]:
+    """Collects all @rules in the given namespaces.
 
-    If no namespaces are given, registers all the @rules in the caller's module namespace.
+    If no namespaces are given, collects all the @rules in the caller's module namespace.
     """
     if not namespaces:
         currentframe = inspect.currentframe()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -24,7 +24,7 @@ from pants.engine.internals.parser import Parser, SymbolTable
 from pants.engine.internals.scheduler import Scheduler, SchedulerSession
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.platform import create_platform_rules
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Params
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
@@ -33,6 +33,7 @@ from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOpti
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.scm.subsystems.changed import rules as changed_rules
 from pants.subsystem.subsystem import Subsystem
+from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
 
@@ -282,24 +283,21 @@ class EngineInitializer:
             return cast(BuildRoot, BuildRoot.instance)
 
         # Create a Scheduler containing graph and filesystem rules, with no installed goals.
-        rules = (
-            RootRule(Console),
-            glob_match_error_behavior_singleton,
-            build_configuration_singleton,
-            symbol_table_singleton,
-            registered_target_types_singleton,
-            union_membership_singleton,
-            build_root_singleton,
-            *fs.rules(),
-            *interactive_process.rules(),
-            *graph.rules(),
-            *uuid.rules(),
-            *options_parsing.rules(),
-            *process.rules(),
-            *create_platform_rules(),
-            *create_graph_rules(address_mapper),
-            *changed_rules(),
-            *rules,
+        rules = FrozenOrderedSet(
+            (
+                *register_rules(locals()),
+                RootRule(Console),
+                *fs.rules(),
+                *interactive_process.rules(),
+                *graph.rules(),
+                *uuid.rules(),
+                *options_parsing.rules(),
+                *process.rules(),
+                *create_platform_rules(),
+                *create_graph_rules(address_mapper),
+                *changed_rules(),
+                *rules,
+            )
         )
 
         goal_map = EngineInitializer._make_goal_map_from_rules(rules)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -24,7 +24,7 @@ from pants.engine.internals.parser import Parser, SymbolTable
 from pants.engine.internals.scheduler import Scheduler, SchedulerSession
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.platform import create_platform_rules
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Params
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
@@ -285,7 +285,7 @@ class EngineInitializer:
         # Create a Scheduler containing graph and filesystem rules, with no installed goals.
         rules = FrozenOrderedSet(
             (
-                *register_rules(locals()),
+                *collect_rules(locals()),
                 RootRule(Console),
                 *fs.rules(),
                 *interactive_process.rules(),

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -61,7 +61,6 @@ class OptionableFactory(ABC):
             func=partial_construct_optionable,
             input_gets=(GetConstraints(product_type=ScopedOptions, subject_declared_type=Scope),),
             canonical_name=name,
-            dependency_optionables=(cls.optionable_cls,),
         )
 
 

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -5,18 +5,14 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, cast
 
-from pants.backend.project_info.dependees import (
-    Dependees,
-    DependeesRequest,
-    find_dependees,
-    map_addresses_to_dependees,
-)
+from pants.backend.project_info import dependees
+from pants.backend.project_info.dependees import Dependees, DependeesRequest
 from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.rules import RootRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get
 from pants.option.option_value_container import OptionValueContainer
 from pants.scm.scm import Scm
@@ -162,8 +158,7 @@ class Changed(Subsystem):
 
 def rules():
     return [
-        map_addresses_to_dependees,
-        find_dependees,
-        find_changed_owners,
+        *register_rules(),
         RootRule(ChangedRequest),
+        *dependees.rules(),
     ]

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -12,7 +12,7 @@ from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get
 from pants.option.option_value_container import OptionValueContainer
 from pants.scm.scm import Scm
@@ -158,7 +158,7 @@ class Changed(Subsystem):
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(ChangedRequest),
         *dependees.rules(),
     ]

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -10,7 +10,7 @@ from typing import Iterable, Optional, Set, Tuple, Union
 
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import PathGlobs, Snapshot
-from pants.engine.rules import RootRule, register_rules, rule
+from pants.engine.rules import RootRule, collect_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -326,6 +326,6 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
 
 def rules():
     return [
-        *register_rules(),
+        *collect_rules(),
         RootRule(SourceRootRequest),
     ]

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -10,7 +10,7 @@ from typing import Iterable, Optional, Set, Tuple, Union
 
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import PathGlobs, Snapshot
-from pants.engine.rules import RootRule, SubsystemRule, rule
+from pants.engine.rules import RootRule, register_rules, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -326,9 +326,6 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
 
 def rules():
     return [
-        get_source_root,
-        get_source_root_strict,
-        all_roots,
-        SubsystemRule(SourceRootConfig),
+        *register_rules(),
         RootRule(SourceRootRequest),
     ]

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -6,7 +6,7 @@ import os
 from pants.base.deprecated import warn_or_error
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule
+from pants.engine.rules import goal_rule, register_rules
 from pants.option.custom_types import file_option
 
 
@@ -58,7 +58,7 @@ async def run_lifecycle_stubs(opts: LifecycleStubsSubsystem) -> LifecycleStubsGo
 
 
 def rules():
-    return [show_warning, run_lifecycle_stubs]
+    return register_rules()
 
 
 if os.environ.get("_RAISE_KEYBOARDINTERRUPT_ON_IMPORT", False):

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -6,7 +6,7 @@ import os
 from pants.base.deprecated import warn_or_error
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import goal_rule, register_rules
+from pants.engine.rules import collect_rules, goal_rule
 from pants.option.custom_types import file_option
 
 
@@ -58,7 +58,7 @@ async def run_lifecycle_stubs(opts: LifecycleStubsSubsystem) -> LifecycleStubsGo
 
 
 def rules():
-    return register_rules()
+    return collect_rules()
 
 
 if os.environ.get("_RAISE_KEYBOARDINTERRUPT_ON_IMPORT", False):


### PR DESCRIPTION
Introduce a register_rules function that can find and register all
@rules and the SubsystemRules they depend on. This can be used to
both reduce boilerplate and also make rule development less surprising.
Using register_rules it now becomes rarer to edit rules and encounter
errors due to forgetting to register rules for the various introduced
subsystems and @rule functions.

Also streamline the Rule interface and the `def rules()` semantics;
now all rules are Rules save for UnionRule which can be dealt away
with later to leave users only exposed to registering Rules and allow
`def rules() -> Iterable[Rule]:`.

[ci skip-rust-tests]