### PR TITLE
Fix some issues from #10535 Address changes

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -323,12 +323,16 @@ class Address:
         if self._relative_file_path:
             parent_count = self._relative_file_path.count(os.path.sep)
             parent_prefix = "@" * parent_count if parent_count else "."
-            file_portion = f".{self._relative_file_path.replace(os.sep, '.')}"
+            file_portion = f".{self._relative_file_path.replace(os.path.sep, '.')}"
         else:
             parent_prefix = "."
             file_portion = ""
-        target_portion = f"{parent_prefix}{self._target_name}" if self._target_name else ""
-        return f"{self.spec_path.replace(os.sep, '.')}{file_portion}{target_portion}"
+        if parent_prefix == ".":
+            target_portion = f"{parent_prefix}{self._target_name}" if self._target_name else ""
+        else:
+            target_name = self._target_name or os.path.basename(self.spec_path)
+            target_portion = f"{parent_prefix}{target_name}"
+        return f"{self.spec_path.replace(os.path.sep, '.')}{file_portion}{target_portion}"
 
     @deprecated(
         removal_version="2.1.0.dev0",

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -3,6 +3,7 @@
 
 import os
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Optional, Sequence
 
 from pants.base.deprecated import deprecated
@@ -53,11 +54,6 @@ class AddressInput:
         if any(component in (".", "..", "") for component in components):
             raise InvalidSpecPath(
                 f"Address spec has un-normalized path part '{self.path_component}'"
-            )
-        if components[-1].startswith("BUILD"):
-            raise InvalidSpecPath(
-                f"Address spec path {self.path_component} has {components[-1]} as the last path "
-                "part and BUILD is a reserved file."
             )
         if os.path.isabs(self.path_component):
             raise InvalidSpecPath(
@@ -162,6 +158,8 @@ class AddressInput:
                 )
             return Address(spec_path=spec_path, relative_file_path=relative_file_path)
 
+        # The target component may be "above" (but not below) the file in the filesystem.
+        # Determine how many levels above the file it is, and validate that the path is relative.
         parent_count = self.target_component.count(os.path.sep)
         if parent_count == 0:
             spec_path, relative_file_path = os.path.split(self.path_component)
@@ -171,7 +169,6 @@ class AddressInput:
                 target_name=self.target_component,
             )
 
-        # The target component may be "above" (but not below) the file in the filesystem.
         expected_prefix = f"..{os.path.sep}" * parent_count
         if self.target_component[: self.target_component.rfind(os.path.sep) + 1] != expected_prefix:
             raise InvalidTargetName(
@@ -264,6 +261,12 @@ class Address:
             target_name if target_name and target_name != os.path.basename(self.spec_path) else None
         )
         self._hash = hash((self.spec_path, self._relative_file_path, self._target_name))
+        if PurePath(spec_path).name.startswith("BUILD"):
+            raise InvalidSpecPath(
+                f"The address {self.spec} has {PurePath(spec_path).name} as the last part of its "
+                f"path, but BUILD is a reserved name. Please make sure that you did not name any "
+                f"directories BUILD."
+            )
 
     @property
     def is_base_target(self) -> bool:
@@ -302,14 +305,15 @@ class Address:
         file_portion = f"{prefix}{self.spec_path}"
         if self._relative_file_path is not None:
             file_portion = os.path.join(file_portion, self._relative_file_path)
-        if self._target_name is None:
-            return file_portion
 
         # Relativize the target name to the dirname of the file.
         parent_prefix = (
             "../" * self._relative_file_path.count(os.path.sep) if self._relative_file_path else ""
         )
-        return f"{file_portion}:{parent_prefix}{self._target_name}"
+        if self._target_name is None and not parent_prefix:
+            return file_portion
+        target_name = self._target_name or os.path.basename(self.spec_path)
+        return f"{file_portion}:{parent_prefix}{target_name}"
 
     @property
     def path_safe_spec(self) -> str:

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -237,6 +237,7 @@ def test_address_spec() -> None:
         assert address.reference() == expected
         assert address.path_safe_spec == expected_path_spec
 
