### PR TITLE
Add XML test results as artifacts on the test goal workunit

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -85,6 +85,11 @@ class TestResult(EngineAware):
             address_ref=address_ref,
         )
 
+    def artifacts(self) -> Optional[Dict[str, Digest]]:
+        if not self.xml_results:
+            return None
+        return {"xml_results_digest": self.xml_results}
+
     def level(self):
         if self.status == Status.FAILURE:
             return LogLevel.ERROR


### PR DESCRIPTION
### Problem

Streaming work unit handlers only get stdout/stderr from process executions.
We want to make more rich data available to those plugins.

### Solution

return the JUnit XML digest, if available, from the artifacts method