### PR TITLE
Rely on the init-injection rules to trigger errors for un-depended-on and non-empty __init__.py files

### DIFF
--- a/src/python/pants/backend/python/rules/missing_init_test.py
+++ b/src/python/pants/backend/python/rules/missing_init_test.py
@@ -49,7 +49,12 @@ class InjectInitTest(TestBase):
             self.make_snapshot({fp: "" for fp in original_declared_files}),
             sources_stripped=declared_files_stripped,
         )
-        bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
+        bootstrapper = create_options_bootstrapper(
+            args=[
+                "--backend-packages=pants.backend.python",
+                f"--source-root-patterns={source_roots}",
+            ]
+        )
         result = self.request_single_product(MissingInit, Params(request, bootstrapper)).snapshot
         assert list(result.files) == sorted(expected_discovered)
 

--- a/src/python/pants/backend/python/rules/python_sources_test.py
+++ b/src/python/pants/backend/python/rules/python_sources_test.py
@@ -75,6 +75,7 @@ class PythonSourcesTest(ExternalToolTestBase):
                 ),
                 create_options_bootstrapper(
                     args=[
+                        "--backend-packages=pants.backend.python",
                         f"--source-root-patterns={source_roots or ['src/python']}",
                         *(extra_args or []),
                     ]
@@ -99,6 +100,7 @@ class PythonSourcesTest(ExternalToolTestBase):
                 ),
                 create_options_bootstrapper(
                     args=[
+                        "--backend-packages=pants.backend.python",
                         f"--source-root-patterns={source_roots or ['src/python']}",
                         *(extra_args or []),
                     ]


### PR DESCRIPTION
### Problem

#10517 restored the automatic inclusion of empty `__init__.py` files, and additionally adds an error for "un-depended-on and non-empty `__init__.py` files". But `--python-infer-inits` also triggered an error for an unowned `__init__.py` file, regardless of whether it had content, which meant that if you had inference on, you would see errors from inference before seeing the error that differentiates between empty and non-empty.   

### Solution

Remove the error for un-owned `__init__.py` files from `--python-infer-inits` and rely on the error from `__init__.py` injection. Additionally, expand the error for `__init__.py` injection to clarify that you need an owning target.

### Result

`--python-infer-inits` won't complain about empty `__init__.py` files not being owned.

[ci skip-rust]
[ci skip-build-wheels]