### PR TITLE
Stop using `AddressWithOrigin` for precise file arguments

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Set
 
 from pants.backend.python.target_types import PythonRequirementsField, PythonSources
 from pants.base.specs import AddressSpecs, DescendantAddresses
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest
+from pants.core.util_rules.determine_source_files import SourceFilesRequest
 from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.engine.addresses import Address
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -73,7 +73,7 @@ async def map_first_party_modules_to_addresses() -> FirstPartyModuleToAddressMap
         for tgt in candidate_explicit_targets
     )
     stripped_sources_per_explicit_target = await MultiGet(
-        Get(StrippedSourceFiles, AllSourceFilesRequest([tgt[PythonSources]]))
+        Get(StrippedSourceFiles, SourceFilesRequest([tgt[PythonSources]]))
         for tgt in candidate_explicit_targets
     )
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -12,7 +12,7 @@ from pants.backend.python.dependency_inference.python_stdlib.combined import com
 from pants.backend.python.rules import ancestor_files
 from pants.backend.python.rules.ancestor_files import AncestorFiles, AncestorFilesRequest
 from pants.backend.python.target_types import PythonSources, PythonTestsSources
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest
+from pants.core.util_rules.determine_source_files import SourceFilesRequest
 from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.internals.graph import Owners, OwnersRequest
