### PR TITLE
Make zip_safe default to False.

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -165,10 +165,13 @@ class PexZipSafe(BoolField):
     """Whether or not this binary is safe to run in compacted (zip-file) form.
 
     If they are not zip safe, they will be written to disk prior to execution.
+
+    We default to False, because there are various gotchas with zipped pexes. Notably,
+    PEP420 implicit namespace packages don't appear to work in that environment.
     """
 
     alias = "zip_safe"
-    default = True
+    default = False
     value: bool
 
 

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -55,5 +55,6 @@ python_binary(
   # dependency on setuptools (for namespace package support).
   emit_warnings=False,
   # To allow for loading `native_engine.so` when built as a pex, we set zip_safe=False.
+  # This is the default, but we set it here explicitly, for emphasis.
   zip_safe=False,
 )


### PR DESCRIPTION
There are too many gotchas for it to be on by default.
Notably, PEP420 doesn't appear to work properly in a
zipped pex. We can document that you may try to turn it
on for a first-time binary startup performance boost.

[ci skip-rust]

[ci skip-build-wheels]
