### PR TITLE
Allow for disabling pantsrc in OptionsBootstrapper independently of options values

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -132,7 +132,9 @@ class DaemonPantsRunner(RawFdRunner):
         # propagated down from the caller.
         #   see https://github.com/pantsbuild/pants/issues/7654
         clean_global_runtime_state(reset_subsystem=True)
-        options_bootstrapper = OptionsBootstrapper.create(env=os.environ, args=sys.argv)
+        options_bootstrapper = OptionsBootstrapper.create(
+            env=os.environ, args=sys.argv, allow_pantsrc=True
+        )
         bootstrap_options = options_bootstrapper.bootstrap_options
         global_bootstrap_options = bootstrap_options.for_global_scope()
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -65,7 +65,9 @@ class PantsRunner:
     def run(self, start_time: float) -> ExitCode:
         self.scrub_pythonpath()
 
-        options_bootstrapper = OptionsBootstrapper.create(env=self.env, args=self.args)
+        options_bootstrapper = OptionsBootstrapper.create(
+            env=self.env, args=self.args, allow_pantsrc=True
+        )
         bootstrap_options = options_bootstrapper.bootstrap_options
         global_bootstrap_options = bootstrap_options.for_global_scope()
 

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -537,7 +537,9 @@ def select(argv):
     # Parse positional arguments to the script.
     args = _create_bootstrap_binary_arg_parser().parse_args(argv[1:])
     # Resolve bootstrap options with a fake empty command line.
-    options_bootstrapper = OptionsBootstrapper.create(env=os.environ, args=[argv[0]])
+    options_bootstrapper = OptionsBootstrapper.create(
+        env=os.environ, args=[argv[0]], allow_pantsrc=True
+    )
     subsystems = (GlobalOptions, BinaryUtil.Factory)
     known_scope_infos = reduce(set.union, (ss.known_scope_infos() for ss in subsystems), set())
     options = options_bootstrapper.get_full_options(known_scope_infos)

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -12,7 +12,9 @@ from pants.util.logging import LogLevel
 class TestEngineOptionsParsing(TestBase):
     def _ob(self, args=tuple(), env=None):
         self.create_file("pants.toml")
-        options_bootstrap = OptionsBootstrapper.create(args=tuple(args), env=env or {},)
+        options_bootstrap = OptionsBootstrapper.create(
+            args=tuple(args), env=env or {}, allow_pantsrc=False,
+        )
         # NB: BuildConfigInitializer has sideeffects on first-run: in actual usage, these
         # sideeffects will happen during setup. We force them here.
         BuildConfigInitializer.get(options_bootstrap)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -359,8 +359,6 @@ class GlobalOptions(Subsystem):
             default=[get_default_pants_config_file()],
             help="Paths to Pants config files.",
         )
