### PR TITLE
Fix `ExternalTool` to use relative paths

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -43,7 +43,7 @@ class Protoc(ExternalTool):
         )
 
     def generate_exe(self, plat: Platform) -> str:
-        return "bin/protoc"
+        return "./bin/protoc"
 
     @property
     def runtime_targets(self) -> List[str]:

--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -35,11 +35,14 @@ class ClocBinary(ExternalTool):
         "1.80|linux |2b23012b1c3c53bd6b9dd43cd6aa75715eed4feb2cb6db56ac3fbbd2dffeac9d|546279",
     ]
 
-    def generate_url(self, plat: Platform) -> str:
+    def generate_url(self, _: Platform) -> str:
         return (
             f"https://github.com/AlDanial/cloc/releases/download/{self.version}/"
             f"cloc-{self.version}.pl"
         )
+
+    def generate_exe(self, _: Platform) -> str:
+        return f"./cloc-{self.version}.pl"
 
 
 class CountLinesOfCodeSubsystem(GoalSubsystem):

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -30,8 +30,11 @@ class PexBin(ExternalTool):
         for plat in ["darwin", "linux "]
     ]
 
-    def generate_url(self, plat: Platform) -> str:
+    def generate_url(self, _: Platform) -> str:
         return f"https://github.com/pantsbuild/pex/releases/download/{self.version}/pex"
+
+    def generate_exe(self, _: Platform) -> str:
+        return "./pex"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -54,23 +54,16 @@ class ExternalTool(Subsystem):
             ...
 
         def generate_exe(self, plat: Platform) -> str:
-            ...
+            return "./path-to/binary
 
     @rule
-    def my_rule(my_external_tool: MyExternalTool):
-      downloaded_tool = await Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        my_external_tool.get_request(Platform.current)
-      )
-
-    ...
-    def rules():
-      return [my_rule, SubsystemRule(MyExternalTool)]
-
-
-    A lightweight replacement for the code in binary_tool.py and binary_util.py,
-    which can be deprecated in favor of this.
+    def my_rule(my_external_tool: MyExternalTool) -> Foo:
+        downloaded_tool = await Get(
+            DownloadedExternalTool,
+            ExternalToolRequest,
+            my_external_tool.get_request(Platform.current)
+        )
+        ...
     """
 
     # The default values for --version and --known-versions.
@@ -140,15 +133,13 @@ class ExternalTool(Subsystem):
         os and arch default to those of the current system.
 
         Implementations should raise ExternalToolError if they cannot resolve the arguments
-        to a URL.  The raised exception need not have a message - a sensible one will be generated.
+        to a URL. The raised exception need not have a message - a sensible one will be generated.
         """
 
+    @abstractmethod
     def generate_exe(self, plat: Platform) -> str:
-        """Returns the archive path to the given version of the tool.
-
-        If the tool is downloaded directly, not in an archive, this can be left unimplemented.
-        """
-        return ""
+        """Returns the relative path in the downloaded archive to the given version of the tool,
+        e.g. `./bin/protoc`."""
 
     def get_request(self, plat: Platform) -> ExternalToolRequest:
         """Generate a request for this tool."""
@@ -164,7 +155,7 @@ class ExternalTool(Subsystem):
                 digest = Digest(fingerprint=sha256, serialized_bytes_length=int(length))
                 try:
                     url = self.generate_url(plat)
-                    exe = self.generate_exe(plat) or url.rsplit("/", 1)[-1]
+                    exe = self.generate_exe(plat)
                 except ExternalToolError as e:
                     raise ExternalToolError(
                         f"Couldn't find {self.name} version {self.version} on {plat.value}"


### PR DESCRIPTION
Before, we weren't prefixing the `exe` path with `./`, so the process would end up searching both for a local file and also on the `$PATH`. (This searching of `$PATH` is the same mechanism that allows us to run `python` for Python processes).

While this might not end up being an issue in most cases, it is less tight than we'd like. For example, it is possible for the user to have `pex` discoverable on their PATH already.

[ci skip-build-wheels]
[ci skip-rust]