### PR TITLE
Revert #10603 so that `conftest.py` belongs to `python_tests` again

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -173,16 +173,14 @@ class PythonDependencyInferenceTest(TestBase):
         )
 
         self.create_file("src/python/root/conftest.py")
-        self.add_to_build_file("src/python/root", "python_library()")
+        self.add_to_build_file("src/python/root", "python_library(sources=['conftest.py'])")
 
         self.create_file("src/python/root/mid/conftest.py")
-        self.add_to_build_file("src/python/root/mid", "python_library()")
+        self.add_to_build_file("src/python/root/mid", "python_library(sources=['conftest.py'])")
 
         self.create_file("src/python/root/mid/leaf/conftest.py")
         self.create_file("src/python/root/mid/leaf/this_is_a_test.py")
-        self.add_to_build_file(
-            "src/python/root/mid/leaf", "python_tests()\npython_library(name='conftest')"
-        )
+        self.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
             target = self.request_single_product(
@@ -197,11 +195,6 @@ class PythonDependencyInferenceTest(TestBase):
             [
                 Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
                 Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),
-                Address(
-                    "src/python/root/mid/leaf",
-                    relative_file_path="conftest.py",
-                    target_name="conftest",
-                ),
             ],
             sibling_dependencies_inferrable=False,
         )

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -27,7 +27,7 @@ from pants.backend.python.target_types import (
     PythonTestsSources,
     PythonTestsTimeout,
 )
-from pants.core.goals.test import TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
+from pants.core.goals.test import Status, TestDebugRequest, TestFieldSet, TestResult, TestSubsystem
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
@@ -48,6 +48,9 @@ class PythonTestFieldSet(TestFieldSet):
 
     sources: PythonTestsSources
     timeout: PythonTestsTimeout
+
+    def is_conftest(self) -> bool:
+        return not self.address.is_base_target and self.address.filename.endswith("conftest.py")
 
 
 @dataclass(frozen=True)
@@ -188,24 +191,27 @@ async def setup_pytest_for_target(
     )
 
 
+# TODO(#10618): Once this is fixed, move `TestTargetSetup` into an `await Get` so that we only set
+#  up the test if it isn't skipped.
 @rule(desc="Run Pytest")
 async def run_python_test(
     field_set: PythonTestFieldSet,
-    test_setup: TestTargetSetup,
+    setup: TestTargetSetup,
     global_options: GlobalOptions,
     test_subsystem: TestSubsystem,
 ) -> TestResult:
-    """Runs pytest for one target."""
-    output_files = []
+    if field_set.is_conftest():
+        return TestResult(Status.SKIPPED, "", "", None, None, field_set.address.spec)
 
     add_opts = [f"--color={'yes' if global_options.options.colors else 'no'}"]
 
+    output_files = []
     # Configure generation of JUnit-compatible test report.
     test_results_file = None
-    if test_setup.xml_dir:
+    if setup.xml_dir:
         test_results_file = f"{field_set.address.path_safe_spec}.xml"
         add_opts.extend(
-            (f"--junitxml={test_results_file}", "-o", f"junit_family={test_setup.junit_family}")
+            (f"--junitxml={test_results_file}", "-o", f"junit_family={setup.junit_family}")
         )
         output_files.append(test_results_file)
 
