### PR TITLE
Fix display of default/current values in help.

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from colors import cyan, green, magenta, red
 
-from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo
+from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo, to_help_str
 from pants.option.ranked_value import Rank, RankedValue
 
 
@@ -81,7 +81,7 @@ class HelpFormatter:
             if isinstance(val.value, (list, dict)):
                 val_lines = json.dumps(val.value, sort_keys=True, indent=4).split("\n")
             else:
-                val_lines = [f"{val.value}"]
+                val_lines = [to_help_str(val.value)]
             val_lines[0] = f"{prefix}{val_lines[0]}"
             val_lines[-1] = f"{val_lines[-1]}{maybe_parens(val.details)}"
             val_lines = [self._maybe_cyan(f"{left_padding}{line}") for line in val_lines]
@@ -96,7 +96,9 @@ class HelpFormatter:
             f"{indent}{'  ' if i != 0 else ''}{self._maybe_cyan(s)}"
             for i, s in enumerate(wrap(f"{choices}", 96))
         ]
-        default_lines = format_value(RankedValue(Rank.HARDCODED, ohi.default), "default: ", indent)
+        default_lines = format_value(
+            RankedValue(Rank.HARDCODED, ohi.default_str), "default: ", indent
+        )
         if not ohi.value_history:
             # Should never happen, but this keeps mypy happy.
             raise ValueError("No value history - options not parsed.")

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -46,12 +46,12 @@ class OptionHelpFormatterTest(unittest.TestCase):
         return lines[4] if choices else lines[3]
 
     def test_format_help(self):
-        default_line = self._format_for_single_option(default="MYDEFAULT")
+        default_line = self._format_for_single_option(default="MYDEFAULT", default_str="MYDEFAULT")
         assert default_line.lstrip() == "default: MYDEFAULT"
 
     def test_format_help_choices(self):
         default_line = self._format_for_single_option(
-            typ=str, default="kiwi", choices=["apple", "banana", "kiwi"]
+            typ=str, default="kiwi", default_str="kiwi", choices=["apple", "banana", "kiwi"]
         )
         assert default_line.lstrip() == "default: kiwi"
 


### PR DESCRIPTION
Previously we stringified the value naively,
even though we already have access to the properly
stringified default, and can easily stringify
the current value.

[ci skip-rust]

[ci skip-build-wheels]
