### PR TITLE
Add a `conftest` target type

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -10,6 +10,7 @@ from pants.backend.python.dependency_inference.rules import (
 )
 from pants.backend.python.dependency_inference.rules import rules as dependency_inference_rules
 from pants.backend.python.target_types import (
+    ConftestTarget,
     PythonLibrary,
     PythonRequirementLibrary,
     PythonSources,
@@ -47,7 +48,7 @@ class PythonDependencyInferenceTest(TestBase):
 
     @classmethod
     def target_types(cls):
-        return [PythonLibrary, PythonRequirementLibrary, PythonTests]
+        return [ConftestTarget, PythonLibrary, PythonRequirementLibrary, PythonTests]
 
     def test_infer_python_imports(self) -> None:
         self.add_to_build_file(
@@ -173,15 +174,15 @@ class PythonDependencyInferenceTest(TestBase):
         )
 
         self.create_file("src/python/root/conftest.py")
-        self.add_to_build_file("src/python/root", "python_library()")
+        self.add_to_build_file("src/python/root", "conftest()")
 
         self.create_file("src/python/root/mid/conftest.py")
-        self.add_to_build_file("src/python/root/mid", "python_library()")
+        self.add_to_build_file("src/python/root/mid", "conftest()")
 
         self.create_file("src/python/root/mid/leaf/conftest.py")
         self.create_file("src/python/root/mid/leaf/this_is_a_test.py")
         self.add_to_build_file(
-            "src/python/root/mid/leaf", "python_tests()\npython_library(name='conftest')"
+            "src/python/root/mid/leaf", "python_tests()\nconftest(name='conftest')"
         )
 
         def run_dep_inference(address: Address) -> InferredDependencies:

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -11,7 +11,12 @@ from pants.backend.python.dependency_inference import rules as dependency_infere
 from pants.backend.python.rules import pex, pex_from_targets, pytest_runner, python_sources
 from pants.backend.python.rules.coverage import create_coverage_config
 from pants.backend.python.rules.pytest_runner import PythonTestFieldSet
-from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary, PythonTests
+from pants.backend.python.target_types import (
+    ConftestTarget,
+    PythonLibrary,
+    PythonRequirementLibrary,
+    PythonTests,
+)
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals.test import Status, TestDebugRequest, TestResult
 from pants.core.util_rules import source_files, stripped_source_files
@@ -112,7 +117,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
 
     @classmethod
     def target_types(cls):
-        return [PythonLibrary, PythonTests, PythonRequirementLibrary]
+        return [ConftestTarget, PythonLibrary, PythonTests, PythonRequirementLibrary]
 
     @classmethod
     def rules(cls):
@@ -369,7 +374,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             relpath=PurePath(self.source_root, self.conftest_source.path).as_posix(),
             contents=self.conftest_source.content.decode(),
         )
-        self.add_to_build_file(self.source_root, "python_library()")
+        self.add_to_build_file(self.source_root, "conftest()")
 
         result = self.run_pytest(passthrough_args="-s")
         assert result.status == Status.SUCCESS

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -300,7 +300,7 @@ class PythonTests(Target):
 
 
 class PythonLibrarySources(PythonSources):
-    default = ("*.py",) + tuple(f"!{pat}" for pat in PythonTestsSources.default)
+    default = ("*.py", "!conftest.py") + tuple(f"!{pat}" for pat in PythonTestsSources.default)
 
 
 class PythonLibrary(Target):
@@ -308,6 +308,26 @@ class PythonLibrary(Target):
 
     alias = "python_library"
     core_fields = (*COMMON_PYTHON_FIELDS, PythonLibrarySources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `conftest` target
+# -----------------------------------------------------------------------------------------------
+
+
+class ConftestSources(PythonLibrarySources):
+    default = ("conftest.py",)
+
+
+class ConftestTarget(Target):
+    """A `conftest.py` file used by Pytest-style tests.
+
+    A `conftest` target behaves the same as a `python_library` target, and is sugar for
+    `python_library(sources=['conftest.py']`.
+    """
+
+    alias = "conftest"
+    core_fields = (*COMMON_PYTHON_FIELDS, ConftestSources)
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

Some Python repositories (like ours) colocate source files with tests.

In https://github.com/pantsbuild/pants/pull/10603, we stopped having `conftest.py` default to a `python_tests` target and to instead default to `python_library`. This was a good conceptual change, and also necessary now that we always run tests one-file-at-a-time.

However, #10603 does not work well in repositories where tests are colocated with source files. Previously, the `python_library` would solely refer to production code, but now it's including a test config file without users realizing it. This means, for example, that test's inferred dependencies will be included in the `python_library()`, so, whenever a user depends on `:library` (rather than file dep), they'll pull in more than they expected.

For example, in Toolchain's Django repo, we have to explicitly declare several dynamic dependencies for our `conftest.py`. To avoid polluting the production targets, this means that we need to declare this in our BUILD files:

```python
python_library(
  sources=["*.py", "!conftest.py", "!*_test.py"],
  dependencies=[
     ...  
  ],
)

python_library(
  name="conftest",
  sources=["conftest.py"],
  dependencies=[
    ...
  ],
)
```

Beyond being clunky, this is subtle. It will be very easy for us to forget to declare two separate targets and to not use default source globs.

### Solution

Leverage the Target API's design to create a new `conftest()` target. This behaves like a `python_library()`, and is basically sugar for `python_library(sources=["conftest.py"])`.

Update `python_library()` to exclude `conftest.py` by default, so that it doesn't mix production and test code.

Note that a macro could solve the problem for an individual codebase, but we want to solve this problem for all our users.

### Result

Now, Toolchain's BUILD file could look like this:

```python
python_library(
  dependencies=[
     ...  
  ],
)

conftest(
  name="conftest",
  dependencies=[
    ...
  ],
)
```

A user can still use a `python_library()` target for their `conftest.py`, of course. They will still use `python_library()` for test utils in general. This is about our default globs doing the right thing.

[ci skip-rust]
[ci skip-build-wheels]