### PR TITLE
Add `--python-infer-string-imports`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -49,10 +49,10 @@ class PythonInference(Subsystem):
             default=False,
             type=bool,
             help=(
-                "Infer a target's dependencies based on strings that look like dynamic imports, "
-                "such as `importlib.import_module('example.subdir.Foo')`. This can be useful if "
-                "you use lots of dynamic imports, such as with Django apps. To ignore any false "
-                "positives, put `!{bad_address}` in the `dependencies` field of your target."
+                "Infer a target's dependencies based on strings that look like dynamic "
+                "dependencies, such as Django settings files expressing dependencies as strings. "
+                "To ignore any false positives, put `!{bad_address}` in the `dependencies` field "
+                "of your target."
             ),
         )
         register(

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -50,9 +50,6 @@ class PythonDependencyInferenceTest(TestBase):
         return [PythonLibrary, PythonRequirementLibrary, PythonTests]
 
     def test_infer_python_imports(self) -> None:
-        options_bootstrapper = create_options_bootstrapper(
-            args=["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
-        )
         self.add_to_build_file(
             "3rdparty/python",
             dedent(
@@ -65,8 +62,8 @@ class PythonDependencyInferenceTest(TestBase):
             ),
         )
 
-        self.create_file("src/python/no_owner/f.py")
-        self.add_to_build_file("src/python/no_owner", "python_library()")
+        self.create_file("src/python/str_import/subdir/f.py")
+        self.add_to_build_file("src/python/str_import/subdir", "python_library()")
 
         self.create_file("src/python/util/dep.py")
         self.add_to_build_file("src/python/util", "python_library()")
@@ -89,12 +86,21 @@ class PythonDependencyInferenceTest(TestBase):
                 import typing
                 # Import from another file in the same target.
                 from app import main
+
+                # Dynamic string import.
+                importlib.import_module('str_import.subdir.f')
                 """
             ),
         )
         self.add_to_build_file("src/python", "python_library()")
 
-        def run_dep_inference(address: Address) -> InferredDependencies:
+        def run_dep_inference(
+            address: Address, *, enable_string_imports: bool = False
+        ) -> InferredDependencies:
+            args = ["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
+            if enable_string_imports:
+                args.append("--python-infer-string-imports")
+            options_bootstrapper = create_options_bootstrapper(args=args)
             target = self.request_single_product(
                 WrappedTarget, Params(address, options_bootstrapper)
             ).target
@@ -103,12 +109,11 @@ class PythonDependencyInferenceTest(TestBase):
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
             )
 
-        # NB: We do not infer `src/python/app.py`, even though it's used by `src/python/f2.py`,
-        # because it is part of the requested address.
         normal_address = Address("src/python")
         assert run_dep_inference(normal_address) == InferredDependencies(
             [
                 Address("3rdparty/python", target_name="Django"),
+                Address("src/python", relative_file_path="app.py"),
                 Address("src/python/util", relative_file_path="dep.py", target_name="util"),
             ],
             sibling_dependencies_inferrable=True,
@@ -119,6 +124,15 @@ class PythonDependencyInferenceTest(TestBase):
         )
         assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
             [Address("src/python", relative_file_path="app.py", target_name="python")],
+            sibling_dependencies_inferrable=True,
+        )
+        assert run_dep_inference(
+            generated_subtarget_address, enable_string_imports=True
+        ) == InferredDependencies(
+            [
+                Address("src/python", relative_file_path="app.py", target_name="python"),
+                Address("src/python/str_import/subdir", relative_file_path="f.py"),
+            ],
             sibling_dependencies_inferrable=True,
         )
 


### PR DESCRIPTION
Certain Python projects, such as Django apps, make frequent use of dynamic imports. Dep inference needs to be able to understand those to work well with those code bases.

We turn string imports inference off by default because it could be surprising and it's much more likely to have false positives.

### Rejected design (for now) - global ignores

With Toolchain's buildgen (which inspired dep inference), false positives were handled via a subsystem option that allowed users to put regex strings to ignore globally. At the time, there was no `!` ignore syntax in the `dependencies` field, so this was the only option.

Now that we have `!` ignores, we start with the simplest solution to only use that for false positives. If we get user feedback that they want a decentralized mechanism, we can easily add a subsystem.

(Also note that we will only infer dependencies on Python targets, whereas Toolchain's Buildgen would infer on `files()` and `resources()`. Many of the ignores in Toolchain were for static assets, like `.css` files.)

[ci skip-rust]
[ci skip-build-wheels]
