### PR TITLE
Remove unused `SymbolTable`

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -29,7 +29,7 @@ from pants.engine.internals.build_files import (
     strip_address_origins,
 )
 from pants.engine.internals.mapper import AddressFamily, AddressMapper
-from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, SymbolTable
+from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import RootRule
@@ -41,7 +41,9 @@ from pants.util.frozendict import FrozenDict
 
 def test_parse_address_family_empty() -> None:
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
-    address_mapper = AddressMapper(parser=Parser(SymbolTable({}), BuildFileAliases()))
+    address_mapper = AddressMapper(
+        parser=Parser(target_type_aliases=[], object_aliases=BuildFileAliases())
+    )
     af = run_rule(
         parse_address_family,
         rule_args=[address_mapper, BuildFilePreludeSymbols(FrozenDict()), Dir("/dev/null")],
@@ -59,7 +61,9 @@ def test_parse_address_family_empty() -> None:
 def resolve_addresses_with_origins_from_address_specs(
     address_specs: AddressSpecs, address_family: AddressFamily,
 ) -> AddressesWithOrigins:
-    address_mapper = AddressMapper(Parser(SymbolTable({}), BuildFileAliases()))
+    address_mapper = AddressMapper(
+        Parser(target_type_aliases=[], object_aliases=BuildFileAliases())
+    )
     snapshot = Snapshot(Digest("xx", 2), ("root/BUILD",), ())
     addresses_with_origins = run_rule(
         addresses_with_origins_from_address_specs,

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -9,14 +9,14 @@ from pants.base.exceptions import DuplicateNameError
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.mapper import AddressFamily, AddressMap, DifferingFamiliesError
-from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, SymbolTable
+from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.util.frozendict import FrozenDict
 
 
 def parse_address_map(build_file: str) -> AddressMap:
     path = "/dev/null"
-    parser = Parser(SymbolTable({"thing": TargetAdaptor}), BuildFileAliases())
+    parser = Parser(target_type_aliases=["thing"], object_aliases=BuildFileAliases())
     address_map = AddressMap.parse(path, build_file, parser, BuildFilePreludeSymbols(FrozenDict()))
     assert path == address_map.path
     return address_map

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -4,13 +4,12 @@
 import pytest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser, SymbolTable
-from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.internals.parser import BuildFilePreludeSymbols, ParseError, Parser
 from pants.util.frozendict import FrozenDict
 
 
 def test_imports_banned() -> None:
-    parser = Parser(SymbolTable({}), BuildFileAliases())
+    parser = Parser(target_type_aliases=[], object_aliases=BuildFileAliases())
     with pytest.raises(ParseError) as exc:
         parser.parse(
             "dir/BUILD", "\nx = 'hello'\n\nimport os\n", BuildFilePreludeSymbols(FrozenDict())
@@ -20,8 +19,8 @@ def test_imports_banned() -> None:
 
 def test_unrecognized_symbol() -> None:
     parser = Parser(
-        SymbolTable({"tgt": TargetAdaptor}),
-        BuildFileAliases(
+        target_type_aliases=["tgt"],
+        object_aliases=BuildFileAliases(
             objects={"obj": 0},
             context_aware_object_factories={"caof": lambda parse_context: lambda _: None},
         ),

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -19,10 +19,9 @@ from pants.engine.internals import graph, options_parsing, uuid
 from pants.engine.internals.build_files import create_graph_rules
 from pants.engine.internals.mapper import AddressMapper
 from pants.engine.internals.native import Native
-from pants.engine.internals.parser import Parser, SymbolTable
+from pants.engine.internals.parser import Parser
 from pants.engine.internals.scheduler import Scheduler, SchedulerSession
 from pants.engine.internals.selectors import Params
-from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.platform import create_platform_rules
 from pants.engine.process import InteractiveRunner
 from pants.engine.rules import RootRule, collect_rules, rule
@@ -246,10 +245,9 @@ class EngineInitializer:
         union_membership = UnionMembership.from_rules(build_configuration.union_rules)
 
         registered_target_types = RegisteredTargetTypes.create(build_configuration.target_types)
-        symbol_table_from_registered_targets = SymbolTable(
-            {target_type.alias: TargetAdaptor for target_type in registered_target_types.types}
+        parser = Parser(
+            target_type_aliases=registered_target_types.aliases, object_aliases=build_file_aliases
         )
-        parser = Parser(symbol_table_from_registered_targets, build_file_aliases)
         address_mapper = AddressMapper(
             parser=parser,
             prelude_glob_patterns=build_file_prelude_globs,
@@ -265,10 +263,6 @@ class EngineInitializer:
         @rule
         def build_configuration_singleton() -> BuildConfiguration:
             return build_configuration
-
-        @rule
-        def symbol_table_singleton() -> SymbolTable:
-            return symbol_table_from_registered_targets
 
         @rule
         def registered_target_types_singleton() -> RegisteredTargetTypes:


### PR DESCRIPTION
All members of the `SymbolTable` are `TargetAdaptor`, so there is no reason for this dictionary anymore.

[ci skip-rust]
[ci skip-build-wheels]
