### PR TITLE
Move `--tag` and `--exclude-target-regexp` out of bootstrap options

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -34,18 +34,17 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
         return [PythonAWSLambda, PythonLibrary]
 
     def create_python_awslambda(self, addr: str) -> Tuple[str, bytes]:
-        target = self.request_single_product(WrappedTarget, Address.parse(addr)).target
+        bootstrapper = create_options_bootstrapper(
+            args=[
+                "--backend-packages=pants.backend.awslambda.python",
+                "--source-root-patterns=src/python",
+            ]
+        )
+        target = self.request_single_product(
+            WrappedTarget, Params(Address.parse(addr), bootstrapper)
+        ).target
         created_awslambda = self.request_single_product(
-            CreatedAWSLambda,
-            Params(
-                PythonAwsLambdaFieldSet.create(target),
-                create_options_bootstrapper(
-                    args=[
-                        "--backend-packages=pants.backend.awslambda.python",
-                        "--source-root-patterns=src/python",
-                    ]
-                ),
-            ),
+            CreatedAWSLambda, Params(PythonAwsLambdaFieldSet.create(target), bootstrapper)
         )
         created_awslambda_digest_contents = self.request_single_product(
             DigestContents, created_awslambda.digest

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -95,7 +95,9 @@ class PythonDependencyInferenceTest(TestBase):
         self.add_to_build_file("src/python", "python_library()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
-            target = self.request_single_product(WrappedTarget, address).target
+            target = self.request_single_product(
+                WrappedTarget, Params(address, options_bootstrapper)
+            ).target
             return self.request_single_product(
                 InferredDependencies,
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
@@ -133,7 +135,9 @@ class PythonDependencyInferenceTest(TestBase):
         self.add_to_build_file("src/python/root/mid/leaf", "python_library()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
-            target = self.request_single_product(WrappedTarget, address).target
+            target = self.request_single_product(
+                WrappedTarget, Params(address, options_bootstrapper)
+            ).target
             return self.request_single_product(
                 InferredDependencies,
                 Params(InferInitDependencies(target[PythonSources]), options_bootstrapper),
@@ -162,7 +166,9 @@ class PythonDependencyInferenceTest(TestBase):
         self.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
-            target = self.request_single_product(WrappedTarget, address).target
+            target = self.request_single_product(
+                WrappedTarget, Params(address, options_bootstrapper)
+            ).target
             return self.request_single_product(
                 InferredDependencies,
                 Params(InferConftestDependencies(target[PythonSources]), options_bootstrapper),

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -73,7 +73,9 @@ class TestSetupPyBase(TestBase):
         ]
 
     def tgt(self, addr: str) -> Target:
-        return self.request_single_product(WrappedTarget, Params(Address.parse(addr))).target
+        return self.request_single_product(
+            WrappedTarget, Params(Address.parse(addr), create_options_bootstrapper())
+        ).target
 
 
 class TestGenerateChroot(TestSetupPyBase):
@@ -94,7 +96,7 @@ class TestGenerateChroot(TestSetupPyBase):
             SetupPyChroot,
             Params(
                 SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
-                create_options_bootstrapper(args=["--source-root-patterns=src/python"]),
+                create_options_bootstrapper(),
             ),
         )
         snapshot = self.request_single_product(Snapshot, Params(chroot.digest))
@@ -108,7 +110,7 @@ class TestGenerateChroot(TestSetupPyBase):
                 SetupPyChroot,
                 Params(
                     SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
-                    create_options_bootstrapper(args=["--source-root-patterns=src/python"]),
+                    create_options_bootstrapper(),
                 ),
             )
         ex = excinfo.value
@@ -254,7 +256,7 @@ class TestGetSources(TestSetupPyBase):
             SetupPySources,
             Params(
                 SetupPySourcesRequest(Targets([self.tgt(addr) for addr in addrs]), py2=False),
-                create_options_bootstrapper(args=["--source-root-patterns=src/python"]),
+                create_options_bootstrapper(),
             ),
         )
         chroot_snapshot = self.request_single_product(Snapshot, Params(srcs.digest))

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -57,6 +57,12 @@ class MyPyIntegrationTest(ExternalToolTestBase):
         ).encode(),
     )
 
+    global_args = (
+        "--backend-packages=pants.backend.python",
+        "--backend-packages=pants.backend.python.typecheck.mypy",
+        "--source-root-patterns=['src/python', 'tests/python']",
+    )
+
     @classmethod
     def rules(cls):
         return (
@@ -95,7 +101,11 @@ class MyPyIntegrationTest(ExternalToolTestBase):
             ),
         )
         target = self.request_single_product(
-            WrappedTarget, Address(package, target_name=name)
+            WrappedTarget,
+            Params(
+                Address(package, target_name=name),
+                create_options_bootstrapper(args=self.global_args),
+            ),
         ).target
         origin = SingleAddress(directory=package, name=name)
         return TargetWithOrigin(target, origin)
@@ -109,11 +119,7 @@ class MyPyIntegrationTest(ExternalToolTestBase):
         skip: bool = False,
         additional_args: Optional[List[str]] = None,
     ) -> TypecheckResults:
