### PR TITLE
Spawning against materialized binaries works.

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -343,6 +343,8 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     script_path = "./script.sh"
     script_content = dedent(
         """
+        #!/usr/bin/env bash
+
         set -euo pipefail
 
         if command -v which > /dev/null; then
@@ -365,7 +367,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             description=f"Searching for `{request.binary_name}` on PATH={search_path}",
             level=LogLevel.DEBUG,
             input_digest=script_digest,
-            argv=["/bin/bash", script_path, request.binary_name],
+            argv=[script_path, request.binary_name],
             env={"PATH": search_path},
         ),
     )

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -789,6 +789,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,6 +2012,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 bytes = "0.4.5"
+derivative = "2.1.1"
 dirs = "1"
 futures = "0.3"
 glob = "0.2.11"

--- a/src/rust/engine/fs/src/tests.rs
+++ b/src/rust/engine/fs/src/tests.rs
@@ -1,0 +1,18 @@
+use crate::RelativePath;
+
+#[test]
+fn relative_path_ok() {
+  assert_eq!(Some("a"), RelativePath::new("a").unwrap().to_str());
+  assert_eq!(Some("a"), RelativePath::new("./a").unwrap().to_str());
+  assert_eq!(Some("a"), RelativePath::new("b/../a").unwrap().to_str());
+  assert_eq!(
+    Some("a/c"),
+    RelativePath::new("b/../a/././c").unwrap().to_str()
+  );
+}
+
+#[test]
+fn relative_path_err() {
+  assert!(RelativePath::new("../a").is_err());
+  assert!(RelativePath::new("/a").is_err());
+}

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -853,16 +853,22 @@ impl Store {
         .load_file_bytes_with(digest, move |bytes| {
           if destination.exists() {
             std::fs::remove_file(&destination)
-              .map_err(|e| format!("Failed to overwrite {:?}: {:?}", destination, e))?;
+              .map_err(|e| format!("Failed to overwrite {}: {:?}", destination.display(), e))?;
           }
           let mut f = OpenOptions::new()
             .create(true)
             .write(true)
             .mode(if is_executable { 0o755 } else { 0o644 })
             .open(&destination)
-            .map_err(|e| format!("Error opening file {:?} for writing: {:?}", destination, e))?;
+            .map_err(|e| {
+              format!(
+                "Error opening file {} for writing: {:?}",
+                destination.display(),
+                e
+              )
+            })?;
           f.write_all(&bytes)
-            .map_err(|e| format!("Error writing file {:?}: {:?}", destination, e))?;
+            .map_err(|e| format!("Error writing file {}: {:?}", destination.display(), e))?;
           Ok(())
         })
         .await?;

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1007,7 +1007,7 @@ async fn materialize_missing_file() {
   let store_dir = TempDir::new().unwrap();
   let store = new_local_store(store_dir.path());
   store
-    .materialize_file(file.clone(), TestData::roland().digest(), false, true)
+    .materialize_file(file.clone(), TestData::roland().digest(), false)
     .compat()
     .await
     .expect_err("Want unknown digest error");
@@ -1027,7 +1027,7 @@ async fn materialize_file() {
     .await
     .expect("Error saving bytes");
   store
-    .materialize_file(file.clone(), testdata.digest(), false, true)
+    .materialize_file(file.clone(), testdata.digest(), false)
     .compat()
     .await
     .expect("Error materializing file");
@@ -1049,7 +1049,7 @@ async fn materialize_file_executable() {
     .await
     .expect("Error saving bytes");
   store
-    .materialize_file(file.clone(), testdata.digest(), true, true)
+    .materialize_file(file.clone(), testdata.digest(), true)
     .compat()
     .await
     .expect("Error materializing file");

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -182,6 +182,10 @@ impl RelativePath {
   pub fn to_str(&self) -> Option<&str> {
     self.0.to_str()
   }
+
+  pub fn join(&self, other: Self) -> RelativePath {
+    RelativePath(self.0.join(other))
+  }
 }
 
 impl AsRef<Path> for RelativePath {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -459,7 +459,9 @@ pub trait CapturedWorkdir {
       };
       if let Some(exe) = executable_path.to_str() {
         let exe_was_materialized = sandbox.contains(exe);
-        debug!("Obtaining exclusive spawn lock for process with argv {:?} since we materialized its binary {}.", &req.argv, exe);
+        if exe_was_materialized {
+          debug!("Obtaining exclusive spawn lock for process with argv {:?} since we materialized its binary {}.", &req.argv, exe);
+        }
         exe_was_materialized
       } else {
         false

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -191,6 +191,7 @@ impl CapturedWorkdir for CommandRunner {
     workdir_path: &'b Path,
     req: Process,
     context: Context,
+    _exclusive_spawn: bool,
   ) -> Result<BoxStream<'c, Result<ChildOutput, String>>, String> {
     // Separate argument lists, to form distinct EPRs for (1) starting the nailgun server and (2) running the client in it.
     let ParsedJVMCommandLines {

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -181,12 +181,13 @@ impl super::CommandRunner for CommandRunner {
   }
 }
 
+#[async_trait]
 impl CapturedWorkdir for CommandRunner {
   fn named_caches(&self) -> &NamedCaches {
     self.inner.named_caches()
   }
 
-  fn run_in_workdir<'a, 'b, 'c>(
+  async fn run_in_workdir<'a, 'b, 'c>(
     &'a self,
     workdir_path: &'b Path,
     req: Process,

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -90,9 +89,8 @@ fn construct_nailgun_client_request(
 /// If that flag is set, it will connect to a running nailgun server and run the command there.
 /// Otherwise, it will just delegate to the regular local runner.
 ///
-#[derive(Clone)]
 pub struct CommandRunner {
-  inner: Arc<super::local::CommandRunner>,
+  inner: super::local::CommandRunner,
   nailgun_pool: NailgunPool,
   async_semaphore: async_semaphore::AsyncSemaphore,
   metadata: ProcessMetadata,
@@ -108,7 +106,7 @@ impl CommandRunner {
     executor: task_executor::Executor,
   ) -> Self {
     CommandRunner {
-      inner: Arc::new(runner),
+      inner: runner,
       nailgun_pool: NailgunPool::new(),
       async_semaphore: AsyncSemaphore::new(1),
       metadata,

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Process, RelativePath};
+use crate::Process;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
@@ -36,21 +36,4 @@ fn process_equality() {
   // Absence of timeout is included in hash.
   assert!(a != d);
   assert!(hash(&a) != hash(&d));
-}
-
-#[test]
-fn relative_path_ok() {
-  assert_eq!(Some("a"), RelativePath::new("a").unwrap().to_str());
-  assert_eq!(Some("a"), RelativePath::new("./a").unwrap().to_str());
-  assert_eq!(Some("a"), RelativePath::new("b/../a").unwrap().to_str());
-  assert_eq!(
-    Some("a/c"),
-    RelativePath::new("b/../a/././c").unwrap().to_str()
-  );
-}
-
-#[test]
-fn relative_path_err() {
-  assert!(RelativePath::new("../a").is_err());
-  assert!(RelativePath::new("/a").is_err());
 }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 clap = "2"
 dirs = "1"
 env_logger = "0.5.4"
+fs = { path = "../fs" }
 futures = { version = "0.3", features = ["compat"] }
 hashing = { path = "../hashing" }
 log = "0.4"

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,11 +36,10 @@ use std::process::exit;
 use std::time::Duration;
 
 use clap::{value_t, App, AppSettings, Arg};
+use fs::RelativePath;
 use futures::compat::Future01CompatExt;
 use hashing::{Digest, Fingerprint};
-use process_execution::{
-  Context, NamedCaches, Platform, PlatformConstraint, ProcessMetadata, RelativePath,
-};
+use process_execution::{Context, NamedCaches, Platform, PlatformConstraint, ProcessMetadata};
 use store::{BackoffConfig, Store};
 use tokio::runtime::Handle;
 use workunit_store::WorkunitStore;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -25,10 +25,10 @@ use bytes::{self, BufMut};
 use cpython::{PyDict, PyString, Python, PythonObject};
 use fs::{
   self, Dir, DirectoryListing, File, FileContent, GlobExpansionConjunction, GlobMatching, Link,
-  PathGlobs, PathStat, PreparedPathGlobs, StrictGlobMatching, VFS,
+  PathGlobs, PathStat, PreparedPathGlobs, RelativePath, StrictGlobMatching, VFS,
 };
 use process_execution::{
-  self, CacheDest, CacheName, MultiPlatformProcess, PlatformConstraint, Process, RelativePath,
+  self, CacheDest, CacheName, MultiPlatformProcess, PlatformConstraint, Process,
 };
 
 use graph::{Entry, Node, NodeError, NodeVisualizer};


### PR DESCRIPTION
It's generically unsafe to fork+exec against binaries written out in a
multithreaded program when concurrent forks are possible. Even if all
files are opened for writing with O_CLOEXEC (which is the case for
Rust) if thread1 opens a file for writing and then thread2 forks,
thread2 will hold an open file descriptor. If thread2's subsequent exec
is delayed past the fork+exec thread1 does against the file it wrote,
then the thread1 fork+exec'd process will encounter ETXTBSY.

OSX "solves" this by retrying some number of times when it hits ETXTBSY,
but Linux does not attempt this hack. O_CLOFORK has been proposed and
adopted by some unices, but not Linux. As such we need to make some
tradeoff to allow this use case. This change introduces a lock around
process spawns (fork+exec) to prevent interleaved fork / exec whenever
there is a spawn that we know exec's a binary we wrote out.

Fixes #10507
