### PR TITLE
Improve errors for invalid `Get` objects

### DIFF
--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -1,12 +1,77 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import ast
 import re
-from typing import Any
+from typing import Any, Tuple
 
 import pytest
 
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get, GetConstraints, GetParseError, MultiGet
+
+
+def parse_get_types(get: str) -> Tuple[str, str]:
+    get_args = ast.parse(get).body[0].value.args  # type: ignore[attr-defined]
+    return GetConstraints.parse_product_and_subject_types(get_args, source_file_name="test.py")
+
+
+def test_parse_get_types_valid() -> None:
+    assert parse_get_types("Get(P, S, subject)") == ("P", "S")
+    assert parse_get_types("Get(P, S())") == ("P", "S")
+
+
+def assert_parse_get_types_fails(get: str, *, expected_explanation: str) -> None:
+    with pytest.raises(GetParseError) as exc:
+        parse_get_types(get)
+    assert str(exc.value) == f"Invalid Get. {expected_explanation} Failed for {get} in test.py."
+
+
+def test_parse_get_types_wrong_number_args() -> None:
+    assert_parse_get_types_fails(
+        "Get()",
+        expected_explanation="Expected either two or three arguments, but got 0 arguments.",
+    )
+    assert_parse_get_types_fails(
+        "Get(P, S1, S2(), S3.create())",
+        expected_explanation="Expected either two or three arguments, but got 4 arguments.",
+    )
+
+
+def test_parse_get_types_invalid_product() -> None:
+    assert_parse_get_types_fails(
+        "Get(P(), S, subject)",
+        expected_explanation=(
+            "The first argument should be the type of the product, like `Digest` or "
+            "`ProcessResult`."
+        ),
+    )
+
+
+def test_parse_get_types_invalid_subject() -> None:
+    assert_parse_get_types_fails(
+        "Get(P, S)",
+        expected_explanation=(
+            "Because you are using the shorthand form Get(ProductType, SubjectType(constructor "
+            "args), the second argument should be a constructor call, like `MergeDigest(...)` or "
+            "`Process(...)`."
+        ),
+    )
+    assert_parse_get_types_fails(
+        "Get(P, Subject.create())",
+        expected_explanation=(
+            "Because you are using the shorthand form Get(ProductType, SubjectType(constructor "
+            "args), the second argument should be a top-level constructor function call, like "
+            "`MergeDigest(...)` or `Process(...)`, rather than a method call."
+        ),
+    )
+    assert_parse_get_types_fails(
+        "Get(P, Subject(), subject)",
+        expected_explanation=(
+            "Because you are using the longhand form Get(ProductType, SubjectType, "
+            "subject_instance), the second argument should be a type, like `MergeDigests` or "
+            "`Process`."
+        ),
+    )
 
 
 class AClass:
@@ -18,19 +83,19 @@ class BClass:
         return type(self) == type(other)
 
 
-def test_create() -> None:
+def test_create_get() -> None:
     get = Get(AClass, BClass, 42)
     assert get.product_type is AClass
     assert get.subject_declared_type is BClass
     assert get.subject == 42
 
 
-def test_create_abbreviated() -> None:
+def test_create_get_abbreviated() -> None:
     # Test the equivalence of the 1-arg and 2-arg versions.
     assert Get(AClass, BClass()) == Get(AClass, BClass, BClass())
 
 
-def test_invalid_abbreviated() -> None:
+def test_invalid_get_abbreviated() -> None:
     with pytest.raises(
         expected_exception=TypeError,
         match=re.escape(f"The subject argument cannot be a type, given {BClass}."),
@@ -38,7 +103,7 @@ def test_invalid_abbreviated() -> None:
         Get(AClass, BClass)
 
 
-def test_invalid_subject() -> None:
+def test_invalid_get_subject() -> None:
     with pytest.raises(
         expected_exception=TypeError,
         match=re.escape(f"The subject argument cannot be a type, given {BClass}."),
@@ -46,7 +111,7 @@ def test_invalid_subject() -> None:
         Get(AClass, BClass, BClass)
 
 
-def test_invalid_subject_declared_type() -> None:
+def test_invalid_get_subject_declared_type() -> None:
     with pytest.raises(
         expected_exception=TypeError,
         match=re.escape(
@@ -56,7 +121,7 @@ def test_invalid_subject_declared_type() -> None:
         Get(AClass, 1, BClass)  # type: ignore[call-overload]
 
 
-def test_invalid_product_type() -> None:
+def test_invalid_get_product_type() -> None:
     with pytest.raises(
         expected_exception=TypeError,
         match=re.escape(f"The product type argument must be a type, given {1} of type {type(1)}."),


### PR DESCRIPTION
There are two times an invalid `Get` can trigger errors: a) when parsing the AST in `rules.py`, or b) when Python creates the actual `Get` object, i.e. calling `Get.__init__()`. Typically, the former happens first, which was resulting in very confusing error messages, like this for the invalid line `await Get(str, AddressInput.parse(""))`:

```
▶ ./pants
'Attribute' object has no attribute 'id'
```

### After
Invalid # of args:

> Invalid Get. Expected either two or three arguments, but got 4 arguments. Failed for Get(Address, AddressInput, AddressInput.parse(), <class '_ast.Num'>) in /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/graph.py.

Invalid product:

> Invalid Get. The first argument should be the type of the product, like `Digest` or `ProcessResult`. Failed for Get(Address(), AddressInput, AddressInput.parse()) in /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/graph.py.

Invalid subject:

> Invalid Get. Because you are using the longhand form Get(ProductType, SubjectType, subject_instance), the second argument should be a type, like `MergeDigests` or `Process`. Failed for Get(Address, AddressInput(), AddressInput.parse()) in /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/graph.py.

> Invalid Get. Because you are using the shorthand form Get(ProductType, SubjectType(constructor args), the second argument should be a constructor call, like `MergeDigest(...)` or `Process(...)`. Failed for Get(Address, AddressInput) in /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/graph.py.

> Invalid Get. Because you are using the shorthand form Get(ProductType, SubjectType(constructor args), the second argument should be a top-level constructor function call, like `MergeDigest(...)` or `Process(...)`, rather than a method call. Failed for Get(Address, AddressInput.parse()) in /Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/graph.py.


[ci skip-rust]
[ci skip-build-wheels]
