### PR TITLE
Support and require disambiguated file addresses

### DIFF
--- a/src/python/pants/backend/project_info/dependees_test.py
+++ b/src/python/pants/backend/project_info/dependees_test.py
@@ -28,6 +28,7 @@ class DependeesTest(GoalRuleTestBase):
         return (*super().rules(), *dependee_rules())
 
     def setUp(self) -> None:
+        super().setUp()
         self.add_to_build_file("base", "tgt()")
         self.add_to_build_file("intermediate", "tgt(dependencies=['base'])")
         self.add_to_build_file("leaf", "tgt(dependencies=['intermediate'])")
@@ -57,44 +58,44 @@ class DependeesTest(GoalRuleTestBase):
         self.assert_dependees(targets=[], output_format=OutputFormat.json, expected=["{}"])
 
     def test_normal(self) -> None:
-        self.assert_dependees(targets=["base:base"], expected=["intermediate:intermediate"])
+        self.assert_dependees(targets=["base"], expected=["intermediate"])
         self.assert_dependees(
-            targets=["base:base"],
+            targets=["base"],
             output_format=OutputFormat.json,
             expected=dedent(
                 """\
                 {
-                    "base:base": [
-                        "intermediate:intermediate"
+                    "base": [
+                        "intermediate"
                     ]
                 }"""
             ).splitlines(),
         )
 
     def test_no_dependees(self) -> None:
-        self.assert_dependees(targets=["leaf:leaf"], expected=[])
+        self.assert_dependees(targets=["leaf"], expected=[])
         self.assert_dependees(
-            targets=["leaf:leaf"],
+            targets=["leaf"],
             output_format=OutputFormat.json,
             expected=dedent(
                 """\
                 {
-                    "leaf:leaf": []
+                    "leaf": []
                 }"""
             ).splitlines(),
         )
 
     def test_closed(self) -> None:
