### PR TITLE
Stream output of `fmt`, rather than dumping at the end

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -121,7 +121,7 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
             description=f"Run Black on {pluralize(len(setup_request.request.field_sets), 'file')}.",
-            level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
+            level=LogLevel.DEBUG,
         ),
     )
     return Setup(process, original_digest=source_files_snapshot.digest)
@@ -130,7 +130,7 @@ async def setup(setup_request: SetupRequest, black: Black) -> Setup:
 @rule(desc="Format with Black")
 async def black_fmt(field_sets: BlackRequest, black: Black) -> FmtResult:
     if black.skip:
-        return FmtResult.noop()
+        return FmtResult.skip(formatter_name="Black")
     setup = await Get(Setup, SetupRequest(field_sets, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -151,5 +151,5 @@ class BlackIntegrationTest(ExternalToolTestBase):
         target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_black([target], skip=True)
         assert not lint_results
-        assert fmt_result == FmtResult.noop()
+        assert fmt_result.skipped is True
         assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -101,7 +101,7 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
             description=(
                 f"Run Docformatter on {pluralize(len(setup_request.request.field_sets), 'file')}."
             ),
-            level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
+            level=LogLevel.DEBUG,
         ),
     )
     return Setup(process, original_digest=source_files_snapshot.digest)
@@ -110,7 +110,7 @@ async def setup(setup_request: SetupRequest, docformatter: Docformatter) -> Setu
 @rule(desc="Format with docformatter")
 async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
     if docformatter.skip:
-        return FmtResult.noop()
+        return FmtResult.skip(formatter_name="Docformatter")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -123,5 +123,5 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         target = self.make_target([self.bad_source])
         lint_results, fmt_result = self.run_docformatter([target], skip=True)
         assert not lint_results
-        assert fmt_result == FmtResult.noop()
+        assert fmt_result.skipped is True
         assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -120,7 +120,7 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
             input_digest=input_digest,
             output_files=source_files_snapshot.files,
             description=f"Run isort on {pluralize(len(setup_request.request.field_sets), 'file')}.",
-            level=LogLevel.DEBUG if setup_request.check_only else LogLevel.INFO,
+            level=LogLevel.DEBUG,
         ),
     )
     return Setup(process, original_digest=source_files_snapshot.digest)
@@ -129,7 +129,7 @@ async def setup(setup_request: SetupRequest, isort: Isort) -> Setup:
 @rule(desc="Format with isort")
 async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     if isort.skip:
-        return FmtResult.noop()
+        return FmtResult.skip(formatter_name="isort")
     setup = await Get(Setup, SetupRequest(request, check_only=False))
     result = await Get(ProcessResult, Process, setup.process)
     return FmtResult.from_process_result(

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -159,5 +159,5 @@ class IsortIntegrationTest(ExternalToolTestBase):
         target = self.make_target_with_origin([self.bad_source])
         lint_results, fmt_result = self.run_isort([target], skip=True)
         assert not lint_results
-        assert fmt_result == FmtResult.noop()
+        assert fmt_result.skipped is True
         assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/python_fmt.py
+++ b/src/python/pants/backend/python/lint/python_fmt.py
@@ -49,8 +49,7 @@ async def format_python_target(
                 prior_formatter_result=prior_formatter_result,
             ),
         )
