### PR TITLE
Remove passive options mechanism

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -624,7 +624,7 @@ class RunTracker(Subsystem):
         scope_to_look_up = scope if scope != "GLOBAL" else ""
         try:
             value = self._all_options.for_scope(
-                scope_to_look_up, inherit_from_enclosing_scope=False, include_passive_options=True
+                scope_to_look_up, inherit_from_enclosing_scope=False
             ).as_dict()
             if option is None:
                 return value

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -244,8 +244,6 @@ class HelpInfoExtracter:
         advanced_options = []
         deprecated_options = []
         for args, kwargs in parser.option_registrations_iter():
-            if kwargs.get("passive"):
-                continue
             history = parser.history(kwargs["dest"])
             ohi = self.get_option_help_info(args, kwargs)
             ohi = dataclasses.replace(ohi, value_history=history)

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -249,9 +249,7 @@ class Options:
             for section in config.sections():
                 scope = GLOBAL_SCOPE if section == GLOBAL_SCOPE_CONFIG_SECTION else section
                 try:
-                    valid_options_under_scope = set(
-                        self.for_scope(scope, include_passive_options=True)
-                    )
+                    valid_options_under_scope = set(self.for_scope(scope))
                 # Only catch ConfigValidationError. Other exceptions will be raised directly.
                 except Config.ConfigValidationError:
                     error_log.append(f"Invalid scope [{section}] in {config.config_path}")
@@ -410,26 +408,19 @@ class Options:
         return sorted(all_scoped_flag_names, key=lambda flag_info: flag_info.scoped_arg)
 
     def _make_parse_args_request(
-        self,
-        flags_in_scope,
-        namespace: OptionValueContainer,
-        include_passive_options: bool = False,
+        self, flags_in_scope, namespace: OptionValueContainer
     ) -> Parser.ParseArgsRequest:
         return Parser.ParseArgsRequest(
             flags_in_scope=flags_in_scope,
             namespace=namespace,
             get_all_scoped_flag_names=lambda: self._all_scoped_flag_names_for_fuzzy_matching,
             passthrough_args=self._passthru,
-            include_passive_options=include_passive_options,
         )
 
     # TODO: Eagerly precompute backing data for this?
     @memoized_method
     def for_scope(
-        self,
-        scope: str,
-        inherit_from_enclosing_scope: bool = True,
-        include_passive_options: bool = False,
+        self, scope: str, inherit_from_enclosing_scope: bool = True,
     ) -> OptionValueContainer:
         """Return the option values for the given scope.
 
@@ -447,9 +438,7 @@ class Options:
 
         # Now add our values.
         flags_in_scope = self._scope_to_flags.get(scope, [])
-        parse_args_request = self._make_parse_args_request(
-            flags_in_scope, values, include_passive_options
-        )
+        parse_args_request = self._make_parse_args_request(flags_in_scope, values)
         self._parser_hierarchy.get_parser_by_scope(scope).parse_args(parse_args_request)
 
         # Check for any deprecation conditions, which are evaluated using `self._flag_matchers`.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -226,12 +226,6 @@ class Parser:
         namespace: OptionValueContainer
         get_all_scoped_flag_names: FlagNameProvider
         passthrough_args: List[str]
-        # A passive option is one that doesn't affect functionality, or appear in help messages, but
-        # can be provided without failing validation. This allows us to conditionally register options
-        # (e.g., v1 only or v2 only) without having to remove usages when the condition changes.
-        # TODO: This is currently only used for the v1/v2 switch. When everything is v2 we'll probably
-        #  want to get rid of this concept.
-        include_passive_options: bool
 
         def __init__(
             self,
@@ -239,7 +233,6 @@ class Parser:
             namespace: OptionValueContainer,
             get_all_scoped_flag_names: FlagNameProvider,
             passthrough_args: List[str],
-            include_passive_options: bool = False,
         ) -> None:
             """
             :param flags_in_scope: Iterable of arg strings to parse into flag values.
@@ -253,7 +246,6 @@ class Parser:
             self.namespace = namespace
             self.get_all_scoped_flag_names = get_all_scoped_flag_names
             self.passthrough_args = passthrough_args
-            self.include_passive_options = include_passive_options
 
         @staticmethod
         def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, List[Optional[str]]]:
@@ -291,9 +283,6 @@ class Parser:
 
         mutex_map: DefaultDict[str, List[str]] = defaultdict(list)
         for args, kwargs in self._unnormalized_option_registrations_iter():
-            if kwargs.get("passive") and not parse_args_request.include_passive_options:
-                continue
-
             self._validate(args, kwargs)
             dest = self.parse_dest(*args, **kwargs)
 
@@ -619,7 +608,6 @@ class Parser:
         "fromfile",
         "mutually_exclusive_group",
         "daemon",
-        "passive",
         "passthrough",
     }
 


### PR DESCRIPTION
This mechanism was solely used to facilitate v1 vs. v2. Removing it simplifies our code.

[ci skip-rust]
[ci skip-build-wheels]