-        self.assert_dependees(targets=["leaf:leaf"], closed=True, expected=["leaf:leaf"])
+        self.assert_dependees(targets=["leaf"], closed=True, expected=["leaf"])
         self.assert_dependees(
-            targets=["leaf:leaf"],
+            targets=["leaf"],
             closed=True,
             output_format=OutputFormat.json,
             expected=dedent(
                 """\
                 {
-                    "leaf:leaf": [
-                        "leaf:leaf"
+                    "leaf": [
+                        "leaf"
                     ]
                 }"""
             ).splitlines(),
@@ -102,20 +103,18 @@ class DependeesTest(GoalRuleTestBase):
 
     def test_transitive(self) -> None:
         self.assert_dependees(
-            targets=["base:base"],
-            transitive=True,
-            expected=["intermediate:intermediate", "leaf:leaf"],
+            targets=["base"], transitive=True, expected=["intermediate", "leaf"],
         )
         self.assert_dependees(
-            targets=["base:base"],
+            targets=["base"],
             transitive=True,
             output_format=OutputFormat.json,
             expected=dedent(
                 """\
                 {
-                    "base:base": [
-                        "intermediate:intermediate",
-                        "leaf:leaf"
+                    "base": [
+                        "intermediate",
+                        "leaf"
                     ]
                 }"""
             ).splitlines(),
@@ -125,24 +124,24 @@ class DependeesTest(GoalRuleTestBase):
         # This tests that --output-format=text will deduplicate and that --output-format=json will
         # preserve which dependee belongs to which specified target.
         self.assert_dependees(
-            targets=["base:base", "intermediate:intermediate"],
+            targets=["base", "intermediate"],
             transitive=True,
             # NB: `intermediate` is not included because it's a root and we have `--no-closed`.
-            expected=["leaf:leaf"],
+            expected=["leaf"],
         )
         self.assert_dependees(
-            targets=["base:base", "intermediate:intermediate"],
+            targets=["base", "intermediate"],
             transitive=True,
             output_format=OutputFormat.json,
             expected=dedent(
                 """\
                 {
-                    "base:base": [
-                        "intermediate:intermediate",
-                        "leaf:leaf"
+                    "base": [
+                        "intermediate",
+                        "leaf"
                     ],
-                    "intermediate:intermediate": [
-                        "leaf:leaf"
+                    "intermediate": [
+                        "leaf"
                     ]
                 }"""
             ).splitlines(),

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -84,18 +84,13 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
         self.assert_dependencies(
             specs=["some/other/target"],
             dependency_type=DependencyType.SOURCE,
-            expected=["3rdparty/python:req2", "some/target:target"],
+            expected=["3rdparty/python:req2", "some/target"],
         )
         self.assert_dependencies(
             specs=["some/other/target"],
             transitive=True,
             dependency_type=DependencyType.SOURCE,
-            expected=[
-                "3rdparty/python:req2",
-                "some/target:target",
-                "3rdparty/python:req1",
-                "dep/target:target",
-            ],
+            expected=["3rdparty/python:req2", "some/target", "3rdparty/python:req1", "dep/target",],
         )
 
         # `--type=3rdparty`
@@ -116,15 +111,15 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
             specs=["some/other/target"],
             transitive=False,
             dependency_type=DependencyType.SOURCE_AND_THIRD_PARTY,
-            expected=["3rdparty/python:req2", "some/target:target", "req2==1.0.0"],
+            expected=["3rdparty/python:req2", "some/target", "req2==1.0.0"],
         )
         self.assert_dependencies(
             specs=["some/other/target"],
             transitive=True,
             dependency_type=DependencyType.SOURCE_AND_THIRD_PARTY,
             expected=[
-                "some/target:target",
-                "dep/target:target",
+                "some/target",
+                "dep/target",
                 "3rdparty/python:req1",
                 "3rdparty/python:req2",
                 "req1==1.0.0",
@@ -136,20 +131,10 @@ class DependenciesIntegrationTest(GoalRuleTestBase):
         # on it.
         self.assert_dependencies(
             specs=["::"],
-            expected=[
-                "3rdparty/python:req1",
-                "3rdparty/python:req2",
-                "dep/target:target",
-                "some/target:target",
-            ],
+            expected=["3rdparty/python:req1", "3rdparty/python:req2", "dep/target", "some/target",],
         )
         self.assert_dependencies(
             specs=["::"],
             transitive=True,
-            expected=[
-                "3rdparty/python:req1",
-                "3rdparty/python:req2",
-                "dep/target:target",
-                "some/target:target",
-            ],
+            expected=["3rdparty/python:req1", "3rdparty/python:req2", "dep/target", "some/target",],
         )

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -114,19 +114,15 @@ class ModuleMapperTest(TestBase):
         assert result.mapping == FrozenDict(
             {
                 "project.util.dirutil": Address(
-                    "src/python/project/util",
-                    target_name="dirutil.py",
-                    generated_base_target_name="util",
+                    "src/python/project/util", relative_file_path="dirutil.py", target_name="util",
                 ),
                 "project.util.tarutil": Address(
-                    "src/python/project/util",
-                    target_name="tarutil.py",
-                    generated_base_target_name="util",
+                    "src/python/project/util", relative_file_path="tarutil.py", target_name="util",
                 ),
                 "project_test.demo_test": Address(
                     "tests/python/project_test/demo_test",
-                    target_name="__init__.py",
-                    generated_base_target_name="demo_test",
+                    relative_file_path="__init__.py",
+                    target_name="demo_test",
                 ),
             }
         )
@@ -197,16 +193,14 @@ class ModuleMapperTest(TestBase):
         self.create_file("source_root1/project/file2.py")
         self.add_to_build_file("source_root1/project", "python_library()")
         assert get_owner("project.app") == Address(
-            "source_root1/project", target_name="app.py", generated_base_target_name="project"
+            "source_root1/project", relative_file_path="app.py", target_name="project"
         )
 
         # Check a package path
         self.create_file("source_root2/project/subdir/__init__.py")
         self.add_to_build_file("source_root2/project/subdir", "python_library()")
         assert get_owner("project.subdir") == Address(
-            "source_root2/project/subdir",
-            target_name="__init__.py",
-            generated_base_target_name="subdir",
+            "source_root2/project/subdir", relative_file_path="__init__.py", target_name="subdir",
         )
 
         # Test a module with no owner (stdlib). This also sanity checks that we can handle when
@@ -218,5 +212,5 @@ class ModuleMapperTest(TestBase):
         self.create_file("script.py")
         self.add_to_build_file("", "python_library(name='script')")
         assert get_owner("script.Demo") == Address(
-            "", target_name="script.py", generated_base_target_name="script"
+            "", relative_file_path="script.py", target_name="script"
         )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -102,19 +102,19 @@ class PythonDependencyInferenceTest(TestBase):
 
         # NB: We do not infer `src/python/app.py`, even though it's used by `src/python/f2.py`,
         # because it is part of the requested address.
-        normal_address = Address("src/python", "python")
+        normal_address = Address("src/python")
         assert run_dep_inference(normal_address) == InferredDependencies(
             [
-                Address("3rdparty/python", "Django"),
-                Address("src/python/util", target_name="dep.py", generated_base_target_name="util"),
+                Address("3rdparty/python", target_name="Django"),
+                Address("src/python/util", relative_file_path="dep.py", target_name="util"),
             ]
         )
 
         generated_subtarget_address = Address(
-            "src/python", target_name="f2.py", generated_base_target_name="python"
+            "src/python", relative_file_path="f2.py", target_name="python"
         )
         assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
-            [Address("src/python", target_name="app.py", generated_base_target_name="python")]
+            [Address("src/python", relative_file_path="app.py", target_name="python")]
         )
 
     def test_infer_python_inits(self) -> None:
@@ -140,8 +140,8 @@ class PythonDependencyInferenceTest(TestBase):
 
         assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
             [
-                Address("src/python/root", "__init__.py", generated_base_target_name="root"),
-                Address("src/python/root/mid", "__init__.py", generated_base_target_name="mid"),
+                Address("src/python/root", relative_file_path="__init__.py", target_name="root"),
+                Address("src/python/root/mid", relative_file_path="__init__.py", target_name="mid"),
             ]
         )
 
@@ -169,7 +169,7 @@ class PythonDependencyInferenceTest(TestBase):
 
         assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
             [
-                Address("src/python/root", "conftest.py", generated_base_target_name="root"),
-                Address("src/python/root/mid", "conftest.py", generated_base_target_name="mid"),
+                Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
+                Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),
             ]
         )

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -123,7 +123,7 @@ async def bandit_lint_partition(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in partition.field_sets)
+        sorted(field_set.address.spec for field_set in partition.field_sets)
     )
     report_path = (
         lint_subsystem.reports_dir / "bandit_report.txt" if lint_subsystem.reports_dir else None

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -125,7 +125,7 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in setup_request.request.field_sets)
+        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
     )
 
     process = await Get(

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -104,7 +104,7 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in setup_request.request.field_sets)
+        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
     )
 
     process = await Get(

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -123,7 +123,7 @@ async def flake8_lint_partition(
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in partition.field_sets)
+        sorted(field_set.address.spec for field_set in partition.field_sets)
     )
     report_path = (
         lint_subsystem.reports_dir / "flake8_report.txt" if lint_subsystem.reports_dir else None

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -129,7 +129,7 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in setup_request.request.field_sets)
+        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
     )
 
     process = await Get(

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -221,7 +221,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
     )
 
     address_references = ", ".join(
-        sorted(field_set.address.reference() for field_set in partition.field_sets)
+        sorted(field_set.address.spec for field_set in partition.field_sets)
     )
 
     result = await Get(

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -76,7 +76,9 @@ class PylintIntegrationTest(ExternalToolTestBase):
                 """
             ),
         )
-        target = self.request_single_product(WrappedTarget, Address(package, name)).target
+        target = self.request_single_product(
+            WrappedTarget, Address(package, target_name=name)
+        ).target
         if origin is None:
             origin = SingleAddress(directory=package, name=name)
         return TargetWithOrigin(target, origin)
@@ -253,7 +255,10 @@ class PylintIntegrationTest(ExternalToolTestBase):
         )
         target = self.make_target_with_origin(
             source_files=[FileContent(f"{self.package}/target.py", source_content.encode())],
-            dependencies=[Address(self.package, "direct_dep"), Address("", "direct_req")],
+            dependencies=[
+                Address(self.package, target_name="direct_dep"),
+                Address("", target_name="direct_req"),
+            ],
         )
 
         result = self.run_pylint([target])

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -253,7 +253,7 @@ async def run_python_test(
             argv=test_setup.args,
             input_digest=test_setup.input_digest,
             output_files=tuple(output_files) if output_files else None,
-            description=f"Run Pytest for {field_set.address.reference()}",
+            description=f"Run Pytest for {field_set.address}",
             timeout_seconds=test_setup.timeout_seconds,
             extra_env=env,
             execution_slot_variable=test_setup.execution_slot_variable,
@@ -287,7 +287,7 @@ async def run_python_test(
         result,
         coverage_data=coverage_data,
         xml_results=xml_results_digest,
-        address_ref=field_set.address.reference(),
+        address_ref=field_set.address.spec,
     )
 
 

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -158,7 +158,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             args.append(f"--pytest-execution-slot-var={execution_slot_var}")
 
         options_bootstrapper = create_options_bootstrapper(args=args)
-        address = Address(self.package, "target")
+        address = Address(self.package, target_name="target")
         if origin is None:
             origin = SingleAddress(directory=address.spec_path, name=address.target_name)
         tgt = PythonTests({}, address=address)

--- a/src/python/pants/backend/python/rules/python_sources_test.py
+++ b/src/python/pants/backend/python/rules/python_sources_test.py
@@ -201,7 +201,7 @@ class PythonSourcesTest(ExternalToolTestBase):
             ),
         )
         self.add_to_build_file("src/protobuf/dir", "protobuf_library()")
-        targets = [ProtobufLibrary({}, address=Address("src/protobuf/dir", "dir"))]
+        targets = [ProtobufLibrary({}, address=Address("src/protobuf/dir"))]
         backend_args = ["--backend-packages=pants.backend.codegen.protobuf.python"]
 
         stripped_result = self.get_stripped_sources(

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -399,7 +399,7 @@ class TestGetOwnedDependencies(TestSetupPyBase):
 
     def assert_owned(self, owned: Iterable[str], exported: str):
         assert sorted(owned) == sorted(
-            od.target.address.reference()
+            od.target.address.spec
             for od in self.request_single_product(
                 OwnedDependencies,
                 Params(
@@ -480,7 +480,7 @@ class TestGetExportingOwner(TestSetupPyBase):
             == self.request_single_product(
                 ExportedTarget,
                 Params(OwnedDependency(self.tgt(owned)), create_options_bootstrapper()),
-            ).target.address.reference()
+            ).target.address.spec
         )
 
     def assert_error(self, owned: str, exc_cls: Type[Exception]):

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -94,7 +94,9 @@ class MyPyIntegrationTest(ExternalToolTestBase):
                 """
             ),
         )