-        # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
-        # to set extra config file locations in an initial bootstrap config file.
         register(
             "--pantsrc",
             advanced=True,

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -93,11 +93,16 @@ class OptionsBootstrapper:
         return bootstrap_options
 
     @classmethod
-    def create(cls, env: Mapping[str, str], args: Sequence[str]) -> "OptionsBootstrapper":
+    def create(
+        cls, env: Mapping[str, str], args: Sequence[str], *, allow_pantsrc: bool = False
+    ) -> "OptionsBootstrapper":
         """Parses the minimum amount of configuration necessary to create an OptionsBootstrapper.
 
         :param env: An environment dictionary, or None to use `os.environ`.
         :param args: An args array, or None to use `sys.argv`.
+        :param allow_pantsrc: True to allow pantsrc files to be used. This defaults to false because
+          of the prevelance of OptionsBootstrapper usage in tests, but should be enabled for
+          production usecases.
         """
         env = {k: v for k, v in env.items() if k.startswith("PANTS_")}
         args = tuple(args)
@@ -150,7 +155,7 @@ class OptionsBootstrapper:
         # Now re-read the config, post-bootstrapping. Note the order: First whatever we bootstrapped
         # from (typically pants.toml), then config override, then rcfiles.
         full_config_paths = pre_bootstrap_config.sources()
-        if bootstrap_option_values.pantsrc:
+        if allow_pantsrc and bootstrap_option_values.pantsrc:
             rcfiles = [
                 os.path.expanduser(str(rcfile)) for rcfile in bootstrap_option_values.pantsrc_files
             ]

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -94,15 +94,16 @@ class OptionsBootstrapper:
 
     @classmethod
     def create(
-        cls, env: Mapping[str, str], args: Sequence[str], *, allow_pantsrc: bool = False
+        cls, env: Mapping[str, str], args: Sequence[str], *, allow_pantsrc: bool
     ) -> "OptionsBootstrapper":
         """Parses the minimum amount of configuration necessary to create an OptionsBootstrapper.
 
         :param env: An environment dictionary, or None to use `os.environ`.
         :param args: An args array, or None to use `sys.argv`.
-        :param allow_pantsrc: True to allow pantsrc files to be used. This defaults to false because
-          of the prevelance of OptionsBootstrapper usage in tests, but should be enabled for
-          production usecases.
+        :param allow_pantsrc: True to allow pantsrc files to be used. Unless tests are expecting to
+          consume pantsrc files, they should pass False in order to avoid reading files from
+          absolute paths. Production usecases should pass True to allow options values to make the
+          decision of whether to respect pantsrc files.
         """
         env = {k: v for k, v in env.items() if k.startswith("PANTS_")}
         args = tuple(args)

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -219,7 +219,7 @@ class OptionsBootstrapperTest(unittest.TestCase):
     def test_options_pantsrc_files(self) -> None:
         def create_options_bootstrapper(*config_paths: str) -> OptionsBootstrapper:
             return OptionsBootstrapper.create(
-                env={}, args=[f"--pantsrc-files={cp}" for cp in config_paths]
+                env={}, args=[f"--pantsrc-files={cp}" for cp in config_paths], allow_pantsrc=True,
             )
 
         with temporary_file(binary_mode=False) as fp:

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -879,7 +879,9 @@ class OptionsTest(TestBase):
             tmp.flush()
             # Note that we prevent loading a real pants.toml during get_bootstrap_options().
             flags = f'--spec-files={tmp.name} --pants-config-files="[]" compile morx:tgt fleem:tgt'
-            bootstrapper = OptionsBootstrapper.create(env={}, args=shlex.split(f"./pants {flags}"))
+            bootstrapper = OptionsBootstrapper.create(
+                env={}, args=shlex.split(f"./pants {flags}"), allow_pantsrc=False
+            )
             bootstrap_options = bootstrapper.bootstrap_options.for_global_scope()
             options = self._parse(flags=flags, bootstrap_option_values=bootstrap_options)
             sorted_specs = sorted(options.specs)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -302,4 +302,6 @@ class PantsDaemon(PantsDaemonProcessManager):
 
 def launch():
     """An external entrypoint that spawns a new pantsd instance."""
-    PantsDaemon.create(OptionsBootstrapper.create(env=os.environ, args=sys.argv)).run_sync()
+    PantsDaemon.create(
+        OptionsBootstrapper.create(env=os.environ, args=sys.argv, allow_pantsrc=True)
+    ).run_sync()

--- a/src/python/pants/testutil/option/util.py
+++ b/src/python/pants/testutil/option/util.py
@@ -10,5 +10,5 @@ def create_options_bootstrapper(
     *, args: Optional[Iterable[str]] = None, env: Optional[Dict[str, str]] = None,
 ) -> OptionsBootstrapper:
     return OptionsBootstrapper.create(
-        args=("--pants-config-files=[]", *(args or [])), env=env or {},
+        args=("--pants-config-files=[]", *(args or [])), env=env or {}, allow_pantsrc=False,
     )

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -81,7 +81,7 @@ def kill_daemon(pid_dir=None):
     if pid_dir:
         args.append(f"--pants-subprocessdir={pid_dir}")
     pantsd_client = PantsDaemonClient(
-        OptionsBootstrapper.create(env=os.environ, args=args).bootstrap_options
+        OptionsBootstrapper.create(env=os.environ, args=args, allow_pantsrc=False).bootstrap_options
     )
     with pantsd_client.lifecycle_lock:
         pantsd_client.terminate()

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -309,7 +309,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
             return
 
         options_bootstrapper = OptionsBootstrapper.create(
-            env={}, args=["--pants-config-files=[]", *self.additional_options]
+            env={}, args=["--pants-config-files=[]", *self.additional_options], allow_pantsrc=False
         )
         global_options = options_bootstrapper.bootstrap_options.for_global_scope()
         local_store_dir = local_store_dir or global_options.local_store_dir
@@ -406,7 +406,9 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         :param cli_options: An iterable of CLI flags to pass as arguments to `OptionsBootstrapper`.
         """
         args = tuple(["--pants-config-files=[]"]) + tuple(cli_options)
-        return OptionsBootstrapper.create(env={}, args=args).bootstrap_options.for_global_scope()
+        return OptionsBootstrapper.create(
+            env={}, args=args, allow_pantsrc=False
+        ).bootstrap_options.for_global_scope()
 
     def make_snapshot(self, files: Dict[str, Union[str, bytes]]) -> Snapshot:
         """Makes a snapshot from a map of file name to file content."""

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -13,7 +13,9 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 class OptionsInitializerTest(unittest.TestCase):
     def test_invalid_version(self):
         options_bootstrapper = OptionsBootstrapper.create(
-            env={}, args=["--backend-packages=[]", "--pants-version=99.99.9999"]
+            env={},
+            args=["--backend-packages=[]", "--pants-version=99.99.9999"],
+            allow_pantsrc=False,
         )
         build_config = BuildConfigInitializer.get(options_bootstrapper)
 
@@ -23,7 +25,7 @@ class OptionsInitializerTest(unittest.TestCase):
     def test_global_options_validation(self):
         # Specify an invalid combination of options.
         ob = OptionsBootstrapper.create(
-            env={}, args=["--backend-packages=[]", "--remote-execution",]
+            env={}, args=["--backend-packages=[]", "--remote-execution",], allow_pantsrc=False
         )
         build_config = BuildConfigInitializer.get(ob)
         with self.assertRaises(OptionsError) as exc:
@@ -33,7 +35,9 @@ class OptionsInitializerTest(unittest.TestCase):
     def test_invalidation_globs(self) -> None:
         # Confirm that an un-normalized relative path in the pythonpath is filtered out.
         suffix = "something-ridiculous"
-        ob = OptionsBootstrapper.create(env={}, args=[f"--pythonpath=../{suffix}"])
+        ob = OptionsBootstrapper.create(
+            env={}, args=[f"--pythonpath=../{suffix}"], allow_pantsrc=False
+        )
         globs = OptionsInitializer.compute_pantsd_invalidation_globs(
             get_buildroot(), ob.bootstrap_options.for_global_scope()
         )

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -137,7 +137,9 @@ class PluginResolverTest(TestBase):
                 touch(configpath)
             args = [f"--pants-config-files=['{configpath}']"]
 
-            options_bootstrapper = OptionsBootstrapper.create(env=env, args=args)
+            options_bootstrapper = OptionsBootstrapper.create(
+                env=env, args=args, allow_pantsrc=False
+            )
             plugin_resolver = PluginResolver(options_bootstrapper, interpreter=interpreter)
             cache_dir = plugin_resolver.plugin_cache_dir
 


### PR DESCRIPTION
### Problem

`pantsrc` file consumption is enabled by default via options, but many usages of `OptionsBootstrapper` forget to disable it in tests. Because `pantsrc` resolution uses absolute file lookups, it is able to break out of the test sandbox, which can make for some confusing errors. 

### Solution

Disable `pantsrc` consumption by default at the `OptionsBootstrapper` level, and then enable it in production usecases, or usecases that intentionally change the default `pantsrc` locations in order to test that feature.

[ci skip-rust]
[ci skip-build-wheels]
