### PR TITLE
Fix Rust 3rdparty logs showing up with `--dynamic-ui`

### DIFF
--- a/src/rust/engine/logging/src/lib.rs
+++ b/src/rust/engine/logging/src/lib.rs
@@ -51,7 +51,7 @@ pub mod logger;
 
 pub use logger::{get_destination, scope_task_destination, set_thread_destination, Destination};
 
-pub type Logger = logger::Logger;
+pub type Logger = logger::PantsLogger;
 
 use num_enum::TryFromPrimitive;
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -61,7 +61,7 @@ use futures::future::{self as future03, TryFutureExt};
 use futures01::Future;
 use hashing::{Digest, EMPTY_DIGEST};
 use log::{self, debug, error, warn, Log};
-use logging::logger::LOGGER;
+use logging::logger::PANTS_LOGGER;
 use logging::{Destination, Logger, PythonLogLevel};
 use rule_graph::{self, RuleGraph};
 use store::SnapshotOps;
@@ -1658,7 +1658,7 @@ fn setup_pantsd_logger(py: Python, log_file: String, level: u64) -> CPyResult<i6
   logging::set_thread_destination(Destination::Pantsd);
 
   let path = PathBuf::from(log_file);
-  LOGGER
+  PANTS_LOGGER
     .set_pantsd_logger(path, level)
     .map(i64::from)
     .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
@@ -1666,7 +1666,7 @@ fn setup_pantsd_logger(py: Python, log_file: String, level: u64) -> CPyResult<i6
 
 fn setup_stderr_logger(_: Python, level: u64) -> PyUnitResult {
   logging::set_thread_destination(Destination::Stderr);
-  LOGGER
+  PANTS_LOGGER
     .set_stderr_logger(level)
     .expect("Error setting up STDERR logger");
   Ok(None)
@@ -1717,7 +1717,7 @@ fn teardown_dynamic_ui(
 
 fn flush_log(py: Python) -> PyUnitResult {
   py.allow_threads(|| {
-    LOGGER.flush();
+    PANTS_LOGGER.flush();
     Ok(None)
   })
 }

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -36,7 +36,7 @@ use indexmap::IndexMap;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use uuid::Uuid;
 
-use logging::logger::{StdioHandler, LOGGER};
+use logging::logger::{StdioHandler, PANTS_LOGGER};
 use task_executor::Executor;
 use workunit_store::WorkunitStore;
 
@@ -192,7 +192,7 @@ impl ConsoleUI {
     self.instance = Some(Instance {
       tasks_to_display: IndexMap::new(),
       multi_progress_task,
-      logger_handle: LOGGER.register_stderr_handler(stderr_handler),
+      logger_handle: PANTS_LOGGER.register_stderr_handler(stderr_handler),
       bars,
     });
     Ok(())
@@ -203,7 +203,7 @@ impl ConsoleUI {
   ///
   pub fn teardown(&mut self) -> impl Future<Output = Result<(), String>> {
     if let Some(instance) = self.instance.take() {
-      LOGGER.deregister_stderr_handler(instance.logger_handle);
+      PANTS_LOGGER.deregister_stderr_handler(instance.logger_handle);
       instance
         .multi_progress_task
         .map_err(|e| format!("Failed to render UI: {}", e))


### PR DESCRIPTION
Before, if `--dynamic-ui` was set and `-ldebug`, we would get messages like:

```
18:51:12.29 [DEBUG] glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)\\.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
18:51:12.29 [DEBUG] built glob set; 0 literals, 2 basenames, 1 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 1 regexes
```

This was because filtering of 3rd party modules happening in `MaybeWriteLogger`, which isn't used by the dynamic UI.

This also renames the logger variables to be less generic so that we can more clearly distinguish between our own abstractions vs. upstream crates.

[ci skip-build-wheels]
