### PR TITLE
set locale vars for remoting image

### DIFF
--- a/build-support/docker/tc_remote_execution/Dockerfile
+++ b/build-support/docker/tc_remote_execution/Dockerfile
@@ -21,12 +21,19 @@ RUN apt-get install -y \
   libssl-dev \
   libsqlite3-dev \
   libffi-dev \
+  locales \
   openjdk-8-jdk-headless \
   openjdk-8-jre-headless \
   python-openssl \
   unzip \
   zip \
   zlib1g-dev
+
+# Configure en_US.UTF-8 locale as Pants requires a UTF-8 locale to operate.
+RUN locale-gen en_US.UTF-8 && update-locale
+ENV LANG "en_US.UTF-8"
+ENV LANGUAGE "en_US.UTF-8"
+ENV LC_ALL "en_US.UTF-8"
 
 # Even though the image already comes installed with Python 2.7, 3.5, and 3.6, we install our own
 # via Pyenv because we need Python 3.7 and want consistency in how we install them.
@@ -48,7 +55,3 @@ ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_36_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_37_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_38_VERSION}/bin:${PATH}"
-
-# Ensure UTF-8 locale is configured as required by Pants.
-ENV LC_ALL "en_US.UTF-8"
-ENV LANG "en_US.UTF-8"

--- a/build-support/docker/tc_remote_execution/Dockerfile
+++ b/build-support/docker/tc_remote_execution/Dockerfile
@@ -48,3 +48,7 @@ ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_36_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_37_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_38_VERSION}/bin:${PATH}"
+
+# Ensure UTF-8 locale is configured as required by Pants.
+ENV LC_ALL "en_US.UTF-8"
+ENV LANG "en_US.UTF-8"


### PR DESCRIPTION
### Problem

The new non-RBE remote execution image did not configure locale-related environment variables which causes [the following failure](https://travis-ci.com/github/pantsbuild/pants/jobs/368034114#L661):

```
E   stderr:
E   	Traceback (most recent call last):
E   	  File "/pyenv-docker-build/versions/3.6.11/lib/python3.6/runpy.py", line 193, in _run_module_as_main
E   	    "__main__", mod_spec)
E   	  File "/pyenv-docker-build/versions/3.6.11/lib/python3.6/runpy.py", line 85, in _run_code
E   	    exec(code, run_globals)
E   	  File "/b/f/w/src/python/pants/__main__.py", line 7, in <module>
E   	    pants_loader.main()
E   	  File "/b/f/w/src/python/pants/bin/pants_loader.py", line 94, in main
E   	    PantsLoader.run()
E   	  File "/b/f/w/src/python/pants/bin/pants_loader.py", line 88, in run
E   	    cls.ensure_locale()
E   	  File "/b/f/w/src/python/pants/bin/pants_loader.py", line 65, in ensure_locale
E   	    encoding, cls.ENCODING_IGNORE_ENV_VAR
E   	pants.bin.pants_loader.InvalidLocaleError: 
E   	Your system's preferred encoding is `ANSI_X3.4-1968`, but Pants requires `UTF-8`.
E   	Specifically, Python's `locale.getpreferredencoding()` must resolve to `UTF-8`.
E   	
E   	Fix it by setting the LC_* and LANG environment settings. Example:
E   	  LC_ALL=en_US.UTF-8
E   	  LANG=en_US.UTF-8
E   	Or, bypass it by setting the below environment variable.
E   	  PANTS_IGNORE_UNRECOGNIZED_ENCODING=1
E   	Note: we cannot guarantee consistent behavior with this bypass enabled.
```

### Solution

Set `LC_ALL` and `LANG` environment variables in the image to UTF-8 locale.

### Result

This issue should be fixed in https://github.com/pantsbuild/pants/pull/10539 CI build.