### PR TITLE
Improve error message for unrecognized BUILD file symbols

### DIFF
--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -36,7 +36,7 @@ class AddressMap:
         try:
             target_adaptors = parser.parse(filepath, build_file_content, extra_symbols)
         except Exception as e:
-            raise MappingError(f"Failed to parse {filepath}:\n{e!r}")
+            raise MappingError(f"Failed to parse {filepath}:\n{e}")
         name_to_target_adaptors: Dict[str, TargetAdaptor] = {}
         for target_adaptor in target_adaptors:
             name = target_adaptor.name

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
@@ -70,19 +70,15 @@ class Parser:
                 self._parse_context._storage.add(obj)
                 return obj
 
-        symbols.update(
-            {
-                alias: Registrar(parse_context, alias, object_type=symbol)
-                for alias, symbol in symbol_table.table.items()
-            }
-        )
+        for alias, symbol in symbol_table.table.items():
+            registrar = Registrar(parse_context, alias, object_type=symbol)
+            symbols[alias] = registrar
+
         symbols.update(aliases.objects)
-        symbols.update(
-            {
-                alias: object_factory(parse_context)
-                for alias, object_factory in aliases.context_aware_object_factories.items()
-            }
-        )
+
+        for alias, object_factory in aliases.context_aware_object_factories.items():
+            symbols[alias] = object_factory(parse_context)
+
         return symbols, parse_context
 
     def parse(

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser, SymbolTable
+from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.util.frozendict import FrozenDict
+
+
+def test_imports_banned() -> None:
+    parser = Parser(SymbolTable({}), BuildFileAliases())
+    with pytest.raises(ParseError) as exc:
+        parser.parse(
+            "dir/BUILD", "\nx = 'hello'\n\nimport os\n", BuildFilePreludeSymbols(FrozenDict())
+        )
+    assert "Import used in dir/BUILD at line 4" in str(exc.value)
+
+
+def test_unrecognized_symbol() -> None:
+    parser = Parser(
+        SymbolTable({"tgt": TargetAdaptor}),
+        BuildFileAliases(
+            objects={"obj": 0},
+            context_aware_object_factories={"caof": lambda parse_context: lambda _: None},
+        ),
+    )
+    prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
+    with pytest.raises(ParseError) as exc:
+        parser.parse("dir/BUILD", "fake", prelude_symbols)
+    assert (
+        str(exc.value)
+        == "Name 'fake' is not defined.\n\nAll registered symbols: ['caof', 'obj', 'prelude', 'tgt']"
+    )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10310.

Before:
```
▶ ./pants list src/python/pants/util --no-pantsd --no-print-exception-stacktrace
01:04:10 [ERROR] 1 Exception encountered:

  MappingError: Failed to parse src/python/pants/util/BUILD:
NameError("name 'fake' is not defined",)
```

After:

```
▶ ./pants list src/python/pants/util --no-pantsd --no-print-exception-stacktrace
01:02:43 [ERROR] 1 Exception encountered:

  MappingError: Failed to parse src/python/pants/util/BUILD:
Name 'fake' is not defined.

All registered symbols: ['_python_requirements_file', 'files', 'pants_requirement', 'pants_setup_py', 'python_artifact', 'python_binary', 'python_integration_tests', 'python_library', 'python_requirement', 'python_requirement_library', 'python_requirements', 'python_tests', 'resources', 'setup_py', 'target']

```

[ci skip-rust]
[ci skip-build-wheels]
