### PR TITLE
Allow restricting use of resolve_all_constraints.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -53,7 +53,7 @@ root_patterns = [
 
 [python-setup]
 requirement_constraints = "3rdparty/python/constraints.txt"
-resolve_all_constraints = true
+resolve_all_constraints = "nondeployables"
 
 [black]
 config = "pyproject.toml"

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules.py
@@ -75,6 +75,7 @@ async def create_python_awslambda(
                 # available and matching the AMI platform.
                 "--resolve-local-platforms",
             ],
+            for_deployable_binary=True,
         )
     )
 

--- a/src/python/pants/backend/python/rules/create_python_binary.py
+++ b/src/python/pants/backend/python/rules/create_python_binary.py
@@ -88,6 +88,7 @@ async def create_python_binary(
                 platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
                 output_filename=output_filename,
                 additional_args=field_set.generate_additional_args(python_binary_defaults),
+                for_deployable_binary=True,
             )
         ),
     )

--- a/src/python/pants/backend/python/rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets.py
@@ -199,7 +199,10 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
             else:
                 requirements = PexRequirements(str(req) for req in constraints_file_reqs)
                 description = description or f"Resolving {python_setup.requirement_constraints}"
-    elif python_setup.resolve_all_constraints != ResolveAllConstraintsOption.NEVER:
+    elif (
+        python_setup.resolve_all_constraints != ResolveAllConstraintsOption.NEVER
+        and python_setup.resolve_all_constraints_was_set_explicitly()
+    ):
         raise ValueError(
             f"[python-setup].resolve_all_constraints is set to "
             f"{python_setup.resolve_all_constraints.value}, so "

--- a/src/python/pants/backend/python/rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets_test.py
@@ -81,12 +81,13 @@ class PexTest(TestBase):
         request = PexFromTargetsRequest([Address.parse("//:tgt")], output_filename="dummy.pex")
 
         def get_pex_request(
-            constraints_file: Optional[str], resolve_all: ResolveAllConstraintsOption
+            constraints_file: Optional[str], resolve_all: Optional[ResolveAllConstraintsOption]
         ) -> PexRequest:
             args = [
                 "--backend-packages=pants.backend.python",
-                f"--python-setup-resolve-all-constraints={resolve_all.value}",
             ]
+            if resolve_all:
+                args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")
             if constraints_file:
                 args.append(f"--python-setup-requirement-constraints={constraints_file}")
             return self.request_single_product(
@@ -109,3 +110,6 @@ class PexTest(TestBase):
             "[python-setup].resolve_all_constraints is set to always, so "
             "[python-setup].requirement_constraints must also be provided."
         ) in str(err.exception)
+
+        # Shouldn't error, as we don't explicitly set --resolve-all-constraints.
+        get_pex_request(None, None)

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -70,7 +70,7 @@ class PythonSetup(Subsystem):
         register(
             "--resolve-all-constraints",
             advanced=True,
-            default=ResolveAllConstraintsOption.NEVER,
+            default=ResolveAllConstraintsOption.NONDEPLOYABLES,
             type=ResolveAllConstraintsOption,
             help=(
                 "If set, and the requirements of the code being operated on are a subset of the "
@@ -186,6 +186,9 @@ class PythonSetup(Subsystem):
     @property
     def resolve_all_constraints(self) -> ResolveAllConstraintsOption:
         return cast(ResolveAllConstraintsOption, self.options.resolve_all_constraints)
+
+    def resolve_all_constraints_was_set_explicitly(self) -> bool:
+        return not self.options.is_default("resolve_all_constraints")
 
     @memoized_property
     def interpreter_search_paths(self):


### PR DESCRIPTION
Now it can be applied always, never, or just to non-deployables
(e.g., test running).  This is useful if you want to deploy a
pex or lambda with just the precise requirements needed, but still
want to enjoy the performance boost of reusing the full resolve
for test running etc.

Also ensures proper canonicalization of project names when
checking for the presence of projects in constraints files.

[ci skip-rust]

[ci skip-build-wheels]