+    assert_spec(Address("a/b"), expected="a/b", expected_path_spec="a.b")
     assert_spec(Address("a/b", target_name="c"), expected="a/b:c", expected_path_spec="a.b.c")
     assert_spec(Address("", target_name="root"), expected="//:root", expected_path_spec=".root")
     assert_spec(
@@ -262,7 +263,12 @@ def test_address_spec() -> None:
     assert_spec(
         Address("a/b", relative_file_path="subdir/f.txt"),
         expected="a/b/subdir/f.txt:../b",
-        expected_path_spec="a.b.subdir.f.txt",
+        expected_path_spec="a.b.subdir.f.txt@b",
+    )
+    assert_spec(
+        Address("a/b", relative_file_path="subdir/dir2/f.txt"),
+        expected="a/b/subdir/dir2/f.txt:../../b",
+        expected_path_spec="a.b.subdir.dir2.f.txt@@b",
     )
 
 

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -92,20 +92,6 @@ def test_address_input_parse_bad_path_component() -> None:
     assert_bad_path_component("/a")
     assert_bad_path_component("///a")
 
-    # The path_component should not end in BUILD.
-    assert_bad_path_component("BUILD")
-    assert_bad_path_component("BUILD.suffix")
-    assert_bad_path_component("//BUILD")
-    assert_bad_path_component("//BUILD.suffix")
-    assert_bad_path_component("a/BUILD")
-    assert_bad_path_component("a/BUILD.suffix")
-    assert_bad_path_component("//a/BUILD")
-    assert_bad_path_component("//a/BUILD.suffix")
-    assert_bad_path_component("a/BUILD:b")
-    assert_bad_path_component("a/BUILD.suffix:b")
-    assert_bad_path_component("//a/BUILD:b")
-    assert_bad_path_component("//a/BUILD.suffix:b")
-
 
 def test_address_input_parse_bad_target_component() -> None:
     def assert_bad_target_component(spec: str) -> None:
@@ -216,6 +202,19 @@ def test_address_normalize_target_name() -> None:
     )
 
 
+def test_address_validate_build_in_spec_path() -> None:
+    with pytest.raises(InvalidSpecPath):
+        Address("a/b/BUILD")
+    with pytest.raises(InvalidSpecPath):
+        Address("a/b/BUILD.ext")
+    with pytest.raises(InvalidSpecPath):
+        Address("a/b/BUILD", target_name="foo")
+
+    # It's fine to use BUILD in the relative_file_path or target_name, though.
+    assert Address("a/b", relative_file_path="BUILD").spec == "a/b/BUILD"
+    assert Address("a/b", target_name="BUILD").spec == "a/b:BUILD"
+
+
 def test_address_equality() -> None:
     assert "Not really an address" != Address("a/b", target_name="c")
 
@@ -232,54 +231,65 @@ def test_address_equality() -> None:
 
 
 def test_address_spec() -> None:
-    normal_addr = Address("a/b", target_name="c")
-    assert normal_addr.spec == "a/b:c" == str(normal_addr) == normal_addr.reference()
-    assert normal_addr.path_safe_spec == "a.b.c"
+    def assert_spec(address: Address, *, expected: str, expected_path_spec: str) -> None:
+        assert address.spec == expected
+        assert str(address) == expected
+        assert address.reference() == expected
+        assert address.path_safe_spec == expected_path_spec
 