-        args = [
-            "--backend-packages=pants.backend.python",
-            "--backend-packages=pants.backend.python.typecheck.mypy",
-            "--source-root-patterns=['src/python', 'tests/python']",
-        ]
+        args = list(self.global_args)
         if config:
             self.create_file(relpath="mypy.ini", contents=config)
             args.append("--mypy-config=mypy.ini")

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Iterable
+
 
 class TargetDefinitionException(Exception):
     """Indicates an invalid target definition.
@@ -38,3 +40,13 @@ class DuplicateNameError(MappingError):
 
 class ResolveError(MappingError):
     """Indicates an error resolving targets."""
+
+    @classmethod
+    def did_you_mean(
+        cls, *, bad_name: str, known_names: Iterable[str], namespace: str
+    ) -> "ResolveError":
+        possibilities = "\n  ".join(f":{target_name}" for target_name in sorted(known_names))
+        return cls(
+            f"'{bad_name}' was not found in namespace '{namespace}'. Did you mean one "
+            f"of:\n  {possibilities}"
+        )

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -19,11 +19,7 @@ from pants.engine.unions import UnionMembership
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.help.help_printer import HelpPrinter
-from pants.init.engine_initializer import (
-    EngineInitializer,
-    LegacyGraphScheduler,
-    LegacyGraphSession,
-)
+from pants.init.engine_initializer import EngineInitializer, GraphScheduler, GraphSession
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.init.specs_calculator import SpecsCalculator
 from pants.option.options import Options
@@ -53,7 +49,7 @@ class LocalPantsRunner:
     options_bootstrapper: OptionsBootstrapper
     build_config: BuildConfiguration
     specs: Specs
-    graph_session: LegacyGraphSession
+    graph_session: GraphSession
     union_membership: UnionMembership
     profile_path: Optional[str]
     _run_tracker: RunTracker
@@ -71,11 +67,11 @@ class LocalPantsRunner:
         options_bootstrapper: OptionsBootstrapper,
         build_config: BuildConfiguration,
         options: Options,
-        scheduler: Optional[LegacyGraphScheduler] = None,
-    ) -> LegacyGraphSession:
+        scheduler: Optional[GraphScheduler] = None,
+    ) -> GraphSession:
         native = Native()
         native.set_panic_handler()
-        graph_scheduler_helper = scheduler or EngineInitializer.setup_legacy_graph(
+        graph_scheduler_helper = scheduler or EngineInitializer.setup_graph(
             options_bootstrapper, build_config
         )
 
@@ -96,7 +92,7 @@ class LocalPantsRunner:
         cls,
         env: Mapping[str, str],
         options_bootstrapper: OptionsBootstrapper,
-        scheduler: Optional[LegacyGraphScheduler] = None,
+        scheduler: Optional[GraphScheduler] = None,
     ) -> "LocalPantsRunner":
         """Creates a new LocalPantsRunner instance by parsing options.
 

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -12,6 +12,8 @@ from pants.core.util_rules.filter_empty_sources import (
 from pants.core.util_rules.filter_empty_sources import rules as filter_empty_sources_rules
 from pants.engine.addresses import Address
 from pants.engine.target import FieldSet, Sources, Tags, Target
+from pants.testutil.engine.util import Params
+from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
 
@@ -28,18 +30,22 @@ class FilterEmptySourcesTest(TestBase):
             tags: Tags
 
         self.create_file("f1.txt")
-        valid_addr = Address.parse(":valid")
+        valid_addr = Address("", target_name="valid")
         valid_field_set = MockFieldSet(
             valid_addr, Sources(["f1.txt"], address=valid_addr), Tags(None, address=valid_addr)
         )
 
-        empty_addr = Address.parse(":empty")
+        empty_addr = Address("", target_name="empty")
         empty_field_set = MockFieldSet(
             empty_addr, Sources(None, address=empty_addr), Tags(None, address=empty_addr)
         )
 
         result = self.request_single_product(
-            FieldSetsWithSources, FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
+            FieldSetsWithSources,
+            Params(
+                FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
+                create_options_bootstrapper(),
+            ),
         )
         assert tuple(result) == (valid_field_set,)
 
@@ -53,11 +59,17 @@ class FilterEmptySourcesTest(TestBase):
             core_fields = ()
 
         self.create_file("f1.txt")
-        valid_tgt = MockTarget({Sources.alias: ["f1.txt"]}, address=Address.parse(":valid"))
-        empty_tgt = MockTarget({}, address=Address.parse(":empty"))
-        invalid_tgt = MockTargetWithNoSourcesField({}, address=Address.parse(":invalid"))
+        valid_tgt = MockTarget(
+            {Sources.alias: ["f1.txt"]}, address=Address("", target_name="valid")
+        )
+        empty_tgt = MockTarget({}, address=Address("", target_name="empty"))
+        invalid_tgt = MockTargetWithNoSourcesField({}, address=Address("", target_name="invalid"))
 
         result = self.request_single_product(
-            TargetsWithSources, TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt]),
+            TargetsWithSources,
+            Params(
+                TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt]),
+                create_options_bootstrapper(),
+            ),
         )
         assert tuple(result) == (valid_tgt,)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,11 +3,10 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple
 
 from pants.engine.collection import Collection
-from pants.engine.rules import RootRule, collect_rules, rule, side_effecting
-from pants.option.global_options import GlobalOptions
+from pants.engine.rules import RootRule, collect_rules, side_effecting
 from pants.option.global_options import GlobMatchErrorBehavior as GlobMatchErrorBehavior
 from pants.util.meta import frozen_after_init
 
