### PR TITLE
remoting: limit retries for execution requests

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "concrete_time 0.0.1",
  "derivative 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "double-checked-cell-async 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "nails 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1972,7 +1972,6 @@ dependencies = [
  "concrete_time 0.0.1",
  "derivative 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "double-checked-cell-async 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -42,6 +42,7 @@ itertools = "0.8.0"
 serde = "1.0.104"
 bincode = "1.2.1"
 double-checked-cell-async = "2.0"
+rand = "0.6"
 
 [dev-dependencies]
 maplit = "1.0.1"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+env_logger = "0.5"
 async-trait = "0.1"
 walkdir = "2"
 async_semaphore = { path = "../async_semaphore" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,7 +6,6 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-env_logger = "0.5"
 async-trait = "0.1"
 walkdir = "2"
 async_semaphore = { path = "../async_semaphore" }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -618,14 +618,9 @@ impl CommandRunner {
     loop {
       // If we are currently retrying a request, then add an exponential backoff.
       if num_retries_since_last_success > 0 {
-        let slot_time = Duration::from_millis(100);
         let multiplier = thread_rng().gen_range(0, 2_u32.pow(num_retries_since_last_success) + 1);
-        let sleep_time = slot_time * multiplier;
+        let sleep_time = self.retry_interval_duration * multiplier;
         trace!("retry sleep: {:?}", sleep_time);
-        trace!(
-          "num_retries_since_last_success: {:?}",
-          num_retries_since_last_success
-        );
         tokio::time::delay_for(sleep_time).await;
       }
 
@@ -722,12 +717,9 @@ impl CommandRunner {
             // of retries allowed since the last successful connection. (There is no point in
             // continually submitting a request if ultimately futile.)
             trace!("retryable error: {}", e);
-            trace!("{} > {}", num_retries_since_last_success, MAX_RETRIES);
             if num_retries_since_last_success >= MAX_RETRIES {
-              trace!("too many retries");
               return Err(format!("Too many failures from server, last error: {}", e));
             } else {
-              trace!("keep on trying");
               // Increment the retry counter and allow loop to retry.
               num_retries_since_last_success += 1;
             }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -686,7 +686,7 @@ impl CommandRunner {
               // continually submitting a request if ultimately futile.)
               if num_retries >= MAX_RETRIES {
                 return Err(
-                  "Too many failures from server, last error was stream close".to_owned(),
+                  "Too many failures from server. The last event was the server disconnecting with no error given.".to_owned(),
                 );
               } else {
                 // Increment the retry counter and allow loop to retry.

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -721,7 +721,7 @@ impl CommandRunner {
             // continually submitting a request if ultimately futile.)
             trace!("retryable error: {}", e);
             if num_retries >= MAX_RETRIES {
-              return Err(format!("Too many failures from server, last error: {}", e));
+              return Err(format!("Too many failures from server. The last error was: {}", e));
             } else {
               // Increment the retry counter and allow loop to retry.
               num_retries += 1;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -25,6 +25,7 @@ use futures01::Future as Future01;
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn, Level};
 use protobuf::{self, Message, ProtobufEnum};
+use rand::{thread_rng, Rng};
 use store::{Snapshot, SnapshotOps, Store, StoreFileByDigest};
 use workunit_store::{with_workunit, SpanId, WorkunitMetadata, WorkunitStore};
 
@@ -83,6 +84,7 @@ pub struct CommandRunner {
   execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
   action_cache_client: Arc<bazel_protos::remote_execution_grpc::ActionCacheClient>,
   overall_deadline: Duration,
+  retry_interval_duration: Duration,
   capabilities_cell: Arc<DoubleCheckedCell<bazel_protos::remote_execution::ServerCapabilities>>,
   capabilities_client: Arc<bazel_protos::remote_execution_grpc::CapabilitiesClient>,
 }
@@ -104,6 +106,7 @@ impl CommandRunner {
     store: Store,
     platform: Platform,
     overall_deadline: Duration,
+    retry_interval_duration: Duration,
   ) -> Result<Self, String> {
     let env = Arc::new(grpcio::EnvBuilder::new().build());
     let channel = {
@@ -163,6 +166,7 @@ impl CommandRunner {
       store,
       platform,
       overall_deadline,
+      retry_interval_duration,
       capabilities_cell: Arc::new(DoubleCheckedCell::new()),
       capabilities_client,
     };
@@ -606,10 +610,21 @@ impl CommandRunner {
     process: Process,
     context: &Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
+    const MAX_RETRIES: u32 = 5;
     let start_time = Instant::now();
     let mut current_operation_name: Option<String> = None;
+    let mut num_retries_since_last_success = 0;
 
     loop {
+      // If we are currently retrying a request, then add an exponential backoff.
+      if num_retries_since_last_success > 0 {
+        let slot_time = Duration::from_millis(100);
+        let multiplier = thread_rng().gen_range(0, 2u32.pow(num_retries_since_last_success) + 1);
+        let sleep_time = slot_time * multiplier;
+        trace!("retry sleep: {:?}", sleep_time);
+        tokio::time::delay_for(sleep_time).await;
+      }
+
       let call_opt = call_option(&self.headers, Some(context.build_id.clone()))?;
       let rpc_result = match current_operation_name {
         None => {
@@ -663,6 +678,20 @@ impl CommandRunner {
             }
             StreamOutcome::StreamClosed(operation_name_opt) => {
               trace!("wait_on_operation_stream (build_id={}) returned stream close, will retry operation_name={:?}", context.build_id, operation_name_opt);
+
+              // Check if the number of request attempts sent thus far have exceeded the number
+              // of retries allowed since the last successful connection. (There is no point in
+              // continually submitting a request if ultimately futile.)
+              if num_retries_since_last_success > MAX_RETRIES {
+                return Err(format!(
+                  "Too many failures from server, last error was stream close"
+                ));
+              } else {
+                // Increment the retry counter and allow loop to retry.
+                num_retries_since_last_success += 1;
+              }
+
+              // Iterate the loop to reconnect to the operation.
               current_operation_name = operation_name_opt;
               continue;
             }
@@ -685,8 +714,16 @@ impl CommandRunner {
         Err(err) => match err {
           ExecutionError::Fatal(e) => return Err(e),
           ExecutionError::Retryable(e) => {
-            // do nothing, will retry
+            // Check if the number of request attempts sent thus far have exceeded the number
+            // of retries allowed since the last successful connection. (There is no point in
+            // continually submitting a request if ultimately futile.)
             trace!("retryable error: {}", e);
+            if num_retries_since_last_success > MAX_RETRIES {
+              return Err(format!("Too many failures from server, last error: {}", e));
+            } else {
+              // Increment the retry counter and allow loop to retry.
+              num_retries_since_last_success += 1;
+            }
           }
           ExecutionError::MissingDigests(missing_digests) => {
             trace!(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -721,7 +721,10 @@ impl CommandRunner {
             // continually submitting a request if ultimately futile.)
             trace!("retryable error: {}", e);
             if num_retries >= MAX_RETRIES {
-              return Err(format!("Too many failures from server. The last error was: {}", e));
+              return Err(format!(
+                "Too many failures from server. The last error was: {}",
+                e
+              ));
             } else {
               // Increment the retry counter and allow loop to retry.
               num_retries += 1;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -619,7 +619,7 @@ impl CommandRunner {
       // If we are currently retrying a request, then add an exponential backoff.
       if num_retries_since_last_success > 0 {
         let slot_time = Duration::from_millis(100);
-        let multiplier = thread_rng().gen_range(0, 2u32.pow(num_retries_since_last_success) + 1);
+        let multiplier = thread_rng().gen_range(0, 2_u32.pow(num_retries_since_last_success) + 1);
         let sleep_time = slot_time * multiplier;
         trace!("retry sleep: {:?}", sleep_time);
         trace!(
@@ -687,9 +687,9 @@ impl CommandRunner {
               // of retries allowed since the last successful connection. (There is no point in
               // continually submitting a request if ultimately futile.)
               if num_retries_since_last_success >= MAX_RETRIES {
-                return Err(format!(
-                  "Too many failures from server, last error was stream close"
-                ));
+                return Err(
+                  "Too many failures from server, last error was stream close".to_owned(),
+                );
               } else {
                 // Increment the retry counter and allow loop to retry.
                 num_retries_since_last_success += 1;

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
-const RETRY_INTERVAL: Duration = Duration::from_micros(100);
+const RETRY_INTERVAL: Duration = Duration::from_micros(0);
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct RemoteTestResult {
@@ -1343,8 +1343,6 @@ async fn initial_response_missing_response_and_error() {
 
 #[tokio::test]
 async fn fails_after_retry_limit_exceeded() {
-  env_logger::init();
-
   let workunit_store = WorkunitStore::new(false);
   workunit_store.init_thread_state(None);
 
@@ -1404,6 +1402,71 @@ async fn fails_after_retry_limit_exceeded() {
   assert_eq!(
     result,
     "Too many failures from server, last error: the bot running the task appears to be lost"
+  );
+}
+
+#[tokio::test]
+async fn fails_after_retry_limit_exceeded_with_stream_close() {
+  let workunit_store = WorkunitStore::new(false);
+  workunit_store.init_thread_state(None);
+
+  let execute_request = echo_foo_request();
+
+  let mock_server = {
+    let op_name = "foo-bar".to_owned();
+    let (action, _, execute_request) = crate::remote::make_execute_request(
+      &execute_request.clone().try_into().unwrap(),
+      empty_request_metadata(),
+    )
+    .unwrap();
+
+    let action_digest = digest(&action).unwrap();
+
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![
+        ExpectedAPICall::GetActionResult {
+          action_digest,
+          response: Err(grpcio::RpcStatus::new(
+            grpcio::RpcStatusCode::NOT_FOUND,
+            None,
+          )),
+        },
+        ExpectedAPICall::Execute {
+          execute_request: execute_request.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+        ExpectedAPICall::WaitExecution {
+          operation_name: op_name.clone(),
+          stream_responses: Ok(vec![make_incomplete_operation(&op_name)]),
+        },
+      ]),
+      None,
+    )
+  };
+
+  let result = run_command_remote(mock_server.address(), execute_request)
+    .await
+    .expect_err("Expected error");
+
+  assert_eq!(
+    result,
+    "Too many failures from server, last error was stream close"
   );
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1401,7 +1401,7 @@ async fn fails_after_retry_limit_exceeded() {
 
   assert_eq!(
     result,
-    "Too many failures from server, last error: the bot running the task appears to be lost"
+    "Too many failures from server. The last error was: the bot running the task appears to be lost"
   );
 }
 
@@ -1466,7 +1466,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
 
   assert_eq!(
     result,
-    "Too many failures from server, last error was stream close"
+    "Too many failures from server. The last event was the server disconnecting with no error given."
   );
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 const OVERALL_DEADLINE_SECS: Duration = Duration::from_secs(10 * 60);
+const RETRY_INTERVAL: Duration = Duration::from_micros(100);
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct RemoteTestResult {
@@ -947,6 +948,7 @@ async fn sends_headers() {
     store,
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
+    RETRY_INTERVAL,
   )
   .unwrap();
   let context = Context {
@@ -1152,6 +1154,7 @@ async fn ensure_inline_stdio_is_stored() {
     store.clone(),
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
+    RETRY_INTERVAL,
   )
   .unwrap();
 
@@ -1435,6 +1438,7 @@ async fn execute_missing_file_uploads_if_known() {
     store.clone(),
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
+    RETRY_INTERVAL,
   )
   .unwrap();
 
@@ -1511,6 +1515,7 @@ async fn execute_missing_file_errors_if_unknown() {
     store,
     Platform::Linux,
     OVERALL_DEADLINE_SECS,
+    RETRY_INTERVAL,
   )
   .unwrap();
 
@@ -2205,6 +2210,7 @@ fn create_command_runner(
     store.clone(),
     platform,
     OVERALL_DEADLINE_SECS,
+    RETRY_INTERVAL,
   )
   .expect("Failed to make command runner");
   (command_runner, store)

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -400,6 +400,7 @@ async fn main() {
             store.clone(),
             Platform::Linux,
             Duration::from_secs(overall_deadline_secs),
+            Duration::from_millis(100),
           )
           .expect("Failed to make command runner"),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -208,6 +208,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             remoting_opts.execution_overall_deadline,
+            Duration::from_millis(100),
           )?)
         };
 


### PR DESCRIPTION
### Problem

The original "polling" remote execution client would fail a request if it was retried too many times. I naively removed that in the current "streaming" client in lieu of relying on the deadline timeout. In practice, the client will just continually send retries to the server for the entire length of the deadline timeout without any backoff and without giving up when futile. For example, if too many "unavailable" errors are returned from the server in a short period of time, the client should just give up.

### Solution

Add a maximum retries check and exponential backoff to `run_execute_request`.

### Result

New tests pass.
