### PR TITLE
Restore the missing init injection logic.

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -10,6 +10,7 @@ from pants.backend.awslambda.common.awslambda_common_rules import CreatedAWSLamb
 from pants.backend.awslambda.python.awslambda_python_rules import PythonAwsLambdaFieldSet
 from pants.backend.awslambda.python.awslambda_python_rules import rules as awslambda_python_rules
 from pants.backend.awslambda.python.target_types import PythonAWSLambda
+from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.target_types import PythonLibrary
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
@@ -26,6 +27,8 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
         return (
             *super().rules(),
             *awslambda_python_rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
             RootRule(PythonAwsLambdaFieldSet),
         )
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -9,8 +9,8 @@ from pants.backend.python.dependency_inference import module_mapper
 from pants.backend.python.dependency_inference.import_parser import find_python_imports
 from pants.backend.python.dependency_inference.module_mapper import PythonModule, PythonModuleOwner
 from pants.backend.python.dependency_inference.python_stdlib.combined import combined_stdlib
-from pants.backend.python.rules import inject_ancestor_files
-from pants.backend.python.rules.inject_ancestor_files import AncestorFiles, AncestorFilesRequest
+from pants.backend.python.rules import ancestor_files
+from pants.backend.python.rules.ancestor_files import AncestorFiles, AncestorFilesRequest
 from pants.backend.python.target_types import PythonSources, PythonTestsSources
 from pants.core.util_rules.strip_source_roots import (
     SourceRootStrippedSources,
@@ -171,7 +171,7 @@ async def infer_python_conftest_dependencies(
 def rules():
     return [
         *collect_rules(),
-        *inject_ancestor_files.rules(),
+        *ancestor_files.rules(),
         *module_mapper.rules(),
         UnionRule(InferDependenciesRequest, InferPythonDependencies),
         UnionRule(InferDependenciesRequest, InferInitDependencies),

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -52,7 +52,10 @@ class PythonInference(Subsystem):
             type=bool,
             help=(
                 "Infer a target's dependencies on any __init__.py files existing for the packages "
-                "it is located in (recursively upward in the directory structure)."
+                "it is located in (recursively upward in the directory structure). Note that if "
+                "inference is disabled, empty ancestor __init__.py files will still be included "
+                "even without an explicit dependency, but ones containing any code (even just "
+                "comments) will not, and must be brought in via an explicit dependency."
             ),
         )
         register(

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -8,7 +8,6 @@ from typing import List, Optional
 from pants.backend.python.lint.pylint.plugin_target_type import PylintSourcePlugin
 from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
-from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -46,8 +45,6 @@ class PylintIntegrationTest(ExternalToolTestBase):
         return (
             *super().rules(),
             *pylint_rules(),
-            *ancestor_files.rules(),
-            *missing_init.rules(),
             RootRule(PylintRequest),
         )
 

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from pants.backend.python.lint.pylint.plugin_target_type import PylintSourcePlugin
 from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
+from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -42,7 +43,13 @@ class PylintIntegrationTest(ExternalToolTestBase):
 
     @classmethod
     def rules(cls):
-        return (*super().rules(), *pylint_rules(), RootRule(PylintRequest))
+        return (
+            *super().rules(),
+            *pylint_rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
+            RootRule(PylintRequest),
+        )
 
     def make_target_with_origin(
         self,

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -11,9 +11,10 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
+    ancestor_files,
     coverage,
     create_python_binary,
-    inject_ancestor_files,
+    missing_init,
     pex,
     pex_cli,
     pex_environment,
@@ -53,7 +54,8 @@ def build_file_aliases():
 def rules():
     return (
         *coverage.rules(),
-        *inject_ancestor_files.rules(),
+        *ancestor_files.rules(),
+        *missing_init.rules(),
         *python_sources.rules(),
         *dependency_inference_rules.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/rules/ancestor_files.py
+++ b/src/python/pants/backend/python/rules/ancestor_files.py
@@ -38,6 +38,7 @@ class AncestorFilesRequest:
 class AncestorFiles:
     """Any ancestor files found."""
 
+    # Files in the snapshot are stripped iff the request had sources_stripped=True.
     snapshot: Snapshot
 
 
@@ -87,6 +88,7 @@ async def find_missing_ancestor_files(
 
     # NB: This will intentionally _not_ error on any unmatched globs.
     discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(missing_ancestor_files))
+
     if request.sources_stripped:
         # We must now strip all discovered paths.
         stripped_snapshot = await Get(

--- a/src/python/pants/backend/python/rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/rules/ancestor_files_test.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import json
 from typing import List
 
 from pants.backend.python.rules.ancestor_files import (
@@ -44,9 +43,7 @@ class InjectAncestorFilesTest(TestBase):
             self.make_snapshot({fp: "# declared" for fp in original_declared_files}),
             sources_stripped=declared_files_stripped,
         )
-        bootstrapper = create_options_bootstrapper(
-            args=[f"--source-root-patterns={json.dumps(source_roots)}"]
-        )
+        bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
         result = self.request_single_product(AncestorFiles, Params(request, bootstrapper)).snapshot
         assert list(result.files) == sorted(expected_discovered)
 

--- a/src/python/pants/backend/python/rules/missing_init.py
+++ b/src/python/pants/backend/python/rules/missing_init.py
@@ -46,7 +46,11 @@ async def find_missing_empty_init_files(request: MissingInitRequest) -> MissingI
     extra_init_files_contents = await Get(DigestContents, Digest, extra_init_files.snapshot.digest)
     non_empty = [fc.path for fc in extra_init_files_contents if fc.content]
     if non_empty:
-        err_msg = f"Missing dependencies on non-empty __init__.py files: {','.join(non_empty)}"
+        err_msg = (
+            f"Missing dependencies on non-empty __init__.py files: {','.join(non_empty)}. "
+            f"To fix, either enable dependency inference or add explicit dependencies on these "
+            f"files."
+        )
         # TODO: Note that in the stripped case these paths will be missing their source roots,
         #  which makes this error message slightly less useful to the end user.
         #  Once we overhaul the whole stripped vs. non-stripped confusion, this should be remedied.

--- a/src/python/pants/backend/python/rules/missing_init.py
+++ b/src/python/pants/backend/python/rules/missing_init.py
@@ -1,0 +1,59 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.backend.python.rules.ancestor_files import AncestorFiles, AncestorFilesRequest
+from pants.engine.fs import Digest, DigestContents, Snapshot
+from pants.engine.rules import Get, rule
+
+
+@dataclass(frozen=True)
+class MissingInitRequest:
+    snapshot: Snapshot
+    sources_stripped: bool  # True iff snapshot has already had source roots stripped.
+
+
+@dataclass(frozen=True)
+class MissingInit:
+    """Any missing empty __init__.py files found."""
+
+    snapshot: Snapshot
+
+
+class MissingNonEmptyInitFiles(Exception):
+    pass
+
+
+@rule
+async def find_missing_empty_init_files(request: MissingInitRequest) -> MissingInit:
+    """Find missing empty __init__.py files.
+
+    This is a convenience hack, so that repos that aren't using dep inference don't have
+    to create explicit dependencies on empty ancestor __init__.py files everywhere just
+    so their imports work.
+
+    NB We only apply this convenience if those __init__.py files are empty. If an __init__.py
+    contains code then that code might have dependencies, and you must bring them in via
+    a dependency (explicit or inferred). This is a compromise that reflects the dual role
+    of __init__.py as both "a sentinel file required for imports to work" and "a regular source
+    file that contains code".
+    """
+    extra_init_files = await Get(
+        AncestorFiles,
+        AncestorFilesRequest("__init__.py", request.snapshot, request.sources_stripped),
+    )
+    extra_init_files_contents = await Get(DigestContents, Digest, extra_init_files.snapshot.digest)
+    non_empty = [fc.path for fc in extra_init_files_contents if fc.content]
+    if non_empty:
+        err_msg = f"Missing dependencies on non-empty __init__.py files: {','.join(non_empty)}"
+        # TODO: Note that in the stripped case these paths will be missing their source roots,
+        #  which makes this error message slightly less useful to the end user.
+        #  Once we overhaul the whole stripped vs. non-stripped confusion, this should be remedied.
+        raise MissingNonEmptyInitFiles(err_msg)
+
+    return MissingInit(extra_init_files.snapshot)
+
+
+def rules():
+    return [find_missing_empty_init_files]

--- a/src/python/pants/backend/python/rules/missing_init_test.py
+++ b/src/python/pants/backend/python/rules/missing_init_test.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import json
+
 from typing import List
 
 import pytest
@@ -49,9 +49,7 @@ class InjectInitTest(TestBase):
             self.make_snapshot({fp: "" for fp in original_declared_files}),
             sources_stripped=declared_files_stripped,
         )
-        bootstrapper = create_options_bootstrapper(
-            args=[f"--source-root-patterns={json.dumps(source_roots)}"]
-        )
+        bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
         result = self.request_single_product(MissingInit, Params(request, bootstrapper)).snapshot
         assert list(result.files) == sorted(expected_discovered)
 

--- a/src/python/pants/backend/python/rules/missing_init_test.py
+++ b/src/python/pants/backend/python/rules/missing_init_test.py
@@ -1,0 +1,204 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from typing import List
+
+import pytest
+
+from pants.backend.python.rules import missing_init
+from pants.backend.python.rules.ancestor_files import find_missing_ancestor_files
+from pants.backend.python.rules.missing_init import (
+    MissingInit,
+    MissingInitRequest,
+    MissingNonEmptyInitFiles,
+)
+from pants.core.util_rules import strip_source_roots
+from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.rules import RootRule
+from pants.testutil.engine.util import Params
+from pants.testutil.option.util import create_options_bootstrapper
+from pants.testutil.test_base import TestBase
+
+
+class InjectInitTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            find_missing_ancestor_files,
+            *missing_init.rules(),
+            *strip_source_roots.rules(),
+            RootRule(MissingInitRequest),
+        )
+
+    def assert_injected(
+        self,
+        *,
+        source_roots: List[str],
+        declared_files_stripped: bool,
+        original_declared_files: List[str],
+        original_undeclared_empty_files: List[str],
+        original_undeclared_nonempty_files: List[str],
+        expected_discovered: List[str],
+    ) -> None:
+        for f in original_undeclared_empty_files:
+            self.create_file(f, "")
+        for f in original_undeclared_nonempty_files:
+            self.create_file(f, "# nonempty")
+        request = MissingInitRequest(
+            self.make_snapshot({fp: "" for fp in original_declared_files}),
+            sources_stripped=declared_files_stripped,
+        )
+        bootstrapper = create_options_bootstrapper(
+            args=[f"--source-root-patterns={json.dumps(source_roots)}"]
+        )
+        result = self.request_single_product(MissingInit, Params(request, bootstrapper)).snapshot
+        assert list(result.files) == sorted(expected_discovered)
+
+    def test_unstripped(self) -> None:
+        self.assert_injected(
+            source_roots=["src/python", "tests/python"],
+            declared_files_stripped=False,
+            original_declared_files=[
+                "src/python/project/lib.py",
+                "src/python/project/subdir/__init__.py",
+                "src/python/project/subdir/lib.py",
+                "src/python/no_init/lib.py",
+            ],
+            original_undeclared_empty_files=[
+                "src/python/project/__init__.py",
+                "tests/python/project/__init__.py",
+            ],
+            original_undeclared_nonempty_files=[],
+            expected_discovered=["src/python/project/__init__.py"],
+        )
+
+    def test_stripped(self) -> None:
+        self.assert_injected(
+            source_roots=["src/python", "tests/python"],
+            declared_files_stripped=True,
+            original_declared_files=[
+                "project/lib.py",
+                "project/subdir/lib.py",
+                "project/subdir/__init__.py",
+                "project/no_init/lib.py",
+            ],
+            # NB: These will strip down to end up being the same file. If they had different
+            # contents, Pants would error when trying to merge them.
+            original_undeclared_empty_files=[
+                "src/python/project/__init__.py",
+                "tests/python/project/__init__.py",
+            ],
+            original_undeclared_nonempty_files=[],
+            expected_discovered=["project/__init__.py"],
+        )
+
+    def test_unstripped_source_root_at_buildroot(self) -> None:
+        self.assert_injected(
+            source_roots=["/"],
+            declared_files_stripped=False,
+            original_declared_files=[
+                "project/lib.py",
+                "project/subdir/lib.py",
+                "project/subdir/__init__.py",
+                "project/no_init/lib.py",
+            ],
+            original_undeclared_empty_files=["project/__init__.py",],
+            original_undeclared_nonempty_files=[],
+            expected_discovered=["project/__init__.py"],
+        )
+
+    def test_stripped_source_root_at_buildroot(self) -> None:
+        self.assert_injected(
+            source_roots=["/"],
+            declared_files_stripped=True,
+            original_declared_files=[
+                "project/lib.py",
+                "project/subdir/lib.py",
+                "project/subdir/__init__.py",
+                "project/no_init/lib.py",
+            ],
+            original_undeclared_empty_files=["project/__init__.py",],
+            original_undeclared_nonempty_files=[],
+            expected_discovered=["project/__init__.py"],
+        )
+
+    def test_nonempty_unstripped(self) -> None:
+        with pytest.raises(ExecutionError) as exc:
+            self.assert_injected(
+                source_roots=["src/python", "tests/python"],
+                declared_files_stripped=False,
+                original_declared_files=[
+                    "src/python/project/lib.py",
+                    "src/python/project/subdir/__init__.py",
+                    "src/python/project/subdir/lib.py",
+                    "src/python/no_init/lib.py",
+                ],
+                original_undeclared_empty_files=[],
+                original_undeclared_nonempty_files=[
+                    "src/python/project/__init__.py",
+                    "tests/python/project/__init__.py",
+                ],
+                expected_discovered=["src/python/project/__init__.py"],
+            )
+        assert len(exc.value.wrapped_exceptions) == 1
+        assert isinstance(exc.value.wrapped_exceptions[0], MissingNonEmptyInitFiles)
+
+    def test_nonempty_stripped(self) -> None:
+        with pytest.raises(ExecutionError) as exc:
+            self.assert_injected(
+                source_roots=["src/python", "tests/python"],
+                declared_files_stripped=True,
+                original_declared_files=[
+                    "project/lib.py",
+                    "project/subdir/lib.py",
+                    "project/subdir/__init__.py",
+                    "project/no_init/lib.py",
+                ],
+                original_undeclared_empty_files=[],
+                # NB: These will strip down to end up being the same file. If they had different
+                # contents, Pants would error when trying to merge them.
+                original_undeclared_nonempty_files=[
+                    "src/python/project/__init__.py",
+                    "tests/python/project/__init__.py",
+                ],
+                expected_discovered=["project/__init__.py"],
+            )
+        assert len(exc.value.wrapped_exceptions) == 1
+        assert isinstance(exc.value.wrapped_exceptions[0], MissingNonEmptyInitFiles)
+
+    def test_nonempty_unstripped_source_root_at_buildroot(self) -> None:
+        with pytest.raises(ExecutionError) as exc:
+            self.assert_injected(
+                source_roots=["/"],
+                declared_files_stripped=False,
+                original_declared_files=[
+                    "project/lib.py",
+                    "project/subdir/lib.py",
+                    "project/subdir/__init__.py",
+                    "project/no_init/lib.py",
+                ],
+                original_undeclared_empty_files=[],
+                original_undeclared_nonempty_files=["project/__init__.py",],
+                expected_discovered=["project/__init__.py"],
+            )
+        assert len(exc.value.wrapped_exceptions) == 1
+        assert isinstance(exc.value.wrapped_exceptions[0], MissingNonEmptyInitFiles)
+
+    def test_nonempty_stripped_source_root_at_buildroot(self) -> None:
+        with pytest.raises(ExecutionError) as exc:
+            self.assert_injected(
+                source_roots=["/"],
+                declared_files_stripped=True,
+                original_declared_files=[
+                    "project/lib.py",
+                    "project/subdir/lib.py",
+                    "project/subdir/__init__.py",
+                    "project/no_init/lib.py",
+                ],
+                original_undeclared_empty_files=[],
+                original_undeclared_nonempty_files=["project/__init__.py",],
+                expected_discovered=["project/__init__.py"],
+            )
+        assert len(exc.value.wrapped_exceptions) == 1
+        assert isinstance(exc.value.wrapped_exceptions[0], MissingNonEmptyInitFiles)

--- a/src/python/pants/backend/python/rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets_test.py
@@ -4,7 +4,12 @@
 from textwrap import dedent
 from typing import Optional
 
-from pants.backend.python.rules import pex_from_targets, python_sources
+from pants.backend.python.rules import (
+    ancestor_files,
+    missing_init,
+    pex_from_targets,
+    python_sources,
+)
 from pants.backend.python.rules.pex import PexRequest, PexRequirements
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.rules.python_sources import StrippedPythonSourcesRequest
@@ -27,6 +32,8 @@ class PexTest(TestBase):
             *super().rules(),
             *pex_from_targets.rules(),
             *python_sources.rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
             RootRule(PexFromTargetsRequest),
             RootRule(StrippedPythonSourcesRequest),
             SubsystemRule(PythonSetup),

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -9,8 +9,6 @@ from typing import List, Optional
 
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.rules import (
-    ancestor_files,
-    missing_init,
     pex,
     pex_from_targets,
     pytest_runner,
@@ -134,8 +132,6 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             *pex.rules(),
             *pex_from_targets.rules(),
             *strip_source_roots.rules(),
-            *ancestor_files.rules(),
-            *missing_init.rules(),
             RootRule(PythonTestFieldSet),
             # For conftest detection.
             *dependency_inference_rules.rules(),

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -8,7 +8,14 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
-from pants.backend.python.rules import pex, pex_from_targets, pytest_runner, python_sources
+from pants.backend.python.rules import (
+    ancestor_files,
+    missing_init,
+    pex,
+    pex_from_targets,
+    pytest_runner,
+    python_sources,
+)
 from pants.backend.python.rules.coverage import create_coverage_config
 from pants.backend.python.rules.pytest_runner import PythonTestFieldSet
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
@@ -127,6 +134,8 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             *pex.rules(),
             *pex_from_targets.rules(),
             *strip_source_roots.rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
             RootRule(PythonTestFieldSet),
             # For conftest detection.
             *dependency_inference_rules.rules(),

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -8,12 +8,7 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
-from pants.backend.python.rules import (
-    pex,
-    pex_from_targets,
-    pytest_runner,
-    python_sources,
-)
+from pants.backend.python.rules import pex, pex_from_targets, pytest_runner, python_sources
 from pants.backend.python.rules.coverage import create_coverage_config
 from pants.backend.python.rules.pytest_runner import PythonTestFieldSet
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple, Type
 
+from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.rules.missing_init import MissingInit, MissingInitRequest
 from pants.backend.python.target_types import PythonSources
 from pants.core.target_types import FilesSources, ResourcesSources
@@ -158,6 +159,8 @@ def rules():
     return [
         *collect_rules(),
         *determine_source_files.rules(),
+        *ancestor_files.rules(),
+        *missing_init.rules(),
         RootRule(StrippedPythonSourcesRequest),
         RootRule(UnstrippedPythonSourcesRequest),
     ]

--- a/src/python/pants/backend/python/rules/python_sources_test.py
+++ b/src/python/pants/backend/python/rules/python_sources_test.py
@@ -6,6 +6,7 @@ from typing import Iterable, List, Optional, Type
 
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
+from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.rules.python_sources import (
     StrippedPythonSources,
     StrippedPythonSourcesRequest,
@@ -39,6 +40,8 @@ class PythonSourcesTest(ExternalToolTestBase):
         return (
             *super().rules(),
             *python_sources_rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
             *protobuf_rules(),
             RootRule(StrippedPythonSourcesRequest),
             RootRule(UnstrippedPythonSourcesRequest),

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
-from pants.backend.python.rules import inject_ancestor_files
+from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.target_types import PythonLibrary
 from pants.backend.python.typecheck.mypy.rules import MyPyFieldSet, MyPyRequest
 from pants.backend.python.typecheck.mypy.rules import rules as mypy_rules
@@ -66,7 +66,8 @@ class MyPyIntegrationTest(ExternalToolTestBase):
             RootRule(MyPyRequest),
             # mypy needs __init__.py files in many cases: we pull in inference to avoid boilerplate.
             *dependency_inference_rules.rules(),
-            *inject_ancestor_files.rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
         )
 
     @classmethod

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
-from pants.backend.python.rules import ancestor_files, missing_init
 from pants.backend.python.target_types import PythonLibrary
 from pants.backend.python.typecheck.mypy.rules import MyPyFieldSet, MyPyRequest
 from pants.backend.python.typecheck.mypy.rules import rules as mypy_rules
@@ -66,8 +65,6 @@ class MyPyIntegrationTest(ExternalToolTestBase):
             RootRule(MyPyRequest),
             # mypy needs __init__.py files in many cases: we pull in inference to avoid boilerplate.
             *dependency_inference_rules.rules(),
-            *ancestor_files.rules(),
-            *missing_init.rules(),
         )
 
     @classmethod

--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -1,7 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.rules import pex, pex_from_targets, python_sources
+from pants.backend.python.rules import (
+    ancestor_files,
+    missing_init,
+    pex,
+    pex_from_targets,
+    python_sources,
+)
 from pants.backend.python.rules import repl as python_repl
 from pants.backend.python.rules.repl import PythonRepl
 from pants.backend.python.target_types import PythonLibrary
@@ -28,6 +34,8 @@ class ReplTest(GoalRuleTestBase):
             *python_sources.rules(),
             *pex_from_targets.rules(),
             *strip_source_roots.rules(),
+            *ancestor_files.rules(),
+            *missing_init.rules(),
             RootRule(PythonRepl),
         )
 


### PR DESCRIPTION
However now we only inject if the missing files exist and
are empty. If they exist but are not empty, we error.

The restored logic is slightly changed from the one
we had previously - it no longer does injection, but
just finds the missing files. It's up to the caller
to merge digests if they so choose.

For consistency, renames inject_ancestor_files.py to
ancestor_files.py, since that code just finds ancestor
files, but doesn't do any injection. Also adds some
more tests to that functionality, to flex it when the
source root is at the buildroot.

[ci skip-rust]

[ci skip-build-wheels]