-        target = self.request_single_product(WrappedTarget, Address(package, name)).target
+        target = self.request_single_product(
+            WrappedTarget, Address(package, target_name=name)
+        ).target
         origin = SingleAddress(directory=package, name=name)
         return TargetWithOrigin(target, origin)
 

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -125,9 +125,9 @@ class SingleAddress(AddressSpec):
         """
         single_af = assert_single_element(address_families)
         addr_tgt_pairs = [
-            (addr, tgt)
-            for addr, tgt in single_af.addressables.items()
-            if addr.target_name == self.name
+            (bfa, tgt)
+            for bfa, tgt in single_af.addressables.items()
+            if bfa.address.target_name == self.name
         ]
         if len(addr_tgt_pairs) == 0:
             raise self._SingleAddressResolutionError(single_af, self.name)

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -30,7 +30,7 @@ class AddressInput:
     """
 
     path_component: str
-    target_component: Optional[str]
+    target_component: Optional[str] = None
 
     def __post_init__(self):
         if self.target_component is not None or self.path_component == "":
@@ -300,7 +300,7 @@ class Address:
         """
         if self._relative_file_path:
             parent_count = self._relative_file_path.count(os.path.sep)
-            parent_prefix = '@' * parent_count if parent_count else '.'
+            parent_prefix = "@" * parent_count if parent_count else "."
             file_portion = f".{self._relative_file_path.replace(os.sep, '.')}"
         else:
             parent_prefix = "."

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -3,92 +3,14 @@
 
 import os
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence
 
+from pants.base.deprecated import deprecated
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
-# @ is currently unused, but reserved for possible future needs.
-BANNED_CHARS_IN_TARGET_NAME = frozenset("@")
-
-
-def parse_spec(
-    spec: str, relative_to: Optional[str] = None, subproject_roots: Optional[Sequence[str]] = None,
-) -> Tuple[str, str]:
-    """Parses a target address spec and returns the path from the root of the repo to this target
-    and target name.
-
-    :API: public
-
-    :param spec: Target address spec.
-    :param relative_to: path to use for sibling specs, ie: ':another_in_same_build_family',
-      interprets the missing spec_path part as `relative_to`.
-    :param subproject_roots: Paths that correspond with embedded build roots under
-      the current build root.
-
-    For example:
-
-        some_target(
-            name='mytarget',
-            dependencies=['path/to/buildfile:targetname'],
-        )
-
-    Where `path/to/buildfile:targetname` is the dependent target address spec.
-
-    In case the target name is empty, it returns the last component of the path as target name, ie:
-
-        spec_path, target_name = parse_spec('path/to/buildfile/foo')
-
-    will return spec_path as 'path/to/buildfile/foo' and target_name as 'foo'.
-
-    Optionally, specs can be prefixed with '//' to denote an absolute spec path.  This is normally
-    not significant except when a spec referring to a root level target is needed from deeper in
-    the tree. For example, in `path/to/buildfile/BUILD`:
-
-        some_target(
-            name='mytarget',
-            dependencies=[':targetname'],
-        )
-
-    The `targetname` spec refers to a target defined in `path/to/buildfile/BUILD*`. If instead
-    you want to reference `targetname` in a root level BUILD file, use the absolute form.
-    For example:
-
-        some_target(
-            name='mytarget',
-            dependencies=['//:targetname'],
-        )
-    """
-
-    def normalize_absolute_refs(ref: str) -> str:
-        return strip_prefix(ref, "//")
-
-    subproject = (
-        longest_dir_prefix(relative_to, subproject_roots)
-        if relative_to and subproject_roots
-        else None
-    )
-
-    def prefix_subproject(spec_path: str) -> str:
-        if not subproject:
-            return spec_path
-        elif spec_path:
-            return os.path.join(subproject, spec_path)
-        else:
-            return os.path.normpath(subproject)
-
-    spec_parts = spec.rsplit(":", 1)
-    if len(spec_parts) == 1:
-        default_target_spec = spec_parts[0]
-        spec_path = prefix_subproject(normalize_absolute_refs(default_target_spec))
-        target_name = os.path.basename(spec_path)
-    else:
-        spec_path, target_name = spec_parts
-        if not spec_path and relative_to:
-            spec_path = fast_relpath(relative_to, subproject) if subproject else relative_to
-        spec_path = prefix_subproject(normalize_absolute_refs(spec_path))
-
-    return spec_path, target_name
+# Currently unused, but reserved for possible future needs.
+BANNED_CHARS_IN_TARGET_NAME = frozenset("@!?=")
 
 
 class InvalidSpecPath(ValueError):
@@ -97,6 +19,130 @@ class InvalidSpecPath(ValueError):
 
 class InvalidTargetName(ValueError):
     """Indicate an invalid target name for `Address`."""
+
+
+@dataclass(frozen=True)
+class AddressInput:
+    """A string that has been parsed and normalized using the Address syntax.
+
+    An AddressInput must be resolved into an Address using the engine (which involves inspecting
+    disk to determine the types of its components).
+    """
+
+    path_component: str
+    target_component: str
+
+    def __post_init__(self):
+        if not self.target_component:
+            raise InvalidTargetName(
+                f"Address spec {self.path_component}:{self.target_component} has no name part."
+            )
+        banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(self.target_component)
+        if banned_chars:
+            raise InvalidTargetName(
+                f"Banned chars found in target name. {banned_chars} not allowed in target "
+                f"name: {self.target_component}"
+            )
+
+        # A root or relative spec is OK
+        if self.path_component == "":
+            return
+        components = self.path_component.split(os.sep)
+        if any(component in (".", "..", "") for component in components):
+            raise InvalidSpecPath(
+                f"Address spec has un-normalized path part '{self.path_component}'"
+            )
+        if components[-1].startswith("BUILD"):
+            raise InvalidSpecPath(
+                f"Address spec path {self.path_component} has {components[-1]} as the last path part and BUILD is "
+                "a reserved file."
+            )
+        if os.path.isabs(self.path_component):
+            raise InvalidSpecPath(
+                f"Address spec has absolute path {self.path_component}; expected a path relative to the build "
+                "root."
+            )
+
+    @classmethod
+    def parse(
+        cls,
+        spec: str,
+        relative_to: Optional[str] = None,
+        subproject_roots: Optional[Sequence[str]] = None,
+    ) -> "AddressInput":
+        """
+        :param spec: Target address spec.
+        :param relative_to: path to use for sibling specs, ie: ':another_in_same_build_family',
+          interprets the missing spec_path part as `relative_to`.
+        :param subproject_roots: Paths that correspond with embedded build roots under
+          the current build root.
+
+        For example:
+
+            some_target(
+                name='mytarget',
+                dependencies=['path/to/buildfile:targetname'],
+            )
+
+        Where `path/to/buildfile:targetname` is the dependent target address spec.
+
+        In case the target name is empty, it returns the last component of the path as target name, ie:
+
+            spec_path, target_name = _parse_spec('path/to/buildfile/foo')
+
+        will return spec_path as 'path/to/buildfile/foo' and target_name as 'foo'.
+
+        Optionally, specs can be prefixed with '//' to denote an absolute spec path.  This is normally
+        not significant except when a spec referring to a root level target is needed from deeper in
+        the tree. For example, in `path/to/buildfile/BUILD`:
+
+            some_target(
+                name='mytarget',
+                dependencies=[':targetname'],
+            )
+
+        The `targetname` spec refers to a target defined in `path/to/buildfile/BUILD*`. If instead
+        you want to reference `targetname` in a root level BUILD file, use the absolute form.
+        For example:
+
+            some_target(
+                name='mytarget',
+                dependencies=['//:targetname'],
+            )
+        """
+        subproject = (
+            longest_dir_prefix(relative_to, subproject_roots)
+            if relative_to and subproject_roots
+            else None
+        )
+
+        def prefix_subproject(spec_path: str) -> str:
+            if not subproject:
+                return spec_path
+            elif spec_path:
+                return os.path.join(subproject, spec_path)
+            else:
+                return os.path.normpath(subproject)
+
+        spec_parts = spec.rsplit(":", 1)
+        if len(spec_parts) == 1:
+            default_target_spec = spec_parts[0]
+            path_component = prefix_subproject(strip_prefix(default_target_spec, "//"))
+            target_component = os.path.basename(path_component)
+        else:
+            path_component, target_component = spec_parts
+            if not path_component and relative_to:
+                path_component = (
+                    fast_relpath(relative_to, subproject) if subproject else relative_to
+                )
+            path_component = prefix_subproject(strip_prefix(path_component, "//"))
+
+        return cls(path_component, target_component)
+
+    def _unsafe_to_address(self) -> "Address":
+        # NB: This will not remain correct: the only caller of this method is deprecated,
+        # and AddressInputs should be converted to Addresses via the engine.
+        return Address(self.path_component, self.target_component)
 
 
 class Address:
@@ -118,12 +164,15 @@ class Address:
     """
 
     @classmethod
