### PR TITLE
Stream output of `lint`, rather than dumping at the end

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -23,6 +23,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
+from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
@@ -114,6 +115,7 @@ async def bandit_lint_partition(
                 f"{address_references}."
             ),
             output_files=(report_file_name,) if report_file_name else None,
+            level=LogLevel.DEBUG,
         ),
     )
 
@@ -132,15 +134,15 @@ async def bandit_lint_partition(
         )
         report = LintReport(report_file_name, report_digest)
 
-    return LintResult.from_fallible_process_result(result, linter_name="Bandit", report=report)
+    return LintResult.from_fallible_process_result(result, report=report)
 
 
-@rule(desc="Lint using Bandit")
+@rule(desc="Lint with Bandit")
 async def bandit_lint(
     request: BanditRequest, bandit: Bandit, python_setup: PythonSetup
 ) -> LintResults:
     if bandit.skip:
-        return LintResults()
+        return LintResults([], linter_name="Bandit")
 
     # NB: Bandit output depends upon which Python interpreter version it's run with
     # ( https://github.com/PyCQA/bandit#under-which-version-of-python-should-i-install-bandit). We
@@ -153,7 +155,7 @@ async def bandit_lint(
         Get(LintResult, BanditPartition(partition_field_sets, partition_compatibility))
         for partition_compatibility, partition_field_sets in constraints_to_field_sets.items()
     )
-    return LintResults(partitioned_results)
+    return LintResults(partitioned_results, linter_name="bandit")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -96,24 +96,17 @@ async def bandit_lint_partition(
         Digest, MergeDigests((source_files.snapshot.digest, requirements_pex.digest, config_digest))
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in partition.field_sets)
-    )
     report_file_name = "bandit_report.txt" if lint_subsystem.reports_dir else None
-    args = generate_args(
-        source_files=source_files, bandit=bandit, report_file_name=report_file_name
-    )
 
     result = await Get(
         FallibleProcessResult,
         PexProcess(
             requirements_pex,
-            argv=args,
-            input_digest=input_digest,
-            description=(
-                f"Run Bandit on {pluralize(len(partition.field_sets), 'target')}: "
-                f"{address_references}."
+            argv=generate_args(
+                source_files=source_files, bandit=bandit, report_file_name=report_file_name
             ),
+            input_digest=input_digest,
+            description=f"Run Bandit on {pluralize(len(partition.field_sets), 'file')}.",
             output_files=(report_file_name,) if report_file_name else None,
             level=LogLevel.DEBUG,
         ),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -127,7 +127,9 @@ async def bandit_lint_partition(
         )
         report = LintReport(report_file_name, report_digest)
 
-    return LintResult.from_fallible_process_result(result, report=report)
+    return LintResult.from_fallible_process_result(
+        result, partition_description=str(sorted(partition.interpreter_constraints)), report=report
+    )
 
 
 @rule(desc="Lint with Bandit")
@@ -148,7 +150,7 @@ async def bandit_lint(
         Get(LintResult, BanditPartition(partition_field_sets, partition_compatibility))
         for partition_compatibility, partition_field_sets in constraints_to_field_sets.items()
     )
-    return LintResults(partitioned_results, linter_name="bandit")
+    return LintResults(partitioned_results, linter_name="Bandit")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -125,12 +125,16 @@ class BanditIntegrationTest(ExternalToolTestBase):
         # to still fail, but Py3 should pass.
         combined_result = self.run_bandit([py2_target, py3_target])
         assert len(combined_result) == 2
+
         batched_py2_result, batched_py3_result = sorted(
             combined_result, key=lambda result: result.stderr
         )
         assert batched_py2_result.exit_code == 0
+        assert batched_py2_result.partition_description == "['CPython==2.7.*']"
         assert "py3.py (syntax error while parsing AST from file)" in batched_py2_result.stdout
+
         assert batched_py3_result.exit_code == 0
+        assert batched_py3_result.partition_description == "['CPython>=3.6']"
         assert "No issues identified." in batched_py3_result.stdout
 
     def test_respects_config_file(self) -> None:

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -1,12 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.rules import RootRule
@@ -46,7 +46,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResults:
+    ) -> Sequence[LintResult]:
         args = ["--backend-packages=pants.backend.python.lint.bandit"]
         if config:
             self.create_file(relpath=".bandit", contents=config)
@@ -57,13 +57,14 @@ class BanditIntegrationTest(ExternalToolTestBase):
             args.append("--bandit-skip")
         if additional_args:
             args.extend(additional_args)
-        return self.request_single_product(
+        results = self.request_single_product(
             LintResults,
             Params(
                 BanditRequest(BanditFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )
+        return results.results
 
     def test_passing_source(self) -> None:
         target = self.make_target([self.good_source])

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -110,10 +110,6 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
         MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
-    )
-
     process = await Get(
         Process,
         PexProcess(
@@ -123,10 +119,7 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
             ),
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
-            description=(
-                f"Run Black on {pluralize(len(setup_request.request.field_sets), 'target')}: "
-                f"{address_references}"
-            ),
+            description=f"Run Black on {pluralize(len(setup_request.request.field_sets), 'file')}.",
             level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
         ),
     )

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -1,13 +1,13 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from pants.backend.python.lint.black.rules import BlackFieldSet, BlackRequest
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -43,7 +43,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
-    ) -> Tuple[LintResults, FmtResult]:
+    ) -> Tuple[Sequence[LintResult], FmtResult]:
         args = ["--backend-packages=pants.backend.python.lint.black"]
         if config is not None:
             self.create_file(relpath="pyproject.toml", contents=config)
