### PR TITLE
Improve test output.

### DIFF
--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -13,6 +13,7 @@ from pants.core.goals.test import (
     CoverageData,
     CoverageDataCollection,
     CoverageReports,
+    ShowOutput,
     Status,
     Test,
     TestDebugRequest,
@@ -137,12 +138,13 @@ class TestTest(TestBase):
         targets: List[TargetWithOrigin],
         debug: bool = False,
         use_coverage: bool = False,
+        show_output: ShowOutput = ShowOutput.ALL,
         include_sources: bool = True,
         valid_targets: bool = True,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
         test_subsystem = create_goal_subsystem(
-            TestSubsystem, debug=debug, use_coverage=use_coverage
+            TestSubsystem, debug=debug, use_coverage=use_coverage, show_output=show_output,
         )
         interactive_runner = InteractiveRunner(self.scheduler)
         workspace = Workspace(self.scheduler)
@@ -244,11 +246,12 @@ class TestTest(TestBase):
             field_set=SuccessfulFieldSet, targets=[self.make_target_with_origin(address)]
         )
         assert exit_code == 0
-        # NB: We don't render a summary when only running one target.
         assert stderr == dedent(
             f"""\
             ✓ {address}
             {SuccessfulFieldSet.stdout(address)}
+
+            {address}                                                                        .....   SUCCESS
             """
         )
 
@@ -275,6 +278,50 @@ class TestTest(TestBase):
             {good_address}                                                                         .....   SUCCESS
             {bad_address}                                                                          .....   FAILURE
             """
+        )
+
+    def test_show_output_failed(self) -> None:
+        good_address = Address.parse(":good")
+        bad_address = Address.parse(":bad")
+
+        exit_code, stderr = self.run_test_rule(
+            field_set=ConditionallySucceedsFieldSet,
+            targets=[
+                self.make_target_with_origin(good_address),
+                self.make_target_with_origin(bad_address),
+            ],
+            show_output=ShowOutput.FAILED,
+        )
+        assert exit_code == 1
+        assert stderr == dedent(
+            f"""\
+                𐄂 {bad_address}
+                {ConditionallySucceedsFieldSet.stderr(bad_address)}
+
+                {good_address}                                                                         .....   SUCCESS
+                {bad_address}                                                                          .....   FAILURE
+                """
+        )
+
+    def test_show_output_none(self) -> None:
+        good_address = Address.parse(":good")
+        bad_address = Address.parse(":bad")
+
+        exit_code, stderr = self.run_test_rule(
+            field_set=ConditionallySucceedsFieldSet,
+            targets=[
+                self.make_target_with_origin(good_address),
+                self.make_target_with_origin(bad_address),
+            ],
+            show_output=ShowOutput.NONE,
+        )
+        assert exit_code == 1
+        assert stderr == dedent(
+            f"""\
+
+                    {good_address}                                                                         .....   SUCCESS
+                    {bad_address}                                                                          .....   FAILURE
+                    """
         )
 
     def test_debug_target(self) -> None:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -138,13 +138,13 @@ class TestTest(TestBase):
         targets: List[TargetWithOrigin],
         debug: bool = False,
         use_coverage: bool = False,
-        show_output: ShowOutput = ShowOutput.ALL,
+        output: ShowOutput = ShowOutput.ALL,
         include_sources: bool = True,
         valid_targets: bool = True,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
         test_subsystem = create_goal_subsystem(
-            TestSubsystem, debug=debug, use_coverage=use_coverage, show_output=show_output,
+            TestSubsystem, debug=debug, use_coverage=use_coverage, output=output,
         )
         interactive_runner = InteractiveRunner(self.scheduler)
         workspace = Workspace(self.scheduler)
@@ -280,7 +280,7 @@ class TestTest(TestBase):
             """
         )
 
-    def test_show_output_failed(self) -> None:
+    def test_output_failed(self) -> None:
         good_address = Address.parse(":good")
         bad_address = Address.parse(":bad")
 
@@ -290,7 +290,7 @@ class TestTest(TestBase):
                 self.make_target_with_origin(good_address),
                 self.make_target_with_origin(bad_address),
             ],
-            show_output=ShowOutput.FAILED,
+            output=ShowOutput.FAILED,
         )
         assert exit_code == 1
         assert stderr == dedent(
@@ -303,7 +303,7 @@ class TestTest(TestBase):
                 """
         )
 
-    def test_show_output_none(self) -> None:
+    def test_output_none(self) -> None:
         good_address = Address.parse(":good")
         bad_address = Address.parse(":bad")
 
@@ -313,7 +313,7 @@ class TestTest(TestBase):
                 self.make_target_with_origin(good_address),
                 self.make_target_with_origin(bad_address),
             ],
-            show_output=ShowOutput.NONE,
+            output=ShowOutput.NONE,
         )
         assert exit_code == 1
         assert stderr == dedent(

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -95,6 +95,10 @@ class Console:
         self.stdout.flush()
         self.stderr.flush()
 
+    @property
+    def use_colors(self):
+        return self._use_colors
+
     def _safe_color(self, text: str, color: Callable[[str], str]) -> str:
         """We should only output color when the global flag --colors is enabled."""
         return color(text) if self._use_colors else text

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -235,7 +235,7 @@ class MockConsole:
     def __init__(self, use_colors=True):
         self.stdout = StringIO()
         self.stderr = StringIO()
-        self._use_colors = use_colors
+        self.use_colors = use_colors
 
     def write_stdout(self, payload):
         self.stdout.write(payload)
@@ -250,7 +250,7 @@ class MockConsole:
         print(payload, file=self.stderr)
 
     def _safe_color(self, text: str, color: Callable[[str], str]) -> str:
-        return color(text) if self._use_colors else text
+        return color(text) if self.use_colors else text
 
     def blue(self, text: str) -> str:
         return self._safe_color(text, blue)


### PR DESCRIPTION
- Adds a flag that allows you to select whether test
  stdout/stderr is displayed for all tests, failed tests
  or no tests.  Defaults to only failed tests, which is the most
  useful setting. That way when running over many tests you
  can easily focus on just the failed ones, particularly in CI.

- Shows the summary in all cases. Previously we omitted it 
  when there's only one test target in play, but that's
  kinda weird and inconsistent.

[ci skip-rust]

[ci skip-build-wheels]
