### PR TITLE
Stream output of `test`, rather than dumping at the end

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -39,6 +39,7 @@ from pants.engine.target import TransitiveTargets
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.python.python_setup import PythonSetup
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger()
 
@@ -253,6 +254,7 @@ async def run_python_test(
             timeout_seconds=setup.timeout_seconds,
             extra_env=env,
             execution_slot_variable=setup.execution_slot_variable,
+            level=LogLevel.DEBUG,
         ),
     )
 
@@ -287,7 +289,7 @@ async def run_python_test(
     )
 
 
-@rule(desc="Setup Pytest to run interactively")
+@rule(desc="Set up Pytest to run interactively")
 def debug_python_test(field_set: PythonTestFieldSet, setup: TestTargetSetup) -> TestDebugRequest:
     if field_set.is_conftest():
         return TestDebugRequest(None)

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -377,7 +377,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         result = self.run_pytest(
             address=Address(self.source_root, relative_file_path="conftest.py")
         )
-        assert result.skipped is True
+        assert result.exit_code is None
 
     def test_execution_slot_variable(self) -> None:
         source = FileContent(

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -21,7 +21,7 @@ from pants.engine.engine_aware import EngineAware
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.rules import Get, MultiGet, RootRule, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     Sources,
@@ -453,4 +453,4 @@ def enrich_test_result(
 
 
 def rules():
-    return collect_rules()
+    return (*collect_rules(), RootRule(TestResult))

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -217,10 +217,10 @@ class TestTest(TestBase):
         )
         assert exit_code == ConditionallySucceedsFieldSet.exit_code(bad_address)
         assert stderr == dedent(
-            f"""\
+            """\
 
-            {good_address}                                                                         .....   SUCCESS
-            {bad_address}                                                                          .....   FAILURE
+            ✓ //:good succeeded.
+            𐄂 //:bad failed.
             """
         )
 
@@ -240,6 +240,26 @@ class TestTest(TestBase):
         )
         assert exit_code == 0
         assert stderr.strip().endswith(f"Ran coverage on {addr1.spec}, {addr2.spec}")
+
+
+def sort_results() -> None:
+    create_test_result = partial(
+        EnrichedTestResult, stdout="", stderr="", output_setting=ShowOutput.ALL
+    )
+    skip1 = create_test_result(exit_code=None, address=Address("t1"))
+    skip2 = create_test_result(exit_code=None, address=Address("t2"))
+    success1 = create_test_result(exit_code=0, address=Address("t1"))
+    success2 = create_test_result(exit_code=0, address=Address("t2"))
+    fail1 = create_test_result(exit_code=1, address=Address("t1"))
+    fail2 = create_test_result(exit_code=1, address=Address("t2"))
+    assert sorted([fail2, success2, skip2, fail1, success1, skip1]) == [
+        skip1,
+        skip2,
+        success1,
+        success2,
+        fail1,
+        fail2,
+    ]
 
 
 def assert_streaming_output(

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -15,29 +15,15 @@ class LogOutputIntegrationTest(PantsRunIntegrationTest):
         src_root = Path(tmpdir, "src", "python", "project")
         src_root.mkdir(parents=True)
         (src_root / "__init__.py").touch()
-
-        (src_root / "fake_test.py").write_text(
+        (src_root / "lib.py").write_text(
             dedent(
                 """\
-
-                def fake_test():
-                    assert 1 == 2
+                def add(x: int, y: int) -> int:
+                    return x + y
                 """
             )
         )
-
-        (src_root / "BUILD").write_text(
-            dedent(
-                """\
-                python_tests(
-                    name="fake",
-                )
-
-                python_library()
-                """
-            )
-        )
-
+        (src_root / "BUILD").write_text("python_library()")
         return tmpdir_relative
 
     def test_completed_log_output(self) -> None:
@@ -46,8 +32,8 @@ class LogOutputIntegrationTest(PantsRunIntegrationTest):
             tmpdir_relative = self._prepare_sources(tmpdir, build_root)
 
             test_run_result = self.run_pants(
-                ["--no-dynamic-ui", "test", f"{tmpdir_relative}/src/python/project:fake"]
+                ["--no-dynamic-ui", "typecheck", f"{tmpdir_relative}/src/python/project"]
             )
 
-            assert "[INFO] Starting: Run Pytest for" in test_run_result.stderr_data
-            assert "[INFO] Completed: Run Pytest for" in test_run_result.stderr_data
+            assert "[INFO] Starting: Run MyPy on" in test_run_result.stderr_data
+            assert "[INFO] Completed: Run MyPy on" in test_run_result.stderr_data


### PR DESCRIPTION
Before:

```
▶ ./pants test src/python/pants/util/{dir,str}util_test.py --test-output=all
11:20:56.32 [INFO] Completed: Run Pytest for src/python/pants/util/dirutil_test.py:tests
11:20:56.99 [INFO] Completed: Run Pytest for src/python/pants/util/strutil_test.py:tests
11:20:56.99 [ERROR] Completed: Run Pytest - tests failed (exit code 1): src/python/pants/util/strutil_test.py:tests
✓ src/python/pants/util/dirutil_test.py:tests
============================= test session starts ==============================
collected 31 items

src/python/pants/util/dirutil_test.py ...............................    [100%]

============================== 31 passed in 0.12s ==============================


𐄂 src/python/pants/util/strutil_test.py:tests
============================= test session starts ==============================
collected 5 items

src/python/pants/util/strutil_test.py ..F..                              [100%]

=================================== FAILURES ===================================
__________________________ StrutilTest.test_pluralize __________________________

self = <pants.util.strutil_test.StrutilTest testMethod=test_pluralize>

    def test_pluralize(self) -> None:
        self.assertEqual("1 bat", pluralize(1, "bat"))
        self.assertEqual("1 boss", pluralize(1, "boss"))
        self.assertEqual("2 bats", pluralize(2, "bat"))
        self.assertEqual("2 bosses", pluralize(2, "boss"))
>       self.assertEqual("0 batz", pluralize(0, "bat"))
E       AssertionError: '0 batz' != '0 bats'
E       - 0 batz
E       ?      ^
E       + 0 bats
E       ?      ^

src/python/pants/util/strutil_test.py:23: AssertionError
=========================== short test summary info ============================
FAILED src/python/pants/util/strutil_test.py::StrutilTest::test_pluralize - A...
========================= 1 failed, 4 passed in 0.12s ==========================


src/python/pants/util/dirutil_test.py:tests                                     .....   SUCCESS
src/python/pants/util/strutil_test.py:tests                                     .....   FAILURE
```

After:

```
▶ ./pants test src/python/pants/util/{dir,str}util_test.py --test-output=all
11:20:08.22 [INFO] Completed: Run tests - src/python/pants/util/dirutil_test.py:tests succeeded.
============================= test session starts ==============================
collected 31 items

src/python/pants/util/dirutil_test.py ...............................    [100%]

============================== 31 passed in 0.12s ==============================

11:20:08.27 [WARN] Completed: Run tests - src/python/pants/util/strutil_test.py:tests failed (exit code 1).
============================= test session starts ==============================
collected 5 items

src/python/pants/util/strutil_test.py ..F..                              [100%]

=================================== FAILURES ===================================
__________________________ StrutilTest.test_pluralize __________________________

self = <pants.util.strutil_test.StrutilTest testMethod=test_pluralize>

    def test_pluralize(self) -> None:
        self.assertEqual("1 bat", pluralize(1, "bat"))
        self.assertEqual("1 boss", pluralize(1, "boss"))
        self.assertEqual("2 bats", pluralize(2, "bat"))
        self.assertEqual("2 bosses", pluralize(2, "boss"))
>       self.assertEqual("0 batz", pluralize(0, "bat"))
E       AssertionError: '0 batz' != '0 bats'
E       - 0 batz
E       ?      ^
E       + 0 bats
E       ?      ^

src/python/pants/util/strutil_test.py:23: AssertionError
=========================== short test summary info ============================
FAILED src/python/pants/util/strutil_test.py::StrutilTest::test_pluralize - A...
========================= 1 failed, 4 passed in 0.17s ==========================


✓ src/python/pants/util/dirutil_test.py:tests succeeded.
𐄂 src/python/pants/util/strutil_test.py:tests failed.
```

We still respect the option `--test-output={all,success,none}`. To support this, we add an `EnrichedTestResult` type and automatically upcast a `TestResult` to this type.

We also now group all failures together at the end of the summary.

[ci skip-rust]
