### PR TITLE
Skip building wheels if no release files have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -370,7 +370,7 @@ jobs:
     dist: xenial
     env:
     - CACHE_NAME=clippy
-    if: commit_message !~ /\[ci skip-rust-tests\]/
+    if: commit_message !~ /\[ci skip-rust\]/
     name: Clippy (Rust linter)
     os: linux
     script:
@@ -530,7 +530,7 @@ jobs:
     env:
     - CACHE_NAME=rust_tests.linux
     - LD_LIBRARY_PATH="/opt/python/3.6.7/lib:${LD_LIBRARY_PATH}"
-    if: commit_message !~ /\[ci skip-rust-tests\]/
+    if: commit_message !~ /\[ci skip-rust\]/
     name: Rust tests - Linux
     os: linux
     script:
@@ -563,7 +563,7 @@ jobs:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY38_VERSION}/bin:${PATH}"
     - CACHE_NAME=rust_tests.osx
-    if: commit_message !~ /\[ci skip-rust-tests\]/
+    if: commit_message !~ /\[ci skip-rust\]/
     name: Rust tests - OSX
     os: osx
     osx_image: xcode8
@@ -615,6 +615,7 @@ jobs:
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.linux
+    if: commit_message !~ /\[ci skip-build-wheels\]/
     language: python
     name: Build Linux wheels and fs_util
     os: linux
@@ -667,6 +668,7 @@ jobs:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.osx
+    if: commit_message !~ /\[ci skip-build-wheels\]/
     language: generic
     name: Build macOS wheels and fs_util
     os: osx

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -435,7 +435,8 @@ def osx_shard(
 
 
 # See https://docs.travis-ci.com/user/conditions-v1.
-SKIP_RUST_CONDITION = r"commit_message !~ /\[ci skip-rust-tests\]/"
+SKIP_RUST_CONDITION = r"commit_message !~ /\[ci skip-rust\]/"
+SKIP_WHEELS_CONDITION = r"commit_message !~ /\[ci skip-build-wheels\]/"
 
 # ----------------------------------------------------------------------
 # Bootstrap engine
@@ -592,6 +593,7 @@ def build_wheels_linux() -> Dict:
         **linux_shard(use_docker=True),
         "name": "Build Linux wheels and fs_util",
         "script": [docker_build_travis_ci_image(), docker_run_travis_ci_image(command)],
+        "if": SKIP_WHEELS_CONDITION,
     }
     safe_extend(shard, "env", _build_wheels_env(platform=Platform.linux))
     return shard
@@ -607,6 +609,7 @@ def build_wheels_osx() -> Dict:
             python_versions=[PythonVersion.py36, PythonVersion.py37, PythonVersion.py38],
             install_py27=False,
         ),
+        "if": SKIP_WHEELS_CONDITION,
     }
     safe_extend(shard, "env", _build_wheels_env(platform=Platform.osx))
     return shard

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -25,12 +25,22 @@ NUM_RUST_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
   -e "^build-support/bin/native" \
   -e "^build-support/bin/generate_travis_yml.py")
 
+NUM_RELEASE_FILES=$(echo "${CHANGED_FILES})" | grep -c -E \
+  -e "^src/python/pants/VERSION" \
+  -e "^src/python/pants/notes" \
+  -e "^src/rust/engine/fs/fs_util" \
+  -e "^build-support/bin/release.sh" \
+  -e "^build-support/bin/packages.py" \
+  -e "^build-support/bin/generate_travis_yml.py")
+
 # To avoid putting skip labels multiple times, check if the labels already exist
 # in the commit message.
-grep "\[ci skip-rust-tests\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
-HAS_RUST_SKIP=$?
 grep "\[ci skip\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
 HAS_CI_SKIP=$?
+grep "\[ci skip-rust\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
+HAS_RUST_SKIP=$?
+grep "\[ci skip-build-wheels\]" "${COMMIT_MSG_FILEPATH}" > /dev/null
+HAS_WHEELS_SKIP=$?
 
 if [[ "${HAS_CI_SKIP}" -eq 1 ]] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
@@ -43,7 +53,15 @@ fi
 if [[ "${HAS_RUST_SKIP}" -eq 1 ]] && [ "${NUM_RUST_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
-# Rust tests will be skipped. Delete if not intended.
-[ci skip-rust-tests]
+# Rust tests and lints will be skipped. Delete if not intended.
+[ci skip-rust]
+EOF
+fi
+
+if [[ "${HAS_WHEELS_SKIP}" -eq 1 ]] && [ "${NUM_RELEASE_FILES}" -eq 0 ]; then
+cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
+
+# Building wheels and fs_util will be skipped. Delete if not intended.
+[ci skip-build-wheels]
 EOF
 fi


### PR DESCRIPTION
The time we really need to run these jobs is when we're doing release prep, which means we will have changed `notes/` and, sometimes, `VERSION`.

We also run the jobs if we've made changes to our release process.

As with Rust skips, developers can ignore this skip by manually changing their commit message.