### PR TITLE
add non-root pantsbuild user to remote execution image

### DIFF
--- a/build-support/docker/tc_remote_execution/Dockerfile
+++ b/build-support/docker/tc_remote_execution/Dockerfile
@@ -62,6 +62,6 @@ RUN adduser \
     --disabled-login \
     --uid 1000 \
     --shell /bin/bash \
-    --gecos 'Pants User' \
-    pants
-USER pants
+    --gecos 'Pants Build User' \
+    pantsbuild
+USER pantsbuild

--- a/build-support/docker/tc_remote_execution/Dockerfile
+++ b/build-support/docker/tc_remote_execution/Dockerfile
@@ -55,3 +55,13 @@ ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_36_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_37_VERSION}/bin:${PATH}"
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_38_VERSION}/bin:${PATH}"
+
+# Add a non-root user and configure image to use that user for running binaries.
+RUN adduser \
+    --disabled-password \
+    --disabled-login \
+    --uid 1000 \
+    --shell /bin/bash \
+    --gecos 'Pants User' \
+    pants
+USER pants


### PR DESCRIPTION
### Problem

The remote execution image used on RBE ran as root. For various reasons (including security), we should run programs in containers using this image as a non-root user.

### Solution

Add a non-root `pantsbuild` user and make the image use it.

### Result

Pants does not run as root in remote execution.
