### PR TITLE
Stop including the origin module in Debug logs

### DIFF
--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -3,7 +3,6 @@
 
 import glob
 import os
-import re
 import subprocess
 import sys
 import unittest

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -359,23 +359,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
         assertion(value, pants_run.returncode, error_msg)
 
-    def assert_run_contains_log(self, msg, level, module, pants_run: PantsResult):
-        """Asserts that the passed run's stderr contained the log message."""
-        self.assert_contains_log(msg, level, module, pants_run.stderr_data, pants_run.pid)
-
-    def assert_contains_log(self, msg, level, module, log, pid=None):
-        """Asserts that the passed log contains the message logged by the module at the level.
-
-        If pid is specified, performs an exact match including the pid of the pants process.
-        Otherwise performs a regex match asserting that some pid is present.
-        """
-        prefix = f"[{level}] {module}:pid="
-        suffix = f": {msg}"
-        if pid is None:
-            self.assertRegex(log, re.escape(prefix) + r"\d+" + re.escape(suffix))
-        else:
-            self.assertIn(f"{prefix}{pid}{suffix}", log)
-
     @contextmanager
     def file_renamed(self, prefix, test_name, real_name):
         real_path = os.path.join(prefix, real_name)

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -243,6 +243,7 @@ impl<W: Write + Send + 'static> MaybeWriteLogger<W> {
       .set_time_to_local(true)
       .set_thread_level(LevelFilter::Off)
       .set_level_padding(LevelPadding::Off)
+      .set_target_level(LevelFilter::Off)
       .build();
 
     MaybeWriteLogger {

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -15,8 +15,8 @@ class NativeEngineLoggingTest(PantsRunIntegrationTest):
         """
         return False
 
-    def test_native_logging(self):
-        expected_msg = r"\[DEBUG\] engine::scheduler: Launching \d+ root"
+    def test_native_logging(self) -> None:
+        expected_msg = r"\[DEBUG\] Launching \d+ root"
         pants_run = self.run_pants(["-linfo", "list", "3rdparty::"])
         self.assertNotRegex(pants_run.stderr_data, expected_msg)
 
@@ -25,19 +25,11 @@ class NativeEngineLoggingTest(PantsRunIntegrationTest):
 
 
 class PantsdNativeLoggingTest(PantsDaemonIntegrationTestBase):
-    def test_pantsd_file_logging(self):
+    def test_pantsd_file_logging(self) -> None:
         with self.pantsd_successful_run_context("debug") as ctx:
             daemon_run = ctx.runner(["list", "3rdparty::"])
             ctx.checker.assert_started()
-
-            self.assert_run_contains_log(
-                "connecting to pantsd on port",
-                "DEBUG",
-                "pants.bin.remote_pants_runner",
-                daemon_run,
-            )
+            assert "[DEBUG] connecting to pantsd on port" in daemon_run.stderr_data
 
             pantsd_log = "\n".join(read_pantsd_log(ctx.workdir))
-            self.assert_contains_log(
-                "logging initialized", "DEBUG", "pants.pantsd.pants_daemon", pantsd_log,
-            )
+            assert "[DEBUG] logging initialized" in pantsd_log


### PR DESCRIPTION
Before:

```
20:28:40 [DEBUG] engine::externs::interface: File handle limit is: 20000
...
15:28:01 [DEBUG] workunit_store: Completed: pants.engine.internals.build_files.strip_address_origins
```

After:

```
20:28:40 [DEBUG] File handle limit is: 20000
...
15:28:01 [DEBUG] Completed: pants.engine.internals.build_files.strip_address_origins
```

[ci skip-build-wheels]