### PR TITLE
Render all frames of a failure in Engine tracebacks

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -226,6 +226,9 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
                 """
                 1 Exception encountered:
 
+                Engine traceback:
+                  in select
+                  in pants.engine.internals.engine_test.nested_raise
                 Traceback (most recent call last):
                   File LOCATION-INFO, in nested_raise
                     fn_raises(x)

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -322,6 +322,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
                  1 Exception encountered:
 
                  Engine traceback:
+                   in select
                    in Nested raise
                  Traceback (most recent call last):
                    File LOCATION-INFO, in nested_raise

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1150,8 +1150,11 @@ impl Node for NodeKey {
 
     let user_facing_name = self.user_facing_name();
     let workunit_name = self.workunit_name();
+    let failure_name = user_facing_name
+      .clone()
+      .unwrap_or_else(|| workunit_name.clone());
     let metadata = WorkunitMetadata {
-      desc: user_facing_name.clone(),
+      desc: user_facing_name,
       message: None,
       level: self.workunit_level(),
       blocked: false,
@@ -1220,9 +1223,7 @@ impl Node for NodeKey {
         }
       };
 
-      if let Some(user_facing_name) = user_facing_name {
-        result = result.map_err(|failure| failure.with_pushed_frame(&user_facing_name));
-      }
+      result = result.map_err(|failure| failure.with_pushed_frame(&failure_name));
 
       // If both the Node and the watch failed, prefer the Node's error message.
       match (&result, maybe_watch) {


### PR DESCRIPTION
### Problem

Currently only workunits with user-visible descriptions will be rendered in engine tracebacks, and this inhibits debugging.

### Solution

Since `--print-exception-stacktrace` is disabled by default, we can safely be more specific, and render the workunit name (ie, rule name) if a workunit does not have a description.

### Result

```
Engine traceback:
  in `dependencies` goal
Traceback (most recent call last):
  <snip>
```
becomes
```
Engine traceback:
  in select
  in `dependencies` goal
  in pants.engine.internals.graph.resolve_targets
  in pants.engine.internals.graph.resolve_target
  in pants.engine.internals.graph.generate_subtargets
  in pants.engine.internals.build_files.find_target_adaptor
Traceback (most recent call last):
  <snip>
```

[ci skip-build-wheels]