### PR TITLE
Fix file metadata fsync.

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -343,6 +343,8 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     script_path = "./script.sh"
     script_content = dedent(
         """
+        #!/usr/bin/env bash
+
         set -euo pipefail
 
         if command -v which > /dev/null; then
@@ -365,7 +367,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             description=f"Searching for `{request.binary_name}` on PATH={search_path}",
             level=LogLevel.DEBUG,
             input_digest=script_digest,
-            argv=["/bin/bash", script_path, request.binary_name],
+            argv=[script_path, request.binary_name],
             env={"PATH": search_path},
         ),
     )

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-  DirectoryMaterializeMetadata, EntryType, FileContent, LoadMetadata, Store, UploadSummary,
-  MEGABYTES,
+  DirectoryMaterializeMetadata, EntryType, FileContent, FileMaterializeMetadata, LoadMetadata,
+  Store, UploadSummary, MEGABYTES,
 };
 
 use bazel_protos;
@@ -1447,16 +1447,16 @@ async fn materialize_directory_metadata_all_local() {
   let local = LoadMetadata::Local;
 
   let want = DirectoryMaterializeMetadata {
-    metadata: local.clone(),
+    loaded_from: local.clone(),
     child_directories: btreemap! {
       "pets".to_owned() => DirectoryMaterializeMetadata {
-        metadata: local.clone(),
+        loaded_from: local.clone(),
         child_directories: btreemap!{
           "cats".to_owned() => DirectoryMaterializeMetadata {
-            metadata: local.clone(),
+            loaded_from: local.clone(),
             child_directories: btreemap!{},
             child_files: btreemap!{
-              "roland".to_owned() => local.clone(),
+              "roland".to_owned() => FileMaterializeMetadata { loaded_from: local.clone(), is_executable: false },
             },
           }
         },
@@ -1504,10 +1504,13 @@ async fn materialize_directory_metadata_mixed() {
     .child_directories
     .get("pets")
     .unwrap()
-    .metadata
+    .loaded_from
     .is_remote());
   assert_eq!(
-    LoadMetadata::Local,
+    FileMaterializeMetadata {
+      loaded_from: LoadMetadata::Local,
+      is_executable: false
+    },
     *metadata
       .child_directories
       .get("pets")

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -4,7 +4,6 @@ use fs::{self, GlobExpansionConjunction, GlobMatching, PathGlobs, StrictGlobMatc
 use futures::compat::Future01CompatExt;
 use futures::future::{FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
-use lazy_static::lazy_static;
 use log::{debug, info};
 use nails::execution::{ChildOutput, ExitCode};
 use shell_quote::bash;
@@ -12,7 +11,7 @@ use shell_quote::bash;
 use std::collections::{BTreeSet, HashSet};
 use std::ffi::OsStr;
 use std::fs::create_dir_all;
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::ops::Neg;
 use std::os::unix::{
   fs::{symlink, OpenOptionsExt},
@@ -113,83 +112,6 @@ impl CommandRunner {
     .compat()
     .to_boxed()
   }
-}
-
-lazy_static! {
-  static ref IS_LIKELY_IN_DOCKER: bool = is_likely_in_docker().unwrap_or_else(|e| {
-    log::warn!(
-      "Failed to detect whether we are running in docker: {}\n\n\
-               Please file an issue at https://github.com/pantsbuild/pants/issues/new",
-      e
-    );
-    false
-  });
-}
-
-///
-/// Attempts to detect whether we are running inside a docker container.
-///
-/// NB: Do not call this directly: it is stored in the IS_LIKELY_IN_DOCKER lazy_static.
-///
-fn is_likely_in_docker() -> Result<bool, String> {
-  if cfg!(not(target_os = "linux")) {
-    return Ok(false);
-  }
-
-  // Attempt to detect whether we are in docker. See:
-  //   https://stackoverflow.com/questions/20010199/how-to-determine-if-a-process-runs-inside-lxc-docker
-  let cgroups_matches = {
-    BufReader::new(
-      std::fs::File::open("/proc/1/cgroup")
-        .map_err(|e| format!("Failed to inspect `/proc` to detect docker: {}", e))?,
-    )
-    .lines()
-    .filter_map(|line_result| match line_result {
-      Ok(line) if line.contains("docker") || line.contains("lxc") => Some(line),
-      _ => None,
-    })
-    .collect::<Vec<_>>()
-  };
-
-  if cgroups_matches.is_empty() {
-    Ok(false)
-  } else {
-    log::debug!(
-      "Detected potential docker container based on cgroups ({}): will `sync` \
-      before executing processes.",
-      cgroups_matches.join(", ")
-    );
-    Ok(true)
-  }
-}
-
-///
-/// If we are potentially running inside a docker container (TODO: technically only `aufs` is
-/// relevant), `sync` the filesystem. Noop on other platforms.
-///
-/// See https://github.com/moby/moby/issues/9547.
-///
-async fn sync_if_needed() -> Result<(), String> {
-  if !(*IS_LIKELY_IN_DOCKER) {
-    return Ok(());
-  }
-
-  let output = Command::new("/bin/sync")
-    .stdin(Stdio::null())
-    .output()
-    .await
-    .map_err(|e| format!("Failed to spawn `sync` in likely docker container: {}", e))?;
-
-  if !output.status.success() {
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    return Err(format!(
-      "Failed to run `/bin/sync` in likely docker container ({}): stdout: {}, stderr: {}",
-      output.status, stdout, stderr
-    ));
-  }
-
-  Ok(())
 }
 
 pub struct StreamedHermeticCommand {
@@ -507,9 +429,6 @@ pub trait CapturedWorkdir {
     // down the line for streaming process results to console logs, etc. as tracked by:
     //   https://github.com/pantsbuild/pants/issues/6089
     let child_results_result = {
-      // Now that all inputs are on disk, `sync` if this platform requires it.
-      sync_if_needed().await?;
-
       let child_results_future =
         ChildResults::collect_from(self.run_in_workdir(&workdir_path, req.clone(), context)?);
       if let Some(req_timeout) = req.timeout {


### PR DESCRIPTION
Previously our materialize_directory tail end fsync could wipe out file
metadata if the os had already flushed the initial create. Thread
through the full create metadata to allow our tail end fsync to be
faithful.

Fixes #10507

[ci skip-build-wheels]