### PR TITLE
Fix bug that caused setup-py to hang if src root==buildroot

### DIFF
--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -528,8 +528,9 @@ async def get_ancestor_init_py(targets: Targets) -> AncestorInitPyFiles:
     for path, source_root in zip(sources.files, source_roots):
         source_dir_ancestor = os.path.dirname(path)
         # Do not allow the repository root to leak (i.e., '.' should not be a package in setup.py).
-        while source_dir_ancestor != source_root.path:
-            source_dir_ancestors.add((source_root.path, source_dir_ancestor))
+        source_root_path = "" if source_root.path == "." else source_root.path
+        while source_dir_ancestor != source_root_path:
+            source_dir_ancestors.add((source_root_path, source_dir_ancestor))
             source_dir_ancestor = os.path.dirname(source_dir_ancestor)
 
     source_dir_ancestors_list = list(source_dir_ancestors)  # To force a consistent order.

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, order=True)
 class SourceRoot:
-    path: str  # Relative path from the repo root.
+    # Relative path from the buildroot. Note that a source root at the buildroot
+    # is represented as ".".
+    path: str
 
 
 class SourceRootError(Exception):


### PR DESCRIPTION
Cherry-pick of https://github.com/pantsbuild/pants/commit/8175171b7e5e3cd288411cd71d50ff61bcb03cb3.

We leave off the updates to the tests due to merge conflicts.

[ci skip-jvm-tests]
[ci skip-rust-tests]