### PR TITLE
Stop validating that `!` dependency ignores are used

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1055,13 +1055,6 @@ class TestDependencies(TestBase):
         self.add_to_build_file("ignore", "smalltalk(dependencies=['//:dep', '!//:dep'])")
         self.assert_dependencies_resolved(requested_address=Address("ignore"), expected=[])
 
-        # Error on unused ignores.
-        self.add_to_build_file("unused", "smalltalk(dependencies=[':sibling', '!:ignore'])")
-        with pytest.raises(ExecutionError) as exc:
-            self.assert_dependencies_resolved(requested_address=Address("unused"), expected=[])
-        assert "'!unused:ignore'" in str(exc.value)
-        assert "* unused:sibling" in str(exc.value)
-
     def test_explicit_file_dependencies(self) -> None:
         self.create_files("src/smalltalk/util", ["f1.st", "f2.st", "f3.st"])
         self.add_to_build_file("src/smalltalk/util", "smalltalk(sources=['*.st'])")
@@ -1087,16 +1080,6 @@ class TestDependencies(TestBase):
                 Address("src/smalltalk/util", relative_file_path="f2.st", target_name="util"),
             ],
         )
-
-        # Error on unused ignores.
-        self.add_to_build_file(
-            "unused",
-            "smalltalk(dependencies=['src/smalltalk/util/f1.st', '!src/smalltalk/util/f2.st'])",
-        )
-        with pytest.raises(ExecutionError) as exc:
-            self.assert_dependencies_resolved(requested_address=Address("unused"), expected=[])
-            assert "'!src/smalltalk/util/f2.st''" in str(exc.value)
-            assert "* src/smalltalk/util/f1.st" in str(exc.value)
 
     def test_dependency_injection(self) -> None:
         self.add_to_build_file("", "smalltalk(name='target')")


### PR DESCRIPTION
As explained in https://github.com/pantsbuild/pants/pull/10420, it is too confusing to get this right, as we must consider how the ignore is used both for the base target and every generated subtarget.

We could fix the validation by always considering what the generated subtargets would be, but this requires more work than we'd like to do for performance reasons. Likewise, the error message would be confusing to users to explain why it's valid to depend on a sibling target despite not being used.

Instead, users will need to use `./pants dependencies` to confirm things are working like they'd expect, just like they do now with `filedeps` and the `sources` field.

[ci skip-rust]
[ci skip-build-wheels]
