### PR TITLE
Simplify source root stripping.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -7,7 +7,7 @@ from typing import List
 from pants.backend.codegen.protobuf.python.rules import GeneratePythonFromProtobufRequest
 from pants.backend.codegen.protobuf.python.rules import rules as protobuf_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary, ProtobufSources
-from pants.core.util_rules import determine_source_files
+from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.rules import RootRule
 from pants.engine.target import (
@@ -32,6 +32,7 @@ class ProtobufPythonIntegrationTest(ExternalToolTestBase):
             *super().rules(),
             *protobuf_rules(),
             *determine_source_files.rules(),
+            *strip_source_roots.rules(),
             RootRule(GeneratePythonFromProtobufRequest),
         )
 

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -7,10 +7,8 @@ from typing import Dict, Optional, Set
 
 from pants.backend.python.target_types import PythonRequirementsField, PythonSources
 from pants.base.specs import AddressSpecs, DescendantAddresses
-from pants.core.util_rules.strip_source_roots import (
-    SourceRootStrippedSources,
-    StripSourcesFieldRequest,
-)
+from pants.core.util_rules.determine_source_files import AllSourceFilesRequest
+from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -75,9 +73,10 @@ async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMap
         for tgt in candidate_explicit_targets
     )
     stripped_sources_per_explicit_target = await MultiGet(
-        Get(SourceRootStrippedSources, StripSourcesFieldRequest(tgt[PythonSources]))
+        Get(StrippedSourceFiles, AllSourceFilesRequest([tgt[PythonSources]]))
         for tgt in candidate_explicit_targets
     )
+
     modules_to_addresses: Dict[str, Address] = {}
     modules_with_multiple_owners: Set[str] = set()
     for explicit_tgt, unstripped_sources, stripped_sources in zip(

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -18,7 +18,7 @@ from pants.backend.python.dependency_inference.module_mapper import (
 )
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.util_rules import strip_source_roots
+from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.rules import RootRule
 from pants.python.python_requirement import PythonRequirement
@@ -84,6 +84,7 @@ class ModuleMapperTest(TestBase):
         return (
             *super().rules(),
             *strip_source_roots.rules(),
+            *determine_source_files.rules(),
             map_first_party_modules_to_addresses,
             map_module_to_address,
             map_third_party_modules_to_addresses,

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -16,7 +16,7 @@ from pants.backend.python.target_types import (
     PythonTests,
 )
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.util_rules import strip_source_roots
+from pants.core.util_rules import determine_source_files, strip_source_roots
 from pants.engine.addresses import Address
 from pants.engine.rules import RootRule
 from pants.engine.target import InferredDependencies, WrappedTarget
@@ -37,6 +37,7 @@ class PythonDependencyInferenceTest(TestBase):
         return (
             *super().rules(),
             *strip_source_roots.rules(),
+            *determine_source_files.rules(),
             *dependency_inference_rules(),
             all_roots,
             RootRule(InferPythonDependencies),

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -111,7 +111,7 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
     all_source_files, requirements_pex, config_digest, specified_source_files = (
         await MultiGet(all_source_files_request, *requests)
         if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT), *await MultiGet(*requests))
+        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
     )
     all_source_files_snapshot = (
         all_source_files.snapshot

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -91,7 +91,7 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
     all_source_files, requirements_pex, specified_source_files = (
         await MultiGet(all_source_files_request, *requests)
         if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT), *await MultiGet(*requests))
+        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
     )
     all_source_files_snapshot = (
         all_source_files.snapshot

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -115,7 +115,7 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
     all_source_files, requirements_pex, config_digest, specified_source_files = (
         await MultiGet(all_source_files_request, *requests)
         if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT), *await MultiGet(*requests))
