### PR TITLE
Stop warning when return code != 0 or 1

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -215,8 +215,6 @@ class LocalPantsRunner:
         run_tracker_result = PANTS_SUCCEEDED_EXIT_CODE
         scheduler_session = self.graph_session.scheduler_session
 
-        # These strings are prepended to the existing exit message when calling the superclass .exit().
-        additional_messages = []
         try:
             metrics = scheduler_session.metrics()
             self._run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
@@ -224,15 +222,9 @@ class LocalPantsRunner:
             self._run_tracker.set_root_outcome(outcome)
             run_tracker_result = self._run_tracker.end()
         except ValueError as e:
-            # If we have been interrupted by a signal, calling .end() sometimes writes to a closed file,
-            # so we just log that fact here and keep going.
+            # If we have been interrupted by a signal, calling .end() sometimes writes to a closed
+            # file, so we just log that fact here and keep going.
             ExceptionSink.log_exception(exc=e)
-
-        if additional_messages:
-            # NB: We do not log to the exceptions log in this case, because we expect that these are
-            # higher level unstructured errors: structured versions will already have been written at
-            # various places.
-            logger.error("\n".join(additional_messages))
 
         return run_tracker_result
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -220,22 +220,7 @@ class LocalPantsRunner:
         try:
             metrics = scheduler_session.metrics()
             self._run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
-
-            if code == PANTS_SUCCEEDED_EXIT_CODE:
-                outcome = WorkUnit.SUCCESS
-            elif code == PANTS_FAILED_EXIT_CODE:
-                outcome = WorkUnit.FAILURE
-            else:
-                run_tracker_msg = (
-                    "unrecognized exit code {} provided to {}.exit() -- "
-                    "interpreting as a failure in the run tracker".format(code, type(self).__name__)
-                )
-                # Log the unrecognized exit code to the fatal exception log.
-                ExceptionSink.log_exception(exc=Exception(run_tracker_msg))
-                # Ensure the unrecognized exit code message is also logged to the terminal.
-                additional_messages.append(run_tracker_msg)
-                outcome = WorkUnit.FAILURE
-
+            outcome = WorkUnit.SUCCESS if code == PANTS_SUCCEEDED_EXIT_CODE else WorkUnit.FAILURE
             self._run_tracker.set_root_outcome(outcome)
             run_tracker_result = self._run_tracker.end()
         except ValueError as e:


### PR DESCRIPTION
This was noisy. Many tools like Flake8 frequently use return codes other than 1.

[ci skip-rust]
[ci skip-build-wheels]