### PR TITLE
Ensure MyPy always runs with at least Python 3.6.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -74,6 +74,10 @@ config = [".isort.cfg", "examples/.isort.cfg"]
 [mypy]
 config = "build-support/mypy/mypy.ini"
 
+# TODO(John Sirois): Remove once proper interpreter selection is performed automatically as part of
+#  https://github.com/pantsbuild/pants/issues/10131
+interpreter_constraints=["CPython>=3.6"]
+
 [pants-releases]
 branch_notes = """
 {


### PR DESCRIPTION
MyPy only requires Python 3.5 but we have lots of code that uses Python 3.6
features which will not parse under Python 3.5. As such bump the default
interpreter constraints to be compatible with both MyPy and our codebase.

This will be fixed correctly as part of #10131.

[ci skip-rust]
[ci skip-build-wheels]
