### PR TITLE
Fix bad indent of default in option help.

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -14,6 +14,8 @@ from typing import Dict, Iterable, Optional, cast
 import pystache
 import requests
 
+from pants.help.help_info_extracter import to_help_str
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,9 +127,9 @@ class ReferenceGenerator:
         # Process the option data.
 
         def munge_option(option_data):
-            # Munge the default str so we can display it nicely when it's multiline, while
+            # Munge the default so we can display it nicely when it's multiline, while
             # still displaying it inline if it's not.
-            default_str = option_data["default_str"]
+            default_str = to_help_str(option_data["default"])
             escaped_default_str = html.escape(default_str, quote=False)
             if "\n" in default_str:
                 option_data["marked_up_default"] = f"<pre>{escaped_default_str}</pre>"

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -96,9 +96,7 @@ class HelpFormatter:
             f"{indent}{'  ' if i != 0 else ''}{self._maybe_cyan(s)}"
             for i, s in enumerate(wrap(f"{choices}", 96))
         ]
-        default_lines = format_value(
-            RankedValue(Rank.HARDCODED, ohi.default_str), "default: ", indent
-        )
+        default_lines = format_value(RankedValue(Rank.HARDCODED, ohi.default), "default: ", indent)
         if not ohi.value_history:
             # Should never happen, but this keeps mypy happy.
             raise ValueError("No value history - options not parsed.")

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -25,7 +25,6 @@ class OptionHelpFormatterTest(unittest.TestCase):
             config_key="foo",
             typ=bool,
             default=None,
-            default_str="None",
             help="help for foo",
             deprecated_message=None,
             removal_version=None,
@@ -46,12 +45,12 @@ class OptionHelpFormatterTest(unittest.TestCase):
         return lines[4] if choices else lines[3]
 
     def test_format_help(self):
-        default_line = self._format_for_single_option(default="MYDEFAULT", default_str="MYDEFAULT")
+        default_line = self._format_for_single_option(default="MYDEFAULT")
         assert default_line.lstrip() == "default: MYDEFAULT"
 
     def test_format_help_choices(self):
         default_line = self._format_for_single_option(
-            typ=str, default="kiwi", default_str="kiwi", choices=["apple", "banana", "kiwi"]
+            typ=str, default="kiwi", choices=["apple", "banana", "kiwi"]
         )
         assert default_line.lstrip() == "default: kiwi"
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -75,7 +75,6 @@ class OptionHelpInfo:
     config_key: str
     typ: Type
     default: Any
-    default_str: str
     help: str
     deprecated_message: Optional[str]
     removal_version: Optional[str]
@@ -172,7 +171,7 @@ class HelpInfoExtracter:
         )
 
     @staticmethod
-    def compute_default(**kwargs) -> Tuple[Any, str]:
+    def compute_default(**kwargs) -> Any:
         """Compute the default val for help display for an option registered with these kwargs.
 
         Returns a pair (default, stringified default suitable for display).
@@ -188,8 +187,7 @@ class HelpInfoExtracter:
             if ranked_default and ranked_default.value is not None
             else fallback
         )
-        default_str = to_help_str(default)
-        return default, default_str
+        return default
 
     @staticmethod
     def stringify_type(t: Type) -> str:
@@ -303,7 +301,7 @@ class HelpInfoExtracter:
                     display_args.append(f"... -- [{type_str} [{type_str} [...]]]")
 
         typ = kwargs.get("type", str)
-        default, default_str = self.compute_default(**kwargs)
+        default = self.compute_default(**kwargs)
         help_msg = kwargs.get("help", "No help available.")
         removal_version = kwargs.get("removal_version")
         deprecated_message = None
@@ -328,7 +326,6 @@ class HelpInfoExtracter:
             config_key=dest,
             typ=typ,
             default=default,
-            default_str=default_str,
             help=help_msg,
             deprecated_message=deprecated_message,
             removal_version=removal_version,

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 from pants.engine.goal import GoalSubsystem
 from pants.engine.unions import UnionMembership
-from pants.help.help_info_extracter import HelpInfoExtracter
+from pants.help.help_info_extracter import HelpInfoExtracter, to_help_str
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
 from pants.option.options import Options
@@ -108,7 +108,7 @@ def test_default() -> None:
         assert oshi.description == "description"
         assert len(oshi.basic) == 1
         ohi = oshi.basic[0]
-        assert ohi.default_str == expected_default_str
+        assert to_help_str(ohi.default) == expected_default_str
 
     do_test(["--foo"], {"type": bool}, "False")
     do_test(["--foo"], {"type": bool, "default": True}, "True")
@@ -124,18 +124,16 @@ def test_default() -> None:
 
 
 def test_compute_default():
-    def do_test(expected_default, expected_default_str, **kwargs):
+    def do_test(expected_default, **kwargs):
         kwargs["default"] = RankedValue(Rank.HARDCODED, kwargs["default"])
-        assert (expected_default, expected_default_str) == HelpInfoExtracter.compute_default(
-            **kwargs
-        )
+        assert expected_default == HelpInfoExtracter.compute_default(**kwargs)
 
-    do_test(False, "False", type=bool, default=False)
-    do_test(42, "42", type=int, default=42)
-    do_test("foo", "foo", type=str, default="foo")
-    do_test(None, "None", type=str, default=None)
-    do_test([1, 2, 3], "[\n  1,\n  2,\n  3\n]", type=list, member_type=int, default=[1, 2, 3])
-    do_test(LogLevel.INFO, "info", type=LogLevel, default=LogLevel.INFO)
+    do_test(False, type=bool, default=False)
+    do_test(42, type=int, default=42)
+    do_test("foo", type=str, default="foo")
+    do_test(None, type=str, default=None)
+    do_test([1, 2, 3], type=list, member_type=int, default=[1, 2, 3])
+    do_test(LogLevel.INFO, type=LogLevel, default=LogLevel.INFO)
 
 
 def test_deprecated():
@@ -260,7 +258,6 @@ def test_get_all_help_info():
                         },
                         "typ": int,
                         "default": 42,
-                        "default_str": "42",
                         "help": "Option 1",
                         "deprecated_message": None,
                         "removal_version": None,
@@ -292,7 +289,6 @@ def test_get_all_help_info():
                         },
                         "typ": bool,
                         "default": True,
-                        "default_str": "True",
                         "help": "Option 2",
                         "deprecated_message": None,
                         "removal_version": None,
@@ -314,7 +310,6 @@ def test_get_all_help_info():
                         },
                         "typ": str,
                         "default": None,
-                        "default_str": "None",
                         "help": "No help available.",
                         "deprecated_message": None,
                         "removal_version": None,


### PR DESCRIPTION
Gets rid of the precomputed default_str entirely.
It's up to the using sites to convert the string
as needed.

[ci skip-rust]

[ci skip-build-wheels]
