### PR TITLE
Fix glob param passed when loading coverage config file.

### DIFF
--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -170,7 +170,7 @@ async def create_coverage_config(coverage: CoverageSubsystem) -> CoverageConfig:
         config_contents = await Get(
             DigestContents,
             PathGlobs(
-                globs=coverage.config,
+                globs=tuple(coverage.config,),
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
                 description_of_origin=f"the option `--{coverage.options_scope}-config`",
             ),


### PR DESCRIPTION
### Problem

PathGlob glob param expects a collection (iterable) of strings, passing it a string prevents it from working properly

### Solution

Pass the correct param type


derp.

<img width="1092" alt="Screen Shot 2020-08-21 at 7 38 04 PM" src="https://user-images.githubusercontent.com/1268088/90946878-291d7100-e3e6-11ea-91f2-fc4b9f347a7a.png">