@@ -65,14 +64,6 @@ class CreateDigest(Collection[FileContent]):
     This does _not_ actually materialize the digest to the build root. You must use
     `engine.fs.Workspace` in a `@goal_rule` to save the resulting digest to disk.
     """
-
-
-@rule
-def glob_match_error_behavior_singleton(global_options: GlobalOptions) -> GlobMatchErrorBehavior:
-    return cast(
-        GlobMatchErrorBehavior,
-        global_options.options.files_not_found_behavior.to_glob_match_error_behavior(),
-    )
 
 
 class GlobExpansionConjunction(Enum):

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -34,10 +34,16 @@ from pants.engine.fs import (
 from pants.engine.fs import rules as fs_rules
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase
+from pants.engine.rules import RootRule
 from pants.testutil.test_base import TestBase
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import http_server, temporary_dir
 from pants.util.dirutil import relative_symlink, safe_file_dump
+
+# TODO: Stop using `SchedulerTestBase` and run tests like we normally would via
+#  `self.request_single_product`. This is a hacky workaround that this filtered rule would be
+#  unreachable when using SchedulerTestBase.
+filtered_fs_rules = [rule for rule in fs_rules() if isinstance(rule, RootRule)]
 
 
 class FSTest(TestBase, SchedulerTestBase):
@@ -79,7 +85,7 @@ class FSTest(TestBase, SchedulerTestBase):
         self, field, filespecs_or_globs, paths, ignore_patterns=None, prepare=None
     ):
         with self.mk_project_tree(ignore_patterns=ignore_patterns) as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree)
             if prepare:
                 prepare(project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
@@ -87,13 +93,13 @@ class FSTest(TestBase, SchedulerTestBase):
 
     def assert_content(self, filespecs_or_globs, expected_content):
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree)
             actual_content = self.read_digest_contents(scheduler, filespecs_or_globs)
             assert expected_content == actual_content
 
     def assert_digest(self, filespecs_or_globs, expected_files):
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree)
             result = self.execute(scheduler, Snapshot, self.path_globs(filespecs_or_globs))[0]
             # Confirm all expected files were digested.
             assert set(expected_files) == set(result.files)
@@ -283,7 +289,7 @@ class FSTest(TestBase, SchedulerTestBase):
         with temporary_dir() as temp_dir:
             Path(temp_dir, "roland").write_text("European Burmese")
             Path(temp_dir, "susannah").write_text("I don't know")
-            scheduler = self.mk_scheduler(rules=fs_rules())
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules)
             snapshots = scheduler.capture_snapshots(
                 (
                     PathGlobsAndRoot(PathGlobs(["roland"]), temp_dir),
@@ -743,7 +749,7 @@ class FSTest(TestBase, SchedulerTestBase):
         on those files."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree,)
             fname = "4.txt"
             new_data = "rouf"
             # read the original file so we have a cached value.
@@ -769,7 +775,7 @@ class FSTest(TestBase, SchedulerTestBase):
         """Test that FileContent is invalidated after deleting parent directory."""
 
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree,)
             fname = "a/b/1.txt"
             # read the original file so we have nodes to invalidate.
             original_content = self.read_digest_contents(scheduler, [fname])
@@ -792,7 +798,7 @@ class FSTest(TestBase, SchedulerTestBase):
         self, mutation_function: Callable[[FileSystemProjectTree, str], Exception]
     ) -> None:
         with self.mk_project_tree() as project_tree:
-            scheduler = self.mk_scheduler(rules=fs_rules(), project_tree=project_tree,)
+            scheduler = self.mk_scheduler(rules=filtered_fs_rules, project_tree=project_tree,)
             dir_path = "a/"
             dir_glob = f"{dir_path}/*"
             initial_snapshot = self.execute_expecting_one_result(

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 from pants.base.exceptions import ResolveError
 from pants.base.project_tree import Dir
 from pants.base.specs import AddressSpec, AddressSpecs
-from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.addresses import (
     Address,
     Addresses,
@@ -19,35 +18,11 @@ from pants.engine.addresses import (
 )
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Snapshot
 from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressMapper
-from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
+from pants.engine.internals.parser import BuildFilePreludeSymbols, error_on_imports
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import RegisteredTargetTypes
-from pants.option.global_options import GlobalOptions
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
-
-
-@rule
-async def setup_address_mapper(
-    global_options: GlobalOptions,
-    registered_target_types: RegisteredTargetTypes,
-    build_configuration: BuildConfiguration,
-) -> AddressMapper:
-    parser = Parser(
-        target_type_aliases=registered_target_types.aliases,
-        object_aliases=build_configuration.registered_aliases,
-    )
-    opts = global_options.options
-    return AddressMapper(
-        parser,
-        prelude_glob_patterns=opts.build_file_prelude_globs,
-        build_patterns=opts.build_patterns,
-        build_ignore_patterns=opts.build_ignore,
-        tags=opts.tag,
-        exclude_target_regexps=opts.exclude_target_regexp,
-        subproject_roots=opts.subproject_roots,
-    )
 
 
 @rule

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -29,7 +29,7 @@ from pants.engine.internals.build_files import (
     parse_address_family,
     strip_address_origins,
 )
-from pants.engine.internals.mapper import AddressFamily, AddressMapper
+from pants.engine.internals.mapper import AddressFamily, AddressMapper, AddressSpecsFilter
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.target_adaptor import TargetAdaptor
@@ -67,15 +67,12 @@ def resolve_addresses_with_origins_from_address_specs(
     tags: Optional[Iterable[str]] = None,
     exclude_patterns: Optional[Iterable[str]] = None
 ) -> AddressesWithOrigins:
-    address_mapper = AddressMapper(
-        Parser(target_type_aliases=[], object_aliases=BuildFileAliases()),
-        tags=tags,
-        exclude_target_regexps=exclude_patterns,
-    )
+    mapper = AddressMapper(Parser(target_type_aliases=[], object_aliases=BuildFileAliases()))
+    specs_filter = AddressSpecsFilter(tags=tags, exclude_target_regexps=exclude_patterns)
     snapshot = Snapshot(Digest("xx", 2), ("root/BUILD",), ())
     addresses_with_origins = run_rule(
         addresses_with_origins_from_address_specs,
-        rule_args=[address_mapper, address_specs],
+        rule_args=[mapper, address_specs, specs_filter],
         mock_gets=[
             MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=lambda _: snapshot),
             MockGet(product_type=AddressFamily, subject_type=Dir, mock=lambda _: address_family,),

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -72,7 +72,7 @@ def resolve_addresses_with_origins_from_address_specs(
     snapshot = Snapshot(Digest("xx", 2), ("root/BUILD",), ())
     addresses_with_origins = run_rule(
         addresses_with_origins_from_address_specs,
-        rule_args=[mapper, address_specs, specs_filter],
+        rule_args=[address_specs, mapper, specs_filter],
         mock_gets=[
             MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=lambda _: snapshot),
             MockGet(product_type=AddressFamily, subject_type=Dir, mock=lambda _: address_family,),

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -30,7 +30,6 @@ from pants.engine.collection import Collection
 from pants.engine.fs import (
     EMPTY_SNAPSHOT,
     Digest,
-    GlobMatchErrorBehavior,
     MergeDigests,
     PathGlobs,
     Snapshot,
@@ -70,7 +69,7 @@ from pants.engine.target import (
     generate_subtarget_address,
 )
 from pants.engine.unions import UnionMembership
-from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
+from pants.option.global_options import FilesNotFoundBehavior, GlobalOptions, OwnersNotFoundBehavior
 from pants.source.filespec import matches_filespec
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
@@ -83,7 +82,7 @@ logger = logging.getLogger(__name__)
 
 @rule
 async def generate_subtargets(
-    address: Address, glob_match_error_behavior: GlobMatchErrorBehavior,
+    address: Address, files_not_found_behavior: FilesNotFoundBehavior
 ) -> Subtargets:
     if not address.is_base_target:
         raise ValueError(f"Cannot generate file Targets for a file Address: {address}")
@@ -97,7 +96,7 @@ async def generate_subtargets(
 
     # Create subtargets for matched sources.
     sources_field = base_target[Sources]
-    sources_field_path_globs = sources_field.path_globs(glob_match_error_behavior)
+    sources_field_path_globs = sources_field.path_globs(files_not_found_behavior)
     if sources_field_path_globs is None:
         return Subtargets(base_target, ())
 
@@ -589,7 +588,7 @@ class AmbiguousCodegenImplementationsException(Exception):
 @rule
 async def hydrate_sources(
     request: HydrateSourcesRequest,
-    glob_match_error_behavior: GlobMatchErrorBehavior,
+    files_not_found_behavior: FilesNotFoundBehavior,
     union_membership: UnionMembership,
 ) -> HydratedSources:
     sources_field = request.field
@@ -635,7 +634,7 @@ async def hydrate_sources(
 
     # Now, hydrate the `globs`. Even if we are going to use codegen, we will need the original
     # protocol sources to be hydrated.
-    path_globs = sources_field.path_globs(glob_match_error_behavior)
+    path_globs = sources_field.path_globs(files_not_found_behavior)
     if path_globs is None:
         return HydratedSources(EMPTY_SNAPSHOT, sources_field.filespec, sources_type=sources_type)
     snapshot = await Get(Snapshot, PathGlobs, path_globs)

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -629,6 +629,9 @@ class TestFindValidFieldSets(TestBase):
 
 
 class TestSources(TestBase):
+    # TODO(#10569): Remove this and simply set the value in the unit test `test_unmatched_globs`.
+    additional_options = ["--files-not-found-behavior=error"]
+
     @classmethod
     def rules(cls):
         return (*super().rules(), RootRule(HydrateSourcesRequest))

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -629,9 +629,6 @@ class TestFindValidFieldSets(TestBase):
 
 
 class TestSources(TestBase):
-    # TODO(#10569): Remove this and simply set the value in the unit test `test_unmatched_globs`.
-    additional_options = ["--files-not-found-behavior=error"]
-
     @classmethod
     def rules(cls):
         return (*super().rules(), RootRule(HydrateSourcesRequest))

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -154,8 +154,6 @@ class AddressMapper:
     prelude_glob_patterns: Tuple[str, ...]
     build_patterns: Tuple[str, ...]
     build_ignore_patterns: Tuple[str, ...]
-    tags: Tuple[str, ...]
-    exclude_target_regexps: Tuple[str, ...]
     subproject_roots: Tuple[str, ...]
 
     def __init__(
@@ -165,20 +163,35 @@ class AddressMapper:
         prelude_glob_patterns: Optional[Iterable[str]] = None,
         build_patterns: Optional[Iterable[str]] = None,
         build_ignore_patterns: Optional[Iterable[str]] = None,
-        tags: Optional[Iterable[str]] = None,
-        exclude_target_regexps: Optional[Iterable[str]] = None,
         subproject_roots: Optional[Iterable[str]] = None,
     ) -> None:
         self.parser = parser
         self.prelude_glob_patterns = tuple(prelude_glob_patterns or [])
         self.build_patterns = tuple(build_patterns or ["BUILD", "BUILD.*"])
         self.build_ignore_patterns = tuple(build_ignore_patterns or [])
-        self.tags = tuple(tags or [])
-        self.exclude_target_regexps = tuple(exclude_target_regexps or [])
         self.subproject_roots = tuple(subproject_roots or [])
 
     def __repr__(self):
         return f"AddressMapper(build_patterns={self.build_patterns})"
+
+
+# TODO(#10569): merge this with AddressMapper.
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class AddressSpecsFilter:
+    """Filters addresses with the `--tags` and `--exclude-target-regexp` options."""
+
+    tags: Tuple[str, ...]
+    exclude_target_regexps: Tuple[str, ...]
+
+    def __init__(
+        self,
+        *,
+        tags: Optional[Iterable[str]] = None,
+        exclude_target_regexps: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.tags = tuple(tags or [])
+        self.exclude_target_regexps = tuple(exclude_target_regexps or [])
 
     @memoized_property
     def _exclude_regexps(self) -> Tuple[Pattern, ...]:
@@ -200,7 +213,7 @@ class AddressMapper:
 
         return and_filters(create_filters(self.tags, filter_for_tag))
 
-    def matches_filter_options(self, address: Address, target: TargetAdaptor) -> bool:
+    def matches(self, address: Address, target: TargetAdaptor) -> bool:
         """Check that the target matches the provided `--tags` and `--exclude-target-regexp`
         options."""
         return self._tag_filter(target) and not self._is_excluded_by_pattern(address)

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -123,6 +123,10 @@ class AddressFamily:
             for name, (path, _) in self.name_to_target_adaptors.items()
         )
 
+    @property
+    def target_names(self) -> Tuple[str, ...]:
+        return tuple(addr.target_name for addr in self.addresses_to_target_adaptors)
+
     def get_target_adaptor(self, address: Address) -> Optional[TargetAdaptor]:
         assert address.spec_path == self.namespace
         entry = self.name_to_target_adaptors.get(address.target_name)

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -11,7 +11,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.internals.mapper import (
     AddressFamily,
     AddressMap,
-    AddressMapper,
+    AddressSpecsFilter,
     DifferingFamiliesError,
 )
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
@@ -123,7 +123,7 @@ def test_address_family_duplicate_names() -> None:
         )
 
 
-def test_match_filter_options() -> None:
+def test_address_specs_filter() -> None:
     def make_target(target_name: str, **kwargs) -> TargetAdaptor:
         parsed_address = Address("", target_name=target_name)
         return TargetAdaptor(
@@ -135,11 +135,10 @@ def test_match_filter_options() -> None:
     a_and_b_tagged_target = make_target(target_name="//:a-and-b-tagged", tags=["a", "b"])
     none_tagged_target = make_target(target_name="//:none-tagged-target", tags=None)
 
-    parser = Parser(target_type_aliases=[], object_aliases=BuildFileAliases())
-    mapper = AddressMapper(parser, tags=["-a", "+b"])
+    specs_filter = AddressSpecsFilter(tags=["-a", "+b"])
 
     def matches(tgt: TargetAdaptor) -> bool:
-        return mapper.matches_filter_options(tgt.kwargs["address"], tgt)
+        return specs_filter.matches(tgt.kwargs["address"], tgt)
 
     assert matches(untagged_target) is False
     assert matches(b_tagged_target) is True

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -210,8 +210,6 @@ class EngineInitializer:
             prelude_glob_patterns=bootstrap_options.build_file_prelude_globs,
             build_patterns=bootstrap_options.build_patterns,
             build_ignore_patterns=bootstrap_options.build_ignore,
-            tags=bootstrap_options.tag,
-            exclude_target_regexps=bootstrap_options.exclude_target_regexp,
             subproject_roots=bootstrap_options.subproject_roots,
         )
 
@@ -223,7 +221,10 @@ class EngineInitializer:
         #  GlobMatchErrorBehavior.
         @rule
         def glob_match_error_behavior_singleton() -> GlobMatchErrorBehavior:
-            return bootstrap_options.files_not_found_behavior.to_glob_match_error_behavior()
+            return cast(
+                GlobMatchErrorBehavior,
+                bootstrap_options.files_not_found_behavior.to_glob_match_error_behavior(),
+            )
 
         @rule
         def build_configuration_singleton() -> BuildConfiguration:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -876,24 +876,6 @@ class GlobalOptions(Subsystem):
             "your machine or when they are ignored by the `--pants-ignore` option.",
         )
 
-        # TODO(#10569): move this out of bootstrap options into normal global options.
-        register(
-            "--tag",
-            type=list,
-            metavar="[+-]tag1,tag2,...",
-            help=(
-                "Include only targets with these tags (optional '+' prefix) or without these "
-                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
-            ),
-        )
-        register(
-            "--exclude-target-regexp",
-            type=list,
-            default=[],
-            metavar="<regexp>",
-            help="Exclude target roots that match these regexes.",
-        )
-
     @classmethod
     def register_options(cls, register):
         """Register options not tied to any particular task or subsystem."""
@@ -928,6 +910,23 @@ class GlobalOptions(Subsystem):
                 "inferred by running `./pants dependencies` on your target. You may still need to "
                 "explicitly provide some `dependencies` that cannot be inferred."
             ),
+        )
+
+        register(
+            "--tag",
+            type=list,
+            metavar="[+-]tag1,tag2,...",
+            help=(
+                "Include only targets with these tags (optional '+' prefix) or without these "
+                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
+            ),
+        )
+        register(
+            "--exclude-target-regexp",
+            type=list,
+            default=[],
+            metavar="<regexp>",
+            help="Exclude target roots that match these regexes.",
         )
 
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -35,7 +35,7 @@ class GlobMatchErrorBehavior(Enum):
     error = "error"
 
 
-class FileNotFoundBehavior(Enum):
+class FilesNotFoundBehavior(Enum):
     """What to do when globs do not match in BUILD files."""
 
     warn = "warn"
@@ -869,8 +869,8 @@ class GlobalOptions(Subsystem):
         register(
             "--files-not-found-behavior",
             advanced=True,
-            type=FileNotFoundBehavior,
-            default=FileNotFoundBehavior.warn,
+            type=FilesNotFoundBehavior,
+            default=FilesNotFoundBehavior.warn,
             help="What to do when files and globs specified in BUILD files, such as in the "
             "`sources` field, cannot be found. This happens when the files do not exist on "
             "your machine or when they are ignored by the `--pants-ignore` option.",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -823,6 +823,77 @@ class GlobalOptions(Subsystem):
             advanced=True,
         )
 
+        # TODO(#10569): move these out of bootstrap options into normal global options.
+        register(
+            "--build-patterns",
+            advanced=True,
+            type=list,
+            default=["BUILD", "BUILD.*"],
+            help=(
+                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
+                "the naming scheme, not the directory paths to look for. To add ignore"
+                "patterns, use the option `--build-ignore`."
+            ),
+        )
+        register(
+            "--build-ignore",
+            advanced=True,
+            type=list,
+            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
+            help=(
+                "Paths to ignore when identifying BUILD files. This does not affect any other "
+                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
+                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
+            ),
+        )
+        register(
+            "--build-file-prelude-globs",
+            advanced=True,
+            type=list,
+            default=[],
+            help=(
+                "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
+                "See https://www.pantsbuild.org/docs/macros."
+            ),
+        )
+        register(
+            "--subproject-roots",
+            type=list,
+            advanced=True,
+            default=[],
+            help="Paths that correspond with build roots for any subproject that this "
+            "project depends on.",
+        )
+
+        # TODO(#10569): move this out of bootstrap options into normal global options.
+        register(
+            "--files-not-found-behavior",
+            advanced=True,
+            type=FileNotFoundBehavior,
+            default=FileNotFoundBehavior.warn,
+            help="What to do when files and globs specified in BUILD files, such as in the "
+            "`sources` field, cannot be found. This happens when the files do not exist on "
+            "your machine or when they are ignored by the `--pants-ignore` option.",
+        )
+
+        # TODO(#10569): move this out of bootstrap options into normal global options.
+        register(
+            "--tag",
+            type=list,
+            metavar="[+-]tag1,tag2,...",
+            help=(
+                "Include only targets with these tags (optional '+' prefix) or without these "
+                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
+            ),
+        )
+        register(
+            "--exclude-target-regexp",
+            type=list,
+            default=[],
+            metavar="<regexp>",
+            help="Exclude target roots that match these regexes.",
+        )
+
     @classmethod
     def register_options(cls, register):
         """Register options not tied to any particular task or subsystem."""
@@ -860,65 +931,6 @@ class GlobalOptions(Subsystem):
         )
 
         register(
-            "--build-patterns",
-            advanced=True,
-            type=list,
-            default=["BUILD", "BUILD.*"],
-            help=(
-                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
-                "the naming scheme, not the directory paths to look for. To add ignore"
-                "patterns, use the option `--build-ignore`."
-            ),
-        )
-        register(
-            "--build-ignore",
-            advanced=True,
-            type=list,
-            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
-            help=(
-                "Paths to ignore when identifying BUILD files. This does not affect any other "
-                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
-                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
-            ),
-        )
-        register(
-            "--build-file-prelude-globs",
-            advanced=True,
-            type=list,
-            default=[],
-            help=(
-                "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
-                "See https://www.pantsbuild.org/docs/macros."
-            ),
-        )
-
-        register(
-            "--tag",
-            type=list,
-            metavar="[+-]tag1,tag2,...",
-            help=(
-                "Include only targets with these tags (optional '+' prefix) or without these "
-                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
-            ),
-        )
-        register(
-            "--exclude-target-regexp",
-            advanced=True,
-            type=list,
-            default=[],
-            metavar="<regexp>",
-            help="Exclude target roots that match these regexes.",
-        )
-        register(
-            "--subproject-roots",
-            type=list,
-            advanced=True,
-            default=[],
-            help="Paths that correspond with build roots for any subproject that this "
-            "project depends on.",
-        )
-
-        register(
             "--owners-not-found-behavior",
             advanced=True,
             type=OwnersNotFoundBehavior,
@@ -927,15 +939,6 @@ class GlobalOptions(Subsystem):
                 "What to do when file arguments do not have any owning target. This happens when "
                 "there are no targets whose `sources` fields include the file argument."
             ),
-        )
-        register(
-            "--files-not-found-behavior",
-            advanced=True,
-            type=FileNotFoundBehavior,
-            default=FileNotFoundBehavior.warn,
-            help="What to do when files and globs specified in BUILD files, such as in the "
-            "`sources` field, cannot be found. This happens when the files do not exist on "
-            "your machine or when they are ignored by the `--pants-ignore` option.",
         )
 
         loop_flag = "--loop"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,12 +16,23 @@ from pants.base.build_environment import (
     get_pants_configdir,
     pants_version,
 )
-from pants.engine.fs import GlobMatchErrorBehavior
 from pants.option.custom_types import dir_option
 from pants.option.errors import OptionsError
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
+
+
+class GlobMatchErrorBehavior(Enum):
+    """Describe the action to perform when matching globs in BUILD files to source files.
+
+    NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
+    be aware of any changes to this object's definition.
+    """
+
+    ignore = "ignore"
+    warn = "warn"
+    error = "error"
 
 
 class FileNotFoundBehavior(Enum):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -424,28 +424,6 @@ class GlobalOptions(Subsystem):
         )
 
         register(
-            "--build-patterns",
-            advanced=True,
-            type=list,
-            default=["BUILD", "BUILD.*"],
-            help=(
-                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
-                "the naming scheme, not the directory paths to look for. To add ignore"
-                "patterns, use the option `--build-ignore`."
-            ),
-        )
-        register(
-            "--build-ignore",
-            advanced=True,
-            type=list,
-            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
-            help=(
-                "Paths to ignore when identifying BUILD files. This does not affect any other "
-                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
-                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
-            ),
-        )
-        register(
             "--pants-ignore",
             advanced=True,
             type=list,
@@ -466,49 +444,6 @@ class GlobalOptions(Subsystem):
             help="Make use of a root .gitignore file when determining whether to ignore filesystem "
             "operations performed by Pants. If used together with `--pants-ignore`, any exclude/include "
             "patterns specified there apply after .gitignore rules.",
-        )
-        register(
-            "--owners-not-found-behavior",
-            advanced=True,
-            type=OwnersNotFoundBehavior,
-            default=OwnersNotFoundBehavior.error,
-            help="What to do when file arguments do not have any owning target. This happens when there "
-            "are no targets whose `sources` fields include the file argument.",
-        )
-        register(
-            "--files-not-found-behavior",
-            advanced=True,
-            type=FileNotFoundBehavior,
-            default=FileNotFoundBehavior.warn,
-            help="What to do when files and globs specified in BUILD files, such as in the "
-            "`sources` field, cannot be found. This happens when the files do not exist on "
-            "your machine or when they are ignored by the `--pants-ignore` option.",
-        )
-
-        register(
-            "--tag",
-            type=list,
-            metavar="[+-]tag1,tag2,...",
-            help=(
-                "Include only targets with these tags (optional '+' prefix) or without these "
-                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
-            ),
-        )
-        register(
-            "--exclude-target-regexp",
-            advanced=True,
-            type=list,
-            default=[],
-            metavar="<regexp>",
-            help="Exclude target roots that match these regexes.",
-        )
-        register(
-            "--subproject-roots",
-            type=list,
-            advanced=True,
-            default=[],
-            help="Paths that correspond with build roots for any subproject that this "
-            "project depends on.",
         )
 
         # These logging options are registered in the bootstrap phase so that plugins can log during
@@ -680,17 +615,6 @@ class GlobalOptions(Subsystem):
             daemon=True,
             help="Filesystem events matching any of these globs will trigger a daemon restart. "
             "Pants's own code, plugins, and `--pants-config-files` are inherently invalidated.",
-        )
-
-        register(
-            "--build-file-prelude-globs",
-            advanced=True,
-            type=list,
-            default=[],
-            help="Python files to evaluate and whose symbols should be exposed to all BUILD files ."
-            "This allows for writing functions which create multiple rules, or set default "
-            "arguments for rules. The order these files will be evaluated is undefined - they should not rely on each "
-            "other, or override symbols from each other.",
         )
 
         cache_instructions = (
@@ -935,6 +859,85 @@ class GlobalOptions(Subsystem):
             ),
         )
 
+        register(
+            "--build-patterns",
+            advanced=True,
+            type=list,
+            default=["BUILD", "BUILD.*"],
+            help=(
+                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
+                "the naming scheme, not the directory paths to look for. To add ignore"
+                "patterns, use the option `--build-ignore`."
+            ),
+        )
+        register(
+            "--build-ignore",
+            advanced=True,
+            type=list,
+            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
+            help=(
+                "Paths to ignore when identifying BUILD files. This does not affect any other "
+                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
+                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
+            ),
+        )
+        register(
+            "--build-file-prelude-globs",
+            advanced=True,
+            type=list,
+            default=[],
+            help=(
+                "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
+                "See https://www.pantsbuild.org/docs/macros."
+            ),
+        )
+
+        register(
+            "--tag",
+            type=list,
+            metavar="[+-]tag1,tag2,...",
+            help=(
+                "Include only targets with these tags (optional '+' prefix) or without these "
+                "tags ('-' prefix). See https://www.pantsbuild.org/docs/advanced-target-selection."
+            ),
+        )
+        register(
+            "--exclude-target-regexp",
+            advanced=True,
+            type=list,
+            default=[],
+            metavar="<regexp>",
+            help="Exclude target roots that match these regexes.",
+        )
+        register(
+            "--subproject-roots",
+            type=list,
+            advanced=True,
+            default=[],
+            help="Paths that correspond with build roots for any subproject that this "
+            "project depends on.",
+        )
+
+        register(
+            "--owners-not-found-behavior",
+            advanced=True,
+            type=OwnersNotFoundBehavior,
+            default=OwnersNotFoundBehavior.error,
+            help=(
+                "What to do when file arguments do not have any owning target. This happens when "
+                "there are no targets whose `sources` fields include the file argument."
+            ),
+        )
+        register(
+            "--files-not-found-behavior",
+            advanced=True,
+            type=FileNotFoundBehavior,
+            default=FileNotFoundBehavior.warn,
+            help="What to do when files and globs specified in BUILD files, such as in the "
+            "`sources` field, cannot be found. This happens when the files do not exist on "
+            "your machine or when they are ignored by the `--pants-ignore` option.",
+        )
+
         loop_flag = "--loop"
         register(
             loop_flag, type=bool, help="Run goals continuously as file changes are detected.",
@@ -946,6 +949,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             help=f"The maximum number of times to loop when `{loop_flag}` is specified.",
         )
+
         register(
             "--lock",
             advanced=True,
@@ -954,6 +958,7 @@ class GlobalOptions(Subsystem):
             help="Use a global lock to exclude other versions of Pants from running during "
             "critical operations.",
         )
+
         register(
             "--streaming-workunits-report-interval",
             type=float,

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -14,7 +14,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
 from pants.bin.daemon_pants_runner import DaemonPantsRunner
 from pants.engine.internals.native import Native
-from pants.init.engine_initializer import LegacyGraphScheduler
+from pants.init.engine_initializer import GraphScheduler
 from pants.init.logging import clear_logging_handlers, init_rust_logger, setup_logging_to_file
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.option_value_container import OptionValueContainer
@@ -119,7 +119,7 @@ class PantsDaemon(PantsDaemonProcessManager):
 
     @staticmethod
     def _setup_services(
-        bootstrap_options: OptionValueContainer, legacy_graph_scheduler: LegacyGraphScheduler,
+        bootstrap_options: OptionValueContainer, graph_scheduler: GraphScheduler,
     ):
         """Initialize pantsd services.
 
