### PR TITLE
Require `provides` field for a `python_distribution` target

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.codegen.protobuf.protoc import Protoc
-from pants.engine.addresses import Address
-from pants.engine.rules import collect_rules, rule
+from pants.engine.addresses import Address, AddressInput
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -45,8 +45,13 @@ class InjectProtobufDependencies(InjectDependenciesRequest):
 
 
 @rule
-def inject_dependencies(_: InjectProtobufDependencies, protoc: Protoc) -> InjectedDependencies:
-    return InjectedDependencies(Address.parse(addr) for addr in protoc.runtime_targets)
+async def inject_dependencies(
+    _: InjectProtobufDependencies, protoc: Protoc
+) -> InjectedDependencies:
+    addresses = await MultiGet(
+        Get(Address, AddressInput, AddressInput.parse(addr)) for addr in protoc.runtime_targets
+    )
+    return InjectedDependencies(addresses)
 
 
 def rules():

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -24,15 +24,13 @@ class PythonArtifact:
         def has(name):
             value = self._kw.get(name)
             if value is None:
-                raise self.MissingArgument(
-                    "PythonArtifact requires {} to be specified!".format(name)
-                )
+                raise self.MissingArgument(f"PythonArtifact requires {name} to be specified!")
             return value
 
         def misses(name):
             if name in self._kw:
                 raise self.UnsupportedArgument(
-                    "PythonArtifact prohibits {} from being specified".format(name)
+                    f"PythonArtifact prohibits {name} from being specified"
                 )
 
         self._version = has("version")
@@ -50,7 +48,7 @@ class PythonArtifact:
 
     @property
     def requirement(self):
-        return "{}=={}".format(self._name, self._version)
+        return f"{self._name}=={self._version}"
 
     @property
     def setup_py_keywords(self):

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -286,7 +286,7 @@ async def run_setup_pys(
 
     for target_with_origin in targets_with_origins:
         tgt = target_with_origin.target
-        if _is_exported(tgt):
+        if tgt.has_field(PythonProvidesField):
             exported_targets.append(ExportedTarget(tgt))
         elif isinstance(target_with_origin.origin, AddressLiteralSpec):
             explicit_nonexported_targets.append(tgt)
@@ -498,10 +498,6 @@ async def get_sources(request: SetupPySourcesRequest) -> SetupPySources:
     )
 
 
-def _is_exported(target: Target) -> bool:
-    return target.has_field(PythonProvidesField) and target[PythonProvidesField].value is not None
-
-
 @rule(desc="Compute distribution's 3rd party requirements")
 async def get_requirements(
     dep_owner: DependencyOwner, union_membership: UnionMembership
@@ -595,7 +591,9 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
     # ancestors of the given target, i.e., their spec_paths are all prefixes. So sorting by
     # address will effectively sort by closeness of ancestry to the given target.
     exported_ancestor_tgts = sorted(
-        [t for t in ancestor_tgts if _is_exported(t)], key=lambda t: t.address, reverse=True,
+        [t for t in ancestor_tgts if t.has_field(PythonProvidesField)],
+        key=lambda t: t.address,
+        reverse=True,
     )
     exported_ancestor_iter = iter(exported_ancestor_tgts)
     for exported_ancestor in exported_ancestor_iter:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -56,23 +56,6 @@ class PythonInterpreterCompatibility(StringOrStringSequenceField):
         return python_setup.compatibility_or_constraints(self.value)
 
 
-class PythonProvidesField(ScalarField, ProvidesField):
-    """The`setup.py` kwargs for the external artifact built from this target.
-
-    See https://www.pantsbuild.org/docs/python-setup-py-goal.
-    """
-
-    expected_type = PythonArtifact
-    expected_type_description = "setup_py(**kwargs)"
-    value: Optional[PythonArtifact]
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Optional[PythonArtifact], *, address: Address
-    ) -> Optional[PythonArtifact]:
-        return super().compute_value(raw_value, address=address)
-
-
 COMMON_PYTHON_FIELDS = (
     *COMMON_TARGET_FIELDS,
     Dependencies,
@@ -388,8 +371,30 @@ class PythonRequirementsFile(Target):
 # -----------------------------------------------------------------------------------------------
 
 
+class PythonProvidesField(ScalarField, ProvidesField):
+    """The`setup.py` kwargs for the external artifact built from this target.
+
+    See https://www.pantsbuild.org/docs/python-setup-py-goal.
+    """
+
+    expected_type = PythonArtifact
+    expected_type_description = "setup_py(**kwargs)"
+    value: PythonArtifact
+    required = True
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[PythonArtifact], *, address: Address
+    ) -> PythonArtifact:
+        return cast(PythonArtifact, super().compute_value(raw_value, address=address))
+
+
+class PythonDistributionDependencies(Dependencies):
+    required = True
+
+
 class PythonDistribution(Target):
     """A publishable Python distribution."""
 
     alias = "python_distribution"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonProvidesField)
+    core_fields = (*COMMON_TARGET_FIELDS, PythonDistributionDependencies, PythonProvidesField)

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -389,12 +389,8 @@ class PythonProvidesField(ScalarField, ProvidesField):
         return cast(PythonArtifact, super().compute_value(raw_value, address=address))
 
 
-class PythonDistributionDependencies(Dependencies):
-    required = True
-
-
 class PythonDistribution(Target):
     """A publishable Python distribution."""
 
     alias = "python_distribution"
-    core_fields = (*COMMON_TARGET_FIELDS, PythonDistributionDependencies, PythonProvidesField)
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonProvidesField)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1489,12 +1489,15 @@ class InjectDependenciesRequest(ABC):
             inject_for = FortranDependencies
 
         @rule
-        def inject_fortran_dependencies(request: InjectFortranDependencies) -> InjectedDependencies:
-            return InjectedDependencies([Address.parse("//:injected")]
+        async def inject_fortran_dependencies(
+            request: InjectFortranDependencies
+        ) -> InjectedDependencies:
+            address = await Get(Address, AddressInput, AddressInput.parse("//:injected"))
+            return InjectedDependencies([address]]
 
         def rules():
             return [
-                inject_fortran_dependencies,
+                *collect_rules(),
                 UnionRule(InjectDependenciesRequest, InjectFortranDependencies),
             ]
     """

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -7,7 +7,7 @@ from typing import Optional, cast
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.specs import AddressLiteralSpec, AddressSpecs, FilesystemSpecs, Specs
 from pants.base.specs_parser import SpecsParser
-from pants.build_graph.address import AddressInput
+from pants.engine.addresses import AddressInput
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
 from pants.option.options import Options


### PR DESCRIPTION
A `python_distribution` target doesn't make sense without a `provides` field.

This also fixes some uses of the deprecated `Address.parse()` still being used in production.

[ci skip-rust]
[ci skip-build-wheels]