+    @deprecated(
+        "2.1.0.dev0",
+        hint_message=(
+            "An Address object should be resolved from an AddressInput using the engine. "
+            "This does not work properly with generated subtargets."
+        ),
+    )
     def parse(cls, spec: str, relative_to: str = "", subproject_roots=None) -> "Address":
         """Parses an address from its serialized form.
-
-        Note that this does not work properly with generated subtargets, e.g. the address
-        `helloworld/app.py`. We would not be able to calculate the `generated_base_target_name`, so
-        we treat this like a normal target address.
 
         :param spec: An address in string form <path>:<name>.
         :param relative_to: For sibling specs, ie: ':another_in_same_build_family', interprets
@@ -131,41 +180,9 @@ class Address:
         :param list subproject_roots: Paths that correspond with embedded build roots
                                       under the current build root.
         """
-        spec_path, target_name = parse_spec(
+        return AddressInput.parse(
             spec, relative_to=relative_to, subproject_roots=subproject_roots
-        )
-        return cls(spec_path, target_name)
-
-    @classmethod
-    def validate_path(cls, path: str) -> None:
-        # A root or relative spec is OK
-        if path == "":
-            return
-        components = path.split(os.sep)
-        if any(component in (".", "..", "") for component in components):
-            raise InvalidSpecPath(f"Address spec has un-normalized path part '{path}'")
-        if components[-1].startswith("BUILD"):
-            raise InvalidSpecPath(
-                f"Address spec path {path} has {components[-1]} as the last path part and BUILD is "
-                "a reserved file."
-            )
-        if os.path.isabs(path):
-            raise InvalidSpecPath(
-                f"Address spec has absolute path {path}; expected a path relative to the build "
-                "root."
-            )
-
-    @classmethod
-    def check_target_name(cls, spec_path: str, name: str) -> None:
-        if not name:
-            raise InvalidTargetName(f"Address spec {spec_path}:{name} has no name part")
-
-        banned_chars = BANNED_CHARS_IN_TARGET_NAME & set(name)
-        if banned_chars:
-            raise InvalidTargetName(
-                f"Banned chars found in target name. {banned_chars} not allowed in target "
-                f"name: {name}"
-            )
+        )._unsafe_to_address()
 
     def __init__(
         self, spec_path: str, target_name: str, *, generated_base_target_name: Optional[str] = None
@@ -176,8 +193,6 @@ class Address:
         :param generated_base_target_name: If this Address refers to a generated subtarget, this
                                            stores the target_name of the original base target.
         """
-        self.validate_path(spec_path)
-        self.check_target_name(spec_path, target_name)
         self._spec_path = spec_path
         self._target_name = target_name
         self.generated_base_target_name = generated_base_target_name

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -147,7 +147,7 @@ class AddressInput:
         return cls(path_component, target_component)
 
     def file_to_address(self) -> "Address":
-        """Converts to an Address by asserting that the path_component is a file on disk."""
+        """Converts to an Address by assuming that the path_component is a file on disk."""
         if self.target_component is None:
             # Use the default target in the same directory as the file.
             spec_path, relative_file_path = os.path.split(self.path_component)
@@ -196,7 +196,7 @@ class AddressInput:
         return Address(spec_path, relative_file_path=relative_file_path, target_name=target_name)
 
     def dir_to_address(self) -> "Address":
-        """Converts to an Address by asserting that the path_component is a directory on disk."""
+        """Converts to an Address by assuming that the path_component is a directory on disk."""
         return Address(spec_path=self.path_component, target_name=self.target_component)
 
 
@@ -259,6 +259,7 @@ class Address:
         """
         self.spec_path = spec_path
         self._relative_file_path = relative_file_path
+        # If the target_name is the same as the default name would be, we normalize to None.
         self._target_name = (
             target_name if target_name and target_name != os.path.basename(self.spec_path) else None
         )
@@ -325,6 +326,10 @@ class Address:
         target_portion = f"{parent_prefix}{self._target_name}" if self._target_name else ""
         return f"{self.spec_path.replace(os.sep, '.')}{file_portion}{target_portion}"
 
+    @deprecated(
+        removal_version="2.1.0.dev0",
+        hint_message="Use the property .spec, which is the same thing.",
+    )
     def reference(self) -> str:
         """How to reference this address in a BUILD file."""
         return self.spec

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -1,148 +1,143 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
+from pants.build_graph.address import Address, AddressInput, InvalidSpecPath, InvalidTargetName
+from pants.testutil.test_base import TestBase
 
-from pants.build_graph.address import Address, InvalidSpecPath, InvalidTargetName, parse_spec
 
-
-class ParseSpecTest(unittest.TestCase):
+class AddressTest(TestBase):
     def test_parse_spec(self) -> None:
-        spec_path, target_name = parse_spec("a/b/c")
-        self.assertEqual(spec_path, "a/b/c")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("a/b/c")
+        self.assertEqual(ai.path_component, "a/b/c")
+        self.assertEqual(ai.target_component, "c")
 
-        spec_path, target_name = parse_spec("a/b/c:c")
-        self.assertEqual(spec_path, "a/b/c")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("a/b/c:c")
+        self.assertEqual(ai.path_component, "a/b/c")
+        self.assertEqual(ai.target_component, "c")
 
-        spec_path, target_name = parse_spec(
-            "a/b/c", relative_to="here"
-        )  # no effect - we have a path
-        self.assertEqual(spec_path, "a/b/c")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("a/b/c", relative_to="here")  # no effect - we have a path
+        self.assertEqual(ai.path_component, "a/b/c")
+        self.assertEqual(ai.target_component, "c")
 
     def test_parse_local_spec(self) -> None:
-        spec_path, target_name = parse_spec(":c")
-        self.assertEqual(spec_path, "")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse(":c")
+        self.assertEqual(ai.path_component, "")
+        self.assertEqual(ai.target_component, "c")
 
-        spec_path, target_name = parse_spec(":c", relative_to="here")
-        self.assertEqual(spec_path, "here")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse(":c", relative_to="here")
+        self.assertEqual(ai.path_component, "here")
+        self.assertEqual(ai.target_component, "c")
 
     def test_parse_absolute_spec(self) -> None:
-        spec_path, target_name = parse_spec("//a/b/c")
-        self.assertEqual(spec_path, "a/b/c")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("//a/b/c")
+        self.assertEqual(ai.path_component, "a/b/c")
+        self.assertEqual(ai.target_component, "c")
 
-        spec_path, target_name = parse_spec("//a/b/c:c")
-        self.assertEqual(spec_path, "a/b/c")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("//a/b/c:c")
+        self.assertEqual(ai.path_component, "a/b/c")
+        self.assertEqual(ai.target_component, "c")
 
-        spec_path, target_name = parse_spec("//:c")
-        self.assertEqual(spec_path, "")
-        self.assertEqual(target_name, "c")
+        ai = AddressInput.parse("//:c")
+        self.assertEqual(ai.path_component, "")
+        self.assertEqual(ai.target_component, "c")
 
     def test_parse_bad_spec_non_normalized(self) -> None:
-        self.do_test_bad_spec_path("..")
-        self.do_test_bad_spec_path(".")
+        self.do_test_bad_path_component("..")
+        self.do_test_bad_path_component(".")
 
-        self.do_test_bad_spec_path("//..")
-        self.do_test_bad_spec_path("//.")
+        self.do_test_bad_path_component("//..")
+        self.do_test_bad_path_component("//.")
 
-        self.do_test_bad_spec_path("a/.")
-        self.do_test_bad_spec_path("a/..")
-        self.do_test_bad_spec_path("../a")
-        self.do_test_bad_spec_path("a/../a")
+        self.do_test_bad_path_component("a/.")
+        self.do_test_bad_path_component("a/..")
+        self.do_test_bad_path_component("../a")
+        self.do_test_bad_path_component("a/../a")
 
-        self.do_test_bad_spec_path("a/")
-        self.do_test_bad_spec_path("a/b/")
+        self.do_test_bad_path_component("a/:a")
+        self.do_test_bad_path_component("a/b/:b")
 
     def test_parse_bad_spec_bad_path(self) -> None:
-        self.do_test_bad_spec_path("/a")
-        self.do_test_bad_spec_path("///a")
+        self.do_test_bad_path_component("/a")
+        self.do_test_bad_path_component("///a")
 
     def test_parse_bad_spec_bad_name(self) -> None:
-        self.do_test_bad_target_name("a:")
-        self.do_test_bad_target_name("a::")
-        self.do_test_bad_target_name("//")
+        self.do_test_bad_target_component("a:")
+        self.do_test_bad_target_component("a::")
+        self.do_test_bad_target_component("//")
 
     def test_parse_bad_spec_build_trailing_path_component(self) -> None:
-        self.do_test_bad_spec_path("BUILD")
-        self.do_test_bad_spec_path("BUILD.suffix")
-        self.do_test_bad_spec_path("//BUILD")
-        self.do_test_bad_spec_path("//BUILD.suffix")
-        self.do_test_bad_spec_path("a/BUILD")
-        self.do_test_bad_spec_path("a/BUILD.suffix")
-        self.do_test_bad_spec_path("//a/BUILD")
-        self.do_test_bad_spec_path("//a/BUILD.suffix")
-        self.do_test_bad_spec_path("a/BUILD:b")
-        self.do_test_bad_spec_path("a/BUILD.suffix:b")
-        self.do_test_bad_spec_path("//a/BUILD:b")
-        self.do_test_bad_spec_path("//a/BUILD.suffix:b")
+        self.do_test_bad_path_component("BUILD")
+        self.do_test_bad_path_component("BUILD.suffix")
+        self.do_test_bad_path_component("//BUILD")
+        self.do_test_bad_path_component("//BUILD.suffix")
+        self.do_test_bad_path_component("a/BUILD")
+        self.do_test_bad_path_component("a/BUILD.suffix")
+        self.do_test_bad_path_component("//a/BUILD")
+        self.do_test_bad_path_component("//a/BUILD.suffix")
+        self.do_test_bad_path_component("a/BUILD:b")
+        self.do_test_bad_path_component("a/BUILD.suffix:b")
+        self.do_test_bad_path_component("//a/BUILD:b")
+        self.do_test_bad_path_component("//a/BUILD.suffix:b")
 
-    def test_banned_chars_in_target_name(self) -> None:
+    def test_banned_chars_in_target_component(self) -> None:
         with self.assertRaises(InvalidTargetName):
-            Address(*parse_spec("a/b:c@d"))
+            AddressInput.parse("a/b:c@d")
 
-    def do_test_bad_spec_path(self, spec: str) -> None:
+    def do_test_bad_path_component(self, spec: str) -> None:
         with self.assertRaises(InvalidSpecPath):
-            Address(*parse_spec(spec))
+            AddressInput.parse(spec)
 
-    def do_test_bad_target_name(self, spec: str) -> None:
+    def do_test_bad_target_component(self, spec: str) -> None:
         with self.assertRaises(InvalidTargetName):
-            Address(*parse_spec(spec))
+            AddressInput.parse(spec)
 
     def test_subproject_spec(self) -> None:
         # Ensure that a spec referring to a subproject gets assigned to that subproject properly.
         def parse(spec, relative_to):
-            return parse_spec(
+            return AddressInput.parse(
                 spec,
                 relative_to=relative_to,
                 subproject_roots=["subprojectA", "path/to/subprojectB"],
             )
 
         # Ensure that a spec in subprojectA is determined correctly.
-        spec_path, target_name = parse("src/python/alib", "subprojectA/src/python")
-        self.assertEqual("subprojectA/src/python/alib", spec_path)
-        self.assertEqual("alib", target_name)
+        ai = parse("src/python/alib", "subprojectA/src/python")
+        self.assertEqual("subprojectA/src/python/alib", ai.path_component)
+        self.assertEqual("alib", ai.target_component)
 
-        spec_path, target_name = parse("src/python/alib:jake", "subprojectA/src/python/alib")
-        self.assertEqual("subprojectA/src/python/alib", spec_path)
-        self.assertEqual("jake", target_name)
+        ai = parse("src/python/alib:jake", "subprojectA/src/python/alib")
+        self.assertEqual("subprojectA/src/python/alib", ai.path_component)
+        self.assertEqual("jake", ai.target_component)
 
-        spec_path, target_name = parse(":rel", "subprojectA/src/python/alib")
-        self.assertEqual("subprojectA/src/python/alib", spec_path)
-        self.assertEqual("rel", target_name)
+        ai = parse(":rel", "subprojectA/src/python/alib")
+        self.assertEqual("subprojectA/src/python/alib", ai.path_component)
+        self.assertEqual("rel", ai.target_component)
 
         # Ensure that a spec in subprojectB, which is more complex, is correct.
-        spec_path, target_name = parse("src/python/blib", "path/to/subprojectB/src/python")
-        self.assertEqual("path/to/subprojectB/src/python/blib", spec_path)
-        self.assertEqual("blib", target_name)
+        ai = parse("src/python/blib", "path/to/subprojectB/src/python")
+        self.assertEqual("path/to/subprojectB/src/python/blib", ai.path_component)
+        self.assertEqual("blib", ai.target_component)
 
-        spec_path, target_name = parse(
-            "src/python/blib:jane", "path/to/subprojectB/src/python/blib"
-        )
-        self.assertEqual("path/to/subprojectB/src/python/blib", spec_path)
-        self.assertEqual("jane", target_name)
+        ai = parse("src/python/blib:jane", "path/to/subprojectB/src/python/blib")
+        self.assertEqual("path/to/subprojectB/src/python/blib", ai.path_component)
+        self.assertEqual("jane", ai.target_component)
 
-        spec_path, target_name = parse(":rel", "path/to/subprojectB/src/python/blib")
-        self.assertEqual("path/to/subprojectB/src/python/blib", spec_path)
-        self.assertEqual("rel", target_name)
+        ai = parse(":rel", "path/to/subprojectB/src/python/blib")
+        self.assertEqual("path/to/subprojectB/src/python/blib", ai.path_component)
+        self.assertEqual("rel", ai.target_component)
 
         # Ensure that a spec in the parent project is not mapped.
-        spec_path, target_name = parse("src/python/parent", "src/python")
-        self.assertEqual("src/python/parent", spec_path)
-        self.assertEqual("parent", target_name)
+        ai = parse("src/python/parent", "src/python")
+        self.assertEqual("src/python/parent", ai.path_component)
+        self.assertEqual("parent", ai.target_component)
 
-        spec_path, target_name = parse("src/python/parent:george", "src/python")
-        self.assertEqual("src/python/parent", spec_path)
-        self.assertEqual("george", target_name)
+        ai = parse("src/python/parent:george", "src/python")
+        self.assertEqual("src/python/parent", ai.path_component)
+        self.assertEqual("george", ai.target_component)
 
-        spec_path, target_name = parse(":rel", "src/python/parent")
-        self.assertEqual("src/python/parent", spec_path)
-        self.assertEqual("rel", target_name)
+        ai = parse(":rel", "src/python/parent")
+        self.assertEqual("src/python/parent", ai.path_component)
+        self.assertEqual("rel", ai.target_component)
 
 
 def test_address_equality() -> None:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -3,13 +3,7 @@
 
 import unittest
 
-from pants.build_graph.address import (
-    Address,
-    BuildFileAddress,
-    InvalidSpecPath,
-    InvalidTargetName,
-    parse_spec,
-)
+from pants.build_graph.address import Address, InvalidSpecPath, InvalidTargetName, parse_spec
 
 
 class ParseSpecTest(unittest.TestCase):
@@ -228,21 +222,3 @@ def test_address_parse_method() -> None:
     # Do not attempt to parse generated subtargets, as we would have no way to find the
     # generated_base_target_name.
     assert_parsed("a/b/f.py", "f.py", Address.parse("a/b/f.py"))
-
-
-def test_build_file_address() -> None:
-    bfa = BuildFileAddress(rel_path="dir/BUILD", target_name="example")
-    assert bfa.spec == "dir:example"
-    assert bfa == Address("dir", "example")
-    assert type(bfa.to_address()) is Address
-    assert bfa.to_address() == Address("dir", "example")
-
-    generated_bfa = BuildFileAddress(
-        rel_path="dir/BUILD", target_name="example.txt", generated_base_target_name="original"
-    )
-    assert generated_bfa != BuildFileAddress(rel_path="dir/BUILD", target_name="example.txt")
-    assert generated_bfa == Address("dir", "example.txt", generated_base_target_name="original")
-    assert generated_bfa.spec == "dir/example.txt"
-    assert generated_bfa.maybe_convert_to_base_target() == BuildFileAddress(
-        rel_path="dir/BUILD", target_name="original"
-    )

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -211,6 +211,9 @@ def test_address_input_from_dir() -> None:
 
 def test_address_normalize_target_name() -> None:
     assert Address("a/b/c", target_name="c") == Address("a/b/c", target_name=None)
+    assert Address("a/b/c", target_name="c", relative_file_path="f.txt") == Address(
+        "a/b/c", target_name=None, relative_file_path="f.txt"
+    )
 
 
 def test_address_equality() -> None:

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -356,7 +356,7 @@ async def run_tests(
         format_str = f"{{addr:80}}.....{{result:>{right_align}}}"
         console.print_stderr(
             format_str.format(
-                addr=result.address.reference(), result=color(result.test_result.status.value)
+                addr=result.address.spec, result=color(result.test_result.status.value)
             )
         )
 

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -82,7 +82,7 @@ def calculate_specified_sources(
 ) -> Union[Snapshot, DigestSubset]:
     # AddressSpecs simply use the entire `sources` field. If it's a generated subtarget, we also
     # know we're as precise as we can get (1 file), so use the whole snapshot.
-    if isinstance(origin, AddressSpec) or address.generated_base_target_name:
+    if isinstance(origin, AddressSpec) or not address.is_base_target:
         return sources_snapshot
     # NB: we ensure that `precise_files_specified` is a subset of the original `sources` field.
     # It's possible when given a glob filesystem spec that the spec will have

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -31,7 +31,7 @@ class Addresses(Collection[Address]):
 
 @dataclass(frozen=True)
 class AddressWithOrigin:
-    """A BuildFileAddress along with the cmd-line spec it was generated from."""
+    """An Address along with the cmd-line spec it was generated from."""
 
     address: Address
     origin: OriginSpec

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from pants.base.exceptions import ResolveError
 from pants.base.specs import OriginSpec
 from pants.build_graph.address import Address as Address
+from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexporting.
 from pants.build_graph.address import BuildFileAddress as BuildFileAddress
 from pants.engine.collection import Collection
 

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -63,7 +63,7 @@ async def resolve_address(address_input: AddressInput) -> Address:
         snapshot = await Get(Snapshot, PathGlobs(globs=(address_input.path_component,)))
         is_file, is_dir = bool(snapshot.files), bool(snapshot.dirs)
     else:
-        # Is a target in the root directory.
+        # It is an address in the root directory.
         is_file, is_dir = False, True
 
     if is_file:
@@ -120,8 +120,6 @@ def _raise_did_you_mean(address_family: AddressFamily, name: str, source=None) -
 
 @rule
 async def find_build_file(address: Address) -> BuildFileAddress:
-    # TODO: if the Address is for a base target, can immediately use its `file`, which is already
-    # the BUILD file.
     address_family = await Get(AddressFamily, Dir(address.spec_path))
     owning_address = address.maybe_convert_to_base_target()
     if address_family.addressable_for_address(owning_address) is None:

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -318,9 +318,12 @@ class ResolveAddressIntegrationTest(TestBase):
             Address("a/b", relative_file_path="c.txt", target_name="c"),
         )
 
-        # Top-level addresses will not have a path_component.
+        # Top-level addresses will not have a path_component, unless they are a file address.
         self.create_file("f.txt")
-        assert_is_expected(AddressInput("f.txt"), Address("", relative_file_path="f.txt"))
+        assert_is_expected(
+            AddressInput("f.txt", target_component="original"),
+            Address("", relative_file_path="f.txt", target_name="original"),
+        )
         assert_is_expected(AddressInput("", target_component="t"), Address("", target_name="t"))
 
         with pytest.raises(ExecutionError) as exc:

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -264,7 +264,10 @@ class BuildFileIntegrationTest(TestBase):
     def test_build_file_address(self) -> None:
         self.create_file("helloworld/BUILD.ext", "mock_tgt()")
         addr = Address.parse("helloworld")
-        expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", target_name="helloworld")
+        expected_bfa = BuildFileAddress(
+            rel_path="helloworld/BUILD.ext",
+            address=Address(spec_path="helloworld", target_name="helloworld"),
+        )
         bfa = self.request_single_product(BuildFileAddress, addr)
         assert bfa == expected_bfa
         bfas = self.request_single_product(BuildFileAddresses, Addresses([addr]))
@@ -273,11 +276,7 @@ class BuildFileIntegrationTest(TestBase):
     def test_build_file_address_generated_subtarget(self) -> None:
         self.create_file("helloworld/BUILD.ext", "mock_tgt(name='original')")
         addr = Address("helloworld", target_name="generated", generated_base_target_name="original")
-        expected_bfa = BuildFileAddress(
-            rel_path="helloworld/BUILD.ext",
-            target_name="generated",
-            generated_base_target_name="original",
-        )
+        expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", address=addr)
         bfa = self.request_single_product(BuildFileAddress, addr)
         assert bfa == expected_bfa
         bfas = self.request_single_product(BuildFileAddresses, Addresses([addr]))

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -275,7 +275,7 @@ class BuildFileIntegrationTest(TestBase):
 
     def test_build_file_address_generated_subtarget(self) -> None:
         self.create_file("helloworld/BUILD.ext", "mock_tgt(name='original')")
-        addr = Address("helloworld", target_name="generated", generated_base_target_name="original")
+        addr = Address("helloworld", target_name="original", relative_file_path="generated")
         expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", address=addr)
         bfa = self.request_single_product(BuildFileAddress, addr)
         assert bfa == expected_bfa

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -621,7 +621,7 @@ async def hydrate_sources(
             conjunction=conjunction,
             glob_match_error_behavior=glob_match_error_behavior,
             # TODO(#9012): add line number referring to the sources field. When doing this, we'll
-            # likely need to `await Get(BuildFileAddress](Address)`.
+            # likely need to `await Get(BuildFileAddress, Address)`.
             description_of_origin=(
                 f"{sources_field.address}'s `{sources_field.alias}` field"
                 if glob_match_error_behavior != GlobMatchErrorBehavior.ignore

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -964,26 +964,14 @@ class TestCodegen(TestBase):
 
 
 def test_parse_dependencies_field() -> None:
-    given_and_expected = {
-        ":relative": AddressInput("demo/subdir", "relative"),
-        "//:top_level": AddressInput("", "top_level"),
-        "demo:tgt": AddressInput("demo", "tgt"),
-        "demo": AddressInput("demo"),
-        "relative.txt": AddressInput("relative.txt"),
-        "child/f.txt": AddressInput("child/f.txt"),
-        "demo/f.txt": AddressInput("demo/f.txt"),
-        "//top_level.txt": AddressInput("top_level.txt"),
-        "top_level2.txt": AddressInput("top_level2.txt"),
-        "demo/no_extension": AddressInput("demo/no_extension"),
-        "//demo/no_extension": AddressInput("demo/no_extension"),
-        "no_extension": AddressInput("no_extension"),
-    }
+    """Ensure that we correctly handle `!` ignores.
+
+    We leave the rest of the parsing to AddressInput and Address.
+    """
     result = parse_dependencies_field(
-        [*given_and_expected.keys(), *(f"!{v}" for v in given_and_expected.keys())],
-        spec_path="demo/subdir",
-        subproject_roots=[],
+        ["a/b/c", "!a/b/c", "f.txt", "!f.txt"], spec_path="demo/subdir", subproject_roots=[],
     )
-    expected_addresses = {*given_and_expected.values()}
+    expected_addresses = {AddressInput("a/b/c"), AddressInput("f.txt")}
     assert set(result.addresses) == expected_addresses
     assert set(result.ignored_addresses) == expected_addresses
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -5,7 +5,7 @@ import itertools
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Iterable, List, Sequence, Tuple, Type
+from typing import Iterable, List, Sequence, Tuple, Type, cast
 
 import pytest
 
@@ -17,7 +17,13 @@ from pants.base.specs import (
     FilesystemSpecs,
     SingleAddress,
 )
-from pants.engine.addresses import Address, Addresses, AddressesWithOrigins, AddressWithOrigin
+from pants.engine.addresses import (
+    Address,
+    Addresses,
+    AddressesWithOrigins,
+    AddressInput,
+    AddressWithOrigin,
+)
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -964,11 +970,11 @@ def test_parse_dependencies_field() -> None:
         subproject_roots=[],
     )
     expected_addresses = {
-        Address("demo/subdir", "relative"),
-        Address("", "top_level"),
-        Address("demo", "tgt"),
-        Address("demo", "demo"),
-        Address("demo/no_extension", "no_extension"),
+        AddressInput("demo/subdir", "relative"),
+        AddressInput("", "top_level"),
+        AddressInput("demo", "tgt"),
+        AddressInput("demo", "demo"),
+        AddressInput("demo/no_extension", "no_extension"),
     }
     assert set(result.addresses) == expected_addresses
     assert set(result.ignored_addresses) == expected_addresses
@@ -1091,7 +1097,7 @@ async def infer_smalltalk_dependencies(request: InferSmalltalkDependencies) -> I
                 target_name=gen_name,
                 generated_base_target_name=base_address.target_name,
             )
-        return Address.parse(line)
+        return cast(Address, Address.parse(line))
 
     return InferredDependencies(infer(line) for line in all_lines)
 

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -66,7 +66,7 @@ def test_address_family_create_single() -> None:
     assert {
         Address.parse("//:one"): TargetAdaptor(type_alias="thing", name="one", age=42),
         Address.parse("//:two"): TargetAdaptor(type_alias="thing", name="two", age=37),
-    } == address_family.addressables
+    } == {bfa.address: ta for bfa, ta in address_family.addressables.items()}
 
 
 def test_address_family_create_multiple() -> None:
@@ -86,7 +86,7 @@ def test_address_family_create_multiple() -> None:
     assert {
         Address.parse("name/space:one"): TargetAdaptor(type_alias="thing", name="one", age=42),
         Address.parse("name/space:two"): TargetAdaptor(type_alias="thing", name="two", age=37),
-    } == address_family.addressables
+    } == {bfa.address: ta for bfa, ta in address_family.addressables.items()}
 
 
 def test_address_family_create_empty() -> None:

