### PR TITLE
Improve test summary output.

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -370,7 +370,11 @@ class Address:
         return f"Address({self.spec})"
 
     def __str__(self) -> str:
-        return self.spec
+        """A useful human-readable representation.
+
+        If this is a base address, it's full spec, if it's a file subtarget, the path to that file.
+        """
+        return self.spec if self.is_base_target else self.filename
 
     def __lt__(self, other):
         return (self.spec_path, (self._relative_file_path or ""), (self._target_name or "")) < (

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -356,7 +356,7 @@ async def run_tests(
         format_str = f"{{addr:80}}.....{{result:>{right_align}}}"
         console.print_stderr(
             format_str.format(
-                addr=result.address.spec, result=color(result.test_result.status.value)
+                addr=str(result.address), result=color(result.test_result.status.value)
             )
         )
 


### PR DESCRIPTION
Previously we used the address spec, which for file
addresses shows, e.g.,
`src/python/pants/base/build_root_test.py:tests.`

With this change we'll show just
`src/python/pants/base/build_root_test.py`

which is more ergonomic for users.

Provides this via Address.__str__, so future code
that needs a useful human-readable Address string
can get one that way.

[ci skip-rust]

[ci skip-build-wheels]