-    top_level_addr = Address("", target_name="root")
-    assert top_level_addr.spec == "//:root" == str(top_level_addr) == top_level_addr.reference()
-    assert top_level_addr.path_safe_spec == ".root"
-
-    generated_addr = Address("a/b", relative_file_path="c.txt", target_name="c")
-    assert generated_addr.spec == "a/b/c.txt:c" == str(generated_addr) == generated_addr.reference()
-    assert generated_addr.path_safe_spec == "a.b.c.txt.c"
-
-    top_level_generated_addr = Address("", relative_file_path="root.txt", target_name="root")
-    assert (
-        top_level_generated_addr.spec
-        == "//root.txt:root"
-        == str(top_level_generated_addr)
-        == top_level_generated_addr.reference()
+    assert_spec(Address("a/b", target_name="c"), expected="a/b:c", expected_path_spec="a.b.c")
+    assert_spec(Address("", target_name="root"), expected="//:root", expected_path_spec=".root")
+    assert_spec(
+        Address("a/b", relative_file_path="c.txt", target_name="c"),
+        expected="a/b/c.txt:c",
+        expected_path_spec="a.b.c.txt.c",
     )
-    assert top_level_generated_addr.path_safe_spec == ".root.txt.root"
-
-    generated_subdirectory_addr = Address(
-        "a/b", relative_file_path="subdir/c.txt", target_name="original"
+    assert_spec(
+        Address("", relative_file_path="root.txt", target_name="root"),
+        expected="//root.txt:root",
+        expected_path_spec=".root.txt.root",
     )
-    assert (
-        generated_subdirectory_addr.spec
-        == "a/b/subdir/c.txt:../original"
-        == str(generated_subdirectory_addr)
-        == generated_subdirectory_addr.reference()
+    assert_spec(
+        Address("a/b", relative_file_path="subdir/c.txt", target_name="original"),
+        expected="a/b/subdir/c.txt:../original",
+        expected_path_spec="a.b.subdir.c.txt@original",
     )
-    assert generated_subdirectory_addr.path_safe_spec == "a.b.subdir.c.txt@original"
-
-    generated_addr_from_default_target = Address("a/b", relative_file_path="c.txt")
-    assert (
-        generated_addr_from_default_target.spec
-        == "a/b/c.txt"
-        == str(generated_addr_from_default_target)
-        == generated_addr_from_default_target.reference()
+    assert_spec(
+        Address("a/b", relative_file_path="c.txt"),
+        expected="a/b/c.txt",
+        expected_path_spec="a.b.c.txt",
     )
-    assert generated_addr_from_default_target.path_safe_spec == "a.b.c.txt"
+    assert_spec(
+        Address("a/b", relative_file_path="subdir/f.txt"),
+        expected="a/b/subdir/f.txt:../b",
+        expected_path_spec="a.b.subdir.f.txt",
+    )
 
 
 def test_address_maybe_convert_to_base_target() -> None:
-    generated_addr = Address("a/b", relative_file_path="c.txt", target_name="c")
-    assert generated_addr.maybe_convert_to_base_target() == Address("a/b", target_name="c")
+    def assert_converts_to_base_target(generated_addr: Address, *, expected: Address) -> None:
+        assert generated_addr.maybe_convert_to_base_target() == expected
 
-    normal_addr = Address("a/b", target_name="c")
-    assert normal_addr.maybe_convert_to_base_target() is normal_addr
+    assert_converts_to_base_target(
+        Address("a/b", relative_file_path="c.txt", target_name="c"),
+        expected=Address("a/b", target_name="c"),
+    )
+    assert_converts_to_base_target(
+        Address("a/b", relative_file_path="c.txt"), expected=Address("a/b")
+    )
+    assert_converts_to_base_target(
+        Address("a/b", relative_file_path="subdir/f.txt"), expected=Address("a/b")
+    )
+    assert_converts_to_base_target(
+        Address("a/b", relative_file_path="subdir/f.txt", target_name="original"),
+        expected=Address("a/b", target_name="original"),
+    )
+
+    def assert_base_target_noops(addr: Address) -> None:
+        assert addr.maybe_convert_to_base_target() is addr
+
+    assert_base_target_noops(Address("a/b", target_name="c"))
+    assert_base_target_noops(Address("a/b"))
 
 
 def test_address_parse_method() -> None:


### PR DESCRIPTION
The old validation for `BUILD` in the spec path would incorrectly error for a generated subtarget with `BUILD` as its file. We only want to error if `BUILD` is in the `spec_path`, but it's okay if it's in the `relative_file_path` or `target_name`.

Our `spec` logic was also incorrect for generated subtargets which live in a directory below the original target, where the original target is the default name.

[ci skip-rust]
[ci skip-build-wheels]