### PR TITLE
Enable Python dependency inference by default

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -52,9 +52,6 @@ root_patterns = [
   "/build-support/migration-support"
 ]
 
-[python-infer]
-imports = true
-
 [python-setup]
 # TODO: Set up an actual lockfile. For now we just "lock" our requirements.txt to itself,
 #  so we can use --python-setup-resolve-all-constraints (which requires a lockfile).

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -40,7 +40,7 @@ class PythonInference(Subsystem):
         super().register_options(register)
         register(
             "--imports",
-            default=False,
+            default=True,
             type=bool,
             help=(
                 "Infer a target's imported dependencies by parsing import statements from sources."

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -50,11 +50,7 @@ class PythonDependencyInferenceTest(TestBase):
 
     def test_infer_python_imports(self) -> None:
         options_bootstrapper = create_options_bootstrapper(
-            args=[
-                "--backend-packages=pants.backend.python",
-                "--source-root-patterns=src/python",
-                "--python-infer-imports",
-            ]
+            args=["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
         )
         self.add_to_build_file(
             "3rdparty/python",

--- a/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
+++ b/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
@@ -52,7 +52,6 @@ class RunPythonBinaryIntegrationTest(PantsRunIntegrationTest):
             (src_root2 / "BUILD").write_text("python_library()")
             result = self.run_pants(
                 [
-                    "--python-infer-imports",
                     (
                         f"--source-root-patterns=['/{tmpdir_relative}/src_root1', "
                         f"'/{tmpdir_relative}/src_root2']"

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -113,7 +113,6 @@ class MyPyIntegrationTest(ExternalToolTestBase):
             "--backend-packages=pants.backend.python",
             "--backend-packages=pants.backend.python.typecheck.mypy",
             "--source-root-patterns=['src/python', 'tests/python']",
-            "--python-infer-imports",
         ]
         if config:
             self.create_file(relpath="mypy.ini", contents=config)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10505.

A followup will fix https://github.com/pantsbuild/pants/issues/10467 by unifying the inference implementation for imports with `__init__.py` and `conftests.py`.

[ci skip-rust]
[ci skip-build-wheels]
