### PR TITLE
Reduce verbosity of logging while finding binaries

### DIFF
--- a/src/python/pants/backend/python/rules/pex_environment.py
+++ b/src/python/pants/backend/python/rules/pex_environment.py
@@ -97,14 +97,15 @@ class PexEnvironment(EngineAware):
             **self.subprocess_environment_dict,
         )
 
-    def level(self) -> Optional[LogLevel]:
+    def level(self) -> LogLevel:
         return LogLevel.DEBUG if self.bootstrap_python else LogLevel.WARN
 
-    def message(self) -> Optional[str]:
+    def message(self) -> str:
         if not self.bootstrap_python:
             return (
-                "No bootstrap Python executable could be found. "
-                "Will attempt to run PEXes directly."
+                "No bootstrap Python executable could be found from the option "
+                "`interpreter_search_paths` in the `[python-setup]` scope. Will attempt to run "
+                "PEXes directly."
             )
         return f"Selected {self.bootstrap_python} to bootstrap PEXes with."
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -316,10 +316,10 @@ class BinaryPaths(EngineAware):
         self.binary_name = binary_name
         self.paths = tuple(OrderedSet(paths))
 
-    def level(self) -> Optional[LogLevel]:
-        return LogLevel.DEBUG if self.paths else LogLevel.WARN
+    def level(self) -> LogLevel:
+        return LogLevel.DEBUG
 
-    def message(self) -> Optional[str]:
+    def message(self) -> str:
         if not self.paths:
             return f"failed to find {self.binary_name}"
         found_msg = f"found {self.binary_name} at {self.paths[0]}"


### PR DESCRIPTION
It should be up to the call site to determine if they want additional logging when a requested binary cannot be found. 

For example, with finding a bootstrap Python interpreter, we search by default for `python`, `python2`, and `python3`. Typically, we will expect at least one of these to be missing, which we don't care about. We only care if none are present, and at that point, we have a better, dedicated warning.

Before:
```
▶ ./pants --python-setup-interpreter-search-paths='[]' run build-support/bin/check_inits.py --no-dynamic-ui --no-pantsd --no-process-execution-use-local-cache
14:02:26 [INFO] Starting: Searching for `python3` on PATH=
14:02:26 [INFO] Starting: Searching for `python` on PATH=
14:02:26 [INFO] Starting: Searching for `python2` on PATH=
14:02:26 [INFO] Completed: Searching for `python2` on PATH=
14:02:26 [INFO] Completed: Searching for `python3` on PATH=
14:02:26 [INFO] Completed: Searching for `python` on PATH=
14:02:26 [WARN] Completed: Find binary path - failed to find python3
14:02:26 [WARN] Completed: Find binary path - failed to find python2
14:02:26 [WARN] Completed: Find binary path - failed to find python
14:02:26 [WARN] Completed: Find PEX Python - No bootstrap Python executable could be found. Will attempt to run PEXes directly.
14:02:26 [INFO] Starting: Building check_inits.py.pex
14:02:27 [INFO] Completed: Building check_inits.py.pex
```

After:
```
▶ ./pants --python-setup-interpreter-search-paths='[]' run build-support/bin/check_inits.py --no-dynamic-ui --no-pantsd --no-process-execution-use-local-cache
13:59:28 [INFO] Starting: Searching for `python2` on PATH=
13:59:28 [INFO] Starting: Searching for `python` on PATH=
13:59:28 [INFO] Starting: Searching for `python3` on PATH=
13:59:29 [INFO] Completed: Searching for `python2` on PATH=
13:59:29 [INFO] Completed: Searching for `python` on PATH=
13:59:29 [INFO] Completed: Searching for `python3` on PATH=
13:59:29 [WARN] Completed: Find PEX Python - No bootstrap Python executable could be found from the option `interpreter_search_paths` in the `[python-setup]` scope. Will attempt to run PEXes directly.
13:59:29 [INFO] Starting: Building check_inits.py.pex
13:59:29 [INFO] Completed: Building check_inits.py.pex
```

This is still too verbose. We should not log the `"Search for"` `Process` workunits.

[ci skip-rust]
[ci skip-build-wheels]
