### PR TITLE
Allow `binary` to be implemented without implementing `run`

### DIFF
--- a/src/python/pants/backend/python/rules/create_python_binary.py
+++ b/src/python/pants/backend/python/rules/create_python_binary.py
@@ -22,6 +22,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.target_types import PythonPlatforms as PythonPlatformsField
 from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
+from pants.core.goals.run import RunFieldSet
 from pants.core.util_rules.source_files import SourceFiles
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.rules import Get, collect_rules, rule
@@ -31,7 +32,7 @@ from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
-class PythonBinaryFieldSet(BinaryFieldSet):
+class PythonBinaryFieldSet(BinaryFieldSet, RunFieldSet):
     required_fields = (PythonEntryPoint, PythonBinarySources)
 
     sources: PythonBinarySources

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -8,8 +8,7 @@ from pants.backend.python.rules.pex import Pex, PexRequest
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.target_types import PythonBinaryDefaults, PythonBinarySources
-from pants.core.goals.binary import BinaryFieldSet
-from pants.core.goals.run import RunRequest
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.source_files import SourceFiles
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.addresses import Addresses
@@ -99,5 +98,5 @@ async def create_python_binary_run_request(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(BinaryFieldSet, PythonBinaryFieldSet),
+        UnionRule(RunFieldSet, PythonBinaryFieldSet),
     ]

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -6,8 +6,7 @@ from typing import cast
 
 from pants.base.build_root import BuildRoot
 from pants.base.specs import AddressLiteralSpec
-from pants.core.goals.binary import BinaryFieldSet
-from pants.core.goals.run import Run, RunRequest, RunSubsystem, run
+from pants.core.goals.run import Run, RunFieldSet, RunRequest, RunSubsystem, run
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveRunner
@@ -44,7 +43,7 @@ class RunTest(TestBase):
         workspace = Workspace(self.scheduler)
         interactive_runner = InteractiveRunner(self.scheduler)
 
-        class TestBinaryFieldSet(BinaryFieldSet):
+        class TestRunFieldSet(RunFieldSet):
             required_fields = ()
 
         class TestBinaryTarget(Target):
@@ -56,7 +55,7 @@ class RunTest(TestBase):
         target_with_origin = TargetWithOrigin(
             target, AddressLiteralSpec(address.spec_path, address.target_name)
         )
-        field_set = TestBinaryFieldSet.create(target)
+        field_set = TestRunFieldSet.create(target)
 
         res = run_rule(
             run,
@@ -76,7 +75,7 @@ class RunTest(TestBase):
                 ),
                 MockGet(
                     product_type=RunRequest,
-                    subject_type=TestBinaryFieldSet,
+                    subject_type=TestRunFieldSet,
                     mock=lambda _: self.create_mock_run_request(program_text),
                 ),
             ],


### PR DESCRIPTION
### Problem

Right now, if you implement `binary` without implementing `run`, the graph will error. Even though `run` and `binary` are typically closely related, they need not be; we should allow a plugin author to implement one of the goals without implementing the other.

### Solution

Add `RunFieldSet`.

If the `run` and `binary` implementations are closely coupled, such as the Python Pex implementation, then the plugin author can create a `FieldSet` that subclasses both `BinaryFieldSet` and `RunFieldSet`.

[ci skip-rust]
[ci skip-build-wheels]
