### PR TITLE
Remove self-inflicted invalidation caused by exception logging

### DIFF
--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -105,17 +105,12 @@ class OptionsInitializer:
 
         add(global_options.pants_workdir)
         add(global_options.pants_distdir)
-        # TODO: We punch a hole in the ignore patterns to allow pantsd to directly watch process
-        # metadata that is written to disk, but we re-ignore the watchman directory (which
-        # contained a named pipe). Over time, as more of the pantsd server components are ported to
-        # rust, we will be able to remove this special case.
-        add(global_options.pants_subprocessdir, include=True)
-        add(os.path.join(global_options.pants_subprocessdir, "watchman"))
+        add(global_options.pants_subprocessdir)
 
         return pants_ignore
 
     @staticmethod
-    def compute_pantsd_invalidation_globs(buildroot, bootstrap_options, absolute_pidfile):
+    def compute_pantsd_invalidation_globs(buildroot, bootstrap_options):
         """Computes the merged value of the `--pantsd-invalidation-globs` option.
 
         Combines --pythonpath and --pants-config-files files that are in {buildroot} dir with those
@@ -126,7 +121,6 @@ class OptionsInitializer:
         # Globs calculated from the sys.path and other file-like configuration need to be sanitized
         # to relative globs (where possible).
         potentially_absolute_globs = (
-            absolute_pidfile,
             *sys.path,
             *bootstrap_options.pythonpath,
             *bootstrap_options.pants_config_files,

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -128,16 +128,17 @@ class PantsDaemon(PantsDaemonProcessManager):
         build_root = get_buildroot()
 
         invalidation_globs = OptionsInitializer.compute_pantsd_invalidation_globs(
-            build_root,
-            bootstrap_options,
-            PantsDaemon.metadata_file_path("pantsd", "pid", bootstrap_options.pants_subprocessdir),
+            build_root, bootstrap_options,
         )
 
         scheduler_service = SchedulerService(
             legacy_graph_scheduler=legacy_graph_scheduler,
             build_root=build_root,
             invalidation_globs=invalidation_globs,
-            max_memory_usage_pid=os.getpid(),
+            pidfile=PantsDaemon.metadata_file_path(
+                "pantsd", "pid", bootstrap_options.pants_subprocessdir
+            ),
+            pid=os.getpid(),
             max_memory_usage_in_bytes=bootstrap_options.pantsd_max_memory_usage,
         )
 
@@ -243,22 +244,12 @@ class PantsDaemon(PantsDaemonProcessManager):
         process starting.
         """
 
-        # Write the pidfile.
+        # Write the pidfile. The SchedulerService will monitor it after a grace period.
         pid = os.getpid()
         self.write_pid(pid=pid)
         self.write_metadata_by_name(
             "pantsd", self.FINGERPRINT_KEY, ensure_text(self.options_fingerprint)
         )
-        pidfile_absolute = self._metadata_file_path("pantsd", "pid")
-
-        # Finally, once watched, confirm that we didn't race another process.
-        try:
-            with open(pidfile_absolute, "r") as f:
-                pid_from_file = f.read()
-        except IOError:
-            raise Exception(f"Could not read pants pidfile at {pidfile_absolute}.")
-        if int(pid_from_file) != os.getpid():
-            raise Exception(f"Another instance of pantsd is running at {pid_from_file}")
 
     def run_sync(self):
         """Synchronously run pantsd."""

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -35,7 +35,7 @@ class OptionsInitializerTest(unittest.TestCase):
         suffix = "something-ridiculous"
         ob = OptionsBootstrapper.create(env={}, args=[f"--pythonpath=../{suffix}"])
         globs = OptionsInitializer.compute_pantsd_invalidation_globs(
-            get_buildroot(), ob.bootstrap_options.for_global_scope(), "/dev/null/pidfile"
+            get_buildroot(), ob.bootstrap_options.for_global_scope()
         )
         for glob in globs:
             assert suffix not in glob


### PR DESCRIPTION
### Problem

Inspecting the `pantsd.log` indicates that each run experiences a small amount of self-inflicted invalidation due to new exceptions logs being written into the `.pids` directory. That directory would otherwise be ignored, if not for a hack put in place a while back to allow us to "watch" the pidfile.

These invalidations can affect any wide-ranging glob: for example, they will be picked up by `**/*`.

### Solution

Replace the hole punched in our ignore patterns with a less expensive hack: polling the pidfile after a grace period.

### Result

No self-inflicted invalidation; faster reruns.

[ci skip-rust]
[ci skip-build-wheels]