@@ -71,7 +71,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
                 options_bootstrapper,
             ),
         )
-        return lint_results, fmt_result
+        return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
         return self.request_single_product(Digest, CreateDigest(source_files))

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -102,8 +102,7 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
             description=(
-                f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'target')}: "
-                f"{address_references}"
+                f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'file')}."
             ),
             level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
         ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -86,10 +86,6 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
         Digest, MergeDigests((source_files_snapshot.digest, requirements_pex.digest))
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
-    )
-
     process = await Get(
         Process,
         PexProcess(

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -24,6 +24,7 @@ from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
@@ -102,14 +103,15 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
             output_files=source_files_snapshot.files,
             description=(
                 f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'target')}: "
-                f"{address_references}."
+                f"{address_references}"
             ),
+            level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
         ),
     )
     return Setup(process, original_digest=source_files_snapshot.digest)
 
 
-@rule(desc="Format Python docstrings with docformatter")
+@rule(desc="Format with docformatter")
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
         return FmtResult.noop()
@@ -120,16 +122,16 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
     )
 
 
-@rule(desc="Lint Python docstrings with docformatter")
+@rule(desc="Lint with docformatter")
 async def docformatter_lint(
     request: DocformatterRequest, docformatter: Docformatter
 ) -> LintResults:
     if docformatter.skip:
-        return LintResults()
+        return LintResults([], linter_name="Docformatter")
     setup = await Get(Setup, SetupRequest(request, check_only=True))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return LintResults(
-        [LintResult.from_fallible_process_result(result, linter_name="Docformatter")]
+        [LintResult.from_fallible_process_result(result)], linter_name="Docformatter"
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -1,13 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from pants.backend.python.lint.docformatter.rules import DocformatterFieldSet, DocformatterRequest
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -35,7 +35,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
 
     def run_docformatter(
         self, targets: List[Target], *, passthrough_args: Optional[str] = None, skip: bool = False,
-    ) -> Tuple[LintResults, FmtResult]:
+    ) -> Tuple[Sequence[LintResult], FmtResult]:
         args = ["--backend-packages=pants.backend.python.lint.docformatter"]
         if passthrough_args:
             args.append(f"--docformatter-args='{passthrough_args}'")
@@ -60,7 +60,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
                 options_bootstrapper,
             ),
         )
