### PR TITLE
Allow `test --debug` to run on multiple targets sequentially

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -287,7 +287,7 @@ async def run_python_test(
     )
 
 
-@rule(desc="Run Pytest in an interactive process")
+@rule(desc="Setup Pytest to run interactively")
 def debug_python_test(setup: TestTargetSetup) -> TestDebugRequest:
     process = InteractiveProcess(
         argv=(setup.test_runner_pex.name, *setup.args), input_digest=setup.input_digest,


### PR DESCRIPTION
It's now possible to run `./pants test --debug ::`, which will behave like v1 in that it will run sequentially.

There was no solid reason for us to put a restriction that you had to run one-at-a-time. Yes, this will lose parallelism that we want users to have, but Everyone Is An Adult Here. If the user wants to run sequentially, all power to them.

For now, we continue running if a certain test fails. We do not add a `--fail-early` flag like we had in V1 because that flag would only end up applying to `--test-debug`, rather than the default of `--no-test-debug`, which is confusing. The user can early exit by using `ctrl-c`. (They could use Pytest's `-x`, but this will only apply to each file; it will cause that file to early return, but it won't cause other files to fail due to the failure in another file.)

[ci skip-rust]
[ci skip-build-wheels]
