### PR TITLE
Rename `--per-target-caching` to `--per-file-caching` for `lint` and `fmt`

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, List, Optional, Tuple, Type, cast
 
+from pants.base.deprecated import resolve_conflicting_options
 from pants.core.util_rules.filter_empty_sources import TargetsWithSources, TargetsWithSourcesRequest
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAware
@@ -138,24 +139,44 @@ class FmtSubsystem(GoalSubsystem):
     def register_options(cls, register) -> None:
         super().register_options(register)
         register(
-            "--per-target-caching",
+            "--per-file-caching",
             advanced=True,
             type=bool,
             default=False,
             help=(
-                "Rather than running all targets in a single batch, run each target as a "
+                "Rather than formatting all files in a single batch, format each file as a "
                 "separate process. Why do this? You'll get many more cache hits. Why not do this? "
                 "Formatters both have substantial startup overhead and are cheap to add one "
                 "additional file to the run. On a cold cache, it is much faster to use "
-                "`--no-per-target-caching`. We only recommend using `--per-target-caching` if you "
+                "`--no-per-file-caching`. We only recommend using `--per-file-caching` if you "
                 "are using a remote cache or if you have benchmarked that this option will be "
-                "faster than `--no-per-target-caching` for your use case."
+                "faster than `--no-per-file-caching` for your use case."
+            ),
+        )
+        register(
+            "--per-target-caching",
+            advanced=True,
+            type=bool,
+            default=False,
+            help="See `--per-file-caching`.",
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "Use the renamed `--per-file-caching` option instead. If this option is set, Pants "
+                "will now run per every file, rather than per target."
             ),
         )
 
     @property
-    def per_target_caching(self) -> bool:
-        return cast(bool, self.options.per_target_caching)
+    def per_file_caching(self) -> bool:
+        val = resolve_conflicting_options(
+            old_option="per_target_caching",
+            new_option="per_file_caching",
+            old_container=self.options,
+            new_container=self.options,
+            old_scope=self.name,
+            new_scope=self.name,
+        )
+        return cast(bool, val)
 
 
 class Fmt(Goal):
@@ -202,7 +223,7 @@ async def fmt(
         if language_targets_with_sources
     )
 
-    if fmt_subsystem.per_target_caching:
+    if fmt_subsystem.per_file_caching:
         per_language_results = await MultiGet(
             Get(
                 LanguageFmtResults,
@@ -244,7 +265,7 @@ async def fmt(
 
     # We group all results for the same formatter so that we can give one final status in the
     # summary. This is only relevant if there were multiple results because of
-    # `--per-target-caching`.
+    # `--per-file-caching`.
     formatter_to_results = defaultdict(set)
     for result in individual_results:
         formatter_to_results[result.formatter_name].add(result)


### PR DESCRIPTION
Thanks to https://github.com/pantsbuild/pants/pull/10511, targets are no longer an atomic unit Pants runs on. Instead, files are the atomic unit.

This option rename reflects that model change.

[ci skip-rust]
[ci skip-build-wheels]
