### PR TITLE
Improve error message for invalid addresses

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -66,9 +66,12 @@ async def resolve_address(address_input: AddressInput) -> Address:
     elif is_dir:
         return address_input.dir_to_address()
     else:
+        spec = address_input.path_component
+        if address_input.target_component:
+            spec += f":{address_input.target_component}"
         raise ResolveError(
             f"The file or directory '{address_input.path_component}' does not exist on disk in the "
-            f"workspace: cannot resolve '{address_input.target_component}' relative to it."
+            f"workspace, so the address '{spec}' cannot be resolved."
         )
 
 


### PR DESCRIPTION
This happens when either the directory of an explicit address dep does not exist, or when the path of an explicit file dep does not exist.

Before:

```
ResolveError: The file or directory 'src/python/pants/util/fake.py' does not exist on disk in the workspace: cannot resolve 'None' relative to it.
```

```
ResolveError: The file or directory 'src/python/pants/fake' does not exist on disk in the workspace: cannot resolve 'tgt' relative to it.
```

After:

```
ResolveError: The file or directory 'src/python/pants/util/fake.py' does not exist on disk in the workspace, so the address 'src/python/pants/util/fake.py' cannot be resolved.
```

```
ResolveError: The file or directory 'src/python/pants/fake' does not exist on disk in the workspace, so the address 'src/python/pants/fake:tgt' cannot be resolved.
```

### Other error messages for addresess

File dep belongs to a target that does not actually own that file, e.g. `src/python/pants/util/strutil.py:tests`.

```
ValueError: Target src/python/pants/util:tests's `sources` field does not match a file src/python/pants/util/strutil.py.
```

Target does not exist, e.g. `src/python/pants/util/strutil.py:fake`

```
ResolveError: 'fake' was not found in namespace 'src/python/pants/util'. Did you mean one of:
  :tests
  :util
```

[ci skip-rust]
[ci skip-build-wheels]
