### PR TITLE
WIP: Simplify logger.rs to always use the global log level

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -133,11 +133,11 @@ class Native(metaclass=SingletonMetaclass):
     def default_config_path(self) -> str:
         return cast(str, self.lib.default_config_path())
 
-    def setup_pantsd_logger(self, log_file_path, level):
-        return self.lib.setup_pantsd_logger(log_file_path, level)
+    def setup_pantsd_logger(self, log_file_path):
+        return self.lib.setup_pantsd_logger(log_file_path)
 
-    def setup_stderr_logger(self, level):
-        return self.lib.setup_stderr_logger(level)
+    def setup_stderr_logger(self):
+        return self.lib.setup_stderr_logger()
 
     def write_log(self, msg: str, *, level: int, target: str):
         """Proxy a log message to the Rust logging faculties."""

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -92,13 +92,9 @@ py_module_initializer!(native_engine, |py, m| {
   m.add(
     py,
     "setup_pantsd_logger",
-    py_fn!(py, setup_pantsd_logger(a: String, b: u64)),
+    py_fn!(py, setup_pantsd_logger(a: String)),
   )?;
-  m.add(
-    py,
-    "setup_stderr_logger",
-    py_fn!(py, setup_stderr_logger(a: u64)),
-  )?;
+  m.add(py, "setup_stderr_logger", py_fn!(py, setup_stderr_logger()))?;
   m.add(py, "flush_log", py_fn!(py, flush_log()))?;
   m.add(
     py,
@@ -1654,21 +1650,18 @@ fn init_logging(
   Ok(None)
 }
 
-fn setup_pantsd_logger(py: Python, log_file: String, level: u64) -> CPyResult<i64> {
+fn setup_pantsd_logger(py: Python, log_file: String) -> CPyResult<i64> {
   logging::set_thread_destination(Destination::Pantsd);
-
   let path = PathBuf::from(log_file);
   PANTS_LOGGER
-    .set_pantsd_logger(path, level)
+    .set_pantsd_logger(path)
     .map(i64::from)
     .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
 }
 
-fn setup_stderr_logger(_: Python, level: u64) -> PyUnitResult {
+fn setup_stderr_logger(_: Python) -> PyUnitResult {
   logging::set_thread_destination(Destination::Stderr);
-  PANTS_LOGGER
-    .set_stderr_logger(level)
-    .expect("Error setting up STDERR logger");
+  PANTS_LOGGER.set_stderr_logger();
   Ok(None)
 }
 


### PR DESCRIPTION
Currently, the `Stderr` and `Pantsd` destinations can have different log levels than the global log level. However, we are not using this functionality.

If we did use this functionality, it would result in an inconsistent experience between `--dynamic-ui` and `--no-dynamic-ui`, as `--dynamic-ui` logs solely use the global log level.

By leaning into this assumption that Stderr and Pantsd use the global log level, we can simplify the code and get closer to https://github.com/pantsbuild/pants/issues/10646, which aims to unify all 3 log implementations so that we are more consistent.

[ci skip-build-wheels]