-        return lint_results, fmt_result
+        return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
         return self.request_single_product(Digest, CreateDigest(source_files))

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -97,9 +97,6 @@ async def flake8_lint_partition(
         MergeDigests((source_files.snapshot.digest, requirements_pex.digest, config_digest)),
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in partition.field_sets)
-    )
     report_file_name = "flake8_report.txt" if lint_subsystem.reports_dir else None
 
     result = await Get(
@@ -111,10 +108,7 @@ async def flake8_lint_partition(
             ),
             input_digest=input_digest,
             output_files=(report_file_name,) if report_file_name else None,
-            description=(
-                f"Run Flake8 on {pluralize(len(partition.field_sets), 'target')}: "
-                f"{address_references}"
-            ),
+            description=f"Run Flake8 on {pluralize(len(partition.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -128,7 +128,9 @@ async def flake8_lint_partition(
         )
         report = LintReport(report_file_name, report_digest)
 
-    return LintResult.from_fallible_process_result(result, report=report)
+    return LintResult.from_fallible_process_result(
+        result, partition_description=str(sorted(partition.interpreter_constraints)), report=report
+    )
 
 
 @rule(desc="Lint with Flake8")

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -126,8 +126,11 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             combined_result, key=lambda result: result.exit_code
         )
         assert batched_py2_result.exit_code == 1
+        assert batched_py2_result.partition_description == "['CPython==2.7.*']"
         assert "py3.py:1:8: E999 SyntaxError" in batched_py2_result.stdout
+
         assert batched_py3_result.exit_code == 0
+        assert batched_py3_result.partition_description == "['CPython>=3.6']"
         assert batched_py3_result.stdout.strip() == ""
 
     def test_respects_config_file(self) -> None:

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -1,12 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from pants.backend.python.lint.flake8.rules import Flake8FieldSet, Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonLibrary
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.rules import RootRule
@@ -45,7 +45,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResults:
+    ) -> Sequence[LintResult]:
         args = ["--backend-packages=pants.backend.python.lint.flake8"]
         if config:
             self.create_file(relpath=".flake8", contents=config)
@@ -56,13 +56,14 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             args.append("--flake8-skip")
         if additional_args:
             args.extend(additional_args)
-        return self.request_single_product(
+        results = self.request_single_product(
             LintResults,
             Params(
                 Flake8Request(Flake8FieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )
+        return results.results
 
     def test_passing_source(self) -> None:
         target = self.make_target([self.good_source])

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -109,10 +109,6 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
         MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in setup_request.request.field_sets)
-    )
-
     process = await Get(
         Process,
         PexProcess(
@@ -122,10 +118,7 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
             ),
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
-            description=(
-                f"Run isort on {pluralize(len(setup_request.request.field_sets), 'target')}: "
-                f"{address_references}"
-            ),
+            description=f"Run isort on {pluralize(len(setup_request.request.field_sets), 'file')}.",
             level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
         ),
     )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -1,13 +1,13 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from pants.backend.python.lint.isort.rules import IsortFieldSet, IsortRequest
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.goals.fmt import FmtResult
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -50,7 +50,7 @@ class IsortIntegrationTest(ExternalToolTestBase):
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
         skip: bool = False,
-    ) -> Tuple[LintResults, FmtResult]:
+    ) -> Tuple[Sequence[LintResult], FmtResult]:
         args = ["--backend-packages=pants.backend.python.lint.isort"]
         if config is not None:
             self.create_file(relpath=".isort.cfg", contents=config)
@@ -78,7 +78,7 @@ class IsortIntegrationTest(ExternalToolTestBase):
                 options_bootstrapper,
             ),
         )
-        return lint_results, fmt_result
+        return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
         return self.request_single_product(Digest, CreateDigest(source_files))

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -49,6 +49,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
+from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize
 
@@ -233,9 +234,10 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
                 f"Run Pylint on {pluralize(len(partition.field_sets), 'target')}: "
                 f"{address_references}."
             ),
+            level=LogLevel.DEBUG,
         ),
     )
-    return LintResult.from_fallible_process_result(result, linter_name="Pylint")
+    return LintResult.from_fallible_process_result(result)
 
 
 @rule(desc="Lint using Pylint")
@@ -243,7 +245,7 @@ async def pylint_lint(
     request: PylintRequest, pylint: Pylint, python_setup: PythonSetup
 ) -> LintResults:
     if pylint.skip:
