### PR TITLE
ArgSplitter operates relative to the buildroot.

### DIFF
--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -6,6 +6,7 @@ python_library()
 python_tests(
   name='tests',
   sources=['*_test.py', '!*_integration_test.py'],
+  dependencies=["//:build_root"],
 )
 
 python_integration_tests(

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -88,7 +88,8 @@ class ArgSplitter:
         *_HELP_ALL_SCOPES_ARGS,
     )
 
-    def __init__(self, known_scope_infos: Iterable[ScopeInfo]) -> None:
+    def __init__(self, known_scope_infos: Iterable[ScopeInfo], buildroot: str) -> None:
+        self._buildroot = Path(buildroot)
         self._known_scope_infos = known_scope_infos
         # TODO: Get rid of our reliance on known scopes here. We don't really need it now
         # that we heuristically identify target specs based on it containing /, : or being
@@ -219,8 +220,7 @@ class ArgSplitter:
             unknown_scopes=self._unknown_scopes,
         )
 
-    @staticmethod
-    def likely_a_spec(arg: str) -> bool:
+    def likely_a_spec(self, arg: str) -> bool:
         """Return whether `arg` looks like a spec, rather than a goal name.
 
         An arg is a spec if it looks like an AddressSpec or a FilesystemSpec. In the future we can
@@ -229,7 +229,7 @@ class ArgSplitter:
         return (
             any(symbol in arg for symbol in (os.path.sep, ":", "*"))
             or arg.startswith("!")
-            or Path(arg).exists()
+            or (self._buildroot / arg).exists()
         )
 
     def _consume_scope(self) -> Tuple[Optional[str], List[str]]:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -5,6 +5,7 @@ import copy
 import logging
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
+from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import resolve_conflicting_options, warn_or_error
 from pants.option.arg_splitter import ArgSplitter, HelpRequest
 from pants.option.config import Config
@@ -126,7 +127,7 @@ class Options:
         # We need parsers for all the intermediate scopes, so inherited option values
         # can propagate through them.
         complete_known_scope_infos = cls.complete_scopes(known_scope_infos)
-        splitter = ArgSplitter(complete_known_scope_infos)
+        splitter = ArgSplitter(complete_known_scope_infos, get_buildroot())
         split_args = splitter.split_args(args)
 
         if split_args.passthru and len(split_args.goals) > 1:


### PR DESCRIPTION
### Problem

#10535 normalizes specs to not include the trailing name when it will default. In order to fix tests, many instances of `src/example/test:test` in _output_ (the form is still supported and normalized in input) will be converted to `src/example/test`. To avoid needing to differentiate input from output though, and allow for a cleaner find-replace, I'm going to change all instances.

While doing so, I noticed that the `ArgSplitter` operates relative to the current directory rather than the buildroot, which meant that `GoalRuleTestBase` was not recognizing file args or defaulted directory specs correctly.

### Solution

Adjust `ArgSplitter` to operate relative to the buildroot.

[ci skip-rust]
[ci skip-build-wheels]