### PR TITLE
Add an FFI function for reading a `FrozenDict`

### DIFF
--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -34,6 +34,7 @@ class FrozenDict(Mapping[K, V]):
                 f"FrozenDict was called with {len(item)} positional arguments but it expects one."
             )
 
+        # NB: Keep the variable name `_data` in sync with `externs/mod.rs`.
         self._data = dict(item[0]) if item else dict()
         self._data.update(**kwargs)
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1561,7 +1561,7 @@ fn run_local_interactive_process(
             command.current_dir(tempdir.path());
           }
 
-          let env = externs::project_tuple_encoded_map(&value, "env")?;
+          let env = externs::project_frozendict(&value, "env");
           for (key, value) in env.iter() {
             command.env(key, value);
           }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -239,7 +239,7 @@ impl MultiPlatformExecuteProcess {
     value: &Value,
     target_platform: PlatformConstraint,
   ) -> Result<Process, String> {
-    let env = externs::project_tuple_encoded_map(&value, "env")?;
+    let env = externs::project_frozendict(&value, "env");
 
     let working_directory = {
       let val = externs::project_str(&value, "working_directory");
@@ -274,7 +274,7 @@ impl MultiPlatformExecuteProcess {
     let description = externs::project_str(&value, "description");
     let level = externs::val_to_log_level(&externs::project_ignoring_type(&value, "level"))?;
 
-    let append_only_caches = externs::project_tuple_encoded_map(&value, "append_only_caches")?
+    let append_only_caches = externs::project_frozendict(&value, "append_only_caches")
       .into_iter()
       .map(|(name, dest)| Ok((CacheName::new(name)?, CacheDest::new(dest)?)))
       .collect::<Result<_, String>>()?;


### PR DESCRIPTION
### Problem

We want to be able to convert the relevant parts of a `Process` to an `InteractiveProcess`. This will help, for example, so that we can use the normal Pytest `Process` to populate the `env` and `argv` for an `InteractiveProcess`. However, this is really tricky to do because we store `Process.env` as a `Tuple[str, ...]`, rather than a `Mapping[str, str]` or `Tuple[Tuple[str, str], ...]`. Instead, we ideally want to store the `env` as a `FrozenDict[str, str]`.

### Solution

Teach Rust how a `FrozenDict` works, which is really a light wrapper around a dictionary. This means we can use the CPython crate's `PyDict` type, then convert that to a `BTreeMap`.

[ci skip-build-wheels]
