### PR TITLE
Move `--files-not-found-behavior` and BUILD file options out of bootstrap options

### DIFF
--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -147,34 +147,6 @@ class AddressFamily:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class AddressMapper:
-    """Configuration to parse BUILD files matching a filename pattern."""
-
-    parser: Parser
-    prelude_glob_patterns: Tuple[str, ...]
-    build_patterns: Tuple[str, ...]
-    build_ignore_patterns: Tuple[str, ...]
-
-    def __init__(
-        self,
-        parser: Parser,
-        *,
-        prelude_glob_patterns: Optional[Iterable[str]] = None,
-        build_patterns: Optional[Iterable[str]] = None,
-        build_ignore_patterns: Optional[Iterable[str]] = None,
-    ) -> None:
-        self.parser = parser
-        self.prelude_glob_patterns = tuple(prelude_glob_patterns or [])
-        self.build_patterns = tuple(build_patterns or ["BUILD", "BUILD.*"])
-        self.build_ignore_patterns = tuple(build_ignore_patterns or [])
-
-    def __repr__(self):
-        return f"AddressMapper(build_patterns={self.build_patterns})"
-
-
-# TODO(#10569): merge this with AddressMapper.
-@frozen_after_init
-@dataclass(unsafe_hash=True)
 class AddressSpecsFilter:
     """Filters addresses with the `--tags` and `--exclude-target-regexp` options."""
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -823,52 +823,6 @@ class GlobalOptions(Subsystem):
             advanced=True,
         )
 
-        # TODO(#10569): move these out of bootstrap options into normal global options, near the
-        #  --subproject-roots option.
-        register(
-            "--build-patterns",
-            advanced=True,
-            type=list,
-            default=["BUILD", "BUILD.*"],
-            help=(
-                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
-                "the naming scheme, not the directory paths to look for. To add ignore"
-                "patterns, use the option `--build-ignore`."
-            ),
-        )
-        register(
-            "--build-ignore",
-            advanced=True,
-            type=list,
-            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
-            help=(
-                "Paths to ignore when identifying BUILD files. This does not affect any other "
-                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
-                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
-            ),
-        )
-        register(
-            "--build-file-prelude-globs",
-            advanced=True,
-            type=list,
-            default=[],
-            help=(
-                "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
-                "See https://www.pantsbuild.org/docs/macros."
-            ),
-        )
-
-        # TODO(#10569): move this out of bootstrap options into normal global options.
-        register(
-            "--files-not-found-behavior",
-            advanced=True,
-            type=FilesNotFoundBehavior,
-            default=FilesNotFoundBehavior.warn,
-            help="What to do when files and globs specified in BUILD files, such as in the "
-            "`sources` field, cannot be found. This happens when the files do not exist on "
-            "your machine or when they are ignored by the `--pants-ignore` option.",
-        )
-
     @classmethod
     def register_options(cls, register):
         """Register options not tied to any particular task or subsystem."""
@@ -923,6 +877,38 @@ class GlobalOptions(Subsystem):
         )
 
         register(
+            "--build-patterns",
+            advanced=True,
+            type=list,
+            default=["BUILD", "BUILD.*"],
+            help=(
+                "The naming scheme for BUILD files, i.e. where you define targets. This only sets "
+                "the naming scheme, not the directory paths to look for. To add ignore"
+                "patterns, use the option `--build-ignore`."
+            ),
+        )
+        register(
+            "--build-ignore",
+            advanced=True,
+            type=list,
+            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
+            help=(
+                "Paths to ignore when identifying BUILD files. This does not affect any other "
+                "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "
+                "gitignore pattern syntax (https://git-scm.com/docs/gitignore)."
+            ),
+        )
+        register(
+            "--build-file-prelude-globs",
+            advanced=True,
+            type=list,
+            default=[],
+            help=(
+                "Python files to evaluate and whose symbols should be exposed to all BUILD files. "
+                "See https://www.pantsbuild.org/docs/macros."
+            ),
+        )
+        register(
             "--subproject-roots",
             type=list,
             advanced=True,
@@ -931,6 +917,15 @@ class GlobalOptions(Subsystem):
             "project depends on.",
         )
 
+        register(
+            "--files-not-found-behavior",
+            advanced=True,
+            type=FilesNotFoundBehavior,
+            default=FilesNotFoundBehavior.warn,
+            help="What to do when files and globs specified in BUILD files, such as in the "
+            "`sources` field, cannot be found. This happens when the files do not exist on "
+            "your machine or when they are ignored by the `--pants-ignore` option.",
+        )
         register(
             "--owners-not-found-behavior",
             advanced=True,

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -21,7 +21,7 @@ from pants.engine.rules import RootRule
 from pants.engine.target import Target
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.util import clean_global_runtime_state
-from pants.option.global_options import ExecutionOptions, FilesNotFoundBehavior
+from pants.option.global_options import ExecutionOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
 from pants.source import source_root
@@ -319,7 +319,6 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         graph_session = EngineInitializer.setup_graph_extended(
             pants_ignore_patterns=[],
             use_gitignore=False,
-            files_not_found_behavior=FilesNotFoundBehavior.error,
             local_store_dir=local_store_dir,
             local_execution_root_dir=local_execution_root_dir,
             named_caches_dir=named_caches_dir,


### PR DESCRIPTION
This simplifies our code and results in less invalidation of Pantsd.

[ci skip-rust]
[ci skip-build-wheels]