### PR TITLE
Fix binary running to correctly work with source roots.

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -186,7 +186,6 @@ class PexPlatforms(DeduplicatedCollection[str]):
 
     @classmethod
     def create_from_platforms_field(cls, field: PythonPlatformsField) -> "PexPlatforms":
-        # TODO(#9562): wire to `--python-setup-platforms` once we know when/where it should be used.
         return cls(field.value or ())
 
     def generate_pex_arg_list(self) -> List[str]:

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -306,8 +306,7 @@ async def create_pex(
     platform: Platform,
     log_level: LogLevel,
 ) -> Pex:
-    """Returns a PEX with the given requirements, optional entry point, optional interpreter
-    constraints, and optional requirement constraints."""
+    """Returns a PEX with the given settings."""
 
     argv = [
         "--output-file",

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from typing import Tuple
 
 from pants.backend.python.rules.pex import Pex, PexRequest, PexRequirements

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -60,7 +60,6 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
         PythonSourceFiles, PythonSourceFilesRequest(repl.targets, include_files=True)
     )
 
-    req_pex_path = repl.in_chroot(requirements_pex_request.output_filename)
     ipython_request = Get(
         Pex,
         PexRequest(
@@ -68,7 +67,6 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
             entry_point=ipython.entry_point,
             requirements=PexRequirements(ipython.all_requirements),
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
-            additional_args=("--pex-path", req_pex_path),
         ),
     )
 
@@ -88,7 +86,10 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
     return ReplRequest(
         digest=merged_digest,
         args=args,
-        env={"PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)},
+        env={
+            "PEX_PATH": repl.in_chroot(requirements_pex_request.output_filename),
+            "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
+        },
     )
 
 

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -66,7 +66,7 @@ async def create_python_binary_run_request(
         Pex,
         PexRequest(
             output_filename=output_filename,
-            additional_args=(*field_set.generate_additional_args(python_binary_defaults),),
+            additional_args=field_set.generate_additional_args(python_binary_defaults),
         ),
     )
 

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -48,7 +48,7 @@ async def create_python_binary_run_request(
     transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
 
     # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
-    # so that we can get the interpreter constraints for use in ipython_request.
+    # so that we can get the interpreter constraints for use in runner_pex_request.
     requirements_pex_request = await Get(
         PexRequest,
         PexFromTargetsRequest,
@@ -66,6 +66,7 @@ async def create_python_binary_run_request(
         Pex,
         PexRequest(
             output_filename=output_filename,
+            interpreter_constraints=requirements_pex_request.interpreter_constraints,
             additional_args=field_set.generate_additional_args(python_binary_defaults),
         ),
     )

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from pants.backend.python.rules.create_python_binary import PythonBinaryFieldSet
 from pants.backend.python.rules.pex import Pex, PexPlatforms
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
@@ -64,11 +66,11 @@ async def create_python_binary_run_request(
     merged_digest = await Get(
         Digest, MergeDigests([pex.digest, sources.source_files.snapshot.digest])
     )
+    chrooted_source_roots = [os.path.join("{chroot}", sr) for sr in sources.source_roots]
     return RunRequest(
         digest=merged_digest,
-        binary_name=pex.output_filename,
-        prefix_args=("-m", entry_point),
-        env={"PEX_EXTRA_SYS_PATH": ":".join(sources.source_roots)},
+        args=(os.path.join("{chroot}", pex.output_filename), "-m", entry_point),
+        env={"PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)},
     )
 
 

--- a/src/python/pants/core/goals/BUILD
+++ b/src/python/pants/core/goals/BUILD
@@ -15,12 +15,6 @@ python_integration_tests(
     'examples/src/python/example:hello_directory',
     '//:isort_cfg',
     'examples:isort_cfg',
-    ':pydevd'
   ],
   timeout=240,
-)
-
-python_requirement_library(
-  name='pydevd',
-  requirements=[python_requirement('pydevd-pycharm')]
 )

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -12,7 +12,6 @@ from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
 from pants.engine.unions import union
 
-# TODO(#6004): use proper Logging singleton, rather than static logger.
 logger = logging.getLogger(__name__)
 
 

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from typing import cast
 
 from pants.base.build_root import BuildRoot
@@ -35,7 +36,7 @@ class RunTest(TestBase):
                 [FileContent(path="program.py", content=program_text, is_executable=True)]
             ),
         )
-        return RunRequest(digest=digest, binary_name="program.py")
+        return RunRequest(digest=digest, args=(os.path.join("{chroot}", "program.py"),))
 
     def single_target_run(
         self, *, console: MockConsole, program_text: bytes, address_spec: str,


### PR DESCRIPTION
When setting the PEX_EXTRA_SYS_PATH env var, we failed to take the
chroot into account. Now we do.

Unfortunately there was no easy way to plumb the chroot through to 
the implementation (as we do for repl), so instead we allow it to be
injected via string formatting. Since "value".format(chroot='path') is
a no-op if the value doesn't contain "{chroot}", this is robust.

For uniformity, we use the same mechanism to add the chroot to the
binary path, and to any other args (e.g., in the future we might want
to reference a file in the args).

Also improves the implementation of python running: 
- Reuses the standard requirements.pex, so we don't have
  to re-resolve just to create the runnable pex. The runner
  pex uses PEX_PATH to bring in the requirements pex.
- Ignores the binary's platform  settings, since `run` is
  always local, so platforms aren't relevant.

[ci skip-rust]

[ci skip-build-wheels]
