### PR TITLE
Preserve Pytest's exit code with `./pants test`

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -211,7 +211,7 @@ async def run_python_test(
     test_subsystem: TestSubsystem,
 ) -> TestResult:
     if field_set.is_conftest():
-        return TestResult.skipped(field_set.address)
+        return TestResult.skip(field_set.address)
 
     add_opts = [f"--color={'yes' if global_options.options.colors else 'no'}"]
 
@@ -288,7 +288,9 @@ async def run_python_test(
 
 
 @rule(desc="Setup Pytest to run interactively")
-def debug_python_test(setup: TestTargetSetup) -> TestDebugRequest:
+def debug_python_test(field_set: PythonTestFieldSet, setup: TestTargetSetup) -> TestDebugRequest:
+    if field_set.is_conftest():
+        return TestDebugRequest(None)
     process = InteractiveProcess(
         argv=(setup.test_runner_pex.name, *setup.args), input_digest=setup.input_digest,
     )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -347,7 +347,6 @@ async def run_tests(
     )
 
     # Print details.
-    exit_code = 0
     for result in results:
         if result.skipped:
             continue
@@ -365,10 +364,9 @@ async def run_tests(
             console.print_stderr(result.stderr)
         if has_output and result != results[-1]:
             console.print_stderr("")
-        if result.exit_code is not None and result.exit_code != 0:
-            exit_code = result.exit_code
 
     # Print summary
+    exit_code = 0
     console.print_stderr("")
     for result in results:
         if result.skipped:
@@ -380,6 +378,8 @@ async def run_tests(
         right_align = 19 if console.use_colors else 10
         format_str = f"{{addr:80}}.....{{result:>{right_align}}}"
         console.print_stderr(format_str.format(addr=result.address.spec, result=result_desc))
+        if result.exit_code is not None and result.exit_code != 0:
+            exit_code = result.exit_code
 
     merged_xml_results = await Get(
         Digest, MergeDigests(result.xml_results for result in results if result.xml_results),

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -9,7 +9,6 @@ from enum import Enum
 from pathlib import PurePath
 from typing import Dict, Iterable, List, Optional, Tuple, Type, TypeVar, cast
 
-from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
@@ -35,12 +34,6 @@ from pants.util.logging import LogLevel
 logger = logging.getLogger(__name__)
 
 
-class Status(Enum):
-    SUCCESS = "SUCCESS"
-    FAILURE = "FAILURE"
-    SKIPPED = "SKIP"
-
-
 class CoverageReportType(Enum):
     CONSOLE = ("console", "report")
     XML = ("xml", None)
@@ -62,26 +55,19 @@ class CoverageReportType(Enum):
 
 @dataclass(frozen=True)
 class TestResult(EngineAware):
-    status: Status
+    exit_code: Optional[int]
     stdout: str
     stderr: str
     address: Address
-    coverage_data: Optional["CoverageData"]
-    xml_results: Optional[Digest]
+    coverage_data: Optional["CoverageData"] = None
+    xml_results: Optional[Digest] = None
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
 
     @classmethod
-    def skipped(cls, address: Address) -> "TestResult":
-        return cls(
-            status=Status.SKIPPED,
-            stdout="",
-            stderr="",
-            address=address,
-            coverage_data=None,
-            xml_results=None,
-        )
+    def skip(cls, address: Address) -> "TestResult":
+        return cls(exit_code=None, stdout="", stderr="", address=address)
 
     @classmethod
     def from_fallible_process_result(
@@ -93,12 +79,22 @@ class TestResult(EngineAware):
         xml_results: Optional[Digest] = None,
     ) -> "TestResult":
         return cls(
-            status=Status.SUCCESS if process_result.exit_code == 0 else Status.FAILURE,
+            exit_code=process_result.exit_code,
             stdout=process_result.stdout.decode(),
             stderr=process_result.stderr.decode(),
             address=address,
             coverage_data=coverage_data,
             xml_results=xml_results,
+        )
+
+    @property
+    def skipped(self) -> bool:
+        return (
+            self.exit_code is None
+            and not self.stdout
+            and not self.stderr
+            and not self.coverage_data
+            and not self.xml_results
         )
 
     def artifacts(self) -> Optional[Dict[str, Digest]]:
@@ -107,18 +103,18 @@ class TestResult(EngineAware):
         return {"xml_results_digest": self.xml_results}
 
     def level(self):
-        if self.status == Status.FAILURE:
+        if self.exit_code != 0:
             return LogLevel.ERROR
         return None
 
     def message(self):
-        result = "succeeded" if self.status == Status.SUCCESS else "failed"
+        result = "succeeded" if self.exit_code == 0 else f"failed (exit code {self.exit_code})"
         return f"tests {result}: {self.address}"
 
 
 @dataclass(frozen=True)
 class TestDebugRequest:
-    process: InteractiveProcess
+    process: Optional[InteractiveProcess]
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -327,6 +323,8 @@ async def run_tests(
         )
         exit_code = 0
         for debug_request in debug_requests:
+            if debug_request.process is None:
+                continue
             debug_result = interactive_runner.run(debug_request.process)
             if debug_result.exit_code != 0:
                 exit_code = debug_result.exit_code
@@ -349,16 +347,17 @@ async def run_tests(
     )
 
     # Print details.
+    exit_code = 0
     for result in results:
-        if result.status == Status.SKIPPED:
+        if result.skipped:
             continue
         if test_subsystem.options.output == ShowOutput.NONE or (
-            test_subsystem.options.output == ShowOutput.FAILED and result.status == Status.SUCCESS
+            test_subsystem.options.output == ShowOutput.FAILED and result.exit_code == 0
         ):
             continue
         has_output = result.stdout or result.stderr
         if has_output:
-            status = console.green("✓") if result.status == Status.SUCCESS else console.red("𐄂")
+            status = console.green("✓") if result.exit_code == 0 else console.red("𐄂")
             console.print_stderr(f"{status} {result.address}")
         if result.stdout:
             console.print_stderr(result.stdout)
@@ -366,21 +365,21 @@ async def run_tests(
             console.print_stderr(result.stderr)
         if has_output and result != results[-1]:
             console.print_stderr("")
+        if result.exit_code is not None and result.exit_code != 0:
+            exit_code = result.exit_code
 
     # Print summary
     console.print_stderr("")
     for result in results:
-        if result.status == Status.SKIPPED:
+        if result.skipped:
             continue
-        color = console.green if result.status == Status.SUCCESS else console.red
+        result_desc = console.green("SUCCESS") if result.exit_code == 0 else console.red("FAILURE")
         # The right-align logic sees the color control codes as characters, so we have
         # to account for that. In f-strings the alignment field widths must be literals,
         # so we have to indirect via a call to .format().
         right_align = 19 if console.use_colors else 10
         format_str = f"{{addr:80}}.....{{result:>{right_align}}}"
-        console.print_stderr(
-            format_str.format(addr=result.address.spec, result=color(result.status.value))
-        )
+        console.print_stderr(format_str.format(addr=result.address.spec, result=result_desc))
 
     merged_xml_results = await Get(
         Digest, MergeDigests(result.xml_results for result in results if result.xml_results),
@@ -415,12 +414,6 @@ async def run_tests(
 
         if coverage_report_files and test_subsystem.open_coverage:
             desktop.ui_open(console, interactive_runner, coverage_report_files)
-
-    exit_code = (
-        PANTS_FAILED_EXIT_CODE
-        if any(res.status == Status.FAILURE for res in results)
-        else PANTS_SUCCEEDED_EXIT_CODE
-    )
 
     return Test(exit_code)
 

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -256,7 +256,7 @@ class TestTest(TestBase):
                 self.make_target_with_origin(bad_address),
             ],
         )
-        assert exit_code == 1
+        assert exit_code == ConditionallySucceedsFieldSet.exit_code(bad_address)
         assert stderr == dedent(
             f"""\
             ✓ {good_address}

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -13,7 +13,6 @@ from pants.core.goals.test import (
     CoverageDataCollection,
     CoverageReports,
     ShowOutput,
-    Status,
     Test,
     TestDebugRequest,
     TestFieldSet,
@@ -59,7 +58,7 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def status(_: Address) -> Status:
+    def exit_code(_: Address) -> int:
         pass
 
     @staticmethod
@@ -73,7 +72,7 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
     @property
     def test_result(self) -> TestResult:
         return TestResult(
-            status=self.status(self.address),
+            exit_code=self.exit_code(self.address),
             stdout=self.stdout(self.address),
             stderr=self.stderr(self.address),
             address=self.address,
@@ -84,8 +83,8 @@ class MockTestFieldSet(TestFieldSet, metaclass=ABCMeta):
 
 class SuccessfulFieldSet(MockTestFieldSet):
     @staticmethod
-    def status(_: Address) -> Status:
-        return Status.SUCCESS
+    def exit_code(_: Address) -> int:
+        return 0
 
     @staticmethod
     def stdout(address: Address) -> str:
@@ -94,8 +93,8 @@ class SuccessfulFieldSet(MockTestFieldSet):
 
 class ConditionallySucceedsFieldSet(MockTestFieldSet):
     @staticmethod
-    def status(address: Address) -> Status:
-        return Status.FAILURE if address.target_name == "bad" else Status.SUCCESS
+    def exit_code(address: Address) -> int:
+        return 27 if address.target_name == "bad" else 0
 
     @staticmethod
     def stdout(address: Address) -> str:
@@ -283,15 +282,15 @@ class TestTest(TestBase):
             ],
             output=ShowOutput.FAILED,
         )
-        assert exit_code == 1
+        assert exit_code == ConditionallySucceedsFieldSet.exit_code(bad_address)
         assert stderr == dedent(
             f"""\
-                𐄂 {bad_address}
-                {ConditionallySucceedsFieldSet.stderr(bad_address)}
+            𐄂 {bad_address}
+            {ConditionallySucceedsFieldSet.stderr(bad_address)}
 
-                {good_address}                                                                         .....   SUCCESS
-                {bad_address}                                                                          .....   FAILURE
-                """
+            {good_address}                                                                         .....   SUCCESS
+            {bad_address}                                                                          .....   FAILURE
+            """
         )
 
     def test_output_none(self) -> None:
@@ -306,13 +305,13 @@ class TestTest(TestBase):
             ],
             output=ShowOutput.NONE,
         )
-        assert exit_code == 1
+        assert exit_code == ConditionallySucceedsFieldSet.exit_code(bad_address)
         assert stderr == dedent(
             f"""\
 
-                    {good_address}                                                                         .....   SUCCESS
-                    {bad_address}                                                                          .....   FAILURE
-                    """
+            {good_address}                                                                         .....   SUCCESS
+            {bad_address}                                                                          .....   FAILURE
+            """
         )
 
     def test_debug_target(self) -> None:


### PR DESCRIPTION
This allows us to output the original exit code to the user, which is helpful because Pytest codes are significant.

This PR also fixes an issue with `test --debug` unintentionally running on `conftest.py` files. Per https://github.com/pantsbuild/pants/pull/10619, we special case that file to skip it.

[ci skip-rust]
[ci skip-build-wheels]