### PR TITLE
avoid Py 3.8 for BanditIntegrationTest.test_3rdparty_plugin

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from typing import List, Optional
-from unittest import skip
 
 from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
@@ -173,10 +172,12 @@ class BanditIntegrationTest(ExternalToolTestBase):
         result = self.run_bandit([target], skip=True)
         assert not result
 
-    @skip("flaky depending on Python version: https://github.com/pantsbuild/pants/issues/10545")
     def test_3rdparty_plugin(self) -> None:
         target = self.make_target_with_origin(
-            [FileContent("bad.py", b"aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n")]
+            [FileContent("bad.py", b"aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n")],
+            # NB: `bandit-aws` does not currently work with Python 3.8. See
+            #  https://github.com/pantsbuild/pants/issues/10545.
+            interpreter_constraints="CPython>=3.6,<3.8",
         )
         result = self.run_bandit(
             [target], additional_args=["--bandit-extra-requirements=bandit-aws"]

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from typing import List, Optional
+from unittest import skip
 
 from pants.backend.python.lint.bandit.rules import BanditFieldSet, BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
@@ -172,6 +173,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         result = self.run_bandit([target], skip=True)
         assert not result
 
+    @skip("flaky depending on Python version: https://github.com/pantsbuild/pants/issues/10545")
     def test_3rdparty_plugin(self) -> None:
         target = self.make_target_with_origin(
             [FileContent("bad.py", b"aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n")]


### PR DESCRIPTION
### Problem

As described in https://github.com/pantsbuild/pants/issues/10545, `BanditIntegrationTest.test_3rdparty_plugin` is flaky because its success depends on specific Python version that the test runs the `bandit-aws` plugin with.

### Solution

Do not allow Python 3.8 to be used to run the test.

### Result

Test passes.