--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -31,6 +31,6 @@ class SchedulerIntegrationTest(PantsRunIntegrationTest):
         pants_result = self.run_pants(args)
         self.assert_failure(pants_result)
         self.assertEqual(
-            pants_result.stdout_data, "examples/src/python/example/hello/greet:greet\n",
+            pants_result.stdout_data, "examples/src/python/example/hello/greet\n",
         )
         self.assertEqual(pants_result.returncode, 42)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -591,11 +591,11 @@ def generate_subtarget_address(base_target_address: Address, *, full_file_name: 
     See generate_subtarget().
     """
     original_spec_path = base_target_address.spec_path
-    relativized_file_name = PurePath(full_file_name).relative_to(original_spec_path).as_posix()
+    relative_file_path = PurePath(full_file_name).relative_to(original_spec_path).as_posix()
     return Address(
         spec_path=original_spec_path,
-        target_name=relativized_file_name,
-        generated_base_target_name=base_target_address.target_name,
+        target_name=base_target_address.target_name,
+        relative_file_path=relative_file_path,
     )
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -425,7 +425,7 @@ def test_generate_subtarget() -> None:
         address=Address.parse("src/fortran:demo"),
     )
     expected_single_source_address = Address(
-        "src/fortran", target_name="demo.f95", generated_base_target_name="demo"
+        "src/fortran", relative_file_path="demo.f95", target_name="demo"
     )
     assert generate_subtarget(
         single_source_tgt, full_file_name="src/fortran/demo.f95"
@@ -441,7 +441,7 @@ def test_generate_subtarget() -> None:
         {Sources.alias: ["demo.f95", "subdir/demo.f95"]}, address=Address.parse("src/fortran:demo")
     )
     expected_subdir_address = Address(
-        "src/fortran", target_name="subdir/demo.f95", generated_base_target_name="demo"
+        "src/fortran", relative_file_path="subdir/demo.f95", target_name="demo"
     )
     assert generate_subtarget(
         subdir_tgt, full_file_name="src/fortran/subdir/demo.f95"
@@ -457,7 +457,7 @@ def test_generate_subtarget() -> None:
 
     no_sources_tgt = NoSourcesTgt({Tags.alias: ["demo"]}, address=Address.parse("//:no_sources"))
     expected_no_sources_address = Address(
-        "", target_name="fake.txt", generated_base_target_name="no_sources"
+        "", relative_file_path="fake.txt", target_name="no_sources"
     )
     assert generate_subtarget(no_sources_tgt, full_file_name="fake.txt") == NoSourcesTgt(
         {Tags.alias: ["demo"]}, address=expected_no_sources_address

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from pathlib import PurePath
 from typing import Iterable, Optional, cast
 
 from pants.base.build_environment import get_buildroot, get_scm
@@ -120,9 +119,10 @@ class SpecsCalculator:
         address_specs = []
         filesystem_specs = []
         for address in cast(ChangedAddresses, changed_addresses):
-            if address.generated_base_target_name:
-                file_name = PurePath(address.spec_path, address.target_name).as_posix()
-                filesystem_specs.append(FilesystemLiteralSpec(file_name))
+            if not address.is_base_target:
+                # TODO: Should adjust Specs parsing to support parsing the disambiguated file
+                # Address, which would bypass-rediscovering owners.
+                filesystem_specs.append(FilesystemLiteralSpec(address.filename))
             else:
                 address_specs.append(SingleAddress(address.spec_path, address.target_name))
         return Specs(

--- a/src/python/pants/testutil/goal_rule_test_base.py
+++ b/src/python/pants/testutil/goal_rule_test_base.py
@@ -134,7 +134,7 @@ class GoalRuleTestBase(TestBase):
         **kwargs: additional kwargs passed to execute_rule.
         """
         result = self.execute_rule(**kwargs)
-        assert list(output) == result.stdout.splitlines()
+        self.assertEqual(list(output), result.stdout.splitlines())
 
     def assert_console_raises(self, exception: Type[Exception], **kwargs) -> None:
         """Verifies the expected exception is raised by the goal rule.

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -36,7 +36,7 @@ class PantsRequirementTest(TestBase):
     ) -> None:
         self.add_to_build_file("3rdparty/python", f"{build_file_entry}\n")
         target = self.request_single_product(
-            WrappedTarget, Address("3rdparty/python", expected_target_name)
+            WrappedTarget, Address("3rdparty/python", target_name=expected_target_name)
         ).target
         assert isinstance(target, PythonRequirementLibrary)
         expected = PythonRequirement(

--- a/tests/python/pants_test/backend/python/test_python_requirement_list.py
+++ b/tests/python/pants_test/backend/python/test_python_requirement_list.py
@@ -28,7 +28,9 @@ class PythonRequirementListTest(TestBase):
         self, build_file_entry: str, *, target_name: str
     ) -> Tuple[PythonRequirement, ...]:
         self.add_to_build_file("lib", f"{build_file_entry}\n")
-        target = self.request_single_product(WrappedTarget, Address("lib", target_name)).target
+        target = self.request_single_product(
+            WrappedTarget, Address("lib", target_name=target_name)
+        ).target
         assert isinstance(target, PythonRequirementLibrary)
         return target[PythonRequirementsField].value
 

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -23,7 +23,7 @@ class BuildIgnoreIntegrationTest(PantsRunIntegrationTest):
         self.assert_failure(ignore_result)
         assert f"{tmpdir_relative}/dir" in ignore_result.stderr_data
         self.assert_success(no_ignore_result)
-        assert f"{tmpdir_relative}/dir:dir" in no_ignore_result.stdout_data
+        assert f"{tmpdir_relative}/dir" in no_ignore_result.stdout_data
 
     def test_build_ignore_dependency(self) -> None:
         with temporary_dir(root_dir=get_buildroot()) as tmpdir:

--- a/tests/python/pants_test/integration/changed_integration_test.py
+++ b/tests/python/pants_test/integration/changed_integration_test.py
@@ -140,13 +140,13 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
     TEST_MAPPING = {
         # A `python_binary` with `sources=['file.name']`.
         "src/python/python_targets/test_binary.py": dict(
-            none=["src/python/python_targets/test_binary.py"],
+            none=["src/python/python_targets/test_binary.py:test"],
             direct=["src/python/python_targets:test"],
             transitive=["src/python/python_targets:test"],
         ),
         # A `python_library` with `sources=['file.name']`.
         "src/python/python_targets/test_library.py": dict(
-            none=["src/python/python_targets/test_library.py"],
+            none=["src/python/python_targets/test_library.py:test_library"],
             direct=[
                 "src/python/python_targets:test",
                 "src/python/python_targets:test_library",

--- a/tests/python/pants_test/integration/changed_integration_test.py
+++ b/tests/python/pants_test/integration/changed_integration_test.py
@@ -165,8 +165,8 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
         # A `python_library` with `sources=['file.name'] .
         "src/python/sources/sources.py": dict(
             none=["src/python/sources/sources.py"],
-            direct=["src/python/sources:sources"],
-            transitive=["src/python/sources:sources"],
+            direct=["src/python/sources"],
+            transitive=["src/python/sources"],
         ),
         # An unclaimed source file.
         "src/python/python_targets/test_unclaimed_src.py": dict(none=[], direct=[], transitive=[]),
@@ -281,7 +281,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
             safe_delete(os.path.join(worktree, "src/python/sources/sources.py"))
             pants_run = self.run_pants(["list", "--changed-since=HEAD"])
             self.assert_success(pants_run)
-            self.assertEqual(pants_run.stdout_data.strip(), "src/python/sources:sources")
+            self.assertEqual(pants_run.stdout_data.strip(), "src/python/sources")
 
     def test_changed_with_deleted_resource(self):
         with create_isolated_git_repo() as worktree:
@@ -319,7 +319,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
             safe_delete(os.path.join(worktree, deleted_file))
             pants_run = self.run_pants(["--changed-since=HEAD", "list"])
             self.assert_success(pants_run)
-            self.assertEqual(pants_run.stdout_data.strip(), "src/python/sources:sources")
+            self.assertEqual(pants_run.stdout_data.strip(), "src/python/sources")
 
 
 ChangedIntegrationTest.generate_tests()

--- a/tests/python/pants_test/integration/goal_rule_integration_test.py
+++ b/tests/python/pants_test/integration/goal_rule_integration_test.py
@@ -23,7 +23,7 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
         result = self.do_command("list", self.target, success=True)
         output_lines = result.stdout_data.splitlines()
         self.assertEqual(len(output_lines), 4)
-        self.assertIn("examples/src/python/example/hello/main:main", output_lines)
+        self.assertIn("examples/src/python/example/hello/main", output_lines)
 
     def test_list_does_not_cache(self):
         with self.pantsd_successful_run_context() as ctx:


### PR DESCRIPTION
This adds a new syntax for generated subtargets / file deps to specify which original base target they come from: `a/b/c.txt:original`, with the following characteristics:

* If the original target has a "default name", meaning the `name` field is left off, then there is no need for the disambiguation.
* As before, a base target can live in an ancestor directory, e.g. `a/b/c.txt:../../original`.

Thanks to this new syntax, we no longer look for the Owners of explicit file dependencies. We require the values to be unambiguous, which improves performance and removes an edge case where we would error if there were multiple owners of the file.

We use the engine now to parse an `AddressInput` into an `Address`. This is necessary so that we can properly determine if a path is a file or a directory, as `a/b/c` could technically be a file or a directory.

In followups, we can extend this syntax to file specs. It also will allow us to consistently use generated subtargets when using file specs, which will simplify lots of that code and resolve https://github.com/pantsbuild/pants/issues/10455.