### PR TITLE
Make independent owners requests per file to improve memoization

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
 from pathlib import PurePath
 
 from pants.backend.python.dependency_inference import module_mapper
@@ -123,11 +124,11 @@ async def infer_python_init_dependencies(
     )
 
     # And add dependencies on their owners.
-    return InferredDependencies(
-        await Get(
-            Owners, OwnersRequest(extra_init_files.snapshot.files, OwnersNotFoundBehavior.error)
-        )
+    owners = await MultiGet(
+        Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
+        for f in extra_init_files.snapshot.files
     )
+    return InferredDependencies(itertools.chain.from_iterable(owners))
 
 
 class InferConftestDependencies(InferDependenciesRequest):
@@ -149,11 +150,11 @@ async def infer_python_conftest_dependencies(
     )
 
     # And add dependencies on their owners.
-    return InferredDependencies(
-        await Get(
-            Owners, OwnersRequest(extra_conftest_files.snapshot.files, OwnersNotFoundBehavior.error)
-        )
+    owners = await MultiGet(
+        Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
+        for f in extra_conftest_files.snapshot.files
     )
+    return InferredDependencies(itertools.chain.from_iterable(owners))
 
 
 def rules():


### PR DESCRIPTION
### Problem

#10441 caused a performance regression from about 10s to run `./pants dependencies --transitive ::` with inference enabled, to about 22s.

### Solution

Make independent owners requests per file we'd like to find owners, which allows the lookups for each file to be memoized independently.

### Result

`./pants dependencies --transitive ::` takes 15s. Although we are doing more work than before (before #10441, conftest discovery would only happen at `test` time), this is not ideal, and we should do further optimization before launch. But there are a few variables that will impact this soon that make it not the best time to optimize: 1) an intrinisic `PathGlobs->Paths` operation, 2) possibly enabling inference by default, allowing all of the strategies to use the module_mapper.

[ci skip-rust-tests]