### PR TITLE
Upgrade setuptools from 49.2.0 to 49.60

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,7 +24,7 @@ python-Levenshtein==0.12.0
 PyYAML>=5.3.1,<5.4
 requests[security]>=2.20.1
 setproctitle==1.1.10
-setuptools>=49.2.1,<49.3
+setuptools>=49.6.0,<49.7
 toml==0.10.1
 typed-ast>=1.4.1,<1.5
 typing-extensions==3.7.4.2

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,7 +24,7 @@ python-Levenshtein==0.12.0
 PyYAML>=5.3.1,<5.4
 requests[security]>=2.20.1
 setproctitle==1.1.10
-setuptools==49.2.0
+setuptools>=49.2.1,<49.3
 toml==0.10.1
 typed-ast>=1.4.1,<1.5
 typing-extensions==3.7.4.2

--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -11,5 +11,5 @@ class Lambdex(PythonToolBase):
     default_version = "lambdex==0.1.3"
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.
-    default_extra_requirements = ["setuptools==49.2.0"]
+    default_extra_requirements = ["setuptools==49.2.1"]
     default_entry_point = "lambdex.bin.lambdex"

--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -11,5 +11,6 @@ class Lambdex(PythonToolBase):
     default_version = "lambdex==0.1.3"
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.
-    default_extra_requirements = ["setuptools==49.2.1"]
+    default_extra_requirements = ["setuptools>=49.6.0,<49.7"]
+    default_interpreter_constraints = ["CPython>=3.5"]
     default_entry_point = "lambdex.bin.lambdex"

--- a/src/python/pants/backend/python/rules/setuptools.py
+++ b/src/python/pants/backend/python/rules/setuptools.py
@@ -10,5 +10,5 @@ class Setuptools(PythonToolBase):
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
     options_scope = "setuptools"
-    default_version = "setuptools>=49.2.1,<49.3"
+    default_version = "setuptools>=49.6.0,<49.7"
     default_extra_requirements = ["wheel==0.31.1"]

--- a/src/python/pants/backend/python/rules/setuptools.py
+++ b/src/python/pants/backend/python/rules/setuptools.py
@@ -10,5 +10,5 @@ class Setuptools(PythonToolBase):
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
     options_scope = "setuptools"
-    default_version = "setuptools==49.2.1"
+    default_version = "setuptools>=49.2.1,<49.3"
     default_extra_requirements = ["wheel==0.31.1"]

--- a/src/python/pants/backend/python/rules/setuptools.py
+++ b/src/python/pants/backend/python/rules/setuptools.py
@@ -10,5 +10,5 @@ class Setuptools(PythonToolBase):
     # NB: setuptools doesn't have an entrypoint, unlike most python tools.
     # We call it via a generated setup.py script.
     options_scope = "setuptools"
-    default_version = "setuptools==49.2.0"
+    default_version = "setuptools==49.2.1"
     default_extra_requirements = ["wheel==0.31.1"]


### PR DESCRIPTION
https://github.com/pypa/setuptools/releases/tag/v49.6.0

https://github.com/pypa/setuptools/blob/master/CHANGES.rst

* #2129: In pkg_resources, no longer detect any pathname ending in .egg as a Python egg. Now the path must be an unpacked egg or a zip file.
* #2306: When running as a PEP 517 backend, setuptools does not try to install
  ``setup_requires`` itself. They are reported as build requirements for the
  frontend to install.
* #2310: Updated vendored packaging version to 20.4.
* #2300: Improve the ``safe_version`` function documentation
* #2297: Once again, in stubs prefer exec_module to the deprecated load_module.
* #2316: Removed warning when ``distutils`` is imported before ``setuptools`` when ``distutils`` replacement is not enabled.
* #2259: Setuptools now provides a .pth file (except for editable installs of setuptools) to the target environment to ensure that when enabled, the setuptools-provided distutils is preferred before setuptools has been imported (and even if setuptools is never imported). Honors the SETUPTOOLS_USE_DISTUTILS environment variable.
https://github.com/pypa/setuptools/issues/2257: Fixed two flaws in distutils._msvccompiler.MSVCCompiler.spawn.

instead of https://github.com/pantsbuild/pants/pull/10561