### PR TITLE
Add transitive excludes for `dependencies` with `!!`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -6,7 +6,11 @@ from typing import Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonSources
 from pants.engine.addresses import Address
-from pants.engine.target import InvalidFieldException, StringField, Target
+from pants.engine.target import Dependencies, InvalidFieldException, StringField, Target
+
+
+class PythonAwsLambdaDependencies(Dependencies):
+    supports_transitive_excludes = True
 
 
 class PythonAwsLambdaHandler(StringField):
@@ -52,6 +56,7 @@ class PythonAWSLambda(Target):
     core_fields = (
         *COMMON_PYTHON_FIELDS,
         PythonSources,
+        PythonAwsLambdaDependencies,
         PythonAwsLambdaHandler,
         PythonAwsLambdaRuntime,
     )

--- a/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
+++ b/src/python/pants/backend/python/lint/pylint/plugin_target_type.py
@@ -3,7 +3,6 @@
 
 from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonSources
 from pants.engine.target import Dependencies, Target
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 class PylintPluginSources(PythonSources):
@@ -57,8 +56,4 @@ class PylintSourcePlugin(Target):
     """
 
     alias = "pylint_source_plugin"
-    core_fields = (
-        *(FrozenOrderedSet(COMMON_PYTHON_FIELDS) - {Dependencies}),  # type: ignore[misc]
-        PylintPluginDependencies,
-        PylintPluginSources,
-    )
+    core_fields = (*COMMON_PYTHON_FIELDS, PylintPluginDependencies, PylintPluginSources)

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -56,11 +56,7 @@ class PythonInterpreterCompatibility(StringOrStringSequenceField):
         return python_setup.compatibility_or_constraints(self.value)
 
 
-COMMON_PYTHON_FIELDS = (
-    *COMMON_TARGET_FIELDS,
-    Dependencies,
-    PythonInterpreterCompatibility,
-)
+COMMON_PYTHON_FIELDS = (*COMMON_TARGET_FIELDS, PythonInterpreterCompatibility)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -112,6 +108,10 @@ class PythonBinarySources(PythonSources):
             return None
         module_base, _ = os.path.splitext(stripped_sources[0])
         return module_base.replace(os.path.sep, ".")
+
+
+class PythonBinaryDependencies(Dependencies):
+    supports_transitive_excludes = True
 
 
 class PythonEntryPoint(StringField):
@@ -226,6 +226,7 @@ class PythonBinary(Target):
     core_fields = (
         *COMMON_PYTHON_FIELDS,
         PythonBinarySources,
+        PythonBinaryDependencies,
         PythonEntryPoint,
         PythonPlatforms,
         PexInheritPath,
@@ -244,6 +245,10 @@ class PythonBinary(Target):
 
 class PythonTestsSources(PythonSources):
     default = ("test_*.py", "*_test.py", "tests.py", "conftest.py")
+
+
+class PythonTestsDependencies(Dependencies):
+    supports_transitive_excludes = True
 
 
 class PythonTestsTimeout(IntField):
@@ -291,7 +296,12 @@ class PythonTests(Target):
     """
 
     alias = "python_tests"
-    core_fields = (*COMMON_PYTHON_FIELDS, PythonTestsSources, PythonTestsTimeout)
+    core_fields = (
+        *COMMON_PYTHON_FIELDS,
+        PythonTestsSources,
+        PythonTestsDependencies,
+        PythonTestsTimeout,
+    )
 
 
 # -----------------------------------------------------------------------------------------------
@@ -307,7 +317,7 @@ class PythonLibrary(Target):
     """A Python library that may be imported by other targets."""
 
     alias = "python_library"
-    core_fields = (*COMMON_PYTHON_FIELDS, PythonLibrarySources)
+    core_fields = (*COMMON_PYTHON_FIELDS, Dependencies, PythonLibrarySources)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -377,6 +387,10 @@ class PythonRequirementsFile(Target):
 # -----------------------------------------------------------------------------------------------
 
 
