### PR TITLE
Change `conftest.py` to default to `python_library` rather than `python_tests`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -159,14 +159,16 @@ class PythonDependencyInferenceTest(TestBase):
         )
 
         self.create_file("src/python/root/conftest.py")
-        self.add_to_build_file("src/python/root", "python_library(sources=['conftest.py'])")
+        self.add_to_build_file("src/python/root", "python_library()")
 
         self.create_file("src/python/root/mid/conftest.py")
-        self.add_to_build_file("src/python/root/mid", "python_library(sources=['conftest.py'])")
+        self.add_to_build_file("src/python/root/mid", "python_library()")
 
         self.create_file("src/python/root/mid/leaf/conftest.py")
         self.create_file("src/python/root/mid/leaf/this_is_a_test.py")
-        self.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
+        self.add_to_build_file(
+            "src/python/root/mid/leaf", "python_tests()\npython_library(name='conftest')"
+        )
 
         def run_dep_inference(address: Address) -> InferredDependencies:
             target = self.request_single_product(
@@ -181,6 +183,11 @@ class PythonDependencyInferenceTest(TestBase):
             [
                 Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
                 Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),
+                Address(
+                    "src/python/root/mid/leaf",
+                    relative_file_path="conftest.py",
+                    target_name="conftest",
+                ),
             ],
             sibling_dependencies_inferrable=False,
         )

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -369,10 +369,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             relpath=PurePath(self.source_root, self.conftest_source.path).as_posix(),
             contents=self.conftest_source.content.decode(),
         )
-
-        self.create_file(
-            relpath=PurePath(self.source_root, "BUILD").as_posix(), contents="python_tests()",
-        )
+        self.add_to_build_file(self.source_root, "python_library()")
 
         result = self.run_pytest(passthrough_args="-s")
         assert result.status == Status.SUCCESS

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -281,6 +281,9 @@ class PythonTests(Target):
 
     These may be written in either Pytest-style or unittest style.
 
+    All test util code, including `conftest.py`, should go into a dedicated `python_library()`
+    target and then be included in the `dependencies` field.
+
     See https://www.pantsbuild.org/docs/python-test-goal.
     """
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -240,7 +240,7 @@ class PythonBinary(Target):
 
 
 class PythonTestsSources(PythonSources):
-    default = ("test_*.py", "*_test.py", "tests.py", "conftest.py")
+    default = ("test_*.py", "*_test.py", "tests.py")
 
 
 class PythonTestsTimeout(IntField):


### PR DESCRIPTION
### Problem

`conftest.py` is (typically) a util file with no tests in it. Now that we always run tests one-file-at-a-time thanks to generated subtargets, this causes Pytest to try to run on `conftest.py`, which fails because there are no tests.

More philosophically, test util code has always meant to go into `python_library`, rather than `python_tests`. A target is "metadata for some files" - it doesn't make sense to say something like `timeout=120` on `conftest.py`.

### Solution

Change default source globs so that `conftest.py` will show up in `python_library()` now.

### Result

Pytest no longer will error if you have a `conftest.py` and were using default source globs.

If you already had a `python_library()` target in the directory where the `conftest.py` was defined—and you have `--python-infer-conftests` enabled (the default)—then you will not need to make any changes for this to work.

If you only had a `python_tests()` target—and you have `--python-infer-conftests`—you simply need to add `python_library(name='conftest')` to your BUILD file.

If you only had a `python_tests` target—and do not have `--python-infer-conftests`—you will need to add `python_library(name='conftest')` and also update your `python_tests()` to explicitly depend on that new target.

For new users, their BUILD file will now look something like this in a folder that solely has tests + `conftest.py`:

```
python_tests()

python_library(name="conftest")
```

[ci skip-rust]
[ci skip-build-wheels]