@@ -89,9 +89,7 @@ async def infer_python_dependencies(
     if not python_inference.imports:
         return InferredDependencies()
 
-    stripped_sources = await Get(
-        StrippedSourceFiles, AllSourceFilesRequest([request.sources_field])
-    )
+    stripped_sources = await Get(StrippedSourceFiles, SourceFilesRequest([request.sources_field]))
     modules = tuple(
         PythonModule.create_from_stripped_path(PurePath(fp))
         for fp in stripped_sources.snapshot.files

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,11 +22,7 @@ from pants.core.goals.lint import (
     LintSubsystem,
 )
 from pants.core.util_rules import determine_source_files, strip_source_roots
-from pants.core.util_rules.determine_source_files import (
-    AllSourceFilesRequest,
-    SourceFiles,
-    SpecifiedSourceFilesRequest,
-)
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
     Digest,
     DigestSubset,
@@ -62,7 +58,7 @@ class BanditPartition:
 
 
 def generate_args(
-    *, specified_source_files: SourceFiles, bandit: Bandit, output_file: Optional[str]
+    *, source_files: SourceFiles, bandit: Bandit, output_file: Optional[str]
 ) -> Tuple[str, ...]:
     args = []
     if bandit.config is not None:
@@ -70,7 +66,7 @@ def generate_args(
     if output_file:
         args.append(f"--output={output_file}")
     args.extend(bandit.args)
-    args.extend(specified_source_files.files)
+    args.extend(source_files.files)
     return tuple(args)
 
 
@@ -100,26 +96,16 @@ async def bandit_lint_partition(
         ),
     )
 
-    all_source_files_request = Get(
-        SourceFiles, AllSourceFilesRequest(field_set.sources for field_set in partition.field_sets)
-    )
-    specified_source_files_request = Get(
-        SourceFiles,
-        SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in partition.field_sets
-        ),
+    source_files_request = Get(
+        SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
-    requirements_pex, config_digest, all_source_files, specified_source_files = await MultiGet(
-        requirements_pex_request,
-        config_digest_request,
-        all_source_files_request,
-        specified_source_files_request,
+    requirements_pex, config_digest, source_files = await MultiGet(
+        requirements_pex_request, config_digest_request, source_files_request
     )
 
     input_digest = await Get(
-        Digest,
-        MergeDigests((all_source_files.snapshot.digest, requirements_pex.digest, config_digest)),
+        Digest, MergeDigests((source_files.snapshot.digest, requirements_pex.digest, config_digest))
     )
 
     address_references = ", ".join(
@@ -129,7 +115,7 @@ async def bandit_lint_partition(
         lint_subsystem.reports_dir / "bandit_report.txt" if lint_subsystem.reports_dir else None
     )
     args = generate_args(
-        specified_source_files=specified_source_files,
+        source_files=source_files,
         bandit=bandit,
         output_file=report_path.name if report_path else None,
     )

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -33,14 +33,14 @@ from pants.engine.fs import (
 )
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class BanditFieldSet(FieldSetWithOrigin):
+class BanditFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -20,12 +20,8 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
-from pants.core.util_rules.determine_source_files import (
-    AllSourceFilesRequest,
-    SourceFiles,
-    SpecifiedSourceFilesRequest,
-)
-from pants.engine.fs import EMPTY_SNAPSHOT, Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSetWithOrigin
@@ -56,9 +52,7 @@ class Setup:
     original_digest: Digest
 
 
-def generate_args(
-    *, specified_source_files: SourceFiles, black: Black, check_only: bool,
-) -> Tuple[str, ...]:
+def generate_args(*, source_files: SourceFiles, black: Black, check_only: bool,) -> Tuple[str, ...]:
     args = []
     if check_only:
         args.append("--check")
@@ -70,8 +64,8 @@ def generate_args(
     # Black to run over everything recursively under the directory of our target, as Black should
     # only touch files directly specified. We can use `--include` to ensure that Black only
     # operates on the files we actually care about.
-    args.extend(["--include", "|".join(re.escape(f) for f in specified_source_files.files)])
-    args.extend(PurePath(f).parent.as_posix() for f in specified_source_files.files)
+    args.extend(["--include", "|".join(re.escape(f) for f in source_files.files)])
+    args.extend(PurePath(f).parent.as_posix() for f in source_files.files)
     return tuple(args)
 
 
@@ -96,32 +90,23 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
         ),
     )
 
-    all_source_files_request = Get(
+    source_files_request = Get(
         SourceFiles,
-        AllSourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
-    )
-    specified_source_files_request = Get(
-        SourceFiles,
-        SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in setup_request.request.field_sets
-        ),
+        SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    requests = requirements_pex_request, config_digest_request, specified_source_files_request
-    all_source_files, requirements_pex, config_digest, specified_source_files = (
-        await MultiGet(all_source_files_request, *requests)
-        if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
+    source_files, requirements_pex, config_digest = await MultiGet(
+        source_files_request, requirements_pex_request, config_digest_request
     )
-    all_source_files_snapshot = (
-        all_source_files.snapshot
+    source_files_snapshot = (
+        source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
     )
 
     input_digest = await Get(
         Digest,
-        MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest, config_digest)),
+        MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
     )
 
     address_references = ", ".join(
@@ -133,19 +118,17 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
         PexProcess(
             requirements_pex,
             argv=generate_args(
-                specified_source_files=specified_source_files,
-                black=black,
-                check_only=setup_request.check_only,
+                source_files=source_files, black=black, check_only=setup_request.check_only
             ),
             input_digest=input_digest,
-            output_files=all_source_files_snapshot.files,
+            output_files=source_files_snapshot.files,
             description=(
                 f"Run Black on {pluralize(len(setup_request.request.field_sets), 'target')}: "
                 f"{address_references}."
             ),
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.digest)
+    return Setup(process, original_digest=source_files_snapshot.digest)
 
 
 @rule(desc="Format using Black")

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -24,13 +24,13 @@ from pants.core.util_rules.determine_source_files import SourceFiles, SourceFile
 from pants.engine.fs import Digest, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class BlackFieldSet(FieldSetWithOrigin):
+class BlackFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResults
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
@@ -66,7 +66,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         input_sources = self.request_single_product(
             SourceFiles,
             Params(
-                AllSourceFilesRequest(field_set.sources for field_set in field_sets),
+                SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -6,14 +6,13 @@ from typing import List, Optional, Tuple
 from pants.backend.python.lint.black.rules import BlackFieldSet, BlackRequest
 from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.target_types import PythonLibrary
-from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResults
 from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
-from pants.engine.target import TargetWithOrigin
+from pants.engine.target import Target
 from pants.testutil.engine.util import Params
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
 from pants.testutil.option.util import create_options_bootstrapper
@@ -32,19 +31,14 @@ class BlackIntegrationTest(ExternalToolTestBase):
     def rules(cls):
         return (*super().rules(), *black_rules(), RootRule(BlackRequest))
 
-    def make_target_with_origin(
-        self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
-    ) -> TargetWithOrigin:
+    def make_target(self, source_files: List[FileContent]) -> Target:
         for source_file in source_files:
             self.create_file(f"{source_file.path}", source_file.content.decode())
-        target = PythonLibrary({}, address=Address.parse(":target"))
-        if origin is None:
-            origin = SingleAddress(directory="", name="target")
-        return TargetWithOrigin(target, origin)
+        return PythonLibrary({}, address=Address.parse(":target"))
 
     def run_black(
         self,
-        targets: List[TargetWithOrigin],
+        targets: List[Target],
         *,
         config: Optional[str] = None,
         passthrough_args: Optional[str] = None,
@@ -83,7 +77,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         return self.request_single_product(Digest, CreateDigest(source_files))
 
     def test_passing_source(self) -> None:
-        target = self.make_target_with_origin([self.good_source])
+        target = self.make_target([self.good_source])
         lint_results, fmt_result = self.run_black([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 0
@@ -93,7 +87,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
-        target = self.make_target_with_origin([self.bad_source])
+        target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_black([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 1
@@ -103,7 +97,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
-        target = self.make_target_with_origin([self.good_source, self.bad_source])
+        target = self.make_target([self.good_source, self.bad_source])
         lint_results, fmt_result = self.run_black([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 1
@@ -116,8 +110,8 @@ class BlackIntegrationTest(ExternalToolTestBase):
 
     def test_multiple_targets(self) -> None:
         targets = [
-            self.make_target_with_origin([self.good_source]),
-            self.make_target_with_origin([self.bad_source]),
+            self.make_target([self.good_source]),
+            self.make_target([self.bad_source]),
         ]
         lint_results, fmt_result = self.run_black(targets)
         assert len(lint_results) == 1
@@ -129,20 +123,8 @@ class BlackIntegrationTest(ExternalToolTestBase):
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
-    def test_precise_file_args(self) -> None:
-        target = self.make_target_with_origin(
-            [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
-        )
-        lint_results, fmt_result = self.run_black([target])
-        assert len(lint_results) == 1
-        assert lint_results[0].exit_code == 0
-        assert "1 file would be left unchanged" in lint_results[0].stderr
-        assert "1 file left unchanged" in fmt_result.stderr
-        assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
-        assert fmt_result.did_change is False
-
     def test_respects_config_file(self) -> None:
-        target = self.make_target_with_origin([self.needs_config_source])
+        target = self.make_target([self.needs_config_source])
         lint_results, fmt_result = self.run_black(
             [target], config="[tool.black]\nskip-string-normalization = 'true'\n"
         )
@@ -154,7 +136,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is False
 
     def test_respects_passthrough_args(self) -> None:
-        target = self.make_target_with_origin([self.needs_config_source])
+        target = self.make_target([self.needs_config_source])
         lint_results, fmt_result = self.run_black(
             [target], passthrough_args="--skip-string-normalization",
         )
@@ -166,7 +148,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
-        target = self.make_target_with_origin([self.bad_source])
+        target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_black([target], skip=True)
         assert not lint_results
         assert fmt_result == FmtResult.noop()

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -22,13 +22,13 @@ from pants.core.util_rules.determine_source_files import SourceFiles, SourceFile
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class DocformatterFieldSet(FieldSetWithOrigin):
+class DocformatterFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -18,12 +18,8 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
-from pants.core.util_rules.determine_source_files import (
-    AllSourceFilesRequest,
-    SourceFiles,
-    SpecifiedSourceFilesRequest,
-)
-from pants.engine.fs import EMPTY_SNAPSHOT, Digest, MergeDigests
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSetWithOrigin
@@ -55,13 +51,9 @@ class Setup:
 
 
 def generate_args(
-    *, specified_source_files: SourceFiles, docformatter: Docformatter, check_only: bool,
+    *, source_files: SourceFiles, docformatter: Docformatter, check_only: bool,
 ) -> Tuple[str, ...]:
-    return (
-        "--check" if check_only else "--in-place",
-        *docformatter.args,
-        *specified_source_files.files,
-    )
+    return ("--check" if check_only else "--in-place", *docformatter.args, *source_files.files)
 
 
 @rule
@@ -76,31 +68,21 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
         ),
     )
 
-    all_source_files_request = Get(
+    source_files_request = Get(
         SourceFiles,
-        AllSourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
-    )
-    specified_source_files_request = Get(
-        SourceFiles,
-        SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in setup_request.request.field_sets
-        ),
+        SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    requests = requirements_pex_request, specified_source_files_request
-    all_source_files, requirements_pex, specified_source_files = (
-        await MultiGet(all_source_files_request, *requests)
-        if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
-    )
-    all_source_files_snapshot = (
-        all_source_files.snapshot
+    source_files, requirements_pex = await MultiGet(source_files_request, requirements_pex_request)
+
+    source_files_snapshot = (
+        source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
     )
 
     input_digest = await Get(
-        Digest, MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest))
+        Digest, MergeDigests((source_files_snapshot.digest, requirements_pex.digest))
     )
 
     address_references = ", ".join(
@@ -112,19 +94,19 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
         PexProcess(
             requirements_pex,
             argv=generate_args(
-                specified_source_files=specified_source_files,
+                source_files=source_files,
                 docformatter=docformatter,
                 check_only=setup_request.check_only,
             ),
             input_digest=input_digest,
-            output_files=all_source_files_snapshot.files,
+            output_files=source_files_snapshot.files,
             description=(
                 f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'target')}: "
                 f"{address_references}."
             ),
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.digest)
+    return Setup(process, original_digest=source_files_snapshot.digest)
 
 
 @rule(desc="Format Python docstrings with docformatter")

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResults
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
@@ -59,7 +59,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         input_sources = self.request_single_product(
             SourceFiles,
             Params(
-                AllSourceFilesRequest(field_set.sources for field_set in field_sets),
+                SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -6,14 +6,13 @@ from typing import List, Optional, Tuple
 from pants.backend.python.lint.docformatter.rules import DocformatterFieldSet, DocformatterRequest
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
 from pants.backend.python.target_types import PythonLibrary
-from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResults
 from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
-from pants.engine.target import TargetWithOrigin
+from pants.engine.target import Target
 from pants.testutil.engine.util import Params
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
 from pants.testutil.option.util import create_options_bootstrapper
@@ -29,22 +28,13 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
     def rules(cls):
         return (*super().rules(), *docformatter_rules(), RootRule(DocformatterRequest))
 
-    def make_target_with_origin(
-        self, source_files: List[FileContent], *, origin: Optional[OriginSpec] = None,
-    ) -> TargetWithOrigin:
+    def make_target(self, source_files: List[FileContent]) -> Target:
         for source_file in source_files:
             self.create_file(f"{source_file.path}", source_file.content.decode())
-        target = PythonLibrary({}, address=Address.parse(":target"))
-        if origin is None:
-            origin = SingleAddress(directory="", name="target")
-        return TargetWithOrigin(target, origin)
+        return PythonLibrary({}, address=Address.parse(":target"))
 
     def run_docformatter(
-        self,
-        targets: List[TargetWithOrigin],
-        *,
-        passthrough_args: Optional[str] = None,
-        skip: bool = False,
+        self, targets: List[Target], *, passthrough_args: Optional[str] = None, skip: bool = False,
     ) -> Tuple[LintResults, FmtResult]:
         args = ["--backend-packages=pants.backend.python.lint.docformatter"]
         if passthrough_args:
@@ -76,7 +66,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         return self.request_single_product(Digest, CreateDigest(source_files))
 
     def test_passing_source(self) -> None:
-        target = self.make_target_with_origin([self.good_source])
+        target = self.make_target([self.good_source])
         lint_results, fmt_result = self.run_docformatter([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 0
@@ -85,7 +75,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is False
 
     def test_failing_source(self) -> None:
-        target = self.make_target_with_origin([self.bad_source])
+        target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_docformatter([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 3
@@ -94,7 +84,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is True
 
     def test_mixed_sources(self) -> None:
-        target = self.make_target_with_origin([self.good_source, self.bad_source])
+        target = self.make_target([self.good_source, self.bad_source])
         lint_results, fmt_result = self.run_docformatter([target])
         assert len(lint_results) == 1
         assert lint_results[0].exit_code == 3
@@ -104,8 +94,8 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
 
     def test_multiple_targets(self) -> None:
         targets = [
-            self.make_target_with_origin([self.good_source]),
-            self.make_target_with_origin([self.bad_source]),
+            self.make_target([self.good_source]),
+            self.make_target([self.bad_source]),
         ]
         lint_results, fmt_result = self.run_docformatter(targets)
         assert len(lint_results) == 1
@@ -114,23 +104,12 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         assert fmt_result.output == self.get_digest([self.good_source, self.fixed_bad_source])
         assert fmt_result.did_change is True
 
-    def test_precise_file_args(self) -> None:
-        target = self.make_target_with_origin(
-            [self.good_source, self.bad_source], origin=FilesystemLiteralSpec(self.good_source.path)
-        )
-        lint_results, fmt_result = self.run_docformatter([target])
-        assert len(lint_results) == 1
-        assert lint_results[0].exit_code == 0
-        assert lint_results[0].stderr == ""
-        assert fmt_result.output == self.get_digest([self.good_source, self.bad_source])
-        assert fmt_result.did_change is False
-
     def test_respects_passthrough_args(self) -> None:
         needs_config = FileContent(
             path="needs_config.py",
             content=b'"""\nOne line docstring acting like it\'s multiline.\n"""\n',
         )
-        target = self.make_target_with_origin([needs_config])
+        target = self.make_target([needs_config])
         lint_results, fmt_result = self.run_docformatter(
             [target], passthrough_args="--make-summary-multi-line"
         )
@@ -141,7 +120,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         assert fmt_result.did_change is False
 
     def test_skip(self) -> None:
-        target = self.make_target_with_origin([self.bad_source])
+        target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_docformatter([target], skip=True)
         assert not lint_results
         assert fmt_result == FmtResult.noop()

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -33,14 +33,14 @@ from pants.engine.fs import (
 )
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class Flake8FieldSet(FieldSetWithOrigin):
+class Flake8FieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
@@ -96,12 +96,12 @@ async def flake8_lint_partition(
         ),
     )
 
-    all_source_files_request = Get(
+    source_files_request = Get(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
     requirements_pex, config_digest, source_files = await MultiGet(
-        requirements_pex_request, config_digest_request, all_source_files_request
+        requirements_pex_request, config_digest_request, source_files_request
     )
 
     input_digest = await Get(

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -18,13 +18,8 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules import determine_source_files, strip_source_roots
-from pants.core.util_rules.determine_source_files import (
-    AllSourceFilesRequest,
-    SourceFiles,
-    SpecifiedSourceFilesRequest,
-)
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
-    EMPTY_SNAPSHOT,
     Digest,
     GlobExpansionConjunction,
     GlobMatchErrorBehavior,
@@ -61,16 +56,14 @@ class Setup:
     original_digest: Digest
 
 
-def generate_args(
-    *, specified_source_files: SourceFiles, isort: Isort, check_only: bool,
-) -> Tuple[str, ...]:
+def generate_args(*, source_files: SourceFiles, isort: Isort, check_only: bool) -> Tuple[str, ...]:
     # NB: isort auto-discovers config files. There is no way to hardcode them via command line
     # flags. So long as the files are in the Pex's input files, isort will use the config.
     args = []
     if check_only:
         args.append("--check-only")
     args.extend(isort.args)
-    args.extend(specified_source_files.files)
+    args.extend(source_files.files)
     return tuple(args)
 
 
@@ -96,36 +89,23 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
         ),
     )
 
-    all_source_files_request = Get(
+    source_files_request = Get(
         SourceFiles,
-        AllSourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
-    )
-    specified_source_files_request = Get(
-        SourceFiles,
-        SpecifiedSourceFilesRequest(
-            (field_set.sources, field_set.origin) for field_set in setup_request.request.field_sets
-        ),
+        SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    requests = (
-        requirements_pex_request,
-        config_digest_request,
-        specified_source_files_request,
+    source_files, requirements_pex, config_digest = await MultiGet(
+        source_files_request, requirements_pex_request, config_digest_request
     )
-    all_source_files, requirements_pex, config_digest, specified_source_files = (
-        await MultiGet(all_source_files_request, *requests)
-        if setup_request.request.prior_formatter_result is None
-        else (SourceFiles(EMPTY_SNAPSHOT, ()), *await MultiGet(*requests))
-    )
-    all_source_files_snapshot = (
-        all_source_files.snapshot
+    source_files_snapshot = (
+        source_files.snapshot
         if setup_request.request.prior_formatter_result is None
         else setup_request.request.prior_formatter_result
     )
 
     input_digest = await Get(
         Digest,
-        MergeDigests((all_source_files_snapshot.digest, requirements_pex.digest, config_digest)),
+        MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
     )
 
     address_references = ", ".join(
@@ -137,19 +117,17 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
         PexProcess(
             requirements_pex,
             argv=generate_args(
-                specified_source_files=specified_source_files,
-                isort=isort,
-                check_only=setup_request.check_only,
+                source_files=source_files, isort=isort, check_only=setup_request.check_only
             ),
             input_digest=input_digest,
-            output_files=all_source_files_snapshot.files,
+            output_files=source_files_snapshot.files,
             description=(
                 f"Run isort on {pluralize(len(setup_request.request.field_sets), 'target')}: "
                 f"{address_references}."
             ),
         ),
     )
-    return Setup(process, original_digest=all_source_files_snapshot.digest)
+    return Setup(process, original_digest=source_files_snapshot.digest)
 
 
 @rule(desc="Format using isort")

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -28,13 +28,13 @@ from pants.engine.fs import (
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class IsortFieldSet(FieldSetWithOrigin):
+class IsortFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -9,7 +9,7 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.core.goals.fmt import FmtResult
 from pants.core.goals.lint import LintResults
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
@@ -73,7 +73,7 @@ class IsortIntegrationTest(ExternalToolTestBase):
         input_sources = self.request_single_product(
             SourceFiles,
             Params(
-                AllSourceFilesRequest(field_set.sources for field_set in field_sets),
+                SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -42,7 +42,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
-    FieldSetWithOrigin,
+    FieldSet,
     Target,
     Targets,
     TransitiveTargets,
@@ -54,7 +54,7 @@ from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class PylintFieldSet(FieldSetWithOrigin):
+class PylintFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -27,13 +27,9 @@ class PythonFmtRequest(StyleRequest):
 async def format_python_target(
     python_fmt_targets: PythonFmtTargets, union_membership: UnionMembership
 ) -> LanguageFmtResults:
-    targets_with_origins = python_fmt_targets.targets_with_origins
     original_sources = await Get(
         SourceFiles,
-        SourceFilesRequest(
-            target_with_origin.target[PythonSources]
-            for target_with_origin in python_fmt_targets.targets_with_origins
-        ),
+        SourceFilesRequest(target[PythonSources] for target in python_fmt_targets.targets),
     )
     prior_formatter_result = original_sources.snapshot
 
@@ -47,8 +43,8 @@ async def format_python_target(
             PythonFmtRequest,
             fmt_request_type(
                 (
-                    fmt_request_type.field_set_type.create(target_with_origin)
-                    for target_with_origin in targets_with_origins
+                    fmt_request_type.field_set_type.create(target)
+                    for target in python_fmt_targets.targets
                 ),
                 prior_formatter_result=prior_formatter_result,
             ),

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -7,7 +7,7 @@ from typing import Iterable, List, Type
 from pants.backend.python.target_types import PythonSources
 from pants.core.goals.fmt import FmtResult, LanguageFmtResults, LanguageFmtTargets
 from pants.core.goals.style_request import StyleRequest
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -30,7 +30,7 @@ async def format_python_target(
     targets_with_origins = python_fmt_targets.targets_with_origins
     original_sources = await Get(
         SourceFiles,
-        AllSourceFilesRequest(
+        SourceFilesRequest(
             target_with_origin.target[PythonSources]
             for target_with_origin in python_fmt_targets.targets_with_origins
         ),

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -9,12 +9,11 @@ from pants.backend.python.lint.isort.rules import IsortRequest
 from pants.backend.python.lint.isort.rules import rules as isort_rules
 from pants.backend.python.lint.python_fmt import PythonFmtTargets, format_python_target
 from pants.backend.python.target_types import PythonLibrary
-from pants.base.specs import SingleAddress
 from pants.core.goals.fmt import LanguageFmtResults
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.rules import RootRule
-from pants.engine.target import TargetsWithOrigins, TargetWithOrigin
+from pants.engine.target import Targets
 from pants.testutil.engine.util import Params
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
 from pants.testutil.option.util import create_options_bootstrapper
@@ -38,9 +37,9 @@ class PythonFmtIntegrationTest(ExternalToolTestBase):
     ) -> LanguageFmtResults:
         for source_file in source_files:
             self.create_file(source_file.path, source_file.content.decode())
-        target = PythonLibrary({}, address=Address.parse(f"test:{name}"))
-        origin = SingleAddress(directory="test", name=name)
-        targets = PythonFmtTargets(TargetsWithOrigins([TargetWithOrigin(target, origin)]))
+        targets = PythonFmtTargets(
+            Targets([PythonLibrary({}, address=Address.parse(f"test:{name}"))])
+        )
         args = [
             "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
             *(extra_args or []),

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -12,7 +12,6 @@ from pants.backend.python.rules import pex, pex_from_targets, pytest_runner, pyt
 from pants.backend.python.rules.coverage import create_coverage_config
 from pants.backend.python.rules.pytest_runner import PythonTestFieldSet
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
-from pants.base.specs import FilesystemLiteralSpec, OriginSpec, SingleAddress
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals.test import Status, TestDebugRequest, TestResult
 from pants.core.util_rules import determine_source_files, strip_source_roots
@@ -20,7 +19,6 @@ from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.process import InteractiveRunner
 from pants.engine.rules import RootRule
-from pants.engine.target import TargetWithOrigin
 from pants.python.python_requirement import PythonRequirement
 from pants.testutil.engine.util import Params
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
@@ -136,7 +134,6 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         self,
         *,
         passthrough_args: Optional[str] = None,
-        origin: Optional[OriginSpec] = None,
         junit_xml_dir: Optional[str] = None,
         use_coverage: bool = False,
         execution_slot_var: Optional[str] = None,
@@ -157,13 +154,11 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         if execution_slot_var:
             args.append(f"--pytest-execution-slot-var={execution_slot_var}")
 
-        options_bootstrapper = create_options_bootstrapper(args=args)
-        address = Address(self.package, target_name="target")
-        if origin is None:
-            origin = SingleAddress(directory=address.spec_path, name=address.target_name)
-        tgt = PythonTests({}, address=address)
         params = Params(
-            PythonTestFieldSet.create(TargetWithOrigin(tgt, origin)), options_bootstrapper
+            PythonTestFieldSet.create(
+                PythonTests({}, address=Address(self.package, target_name="target"))
+            ),
+            create_options_bootstrapper(args=args),
         )
         test_result = self.request_single_product(TestResult, params)
         debug_request = self.request_single_product(TestDebugRequest, params)
@@ -192,14 +187,6 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert result.status == Status.FAILURE
         assert f"{self.package}/test_good.py ." in result.stdout
         assert f"{self.package}/test_bad.py F" in result.stdout
-
-    def test_precise_file_args(self) -> None:
-        self.create_python_test_target([self.good_source, self.bad_source])
-        file_arg = FilesystemLiteralSpec(PurePath(self.package, self.good_source.path).as_posix())
-        result = self.run_pytest(origin=file_arg)
-        assert result.status == Status.SUCCESS
-        assert f"{self.package}/test_good.py ." in result.stdout
-        assert f"{self.package}/test_bad.py F" not in result.stdout
 
     def test_absolute_import(self) -> None:
         self.create_python_library([self.library_source])

--- a/src/python/pants/backend/python/rules/python_sources.py
+++ b/src/python/pants/backend/python/rules/python_sources.py
@@ -9,7 +9,7 @@ from pants.backend.python.rules.ancestor_files import AncestorFiles, AncestorFil
 from pants.backend.python.target_types import PythonSources
 from pants.core.target_types import FilesSources, ResourcesSources
 from pants.core.util_rules import determine_source_files
-from pants.core.util_rules.determine_source_files import AllSourceFilesRequest, SourceFiles
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.strip_source_roots import StrippedSourceFiles
 from pants.core.util_rules.strip_source_roots import rules as strip_source_roots_rules
 from pants.engine.fs import MergeDigests, Snapshot
@@ -81,7 +81,7 @@ async def prepare_python_sources(
 ) -> PythonSourceFiles:
     sources = await Get(
         SourceFiles,
-        AllSourceFilesRequest(
+        SourceFilesRequest(
             (tgt.get(Sources) for tgt in request.targets),
             for_sources_types=request.valid_sources_types,
             enable_codegen=True,

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -11,7 +11,7 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import Field, Target, Targets, TargetsWithOrigins
+from pants.engine.target import Field, Target, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.strutil import strip_v2_chroot_path
 

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -18,7 +18,7 @@ from pants.core.goals.fmt import (
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, Digest, FileContent, MergeDigests, Workspace
-from pants.engine.target import Sources, Target, TargetsWithOrigins, TargetWithOrigin
+from pants.engine.target import Sources, Target, Targets
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
 from pants.testutil.test_base import TestBase
@@ -55,9 +55,7 @@ class MockLanguageTargets(LanguageFmtTargets, metaclass=ABCMeta):
         pass
 
     def language_fmt_results(self, result_digest: Digest) -> LanguageFmtResults:
-        addresses = [
-            target_with_origin.target.address for target_with_origin in self.targets_with_origins
-        ]
+        addresses = [target.address for target in self.targets]
         return LanguageFmtResults(
             (
                 FmtResult(
@@ -113,21 +111,16 @@ class FmtTest(TestBase):
         ).digest
 
     @staticmethod
-    def make_target_with_origin(
+    def make_target(
         address: Optional[Address] = None, *, target_cls: Type[Target] = FortranTarget
-    ) -> TargetWithOrigin:
-        if address is None:
-            address = Address.parse(":tests")
-        return TargetWithOrigin(
-            target_cls({}, address=address),
-            origin=SingleAddress(directory=address.spec_path, name=address.target_name),
-        )
+    ) -> Target:
+        return target_cls({}, address=address or Address.parse(":tests"))
 
     def run_fmt_rule(
         self,
         *,
         language_target_collection_types: List[Type[LanguageFmtTargets]],
-        targets: List[TargetWithOrigin],
+        targets: List[Target],
         result_digest: Digest,
         per_target_caching: bool,
         include_sources: bool = True,
@@ -138,7 +131,7 @@ class FmtTest(TestBase):
             fmt,
             rule_args=[
                 console,
-                TargetsWithOrigins(targets),
+                Targets(targets),
                 create_goal_subsystem(FmtSubsystem, per_target_caching=per_target_caching),
                 Workspace(self.scheduler),
                 union_membership,
@@ -182,7 +175,7 @@ class FmtTest(TestBase):
         def assert_noops(*, per_target_caching: bool) -> None:
             stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets],
-                targets=[self.make_target_with_origin()],
+                targets=[self.make_target()],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
                 include_sources=False,
@@ -197,7 +190,7 @@ class FmtTest(TestBase):
         def assert_noops(*, per_target_caching: bool) -> None:
             stderr = self.run_fmt_rule(
                 language_target_collection_types=[InvalidTargets],
-                targets=[self.make_target_with_origin()],
+                targets=[self.make_target()],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
             )
@@ -209,7 +202,7 @@ class FmtTest(TestBase):
 
     def test_single_language_with_single_target(self) -> None:
         address = Address.parse(":tests")
-        target_with_origin = self.make_target_with_origin(address)
+        target_with_origin = self.make_target(address)
 
         def assert_expected(*, per_target_caching: bool) -> None:
             stderr = self.run_fmt_rule(
@@ -235,7 +228,7 @@ class FmtTest(TestBase):
         def get_stderr(*, per_target_caching: bool) -> str:
             stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets],
-                targets=[self.make_target_with_origin(addr) for addr in addresses],
+                targets=[self.make_target(addr) for addr in addresses],
                 result_digest=self.fortran_digest,
                 per_target_caching=per_target_caching,
             )
@@ -266,8 +259,8 @@ class FmtTest(TestBase):
             stderr = self.run_fmt_rule(
                 language_target_collection_types=[FortranTargets, SmalltalkTargets],
                 targets=[
-                    self.make_target_with_origin(fortran_address, target_cls=FortranTarget),
-                    self.make_target_with_origin(smalltalk_address, target_cls=SmalltalkTarget),
+                    self.make_target(fortran_address, target_cls=FortranTarget),
+                    self.make_target(smalltalk_address, target_cls=SmalltalkTarget),
                 ],
                 result_digest=self.merged_digest,
                 per_target_caching=per_target_caching,
@@ -291,12 +284,10 @@ class FmtTest(TestBase):
         smalltalk_addresses = [Address.parse(":py1"), Address.parse(":py2")]
 
         fortran_targets = [
-            self.make_target_with_origin(addr, target_cls=FortranTarget)
-            for addr in fortran_addresses
+            self.make_target(addr, target_cls=FortranTarget) for addr in fortran_addresses
         ]
         smalltalk_targets = [
-            self.make_target_with_origin(addr, target_cls=SmalltalkTarget)
-            for addr in smalltalk_addresses
+            self.make_target(addr, target_cls=SmalltalkTarget) for addr in smalltalk_addresses
         ]
 
         def get_stderr(*, per_target_caching: bool) -> str:

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import ClassVar, Iterable, List, Optional, Type, cast
 
-from pants.base.specs import SingleAddress
 from pants.core.goals.fmt import (
     Fmt,
     FmtResult,

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -17,7 +17,7 @@ from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import TargetsWithOrigins
+from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
 from pants.util.strutil import strip_v2_chroot_path
 
@@ -132,16 +132,16 @@ class Lint(Goal):
 async def lint(
     console: Console,
     workspace: Workspace,
-    targets_with_origins: TargetsWithOrigins,
+    targets: Targets,
     lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,
 ) -> Lint:
     request_types = union_membership[LintRequest]
     requests: Iterable[StyleRequest] = tuple(
         request_type(
-            request_type.field_set_type.create(target_with_origin)
-            for target_with_origin in targets_with_origins
-            if request_type.field_set_type.is_valid(target_with_origin.target)
+            request_type.field_set_type.create(target)
+            for target in targets
+            if request_type.field_set_type.is_valid(target)
         )
         for request_type in request_types
     )

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -5,7 +5,6 @@ from abc import ABCMeta, abstractmethod
 from textwrap import dedent
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type
 
-from pants.base.specs import SingleAddress
 from pants.core.goals.lint import Lint, LintRequest, LintResult, LintResults, LintSubsystem, lint
 from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -23,7 +23,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
-    FieldSetWithOrigin,
+    FieldSet,
     Sources,
     TargetsToValidFieldSets,
     TargetsToValidFieldSetsRequest,
@@ -104,7 +104,7 @@ class TestDebugRequest:
 
 
 @union
-class TestFieldSet(FieldSetWithOrigin, metaclass=ABCMeta):
+class TestFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary to run tests on a target."""
 
     sources: Sources

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -159,7 +159,7 @@ class TestTest(TestBase):
                 return TargetsToValidFieldSets({})
             return TargetsToValidFieldSets(
                 {
-                    tgt_with_origin: [field_set.create(tgt_with_origin)]
+                    tgt_with_origin: [field_set.create(tgt_with_origin.target)]
                     for tgt_with_origin in targets
                 }
             )

--- a/src/python/pants/core/util_rules/determine_source_files.py
+++ b/src/python/pants/core/util_rules/determine_source_files.py
@@ -2,12 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple, Type, Union
+from typing import Iterable, Set, Tuple, Type
 
-from pants.base.specs import AddressSpec, OriginSpec
 from pants.core.target_types import FilesSources
-from pants.engine.addresses import Address
-from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, Snapshot
+from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, RootRule, collect_rules, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.engine.target import Sources as SourcesField
@@ -35,7 +33,7 @@ class SourceFiles:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class AllSourceFilesRequest:
+class SourceFilesRequest:
     sources_fields: Tuple[SourcesField, ...]
     for_sources_types: Tuple[Type[SourcesField], ...]
     enable_codegen: bool
@@ -52,41 +50,8 @@ class AllSourceFilesRequest:
         self.enable_codegen = enable_codegen
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class SpecifiedSourceFilesRequest:
-    sources_fields_with_origins: Tuple[Tuple[SourcesField, OriginSpec], ...]
-    for_sources_types: Tuple[Type[SourcesField], ...]
-    enable_codegen: bool
-
-    def __init__(
-        self,
-        sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-        *,
-        for_sources_types: Iterable[Type[SourcesField]] = (SourcesField,),
-        enable_codegen: bool = False,
-    ) -> None:
-        self.sources_fields_with_origins = tuple(sources_fields_with_origins)
-        self.for_sources_types = tuple(for_sources_types)
-        self.enable_codegen = enable_codegen
-
-
-def calculate_specified_sources(
-    sources_snapshot: Snapshot, address: Address, origin: OriginSpec
-) -> Union[Snapshot, DigestSubset]:
-    # AddressSpecs simply use the entire `sources` field. If it's a generated subtarget, we also
-    # know we're as precise as we can get (1 file), so use the whole snapshot.
-    if isinstance(origin, AddressSpec) or not address.is_base_target:
-        return sources_snapshot
-    # NB: we ensure that `precise_files_specified` is a subset of the original `sources` field.
-    # It's possible when given a glob filesystem spec that the spec will have
-    # resolved files not belonging to this target - those must be filtered out.
-    precise_files_specified = set(sources_snapshot.files).intersection(origin.resolved_files)
-    return DigestSubset(sources_snapshot.digest, PathGlobs(sorted(precise_files_specified)))
-
-
 @rule
-async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFiles:
+async def determine_source_files(request: SourceFilesRequest) -> SourceFiles:
     """Merge all `Sources` fields into one Snapshot."""
     unrooted_files: Set[str] = set()
     all_hydrated_sources = await MultiGet(
@@ -112,58 +77,5 @@ async def determine_all_source_files(request: AllSourceFilesRequest) -> SourceFi
     return SourceFiles(result, tuple(sorted(unrooted_files)))
 
 
-@rule
-async def determine_specified_source_files(request: SpecifiedSourceFilesRequest) -> SourceFiles:
-    """Determine the specified `sources` for targets.
-
-    Possibly finding a subset of the original `sources` fields if the user supplied file arguments.
-    """
-    all_unrooted_files: Set[str] = set()
-    all_hydrated_sources = await MultiGet(
-        Get(
-            HydratedSources,
-            HydrateSourcesRequest(
-                sources_field_with_origin[0],
-                for_sources_types=request.for_sources_types,
-                enable_codegen=request.enable_codegen,
-            ),
-        )
-        for sources_field_with_origin in request.sources_fields_with_origins
-    )
-
-    full_snapshots = {}
-    digest_subset_requests = {}
-    for hydrated_sources, sources_field_with_origin in zip(
-        all_hydrated_sources, request.sources_fields_with_origins
-    ):
-        sources_field, origin = sources_field_with_origin
-        if isinstance(sources_field, FilesSources):
-            all_unrooted_files.update(hydrated_sources.snapshot.files)
-        if not hydrated_sources.snapshot.files:
-            continue
-        specified_sources = calculate_specified_sources(
-            hydrated_sources.snapshot, sources_field.address, origin
-        )
-        if isinstance(specified_sources, Snapshot):
-            full_snapshots[sources_field] = specified_sources
-        else:
-            digest_subset_requests[sources_field] = specified_sources
-
-    snapshot_subsets: Tuple[Snapshot, ...] = ()
-    if digest_subset_requests:
-        snapshot_subsets = await MultiGet(
-            Get(Snapshot, DigestSubset, request) for request in digest_subset_requests.values()
-        )
-
-    all_snapshots: Iterable[Snapshot] = (*full_snapshots.values(), *snapshot_subsets)
-    result = await Get(Snapshot, MergeDigests(snapshot.digest for snapshot in all_snapshots))
-    unrooted_files = all_unrooted_files.intersection(result.files)
-    return SourceFiles(result, tuple(sorted(unrooted_files)))
-
-
 def rules():
-    return [
-        *collect_rules(),
-        RootRule(AllSourceFilesRequest),
-        RootRule(SpecifiedSourceFilesRequest),
-    ]
+    return [*collect_rules(), RootRule(SourceFilesRequest)]

--- a/src/python/pants/core/util_rules/determine_source_files_test.py
+++ b/src/python/pants/core/util_rules/determine_source_files_test.py
@@ -1,24 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
 from pathlib import PurePath
-from typing import Iterable, List, NamedTuple, Optional, Tuple, Type
+from typing import Iterable, List, NamedTuple, Type
 
-from pants.base.specs import (
-    AscendantAddresses,
-    DescendantAddresses,
-    FilesystemLiteralSpec,
-    FilesystemResolvedGlobSpec,
-    OriginSpec,
-    SiblingAddresses,
-    SingleAddress,
-)
 from pants.core.target_types import FilesSources
-from pants.core.util_rules.determine_source_files import (
-    AllSourceFilesRequest,
-    SourceFiles,
-    SpecifiedSourceFilesRequest,
-)
+from pants.core.util_rules.determine_source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.determine_source_files import rules as determine_source_files_rules
 from pants.engine.addresses import Address
 from pants.engine.target import Sources as SourcesField
@@ -32,227 +20,74 @@ class TargetSources(NamedTuple):
     source_files: List[str]
 
     @property
-    def source_file_absolute_paths(self) -> List[str]:
+    def full_paths(self) -> List[str]:
         return [PurePath(self.source_root, name).as_posix() for name in self.source_files]
 
 
 SOURCES1 = TargetSources("src/python", ["s1.py", "s2.py", "s3.py"])
 SOURCES2 = TargetSources("tests/python", ["t1.py", "t2.java"])
 SOURCES3 = TargetSources("src/java", ["j1.java", "j2.java"])
-SOURCES4 = TargetSources("src/python", ["README.md"])
 
 
 class DetermineSourceFilesTest(TestBase):
     @classmethod
     def rules(cls):
-        return (
-            *super().rules(),
-            *determine_source_files_rules(),
-        )
+        return (*super().rules(), *determine_source_files_rules())
 
-    def mock_sources_field_with_origin(
+    def mock_sources_field(
         self,
         sources: TargetSources,
         *,
-        origin: Optional[OriginSpec] = None,
         include_sources: bool = True,
         sources_field_cls: Type[SourcesField] = SourcesField,
-    ) -> Tuple[SourcesField, OriginSpec]:
+    ) -> SourcesField:
         sources_field = sources_field_cls(
             sources.source_files if include_sources else [],
             address=Address.parse(f"{sources.source_root}:lib"),
         )
         self.create_files(path=sources.source_root, files=sources.source_files)
-        if origin is None:
-            origin = SiblingAddresses(sources.source_root)
-        return sources_field, origin
+        return sources_field
 
-    def _do_get_all_source_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-    ) -> SourceFiles:
-        request = AllSourceFilesRequest(
-            (
-                sources_field_with_origin[0]
-                for sources_field_with_origin in sources_fields_with_origins
-            ),
+    def assert_sources_resolved(
+        self,
+        sources_fields: Iterable[SourcesField],
+        *,
+        expected: Iterable[TargetSources],
+        expected_unrooted: Iterable[str] = (),
+    ) -> None:
+        result = self.request_single_product(
+            SourceFiles, Params(SourceFilesRequest(sources_fields), create_options_bootstrapper()),
         )
-        return self.request_single_product(
-            SourceFiles,
-            Params(
-                request,
-                create_options_bootstrapper(
-                    args=[
-                        "--source-root-patterns=src/python",
-                        "--source-root-patterns=src/java",
-                        "--source-root-patterns=tests/python",
-                    ]
-                ),
-            ),
+        assert list(result.snapshot.files) == sorted(
+            set(itertools.chain.from_iterable(sources.full_paths for sources in expected))
         )
-
-    def get_all_source_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-    ) -> List[str]:
-        return sorted(self._do_get_all_source_files(sources_fields_with_origins).snapshot.files)
-
-    def get_all_unrooted_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]]
-    ):
-        return list(self._do_get_all_source_files(sources_fields_with_origins).unrooted_files)
-
-    def _do_get_specified_source_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-    ) -> SourceFiles:
-        request = SpecifiedSourceFilesRequest(sources_fields_with_origins,)
-        return self.request_single_product(
-            SourceFiles,
-            Params(
-                request,
-                create_options_bootstrapper(
-                    args=[
-                        "--source-root-patterns=src/python",
-                        "--source-root-patterns=src/java",
-                        "--source-root-patterns=tests/python",
-                    ]
-                ),
-            ),
-        )
-
-    def get_specified_source_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]],
-    ) -> List[str]:
-        return sorted(
-            self._do_get_specified_source_files(sources_fields_with_origins).snapshot.files
-        )
-
-    def get_specified_unrooted_files(
-        self, sources_fields_with_origins: Iterable[Tuple[SourcesField, OriginSpec]]
-    ):
-        return list(self._do_get_specified_source_files(sources_fields_with_origins).unrooted_files)
+        assert list(result.unrooted_files) == sorted(expected_unrooted)
 
     def test_address_specs(self) -> None:
-        sources_field1 = self.mock_sources_field_with_origin(
-            SOURCES1, origin=SingleAddress(directory=SOURCES1.source_root, name="lib")
-        )
-        sources_field2 = self.mock_sources_field_with_origin(
-            SOURCES2, origin=SiblingAddresses(SOURCES2.source_root)
-        )
-        sources_field3 = self.mock_sources_field_with_origin(
-            SOURCES3, origin=DescendantAddresses(SOURCES3.source_root)
-        )
-        sources_field4 = self.mock_sources_field_with_origin(
-            SOURCES1, origin=AscendantAddresses(SOURCES1.source_root)
-        )
+        sources_field1 = self.mock_sources_field(SOURCES1)
+        sources_field2 = self.mock_sources_field(SOURCES2)
+        sources_field3 = self.mock_sources_field(SOURCES3)
+        sources_field4 = self.mock_sources_field(SOURCES1)
 
-        def assert_all_source_files_resolved(
-            sources_field_with_origin: Tuple[SourcesField, OriginSpec], sources: TargetSources
-        ) -> None:
-            expected = sources.source_file_absolute_paths
-            assert self.get_all_source_files([sources_field_with_origin]) == expected
-            assert self.get_specified_source_files([sources_field_with_origin]) == expected
+        self.assert_sources_resolved([sources_field1], expected=[SOURCES1])
+        self.assert_sources_resolved([sources_field2], expected=[SOURCES2])
+        self.assert_sources_resolved([sources_field3], expected=[SOURCES3])
+        self.assert_sources_resolved([sources_field4], expected=[SOURCES1])
 
-        assert_all_source_files_resolved(sources_field1, SOURCES1)
-        assert_all_source_files_resolved(sources_field2, SOURCES2)
-        assert_all_source_files_resolved(sources_field3, SOURCES3)
-        assert_all_source_files_resolved(sources_field4, SOURCES1)
         # NB: sources_field1 and sources_field4 refer to the same files. We should be able to
         # handle this gracefully.
-        combined_sources_fields = [sources_field1, sources_field2, sources_field3, sources_field4]
-        combined_expected = sorted(
-            [
-                *SOURCES1.source_file_absolute_paths,
-                *SOURCES2.source_file_absolute_paths,
-                *SOURCES3.source_file_absolute_paths,
-            ]
-        )
-        assert self.get_all_source_files(combined_sources_fields) == combined_expected
-        assert self.get_all_unrooted_files(combined_sources_fields) == []
-        assert self.get_specified_source_files(combined_sources_fields) == combined_expected
-        assert self.get_specified_unrooted_files(combined_sources_fields) == []
-
-    def test_filesystem_specs(self) -> None:
-        # Literal file arg.
-        sources_field1_all_sources = SOURCES1.source_file_absolute_paths
-        sources_field1_slice = slice(0, 1)
-        sources_field1 = self.mock_sources_field_with_origin(
-            SOURCES1, origin=FilesystemLiteralSpec(sources_field1_all_sources[0])
+        self.assert_sources_resolved(
+            [sources_field1, sources_field2, sources_field3, sources_field4],
+            expected=[SOURCES1, SOURCES2, SOURCES3],
         )
 
-        # Glob file arg that matches the entire `sources`.
-        sources_field2_all_sources = SOURCES2.source_file_absolute_paths
-        sources_field2_slice = slice(0, len(sources_field2_all_sources))
-        sources_field2_origin = FilesystemResolvedGlobSpec(
-            f"{SOURCES2.source_root}/*.py", files=tuple(sources_field2_all_sources)
-        )
-        sources_field2 = self.mock_sources_field_with_origin(SOURCES2, origin=sources_field2_origin)
-
-        # Glob file arg that only matches a subset of the `sources` _and_ includes resolved
-        # files not owned by the target.
-        sources_field3_all_sources = SOURCES3.source_file_absolute_paths
-        sources_field3_slice = slice(0, 1)
-        sources_field3_origin = FilesystemResolvedGlobSpec(
-            f"{SOURCES3.source_root}/*.java",
-            files=tuple(
-                PurePath(SOURCES3.source_root, name).as_posix()
-                for name in [SOURCES3.source_files[0], "other_target.java", "j.tmp.java"]
-            ),
-        )
-        sources_field3 = self.mock_sources_field_with_origin(SOURCES3, origin=sources_field3_origin)
-
-        # FilesSources should appear in the "all_source_files" results but not in the
-        # "all_rooted_files" results.
-        sources_field4 = self.mock_sources_field_with_origin(
-            SOURCES4, sources_field_cls=FilesSources
-        )
-        sources_field4_all_sources = SOURCES4.source_file_absolute_paths
-
-        def assert_file_args_resolved(
-            sources_field_with_origin: Tuple[SourcesField, OriginSpec],
-            all_sources: List[str],
-            expected_slice: slice,
-        ) -> None:
-            assert self.get_all_source_files([sources_field_with_origin]) == all_sources
-            assert self.get_all_unrooted_files([sources_field_with_origin]) == []
-
-            assert (
-                self.get_specified_source_files([sources_field_with_origin])
-                == all_sources[expected_slice]
-            )
-            assert self.get_specified_unrooted_files([sources_field_with_origin]) == []
-
-        assert_file_args_resolved(sources_field1, sources_field1_all_sources, sources_field1_slice)
-        assert_file_args_resolved(sources_field2, sources_field2_all_sources, sources_field2_slice)
-        assert_file_args_resolved(sources_field3, sources_field3_all_sources, sources_field3_slice)
-
-        combined_sources_fields = [sources_field1, sources_field2, sources_field3, sources_field4]
-        assert self.get_all_source_files(combined_sources_fields) == sorted(
-            [
-                *sources_field1_all_sources,
-                *sources_field2_all_sources,
-                *sources_field3_all_sources,
-                *sources_field4_all_sources,
-            ]
-        )
-        assert self.get_all_unrooted_files(combined_sources_fields) == sorted(
-            [*sources_field4_all_sources]
-        )
-
-        assert self.get_specified_source_files(combined_sources_fields) == sorted(
-            [
-                *sources_field1_all_sources[sources_field1_slice],
-                *sources_field2_all_sources[sources_field2_slice],
-                *sources_field3_all_sources[sources_field3_slice],
-                *sources_field4_all_sources,
-            ]
-        )
-
-        assert self.get_specified_unrooted_files(combined_sources_fields) == sorted(
-            [*sources_field4_all_sources,]
+    def test_file_sources(self) -> None:
+        sources = TargetSources("src/python", ["README.md"])
+        field = self.mock_sources_field(sources, sources_field_cls=FilesSources)
+        self.assert_sources_resolved(
+            [field], expected=[sources], expected_unrooted=sources.full_paths
         )
 
     def test_gracefully_handle_no_sources(self) -> None:
-        sources_field = self.mock_sources_field_with_origin(SOURCES1, include_sources=False)
-        assert self.get_all_source_files([sources_field]) == []
-        assert self.get_specified_source_files([sources_field]) == []
-        assert self.get_all_unrooted_files([sources_field]) == []
-        assert self.get_specified_unrooted_files([sources_field]) == []
+        sources_field = self.mock_sources_field(SOURCES1, include_sources=False)
+        self.assert_sources_resolved([sources_field], expected=[])

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Sequence
 
 from pants.base.exceptions import ResolveError
-from pants.base.specs import OriginSpec
+from pants.base.specs import Spec
 from pants.build_graph.address import Address as Address
 from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexporting.
 from pants.build_graph.address import BuildFileAddress as BuildFileAddress
@@ -35,7 +35,7 @@ class AddressWithOrigin:
     """An Address along with the cmd-line spec it was generated from."""
 
     address: Address
-    origin: OriginSpec
+    origin: Spec
 
 
 class AddressesWithOrigins(Collection[AddressWithOrigin]):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -25,7 +25,7 @@ from typing import (
 
 from typing_extensions import final
 
-from pants.base.specs import OriginSpec
+from pants.base.specs import Spec
 from pants.engine.addresses import Address, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.fs import Snapshot
@@ -494,7 +494,7 @@ class WrappedTarget:
 @dataclass(frozen=True)
 class TargetWithOrigin:
     target: Target
-    origin: OriginSpec
+    origin: Spec
 
 
 class Targets(Collection[Target]):
@@ -733,7 +733,7 @@ class FieldSetWithOrigin(_AbstractFieldSet, metaclass=ABCMeta):
     See FieldSet for documentation on how subclasses should use this base class.
     """
 
-    origin: OriginSpec
+    origin: Spec
 
     @classmethod
     def create(cls: Type[_FSWO], target_with_origin: TargetWithOrigin) -> _FSWO:


### PR DESCRIPTION
We used to achieve precise file arguments—where you only run on the file you specified—via `AddressWithOrigin` et al., including the `SpecifiedSourceFiles` type.

Now that we always use a generated subtarget when a user gives us file args, we know that the target will always have exactly one source file, so we can simply run on the entire target's `sources` without needing to consider taking a subset of its sources.

This allows us to remove `SpecifiedSourceFiles`, along with storing which files were actually resolved on the `FilesystemSpec`. We also simplify `test`, `lint`, and `fmt` to stop using `WithOrigin`, as none of the downstream rules need that information anymore.

We still keep around `WithOrigin` for the sake of errors, such as allowing us to error if a user specifies a literal file arg and it does not meet an invariant, but to no-op if they specified a looser glob.