+class PythonDistributionDependencies(Dependencies):
+    supports_transitive_excludes = True
+
+
 class PythonProvidesField(ScalarField, ProvidesField):
     """The`setup.py` kwargs for the external artifact built from this target.
 
@@ -399,4 +413,4 @@ class PythonDistribution(Target):
     """A publishable Python distribution."""
 
     alias = "python_distribution"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, PythonProvidesField)
+    core_fields = (*COMMON_TARGET_FIELDS, PythonDistributionDependencies, PythonProvidesField)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -27,7 +27,7 @@ from typing import (
 from typing_extensions import final
 
 from pants.base.specs import Spec
-from pants.engine.addresses import Address, assert_single_address
+from pants.engine.addresses import Address, AddressInput, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.fs import GlobExpansionConjunction, GlobMatchErrorBehavior, PathGlobs, Snapshot
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -469,6 +469,31 @@ class Target(ABC):
         return cls._has_fields(
             fields, registered_fields=cls.class_field_types(union_membership=union_membership)
         )
+
+    @final
+    @classmethod
+    def class_get_field(cls, field: Type[_F], *, union_membership: UnionMembership) -> Type[_F]:
+        """Get the requested Field type registered with this target type.
+
+        This will error if the field is not registered, so you should call Target.class_has_field()
+        first.
+        """
+        class_fields = cls.class_field_types(union_membership=union_membership)
+        result = next(
+            (
+                registered_field
+                for registered_field in class_fields
+                if issubclass(registered_field, field)
+            ),
+            None,
+        )
+        if result is None:
+            raise KeyError(
+                f"The target type `{cls.alias}` does not have a field `{field.__name__}`. Before "
+                f"calling `TargetType.class_get_field({field.__name__})`, call "
+                f"`TargetType.class_has_field({field.__name__})`."
+            )
+        return result
 
     @final
     @classmethod
@@ -1443,6 +1468,7 @@ class Dependencies(AsyncField):
     alias = "dependencies"
     sanitized_raw_value: Optional[Tuple[str, ...]]
     default: ClassVar[Optional[Tuple[str, ...]]] = None
+    supports_transitive_excludes = False
 
     @classmethod
     def sanitize_raw_value(
@@ -1461,6 +1487,14 @@ class Dependencies(AsyncField):
                 expected_type="an iterable of strings (e.g. a list of strings)",
             )
         return tuple(sorted(value_or_default))
+
+    @memoized_property
+    def unevaluated_transitive_excludes(self) -> Tuple[AddressInput, ...]:
+        if not self.supports_transitive_excludes or not self.sanitized_raw_value:
+            return ()
+        return tuple(
+            AddressInput.parse(v[2:]) for v in self.sanitized_raw_value if v.startswith("!!")
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10661. As described there, sometimes users want to be able to exclude certain problematic dependencies from things like `python_binary` or `python_tests`, such as TensorFlow. Direct dependency ignores via `!` are not adequate because those dependencies might be a transitive dependency.

The user could instead be disciplined with their transitive dependencies to make sure the dep they don't want is not used. However, this is difficult to get right. It would also often mean creating two targets for the same library code, one with the dep and one without; that would mean dependency inference couldn't work anymore due to ambiguous owners.

To limit the risk of confusion, this new mechanism only works with certain target types that have declared they support the syntax, such as `python_binary`. These target types are meant to be "roots", i.e. not have dependees. Otherwise, users get this error:

```
▶ ./pants dependencies src/python/pants/util
15:59:08 [ERROR] 1 Exception encountered:

  TransitiveExcludesNotSupportedError: Bad value '!!//:pants_toml' in the `dependencies` field for src/python/pants/util. Transitive excludes with `!!` are not supported for this target type. Did you mean to use a single `!` for a direct exclude?

Transitive excludes work with these target types: ['python_binary', 'python_distribution', 'python_tests']

(Use --print-exception-stacktrace to see more error details.)
```

[ci skip-rust]
[ci skip-build-wheels]