-        if result != FmtResult.noop():
-            results.append(result)
+        results.append(result)
         if result.did_change:
             prior_formatter_result = await Get(Snapshot, Digest, result.output)
     return LanguageFmtResults(

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type, cast
 
@@ -244,12 +245,10 @@ async def fmt(
     # We group all results for the same formatter so that we can give one final status in the
     # summary. This is only relevant if there were multiple results because of
     # `--per-target-caching`.
-    formatter_to_results = {
-        formatter_name: tuple(results)
-        for formatter_name, results in itertools.groupby(
-            individual_results, key=lambda result: result.formatter_name
-        )
-    }
+    formatter_to_results = defaultdict(set)
+    for result in individual_results:
+        formatter_to_results[result.formatter_name].add(result)
+
     for formatter, results in sorted(formatter_to_results.items()):
         if any(result.did_change for result in results):
             sigil = console.red("𐄂")

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -3,35 +3,42 @@
 
 import itertools
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, List, Tuple, Type, cast
+from typing import ClassVar, Iterable, List, Optional, Tuple, Type, cast
 
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.console import Console
+from pants.engine.engine_aware import EngineAware
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import Field, Target, Targets
 from pants.engine.unions import UnionMembership, union
+from pants.util.logging import LogLevel
 from pants.util.strutil import strip_v2_chroot_path
 
 
 @dataclass(frozen=True)
-class FmtResult:
+class FmtResult(EngineAware):
     input: Digest
     output: Digest
     stdout: str
     stderr: str
     formatter_name: str
 
-    @staticmethod
-    def noop() -> "FmtResult":
-        return FmtResult(
-            input=EMPTY_DIGEST, output=EMPTY_DIGEST, stdout="", stderr="", formatter_name=""
+    @classmethod
+    def skip(cls, *, formatter_name: str) -> "FmtResult":
+        return cls(
+            input=EMPTY_DIGEST,
+            output=EMPTY_DIGEST,
+            stdout="",
+            stderr="",
+            formatter_name=formatter_name,
         )
 
-    @staticmethod
+    @classmethod
     def from_process_result(
+        cls,
         process_result: ProcessResult,
         *,
         original_digest: Digest,
@@ -41,7 +48,7 @@ class FmtResult:
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 
-        return FmtResult(
+        return cls(
             input=original_digest,
             output=process_result.output_digest,
             stdout=prep_output(process_result.stdout),
@@ -50,8 +57,35 @@ class FmtResult:
         )
 
     @property
+    def skipped(self) -> bool:
+        return (
+            self.input == EMPTY_DIGEST
+            and self.output == EMPTY_DIGEST
+            and not self.stdout
+            and not self.stderr
+        )
+
+    @property
     def did_change(self) -> bool:
         return self.output != self.input
+
+    def level(self) -> Optional[LogLevel]:
+        if self.skipped:
+            return LogLevel.DEBUG
+        return LogLevel.WARN if self.did_change else LogLevel.INFO
+
+    def message(self) -> Optional[str]:
+        if self.skipped:
+            return "skipped."
+        message = "made changes." if self.did_change else "made no changes."
+        output = ""
+        if self.stdout:
+            output += f"\n{self.stdout}"
+        if self.stderr:
+            output += f"\n{self.stderr}"
+        if output:
+            output = f"{output.rstrip()}\n\n"
+        return f"{message}{output}"
 
 
 @union
@@ -204,19 +238,29 @@ async def fmt(
         merged_formatted_digest = await Get(Digest, MergeDigests(changed_digests))
         workspace.write_digest(merged_formatted_digest)
 
-    sorted_results = sorted(individual_results, key=lambda res: res.formatter_name)
-    for result in sorted_results:
-        console.print_stderr(
-            f"{console.green('✓')} {result.formatter_name} made no changes."
-            if not result.did_change
-            else f"{console.red('𐄂')} {result.formatter_name} made changes."
+    if individual_results:
+        console.print_stderr("")
+
+    # We group all results for the same formatter so that we can give one final status in the
+    # summary. This is only relevant if there were multiple results because of
+    # `--per-target-caching`.
+    formatter_to_results = {
+        formatter_name: tuple(results)
+        for formatter_name, results in itertools.groupby(
+            individual_results, key=lambda result: result.formatter_name
         )
-        if result.stdout:
-            console.print_stderr(result.stdout)
-        if result.stderr:
-            console.print_stderr(result.stderr)
-        if result != sorted_results[-1]:
-            console.print_stderr("")
+    }
+    for formatter, results in sorted(formatter_to_results.items()):
+        if any(result.did_change for result in results):
+            sigil = console.red("𐄂")
+            status = "made changes"
+        elif all(result.skipped for result in results):
+            sigil = console.yellow("-")
+            status = "skipped"
+        else:
+            sigil = console.green("✓")
+            status = "made no changes"
+        console.print_stderr(f"{sigil} {formatter} {status}.")
 
     # Since the rules to produce FmtResult should use ExecuteRequest, rather than
     # FallibleProcess, we assume that there were no failures.


### PR DESCRIPTION
Before:

```
▶ ./pants fmt src/python/pants/util/strutil_test.py
08:28:47.09 [INFO] Completed: Run Black on 1 file.
08:28:47.81 [INFO] Completed: Run Docformatter on 1 file.
08:28:48.67 [INFO] Completed: Run isort on 1 file.
✓ Black made no changes.
All done! ✨ 🍰 ✨
1 file left unchanged.


✓ Docformatter made no changes.

✓ isort made no changes.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "
```


After:

```
▶ ./pants fmt src/python/pants/util/strutil.py
08:23:25.10 [WARN] Completed: Format with Black - made changes.
reformatted src/python/pants/util/strutil.py
All done! ✨ 🍰 ✨
1 file reformatted.

08:23:25.81 [INFO] Completed: Format with docformatter - made no changes.
08:23:26.63 [INFO] Completed: Format with isort - made no changes.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "


𐄂 Black made changes.
✓ Docformatter made no changes.
✓ isort made no changes.
```

We now say when a formatter was skipped:

```
▶ ./pants fmt src/python/pants/util/strutil.py --isort-skip --docformatter-skip
08:24:19.15 [INFO] Completed: Format with Black - made no changes.
All done! ✨ 🍰 ✨
1 file left unchanged.


✓ Black made no changes.
- Docformatter skipped.
- isort skipped.
```

With `--per-target-caching`, it will look like this, where we merge into one final summary:

```
▶ ./pants fmt src/python/pants/util/{str,dir}util.py --fmt-per-target-caching
08:25:14.58 [WARN] Completed: Format with Black - made changes.
reformatted src/python/pants/util/strutil.py
All done! ✨ 🍰 ✨
1 file reformatted.

08:25:14.60 [INFO] Completed: Format with docformatter - made no changes.
08:25:14.60 [INFO] Completed: Format with isort - made no changes.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "

08:25:19.05 [INFO] Completed: Format with Black - made no changes.
All done! ✨ 🍰 ✨
1 file left unchanged.

08:25:19.67 [INFO] Completed: Format with docformatter - made no changes.
08:25:20.43 [INFO] Completed: Format with isort - made no changes.
/Users/eric/.pex/installed_wheels/fe0462426518d1eb662d92fd867eac898630585e/setuptools-49.2.0-py3-none-any.whl/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "


𐄂 Black made changes.
✓ Docformatter made no changes.
✓ isort made no changes.
```

[ci skip-rust]
[ci skip-build-wheels]
