### PR TITLE
Store SpanIds as integers

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -26,7 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-#![type_length_limit = "1303889"]
+#![type_length_limit = "1303894"]
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -373,7 +373,7 @@ impl CommandRunner {
           result_cached,
           "remote execution action scheduling",
           time_span,
-          parent_id.clone(),
+          parent_id,
           &workunit_store,
           WorkunitMetadata::with_level(Level::Debug),
         );
@@ -391,7 +391,7 @@ impl CommandRunner {
           result_cached,
           "remote execution worker input fetching",
           time_span,
-          parent_id.clone(),
+          parent_id,
           &workunit_store,
           WorkunitMetadata::with_level(Level::Debug),
         );
@@ -409,7 +409,7 @@ impl CommandRunner {
           result_cached,
           "remote execution worker command executing",
           time_span,
-          parent_id.clone(),
+          parent_id,
           &workunit_store,
           WorkunitMetadata::with_level(Level::Debug),
         );

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -26,7 +26,7 @@ use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn, Level};
 use protobuf::{self, Message, ProtobufEnum};
 use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
-use workunit_store::{with_workunit, WorkunitMetadata, WorkunitStore};
+use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
 
 use crate::{
   Context, ExecutionStats, FallibleProcessResultWithPlatform, MultiPlatformProcess, Platform,
@@ -841,7 +841,7 @@ fn maybe_add_workunit(
   result_cached: bool,
   name: &str,
   time_span: concrete_time::TimeSpan,
-  parent_id: Option<String>,
+  parent_id: Option<SpanId>,
   workunit_store: &WorkunitStore,
   metadata: WorkunitMetadata,
 ) {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -22,7 +22,7 @@ use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 use testutil::owned_string_vec;
 use tokio::runtime::Handle;
-use workunit_store::{Level, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
+use workunit_store::{Level, SpanId, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 use crate::remote::{digest, CommandRunner, ExecutionError, OperationOrStatus};
 use crate::{
@@ -1708,7 +1708,8 @@ async fn remote_workunits_are_stored() {
     .await
     .unwrap();
 
-  let got_workunits = workunits_with_constant_span_id(&mut workunit_store);
+  let span_id = SpanId::new();
+  let got_workunits = workunits_with_constant_span_id(&mut workunit_store, span_id);
 
   use concrete_time::Duration;
   use concrete_time::TimeSpan;
@@ -1722,7 +1723,7 @@ async fn remote_workunits_are_stored() {
           duration: Duration::new(1, 0),
         }
       },
-      span_id: String::from("ignore"),
+      span_id,
       parent_id: None,
       metadata: WorkunitMetadata::with_level(Level::Debug),
     },
@@ -1734,7 +1735,7 @@ async fn remote_workunits_are_stored() {
           duration: Duration::new(1, 0),
         }
       },
-      span_id: String::from("ignore"),
+      span_id,
       parent_id: None,
       metadata: WorkunitMetadata::with_level(Level::Debug),
     },
@@ -1746,7 +1747,7 @@ async fn remote_workunits_are_stored() {
           duration: Duration::new(1, 0),
         }
       },
-      span_id: String::from("ignore"),
+      span_id,
       parent_id: None,
       metadata: WorkunitMetadata::with_level(Level::Debug),
     },
@@ -1758,7 +1759,7 @@ async fn remote_workunits_are_stored() {
           duration: Duration::new(1, 0),
         }
       },
-      span_id: String::from("ignore"),
+      span_id,
       parent_id: None,
       metadata: WorkunitMetadata::with_level(Level::Debug),
     }