@@ -132,7 +132,7 @@ class PantsDaemon(PantsDaemonProcessManager):
         )
 
         scheduler_service = SchedulerService(
-            legacy_graph_scheduler=legacy_graph_scheduler,
+            graph_scheduler=graph_scheduler,
             build_root=build_root,
             invalidation_globs=invalidation_globs,
             pidfile=PantsDaemon.metadata_file_path(
@@ -142,7 +142,7 @@ class PantsDaemon(PantsDaemonProcessManager):
             max_memory_usage_in_bytes=bootstrap_options.pantsd_max_memory_usage,
         )
 
-        store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
+        store_gc_service = StoreGCService(graph_scheduler.scheduler)
         return PantsServices(services=(scheduler_service, store_gc_service))
 
     def __init__(

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -9,7 +9,7 @@ import psutil
 
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.internals.scheduler import ExecutionTimeoutError
-from pants.init.engine_initializer import LegacyGraphScheduler
+from pants.init.engine_initializer import GraphScheduler
 from pants.pantsd.service.pants_service import PantsService
 
 
@@ -30,7 +30,7 @@ class SchedulerService(PantsService):
     def __init__(
         self,
         *,
-        legacy_graph_scheduler: LegacyGraphScheduler,
+        graph_scheduler: GraphScheduler,
         build_root: str,
         invalidation_globs: List[str],
         pidfile: str,
@@ -38,7 +38,7 @@ class SchedulerService(PantsService):
         max_memory_usage_in_bytes: int,
     ) -> None:
         """
-        :param legacy_graph_scheduler: The LegacyGraphScheduler instance for graph construction.
+        :param graph_scheduler: The GraphScheduler instance for graph construction.
         :param build_root: The current build root.
         :param invalidation_globs: A list of `globs` that when encountered in filesystem event
                                    subscriptions will tear down the daemon.
@@ -49,10 +49,10 @@ class SchedulerService(PantsService):
                                           shut down if it observes more than this amount in use.
         """
         super().__init__()
-        self._graph_helper = legacy_graph_scheduler
+        self._graph_helper = graph_scheduler
         self._build_root = build_root
 
-        self._scheduler = legacy_graph_scheduler.scheduler
+        self._scheduler = graph_scheduler.scheduler
         # This session is only used for checking whether any invalidation globs have been invalidated.
         # It is not involved with a build itself; just with deciding when we should restart pantsd.
         self._scheduler_session = self._scheduler.new_session(build_id="scheduler_service_session",)

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -318,7 +318,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
         # NB: This uses the long form of initialization because it needs to directly specify
         # `cls.alias_groups` rather than having them be provided by bootstrap options.
-        graph_session = EngineInitializer.setup_legacy_graph_extended(
+        graph_session = EngineInitializer.setup_graph_extended(
             pants_ignore_patterns=[],
             use_gitignore=False,
             local_store_dir=local_store_dir,

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -15,7 +15,7 @@ from pants.base.build_root import BuildRoot
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addresses import Address
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, PathGlobsAndRoot, Snapshot
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot, Snapshot
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.rules import RootRule
 from pants.engine.target import Target
@@ -316,16 +316,12 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         local_execution_root_dir = global_options.local_execution_root_dir
         named_caches_dir = global_options.named_caches_dir
 
-        # NB: This uses the long form of initialization because it needs to directly specify
-        # `cls.alias_groups` rather than having them be provided by bootstrap options.
         graph_session = EngineInitializer.setup_graph_extended(
             pants_ignore_patterns=[],
             use_gitignore=False,
             local_store_dir=local_store_dir,
             local_execution_root_dir=local_execution_root_dir,
             named_caches_dir=named_caches_dir,
-            build_file_prelude_globs=(),
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
             native=init_native(),
             options_bootstrapper=options_bootstrapper,
             build_root=self.build_root,

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -21,7 +21,7 @@ from pants.engine.rules import RootRule
 from pants.engine.target import Target
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.util import clean_global_runtime_state
-from pants.option.global_options import ExecutionOptions
+from pants.option.global_options import ExecutionOptions, FilesNotFoundBehavior
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
 from pants.source import source_root
@@ -319,6 +319,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         graph_session = EngineInitializer.setup_graph_extended(
             pants_ignore_patterns=[],
             use_gitignore=False,
+            files_not_found_behavior=FilesNotFoundBehavior.error,
             local_store_dir=local_store_dir,
             local_execution_root_dir=local_execution_root_dir,
             named_caches_dir=named_caches_dir,

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -11,6 +11,8 @@ from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import WrappedTarget
 from pants.python.python_requirement import PythonRequirement
+from pants.testutil.engine.util import Params
+from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
 
@@ -36,7 +38,11 @@ class PantsRequirementTest(TestBase):
     ) -> None:
         self.add_to_build_file("3rdparty/python", f"{build_file_entry}\n")
         target = self.request_single_product(
-            WrappedTarget, Address("3rdparty/python", target_name=expected_target_name)
+            WrappedTarget,
+            Params(
+                Address("3rdparty/python", target_name=expected_target_name),
+                create_options_bootstrapper(),
+            ),
         ).target
         assert isinstance(target, PythonRequirementLibrary)
         expected = PythonRequirement(

--- a/tests/python/pants_test/backend/python/test_python_requirement_list.py
+++ b/tests/python/pants_test/backend/python/test_python_requirement_list.py
@@ -12,6 +12,8 @@ from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import WrappedTarget
 from pants.python.python_requirement import PythonRequirement
+from pants.testutil.engine.util import Params
+from pants.testutil.option.util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 
 
@@ -29,7 +31,8 @@ class PythonRequirementListTest(TestBase):
     ) -> Tuple[PythonRequirement, ...]:
         self.add_to_build_file("lib", f"{build_file_entry}\n")
         target = self.request_single_product(
-            WrappedTarget, Address("lib", target_name=target_name)
+            WrappedTarget,
+            Params(Address("lib", target_name=target_name), create_options_bootstrapper()),
         ).target
         assert isinstance(target, PythonRequirementLibrary)
         return target[PythonRequirementsField].value


### PR DESCRIPTION
This fixes it so that those two options no longer cause us to need to rebuild a scheduler.

Originally, the change entirely removed the special casing of `AddressMapper` and `GlobMatchErrorBehavior`, but that resulted in graph issues for some reason. https://github.com/pantsbuild/pants/pull/10569#issuecomment-670682604

This also applies some fixes that were meant to be included in https://github.com/pantsbuild/pants/pull/10563. It also renames `LegacyGraph` to `Graph`.