@@ -213,10 +219,7 @@ async def run_python_test(
     if test_subsystem.use_coverage:
         output_files.append(".coverage")
 
-    env = {
-        "PYTEST_ADDOPTS": " ".join(add_opts),
-        "PEX_EXTRA_SYS_PATH": ":".join(test_setup.source_roots),
-    }
+    env = {"PYTEST_ADDOPTS": " ".join(add_opts), "PEX_EXTRA_SYS_PATH": ":".join(setup.source_roots)}
 
     if test_subsystem.force:
         # This is a slightly hacky way to force the process to run: since the env var
@@ -232,14 +235,14 @@ async def run_python_test(
     result = await Get(
         FallibleProcessResult,
         PexProcess(
-            test_setup.test_runner_pex,
-            argv=test_setup.args,
-            input_digest=test_setup.input_digest,
+            setup.test_runner_pex,
+            argv=setup.args,
+            input_digest=setup.input_digest,
             output_files=tuple(output_files) if output_files else None,
             description=f"Run Pytest for {field_set.address}",
-            timeout_seconds=test_setup.timeout_seconds,
+            timeout_seconds=setup.timeout_seconds,
             extra_env=env,
-            execution_slot_variable=test_setup.execution_slot_variable,
+            execution_slot_variable=setup.execution_slot_variable,
         ),
     )
 
@@ -261,7 +264,7 @@ async def run_python_test(
         if xml_results_snapshot.files == (test_results_file,):
             xml_results_digest = await Get(
                 Digest,
-                AddPrefix(xml_results_snapshot.digest, test_setup.xml_dir),  # type: ignore[arg-type]
+                AddPrefix(xml_results_snapshot.digest, setup.xml_dir),  # type: ignore[arg-type]
             )
         else:
             logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")
@@ -275,16 +278,12 @@ async def run_python_test(
 
 
 @rule(desc="Run Pytest in an interactive process")
-async def debug_python_test(test_setup: TestTargetSetup) -> TestDebugRequest:
+def debug_python_test(setup: TestTargetSetup) -> TestDebugRequest:
     process = InteractiveProcess(
-        argv=(test_setup.test_runner_pex.output_filename, *test_setup.args),
-        input_digest=test_setup.input_digest,
+        argv=(setup.test_runner_pex.output_filename, *setup.args), input_digest=setup.input_digest,
     )
     return TestDebugRequest(process)
 
 
 def rules():
-    return [
-        *collect_rules(),
-        UnionRule(TestFieldSet, PythonTestFieldSet),
-    ]
+    return [*collect_rules(), UnionRule(TestFieldSet, PythonTestFieldSet)]

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -369,7 +369,10 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             relpath=PurePath(self.source_root, self.conftest_source.path).as_posix(),
             contents=self.conftest_source.content.decode(),
         )
-        self.add_to_build_file(self.source_root, "python_library()")
+
+        self.create_file(
+            relpath=PurePath(self.source_root, "BUILD").as_posix(), contents="python_tests()",
+        )
 
         result = self.run_pytest(passthrough_args="-s")
         assert result.status == Status.SUCCESS

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -284,6 +284,9 @@ class PythonTests(Target):
 
     These may be written in either Pytest-style or unittest style.
 
+    All test util code, other than `conftest.py`, should go into a dedicated `python_library()`
+    target and then be included in the `dependencies` field.
+
     See https://www.pantsbuild.org/docs/python-test-goal.
     """
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -243,7 +243,7 @@ class PythonBinary(Target):
 
 
 class PythonTestsSources(PythonSources):
-    default = ("test_*.py", "*_test.py", "tests.py")
+    default = ("test_*.py", "*_test.py", "tests.py", "conftest.py")
 
 
 class PythonTestsTimeout(IntField):
@@ -283,9 +283,6 @@ class PythonTests(Target):
     """Python tests.
 
     These may be written in either Pytest-style or unittest style.
-
-    All test util code, including `conftest.py`, should go into a dedicated `python_library()`
-    target and then be included in the `dependencies` field.
 
     See https://www.pantsbuild.org/docs/python-test-goal.
     """

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -78,6 +78,7 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
             status=self.status(self.address),
             stdout=self.stdout(self.address),
             stderr=self.stderr(self.address),
+            address=self.address,
             coverage_data=MockCoverageData(self.address),
             xml_results=None,
         )


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/10603, we moved `conftest.py` from `python_tests` to `python_library`. This is because Pants now runs file-at-a-time for Pytest thanks to the model change in https://github.com/pantsbuild/pants/pull/10511. This causes `conftest.py` to error because it doesn't have any test files.

We decided in #10603 that `conftest.py` should be under `python_library` because it is not actual tests. For example, test util code goes under a `python_library` target already.

However, `python_library` owning a `conftest.py` by default ended up being problematic, as it caused test code to be mixed with production code, which is generally not desired. See https://github.com/pantsbuild/pants/pull/10613 for an approach to fix this.

Instead of adding a `conftest` target, this PR instead moves back `conftest.py` to `python_tests` and special cases `pytest_runner.py` to skip `conftest.py`. Even though this is less correct, it's simpler for users and it avoids making 1.x users having to change a bunch of things. Conceptually, `conftest.py` can be seen as "config" for tests, rather than traditional "test utils" like you'd have in a `python_library`.

[ci skip-rust]