-        return LintResults()
+        return LintResults([], linter_name="Pylint")
 
     plugin_targets_request = Get(
         TransitiveTargets,
@@ -296,7 +298,7 @@ async def pylint_lint(
     partitioned_results = await MultiGet(
         Get(LintResult, PylintPartition, partition) for partition in partitions
     )
-    return LintResults(partitioned_results)
+    return LintResults(partitioned_results, linter_name="Pylint")
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -219,10 +219,6 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         ),
     )
 
-    address_references = ", ".join(
-        sorted(field_set.address.spec for field_set in partition.field_sets)
-    )
-
     result = await Get(
         FallibleProcessResult,
         PexProcess(
@@ -230,10 +226,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
             argv=generate_args(source_files=field_set_sources, pylint=pylint),
             input_digest=input_digest,
             extra_env={"PEX_EXTRA_SYS_PATH": ":".join(pythonpath)},
-            description=(
-                f"Run Pylint on {pluralize(len(partition.field_sets), 'target')}: "
-                f"{address_references}."
-            ),
+            description=f"Run Pylint on {pluralize(len(partition.field_sets), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -230,7 +230,9 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
             level=LogLevel.DEBUG,
         ),
     )
-    return LintResult.from_fallible_process_result(result)
+    return LintResult.from_fallible_process_result(
+        result, partition_description=str(sorted(partition.interpreter_constraints))
+    )
 
 
 @rule(desc="Lint using Pylint")

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -175,9 +175,13 @@ class PylintIntegrationTest(ExternalToolTestBase):
         batched_py3_result, batched_py2_result = sorted(
             combined_result, key=lambda result: result.exit_code
         )
+
         assert batched_py2_result.exit_code == 2
+        assert batched_py2_result.partition_description == "['CPython==2.7.*']"
         assert "invalid syntax (<string>, line 2) (syntax-error)" in batched_py2_result.stdout
+
         assert batched_py3_result.exit_code == 0
+        assert batched_py3_result.partition_description == "['CPython>=3.6,<3.8']"
         assert "Your code has been rated at 10.00/10" in batched_py3_result.stdout.strip()
 
     def test_respects_config_file(self) -> None:

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -3,14 +3,14 @@
 
 from pathlib import PurePath
 from textwrap import dedent
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from pants.backend.python.lint.pylint.plugin_target_type import PylintSourcePlugin
 from pants.backend.python.lint.pylint.rules import PylintFieldSet, PylintRequest
 from pants.backend.python.lint.pylint.rules import rules as pylint_rules
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.goals.lint import LintResults
+from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import RootRule
@@ -91,7 +91,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
         passthrough_args: Optional[str] = None,
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
-    ) -> LintResults:
+    ) -> Sequence[LintResult]:
         args = list(self.global_args)
         if config:
             self.create_file(relpath="pylintrc", contents=config)
@@ -102,13 +102,14 @@ class PylintIntegrationTest(ExternalToolTestBase):
             args.append("--pylint-skip")
         if additional_args:
             args.extend(additional_args)
