### PR TITLE
Targets act as aliases for their files

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -35,8 +35,6 @@ async def map_addresses_to_dependees() -> AddressToDependees:
     address_to_dependees = defaultdict(set)
     for tgt, dependencies in zip(all_explicit_targets, dependencies_per_target):
         for dependency in dependencies:
-            # TODO(#10354): teach dependees how to work with generated subtargets.
-            dependency = dependency.maybe_convert_to_base_target()
             address_to_dependees[dependency].add(tgt.address)
     return AddressToDependees(
         FrozenDict(
@@ -55,7 +53,7 @@ class DependeesRequest:
     def __init__(
         self, addresses: Iterable[Address], *, transitive: bool, include_roots: bool
     ) -> None:
-        self.addresses = FrozenOrderedSet(addr.maybe_convert_to_base_target() for addr in addresses)
+        self.addresses = FrozenOrderedSet(addresses)
         self.transitive = transitive
         self.include_roots = include_roots
 

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import Dependencies as DependenciesField
-from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets
+from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets, UnexpandedTargets
 
 
 class DependencyType(Enum):
@@ -67,7 +67,7 @@ async def dependencies(
         transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
         targets = Targets(transitive_targets.dependencies)
     else:
-        target_roots = await Get(Targets, Addresses, addresses)
+        target_roots = await Get(UnexpandedTargets, Addresses, addresses)
         dependencies_per_target_root = await MultiGet(
             Get(Targets, DependenciesRequest(tgt.get(DependenciesField))) for tgt in target_roots
         )

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     Target,
     Targets,
     TransitiveTargets,
+    UnexpandedTargets,
 )
 
 
@@ -84,6 +85,8 @@ async def file_deps(
     if filedeps_subsystem.transitive:
         transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
         targets = transitive_targets.closure
+    elif filedeps_subsystem.globs:
+        targets = await Get(UnexpandedTargets, Addresses, addresses)
     else:
         targets = await Get(Targets, Addresses, addresses)
 

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -13,7 +13,7 @@ from pants.engine.target import (
     RegisteredTargetTypes,
     Tags,
     Target,
-    Targets,
+    UnexpandedTargets,
     UnrecognizedTargetTypeException,
 )
 from pants.util.filtering import and_filters, create_filters
@@ -113,7 +113,7 @@ TargetFilter = Callable[[Target], bool]
 
 @goal_rule
 def filter_targets(
-    targets: Targets,
+    targets: UnexpandedTargets,
     filter_subsystem: FilterSubsystem,
     console: Console,
     registered_target_types: RegisteredTargetTypes,

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -7,7 +7,7 @@ from pants.engine.addresses import Address, Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, collect_rules, goal_rule
-from pants.engine.target import DescriptionField, ProvidesField, Targets
+from pants.engine.target import DescriptionField, ProvidesField, UnexpandedTargets
 
 
 class ListSubsystem(LineOriented, GoalSubsystem):
@@ -76,7 +76,7 @@ async def list_targets(
         )
 
     if list_subsystem.provides:
-        targets = await Get(Targets, Addresses, addresses)
+        targets = await Get(UnexpandedTargets, Addresses, addresses)
         addresses_with_provide_artifacts = {
             tgt.address: tgt[ProvidesField].value
             for tgt in targets
@@ -88,7 +88,7 @@ async def list_targets(
         return List(exit_code=0)
 
     if list_subsystem.documented:
-        targets = await Get(Targets, Addresses, addresses)
+        targets = await Get(UnexpandedTargets, Addresses, addresses)
         addresses_with_descriptions = cast(
             Dict[Address, str],
             {

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, cast
 from pants.backend.project_info.list_targets import ListSubsystem, list_targets
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.engine.addresses import Address, Addresses
-from pants.engine.target import DescriptionField, ProvidesField, Target, Targets
+from pants.engine.target import DescriptionField, ProvidesField, Target, UnexpandedTargets
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
 
 
@@ -38,7 +38,13 @@ def run_goal(
             ),
             console,
         ],
-        mock_gets=[MockGet(product_type=Targets, subject_type=Addresses, mock=lambda _: targets)],
+        mock_gets=[
+            MockGet(
+                product_type=UnexpandedTargets,
+                subject_type=Addresses,
+                mock=lambda _: UnexpandedTargets(targets),
+            )
+        ],
     )
     return cast(str, console.stdout.getvalue()), cast(str, console.stderr.getvalue())
 

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -59,8 +59,8 @@ class FirstPartyModuleToAddressMapping:
 
 @rule
 async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMapping:
-    all_explicit_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    candidate_targets = tuple(tgt for tgt in all_explicit_targets if tgt.has_field(PythonSources))
+    all_expanded_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
+    candidate_targets = tuple(tgt for tgt in all_expanded_targets if tgt.has_field(PythonSources))
     stripped_sources_per_explicit_target = await MultiGet(
         Get(StrippedSourceFiles, SourceFilesRequest([tgt[PythonSources]]))
         for tgt in candidate_targets

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -11,12 +11,7 @@ from pants.core.util_rules.determine_source_files import SourceFilesRequest
 from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    HydratedSources,
-    HydrateSourcesRequest,
-    Targets,
-    generate_subtarget_address,
-)
+from pants.engine.target import Targets
 from pants.util.frozendict import FrozenDict
 
 
@@ -65,35 +60,21 @@ class FirstPartyModuleToAddressMapping:
 @rule
 async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMapping:
     all_explicit_targets = await Get(Targets, AddressSpecs([DescendantAddresses("")]))
-    candidate_explicit_targets = tuple(
-        tgt for tgt in all_explicit_targets if tgt.has_field(PythonSources)
-    )
-    unstripped_sources_per_explicit_target = await MultiGet(
-        Get(HydratedSources, HydrateSourcesRequest(tgt[PythonSources]))
-        for tgt in candidate_explicit_targets
-    )
+    candidate_targets = tuple(tgt for tgt in all_explicit_targets if tgt.has_field(PythonSources))
     stripped_sources_per_explicit_target = await MultiGet(
         Get(StrippedSourceFiles, SourceFilesRequest([tgt[PythonSources]]))
-        for tgt in candidate_explicit_targets
+        for tgt in candidate_targets
     )
 
     modules_to_addresses: Dict[str, Address] = {}
     modules_with_multiple_owners: Set[str] = set()
-    for explicit_tgt, unstripped_sources, stripped_sources in zip(
-        candidate_explicit_targets,
-        unstripped_sources_per_explicit_target,
-        stripped_sources_per_explicit_target,
-    ):
-        for unstripped_f, stripped_f in zip(
-            unstripped_sources.snapshot.files, stripped_sources.snapshot.files
-        ):
+    for tgt, stripped_sources in zip(candidate_targets, stripped_sources_per_explicit_target):
+        for stripped_f in stripped_sources.snapshot.files:
             module = PythonModule.create_from_stripped_path(PurePath(stripped_f)).module
             if module in modules_to_addresses:
                 modules_with_multiple_owners.add(module)
             else:
-                modules_to_addresses[module] = generate_subtarget_address(
-                    explicit_tgt.address, full_file_name=unstripped_f
-                )
+                modules_to_addresses[module] = tgt.address
 
     # Remove modules with ambiguous owners.
     for module in modules_with_multiple_owners:

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -156,7 +156,9 @@ class ModuleMapperTest(TestBase):
                 """
             ),
         )
-        result = self.request_single_product(ThirdPartyModuleToAddressMapping, Params())
+        result = self.request_single_product(
+            ThirdPartyModuleToAddressMapping, Params(create_options_bootstrapper())
+        )
         assert result.mapping == FrozenDict(
             {
                 "colors": Address.parse("3rdparty/python:ansicolors"),

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -101,9 +101,21 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        generated_subtarget_address = Address("src/python", relative_file_path="f2.py")
+        # NB: We do not infer `src/python/app.py`, even though it's used by `src/python/f2.py`,
+        # because it is part of the requested address.
+        normal_address = Address("src/python")
+        assert run_dep_inference(normal_address) == InferredDependencies(
+            [
+                Address("3rdparty/python", target_name="Django"),
+                Address("src/python/util", relative_file_path="dep.py", target_name="util"),
+            ]
+        )
+
+        generated_subtarget_address = Address(
+            "src/python", relative_file_path="f2.py", target_name="python"
+        )
         assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
-            [Address("src/python", relative_file_path="app.py")]
+            [Address("src/python", relative_file_path="app.py", target_name="python")]
         )
 
     def test_infer_python_inits(self) -> None:
@@ -127,12 +139,10 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferInitDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        assert run_dep_inference(
-            Address("src/python/root/mid/leaf", relative_file_path="__init__.py")
-        ) == InferredDependencies(
+        assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
             [
-                Address("src/python/root", relative_file_path="__init__.py"),
-                Address("src/python/root/mid", relative_file_path="__init__.py"),
+                Address("src/python/root", relative_file_path="__init__.py", target_name="root"),
+                Address("src/python/root/mid", relative_file_path="__init__.py", target_name="mid"),
             ]
         )
 
@@ -158,12 +168,9 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferConftestDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        assert run_dep_inference(
-            Address("src/python/root/mid/leaf", relative_file_path="this_is_a_test.py")
-        ) == InferredDependencies(
+        assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
             [
-                Address("src/python/root", relative_file_path="conftest.py"),
-                Address("src/python/root/mid", relative_file_path="conftest.py"),
-                Address("src/python/root/mid/leaf", relative_file_path="conftest.py"),
+                Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
+                Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),
             ]
         )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -101,21 +101,9 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        # NB: We do not infer `src/python/app.py`, even though it's used by `src/python/f2.py`,
-        # because it is part of the requested address.
-        normal_address = Address("src/python")
-        assert run_dep_inference(normal_address) == InferredDependencies(
-            [
-                Address("3rdparty/python", target_name="Django"),
-                Address("src/python/util", relative_file_path="dep.py", target_name="util"),
-            ]
-        )
-
-        generated_subtarget_address = Address(
-            "src/python", relative_file_path="f2.py", target_name="python"
-        )
+        generated_subtarget_address = Address("src/python", relative_file_path="f2.py")
         assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
-            [Address("src/python", relative_file_path="app.py", target_name="python")]
+            [Address("src/python", relative_file_path="app.py")]
         )
 
     def test_infer_python_inits(self) -> None:
@@ -139,10 +127,12 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferInitDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+        assert run_dep_inference(
+            Address("src/python/root/mid/leaf", relative_file_path="__init__.py")
+        ) == InferredDependencies(
             [
-                Address("src/python/root", relative_file_path="__init__.py", target_name="root"),
-                Address("src/python/root/mid", relative_file_path="__init__.py", target_name="mid"),
+                Address("src/python/root", relative_file_path="__init__.py"),
+                Address("src/python/root/mid", relative_file_path="__init__.py"),
             ]
         )
 
@@ -168,9 +158,12 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferConftestDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+        assert run_dep_inference(
+            Address("src/python/root/mid/leaf", relative_file_path="this_is_a_test.py")
+        ) == InferredDependencies(
             [
-                Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
-                Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),
+                Address("src/python/root", relative_file_path="conftest.py"),
+                Address("src/python/root/mid", relative_file_path="conftest.py"),
+                Address("src/python/root/mid/leaf", relative_file_path="conftest.py"),
             ]
         )

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -103,6 +103,7 @@ class TestGenerateChroot(TestSetupPyBase):
         assert len(ex.wrapped_exceptions) == 1
         assert type(ex.wrapped_exceptions[0]) == exc_cls
 
+    @pytest.mark.skip("TODO: see https://github.com/pantsbuild/pants/issues/10564")
     def test_generate_chroot(self) -> None:
         self.create_file(
             "src/python/foo/bar/baz/BUILD",

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -7,7 +7,7 @@ These are always activated and cannot be disabled.
 """
 
 from pants.core.goals import binary, fmt, lint, repl, run, test, typecheck
-from pants.core.target_types import Files, GenericTarget, Resources
+from pants.core.target_types import Files, Resources, TargetAlias
 from pants.core.util_rules import (
     archive,
     determine_source_files,
@@ -43,4 +43,4 @@ def rules():
 
 
 def target_types():
-    return [Files, GenericTarget, Resources]
+    return [Files, TargetAlias, Resources]

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -7,7 +7,7 @@ These are always activated and cannot be disabled.
 """
 
 from pants.core.goals import binary, fmt, lint, repl, run, test, typecheck
-from pants.core.target_types import Files, Resources, TargetAlias
+from pants.core.target_types import Files, GenericTarget, Resources
 from pants.core.util_rules import (
     archive,
     determine_source_files,
@@ -43,4 +43,4 @@ def rules():
 
 
 def target_types():
-    return [Files, TargetAlias, Resources]
+    return [Files, GenericTarget, Resources]

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -52,11 +52,11 @@ class Resources(Target):
 # -----------------------------------------------------------------------------------------------
 
 
-class GenericTarget(Target):
+class TargetAlias(Target):
     """A generic target with no specific target type.
 
     This is useful for aggregate targets: https://www.pantsbuild.org/target_aggregate.html.
     """
 
     alias = "target"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, Sources)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies)

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -52,10 +52,11 @@ class Resources(Target):
 # -----------------------------------------------------------------------------------------------
 
 
-class TargetAlias(Target):
+class GenericTarget(Target):
     """A generic target with no specific target type.
 
-    This is useful for aggregate targets: https://www.pantsbuild.org/target_aggregate.html.
+    This can be used as a generic "bag of dependencies", i.e. you can group several different
+    targets into one single target so that your other targets only need to depend on one thing.
     """
 
     alias = "target"

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -142,6 +142,10 @@ async def find_build_files(addresses: Addresses) -> BuildFileAddresses:
 @rule
 async def find_target_adaptor(address: Address) -> TargetAdaptor:
     """Hydrate a TargetAdaptor so that it may be converted into the Target API."""
+    if not address.is_base_target:
+        raise ValueError(
+            f"Subtargets are not resident in BUILD files, and so do not have TargetAdaptors: {address}"
+        )
     address_family = await Get(AddressFamily, Dir(address.spec_path))
     target_adaptor = address_family.addressable_for_address(address)
     if target_adaptor is None:

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -149,7 +149,7 @@ class GraphTest(TestBase):
             Params(Addresses([Address("", target_name="t2")]), create_options_bootstrapper()),
         )
         assert len(result.roots) == 1
-        assert result.roots[0].address == Address("", target_name="t2")
+        assert result.roots[0].address == Address("", relative_file_path="t2.txt", target_name="t2")
         assert [tgt.address for tgt in result.dependencies] == [
             Address("", relative_file_path="t1.txt", target_name="t1"),
             Address("", relative_file_path="dep.txt", target_name="dep"),
@@ -292,12 +292,11 @@ class TestOwners(TestBase):
         # For files that do exist, we should still use a generated subtarget, though.
         result = self.request_single_product(Owners, OwnersRequest(("demo/f.txt",)))
         assert result == Owners([Address("demo", relative_file_path="f.txt", target_name="demo")])
-        # However, if a sibling file must use the original target, then we should always use
-        # the original target to avoid redundancy.
+        # However, if a sibling file uses the original target, then both should be used.
         result = self.request_single_product(
             Owners, OwnersRequest(("demo/f.txt", "demo/deleted.txt"))
         )
-        assert result == Owners([Address("demo", target_name="demo")])
+        assert result == Owners([Address("demo", relative_file_path="f.txt"), Address("demo")])
 
     def test_owners_multiple_owners(self) -> None:
         """Even if there are multiple owners of the same file, we still use generated subtargets."""
@@ -441,16 +440,17 @@ class TestSpecsToAddresses(TestBase):
         assert not glob_file_result
 
     def test_resolve_addresses(self) -> None:
-        """This tests that we correctly merge addresses resolved from address specs with those
-        resolved from filesystem specs."""
+        """This tests that we correctly handle resolving from both address and filesystem specs."""
         self.create_file("fs_spec/f.txt")
         self.add_to_build_file("fs_spec", "target(sources=['f.txt'])")
         self.create_file("address_spec/f.txt")
         self.add_to_build_file("address_spec", "target(sources=['f.txt'])")
         no_interaction_specs = ["fs_spec/f.txt", "address_spec:address_spec"]
 
-        # If a generated subtarget's original base target is already included via an address spec,
-        # then we should not include the generated subtarget because it would be redundant.
+        # If a generated subtarget's original base target is included via an address spec,
+        # we will still include the generated subtarget for consistency. When we expand Targets
+        # into their base targets this redundancy is removed, but during Address expansion we
+        # get literal matches.
         self.create_files("multiple_files", ["f1.txt", "f2.txt"])
         self.add_to_build_file("multiple_files", "target(sources=['*.txt'])")
         multiple_files_specs = ["multiple_files/f2.txt", "multiple_files:multiple_files"]
@@ -461,16 +461,18 @@ class TestSpecsToAddresses(TestBase):
         )
         assert set(result) == {
             AddressWithOrigin(
-                Address("fs_spec", relative_file_path="f.txt", target_name="fs_spec"),
+                Address("fs_spec", relative_file_path="f.txt"),
                 origin=FilesystemLiteralSpec("fs_spec/f.txt"),
             ),
             AddressWithOrigin(
-                Address("address_spec", target_name="address_spec"),
-                origin=SingleAddress("address_spec", "address_spec"),
+                Address("address_spec"), origin=SingleAddress("address_spec", "address_spec"),
             ),
             AddressWithOrigin(
-                Address("multiple_files", target_name="multiple_files"),
-                origin=SingleAddress("multiple_files", "multiple_files"),
+                Address("multiple_files"), origin=SingleAddress("multiple_files", "multiple_files"),
+            ),
+            AddressWithOrigin(
+                Address("multiple_files", relative_file_path="f2.txt"),
+                origin=FilesystemLiteralSpec(file="multiple_files/f2.txt"),
             ),
         }
 
@@ -991,7 +993,7 @@ class TestDependencies(TestBase):
             Addresses,
             Params(DependenciesRequest(target[Dependencies]), create_options_bootstrapper()),
         )
-        assert result == Addresses(sorted(expected))
+        assert sorted(result) == sorted(expected)
 
     def test_normal_resolution(self) -> None:
         self.add_to_build_file(
@@ -1084,8 +1086,9 @@ class TestDependencies(TestBase):
         """We test that dependency inference works generally and that we merge it correctly with
         explicitly provided dependencies.
 
-        If dep inference returns a generated subtarget, but the original owning target was
-        explicitly provided, then we should not use the generated subtarget.
+        For consistency, dep inference does not merge generated subtargets with base targets: if
+        both are inferred, expansion to Targets will remove the redundancy while converting to
+        subtargets.
         """
         self.create_files(
             "",
@@ -1155,6 +1158,13 @@ class TestDependencies(TestBase):
                 Address("", relative_file_path="inferred2.st", target_name="inferred2"),
                 Address("", target_name="inferred_and_provided1"),
                 Address("", target_name="inferred_and_provided2"),
+                Address(
+                    "",
+                    relative_file_path="inferred_and_provided2.st",
+                    target_name="inferred_and_provided2",
+                ),
+                Address("demo", relative_file_path="f1.st"),
+                Address("demo", relative_file_path="f2.st"),
             ],
         )
 
@@ -1173,5 +1183,10 @@ class TestDependencies(TestBase):
             expected=[
                 Address("", target_name="inferred_and_provided1"),
                 Address("", target_name="inferred_and_provided2"),
+                Address(
+                    "",
+                    relative_file_path="inferred_and_provided2.st",
+                    target_name="inferred_and_provided2",
+                ),
             ],
         )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -526,6 +526,14 @@ class Targets(Collection[Target]):
         return self[0]
 
 
+class UnexpandedTargets(Collection[Target]):
+    """Like `Targets`, but will not contain the expansion of `TargetAlias` instances."""
+
+    def expect_single(self) -> Target:
+        assert_single_address([tgt.address for tgt in self])
+        return self[0]
+
+
 class TargetsWithOrigins(Collection[TargetWithOrigin]):
     """A heterogeneous collection of instances of Target subclasses with the original Spec used to
     resolve the target.
@@ -533,6 +541,18 @@ class TargetsWithOrigins(Collection[TargetWithOrigin]):
     See the docstring for `Targets` for an explanation of the `Target`s being heterogeneous and how
     you should filter out the targets you care about.
     """
+
+    def expect_single(self) -> TargetWithOrigin:
+        assert_single_address([tgt_with_origin.target.address for tgt_with_origin in self])
+        return self[0]
+
+    @memoized_property
+    def targets(self) -> Tuple[Target, ...]:
+        return tuple(tgt_with_origin.target for tgt_with_origin in self)
+
+
+class UnexpandedTargetsWithOrigins(Collection[TargetWithOrigin]):
+    """Like `TargetsWithOrigins`, but will not contain the expansion of `TargetAlias` instances."""
 
     def expect_single(self) -> TargetWithOrigin:
         assert_single_address([tgt_with_origin.target.address for tgt_with_origin in self])

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -481,6 +481,15 @@ class Target(ABC):
 
 
 @dataclass(frozen=True)
+class Subtargets:
+    # The base target from which the subtargets were extracted. Depends on all of its subtargets.
+    base: Target
+    # The subtargets, one per file that was owned by the base target, with filenames relative to
+    # the spec_path of the base target.
+    subtargets: Dict[str, Target]
+
+
+@dataclass(frozen=True)
 class WrappedTarget:
     """A light wrapper to encapsulate all the distinct `Target` subclasses into a single type.
 
@@ -590,6 +599,8 @@ def generate_subtarget_address(base_target_address: Address, *, full_file_name: 
 
     See generate_subtarget().
     """
+    if not base_target_address.is_base_target:
+        raise ValueError(f"Cannot generate file targets for a file Address: {base_target_address}")
     original_spec_path = base_target_address.spec_path
     relative_file_path = PurePath(full_file_name).relative_to(original_spec_path).as_posix()
     return Address(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -632,7 +632,15 @@ def generate_subtarget_address(base_target_address: Address, *, full_file_name: 
 _Tgt = TypeVar("_Tgt", bound=Target)
 
 
-def generate_subtarget(base_target: _Tgt, *, full_file_name: str) -> _Tgt:
+def generate_subtarget(
+    base_target: _Tgt,
+    *,
+    full_file_name: str,
+    # NB: `union_membership` is only optional to facilitate tests. In production, we should
+    # always provide this parameter. This should be safe to do because production code should
+    # rarely directly instantiate Targets and should instead use the engine to request them.
+    union_membership: Optional[UnionMembership] = None,
+) -> _Tgt:
     """Generate a new target with the exact same metadata as the original, except for the `sources`
     field only referring to the single file `full_file_name` and with a new address.
 
@@ -682,6 +690,7 @@ def generate_subtarget(base_target: _Tgt, *, full_file_name: str) -> _Tgt:
     return target_cls(
         generated_target_fields,
         address=generate_subtarget_address(base_target.address, full_file_name=full_file_name),
+        union_membership=union_membership,
     )
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -451,14 +451,21 @@ def test_generate_subtarget() -> None:
         == expected_subdir_address
     )
 
-    class NoSourcesTgt(Target):
-        alias = "no_sources_tgt"
+    # The full_file_name must match the filespec of the base target's Sources field.
+    with pytest.raises(ValueError) as exc:
+        generate_subtarget(single_source_tgt, full_file_name="src/fortran/fake_file.f95")
+    assert "does not match a file src/fortran/fake_file.f95" in str(exc.value)
+
+    class MissingFieldsTarget(Target):
+        alias = "missing_fields_tgt"
         core_fields = (Tags,)
 
-    no_sources_tgt = NoSourcesTgt({Tags.alias: ["demo"]}, address=Address.parse("//:no_sources"))
+    missing_fields_tgt = MissingFieldsTarget(
+        {Tags.alias: ["demo"]}, address=Address("", target_name="missing_fields")
+    )
     with pytest.raises(ValueError) as exc:
-        generate_subtarget(no_sources_tgt, full_file_name="fake.txt")
-    assert "does not support dependencies" in str(exc.value)
+        generate_subtarget(missing_fields_tgt, full_file_name="fake.txt")
+    assert "does not have both a `dependencies` and `sources` field" in str(exc.value)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -416,7 +416,7 @@ def test_required_field() -> None:
 def test_generate_subtarget() -> None:
     class MockTarget(Target):
         alias = "mock_target"
-        core_fields = (Tags, Sources)
+        core_fields = (Dependencies, Tags, Sources)
 
     # When the target already only has a single source, the result should be the same, except for a
     # different address.
@@ -456,16 +456,9 @@ def test_generate_subtarget() -> None:
         core_fields = (Tags,)
 
     no_sources_tgt = NoSourcesTgt({Tags.alias: ["demo"]}, address=Address.parse("//:no_sources"))
-    expected_no_sources_address = Address(
-        "", relative_file_path="fake.txt", target_name="no_sources"
-    )
-    assert generate_subtarget(no_sources_tgt, full_file_name="fake.txt") == NoSourcesTgt(
-        {Tags.alias: ["demo"]}, address=expected_no_sources_address
-    )
-    assert (
-        generate_subtarget_address(no_sources_tgt.address, full_file_name="fake.txt")
-        == expected_no_sources_address
-    )
+    with pytest.raises(ValueError) as exc:
+        generate_subtarget(no_sources_tgt, full_file_name="fake.txt")
+    assert "does not support dependencies" in str(exc.value)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -6,6 +6,11 @@ python_library()
 python_tests(
   name="tests",
   sources=['*_test.py', '!*_integration_test.py'],
+  dependencies=[
+    # Used by `options_bootstrapper_test` and `config_test`.
+    '//:build_root',
+    '//:pants_toml',
+  ],
   timeout=300,
 )
 

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -103,7 +103,7 @@ class GoalRuleTestBase(TestBase):
         # ['1', '2', '3', ''] - always an extra empty string if the separator is properly always
         # a suffix and not applied just between entries.
         result = self.execute_rule(**kwargs)
-        assert sorted([*output, ""]) == sorted(result.stdout.split(sep))
+        self.assertEqual(sorted([*output, ""]), sorted(result.stdout.split(sep)))
 
     def assert_console_output(self, *output, **kwargs) -> None:
         """Verifies the expected output entries are emitted by the goal rule.
@@ -114,7 +114,7 @@ class GoalRuleTestBase(TestBase):
         **kwargs: additional kwargs passed to execute_rule.
         """
         result = self.execute_rule(**kwargs)
-        assert sorted(output) == sorted(result.stdout.splitlines())
+        self.assertEqual(sorted(output), sorted(result.stdout.splitlines()))
 
     def assert_console_output_contains(self, output, **kwargs) -> None:
         """Verifies the expected output string is emitted by the goal rule.

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -4,6 +4,10 @@
 python_tests(
   name='tests',
   timeout = 270,
+  dependencies=[
+    # Used by `test_options_initializer`.
+    '//:build_root',
+  ],
 )
 
 python_library()

--- a/tests/python/pants_test/integration/changed_integration_test.py
+++ b/tests/python/pants_test/integration/changed_integration_test.py
@@ -135,24 +135,30 @@ def create_isolated_git_repo():
 
 class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
 
-    # TODO(#10355): Once we teach `dependees` to understand generated subtargets, some of these
-    #  should change to be generated subtargets.
     TEST_MAPPING = {
         # A `python_binary` with `sources=['file.name']`.
         "src/python/python_targets/test_binary.py": dict(
             none=["src/python/python_targets/test_binary.py:test"],
-            direct=["src/python/python_targets:test"],
-            transitive=["src/python/python_targets:test"],
+            direct=[
+                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets:test",
+            ],
+            transitive=[
+                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets:test",
+            ],
         ),
         # A `python_library` with `sources=['file.name']`.
         "src/python/python_targets/test_library.py": dict(
             none=["src/python/python_targets/test_library.py:test_library"],
             direct=[
-                "src/python/python_targets:test",
+                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets/test_library.py:test_library",
                 "src/python/python_targets:test_library",
-                "src/python/python_targets:test_library_direct_dependee",
             ],
             transitive=[
+                "src/python/python_targets/test_binary.py:test",
+                "src/python/python_targets/test_library.py:test_library",
                 "src/python/python_targets:test",
                 "src/python/python_targets:test_library",
                 "src/python/python_targets:test_library_direct_dependee",
@@ -165,8 +171,8 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
         # A `python_library` with `sources=['file.name'] .
         "src/python/sources/sources.py": dict(
             none=["src/python/sources/sources.py"],
-            direct=["src/python/sources"],
-            transitive=["src/python/sources"],
+            direct=["src/python/sources", "src/python/sources/sources.py",],
+            transitive=["src/python/sources", "src/python/sources/sources.py",],
         ),
         # An unclaimed source file.
         "src/python/python_targets/test_unclaimed_src.py": dict(none=[], direct=[], transitive=[]),

--- a/tests/python/pants_test/integration/changed_integration_test.py
+++ b/tests/python/pants_test/integration/changed_integration_test.py
@@ -154,6 +154,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
             direct=[
                 "src/python/python_targets/test_binary.py:test",
                 "src/python/python_targets/test_library.py:test_library",
+                "src/python/python_targets:test",
                 "src/python/python_targets:test_library",
             ],
             transitive=[
@@ -283,6 +284,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
             self.assertEqual(stdout_data.strip(), "")
 
     def test_changed_with_deleted_source(self):
+        # TODO: Update to use multiple sources, with only one deleted.
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, "src/python/sources/sources.py"))
             pants_run = self.run_pants(["list", "--changed-since=HEAD"])

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -4,6 +4,7 @@
 python_integration_tests(
   name='tests',
   uses_pants_run=True,
+  timeout=120,
 )
 
 python_library()


### PR DESCRIPTION
### Problem

After extensive discussion, we think that in Pants 2.0, the definition of a target in a BUILD file will be approximately: "some metadata applied to a set of files, which can be used as an alias for those files". This is a fundamental change from the previous definition, which was something like: "a target is a collection of files with metadata that must always be built together".

But as described in #10455 and #10423, when "sub" (aka "file") targets are used inconsistently, it becomes necessary to worry about both:
1. whether a target builds as an atomic unit
2. whether each file in the target builds as an atomic unit

...whereas before file dependencies existed, only the former was necessary.

### Solution

Given the new definition, Pants ever operating on "the target as defined in the BUILD file" as the atomic unit no longer makes sense. Instead, for consistency: files should always be the new atomic unit (with batching applied only where it is possible to do so safely and transparently).

To accomplish this without also making significant changes to the `Target` API, this change adds expansion logic to the creation of `Targets` instances that replaces base targets with their corresponding file/sub targets. Additionally, base targets are adapted to always depend on their subtargets. This means that although all nodes in the build graph are still `Target` objects, post-expansion in `Targets`, each `Target` object will own either zero or one file.

Graph introspection goals mostly continue to operate directly on the targets as defined in BUILD files, and so an `UnexpandedTargets` type is introduced to be used in cases where the BUILD definitions should be used verbatim. Other cases where these are used include:
1. deleted files in `Owners`: a deleted file is matched against `UnexpandedTargets` to ensure that we detect what the owner "would have been" if the file had not been deleted.
2. in the `filedeps` goal, when the `--globs` option is used: it's likely that this case should migrate to a goal that is capable of introspecting the fields of all `Target` objects, possibly in a way that is symmetrical to the `filter` goal.

Unfortunately, this differentiation is not typesafe: both `Targets` and `UnexpandedTargets` contain `Target` objects, but with different guarantees. We will likely want to follow up in the future to adapt the `Target` API to make this case typesafe.

### Result

From a user perspective, the most visible impact of this change will be that a goal like `./pants test` will now _always_ operate per-file. This will mean that it is critically important for us to optimize per-test-run overhead before 2.0, and to work with users to determine whether implementing dynamic batching strategies is necessary.

`dependencies` and `dependees` will now result in both file and target addresses showing up, unless the target has no source files. This will happen even if the user is not using explicit file deps and dep inference.

Fixes #10354, and fixes #10455.