### PR TITLE
Only skip building wheels on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -615,7 +615,7 @@ jobs:
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.linux
-    if: commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request,
+    if: commit_message !~ /\[ci skip-build-wheels\]/ OR type NOT IN (pull_request,
       cron)
     language: python
     name: Build Linux wheels and fs_util
@@ -669,7 +669,7 @@ jobs:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.osx
-    if: commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request,
+    if: commit_message !~ /\[ci skip-build-wheels\]/ OR type NOT IN (pull_request,
       cron)
     language: generic
     name: Build macOS wheels and fs_util

--- a/.travis.yml
+++ b/.travis.yml
@@ -615,7 +615,8 @@ jobs:
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.linux
-    if: commit_message !~ /\[ci skip-build-wheels\]/
+    if: commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request,
+      cron)
     language: python
     name: Build Linux wheels and fs_util
     os: linux
@@ -668,7 +669,8 @@ jobs:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.osx
-    if: commit_message !~ /\[ci skip-build-wheels\]/
+    if: commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request,
+      cron)
     language: generic
     name: Build macOS wheels and fs_util
     os: osx

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -437,7 +437,7 @@ def osx_shard(
 # See https://docs.travis-ci.com/user/conditions-v1.
 SKIP_RUST_CONDITION = r"commit_message !~ /\[ci skip-rust\]/"
 SKIP_WHEELS_CONDITION = (
-    r"commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request, cron)"
+    r"commit_message !~ /\[ci skip-build-wheels\]/ OR type NOT IN (pull_request, cron)"
 )
 
 # ----------------------------------------------------------------------

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -436,7 +436,9 @@ def osx_shard(
 
 # See https://docs.travis-ci.com/user/conditions-v1.
 SKIP_RUST_CONDITION = r"commit_message !~ /\[ci skip-rust\]/"
-SKIP_WHEELS_CONDITION = r"commit_message !~ /\[ci skip-build-wheels\]/"
+SKIP_WHEELS_CONDITION = (
+    r"commit_message !~ /\[ci skip-build-wheels\]/ AND type NOT IN (pull_request, cron)"
+)
 
 # ----------------------------------------------------------------------
 # Bootstrap engine

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -58,7 +58,9 @@ cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 EOF
 fi
 
-if [[ "${HAS_WHEELS_SKIP}" -eq 1 ]] && [ "${NUM_RELEASE_FILES}" -eq 0 ]; then
+# We only skip building wheels if on a PR build, even if the user put the skip label in the merged
+# commit message.
+if [[ "${TRAVIS_PULL_REQUEST}" -ne false ]] && [[ "${HAS_WHEELS_SKIP}" -eq 1 ]] && [ "${NUM_RELEASE_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
 # Building wheels and fs_util will be skipped. Delete if not intended.

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -58,9 +58,7 @@ cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 EOF
 fi
 
-# We only skip building wheels if on a PR build, even if the user put the skip label in the merged
-# commit message.
-if [[ "${TRAVIS_PULL_REQUEST}" -ne false ]] && [[ "${HAS_WHEELS_SKIP}" -eq 1 ]] && [ "${NUM_RELEASE_FILES}" -eq 0 ]; then
+if [[ "${HAS_WHEELS_SKIP}" -eq 1 ]] && [ "${NUM_RELEASE_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
 # Building wheels and fs_util will be skipped. Delete if not intended.


### PR DESCRIPTION
Building on all branch builds has the following benefits:
1) We'll detect the release process breaking before the day of a release.
2) Downstream users can consume any arbitrary Pants commit.

[ci skip-rust]
[ci skip-build-wheels]
