### PR TITLE
Reduce noisy log messages from `@rule` params

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1252,7 +1252,7 @@ impl Display for NodeKey {
         // the Params of an @rule when we stringify the @rule. But we need to make
         // sure we don't naively dump the string representation of a Key, which
         // could get gigantic.
-        write!(f, "@rule {}", task.task.display_info.name)
+        write!(f, "@rule({})", task.task.display_info.name)
       }
       &NodeKey::Snapshot(ref s) => write!(f, "Snapshot({})", s.0),
     }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1248,7 +1248,11 @@ impl Display for NodeKey {
       &NodeKey::Scandir(ref s) => write!(f, "Scandir({})", (s.0).0.display()),
       &NodeKey::Select(ref s) => write!(f, "{}", s.product),
       &NodeKey::Task(ref task) => {
-        write!(f, "@rule {}({})", task.task.display_info.name, task.params)
+        // TODO(#7907) we probably want to include some kind of representation of
+        // the Params of an @rule when we stringify the @rule. But we need to make
+        // sure we don't naively dump the string representation of a Key, which
+        // could get gigantic.
+        write!(f, "@rule {}", task.task.display_info.name)
       }
       &NodeKey::Snapshot(ref s) => write!(f, "Snapshot({})", s.0),
     }


### PR DESCRIPTION
### Problem

cf. https://github.com/pantsbuild/pants/issues/10518 , it's possible for pants to emit extremely large log messages whenever it prints a long containing the string representation of large Python types. In the above issue, the large Python types are  `FieldSet` subclasses (which can include lots of e.g. file path names) in their Python `__str__` representation. These types appear as the `params` field on a `Task`, and are part of the Rust `Display` representation of a `Task`, which is part of the log message when a node is invalidated because of a file system change, and might more generally show up in any pants log message.

### Solution

A quick fix for the above problem is to simply remove the `Params` from the `Display` implementation of an `@rule`'s task, and only include the name of the Python function corresponding to the rule. cf. https://github.com/pantsbuild/pants/issues/7907 ,  we probably want to eventually implement a more sophisticated way of deciding what Python type information we do and do not need to include in useful pants logs from Rust.