### PR TITLE
add --pex-verbosity option independent of log level

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -44,7 +44,6 @@ from pants.engine.rules import Get, RootRule, collect_rules, rule
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
 from pants.util.frozendict import FrozenDict
-from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize
 
@@ -382,13 +381,9 @@ async def create_pex(
     )
 
     if verbosity > 0:
-        lines = result.stderr.decode().splitlines()
-
-        if lines:
-            log_level = LogLevel.DEBUG if verbosity <= 3 else LogLevel.TRACE
-            log_level.log(logger, f"Verbose output from Pex for: {process}")
-            for line in lines:
-                log_level.log(logger, line)
+        log_output = result.stderr.decode()
+        if log_output:
+            logger.info("%s", log_output)
 
     return Pex(digest=result.output_digest, output_filename=request.output_filename)
 

--- a/src/python/pants/backend/python/rules/pex_environment.py
+++ b/src/python/pants/backend/python/rules/pex_environment.py
@@ -3,7 +3,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import Iterable, Mapping, Optional, Tuple, cast
 
 from pants.backend.python.subsystems import subprocess_environment
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
@@ -55,6 +55,18 @@ class PexRuntimeEnvironment(Subsystem):
                 "`[python-setup]` to influence where interpreters are searched for."
             ),
         )
+        register(
+            "--verbosity",
+            advanced=True,
+            type=int,
+            default=0,
+            help=(
+                "Set the verbosity level of PEX debug logging. "
+                "The higher the number, the more logging, with 0 being disabled, 3 being "
+                "equivalent to debug-devel logging, and 9 being equivalent to "
+                "trace-level logging."
+            ),
+        )
 
     @memoized_property
     def path(self) -> Tuple[str, ...]:
@@ -73,6 +85,13 @@ class PexRuntimeEnvironment(Subsystem):
     @property
     def bootstrap_interpreter_names(self) -> Tuple[str, ...]:
         return tuple(self.options.bootstrap_interpreter_names)
+
+    @property
+    def verbosity(self) -> int:
+        level = cast(int, self.options.verbosity)
+        if level < 0 or level > 9:
+            raise ValueError("verbosity level must be between 0 and 9")
+        return level
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/rules/pex_environment.py
+++ b/src/python/pants/backend/python/rules/pex_environment.py
@@ -60,12 +60,7 @@ class PexRuntimeEnvironment(Subsystem):
             advanced=True,
             type=int,
             default=0,
-            help=(
-                "Set the verbosity level of PEX debug logging. "
-                "The higher the number, the more logging, with 0 being disabled, 3 being "
-                "equivalent to debug-devel logging, and 9 being equivalent to "
-                "trace-level logging."
-            ),
+            help="Set the verbosity level of PEX logging, from 0 (no logging) up to 9 (max logging).",
         )
 
     @memoized_property


### PR DESCRIPTION
### Problem

Pants currently sets the `pex` verbosity level based on Pants' own log level. This results in a voluminous amount of logging in `-ldebug` and `-ltrace` modes that tends to subsume Pants' own log output in those modes.

Moreover and relevant to debugging remote execution, it changes the underlying remote execution requests (and thus their digests) used to create pexs because of the additional `-v` options in the arguments of the remote execution requests. Thus, trying to debug caching of remote execution requests in a subsequent run by enabling `-ldebug` actual changes the requests being debugged and varies their digests.

### Solution

Add a `--pex-verbosity` option that controls the logging of `pex` requests. The default is 0 which means no `-v` options are passed to `pex`.

### Result

Tests pass. Manual testing shows that `-ldebug` without also specifying `--pex-verbosity` results in just Pants debug output and not `pex` output, as expected.