-        return self.request_single_product(
+        results = self.request_single_product(
             LintResults,
             Params(
                 PylintRequest(PylintFieldSet.create(tgt) for tgt in targets),
                 create_options_bootstrapper(args=args),
             ),
         )
+        return results.results
 
     def test_passing_source(self) -> None:
         target = self.make_target([self.good_source])

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -44,6 +44,7 @@ from pants.engine.rules import Get, RootRule, collect_rules, rule
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
 from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize
 
@@ -434,6 +435,7 @@ class PexProcess:
     pex: Pex
     argv: Tuple[str, ...]
     description: str = dataclasses.field(compare=False)
+    level: LogLevel
     input_digest: Digest
     extra_env: Optional[FrozenDict[str, str]]
     output_files: Optional[Tuple[str, ...]]
@@ -447,6 +449,7 @@ class PexProcess:
         *,
         argv: Iterable[str],
         description: str,
+        level: LogLevel = LogLevel.INFO,
         input_digest: Optional[Digest] = None,
         extra_env: Optional[Mapping[str, str]] = None,
         output_files: Optional[Iterable[str]] = None,
@@ -457,6 +460,7 @@ class PexProcess:
         self.pex = pex
         self.argv = tuple(argv)
         self.description = description
+        self.level = level
         self.input_digest = input_digest or pex.digest
         self.extra_env = FrozenDict(extra_env) if extra_env else None
         self.output_files = tuple(output_files) if output_files else None
@@ -472,6 +476,7 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
     return Process(
         argv,
         description=request.description,
+        level=request.level,
         input_digest=request.input_digest,
         env=env,
         output_files=request.output_files,

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -115,10 +115,9 @@ class LintResults(EngineAware):
             results_msg = msg_for_result(self.results[0])
         else:
             results_msg = "\n"
-            results_msg += "".join(
-                f"Partition #{i + 1}:{msg_for_result(result)}"
-                for i, result in enumerate(self.results)
-            )
+            for i, result in enumerate(self.results):
+                msg = msg_for_result(result) or "\n"
+                results_msg += f"Partition #{i + 1}{msg}"
         message += results_msg
         return message
 
@@ -258,6 +257,8 @@ async def lint(
         logger.info(f"Wrote lint result files to {lint_subsystem.reports_dir}.")
 
     exit_code = 0
+    if all_results:
+        console.print_stderr("")
     for results in all_results:
         if results.skipped:
             sigil = console.yellow("-")

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -44,8 +44,9 @@ class LintResult(EngineAware):
     stderr: str
     report: Optional[LintReport]
 
-    @staticmethod
+    @classmethod
     def from_fallible_process_result(
+        cls,
         process_result: FallibleProcessResult,
         *,
         strip_chroot_path: bool = False,
@@ -54,7 +55,7 @@ class LintResult(EngineAware):
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 
-        return LintResult(
+        return cls(
             exit_code=process_result.exit_code,
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -117,7 +117,7 @@ class LintResults(EngineAware):
             results_msg = "\n"
             for i, result in enumerate(self.results):
                 msg = msg_for_result(result) or "\n"
-                results_msg += f"Partition #{i + 1}{msg}"
+                results_msg += f"Partition #{i + 1}:{msg}"
         message += results_msg
         return message
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -236,7 +236,7 @@ def test_streaming_output_skip() -> None:
 
 
 def test_streaming_output_success() -> None:
-    results = LintResults([LintResult(0, "stdout", "stderr", report=None)], linter_name="linter")
+    results = LintResults([LintResult(0, "stdout", "stderr")], linter_name="linter")
     assert results.level() == LogLevel.INFO
     assert results.message() == dedent(
         """\
@@ -249,11 +249,11 @@ def test_streaming_output_success() -> None:
 
 
 def test_streaming_output_failure() -> None:
-    results = LintResults([LintResult(1, "stdout", "stderr", report=None)], linter_name="linter")
+    results = LintResults([LintResult(18, "stdout", "stderr")], linter_name="linter")
     assert results.level() == LogLevel.WARN
     assert results.message() == dedent(
         """\
-        failed.
+        failed (exit code 18).
         stdout
         stderr
 
@@ -263,15 +263,19 @@ def test_streaming_output_failure() -> None:
 
 def test_streaming_output_partitions() -> None:
     results = LintResults(
-        [LintResult(1, "", "", report=None), LintResult(0, "stdout", "stderr", report=None)],
+        [
+            LintResult(21, "", "", partition_description="ghc8.1"),
+            LintResult(0, "stdout", "stderr", partition_description="ghc9.2"),
+        ],
         linter_name="linter",
     )
     assert results.level() == LogLevel.WARN
     assert results.message() == dedent(
         """\
-        failed.
-        Partition #1:
-        Partition #2:
+        failed (exit code 21).
+        Partition #1 - ghc8.1:
+
+        Partition #2 - ghc9.2:
         stdout
         stderr
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -263,10 +263,7 @@ def test_streaming_output_failure() -> None:
 
 def test_streaming_output_partitions() -> None:
     results = LintResults(
-        [
-            LintResult(1, "", "", report=None),
-            LintResult(0, "stdout", "stderr", report=None),
-        ],
+        [LintResult(1, "", "", report=None), LintResult(0, "stdout", "stderr", report=None)],
         linter_name="linter",
     )
     assert results.level() == LogLevel.WARN

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -174,7 +174,7 @@ class LintTest(TestBase):
                 per_target_caching=per_target_caching,
             )
             assert exit_code == FailingRequest.exit_code([address])
-            assert stderr == "𐄂 FailingLinter failed.\n"
+            assert stderr == "\n𐄂 FailingLinter failed.\n"
 
         assert_expected(per_target_caching=False)
         assert_expected(per_target_caching=True)
@@ -192,6 +192,7 @@ class LintTest(TestBase):
             assert exit_code == FailingRequest.exit_code([address])
             assert stderr == dedent(
                 """\
+
                 𐄂 FailingLinter failed.
                 ✓ SuccessfulLinter succeeded.
                 """
@@ -218,6 +219,7 @@ class LintTest(TestBase):
             assert exit_code == ConditionallySucceedsRequest.exit_code([bad_address])
             assert stderr == dedent(
                 """\
+
                 𐄂 ConditionallySucceedsLinter failed.
                 ✓ SuccessfulLinter succeeded.
                 """
@@ -262,7 +264,7 @@ def test_streaming_output_failure() -> None:
 def test_streaming_output_partitions() -> None:
     results = LintResults(
         [
-            LintResult(1, "stdout", "stderr", report=None),
+            LintResult(1, "", "", report=None),
             LintResult(0, "stdout", "stderr", report=None),
         ],
         linter_name="linter",
@@ -272,9 +274,6 @@ def test_streaming_output_partitions() -> None:
         """\
         failed.
         Partition #1:
-        stdout
-        stderr
-
         Partition #2:
         stdout
         stderr

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -5,7 +5,7 @@ import sys
 from dataclasses import dataclass
 from typing import Callable, Optional, cast
 
-from colors import blue, cyan, green, magenta, red
+from colors import blue, cyan, green, magenta, red, yellow
 
 from pants.engine.internals.native import Native
 from pants.engine.internals.scheduler import SchedulerSession
@@ -117,3 +117,6 @@ class Console:
 
     def red(self, text: str) -> str:
         return self._safe_color(text, red)
+
+    def yellow(self, text: str) -> str:
+        return self._safe_color(text, yellow)

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -19,7 +19,7 @@ from typing import (
     get_type_hints,
 )
 
-from colors import blue, cyan, green, magenta, red
+from colors import blue, cyan, green, magenta, red, yellow
 
 from pants.engine.goal import GoalSubsystem
 from pants.engine.internals.native import Native
@@ -267,6 +267,9 @@ class MockConsole:
 
     def red(self, text: str) -> str:
         return self._safe_color(text, red)
+
+    def yellow(self, text: str) -> str:
+        return self._safe_color(text, yellow)
 
 
 def fmt_rust_function(func: Callable) -> str:


### PR DESCRIPTION
Before:

```
▶ ./pants lint src/python/pants/util/strutil.py
09:21:31.63 [INFO] Completed: Run Docformatter on 1 target: src/python/pants/util/strutil.py.
09:21:31.63 [INFO] Completed: Run isort on 1 target: src/python/pants/util/strutil.py.
09:21:31.76 [INFO] Completed: Run Flake8 on 1 target: src/python/pants/util/strutil.py
09:21:34.59 [INFO] Completed: Run Black on 1 target: src/python/pants/util/strutil.py.
𐄂 Black failed.
would reformat src/python/pants/util/strutil.py
Oh no! 💥 💔 💥
1 file would be reformatted.


✓ Docformatter succeeded.

✓ Flake8 succeeded.

✓ isort succeeded.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "


```

After:

```
▶ ./pants lint src/python/pants/util/strutil.py
09:10:02.67 [INFO] Completed: Lint with docformatter - succeeded.
09:10:02.79 [INFO] Completed: Lint with isort - succeeded.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "

09:10:02.92 [WARN] Completed: Lint with Flake8 - failed.
src/python/pants/util/strutil.py:28:5: E125 continuation line with same indent as next logical line

09:10:05.67 [WARN] Completed: Lint with Black - failed.
would reformat src/python/pants/util/strutil.py
Oh no! 💥 💔 💥
1 file would be reformatted.


𐄂 Black failed.
✓ Docformatter succeeded.
𐄂 Flake8 failed.
✓ isort succeeded.
```

We also now say when a linter was skipped.

```
▶ ./pants lint src/python/pants/util/strutil.py --black-skip --isort-skip --no-pantsd
09:10:41.66 [INFO] Completed: Lint with docformatter - succeeded.
09:10:41.66 [WARN] Completed: Lint with Flake8 - failed.
src/python/pants/util/strutil.py:28:5: E125 continuation line with same indent as next logical line


- Black skipped.
✓ Docformatter succeeded.
𐄂 Flake8 failed.
- isort skipped.
```

If a linter partitions, e.g. by interpreter constraints, the output will look like:

```
▶ ./pants lint src/python/pants/util:{t1,t2}
▶ ./pants --backend-packages=pants.backend.python.lint.pylint lint src/python/pants/util:t{1,2}
07:34:25.21 [INFO] Completed: Lint with Flake8 - succeeded.
Partition #1 - ['CPython==3.7.*']:

Partition #2 - ['CPython==3.6.*']:

07:34:25.21 [INFO] Completed: Lint with docformatter - succeeded.
07:34:25.22 [INFO] Completed: Lint with isort - succeeded.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "

07:34:25.22 [INFO] Completed: Lint with Black - succeeded.
All done! ✨ 🍰 ✨
2 files would be left unchanged.

07:34:30.29 [WARN] Completed: Lint using Pylint - failed (exit code 20).
Partition #1 - ['CPython>=3.6,==3.7.*']:
************* Module pants.util.strutil_test
src/python/pants/util/strutil_test.py:16:2: W0511: TODO(Eric Ayers): Backfill tests for other methods in strutil.py (fixme)
src/python/pants/util/strutil_test.py:53:0: C0301: Line too long (129/100) (line-too-long)
....

------------------------------------------------------------------
Your code has been rated at 7.22/10 (previous run: 7.22/10, +0.00)

Partition #2 - ['CPython>=3.6,==3.6.*']:
************* Module pants.util.dirutil_test
src/python/pants/util/dirutil_test.py:84:0: C0330: Wrong hanging indentation before block (add 4 spaces).
        self, tempfile_mkdtemp, dirutil_safe_rmtree, os_getpid, atexit_register
        ^   | (bad-continuation)
...

------------------------------------------------------------------
Your code has been rated at 7.14/10 (previous run: 7.14/10, +0.00)


✓ Black succeeded.
✓ Docformatter succeeded.
✓ Flake8 succeeded.
𐄂 Pylint failed.
✓ isort succeeded.
```

With `--per-target-caching`, it will look like:

```
▶ ./pants lint src/python/pants/util/{dir,str}util.py --lint-per-target-caching
09:12:23.10 [INFO] Completed: Lint with docformatter - succeeded.
09:12:23.10 [INFO] Completed: Lint with isort - succeeded.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "

09:12:23.10 [WARN] Completed: Lint with Black - failed.
would reformat src/python/pants/util/strutil.py
Oh no! 💥 💔 💥
1 file would be reformatted.

09:12:23.10 [WARN] Completed: Lint with Flake8 - failed.
src/python/pants/util/strutil.py:28:5: E125 continuation line with same indent as next logical line

09:12:23.10 [INFO] Completed: Lint with Black - succeeded.
All done! ✨ 🍰 ✨
1 file would be left unchanged.

09:12:23.10 [INFO] Completed: Lint with docformatter - succeeded.
09:12:23.10 [INFO] Completed: Lint with isort - succeeded.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "

09:12:23.95 [INFO] Completed: Lint with Flake8 - succeeded.

𐄂 Black failed.
✓ Docformatter succeeded.
𐄂 Flake8 failed.
✓ isort succeeded.
```

[ci skip-rust]
[ci skip-build-wheels]