+        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
     )
     all_source_files_snapshot = (
         all_source_files.snapshot

--- a/src/python/pants/backend/python/rules/ancestor_files.py
+++ b/src/python/pants/backend/python/rules/ancestor_files.py
@@ -1,16 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
 import os
 from dataclasses import dataclass
-from pathlib import PurePath
 from typing import Sequence, Set
 
-from pants.core.util_rules.strip_source_roots import SourceRootStrippedSources, StripSnapshotRequest
 from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
-from pants.source.source_root import AllSourceRoots
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -31,25 +27,22 @@ class AncestorFilesRequest:
 
     name: str
     snapshot: Snapshot
-    sources_stripped: bool  # True iff snapshot has already had source roots stripped.
 
 
 @dataclass(frozen=True)
 class AncestorFiles:
     """Any ancestor files found."""
 
-    # Files in the snapshot are stripped iff the request had sources_stripped=True.
     snapshot: Snapshot
 
 
 def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> FrozenOrderedSet[str]:
     """Return the paths of potentially missing ancestor files.
 
-    NB: If the sources have not had their source roots (e.g., 'src/python') stripped, this
-    function will consider superfluous files at and above the source roots, (e.g.,
-    src/python/<name>, src/<name>). It is the caller's responsibility to filter these
-    out if necessary. If the sources have had their source roots stripped, then this function
-    will only identify consider files in actual packages.
+    NB: The sources are expected to not have had their source roots stripped.
+    Therefore this function will consider superfluous files at and above the source roots,
+    (e.g., src/python/<name>, src/<name>). It is the caller's responsibility to filter these
+    out if necessary.
     """
     packages: Set[str] = set()
     for source in sources:
@@ -69,33 +62,14 @@ def identify_missing_ancestor_files(name: str, sources: Sequence[str]) -> Frozen
 
 
 @rule
-async def find_missing_ancestor_files(
-    request: AncestorFilesRequest, all_source_roots: AllSourceRoots
-) -> AncestorFiles:
+async def find_missing_ancestor_files(request: AncestorFilesRequest) -> AncestorFiles:
     """Find any named ancestor files that exist on the filesystem but are not in the snapshot."""
     missing_ancestor_files = identify_missing_ancestor_files(request.name, request.snapshot.files)
     if not missing_ancestor_files:
         return AncestorFiles(EMPTY_SNAPSHOT)
 
-    if request.sources_stripped:
-        # If files are stripped, we don't know what source root they might live in, so we look
-        # up every source root.
-        roots = tuple(root.path for root in all_source_roots)
-        missing_ancestor_files = FrozenOrderedSet(
-            PurePath(root, f).as_posix()
-            for root, f in itertools.product(roots, missing_ancestor_files)
-        )
-
     # NB: This will intentionally _not_ error on any unmatched globs.
     discovered_ancestors_snapshot = await Get(Snapshot, PathGlobs(missing_ancestor_files))
-
-    if request.sources_stripped:
-        # We must now strip all discovered paths.
-        stripped_snapshot = await Get(
-            SourceRootStrippedSources, StripSnapshotRequest(discovered_ancestors_snapshot)
-        )
-        discovered_ancestors_snapshot = stripped_snapshot.snapshot
-
     return AncestorFiles(discovered_ancestors_snapshot)
 
 

--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -14,10 +14,7 @@ from pants.backend.python.rules.pex import (
     PexRequest,
     PexRequirements,
 )
-from pants.backend.python.rules.python_sources import (
-    UnstrippedPythonSources,
-    UnstrippedPythonSourcesRequest,
-)
+from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.core.goals.test import (
     ConsoleCoverageReport,
@@ -246,8 +243,8 @@ async def generate_coverage_reports(
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
     sources = await Get(
-        UnstrippedPythonSources,
-        UnstrippedPythonSourcesRequest(transitive_targets.closure, include_resources=False),
+        PythonSourceFiles,
+        PythonSourceFilesRequest(transitive_targets.closure, include_resources=False),
     )
     input_digest = await Get(
         Digest,
@@ -256,7 +253,7 @@ async def generate_coverage_reports(
                 merged_coverage_data.coverage_data,
                 coverage_config.digest,
                 coverage_setup.pex.digest,
-                sources.snapshot.digest,
+                sources.source_files.snapshot.digest,
             )
         ),
     )

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -16,8 +16,8 @@ from pants.backend.python.rules.pex import (
     TwoStepPexRequest,
 )
 from pants.backend.python.rules.python_sources import (
-    StrippedPythonSources,
-    StrippedPythonSourcesRequest,
+    PythonSourceFilesRequest,
+    StrippedPythonSourceFiles,
 )
 from pants.backend.python.target_types import (
     PythonInterpreterCompatibility,
@@ -109,9 +109,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         input_digests.append(request.additional_sources)
     if request.include_source_files:
         prepared_sources = await Get(
-            StrippedPythonSources, StrippedPythonSourcesRequest(all_targets)
+            StrippedPythonSourceFiles, PythonSourceFilesRequest(all_targets)
         )
-        input_digests.append(prepared_sources.snapshot.digest)
+        input_digests.append(prepared_sources.stripped_source_files.snapshot.digest)
     merged_input_digest = await Get(Digest, MergeDigests(input_digests))
 
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(

--- a/src/python/pants/backend/python/rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets_test.py
@@ -7,7 +7,7 @@ from typing import Optional
 from pants.backend.python.rules import pex_from_targets, python_sources
 from pants.backend.python.rules.pex import PexRequest, PexRequirements
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.rules.python_sources import StrippedPythonSourcesRequest
+from pants.backend.python.rules.python_sources import PythonSourceFilesRequest
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -28,7 +28,7 @@ class PexTest(TestBase):
             *pex_from_targets.rules(),
             *python_sources.rules(),
             RootRule(PexFromTargetsRequest),
-            RootRule(StrippedPythonSourcesRequest),
+            RootRule(PythonSourceFilesRequest),
             SubsystemRule(PythonSetup),
         )
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -21,10 +21,7 @@ from pants.backend.python.rules.pex import (
     PexRequirements,
 )
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.rules.python_sources import (
-    UnstrippedPythonSources,
-    UnstrippedPythonSourcesRequest,
-)
+from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
     PythonInterpreterCompatibility,
@@ -150,7 +147,7 @@ async def setup_pytest_for_target(
     )
 
     prepared_sources_request = Get(
-        UnstrippedPythonSources, UnstrippedPythonSourcesRequest(all_targets, include_files=True)
+        PythonSourceFiles, PythonSourceFilesRequest(all_targets, include_files=True)
     )
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
@@ -178,7 +175,7 @@ async def setup_pytest_for_target(
         MergeDigests(
             (
                 coverage_config.digest,
-                prepared_sources.snapshot.digest,
+                prepared_sources.source_files.snapshot.digest,
                 requirements_pex.digest,
                 pytest_pex.digest,
                 test_runner_pex.digest,

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -10,7 +10,8 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
-from pants.core.util_rules.strip_source_roots import representative_path_from_address
+from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
+from pants.core.util_rules.strip_source_roots import rules as strip_source_roots_rules
 from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, RootRule, collect_rules, rule
 from pants.engine.target import Sources, Target
@@ -19,9 +20,36 @@ from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.meta import frozen_after_init
 
 
+@dataclass(frozen=True)
+class PythonSourceFiles:
+    """Sources that can be introspected by Python, relative to a set of source roots.
+
+    Specifically, this will filter out to only have Python, and, optionally, resources() and
+    files() targets; and will add any missing `__init__.py` files to ensure that modules are
+    recognized correctly.
+
+    Use-cases that introspect Python source code (e.g., the `test, `lint`, `fmt` goals) can
+    request this type to get relevant sources that are still relative to their source roots.
+    That way the paths they report are the unstripped ones the user is familiar with.
+
+    The sources can also be imported and used by Python (e.g., for the `test` goal), but only
+    if sys.path is modified to include the source roots.
+    """
+
+    source_files: SourceFiles
+    source_roots: Tuple[str, ...]  # Source roots for the specified source files.
+
+
+@dataclass(frozen=True)
+class StrippedPythonSourceFiles:
+    """A PythonSourceFiles that has had its source roots stripped."""
+
+    stripped_source_files: StrippedSourceFiles
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class _BasePythonSourcesRequest:
+class PythonSourceFilesRequest:
     targets: Tuple[Target, ...]
     include_resources: bool
     include_files: bool
@@ -47,94 +75,21 @@ class _BasePythonSourcesRequest:
         return tuple(types)
 
 
-@dataclass(frozen=True)
-class StrippedPythonSources:
-    """Sources that can be imported and used by Python, relative to the root.
-
-    Specifically, this will filter out to only have Python, and, optionally, resources() and files()
-    targets; strip source roots, e.g. `src/python/f.py` -> `f.py`; and will add any missing
-    `__init__.py` files to ensure that modules are recognized correctly.
-
-    Use-cases that execute the Python source code (e.g., the `run`, `binary` and `repl` goals) can
-    request this type to get a single tree of relevant sources that can be run without sys.path
-    manipulation.
-    """
-
-    snapshot: Snapshot
-
-
-class StrippedPythonSourcesRequest(_BasePythonSourcesRequest):
-    pass
-
-
-@dataclass(frozen=True)
-class UnstrippedPythonSources:
-    """Sources that can be introspected by Python, relative to a set of source roots.
-
-    Specifically, this will filter out to only have Python, and, optionally, resources() and
-    files() targets; and will add any missing `__init__.py` files to ensure that modules are
-    recognized correctly.
-
-    Use-cases that introspect Python source code (e.g., the `test, `lint`, `fmt` goals) can
-    request this type to get relevant sources that are still relative to their source roots.
-    That way the paths they report are the unstripped ones the user is familiar with.
-
-    The sources can also be imported and used by Python (e.g., for the `test` goal), but only
-    if sys.path is modified to include the source roots.
-    """
-
-    snapshot: Snapshot
-    source_roots: Tuple[str, ...]
-
-
-class UnstrippedPythonSourcesRequest(_BasePythonSourcesRequest):
-    pass
-
-
 @rule
-async def prepare_stripped_python_sources(
-    request: StrippedPythonSourcesRequest,
-) -> StrippedPythonSources:
-    stripped_sources = await Get(
-        SourceFiles,
-        AllSourceFilesRequest(
-            (tgt.get(Sources) for tgt in request.targets),
-            for_sources_types=request.valid_sources_types,
-            enable_codegen=True,
-            strip_source_roots=True,
-        ),
-    )
-
-    missing_init_files = await Get(
-        AncestorFiles,
-        AncestorFilesRequest("__init__.py", stripped_sources.snapshot, sources_stripped=True),
-    )
-
-    init_injected = await Get(
-        Snapshot,
-        MergeDigests((stripped_sources.snapshot.digest, missing_init_files.snapshot.digest)),
-    )
-
-    return StrippedPythonSources(init_injected)
-
-
-@rule
-async def prepare_unstripped_python_sources(
-    request: UnstrippedPythonSourcesRequest, union_membership: UnionMembership
-) -> UnstrippedPythonSources:
+async def prepare_python_sources(
+    request: PythonSourceFilesRequest, union_membership: UnionMembership
+) -> PythonSourceFiles:
     sources = await Get(
         SourceFiles,
         AllSourceFilesRequest(
             (tgt.get(Sources) for tgt in request.targets),
             for_sources_types=request.valid_sources_types,
             enable_codegen=True,
-            strip_source_roots=False,
         ),
     )
 
     missing_init_files = await Get(
-        AncestorFiles,
-        AncestorFilesRequest("__init__.py", sources.snapshot, sources_stripped=False),
+        AncestorFiles, AncestorFilesRequest("__init__.py", sources.snapshot),
     )
 
     init_injected = await Get(
@@ -142,11 +97,7 @@ async def prepare_unstripped_python_sources(
     )
 
     source_root_objs = await MultiGet(
-        Get(
-            SourceRoot,
-            SourceRootRequest,
-            SourceRootRequest.for_file(representative_path_from_address(tgt.address)),
-        )
+        Get(SourceRoot, SourceRootRequest, SourceRootRequest.for_target(tgt))
         for tgt in request.targets
         if (
             tgt.has_field(PythonSources)
@@ -156,7 +107,15 @@ async def prepare_unstripped_python_sources(
         )
     )
     source_root_paths = {source_root_obj.path for source_root_obj in source_root_objs}
-    return UnstrippedPythonSources(init_injected, tuple(sorted(source_root_paths)))
+    return PythonSourceFiles(
+        SourceFiles(init_injected, sources.unrooted_files), tuple(sorted(source_root_paths))
+    )
+
+
+@rule
+async def strip_python_sources(python_sources: PythonSourceFiles) -> StrippedPythonSourceFiles:
+    stripped = await Get(StrippedSourceFiles, SourceFiles, python_sources.source_files)
+    return StrippedPythonSourceFiles(stripped)
 
 
 def rules():
@@ -164,6 +123,6 @@ def rules():
         *collect_rules(),
         *determine_source_files.rules(),
         *ancestor_files.rules(),
-        RootRule(StrippedPythonSourcesRequest),
-        RootRule(UnstrippedPythonSourcesRequest),
+        *strip_source_roots_rules(),
+        RootRule(PythonSourceFilesRequest),
     ]

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -3,10 +3,7 @@
 
 from pants.backend.python.rules.pex import Pex
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.rules.python_sources import (
-    UnstrippedPythonSources,
-    UnstrippedPythonSourcesRequest,
-)
+from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.repl import ReplImplementation, ReplRequest
@@ -30,15 +27,15 @@ async def create_python_repl_request(repl: PythonRepl) -> ReplRequest:
             include_source_files=False,
         ),
     )
-    source_files_request = Get(
-        UnstrippedPythonSources, UnstrippedPythonSourcesRequest(repl.targets)
+    sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(repl.targets))
+    pex, sources = await MultiGet(pex_request, sources_request)
+    merged_digest = await Get(
+        Digest, MergeDigests((pex.digest, sources.source_files.snapshot.digest))
     )
-    pex, source_files = await MultiGet(pex_request, source_files_request)
-    merged_digest = await Get(Digest, MergeDigests((pex.digest, source_files.snapshot.digest)))
     return ReplRequest(
         digest=merged_digest,
         binary_name=pex.output_filename,
-        env={"PEX_EXTRA_SYS_PATH": ":".join(source_files.source_roots)},
+        env={"PEX_EXTRA_SYS_PATH": ":".join(sources.source_roots)},
     )
 
 
@@ -59,15 +56,15 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
             include_source_files=True,
         ),
     )
-    source_files_request = Get(
-        UnstrippedPythonSources, UnstrippedPythonSourcesRequest(repl.targets)
+    sources_request = Get(PythonSourceFiles, PythonSourceFilesRequest(repl.targets))
+    pex, sources = await MultiGet(pex_request, sources_request)
+    merged_digest = await Get(
+        Digest, MergeDigests((pex.digest, sources.source_files.snapshot.digest))
     )
-    pex, source_files = await MultiGet(pex_request, source_files_request)
-    merged_digest = await Get(Digest, MergeDigests((pex.digest, source_files.snapshot.digest)))
     return ReplRequest(
         digest=merged_digest,
         binary_name=pex.output_filename,
-        env={"PEX_EXTRA_SYS_PATH": ":".join(source_files.source_roots)},
+        env={"PEX_EXTRA_SYS_PATH": ":".join(sources.source_roots)},
     )
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -4,7 +4,6 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.python.rules import pex, python_sources
 from pants.backend.python.rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -12,10 +11,9 @@ from pants.backend.python.rules.pex import (
     PexRequest,
     PexRequirements,
 )
-from pants.backend.python.rules.python_sources import (
-    UnstrippedPythonSources,
-    UnstrippedPythonSourcesRequest,
-)
+from pants.backend.python.rules.pex import rules as pex_rules
+from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
+from pants.backend.python.rules.python_sources import rules as python_sources_rules
 from pants.backend.python.target_types import PythonSources
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
@@ -58,8 +56,8 @@ def generate_args(mypy: MyPy, *, file_list_path: str) -> Tuple[str, ...]:
 
 # TODO(#10131): Improve performance, e.g. by leveraging the MyPy cache.
 # TODO(#10131): Support plugins and type stubs.
-@rule(desc="Lint using MyPy")
-async def mypy_lint(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
+@rule(desc="Typecheck using MyPy")
+async def mypy_typecheck(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
     if mypy.skip:
         return TypecheckResults()
 
@@ -68,7 +66,7 @@ async def mypy_lint(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
     )
 
     prepared_sources_request = Get(
-        UnstrippedPythonSources, UnstrippedPythonSourcesRequest(transitive_targets.closure),
+        PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure),
     )
     pex_request = Get(
         Pex,
@@ -96,17 +94,15 @@ async def mypy_lint(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
         prepared_sources_request, pex_request, config_digest_request
     )
 
+    srcs_snapshot = prepared_sources.source_files.snapshot
     file_list_path = "__files.txt"
-    python_files = "\n".join(f for f in prepared_sources.snapshot.files if f.endswith(".py"))
+    python_files = "\n".join(f for f in srcs_snapshot.files if f.endswith(".py"))
     file_list_digest = await Get(
         Digest, CreateDigest([FileContent(file_list_path, python_files.encode())]),
     )
 
     merged_input_files = await Get(
-        Digest,
-        MergeDigests(
-            [file_list_digest, prepared_sources.snapshot.digest, pex.digest, config_digest]
-        ),
+        Digest, MergeDigests([file_list_digest, srcs_snapshot.digest, pex.digest, config_digest]),
     )
 
     result = await Get(
@@ -116,7 +112,7 @@ async def mypy_lint(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
             argv=generate_args(mypy, file_list_path=file_list_path),
             input_digest=merged_input_files,
             extra_env={"PEX_EXTRA_SYS_PATH": ":".join(prepared_sources.source_roots)},
-            description=f"Run MyPy on {pluralize(len(prepared_sources.snapshot.files), 'file')}.",
+            description=f"Run MyPy on {pluralize(len(srcs_snapshot.files), 'file')}.",
         ),
     )
     return TypecheckResults(
@@ -130,7 +126,7 @@ def rules():
         UnionRule(TypecheckRequest, MyPyRequest),
         *determine_source_files.rules(),
         *pants_bin.rules(),
-        *pex.rules(),
-        *python_sources.rules(),
+        *pex_rules(),
+        *python_sources_rules(),
         *strip_source_roots.rules(),
     ]

--- a/src/python/pants/core/util_rules/determine_source_files_test.py
+++ b/src/python/pants/core/util_rules/determine_source_files_test.py
@@ -20,7 +20,6 @@ from pants.core.util_rules.determine_source_files import (
     SpecifiedSourceFilesRequest,
 )
 from pants.core.util_rules.determine_source_files import rules as determine_source_files_rules
-from pants.core.util_rules.strip_source_roots import rules as strip_source_roots_rules
 from pants.engine.addresses import Address
 from pants.engine.target import Sources as SourcesField
 from pants.testutil.engine.util import Params
@@ -40,6 +39,7 @@ class TargetSources(NamedTuple):
 SOURCES1 = TargetSources("src/python", ["s1.py", "s2.py", "s3.py"])
 SOURCES2 = TargetSources("tests/python", ["t1.py", "t2.java"])
 SOURCES3 = TargetSources("src/java", ["j1.java", "j2.java"])
+SOURCES4 = TargetSources("src/python", ["README.md"])
 
 
 class DetermineSourceFilesTest(TestBase):
@@ -48,7 +48,6 @@ class DetermineSourceFilesTest(TestBase):
         return (
             *super().rules(),
             *determine_source_files_rules(),
-            *strip_source_roots_rules(),
         )
 
     def mock_sources_field_with_origin(
@@ -68,20 +67,16 @@ class DetermineSourceFilesTest(TestBase):
             origin = SiblingAddresses(sources.source_root)
         return sources_field, origin
 
-    def get_all_source_files(
-        self,
-        sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-        *,
-        strip_source_roots: bool = False,
-    ) -> List[str]:
+    def _do_get_all_source_files(
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
+    ) -> SourceFiles:
         request = AllSourceFilesRequest(
             (
                 sources_field_with_origin[0]
                 for sources_field_with_origin in sources_fields_with_origins
             ),
-            strip_source_roots=strip_source_roots,
         )
-        result = self.request_single_product(
+        return self.request_single_product(
             SourceFiles,
             Params(
                 request,
@@ -94,31 +89,46 @@ class DetermineSourceFilesTest(TestBase):
                 ),
             ),
         )
-        return sorted(result.snapshot.files)
+
+    def get_all_source_files(
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
+    ) -> List[str]:
+        return sorted(self._do_get_all_source_files(sources_fields_with_origins).snapshot.files)
+
+    def get_all_unrooted_files(
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]]
+    ):
+        return list(self._do_get_all_source_files(sources_fields_with_origins).unrooted_files)
+
+    def _do_get_specified_source_files(
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
+    ) -> SourceFiles:
+        request = SpecifiedSourceFilesRequest(sources_fields_with_origins,)
+        return self.request_single_product(
+            SourceFiles,
+            Params(
+                request,
+                create_options_bootstrapper(
+                    args=[
+                        "--source-root-patterns=src/python",
+                        "--source-root-patterns=src/java",
+                        "--source-root-patterns=tests/python",
+                    ]
+                ),
+            ),
+        )
 
     def get_specified_source_files(
-        self,
-        sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-        *,
-        strip_source_roots: bool = False,
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
     ) -> List[str]:
-        request = SpecifiedSourceFilesRequest(
-            sources_fields_with_origins, strip_source_roots=strip_source_roots,
+        return sorted(
+            self._do_get_specified_source_files(sources_fields_with_origins).snapshot.files
         )
-        result = self.request_single_product(
-            SourceFiles,
-            Params(
-                request,
-                create_options_bootstrapper(
-                    args=[
-                        "--source-root-patterns=src/python",
-                        "--source-root-patterns=src/java",
-                        "--source-root-patterns=tests/python",
-                    ]
-                ),
-            ),
-        )
-        return sorted(result.snapshot.files)
+
+    def get_specified_unrooted_files(
+        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]]
+    ):
+        return list(self._do_get_specified_source_files(sources_fields_with_origins).unrooted_files)
 
     def test_address_specs(self) -> None:
         sources_field1 = self.mock_sources_field_with_origin(
@@ -145,7 +155,7 @@ class DetermineSourceFilesTest(TestBase):
         assert_all_source_files_resolved(sources_field2, SOURCES2)
         assert_all_source_files_resolved(sources_field3, SOURCES3)
         assert_all_source_files_resolved(sources_field4, SOURCES1)
-        # NB: sources_field1 and sources_field3 refer to the same files. We should be able to
+        # NB: sources_field1 and sources_field4 refer to the same files. We should be able to
         # handle this gracefully.
         combined_sources_fields = [sources_field1, sources_field2, sources_field3, sources_field4]
         combined_expected = sorted(
@@ -156,7 +166,9 @@ class DetermineSourceFilesTest(TestBase):
             ]
         )
         assert self.get_all_source_files(combined_sources_fields) == combined_expected
+        assert self.get_all_unrooted_files(combined_sources_fields) == []
         assert self.get_specified_source_files(combined_sources_fields) == combined_expected
+        assert self.get_specified_unrooted_files(combined_sources_fields) == []
 
     def test_filesystem_specs(self) -> None:
         # Literal file arg.
@@ -187,98 +199,60 @@ class DetermineSourceFilesTest(TestBase):
         )
         sources_field3 = self.mock_sources_field_with_origin(SOURCES3, origin=sources_field3_origin)
 
+        # FilesSources should appear in the "all_source_files" results but not in the
+        # "all_rooted_files" results.
+        sources_field4 = self.mock_sources_field_with_origin(
+            SOURCES4, sources_field_cls=FilesSources
+        )
+        sources_field4_all_sources = SOURCES4.source_file_absolute_paths
+
         def assert_file_args_resolved(
             sources_field_with_origin: Tuple[SourcesField, OriginSpec],
             all_sources: List[str],
             expected_slice: slice,
         ) -> None:
             assert self.get_all_source_files([sources_field_with_origin]) == all_sources
+            assert self.get_all_unrooted_files([sources_field_with_origin]) == []
+
             assert (
                 self.get_specified_source_files([sources_field_with_origin])
                 == all_sources[expected_slice]
             )
+            assert self.get_specified_unrooted_files([sources_field_with_origin]) == []
 
         assert_file_args_resolved(sources_field1, sources_field1_all_sources, sources_field1_slice)
         assert_file_args_resolved(sources_field2, sources_field2_all_sources, sources_field2_slice)
         assert_file_args_resolved(sources_field3, sources_field3_all_sources, sources_field3_slice)
 
-        combined_sources_fields = [sources_field1, sources_field2, sources_field3]
+        combined_sources_fields = [sources_field1, sources_field2, sources_field3, sources_field4]
         assert self.get_all_source_files(combined_sources_fields) == sorted(
-            [*sources_field1_all_sources, *sources_field2_all_sources, *sources_field3_all_sources]
+            [
+                *sources_field1_all_sources,
+                *sources_field2_all_sources,
+                *sources_field3_all_sources,
+                *sources_field4_all_sources,
+            ]
         )
+        assert self.get_all_unrooted_files(combined_sources_fields) == sorted(
+            [*sources_field4_all_sources]
+        )
+
         assert self.get_specified_source_files(combined_sources_fields) == sorted(
             [
                 *sources_field1_all_sources[sources_field1_slice],
                 *sources_field2_all_sources[sources_field2_slice],
                 *sources_field3_all_sources[sources_field3_slice],
+                *sources_field4_all_sources,
             ]
         )
 
-    def test_strip_source_roots(self) -> None:
-        sources_field1 = self.mock_sources_field_with_origin(SOURCES1)
-        sources_field2 = self.mock_sources_field_with_origin(SOURCES2)
-        sources_field3 = self.mock_sources_field_with_origin(SOURCES3)
-
-        def assert_source_roots_stripped(
-            sources_field_with_origin: Tuple[SourcesField, OriginSpec], sources: TargetSources
-        ) -> None:
-            expected = sources.source_files
-            assert (
-                self.get_all_source_files([sources_field_with_origin], strip_source_roots=True)
-                == expected
-            )
-            assert (
-                self.get_specified_source_files(
-                    [sources_field_with_origin], strip_source_roots=True
-                )
-                == expected
-            )
-
-        assert_source_roots_stripped(sources_field1, SOURCES1)
-        assert_source_roots_stripped(sources_field2, SOURCES2)
-        assert_source_roots_stripped(sources_field3, SOURCES3)
-
-        # We must be careful to not strip source roots for `FilesSources`.
-        files_sources_field = self.mock_sources_field_with_origin(
-            SOURCES1, sources_field_cls=FilesSources
-        )
-        files_expected = SOURCES1.source_file_absolute_paths
-
-        assert (
-            self.get_all_source_files([files_sources_field], strip_source_roots=True)
-            == files_expected
-        )
-        assert (
-            self.get_specified_source_files([files_sources_field], strip_source_roots=True)
-            == files_expected
-        )
-
-        combined_sources_fields = [
-            sources_field1,
-            sources_field2,
-            sources_field3,
-            files_sources_field,
-        ]
-        combined_expected = sorted(
-            [
-                *SOURCES1.source_files,
-                *SOURCES2.source_files,
-                *SOURCES3.source_files,
-                *files_expected,
-            ],
-        )
-        assert (
-            self.get_all_source_files(combined_sources_fields, strip_source_roots=True)
-            == combined_expected
-        )
-        assert (
-            self.get_specified_source_files(combined_sources_fields, strip_source_roots=True)
-            == combined_expected
+        assert self.get_specified_unrooted_files(combined_sources_fields) == sorted(
+            [*sources_field4_all_sources,]
         )
 
     def test_gracefully_handle_no_sources(self) -> None:
         sources_field = self.mock_sources_field_with_origin(SOURCES1, include_sources=False)
         assert self.get_all_source_files([sources_field]) == []
         assert self.get_specified_source_files([sources_field]) == []
-        assert self.get_all_source_files([sources_field], strip_source_roots=True) == []
-        assert self.get_specified_source_files([sources_field], strip_source_roots=True) == []
+        assert self.get_all_unrooted_files([sources_field]) == []
+        assert self.get_specified_unrooted_files([sources_field]) == []

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -28,10 +28,9 @@ async def strip_source_roots(source_files: SourceFiles) -> StrippedSourceFiles:
 
     if source_files.unrooted_files:
         rooted_files = set(source_files.snapshot.files) - set(source_files.unrooted_files)
-        rooted_files_digest = await Get(
-            Digest, DigestSubset(source_files.snapshot.digest, PathGlobs(rooted_files))
+        rooted_files_snapshot = await Get(
+            Snapshot, DigestSubset(source_files.snapshot.digest, PathGlobs(rooted_files))
         )
-        rooted_files_snapshot = await Get(Snapshot, Digest, rooted_files_digest)
     else:
         rooted_files_snapshot = source_files.snapshot
 

--- a/src/python/pants/core/util_rules/strip_source_roots.py
+++ b/src/python/pants/core/util_rules/strip_source_roots.py
@@ -2,187 +2,86 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
-import os
 from dataclasses import dataclass
-from pathlib import PurePath
-from typing import Iterable, Optional, Tuple, Type
 
-from pants.build_graph.address import Address
-from pants.core.target_types import FilesSources
-from pants.engine.fs import (
-    EMPTY_SNAPSHOT,
-    Digest,
-    DigestSubset,
-    MergeDigests,
-    PathGlobs,
-    RemovePrefix,
-    Snapshot,
-)
-from pants.engine.rules import Get, MultiGet, RootRule, collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest
-from pants.engine.target import Sources as SourcesField
+from pants.core.util_rules.determine_source_files import SourceFiles
+from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
-from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
 
 
 @dataclass(frozen=True)
-class SourceRootStrippedSources:
+class StrippedSourceFiles:
     """Wrapper for a snapshot of files whose source roots have been stripped."""
 
     snapshot: Snapshot
-    # source root -> file paths relative to that root.
-    # Note that this will not contain entries for files to which the concept of source roots
-    # doesn't apply (e.g., the sources of a files(...) target), even when such files are
-    # in the snapshot.
-    root_to_relfiles: FrozenDict[str, Tuple[str, ...]]
-
-    @classmethod
-    def for_single_source_root(
-        cls, snapshot: Snapshot, source_root: str
-    ) -> "SourceRootStrippedSources":
-        return cls(snapshot, FrozenDict({source_root: snapshot.files}))
-
-    def get_file_to_stripped_file_mapping(self) -> FrozenDict[str, str]:
-        """Generate a mapping from original path to stripped path."""
-        return FrozenDict(
-            {
-                (os.path.join(root, relpath) if root != "." else relpath): relpath
-                for root, relpaths in self.root_to_relfiles.items()
-                for relpath in relpaths
-            }
-        )
-
-
-@dataclass(frozen=True)
-class StripSnapshotRequest:
-    """A request to strip source roots for every file in the snapshot."""
-
-    snapshot: Snapshot
-
-
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class StripSourcesFieldRequest:
-    """A request to strip source roots for every file in a `Sources` field.
-
-    The call site may optionally give a snapshot to `specified_files_snapshot` to only strip a
-    subset of the target's `sources`, rather than every `sources` file. This is useful when working
-    with precise file arguments.
-    """
-
-    sources_field: SourcesField
-    for_sources_types: Tuple[Type[SourcesField], ...]
-    enable_codegen: bool
-    specified_files_snapshot: Optional[Snapshot]
-
-    def __init__(
-        self,
-        sources_field: SourcesField,
-        *,
-        for_sources_types: Iterable[Type[SourcesField]] = (SourcesField,),
-        enable_codegen: bool = False,
-        specified_files_snapshot: Optional[Snapshot] = None,
-    ) -> None:
-        self.sources_field = sources_field
-        self.for_sources_types = tuple(for_sources_types)
-        self.enable_codegen = enable_codegen
-        self.specified_files_snapshot = specified_files_snapshot
 
 
 @rule
-async def strip_source_roots_from_snapshot(
-    request: StripSnapshotRequest,
-) -> SourceRootStrippedSources:
+async def strip_source_roots(source_files: SourceFiles) -> StrippedSourceFiles:
     """Removes source roots from a snapshot.
 
     E.g. `src/python/pants/util/strutil.py` -> `pants/util/strutil.py`.
     """
-    if not request.snapshot.files:
-        return SourceRootStrippedSources(request.snapshot, FrozenDict())
+    if not source_files.snapshot.files:
+        return StrippedSourceFiles(source_files.snapshot)
 
-    result = await Get(
-        SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(request.snapshot.files)
+    if source_files.unrooted_files:
+        rooted_files = set(source_files.snapshot.files) - set(source_files.unrooted_files)
+        rooted_files_digest = await Get(
+            Digest, DigestSubset(source_files.snapshot.digest, PathGlobs(rooted_files))
+        )
+        rooted_files_snapshot = await Get(Snapshot, Digest, rooted_files_digest)
+    else:
+        rooted_files_snapshot = source_files.snapshot
+
+    source_roots_result = await Get(
+        SourceRootsResult,
+        SourceRootsRequest,
+        SourceRootsRequest.for_files(rooted_files_snapshot.files),
     )
 
-    file_to_source_root = {str(file): root for file, root in result.path_to_root.items()}
+    file_to_source_root = {
+        str(file): root for file, root in source_roots_result.path_to_root.items()
+    }
     files_grouped_by_source_root = {
         source_root.path: tuple(str(f) for f in files)
         for source_root, files in itertools.groupby(
-            request.snapshot.files, key=file_to_source_root.__getitem__
+            file_to_source_root.keys(), key=file_to_source_root.__getitem__
         )
     }
 
     if len(files_grouped_by_source_root) == 1:
         source_root = next(iter(files_grouped_by_source_root.keys()))
         if source_root == ".":
-            return SourceRootStrippedSources.for_single_source_root(request.snapshot, source_root)
-        resulting_snapshot = await Get(Snapshot, RemovePrefix(request.snapshot.digest, source_root))
-        return SourceRootStrippedSources.for_single_source_root(resulting_snapshot, source_root)
-
-    digest_subsets = await MultiGet(
-        Get(Digest, DigestSubset(request.snapshot.digest, PathGlobs(files)))
-        for files in files_grouped_by_source_root.values()
-    )
-    resulting_digests = await MultiGet(
-        Get(Digest, RemovePrefix(digest, source_root))
-        for digest, source_root in zip(digest_subsets, files_grouped_by_source_root.keys())
-    )
-
-    resulting_snapshot = await Get(Snapshot, MergeDigests(resulting_digests))
-    return SourceRootStrippedSources(
-        resulting_snapshot,
-        FrozenDict(
-            {
-                source_root: tuple(file[len(source_root) + 1 :] for file in files)
-                for source_root, files in files_grouped_by_source_root.items()
-            }
-        ),
-    )
-
-
-def representative_path_from_address(address: Address) -> str:
-    """Generate a representative path for an address.
-
-    Allows us to get a single source root for an entire target.
-    """
-    return PurePath(address.spec_path, "BUILD").as_posix()
-
-
-@rule
-async def strip_source_roots_from_sources_field(
-    request: StripSourcesFieldRequest,
-) -> SourceRootStrippedSources:
-    """Remove source roots from a target, e.g. `src/python/pants/util/strutil.py` ->
-    `pants/util/strutil.py`."""
-    if request.specified_files_snapshot is not None:
-        sources_snapshot = request.specified_files_snapshot
+            resulting_snapshot = rooted_files_snapshot
+        else:
+            resulting_snapshot = await Get(
+                Snapshot, RemovePrefix(rooted_files_snapshot.digest, source_root)
+            )
     else:
-        hydrated_sources = await Get(
-            HydratedSources,
-            HydrateSourcesRequest(
-                request.sources_field,
-                for_sources_types=request.for_sources_types,
-                enable_codegen=request.enable_codegen,
-            ),
+        digest_subsets = await MultiGet(
+            Get(Digest, DigestSubset(rooted_files_snapshot.digest, PathGlobs(files)))
+            for files in files_grouped_by_source_root.values()
         )
-        sources_snapshot = hydrated_sources.snapshot
+        resulting_digests = await MultiGet(
+            Get(Digest, RemovePrefix(digest, source_root))
+            for digest, source_root in zip(digest_subsets, files_grouped_by_source_root.keys())
+        )
+        resulting_snapshot = await Get(Snapshot, MergeDigests(resulting_digests))
 
-    if not sources_snapshot.files:
-        return SourceRootStrippedSources(EMPTY_SNAPSHOT, FrozenDict())
+    # Add the unrooted files back in.
+    if source_files.unrooted_files:
+        unrooted_files_digest = await Get(
+            Digest,
+            DigestSubset(source_files.snapshot.digest, PathGlobs(source_files.unrooted_files)),
+        )
+        resulting_snapshot = await Get(
+            Snapshot, MergeDigests((resulting_snapshot.digest, unrooted_files_digest))
+        )
 
-    # Unlike all other `Sources` subclasses, `FilesSources` (and its subclasses) do not remove
-    # their source root. This is so that filesystem APIs (e.g. Python's `open()`) may still access
-    # the files as they normally would, with the full path relative to the build root.
-    if isinstance(request.sources_field, FilesSources):
-        return SourceRootStrippedSources(sources_snapshot, FrozenDict())
-
-    return await Get(SourceRootStrippedSources, StripSnapshotRequest(sources_snapshot))
+    return StrippedSourceFiles(resulting_snapshot)
 
 
 def rules():
-    return [
-        *collect_rules(),
-        RootRule(StripSnapshotRequest),
-        RootRule(StripSourcesFieldRequest),
-    ]
+    return collect_rules()

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -6,11 +6,13 @@ from typing import List, Optional
 
 import pytest
 
+from pants.core.util_rules import determine_source_files
 from pants.core.util_rules.determine_source_files import SourceFiles
 from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.core.util_rules.strip_source_roots import rules as strip_source_root_rules
 from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.rules import RootRule
 from pants.testutil.engine.util import Params
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
@@ -19,7 +21,12 @@ from pants.testutil.test_base import TestBase
 class StripSourceRootsTest(TestBase):
     @classmethod
     def rules(cls):
-        return (*super().rules(), *strip_source_root_rules())
+        return (
+            *super().rules(),
+            *strip_source_root_rules(),
+            *determine_source_files.rules(),
+            RootRule(SourceFiles),
+        )
 
     def get_stripped_files(
         self, request: SourceFiles, *, args: Optional[List[str]] = None,

--- a/src/python/pants/core/util_rules/strip_source_roots_test.py
+++ b/src/python/pants/core/util_rules/strip_source_roots_test.py
@@ -2,26 +2,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import List, Optional
 
 import pytest
 
-from pants.core.target_types import FilesSources
-from pants.core.util_rules.strip_source_roots import (
-    SourceRootStrippedSources,
-    StripSnapshotRequest,
-    StripSourcesFieldRequest,
-)
+from pants.core.util_rules.determine_source_files import SourceFiles
+from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.core.util_rules.strip_source_roots import rules as strip_source_root_rules
-from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import Sources as SourcesField
 from pants.testutil.engine.util import Params
 from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
-
-StrippedResponseData = Tuple[List[str], Dict[str, Tuple[str, ...]]]
 
 
 class StripSourceRootsTest(TestBase):
@@ -30,11 +22,8 @@ class StripSourceRootsTest(TestBase):
         return (*super().rules(), *strip_source_root_rules())
 
     def get_stripped_files(
-        self,
-        request: Union[StripSnapshotRequest, StripSourcesFieldRequest],
-        *,
-        args: Optional[List[str]] = None,
-    ) -> StrippedResponseData:
+        self, request: SourceFiles, *, args: Optional[List[str]] = None,
+    ) -> List[str]:
         args = args or []
         has_source_root_patterns = False
         for arg in args:
@@ -45,36 +34,32 @@ class StripSourceRootsTest(TestBase):
             source_root_patterns = ["src/python", "src/java", "tests/python"]
             args.append(f"--source-root-patterns={json.dumps(source_root_patterns)}")
         result = self.request_single_product(
-            SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),
+            StrippedSourceFiles, Params(request, create_options_bootstrapper(args=args)),
         )
-        return list(result.snapshot.files), dict(result.root_to_relfiles)
+        return list(result.snapshot.files)
 
     def test_strip_snapshot(self) -> None:
         def get_stripped_files_for_snapshot(
             paths: List[str], *, args: Optional[List[str]] = None,
-        ) -> StrippedResponseData:
+        ) -> List[str]:
             input_snapshot = self.make_snapshot_of_empty_files(paths)
-            request = StripSnapshotRequest(input_snapshot,)
+            request = SourceFiles(input_snapshot, ())
             return self.get_stripped_files(request, args=args)
 
         # Normal source roots
-        assert get_stripped_files_for_snapshot(["src/python/project/example.py"]) == (
-            ["project/example.py"],
-            {"src/python": ("project/example.py",)},
-        )
-        assert get_stripped_files_for_snapshot(["src/python/project/example.py"],) == (
-            ["project/example.py"],
-            {"src/python": ("project/example.py",)},
-        )
+        assert get_stripped_files_for_snapshot(["src/python/project/example.py"]) == [
+            "project/example.py"
+        ]
+        assert get_stripped_files_for_snapshot(["src/python/project/example.py"],) == [
+            "project/example.py"
+        ]
 
-        assert get_stripped_files_for_snapshot(["src/java/com/project/example.java"]) == (
-            ["com/project/example.java"],
-            {"src/java": ("com/project/example.java",)},
-        )
-        assert get_stripped_files_for_snapshot(["tests/python/project_test/example.py"]) == (
-            ["project_test/example.py"],
-            {"tests/python": ("project_test/example.py",)},
-        )
+        assert get_stripped_files_for_snapshot(["src/java/com/project/example.java"]) == [
+            "com/project/example.java"
+        ]
+        assert get_stripped_files_for_snapshot(["tests/python/project_test/example.py"]) == [
+            "project_test/example.py"
+        ]
 
         # Unrecognized source root
         unrecognized_source_root = "no-source-root/example.txt"
@@ -86,10 +71,10 @@ class StripSourceRootsTest(TestBase):
 
         # Support for multiple source roots
         file_names = ["src/python/project/example.py", "src/java/com/project/example.java"]
-        assert get_stripped_files_for_snapshot(file_names) == (
-            ["com/project/example.java", "project/example.py"],
-            {"src/python": ("project/example.py",), "src/java": ("com/project/example.java",)},
-        )
+        assert get_stripped_files_for_snapshot(file_names) == [
+            "com/project/example.java",
+            "project/example.py",
+        ]
 
         # Test a source root at the repo root. We have performance optimizations for this case
         # because there is nothing to strip.
@@ -97,91 +82,11 @@ class StripSourceRootsTest(TestBase):
 
         assert get_stripped_files_for_snapshot(
             ["project/f1.py", "project/f2.py"], args=source_root_config,
-        ) == (["project/f1.py", "project/f2.py"], {".": ("project/f1.py", "project/f2.py")})
+        ) == ["project/f1.py", "project/f2.py"]
 
         assert get_stripped_files_for_snapshot(
             ["dir1/f.py", "dir2/f.py"], args=source_root_config,
-        ) == (["dir1/f.py", "dir2/f.py"], {".": ("dir1/f.py", "dir2/f.py")})
+        ) == ["dir1/f.py", "dir2/f.py"]
 
         # Gracefully handle an empty snapshot
-        assert self.get_stripped_files(StripSnapshotRequest(EMPTY_SNAPSHOT)) == ([], {})
-
-    def test_strip_sources_field(self) -> None:
-        source_root = "src/python/project"
-
-        def get_stripped_files_for_sources_field(
-            *,
-            source_files: Optional[List[str]],
-            sources_field_cls: Type[SourcesField] = SourcesField,
-            specified_source_files: Optional[List[str]] = None,
-        ) -> StrippedResponseData:
-            if source_files:
-                self.create_files(path=source_root, files=source_files)
-            sources_field = sources_field_cls(
-                source_files, address=Address.parse(f"{source_root}:lib")
-            )
-            specified_sources_snapshot = (
-                None
-                if not specified_source_files
-                else self.make_snapshot_of_empty_files(
-                    f"{source_root}/{f}" for f in specified_source_files
-                )
-            )
-            return self.get_stripped_files(
-                StripSourcesFieldRequest(
-                    sources_field, specified_files_snapshot=specified_sources_snapshot,
-                )
-            )
-
-        # normal sources
-        assert get_stripped_files_for_sources_field(source_files=["f1.py", "f2.py"]) == (
-            ["project/f1.py", "project/f2.py"],
-            {"src/python": ("project/f1.py", "project/f2.py")},
-        )
-
-        # empty sources
-        assert get_stripped_files_for_sources_field(source_files=None) == ([], {})
-
-        # FilesSources is not stripped
-        assert get_stripped_files_for_sources_field(
-            source_files=["f1.py"], sources_field_cls=FilesSources,
-        ) == ([f"{source_root}/f1.py"], {})
-
-        # When given `specified_files_snapshot`, only strip what is specified, even if that snapshot
-        # has files not belonging to the corresponding Sources field! (Validation of ownership
-        # would have a performance cost.)
-        assert get_stripped_files_for_sources_field(
-            source_files=["f1.py"], specified_source_files=["f1.py", "different_owner.py"],
-        ) == (
-            ["project/different_owner.py", "project/f1.py"],
-            {"src/python": ("project/different_owner.py", "project/f1.py")},
-        )
-
-    def test_get_file_to_stripped_file_mapping(self) -> None:
-        def get_stripped_file_mapping(
-            paths: List[str], args: Optional[List[str]] = None
-        ) -> Dict[str, str]:
-            args = args or []
-            args.append("--source-root-patterns=src/python")
-            args.append("--source-root-patterns=src/java")
-            request = StripSnapshotRequest(self.make_snapshot_of_empty_files(paths))
-            result = self.request_single_product(
-                SourceRootStrippedSources, Params(request, create_options_bootstrapper(args=args)),
-            )
-            return dict(result.get_file_to_stripped_file_mapping())
-
-        assert get_stripped_file_mapping(["src/python/project/example.py"]) == {
-            "src/python/project/example.py": "project/example.py"
-        }
-        assert get_stripped_file_mapping(
-            ["src/python/project/example.py", "src/java/com/project/example.java"]
-        ) == {
-            "src/python/project/example.py": "project/example.py",
-            "src/java/com/project/example.java": "com/project/example.java",
-        }
-
-        source_root_config = [f"--source-root-patterns={json.dumps(['/'])}"]
-        assert get_stripped_file_mapping(
-            ["project/f1.py", "project/f2.py"], args=source_root_config
-        ) == {"project/f1.py": "project/f1.py", "project/f2.py": "project/f2.py",}
-        assert get_stripped_file_mapping([]) == {}
+        assert self.get_stripped_files(SourceFiles(EMPTY_SNAPSHOT, ())) == []

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Dict, Iterable, Optional, Set, Tuple, Union
 
+from pants.build_graph.address import Address
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.rules import Get, MultiGet, RootRule, collect_rules, rule
+from pants.engine.target import Target
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method
@@ -186,6 +188,15 @@ class SourceRootRequest:
         # The file itself cannot be a source root, so we may as well start the search
         # from its enclosing directory, and save on some superfluous checking.
         return cls(PurePath(file_path).parent)
+
+    @classmethod
+    def for_address(cls, address: Address) -> "SourceRootRequest":
+        # Note that we don't use for_file() here because the spec_path is a directory.
+        return cls(PurePath(address.spec_path))
+
+    @classmethod
+    def for_target(cls, target: Target) -> "SourceRootRequest":
+        return cls.for_address(target.address)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Previously we had two parallel rule paths for stripped and unstripped source files.

This added a lot of complication: various types could contain either stripped or
unstripped sources, and there wasn't always an easy way to know which. This also
required a lot of near-duplication of code, to handle each of the two paths.

This change simplifies the types and rules, as follows:

- Unstripped generic sources are represented by the SourceFiles type.
- Stripped generic sources are represented by the StrippedSourceFiles type.
- Unstripped Python sources are represented by the PythonSourceFiles type,
  which wraps a SourceFiles.
- Stripped Python sources are represented by the StrippedPythonSourceFiles type,
  which wraps a StrippedSourceFiles.

The only way to get a StrippedSourceFiles is to request via a SourceFiles subject.
The only way to get a StrippedPythonSourceFiles is to request it via a PythonSourceFiles subject.

The SourceFiles type carries just enough extra information to allow source-root stripping
even in a merged snapshot, where the originating target information is lost.

As a result, other rules operate primarily on unstripped sources, and strip them just as needed.
For example, finding ancestor files operates only on unstripped sources, and no longer needs
to implement logic to handle the stripped case.

[ci skip-rust]

[ci skip-build-wheels]
