### PR TITLE
Fix linter reports when there are multiple generated

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -17,14 +17,7 @@ from pants.backend.python.target_types import PythonInterpreterCompatibility, Py
 from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
 from pants.core.util_rules import source_files, stripped_source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import (
-    Digest,
-    DigestSubset,
-    GlobMatchErrorBehavior,
-    MergeDigests,
-    PathGlobs,
-    Snapshot,
-)
+from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -71,7 +71,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 0
         assert "No issues identified." in result[0].stdout.strip()
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_failing_source(self) -> None:
         target = self.make_target([self.bad_source])
@@ -79,7 +79,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_mixed_sources(self) -> None:
         target = self.make_target([self.good_source, self.bad_source])
@@ -88,7 +88,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert result[0].exit_code == 1
         assert "good.py" not in result[0].stdout
         assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_multiple_targets(self) -> None:
         targets = [
@@ -100,7 +100,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert result[0].exit_code == 1
         assert "good.py" not in result[0].stdout
         assert "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in result[0].stdout
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     @skip_unless_python27_and_python3_present
     def test_uses_correct_python_version(self) -> None:
@@ -138,7 +138,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 0
         assert "No issues identified." in result[0].stdout.strip()
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_respects_passthrough_args(self) -> None:
         target = self.make_target([self.bad_source])
@@ -146,7 +146,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 0
         assert "No issues identified." in result[0].stdout.strip()
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_skip(self) -> None:
         target = self.make_target([self.bad_source])
@@ -166,18 +166,18 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert "Issue: [C100:hardcoded_aws_key]" in result[0].stdout
-        assert result[0].results_file is None
+        assert result[0].report is None
 
-    def test_output_file(self) -> None:
+    def test_report_file(self) -> None:
         target = self.make_target([self.bad_source])
         result = self.run_bandit([target], additional_args=["--lint-reports-dir='.'"])
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert result[0].stdout.strip() == ""
-        assert result[0].results_file is not None
-        output_files = self.request_single_product(DigestContents, result[0].results_file.digest)
-        assert len(output_files) == 1
+        assert result[0].report is not None
+        report_files = self.request_single_product(DigestContents, result[0].report.digest)
+        assert len(report_files) == 1
         assert (
             "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5"
-            in output_files[0].content.decode()
+            in report_files[0].content.decode()
         )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -17,14 +17,7 @@ from pants.backend.python.target_types import PythonInterpreterCompatibility, Py
 from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
 from pants.core.util_rules import source_files, stripped_source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import (
-    Digest,
-    DigestSubset,
-    GlobMatchErrorBehavior,
-    MergeDigests,
-    PathGlobs,
-    Snapshot,
-)
+from pants.engine.fs import Digest, DigestSubset, GlobMatchErrorBehavior, MergeDigests, PathGlobs
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -14,13 +14,7 @@ from pants.backend.python.rules.pex import (
     PexRequirements,
 )
 from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
-from pants.core.goals.lint import (
-    LintRequest,
-    LintResult,
-    LintResultFile,
-    LintResults,
-    LintSubsystem,
-)
+from pants.core.goals.lint import LintReport, LintRequest, LintResult, LintResults, LintSubsystem
 from pants.core.util_rules import source_files, stripped_source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
@@ -58,13 +52,13 @@ class Flake8Partition:
 
 
 def generate_args(
-    *, source_files: SourceFiles, flake8: Flake8, output_file: Optional[str]
+    *, source_files: SourceFiles, flake8: Flake8, report_file_name: Optional[str]
 ) -> Tuple[str, ...]:
     args = []
     if flake8.config:
         args.append(f"--config={flake8.config}")
-    if output_file:
-        args.append(f"--output-file={output_file}")
+    if report_file_name:
+        args.append(f"--output-file={report_file_name}")
     args.extend(flake8.args)
     args.extend(source_files.files)
     return tuple(args)
@@ -112,40 +106,40 @@ async def flake8_lint_partition(
     address_references = ", ".join(
         sorted(field_set.address.spec for field_set in partition.field_sets)
     )
-    report_path = (
-        lint_subsystem.reports_dir / "flake8_report.txt" if lint_subsystem.reports_dir else None
-    )
+    report_file_name = "flake8_report.txt" if lint_subsystem.reports_dir else None
 
     result = await Get(
         FallibleProcessResult,
         PexProcess(
             requirements_pex,
             argv=generate_args(
-                source_files=source_files,
-                flake8=flake8,
-                output_file=report_path.name if report_path else None,
+                source_files=source_files, flake8=flake8, report_file_name=report_file_name,
             ),
             input_digest=input_digest,
-            output_files=(report_path.name,) if report_path else None,
+            output_files=(report_file_name,) if report_file_name else None,
             description=(
                 f"Run Flake8 on {pluralize(len(partition.field_sets), 'target')}: "
-                f"{address_references}."
+                f"{address_references}"
             ),
         ),
     )
 
-    results_file = None
-    if report_path:
-        report_file_snapshot = await Get(
-            Snapshot, DigestSubset(result.output_digest, PathGlobs([report_path.name]))
+    report = None
+    if report_file_name:
+        report_digest = await Get(
+            Digest,
+            DigestSubset(
+                result.output_digest,
+                PathGlobs(
+                    [report_file_name],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.warn,
+                    description_of_origin="Flake8 report file",
+                ),
+            ),
         )
-        if len(report_file_snapshot.files) != 1:
-            raise Exception(f"Unexpected report file snapshot: {report_file_snapshot.files}")
-        results_file = LintResultFile(output_path=report_path, digest=report_file_snapshot.digest)
+        report = LintReport(report_file_name, report_digest)
 
-    return LintResult.from_fallible_process_result(
-        result, linter_name="Flake8", results_file=results_file
-    )
+    return LintResult.from_fallible_process_result(result, linter_name="Flake8", report=report)
 
 
 @rule(desc="Lint using Flake8")

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -70,7 +70,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 0
         assert result[0].stdout.strip() == ""
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_failing_source(self) -> None:
         target = self.make_target([self.bad_source])
@@ -78,7 +78,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert "bad.py:1:1: F401" in result[0].stdout
-        assert result[0].results_file is None
+        assert result[0].report is None
 
     def test_mixed_sources(self) -> None:
         target = self.make_target([self.good_source, self.bad_source])
@@ -157,13 +157,13 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         assert result[0].exit_code == 1
         assert "bad.py:1:1: PB11" in result[0].stdout
 
-    def test_output_file(self) -> None:
+    def test_report_file(self) -> None:
         target = self.make_target([self.bad_source])
         result = self.run_flake8([target], additional_args=["--lint-reports-dir='.'"])
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert result[0].stdout.strip() == ""
-        assert result[0].results_file is not None
-        output_files = self.request_single_product(DigestContents, result[0].results_file.digest)
-        assert len(output_files) == 1
-        assert "bad.py:1:1: F401" in output_files[0].content.decode()
+        assert result[0].report is not None
+        report_files = self.request_single_product(DigestContents, result[0].report.digest)
+        assert len(report_files) == 1
+        assert "bad.py:1:1: F401" in report_files[0].content.decode()

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -11,7 +11,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
-from pants.engine.fs import Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.target import FieldSet, Sources, Target, Targets
 from pants.engine.unions import UnionMembership
 from pants.testutil.engine.util import MockConsole, MockGet, create_goal_subsystem, run_rule
@@ -51,7 +51,7 @@ class MockLintRequest(LintRequest, metaclass=ABCMeta):
                     self.stdout(addresses),
                     "",
                     linter_name=self.linter_name,
-                    results_file=None,
+                    report=None,
                 )
             ]
         )
@@ -153,6 +153,9 @@ class LintTest(TestBase):
                     mock=lambda field_sets: FieldSetsWithSources(
                         field_sets if include_sources else ()
                     ),
+                ),
+                MockGet(
+                    product_type=Digest, subject_type=MergeDigests, mock=lambda _: EMPTY_DIGEST
                 ),
             ],
             union_membership=union_membership,


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10532. If a linter has multiple reports generated, it's not safe to attempt to write any of them. We used to overwrite files because we would call `workspace.write_digest()` in a loop. Now, we eagerly detect this condition and error with a helpful message.

[ci skip-rust]
[ci skip-build-wheels]