@@ -1989,12 +1990,13 @@ async fn extract_output_files_from_response_no_prefix() {
 
 pub(crate) fn workunits_with_constant_span_id(
   workunit_store: &mut WorkunitStore,
+  span_id: SpanId,
 ) -> HashSet<Workunit> {
   workunit_store.with_latest_workunits(log::Level::Trace, |_, completed_workunits| {
     completed_workunits
       .iter()
       .map(|workunit| Workunit {
-        span_id: String::from("ignore"),
+        span_id,
         ..workunit.clone()
       })
       .collect()

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -804,17 +804,17 @@ fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResult<Valu
     ),
     (
       externs::store_utf8("span_id"),
-      externs::store_utf8(&workunit.span_id),
+      externs::store_utf8(&format!("{}", workunit.span_id)),
     ),
     (
       externs::store_utf8("level"),
       externs::store_utf8(&workunit.metadata.level.to_string()),
     ),
   ];
-  if let Some(parent_id) = &workunit.parent_id {
+  if let Some(parent_id) = workunit.parent_id {
     dict_entries.push((
       externs::store_utf8("parent_id"),
-      externs::store_utf8(parent_id),
+      externs::store_utf8(&format!("{}", parent_id)),
     ));
   }
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -210,8 +210,8 @@ impl StreamingWorkunitData {
       let mut workunit_records = self.workunit_records.lock();
       let mut started_workunits: Vec<Workunit> = vec![];
       for mut started in started_messages.into_iter() {
-        let span_id = started.span_id.clone();
-        workunit_records.insert(span_id.clone(), started.clone());
+        let span_id = started.span_id;
+        workunit_records.insert(span_id, started.clone());
 
         if should_emit(&started) {
           started.parent_id =
@@ -222,7 +222,7 @@ impl StreamingWorkunitData {
 
       let mut completed_workunits: Vec<Workunit> = vec![];
       for (span_id, new_metadata, end_time) in completed_messages.into_iter() {
-        match workunit_records.entry(span_id.clone()) {
+        match workunit_records.entry(span_id) {
           Entry::Vacant(_) => {
             log::warn!("No previously-started workunit found for id: {}", span_id);
             continue;
@@ -243,7 +243,7 @@ impl StreamingWorkunitData {
             if let Some(metadata) = new_metadata {
               workunit.metadata = metadata;
             }
-            workunit_records.insert(span_id.clone(), workunit.clone());
+            workunit_records.insert(span_id, workunit.clone());
 
             if should_emit(&workunit) {
               workunit.parent_id =
@@ -282,14 +282,12 @@ impl HeavyHittersData {
   }
 
   fn add_started_workunit_to_store(started: Workunit, inner_store: &mut HeavyHittersInnerStore) {
-    let span_id = started.span_id.clone();
-    let parent_id = started.parent_id.clone();
+    let span_id = started.span_id;
+    let parent_id = started.parent_id;
 
-    inner_store
-      .workunit_records
-      .insert(span_id.clone(), started);
+    inner_store.workunit_records.insert(span_id, started);
 
-    let child = inner_store.graph.add_node(span_id.clone());
+    let child = inner_store.graph.add_node(span_id);
     inner_store.span_id_to_graph.insert(span_id, child);
     if let Some(parent_id) = parent_id {
       if let Some(parent) = inner_store.span_id_to_graph.get(&parent_id).cloned() {
@@ -306,7 +304,7 @@ impl HeavyHittersData {
   ) {
     use std::collections::hash_map::Entry;
 
-    match inner_store.workunit_records.entry(span_id.clone()) {
+    match inner_store.workunit_records.entry(span_id) {
       Entry::Vacant(_) => {
         log::warn!("No previously-started workunit found for id: {}", span_id);
       }
@@ -365,12 +363,12 @@ impl HeavyHittersData {
     // Initialize the heap with the leaves of the workunit graph.
     let mut queue: BinaryHeap<(Duration, SpanId)> = workunit_graph
       .externals(Direction::Outgoing)
-      .map(|entry| workunit_graph[entry].clone())
+      .map(|entry| workunit_graph[entry])
       .flat_map(|span_id: SpanId| {
         let workunit: Option<&Workunit> = inner.workunit_records.get(&span_id);
         match workunit {
           Some(workunit) if !workunit.metadata.blocked => {
-            duration_for(workunit).map(|d| (d, span_id.clone()))
+            duration_for(workunit).map(|d| (d, span_id))
           }
           _ => None,
         }
@@ -422,7 +420,7 @@ fn first_matched_parent(
     }
 
     // If not, try its parent.
-    span_id = workunit.and_then(|workunit| workunit.parent_id.clone());
+    span_id = workunit.and_then(|workunit| workunit.parent_id);
   }
   None
 }
@@ -484,16 +482,12 @@ impl WorkunitStore {
   }
 
   fn complete_workunit_impl(&self, mut workunit: Workunit, end_time: SystemTime) {
-    let span_id = workunit.span_id.clone();
+    let span_id = workunit.span_id;
     let new_metadata = Some(workunit.metadata.clone());
 
     let tx = self.streaming_workunit_data.msg_tx.lock();
-    tx.send(StoreMsg::Completed(
-      span_id.clone(),
-      new_metadata.clone(),
-      end_time,
-    ))
-    .unwrap();
+    tx.send(StoreMsg::Completed(span_id, new_metadata.clone(), end_time))
+      .unwrap();
 
     if self.rendering_dynamic_ui {
       let tx = self.heavy_hitters_data.msg_tx.lock();
@@ -605,7 +599,7 @@ where
 {
   let mut workunit_state = expect_workunit_state();
   let span_id = SpanId::new();
-  let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id.clone()));
+  let parent_id = std::mem::replace(&mut workunit_state.parent_id, Some(span_id));
   let mut workunit =
     workunit_store.start_workunit(span_id, name, parent_id, initial_metadata.clone());
   scope_task_workunit_state(Some(workunit_state), async move {

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -1,9 +1,9 @@
-use crate::hex_16_digit_string;
+use crate::SpanId;
 
 #[test]
 fn workunit_span_id_has_16_digits_len_hex_format() {
   let number: u64 = 1;
-  let hex_string = hex_16_digit_string(number);
+  let hex_string = SpanId(number).to_string();
   assert_eq!(16, hex_string.len());
   for ch in hex_string.chars() {
     assert!(ch.is_ascii_hexdigit())
@@ -13,12 +13,12 @@ fn workunit_span_id_has_16_digits_len_hex_format() {
 #[test]
 fn hex_16_digit_string_actually_uses_input_number() {
   assert_eq!(
-    hex_16_digit_string(0x_ffff_ffff_ffff_ffff),
+    SpanId(0x_ffff_ffff_ffff_ffff).to_string(),
     "ffffffffffffffff"
   );
-  assert_eq!(hex_16_digit_string(0x_1), "0000000000000001");
+  assert_eq!(SpanId(0x_1).to_string(), "0000000000000001");
   assert_eq!(
-    hex_16_digit_string(0x_0123_4567_89ab_cdef),
+    SpanId(0x_0123_4567_89ab_cdef).to_string(),
     "0123456789abcdef"
   );
 }


### PR DESCRIPTION
### Problem

We currently store `SpanId`s as hex strings (meaning that we have to allocate), but they are always 64 bit random values.

### Solution

Switch the internal representation of a `SpanId` to a newtype wrapping `u64`.

### Result

Less memory usage and allocation.

[ci skip-build-wheels]