### PR TITLE
Change `pants_integration_test.py` to use Pytest-style functions

### DIFF
--- a/src/python/pants/backend/python/rules/coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/coverage_integration_test.py
@@ -109,7 +109,7 @@ class CoverageIntegrationTest(PantsIntegrationTest):
             *more_args,
         ]
         result = self.run_pants(command)
-        self.assert_success(result)
+        result.assert_success()
         # Regression test: make sure that individual tests do not complain about failing to
         # generate reports. This was showing up at test-time, even though the final merged
         # report would work properly.

--- a/src/python/pants/backend/python/rules/coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/coverage_integration_test.py
@@ -6,193 +6,194 @@ from pathlib import Path
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
-from pants.testutil.pants_integration_test import PantsIntegrationTest, PantsResult, setup_tmpdir
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
+
+SOURCES = {
+    # Only `lib.py` will actually be tested, but we still expect `random.py` t`o show up in
+    # the final report correctly.
+    "src/python/project/__init__.py": "",
+    "src/python/project/lib.py": dedent(
+        """\
+        def add(x, y):
+            return x + y
+
+        def subtract(x, y):
+            return x - y
+
+        def multiply(x, y):
+            return x * y
+        """
+    ),
+    "src/python/project/random.py": dedent(
+        """\
+        def capitalize(s):
+            return s.capitalize()
+        """
+    ),
+    # Only test half of the library.
+    "src/python/project/lib_test.py": dedent(
+        """\
+        from project.lib import add
+
+        def test_add():
+            assert add(2, 3) == 5
+        """
+    ),
+    "src/python/project/BUILD": dedent(
+        """\
+        python_library()
+
+        python_tests(
+            name="tests",
+            dependencies=[":project"],
+        )
+        """
+    ),
+    # Test that a `tests/` source root accurately gets coverage data for the `src/`
+    # root.
+    "tests/python/project_test/__init__.py": "",
+    "tests/python/project_test/test_multiply.py": dedent(
+        """\
+        from project.lib import multiply
+
+        def test_multiply():
+            assert multiply(2, 3) == 6
+        """
+    ),
+    "tests/python/project_test/test_arithmetic.py": dedent(
+        """\
+        from project.lib import add, subtract
+
+        def test_arithmetic():
+            assert add(4, 3) == 7 == subtract(10, 3)
+        """
+    ),
+    "tests/python/project_test/BUILD": dedent(
+        """\
+        python_tests(
+            name="multiply",
+            sources=["test_multiply.py"],
+            dependencies=['{tmpdir}/src/python/project'],
+        )
+
+        python_tests(
+            name="arithmetic",
+            sources=["test_arithmetic.py"],
+            dependencies=['{tmpdir}/src/python/project'],
+        )
+        """
+    ),
+    # Test a file that does not cover any src code. While this is unlikely to happen,
+    # this tests that we can properly handle the edge case.
+    "tests/python/project_test/no_src/__init__.py": "",
+    "tests/python/project_test/no_src/test_no_src.py": dedent(
+        """\
+        def test_true():
+           assert True is True
+        """
+    ),
+    "tests/python/project_test/no_src/BUILD.py": "python_tests()",
+}
 
 
-class CoverageIntegrationTest(PantsIntegrationTest):
-    sources = {
-        # Only `lib.py` will actually be tested, but we still expect `random.py` t`o show up in
-        # the final report correctly.
-        "src/python/project/__init__.py": "",
-        "src/python/project/lib.py": dedent(
-            """\
-            def add(x, y):
-                return x + y
+def run_coverage(tmpdir: str, *more_args: str) -> PantsResult:
+    command = [
+        "--backend-packages=pants.backend.python",
+        "test",
+        "--use-coverage",
+        f"{tmpdir}/src/python/project:tests",
+        f"{tmpdir}/tests/python/project_test:multiply",
+        f"{tmpdir}/tests/python/project_test:arithmetic",
+        f"{tmpdir}/tests/python/project_test/no_src",
+        *more_args,
+    ]
+    result = run_pants(command)
+    result.assert_success()
+    # Regression test: make sure that individual tests do not complain about failing to
+    # generate reports. This was showing up at test-time, even though the final merged
+    # report would work properly.
+    assert "Failed to generate report" not in result.stderr
+    return result
 
-            def subtract(x, y):
-                return x - y
 
-            def multiply(x, y):
-                return x * y
+def test_coverage() -> None:
+    with setup_tmpdir(SOURCES) as tmpdir:
+        result = run_coverage(tmpdir)
+    assert (
+        dedent(
+            f"""\
+            Name                                                          Stmts   Miss  Cover
+            ---------------------------------------------------------------------------------
+            {tmpdir}/src/python/project/__init__.py                        0      0   100%
+            {tmpdir}/src/python/project/lib.py                             6      0   100%
+            {tmpdir}/src/python/project/lib_test.py                        3      0   100%
+            {tmpdir}/tests/python/project_test/__init__.py                 0      0   100%
+            {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
+            {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
+            {tmpdir}/tests/python/project_test/test_arithmetic.py          3      0   100%
+            {tmpdir}/tests/python/project_test/test_multiply.py            3      0   100%
+            ---------------------------------------------------------------------------------
+            TOTAL                                                            17      0   100%
             """
-        ),
-        "src/python/project/random.py": dedent(
-            """\
-            def capitalize(s):
-                return s.capitalize()
-            """
-        ),
-        # Only test half of the library.
-        "src/python/project/lib_test.py": dedent(
-            """\
-            from project.lib import add
+        )
+        in result.stderr
+    )
 
-            def test_add():
-                assert add(2, 3) == 5
-            """
-        ),
-        "src/python/project/BUILD": dedent(
-            """\
-            python_library()
 
-            python_tests(
-                name="tests",
-                dependencies=[":project"],
-            )
+def test_coverage_with_filter() -> None:
+    with setup_tmpdir(SOURCES) as tmpdir:
+        result = run_coverage(tmpdir, "--coverage-py-filter=['project.lib', 'project_test.no_src']")
+    assert (
+        dedent(
+            f"""\
+            Name                                                          Stmts   Miss  Cover
+            ---------------------------------------------------------------------------------
+            {tmpdir}/src/python/project/lib.py                             6      0   100%
+            {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
+            {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
+            ---------------------------------------------------------------------------------
+            TOTAL                                                             8      0   100%
             """
-        ),
-        # Test that a `tests/` source root accurately gets coverage data for the `src/`
-        # root.
-        "tests/python/project_test/__init__.py": "",
-        "tests/python/project_test/test_multiply.py": dedent(
-            """\
-            from project.lib import multiply
+        )
+        in result.stderr
+    )
 
-            def test_multiply():
-                assert multiply(2, 3) == 6
-            """
-        ),
-        "tests/python/project_test/test_arithmetic.py": dedent(
-            """\
-            from project.lib import add, subtract
 
-            def test_arithmetic():
-                assert add(4, 3) == 7 == subtract(10, 3)
-            """
-        ),
-        "tests/python/project_test/BUILD": dedent(
-            """\
-            python_tests(
-                name="multiply",
-                sources=["test_multiply.py"],
-                dependencies=['{tmpdir}/src/python/project'],
-            )
-
-            python_tests(
-                name="arithmetic",
-                sources=["test_arithmetic.py"],
-                dependencies=['{tmpdir}/src/python/project'],
-            )
-            """
-        ),
-        # Test a file that does not cover any src code. While this is unlikely to happen,
-        # this tests that we can properly handle the edge case.
-        "tests/python/project_test/no_src/__init__.py": "",
-        "tests/python/project_test/no_src/test_no_src.py": dedent(
-            """\
-            def test_true():
-               assert True is True
-            """
-        ),
-        "tests/python/project_test/no_src/BUILD.py": "python_tests()",
+def test_coverage_raw() -> None:
+    with setup_tmpdir(SOURCES) as tmpdir:
+        result = run_coverage(tmpdir, "--coverage-py-report=raw")
+    assert "Wrote raw coverage report to `dist/coverage/python`" in result.stderr
+    coverage_data = Path(get_buildroot(), "dist", "coverage", "python", ".coverage")
+    assert coverage_data.exists() is True
+    conn = sqlite3.connect(coverage_data.as_posix())
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+    assert {row[0] for row in cursor.fetchall()} == {
+        "arc",
+        "context",
+        "coverage_schema",
+        "file",
+        "line_bits",
+        "meta",
+        "tracer",
     }
 
-    def run_coverage(self, tmpdir: str, *more_args: str) -> PantsResult:
-        command = [
-            "--backend-packages=pants.backend.python",
-            "test",
-            "--use-coverage",
-            f"{tmpdir}/src/python/project:tests",
-            f"{tmpdir}/tests/python/project_test:multiply",
-            f"{tmpdir}/tests/python/project_test:arithmetic",
-            f"{tmpdir}/tests/python/project_test/no_src",
-            *more_args,
-        ]
-        result = self.run_pants(command)
-        result.assert_success()
-        # Regression test: make sure that individual tests do not complain about failing to
-        # generate reports. This was showing up at test-time, even though the final merged
-        # report would work properly.
-        assert "Failed to generate report" not in result.stderr
-        return result
 
-    def test_coverage(self) -> None:
-        with setup_tmpdir(self.sources) as tmpdir:
-            result = self.run_coverage(tmpdir)
-        assert (
-            dedent(
-                f"""\
-                Name                                                          Stmts   Miss  Cover
-                ---------------------------------------------------------------------------------
-                {tmpdir}/src/python/project/__init__.py                        0      0   100%
-                {tmpdir}/src/python/project/lib.py                             6      0   100%
-                {tmpdir}/src/python/project/lib_test.py                        3      0   100%
-                {tmpdir}/tests/python/project_test/__init__.py                 0      0   100%
-                {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
-                {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
-                {tmpdir}/tests/python/project_test/test_arithmetic.py          3      0   100%
-                {tmpdir}/tests/python/project_test/test_multiply.py            3      0   100%
-                ---------------------------------------------------------------------------------
-                TOTAL                                                            17      0   100%
-                """
-            )
-            in result.stderr
-        )
+def test_coverage_html_xml_json() -> None:
+    with setup_tmpdir(SOURCES) as tmpdir:
+        result = run_coverage(tmpdir, "--coverage-py-report=['xml', 'html', 'json']")
+    coverage_path = Path(get_buildroot(), "dist", "coverage", "python")
+    assert coverage_path.exists() is True
 
-    def test_coverage_with_filter(self) -> None:
-        with setup_tmpdir(self.sources) as tmpdir:
-            result = self.run_coverage(
-                tmpdir, "--coverage-py-filter=['project.lib', 'project_test.no_src']"
-            )
-        assert (
-            dedent(
-                f"""\
-                Name                                                          Stmts   Miss  Cover
-                ---------------------------------------------------------------------------------
-                {tmpdir}/src/python/project/lib.py                             6      0   100%
-                {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
-                {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
-                ---------------------------------------------------------------------------------
-                TOTAL                                                             8      0   100%
-                """
-            )
-            in result.stderr
-        )
+    assert "Wrote xml coverage report to `dist/coverage/python`" in result.stderr
+    xml_coverage = coverage_path / "coverage.xml"
+    assert xml_coverage.exists() is True
 
-    def test_coverage_raw(self) -> None:
-        with setup_tmpdir(self.sources) as tmpdir:
-            result = self.run_coverage(tmpdir, "--coverage-py-report=raw")
-        assert "Wrote raw coverage report to `dist/coverage/python`" in result.stderr
-        coverage_data = Path(get_buildroot(), "dist", "coverage", "python", ".coverage")
-        assert coverage_data.exists() is True
-        conn = sqlite3.connect(coverage_data.as_posix())
-        cursor = conn.cursor()
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
-        assert {row[0] for row in cursor.fetchall()} == {
-            "arc",
-            "context",
-            "coverage_schema",
-            "file",
-            "line_bits",
-            "meta",
-            "tracer",
-        }
+    assert "Wrote html coverage report to `dist/coverage/python`" in result.stderr
+    html_cov_dir = coverage_path / "htmlcov"
+    assert html_cov_dir.exists() is True
+    assert (html_cov_dir / "index.html").exists() is True
 
-    def test_coverage_html_xml_json(self) -> None:
-        with setup_tmpdir(self.sources) as tmpdir:
-            result = self.run_coverage(tmpdir, "--coverage-py-report=['xml', 'html', 'json']")
-        coverage_path = Path(get_buildroot(), "dist", "coverage", "python")
-        assert coverage_path.exists() is True
-
-        assert "Wrote xml coverage report to `dist/coverage/python`" in result.stderr
-        xml_coverage = coverage_path / "coverage.xml"
-        assert xml_coverage.exists() is True
-
-        assert "Wrote html coverage report to `dist/coverage/python`" in result.stderr
-        html_cov_dir = coverage_path / "htmlcov"
-        assert html_cov_dir.exists() is True
-        assert (html_cov_dir / "index.html").exists() is True
-
-        assert "Wrote json coverage report to `dist/coverage/python`" in result.stderr_data
-        json_coverage = coverage_path / "coverage.json"
-        assert json_coverage.exists() is True
+    assert "Wrote json coverage report to `dist/coverage/python`" in result.stderr_data
+    json_coverage = coverage_path / "coverage.json"
+    assert json_coverage.exists() is True

--- a/src/python/pants/backend/python/rules/coverage_integration_test.py
+++ b/src/python/pants/backend/python/rules/coverage_integration_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
-from pants.testutil.pants_integration_test import PantsIntegrationTest, PantsResult
+from pants.testutil.pants_integration_test import PantsIntegrationTest, PantsResult, setup_tmpdir
 
 
 class CoverageIntegrationTest(PantsIntegrationTest):
@@ -117,7 +117,7 @@ class CoverageIntegrationTest(PantsIntegrationTest):
         return result
 
     def test_coverage(self) -> None:
-        with self.setup_tmpdir(self.sources) as tmpdir:
+        with setup_tmpdir(self.sources) as tmpdir:
             result = self.run_coverage(tmpdir)
         assert (
             dedent(
@@ -140,7 +140,7 @@ class CoverageIntegrationTest(PantsIntegrationTest):
         )
 
     def test_coverage_with_filter(self) -> None:
-        with self.setup_tmpdir(self.sources) as tmpdir:
+        with setup_tmpdir(self.sources) as tmpdir:
             result = self.run_coverage(
                 tmpdir, "--coverage-py-filter=['project.lib', 'project_test.no_src']"
             )
@@ -160,7 +160,7 @@ class CoverageIntegrationTest(PantsIntegrationTest):
         )
 
     def test_coverage_raw(self) -> None:
-        with self.setup_tmpdir(self.sources) as tmpdir:
+        with setup_tmpdir(self.sources) as tmpdir:
             result = self.run_coverage(tmpdir, "--coverage-py-report=raw")
         assert "Wrote raw coverage report to `dist/coverage/python`" in result.stderr
         coverage_data = Path(get_buildroot(), "dist", "coverage", "python", ".coverage")
@@ -179,7 +179,7 @@ class CoverageIntegrationTest(PantsIntegrationTest):
         }
 
     def test_coverage_html_xml_json(self) -> None:
-        with self.setup_tmpdir(self.sources) as tmpdir:
+        with setup_tmpdir(self.sources) as tmpdir:
             result = self.run_coverage(tmpdir, "--coverage-py-report=['xml', 'html', 'json']")
         coverage_path = Path(get_buildroot(), "dist", "coverage", "python")
         assert coverage_path.exists() is True

--- a/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
+++ b/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
@@ -3,7 +3,7 @@
 
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
 
 
 class RunPythonBinaryIntegrationTest(PantsIntegrationTest):
@@ -37,7 +37,7 @@ class RunPythonBinaryIntegrationTest(PantsIntegrationTest):
             ),
             "src_root2/utils/BUILD": "python_library()",
         }
-        with self.setup_tmpdir(sources) as tmpdir:
+        with setup_tmpdir(sources) as tmpdir:
             result = self.run_pants(
                 [
                     "--backend-packages=pants.backend.python",

--- a/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
+++ b/src/python/pants/backend/python/rules/run_python_binary_integration_test.py
@@ -3,52 +3,51 @@
 
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
-class RunPythonBinaryIntegrationTest(PantsIntegrationTest):
-    def test_sample_script(self) -> None:
-        """Test that we properly run a `python_binary` target.
+def test_run_sample_script() -> None:
+    """Test that we properly run a `python_binary` target.
 
-        This checks a few things:
-        - We can handle source roots.
-        - We properly load third party requirements.
-        - We propagate the error code.
-        """
-        sources = {
-            "src_root1/project/app.py": dedent(
-                """\
-                import sys
-                from utils.strutil import upper_case
+    This checks a few things:
+    - We can handle source roots.
+    - We properly load third party requirements.
+    - We propagate the error code.
+    """
+    sources = {
+        "src_root1/project/app.py": dedent(
+            """\
+            import sys
+            from utils.strutil import upper_case
 
 
-                if __name__ == "__main__":
-                    print(upper_case("Hello world."))
-                    print("Hola, mundo.", file=sys.stderr)
-                    sys.exit(23)
-                """
-            ),
-            "src_root1/project/BUILD": "python_binary(sources=['app.py'])",
-            "src_root2/utils/strutil.py": dedent(
-                """\
-                def upper_case(s):
-                    return s.upper()
-                """
-            ),
-            "src_root2/utils/BUILD": "python_library()",
-        }
-        with setup_tmpdir(sources) as tmpdir:
-            result = self.run_pants(
-                [
-                    "--backend-packages=pants.backend.python",
-                    f"--source-root-patterns=['/{tmpdir}/src_root1', '/{tmpdir}/src_root2']",
-                    "--pants-ignore=__pycache__",
-                    "--pants-ignore=/src/python",
-                    "run",
-                    f"{tmpdir}/src_root1/project/app.py",
-                ]
-            )
+            if __name__ == "__main__":
+                print(upper_case("Hello world."))
+                print("Hola, mundo.", file=sys.stderr)
+                sys.exit(23)
+            """
+        ),
+        "src_root1/project/BUILD": "python_binary(sources=['app.py'])",
+        "src_root2/utils/strutil.py": dedent(
+            """\
+            def upper_case(s):
+                return s.upper()
+            """
+        ),
+        "src_root2/utils/BUILD": "python_library()",
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        result = run_pants(
+            [
+                "--backend-packages=pants.backend.python",
+                f"--source-root-patterns=['/{tmpdir}/src_root1', '/{tmpdir}/src_root2']",
+                "--pants-ignore=__pycache__",
+                "--pants-ignore=/src/python",
+                "run",
+                f"{tmpdir}/src_root1/project/app.py",
+            ]
+        )
 
-        assert "Hola, mundo.\n" in result.stderr
-        assert result.stdout == "HELLO WORLD.\n"
-        assert result.exit_code == 23
+    assert "Hola, mundo.\n" in result.stderr
+    assert result.stdout == "HELLO WORLD.\n"
+    assert result.exit_code == 23

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -52,7 +52,7 @@ Exception message:.* 1 Exception encountered:
                 pants_run = self.run_pants_with_workdir(
                     self._lifecycle_stub_cmdline(), workdir=tmpdir
                 )
-                self.assert_failure(pants_run)
+                pants_run.assert_failure()
 
                 self.assertIn(
                     "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!",
@@ -79,7 +79,7 @@ Exception message:.* 1 Exception encountered:
                 pants_run = self.run_pants_with_workdir(
                     self._lifecycle_stub_cmdline(), workdir=tmpdir
                 )
-                self.assert_failure(pants_run)
+                pants_run.assert_failure()
 
                 self.assertIn(
                     dedent(
@@ -107,7 +107,7 @@ Exception message:.* 1 Exception encountered:
                 # The backtrace should be omitted when --print-exception-stacktrace=False.
                 print_exception_stacktrace=False,
             )
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertRegex(
                 pants_run.stderr,
                 f"""\

--- a/src/python/pants/base/exiter_integration_test.py
+++ b/src/python/pants/base/exiter_integration_test.py
@@ -16,5 +16,5 @@ class ExiterIntegrationTest(PantsIntegrationTest):
                 "testprojects/src/python/unicode/compilation_failure",
             ]
         )
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("import sys¡", pants_run.stderr)

--- a/src/python/pants/base/exiter_integration_test.py
+++ b/src/python/pants/base/exiter_integration_test.py
@@ -1,20 +1,17 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, ensure_daemon
+from pants.testutil.pants_integration_test import ensure_daemon, run_pants
 
 
-class ExiterIntegrationTest(PantsIntegrationTest):
-    """Tests that "interesting" exceptions are properly rendered."""
-
-    @ensure_daemon
-    def test_unicode_containing_exception(self):
-        pants_run = self.run_pants(
-            [
-                "--backend-packages=pants.backend.python",
-                "run",
-                "testprojects/src/python/unicode/compilation_failure",
-            ]
-        )
-        pants_run.assert_failure()
-        self.assertIn("import sys¡", pants_run.stderr)
+@ensure_daemon
+def test_unicode_containing_exception():
+    pants_run = run_pants(
+        [
+            "--backend-packages=pants.backend.python",
+            "run",
+            "testprojects/src/python/unicode/compilation_failure",
+        ]
+    )
+    pants_run.assert_failure()
+    assert "import sys¡" in pants_run.stderr

--- a/src/python/pants/build_graph/subproject_integration_test.py
+++ b/src/python/pants/build_graph/subproject_integration_test.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 from typing import Iterator
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 from pants.util.dirutil import safe_file_dump, safe_rmtree
 
 """
@@ -73,36 +73,35 @@ def harness() -> Iterator[None]:
         safe_rmtree(SUBPROJ_SPEC)
 
 
-class SubprojectIntegrationTest(PantsIntegrationTest):
-    def test_subproject(self) -> None:
-        with harness():
-            # If `--subproject-roots` are not specified, we expect a failure.
-            self.run_pants(
-                [
-                    "--backend-packages=pants.backend.python",
-                    "dependencies",
-                    "--transitive",
-                    SUBPROJ_SPEC,
-                ]
-            ).assert_failure()
+def test_subproject() -> None:
+    with harness():
+        # If `--subproject-roots` are not specified, we expect a failure.
+        run_pants(
+            [
+                "--backend-packages=pants.backend.python",
+                "dependencies",
+                "--transitive",
+                SUBPROJ_SPEC,
+            ]
+        ).assert_failure()
 
-            # The same command should succeed when `--subproject-roots` are specified.
-            self.run_pants(
-                [
-                    "--backend-packages=pants.backend.python",
-                    f"--subproject-roots={SUBPROJ_ROOT}",
-                    "dependencies",
-                    "--transitive",
-                    SUBPROJ_SPEC,
-                ]
-            ).assert_success()
+        # The same command should succeed when `--subproject-roots` are specified.
+        run_pants(
+            [
+                "--backend-packages=pants.backend.python",
+                f"--subproject-roots={SUBPROJ_ROOT}",
+                "dependencies",
+                "--transitive",
+                SUBPROJ_SPEC,
+            ]
+        ).assert_success()
 
-            # Both relative and absolute dependencies should work.
-            self.run_pants(
-                [
-                    "--backend-packages=pants.backend.python",
-                    f"--subproject-roots={SUBPROJ_ROOT}",
-                    "dependencies",
-                    f"{SUBPROJ_ROOT}:local",
-                ]
-            ).assert_success()
+        # Both relative and absolute dependencies should work.
+        run_pants(
+            [
+                "--backend-packages=pants.backend.python",
+                f"--subproject-roots={SUBPROJ_ROOT}",
+                "dependencies",
+                f"{SUBPROJ_ROOT}:local",
+            ]
+        ).assert_success()

--- a/src/python/pants/build_graph/subproject_integration_test.py
+++ b/src/python/pants/build_graph/subproject_integration_test.py
@@ -77,38 +77,32 @@ class SubprojectIntegrationTest(PantsIntegrationTest):
     def test_subproject(self) -> None:
         with harness():
             # If `--subproject-roots` are not specified, we expect a failure.
-            self.assert_failure(
-                self.run_pants(
-                    [
-                        "--backend-packages=pants.backend.python",
-                        "dependencies",
-                        "--transitive",
-                        SUBPROJ_SPEC,
-                    ]
-                )
-            )
+            self.run_pants(
+                [
+                    "--backend-packages=pants.backend.python",
+                    "dependencies",
+                    "--transitive",
+                    SUBPROJ_SPEC,
+                ]
+            ).assert_failure()
 
             # The same command should succeed when `--subproject-roots` are specified.
-            self.assert_success(
-                self.run_pants(
-                    [
-                        "--backend-packages=pants.backend.python",
-                        f"--subproject-roots={SUBPROJ_ROOT}",
-                        "dependencies",
-                        "--transitive",
-                        SUBPROJ_SPEC,
-                    ]
-                )
-            )
+            self.run_pants(
+                [
+                    "--backend-packages=pants.backend.python",
+                    f"--subproject-roots={SUBPROJ_ROOT}",
+                    "dependencies",
+                    "--transitive",
+                    SUBPROJ_SPEC,
+                ]
+            ).assert_success()
 
             # Both relative and absolute dependencies should work.
-            self.assert_success(
-                self.run_pants(
-                    [
-                        "--backend-packages=pants.backend.python",
-                        f"--subproject-roots={SUBPROJ_ROOT}",
-                        "dependencies",
-                        f"{SUBPROJ_ROOT}:local",
-                    ]
-                )
-            )
+            self.run_pants(
+                [
+                    "--backend-packages=pants.backend.python",
+                    f"--subproject-roots={SUBPROJ_ROOT}",
+                    "dependencies",
+                    f"{SUBPROJ_ROOT}:local",
+                ]
+            ).assert_success()

--- a/src/python/pants/core/goals/fmt_integration_test.py
+++ b/src/python/pants/core/goals/fmt_integration_test.py
@@ -4,38 +4,37 @@
 import re
 
 from pants.testutil.pants_integration_test import (
-    PantsIntegrationTest,
     ensure_daemon,
+    run_pants_with_workdir,
     temporary_workdir,
 )
 from pants.util.contextutil import overwrite_file_content
 from pants.util.dirutil import read_file
 
 
-class FmtIntegrationTest(PantsIntegrationTest):
-    @ensure_daemon
-    def test_fmt_then_edit(self):
-        f = "examples/src/python/example/hello/greet/greet.py"
-        with temporary_workdir() as workdir:
+@ensure_daemon
+def test_fmt_then_edit():
+    f = "examples/src/python/example/hello/greet/greet.py"
+    with temporary_workdir() as workdir:
 
-            def run() -> None:
-                self.run_pants_with_workdir(
-                    [
-                        "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.black']",
-                        "fmt",
-                        f,
-                    ],
-                    workdir=workdir,
-                ).assert_success()
+        def run() -> None:
+            run_pants_with_workdir(
+                [
+                    "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.black']",
+                    "fmt",
+                    f,
+                ],
+                workdir=workdir,
+            ).assert_success()
 
-            # Run once to start up, and then capture the file content.
+        # Run once to start up, and then capture the file content.
+        run()
+        good_content = read_file(f)
+
+        # Edit the file.
+        with overwrite_file_content(f, lambda c: re.sub(b"def greet", b"def  greet", c)):
+            assert good_content != read_file(f)
+
+            # Re-run and confirm that the file was fixed.
             run()
-            good_content = read_file(f)
-
-            # Edit the file.
-            with overwrite_file_content(f, lambda c: re.sub(b"def greet", b"def  greet", c)):
-                assert good_content != read_file(f)
-
-                # Re-run and confirm that the file was fixed.
-                run()
-                assert good_content == read_file(f)
+            assert good_content == read_file(f)

--- a/src/python/pants/core/goals/fmt_integration_test.py
+++ b/src/python/pants/core/goals/fmt_integration_test.py
@@ -14,15 +14,14 @@ class FmtIntegrationTest(PantsIntegrationTest):
         with self.temporary_workdir() as workdir:
 
             def run() -> None:
-                result = self.run_pants_with_workdir(
+                self.run_pants_with_workdir(
                     [
                         "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.black']",
                         "fmt",
                         f,
                     ],
                     workdir=workdir,
-                )
-                self.assert_success(result)
+                ).assert_success()
 
             # Run once to start up, and then capture the file content.
             run()

--- a/src/python/pants/core/goals/fmt_integration_test.py
+++ b/src/python/pants/core/goals/fmt_integration_test.py
@@ -3,7 +3,12 @@
 
 import re
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, ensure_daemon
+from pants.testutil.pants_integration_test import (
+    PantsIntegrationTest,
+    ensure_daemon,
+    temporary_workdir,
+)
+from pants.util.contextutil import overwrite_file_content
 from pants.util.dirutil import read_file
 
 
@@ -11,7 +16,7 @@ class FmtIntegrationTest(PantsIntegrationTest):
     @ensure_daemon
     def test_fmt_then_edit(self):
         f = "examples/src/python/example/hello/greet/greet.py"
-        with self.temporary_workdir() as workdir:
+        with temporary_workdir() as workdir:
 
             def run() -> None:
                 self.run_pants_with_workdir(
@@ -28,7 +33,7 @@ class FmtIntegrationTest(PantsIntegrationTest):
             good_content = read_file(f)
 
             # Edit the file.
-            with self.overwrite_file_content(f, lambda c: re.sub(b"def greet", b"def  greet", c)):
+            with overwrite_file_content(f, lambda c: re.sub(b"def greet", b"def  greet", c)):
                 assert good_content != read_file(f)
 
                 # Re-run and confirm that the file was fixed.

--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -3,34 +3,36 @@
 
 from pathlib import Path
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, ensure_daemon
+from pants.testutil.pants_integration_test import ensure_daemon, run_pants
 from pants.util.contextutil import temporary_dir
 
 
-class SchedulerIntegrationTest(PantsIntegrationTest):
-    def test_visualize_to(self):
-        # Tests usage of the `--native-engine-visualize-to=` option, which triggers background
-        # visualization of the graph. There are unit tests confirming the content of the rendered
-        # results.
-        with temporary_dir() as destdir:
-            args = [
+def test_visualize_to():
+    # Tests usage of the `--native-engine-visualize-to=` option, which triggers background
+    # visualization of the graph. There are unit tests confirming the content of the rendered
+    # results.
+    with temporary_dir() as destdir:
+        run_pants(
+            [
                 f"--native-engine-visualize-to={destdir}",
                 "--backend-packages=pants.backend.python",
                 "list",
                 "examples/src/python/example/hello/greet",
             ]
-            self.run_pants(args).assert_success()
-            destdir_files = list(Path(destdir).iterdir())
-            self.assertTrue(len(destdir_files) > 0)
+        ).assert_success()
+        destdir_files = list(Path(destdir).iterdir())
+        assert len(destdir_files) > 0
 
-    @ensure_daemon
-    def test_graceful_termination(self):
-        args = [
+
+@ensure_daemon
+def test_graceful_termination():
+    result = run_pants(
+        [
             "--backend-packages=['pants.backend.python', 'internal_backend.rules_for_testing']",
             "list-and-die-for-testing",
             "examples/src/python/example/hello/greet",
         ]
-        result = self.run_pants(args)
-        result.assert_failure()
-        self.assertEqual(result.stdout, "examples/src/python/example/hello/greet\n")
-        self.assertEqual(result.exit_code, 42)
+    )
+    result.assert_failure()
+    assert result.stdout == "examples/src/python/example/hello/greet\n"
+    assert result.exit_code == 42

--- a/src/python/pants/engine/internals/scheduler_integration_test.py
+++ b/src/python/pants/engine/internals/scheduler_integration_test.py
@@ -19,7 +19,7 @@ class SchedulerIntegrationTest(PantsIntegrationTest):
                 "list",
                 "examples/src/python/example/hello/greet",
             ]
-            self.assert_success(self.run_pants(args))
+            self.run_pants(args).assert_success()
             destdir_files = list(Path(destdir).iterdir())
             self.assertTrue(len(destdir_files) > 0)
 
@@ -30,7 +30,7 @@ class SchedulerIntegrationTest(PantsIntegrationTest):
             "list-and-die-for-testing",
             "examples/src/python/example/hello/greet",
         ]
-        pants_result = self.run_pants(args)
-        self.assert_failure(pants_result)
-        self.assertEqual(pants_result.stdout, "examples/src/python/example/hello/greet\n")
-        self.assertEqual(pants_result.exit_code, 42)
+        result = self.run_pants(args)
+        result.assert_failure()
+        self.assertEqual(result.stdout, "examples/src/python/example/hello/greet\n")
+        self.assertEqual(result.exit_code, 42)

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -10,7 +10,7 @@ class TestHelpIntegration(PantsIntegrationTest):
     def test_help(self):
         command = ["help"]
         pants_run = self.run_pants(command=command)
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         assert "Usage:" in pants_run.stdout
         # spot check to see that a public global option is printed
         assert "--level" in pants_run.stdout
@@ -19,7 +19,7 @@ class TestHelpIntegration(PantsIntegrationTest):
     def test_help_advanced(self):
         command = ["help-advanced"]
         pants_run = self.run_pants(command=command)
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         assert "Global advanced options" in pants_run.stdout
         # Spot check to see that a global advanced option is printed
         assert "--pants-bootstrapdir" in pants_run.stdout
@@ -27,7 +27,7 @@ class TestHelpIntegration(PantsIntegrationTest):
     def test_help_all(self):
         command = ["--backend-packages=pants.backend.python", "help-all"]
         pants_run = self.run_pants(command=command)
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         all_help = json.loads(pants_run.stdout)
 
         # Spot check the data.

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -3,38 +3,36 @@
 
 import json
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class TestHelpIntegration(PantsIntegrationTest):
-    def test_help(self):
-        command = ["help"]
-        pants_run = self.run_pants(command=command)
-        pants_run.assert_success()
-        assert "Usage:" in pants_run.stdout
-        # spot check to see that a public global option is printed
-        assert "--level" in pants_run.stdout
-        assert "Global options" in pants_run.stdout
+def test_help() -> None:
+    pants_run = run_pants(["help"])
+    pants_run.assert_success()
+    assert "Usage:" in pants_run.stdout
+    # spot check to see that a public global option is printed
+    assert "--level" in pants_run.stdout
+    assert "Global options" in pants_run.stdout
 
-    def test_help_advanced(self):
-        command = ["help-advanced"]
-        pants_run = self.run_pants(command=command)
-        pants_run.assert_success()
-        assert "Global advanced options" in pants_run.stdout
-        # Spot check to see that a global advanced option is printed
-        assert "--pants-bootstrapdir" in pants_run.stdout
 
-    def test_help_all(self):
-        command = ["--backend-packages=pants.backend.python", "help-all"]
-        pants_run = self.run_pants(command=command)
-        pants_run.assert_success()
-        all_help = json.loads(pants_run.stdout)
+def test_help_advanced() -> None:
+    pants_run = run_pants(["help-advanced"])
+    pants_run.assert_success()
+    assert "Global advanced options" in pants_run.stdout
+    # Spot check to see that a global advanced option is printed
+    assert "--pants-bootstrapdir" in pants_run.stdout
 
-        # Spot check the data.
-        assert "name_to_goal_info" in all_help
-        assert "test" in all_help["name_to_goal_info"]
 
-        assert "scope_to_help_info" in all_help
-        assert "" in all_help["scope_to_help_info"]
-        assert "pytest" in all_help["scope_to_help_info"]
-        assert len(all_help["scope_to_help_info"]["pytest"]["basic"]) > 0
+def test_help_all() -> None:
+    pants_run = run_pants(["--backend-packages=pants.backend.python", "help-all"])
+    pants_run.assert_success()
+    all_help = json.loads(pants_run.stdout)
+
+    # Spot check the data.
+    assert "name_to_goal_info" in all_help
+    assert "test" in all_help["name_to_goal_info"]
+
+    assert "scope_to_help_info" in all_help
+    assert "" in all_help["scope_to_help_info"]
+    assert "pytest" in all_help["scope_to_help_info"]
+    assert len(all_help["scope_to_help_info"]["pytest"]["basic"]) > 0

--- a/src/python/pants/help/list_goals_integration_test.py
+++ b/src/python/pants/help/list_goals_integration_test.py
@@ -6,9 +6,8 @@ from pants.testutil.pants_integration_test import PantsIntegrationTest
 
 class TestListGoalsIntegration(PantsIntegrationTest):
     def test_goals(self) -> None:
-        command = ["goals"]
-        pants_run = self.run_pants(command=command)
-        self.assert_success(pants_run)
+        pants_run = self.run_pants(["goals"])
+        pants_run.assert_success()
         assert "to get help for a particular goal" in pants_run.stdout
         # Spot check a few core goals.
         for goal in ["filedeps", "list", "roots", "validate"]:
@@ -20,8 +19,8 @@ class TestListGoalsIntegration(PantsIntegrationTest):
         goals_that_need_implementation = ["binary", "fmt", "lint", "run", "test"]
         command = ["--pants-config-files=[]", "goals"]
 
-        not_implemented_run = self.run_pants(["--backend-packages=[]", *command,])
-        self.assert_success(not_implemented_run)
+        not_implemented_run = self.run_pants(["--backend-packages=[]", *command])
+        not_implemented_run.assert_success()
         for goal in goals_that_need_implementation:
             assert goal not in not_implemented_run.stdout
 
@@ -31,13 +30,12 @@ class TestListGoalsIntegration(PantsIntegrationTest):
                 *command,
             ],
         )
-        self.assert_success(implemented_run)
+        implemented_run.assert_success()
         for goal in goals_that_need_implementation:
             assert goal in implemented_run.stdout
 
     def test_ignored_args(self) -> None:
         # Test that arguments (some of which used to be relevant) are ignored.
-        command = ["goals", "--all", "--graphviz", "--llama"]
-        pants_run = self.run_pants(command=command)
-        self.assert_success(pants_run)
+        pants_run = self.run_pants(["goals", "--all", "--graphviz", "--llama"])
+        pants_run.assert_success()
         assert "to get help for a particular goal" in pants_run.stdout

--- a/src/python/pants/help/list_goals_integration_test.py
+++ b/src/python/pants/help/list_goals_integration_test.py
@@ -1,41 +1,42 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class TestListGoalsIntegration(PantsIntegrationTest):
-    def test_goals(self) -> None:
-        pants_run = self.run_pants(["goals"])
-        pants_run.assert_success()
-        assert "to get help for a particular goal" in pants_run.stdout
-        # Spot check a few core goals.
-        for goal in ["filedeps", "list", "roots", "validate"]:
-            assert goal in pants_run.stdout
+def test_goals() -> None:
+    pants_run = run_pants(["goals"])
+    pants_run.assert_success()
+    assert "to get help for a particular goal" in pants_run.stdout
+    # Spot check a few core goals.
+    for goal in ["filedeps", "list", "roots", "validate"]:
+        assert goal in pants_run.stdout
 
-    def test_only_show_implemented_goals(self) -> None:
-        # Some core goals, such as `./pants test`, require downstream implementations to work
-        # properly. We should only show those goals when an implementation is provided.
-        goals_that_need_implementation = ["binary", "fmt", "lint", "run", "test"]
-        command = ["--pants-config-files=[]", "goals"]
 
-        not_implemented_run = self.run_pants(["--backend-packages=[]", *command])
-        not_implemented_run.assert_success()
-        for goal in goals_that_need_implementation:
-            assert goal not in not_implemented_run.stdout
+def test_only_show_implemented_goals() -> None:
+    # Some core goals, such as `./pants test`, require downstream implementations to work
+    # properly. We should only show those goals when an implementation is provided.
+    goals_that_need_implementation = ["binary", "fmt", "lint", "run", "test"]
+    command = ["--pants-config-files=[]", "goals"]
 
-        implemented_run = self.run_pants(
-            [
-                "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.isort']",
-                *command,
-            ],
-        )
-        implemented_run.assert_success()
-        for goal in goals_that_need_implementation:
-            assert goal in implemented_run.stdout
+    not_implemented_run = run_pants(["--backend-packages=[]", *command])
+    not_implemented_run.assert_success()
+    for goal in goals_that_need_implementation:
+        assert goal not in not_implemented_run.stdout
 
-    def test_ignored_args(self) -> None:
-        # Test that arguments (some of which used to be relevant) are ignored.
-        pants_run = self.run_pants(["goals", "--all", "--graphviz", "--llama"])
-        pants_run.assert_success()
-        assert "to get help for a particular goal" in pants_run.stdout
+    implemented_run = run_pants(
+        [
+            "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.isort']",
+            *command,
+        ],
+    )
+    implemented_run.assert_success()
+    for goal in goals_that_need_implementation:
+        assert goal in implemented_run.stdout
+
+
+def test_ignored_args() -> None:
+    # Test that arguments (some of which used to be relevant) are ignored.
+    pants_run = run_pants(["goals", "--all", "--graphviz", "--llama"])
+    pants_run.assert_success()
+    assert "to get help for a particular goal" in pants_run.stdout

--- a/src/python/pants/init/load_backends_integration_test.py
+++ b/src/python/pants/init/load_backends_integration_test.py
@@ -4,37 +4,37 @@
 from pathlib import Path
 from typing import List
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class LoadBackendsIntegrationTest(PantsIntegrationTest):
-    """Ensure that the rule graph can be loaded properly for each backend."""
+def discover_backends() -> List[str]:
+    register_pys = Path().glob("src/python/**/register.py")
+    backends = {
+        str(register_py.parent).replace("src/python/", "").replace("/", ".")
+        for register_py in register_pys
+    }
+    always_activated = {"pants.core", "pants.backend.project_info", "pants.backend.pants_info"}
+    return sorted(backends - always_activated)
 
-    @staticmethod
-    def discover_backends() -> List[str]:
-        register_pys = Path().glob("src/python/**/register.py")
-        backends = {
-            str(register_py.parent).replace("src/python/", "").replace("/", ".")
-            for register_py in register_pys
-        }
-        always_activated = {"pants.core", "pants.backend.project_info", "pants.backend.pants_info"}
-        return sorted(backends - always_activated)
 
-    def assert_backends_load(self, backends: List[str]) -> None:
-        self.run_pants(
-            ["--no-verify-config", "--version"], config={"GLOBAL": {"backend_packages": backends}}
-        ).assert_success(f"Failed to load: {backends}")
+def assert_backends_load(backends: List[str]) -> None:
+    run_pants(
+        ["--no-verify-config", "--version"], config={"GLOBAL": {"backend_packages": backends}}
+    ).assert_success(f"Failed to load: {backends}")
 
-    def test_no_backends_loaded(self) -> None:
-        self.assert_backends_load([])
 
-    def test_all_backends_loaded(self) -> None:
-        """This should catch all ambiguity issues."""
-        all_backends = self.discover_backends()
-        self.assert_backends_load(all_backends)
+def test_no_backends_loaded() -> None:
+    assert_backends_load([])
 
-    def test_each_distinct_backend_loads(self) -> None:
-        """This should catch graph incompleteness errors, i.e. when a required rule is not
-        registered."""
-        for backend in self.discover_backends():
-            self.assert_backends_load([backend])
+
+def test_all_backends_loaded() -> None:
+    """This should catch all ambiguity issues."""
+    all_backends = discover_backends()
+    assert_backends_load(all_backends)
+
+
+def test_each_distinct_backend_loads() -> None:
+    """This should catch graph incompleteness errors, i.e. when a required rule is not
+    registered."""
+    for backend in discover_backends():
+        assert_backends_load([backend])

--- a/src/python/pants/init/load_backends_integration_test.py
+++ b/src/python/pants/init/load_backends_integration_test.py
@@ -21,10 +21,9 @@ class LoadBackendsIntegrationTest(PantsIntegrationTest):
         return sorted(backends - always_activated)
 
     def assert_backends_load(self, backends: List[str]) -> None:
-        result = self.run_pants(
+        self.run_pants(
             ["--no-verify-config", "--version"], config={"GLOBAL": {"backend_packages": backends}}
-        )
-        self.assert_success(result, msg=f"Failed to load: {backends}")
+        ).assert_success(f"Failed to load: {backends}")
 
     def test_no_backends_loaded(self) -> None:
         self.assert_backends_load([])

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -15,17 +15,17 @@ from pants.util.contextutil import temporary_dir
 @pytest.mark.skip("Skip until https://github.com/pantsbuild/pants/issues/10206")
 class TestOptionsIntegration(PantsIntegrationTest):
     def test_options_works_at_all(self) -> None:
-        self.assert_success(self.run_pants(["options"]))
+        self.run_pants(["options"]).assert_success()
 
     def test_options_scope(self) -> None:
         pants_run = self.run_pants(["options", "--no-colors", "--scope=options"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("options.scope = options", pants_run.stdout)
         self.assertIn("options.name = None", pants_run.stdout)
         self.assertNotIn("pytest.timeouts = ", pants_run.stdout)
 
         pants_run = self.run_pants(["options", "--no-colors", "--scope=pytest"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertNotIn("options.colors = False", pants_run.stdout)
         self.assertNotIn("options.scope = options", pants_run.stdout)
         self.assertNotIn("options.name = None", pants_run.stdout)
@@ -33,7 +33,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
 
     def test_valid_json(self) -> None:
         pants_run = self.run_pants(["options", "--output-format=json"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         try:
             output_map = json.loads(pants_run.stdout)
             self.assertIn("time", output_map)
@@ -44,7 +44,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
 
     def test_valid_json_with_history(self) -> None:
         pants_run = self.run_pants(["options", "--output-format=json", "--show-history"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         try:
             output_map = json.loads(pants_run.stdout)
             self.assertIn("time", output_map)
@@ -60,14 +60,14 @@ class TestOptionsIntegration(PantsIntegrationTest):
         pants_run = self.run_pants(
             ["options", "--no-colors", "--name=colors", "--no-skip-inherited"]
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("options.colors = ", pants_run.stdout)
         self.assertIn("pytest.colors = ", pants_run.stdout)
         self.assertNotIn("options.scope = ", pants_run.stdout)
 
     def test_options_only_overridden(self) -> None:
         pants_run = self.run_pants(["options", "--no-colors", "--only-overridden"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("options.only_overridden = True", pants_run.stdout)
         self.assertNotIn("options.scope =", pants_run.stdout)
         self.assertNotIn("from HARDCODED", pants_run.stdout)
@@ -75,7 +75,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
 
     def test_options_rank(self) -> None:
         pants_run = self.run_pants(["options", "--no-colors", "--rank=FLAG"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("options.rank = ", pants_run.stdout)
         self.assertIn("(from FLAG)", pants_run.stdout)
         self.assertNotIn("(from CONFIG", pants_run.stdout)
@@ -86,7 +86,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
         pants_run = self.run_pants(
             ["options", "--no-colors", "--only-overridden", "--show-history"]
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("options.only_overridden = True", pants_run.stdout)
         self.assertIn("overrode False (from HARDCODED", pants_run.stdout)
 
@@ -106,7 +106,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                     )
                 )
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "options"])
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertIn("options.only_overridden = True", pants_run.stdout)
             self.assertIn(f"(from CONFIG in {config_path})", pants_run.stdout)
 
@@ -133,7 +133,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                     )
                 )
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "options"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("mock-options.normal_option", pants_run.stdout)
         self.assertIn("mock-options.crufty_deprecated_but_still_functioning", pants_run.stdout)
 
@@ -158,7 +158,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                     )
                 )
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "goals"])
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertIn("ERROR] Invalid scope [invalid_scope]", pants_run.stderr)
             self.assertIn("ERROR] Invalid scope [another_invalid_scope]", pants_run.stderr)
 
@@ -179,7 +179,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                     )
                 )
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "goals"])
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertIn("ERROR] Invalid option 'invalid_option' under [pytest]", pants_run.stderr)
 
     def test_from_config_invalid_global_option(self) -> None:
@@ -204,7 +204,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                     )
                 )
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "goals"])
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertIn("ERROR] Invalid option 'invalid_global' under [GLOBAL]", pants_run.stderr)
             self.assertIn(
                 "ERROR] Invalid option 'another_invalid_global' under [GLOBAL]", pants_run.stderr,
@@ -232,7 +232,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
             pants_run = self.run_pants(
                 [f"--pants-config-files={config_path}", "--pytest-invalid=ALL", "goals"]
             )
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertIn(
                 "Unrecognized command line flag '--invalid' on scope 'pytest'", pants_run.stderr,
             )
@@ -240,13 +240,13 @@ class TestOptionsIntegration(PantsIntegrationTest):
             # Run with invalid config only.
             # Should error out with `bad_option` and `invalid_scope` in config.
             pants_run = self.run_pants([f"--pants-config-files={config_path}", "goals"])
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertIn("ERROR] Invalid option 'bad_option' under [pytest]", pants_run.stderr)
             self.assertIn("ERROR] Invalid scope [invalid_scope]", pants_run.stderr)
 
     def test_command_line_option_unused_by_goals(self) -> None:
-        self.assert_success(self.run_pants(["filter", "--test-debug"]))
-        self.assert_failure(self.run_pants(["filter", "--debug"]))
+        self.run_pants(["filter", "--test-debug"]).assert_success()
+        self.run_pants(["filter", "--debug"]).assert_failure()
 
     def test_skip_inherited(self) -> None:
         pants_run = self.run_pants(
@@ -260,7 +260,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                 "--name=colors",
             ]
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         unstripped_lines = (s.split("(", 1)[0] for s in pants_run.stdout.split("\n") if "(" in s)
         lines = [s.strip() for s in unstripped_lines]
         # This should be included because it has no super-scopes.
@@ -285,7 +285,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
             pants_run = self.run_pants(
                 [f"--pants-config-files={config_path}", "--no-colors", "options"]
             )
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertIn(
                 f"pants_ignore = ['.*/', '/dist/', 'some/random/dir'] (from CONFIG in {config_path})",
                 pants_run.stdout,
@@ -301,7 +301,7 @@ class TestOptionsIntegration(PantsIntegrationTest):
                 [f"--pants-physical-workdir-base={physical_workdir_base}", "help"],
                 workdir=symlink_workdir,
             )
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             # Make sure symlink workdir is pointing to physical workdir
             self.assertTrue(os.readlink(symlink_workdir) == physical_workdir)
 

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -8,9 +8,7 @@ import sys
 import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
-from threading import Lock
-from typing import Any, Callable, Iterator, List, Mapping, Optional, Union
+from typing import Any, Iterator, List, Mapping, Optional, Union
 
 from pants.base.build_environment import get_buildroot
 from pants.base.deprecated import warn_or_error
@@ -116,6 +114,146 @@ class PantsJoinHandle:
             stderr=stderr.decode(),
             workdir=self.workdir,
             pid=self.process.pid,
+        )
+
+
+def run_pants_with_workdir_without_waiting(
+    command: Command,
+    *,
+    workdir: str,
+    hermetic: bool = True,
+    use_pantsd: bool = True,
+    config: Optional[Mapping] = None,
+    extra_env: Optional[Mapping[str, str]] = None,
+    print_exception_stacktrace: bool = True,
+    **kwargs: Any,
+) -> PantsJoinHandle:
+    args = [
+        "--no-pantsrc",
+        f"--pants-workdir={workdir}",
+        f"--print-exception-stacktrace={print_exception_stacktrace}",
+    ]
+
+    pantsd_in_command = "--no-pantsd" in command or "--pantsd" in command
+    pantsd_in_config = config and "GLOBAL" in config and "pantsd" in config["GLOBAL"]
+    if not pantsd_in_command and not pantsd_in_config:
+        args.append("--pantsd" if use_pantsd else "--no-pantsd")
+
+    if hermetic:
+        args.append("--pants-config-files=[]")
+
+    if config:
+        toml_file_name = os.path.join(workdir, "pants.toml")
+        with safe_open(toml_file_name, mode="w") as fp:
+            fp.write(TomlSerializer(config).serialize())  # type: ignore[arg-type]
+        args.append(f"--pants-config-files={toml_file_name}")
+
+    pants_script = [sys.executable, "-m", "pants"]
+
+    # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.
+    pants_command: Command
+    if kwargs.get("shell") is True:
+        assert not isinstance(command, list), "must pass command as a string when using shell=True"
+        pants_command = " ".join([*pants_script, " ".join(args), command])
+    else:
+        pants_command = [*pants_script, *args, *command]
+
+    # Only allow-listed entries will be included in the environment if hermetic=True. Note that
+    # the env will already be fairly hermetic thanks to the v2 engine; this provides an
+    # additional layer of hermiticity.
+    if hermetic:
+        # With an empty environment, we would generally get the true underlying system default
+        # encoding, which is unlikely to be what we want (it's generally ASCII, still). So we
+        # explicitly set an encoding here.
+        env = {"LC_ALL": "en_US.UTF-8"}
+        # Apply our allowlist.
+        for h in (
+            "HOME",
+            "PATH",  # Needed to find Python interpreters and other binaries.
+            "PANTS_PROFILE",
+            "RUN_PANTS_FROM_PEX",
+        ):
+            value = os.getenv(h)
+            if value is not None:
+                env[h] = value
+        hermetic_env = os.getenv("HERMETIC_ENV")
+        if hermetic_env:
+            for h in hermetic_env.strip(",").split(","):
+                value = os.getenv(h)
+                if value is not None:
+                    env[h] = value
+    else:
+        env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    env.update(PYTHONPATH=os.pathsep.join(sys.path))
+
+    # Pants command that was called from the test shouldn't have a parent.
+    if "PANTS_PARENT_BUILD_ID" in env:
+        del env["PANTS_PARENT_BUILD_ID"]
+
+    return PantsJoinHandle(
+        command=pants_command,
+        process=subprocess.Popen(
+            pants_command,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **kwargs,
+        ),
+        workdir=workdir,
+    )
+
+
+def run_pants_with_workdir(
+    command: Command,
+    *,
+    workdir: str,
+    hermetic: bool = True,
+    use_pantsd: bool = True,
+    config: Optional[Mapping] = None,
+    stdin_data: Optional[Union[bytes, str]] = None,
+    tee_output: bool = False,
+    **kwargs: Any,
+) -> PantsResult:
+    if config:
+        kwargs["config"] = config
+    handle = run_pants_with_workdir_without_waiting(
+        command, workdir=workdir, hermetic=hermetic, use_pantsd=use_pantsd, **kwargs
+    )
+    return handle.join(stdin_data=stdin_data, tee_output=tee_output)
+
+
+def run_pants(
+    command: Command,
+    *,
+    hermetic: bool = True,
+    use_pantsd: bool = True,
+    config: Optional[Mapping] = None,
+    extra_env: Optional[Mapping[str, str]] = None,
+    stdin_data: Optional[Union[bytes, str]] = None,
+    **kwargs: Any,
+) -> PantsResult:
+    """Runs Pants in a subprocess.
+
+    :param command: A list of command line arguments coming after `./pants`.
+    :param hermetic: If hermetic, your actual `pants.toml` will not be used.
+    :param use_pantsd: If True, the Pants process will use pantsd.
+    :param config: Optional data for a generated TOML file. A map of <section-name> ->
+        map of key -> value.
+    :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
+    """
+    with temporary_workdir() as workdir:
+        return run_pants_with_workdir(
+            command,
+            workdir=workdir,
+            hermetic=hermetic,
+            use_pantsd=use_pantsd,
+            config=config,
+            stdin_data=stdin_data,
+            extra_env=extra_env,
+            **kwargs,
         )
 
 
@@ -231,26 +369,7 @@ class PantsIntegrationTest(unittest.TestCase):
 
     # Classes can optionally override these.
     hermetic = True  # If False, pants.toml will be used.
-    hermetic_env_allowlist = (
-        "HOME",
-        "PATH",  # Needed to find Python interpreters and other binaries.
-        "PANTS_PROFILE",
-        "RUN_PANTS_FROM_PEX",
-    )
     use_pantsd = True
-
-    # Incremented each time we spawn a pants subprocess.
-    # Appended to PANTS_PROFILE in the called pants process, so that each subprocess
-    # writes to its own profile file, instead of all stomping on the parent process's profile.
-    _profile_disambiguator = 0
-    _profile_disambiguator_lock = Lock()
-
-    @classmethod
-    def _get_profile_disambiguator(cls) -> int:
-        with cls._profile_disambiguator_lock:
-            ret = cls._profile_disambiguator
-            cls._profile_disambiguator += 1
-            return ret
 
     def run_pants_with_workdir_without_waiting(
         self,
@@ -262,87 +381,23 @@ class PantsIntegrationTest(unittest.TestCase):
         print_exception_stacktrace: bool = True,
         **kwargs: Any,
     ) -> PantsJoinHandle:
-        args = [
-            "--no-pantsrc",
-            f"--pants-workdir={workdir}",
-            f"--print-exception-stacktrace={print_exception_stacktrace}",
-        ]
-
-        pantsd_in_command = "--no-pantsd" in command or "--pantsd" in command
-        pantsd_in_config = config and "GLOBAL" in config and "pantsd" in config["GLOBAL"]
-        if not pantsd_in_command and not pantsd_in_config:
-            args.append("--pantsd" if self.use_pantsd else "--no-pantsd")
-
-        if self.hermetic:
-            args.append("--pants-config-files=[]")
-
-        if config:
-            toml_file_name = os.path.join(workdir, "pants.toml")
-            with safe_open(toml_file_name, mode="w") as fp:
-                fp.write(TomlSerializer(config).serialize())  # type: ignore[arg-type]
-            args.append(f"--pants-config-files={toml_file_name}")
-
-        pants_script = [sys.executable, "-m", "pants"]
-
-        # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.
-        pants_command: Command
-        if kwargs.get("shell") is True:
-            assert not isinstance(
-                command, list
-            ), "must pass command as a string when using shell=True"
-            pants_command = " ".join([*pants_script, " ".join(args), command])
-        else:
-            pants_command = [*pants_script, *args, *command]
-
-        # Only allow-listed entries will be included in the environment if hermetic=True. Note that
-        # the env will already be fairly hermetic thanks to the v2 engine; this provides an
-        # additional layer of hermiticity.
-        if self.hermetic:
-            # With an empty environment, we would generally get the true underlying system default
-            # encoding, which is unlikely to be what we want (it's generally ASCII, still). So we
-            # explicitly set an encoding here.
-            env = {"LC_ALL": "en_US.UTF-8"}
-            for h in self.hermetic_env_allowlist:
-                value = os.getenv(h)
-                if value is not None:
-                    env[h] = value
-            hermetic_env = os.getenv("HERMETIC_ENV")
-            if hermetic_env:
-                for h in hermetic_env.strip(",").split(","):
-                    value = os.getenv(h)
-                    if value is not None:
-                        env[h] = value
-        else:
-            env = os.environ.copy()
-        if extra_env:
-            env.update(extra_env)
-        env.update(PYTHONPATH=os.pathsep.join(sys.path))
-
-        # Pants command that was called from the test shouldn't have a parent.
-        if "PANTS_PARENT_BUILD_ID" in env:
-            del env["PANTS_PARENT_BUILD_ID"]
-
-        # Don't overwrite the profile of this process in the called process.
-        # Instead, write the profile into a sibling file.
-        if env.get("PANTS_PROFILE"):
-            prof = f"{env['PANTS_PROFILE']}.{self._get_profile_disambiguator()}"
-            env["PANTS_PROFILE"] = prof
-            # Make a note of the subprocess command, so the user can correctly interpret the
-            # profile files.
-            with open(f"{prof}.cmd", "w") as fp:
-                fp.write(" ".join(pants_command))
-
-        return PantsJoinHandle(
-            command=pants_command,
-            process=subprocess.Popen(
-                pants_command,
-                env=env,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                **kwargs,
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.run_pants_with_workdir_without_waiting()",
+            hint=(
+                "Use the top-level function `run_pants_with_workdir_without_waiting()`. "
+                "`PantsIntegrationTest` is deprecated."
             ),
+        )
+        return run_pants_with_workdir_without_waiting(
+            command,
             workdir=workdir,
+            hermetic=self.hermetic,
+            use_pantsd=self.use_pantsd,
+            config=config,
+            extra_env=extra_env,
+            print_exception_stacktrace=print_exception_stacktrace,
+            **kwargs,
         )
 
     def run_pants_with_workdir(
@@ -355,78 +410,77 @@ class PantsIntegrationTest(unittest.TestCase):
         tee_output: bool = False,
         **kwargs: Any,
     ) -> PantsResult:
-        if config:
-            kwargs["config"] = config
-        handle = self.run_pants_with_workdir_without_waiting(command, workdir=workdir, **kwargs)
-        return handle.join(stdin_data=stdin_data, tee_output=tee_output)
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.run_pants_with_workdir()",
+            hint=(
+                "Use the top-level function `run_pants_with_workdir()`. "
+                "`PantsIntegrationTest` is deprecated."
+            ),
+        )
+        return run_pants_with_workdir(
+            command,
+            workdir=workdir,
+            hermetic=self.hermetic,
+            use_pantsd=self.use_pantsd,
+            config=config,
+            stdin_data=stdin_data,
+            tee_output=tee_output,
+            **kwargs,
+        )
 
     def run_pants(
         self,
         command: Command,
+        *,
         config: Optional[Mapping] = None,
-        stdin_data: Optional[Union[bytes, str]] = None,
         extra_env: Optional[Mapping[str, str]] = None,
+        stdin_data: Optional[Union[bytes, str]] = None,
         **kwargs: Any,
     ) -> PantsResult:
-        """Runs Pants in a subprocess.
-
-        :param command: A list of command line arguments coming after `./pants`.
-        :param config: Optional data for a generated TOML file. A map of <section-name> ->
-            map of key -> value.
-        :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
-        """
-        with temporary_workdir() as workdir:
-            return self.run_pants_with_workdir(
-                command,
-                workdir=workdir,
-                config=config,
-                stdin_data=stdin_data,
-                extra_env=extra_env,
-                **kwargs,
-            )
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.run_pants()",
+            hint=(
+                "Use the top-level function `run_pants()`. `PantsIntegrationTest` is deprecated."
+            ),
+        )
+        return run_pants(
+            command,
+            hermetic=self.hermetic,
+            use_pantsd=self.use_pantsd,
+            config=config,
+            extra_env=extra_env,
+            stdin_data=stdin_data,
+            **kwargs,
+        )
 
     @staticmethod
     def assert_success(pants_run: PantsResult, msg: Optional[str] = None) -> None:
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.assert_success()",
+            hint="Use `PantsResult.assert_success()`. `PantsIntegrationTest` is deprecated.",
+        )
         pants_run.assert_success(msg)
 
     @staticmethod
     def assert_failure(pants_run: PantsResult, msg: Optional[str] = None) -> None:
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.assert_failure()",
+            hint="Use `PantsResult.assert_failure()`. `PantsIntegrationTest` is deprecated.",
+        )
         pants_run.assert_failure(msg)
 
     @staticmethod
     def temporary_workdir(cleanup: bool = True):
-        # We can hard-code '.pants.d' here because we know that will always be its value
-        # in the pantsbuild/pants repo (e.g., that's what we .gitignore in that repo).
-        # Grabbing the pants_workdir config would require this pants's config object,
-        # which we don't have a reference to here.
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="PantsIntegrationTest.temporary_workdir()",
+            hint=(
+                "Use the top-level function `temporary_workdir`. `PantsIntegrationTest` is "
+                "deprecated."
+            ),
+        )
         return temporary_workdir(cleanup=cleanup)
-
-    @staticmethod
-    @contextmanager
-    def overwrite_file_content(
-        file_path: Union[str, Path],
-        temporary_content: Optional[Union[bytes, str, Callable[[bytes], bytes]]] = None,
-    ) -> Iterator[None]:
-        """A helper that resets a file after the method runs.
-
-         It will read a file, save the content, maybe write temporary_content to it, yield, then
-         write the original content to the file.
-
-        :param file_path: Absolute path to the file to be reset after the method runs.
-        :param temporary_content: Content to write to the file, or a function from current content
-          to new temporary content.
-        """
-        file_path = Path(file_path)
-        original_content = file_path.read_bytes()
-        try:
-            if temporary_content is not None:
-                if callable(temporary_content):
-                    content = temporary_content(original_content)
-                elif isinstance(temporary_content, bytes):
-                    content = temporary_content
-                else:
-                    content = temporary_content.encode()
-                file_path.write_bytes(content)
-            yield
-        finally:
-            file_path.write_bytes(original_content)

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -314,7 +314,7 @@ def kill_daemon(pid_dir=None):
 def ensure_daemon(f):
     """A decorator for running an integration test with and without the daemon enabled."""
 
-    def wrapper(self, *args, **kwargs):
+    def wrapper(*args, **kwargs):
         for enable_daemon in [False, True]:
             enable_daemon_str = str(enable_daemon)
             env = {
@@ -323,7 +323,7 @@ def ensure_daemon(f):
             }
             with environment_as(**env):
                 try:
-                    f(self, *args, **kwargs)
+                    f(*args, **kwargs)
                 except Exception:
                     print(f"Test failed with enable-pantsd={enable_daemon}:")
                     if not enable_daemon:

--- a/tests/python/pants_test/bin/loader_integration_test.py
+++ b/tests/python/pants_test/bin/loader_integration_test.py
@@ -11,33 +11,32 @@ class LoaderIntegrationTest(PantsIntegrationTest):
         pants_run = self.run_pants(
             command=["help"], extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0"}
         )
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("Pants requires", pants_run.stderr)
         self.assertIn(bypass_env, pants_run.stderr)
 
-        pants_run = self.run_pants(
+        self.run_pants(
             command=["help"],
             extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0", bypass_env: "1"},
-        )
-        self.assert_success(pants_run)
+        ).assert_success()
 
     def test_alternate_entrypoint(self):
         pants_run = self.run_pants(
             command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test"}
         )
-        self.assert_success(pants_run)
+        pants_run.assert_failure()
         self.assertIn("T E S T", pants_run.stdout)
 
     def test_alternate_entrypoint_bad(self):
         pants_run = self.run_pants(command=["help"], extra_env={"PANTS_ENTRYPOINT": "badness"})
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("entrypoint must be", pants_run.stderr)
 
     def test_alternate_entrypoint_not_callable(self):
         pants_run = self.run_pants(
             command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:TEST_STR"}
         )
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("TEST_STR", pants_run.stderr)
         self.assertIn("not callable", pants_run.stderr)
 
@@ -45,5 +44,5 @@ class LoaderIntegrationTest(PantsIntegrationTest):
         pants_run = self.run_pants(
             command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test_env"}
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("PANTS_ENTRYPOINT=None", pants_run.stdout)

--- a/tests/python/pants_test/bin/loader_integration_test.py
+++ b/tests/python/pants_test/bin/loader_integration_test.py
@@ -24,7 +24,7 @@ def test_alternate_entrypoint() -> None:
     pants_run = run_pants(
         command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test"}
     )
-    pants_run.assert_failure()
+    pants_run.assert_success()
     assert "T E S T" in pants_run.stdout
 
 

--- a/tests/python/pants_test/bin/loader_integration_test.py
+++ b/tests/python/pants_test/bin/loader_integration_test.py
@@ -2,47 +2,50 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.bin.pants_loader import PantsLoader
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class LoaderIntegrationTest(PantsIntegrationTest):
-    def test_invalid_locale(self):
-        bypass_env = PantsLoader.ENCODING_IGNORE_ENV_VAR
-        pants_run = self.run_pants(
-            command=["help"], extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0"}
-        )
-        pants_run.assert_failure()
-        self.assertIn("Pants requires", pants_run.stderr)
-        self.assertIn(bypass_env, pants_run.stderr)
+def test_invalid_locale() -> None:
+    bypass_env = PantsLoader.ENCODING_IGNORE_ENV_VAR
+    pants_run = run_pants(
+        command=["help"], extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0"}
+    )
+    pants_run.assert_failure()
+    assert "Pants requires" in pants_run.stderr
+    assert bypass_env in pants_run.stderr
 
-        self.run_pants(
-            command=["help"],
-            extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0", bypass_env: "1"},
-        ).assert_success()
+    run_pants(
+        command=["help"],
+        extra_env={"LC_ALL": "iNvALiD-lOcALe", "PYTHONUTF8": "0", bypass_env: "1"},
+    ).assert_success()
 
-    def test_alternate_entrypoint(self):
-        pants_run = self.run_pants(
-            command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test"}
-        )
-        pants_run.assert_failure()
-        self.assertIn("T E S T", pants_run.stdout)
 
-    def test_alternate_entrypoint_bad(self):
-        pants_run = self.run_pants(command=["help"], extra_env={"PANTS_ENTRYPOINT": "badness"})
-        pants_run.assert_failure()
-        self.assertIn("entrypoint must be", pants_run.stderr)
+def test_alternate_entrypoint() -> None:
+    pants_run = run_pants(
+        command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test"}
+    )
+    pants_run.assert_failure()
+    assert "T E S T" in pants_run.stdout
 
-    def test_alternate_entrypoint_not_callable(self):
-        pants_run = self.run_pants(
-            command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:TEST_STR"}
-        )
-        pants_run.assert_failure()
-        self.assertIn("TEST_STR", pants_run.stderr)
-        self.assertIn("not callable", pants_run.stderr)
 
-    def test_alternate_entrypoint_scrubbing(self):
-        pants_run = self.run_pants(
-            command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test_env"}
-        )
-        pants_run.assert_success()
-        self.assertIn("PANTS_ENTRYPOINT=None", pants_run.stdout)
+def test_alternate_entrypoint_bad() -> None:
+    pants_run = run_pants(command=["help"], extra_env={"PANTS_ENTRYPOINT": "badness"})
+    pants_run.assert_failure()
+    assert "entrypoint must be" in pants_run.stderr
+
+
+def test_alternate_entrypoint_not_callable() -> None:
+    pants_run = run_pants(
+        command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:TEST_STR"}
+    )
+    pants_run.assert_failure()
+    assert "TEST_STR" in pants_run.stderr
+    assert "not callable" in pants_run.stderr
+
+
+def test_alternate_entrypoint_scrubbing() -> None:
+    pants_run = run_pants(
+        command=["help"], extra_env={"PANTS_ENTRYPOINT": "pants.bin.pants_exe:test_env"}
+    )
+    pants_run.assert_success()
+    assert "PANTS_ENTRYPOINT=None" in pants_run.stdout

--- a/tests/python/pants_test/bin/runner_integration_test.py
+++ b/tests/python/pants_test/bin/runner_integration_test.py
@@ -1,43 +1,43 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import re
 from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class RunnerIntegrationTest(PantsIntegrationTest):
-    """Test logic performed in PantsRunner."""
+def test_warning_filter() -> None:
+    # We load the testprojects pants-plugins to get some testing tasks and subsystems.
+    cmdline = [
+        "--no-pantsd",
+        f"--pythonpath=+['{Path(get_buildroot(), 'testprojects/pants-plugins/src/python')}']",
+        "--backend-packages=+['test_pants_plugin']",
+        # This task will always emit a DeprecationWarning.
+        "deprecation-warning",
+    ]
 
-    def test_warning_filter(self):
-        # We load the testprojects pants-plugins to get some testing tasks and subsystems.
-        cmdline = [
-            "--no-pantsd",
-            f"--pythonpath=+['{Path(get_buildroot(), 'testprojects/pants-plugins/src/python')}']",
-            "--backend-packages=+['test_pants_plugin']",
-            # This task will always emit a DeprecationWarning.
-            "deprecation-warning",
-        ]
-
-        warning_run = self.run_pants(cmdline)
-        warning_run.assert_success()
-        self.assertRegex(
-            warning_run.stderr,
-            "\\[WARN\\].*DeprecationWarning: DEPRECATED: This is a test warning!",
+    warning_run = run_pants(cmdline)
+    warning_run.assert_success()
+    assert bool(
+        re.search(
+            r"\[WARN\].*DeprecationWarning: DEPRECATED: This is a test warning!", warning_run.stderr
         )
+    )
 
-        non_warning_run = self.run_pants(
-            cmdline,
-            config={
-                GLOBAL_SCOPE_CONFIG_SECTION: {
-                    # NB: We do *not* include the exclamation point at the end, which tests that the regexps
-                    # match from the beginning of the warning string, and don't require matching the entire
-                    # string! We also lowercase the message to check that they are matched case-insensitively.
-                    "ignore_pants_warnings": ["deprecated: this is a test warning"]
-                },
+    non_warning_run = run_pants(
+        cmdline,
+        config={
+            GLOBAL_SCOPE_CONFIG_SECTION: {
+                # NB: We do *not* include the exclamation point at the end, which tests that the
+                # regexps match from the beginning of the warning string, and don't require
+                # matching the entire string! We also lowercase the message to check that they are
+                # matched case-insensitively.
+                "ignore_pants_warnings": ["deprecated: this is a test warning"]
             },
-        )
-        non_warning_run.assert_success()
-        self.assertNotIn("test warning", non_warning_run.stderr)
+        },
+    )
+    non_warning_run.assert_success()
+    assert "test warning" not in non_warning_run.stderr

--- a/tests/python/pants_test/bin/runner_integration_test.py
+++ b/tests/python/pants_test/bin/runner_integration_test.py
@@ -22,7 +22,7 @@ class RunnerIntegrationTest(PantsIntegrationTest):
         ]
 
         warning_run = self.run_pants(cmdline)
-        self.assert_success(warning_run)
+        warning_run.assert_success()
         self.assertRegex(
             warning_run.stderr,
             "\\[WARN\\].*DeprecationWarning: DEPRECATED: This is a test warning!",
@@ -39,5 +39,5 @@ class RunnerIntegrationTest(PantsIntegrationTest):
                 },
             },
         )
-        self.assert_success(non_warning_run)
+        non_warning_run.assert_success()
         self.assertNotIn("test warning", non_warning_run.stderr)

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -1,32 +1,30 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
-class BuildIgnoreIntegrationTest(PantsIntegrationTest):
-    def test_build_ignore_list(self) -> None:
-        with setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
-            ignore_result = self.run_pants(
-                [f"--build-ignore={tmpdir}/dir", "list", f"{tmpdir}/dir"]
-            )
-            no_ignore_result = self.run_pants(["list", f"{tmpdir}/dir"])
-        ignore_result.assert_failure()
-        assert f"{tmpdir}/dir" in ignore_result.stderr
-        no_ignore_result.assert_success()
-        assert f"{tmpdir}/dir" in no_ignore_result.stdout
+def test_build_ignore_list() -> None:
+    with setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
+        ignore_result = run_pants([f"--build-ignore={tmpdir}/dir", "list", f"{tmpdir}/dir"])
+        no_ignore_result = run_pants(["list", f"{tmpdir}/dir"])
+    ignore_result.assert_failure()
+    assert f"{tmpdir}/dir" in ignore_result.stderr
+    no_ignore_result.assert_success()
+    assert f"{tmpdir}/dir" in no_ignore_result.stdout
 
-    def test_build_ignore_dependency(self) -> None:
-        sources = {
-            "dir1/BUILD": "files(sources=[])",
-            "dir2/BUILD": "files(sources=[], dependencies=['{tmpdir}/dir1'])",
-        }
-        with setup_tmpdir(sources) as tmpdir:
-            ignore_result = self.run_pants(
-                [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2"]
-            )
-            no_ignore_result = self.run_pants(["dependencies", f"{tmpdir}/dir2"])
-        ignore_result.assert_failure()
-        assert f"{tmpdir}/dir1" in ignore_result.stderr
-        no_ignore_result.assert_success()
-        assert f"{tmpdir}/dir1" in no_ignore_result.stdout
+
+def test_build_ignore_dependency() -> None:
+    sources = {
+        "dir1/BUILD": "files(sources=[])",
+        "dir2/BUILD": "files(sources=[], dependencies=['{tmpdir}/dir1'])",
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        ignore_result = run_pants(
+            [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2"]
+        )
+        no_ignore_result = run_pants(["dependencies", f"{tmpdir}/dir2"])
+    ignore_result.assert_failure()
+    assert f"{tmpdir}/dir1" in ignore_result.stderr
+    no_ignore_result.assert_success()
+    assert f"{tmpdir}/dir1" in no_ignore_result.stdout

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -1,12 +1,12 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
 
 
 class BuildIgnoreIntegrationTest(PantsIntegrationTest):
     def test_build_ignore_list(self) -> None:
-        with self.setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
+        with setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
             ignore_result = self.run_pants(
                 [f"--build-ignore={tmpdir}/dir", "list", f"{tmpdir}/dir"]
             )
@@ -21,7 +21,7 @@ class BuildIgnoreIntegrationTest(PantsIntegrationTest):
             "dir1/BUILD": "files(sources=[])",
             "dir2/BUILD": "files(sources=[], dependencies=['{tmpdir}/dir1'])",
         }
-        with self.setup_tmpdir(sources) as tmpdir:
+        with setup_tmpdir(sources) as tmpdir:
             ignore_result = self.run_pants(
                 [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2"]
             )

--- a/tests/python/pants_test/integration/build_ignore_integration_test.py
+++ b/tests/python/pants_test/integration/build_ignore_integration_test.py
@@ -5,15 +5,15 @@ from pants.testutil.pants_integration_test import PantsIntegrationTest
 
 
 class BuildIgnoreIntegrationTest(PantsIntegrationTest):
-    def test_build_ignore_list(self):
+    def test_build_ignore_list(self) -> None:
         with self.setup_tmpdir({"dir/BUILD": "files(sources=[])"}) as tmpdir:
             ignore_result = self.run_pants(
                 [f"--build-ignore={tmpdir}/dir", "list", f"{tmpdir}/dir"]
             )
             no_ignore_result = self.run_pants(["list", f"{tmpdir}/dir"])
-        self.assert_failure(ignore_result)
+        ignore_result.assert_failure()
         assert f"{tmpdir}/dir" in ignore_result.stderr
-        self.assert_success(no_ignore_result)
+        no_ignore_result.assert_success()
         assert f"{tmpdir}/dir" in no_ignore_result.stdout
 
     def test_build_ignore_dependency(self) -> None:
@@ -26,7 +26,7 @@ class BuildIgnoreIntegrationTest(PantsIntegrationTest):
                 [f"--build-ignore={tmpdir}/dir1", "dependencies", f"{tmpdir}/dir2"]
             )
             no_ignore_result = self.run_pants(["dependencies", f"{tmpdir}/dir2"])
-        self.assert_failure(ignore_result)
+        ignore_result.assert_failure()
         assert f"{tmpdir}/dir1" in ignore_result.stderr
-        self.assert_success(no_ignore_result)
+        no_ignore_result.assert_success()
         assert f"{tmpdir}/dir1" in no_ignore_result.stdout

--- a/tests/python/pants_test/integration/changed_integration_test.py
+++ b/tests/python/pants_test/integration/changed_integration_test.py
@@ -215,7 +215,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
 
     def run_list(self, extra_args: Optional[List[str]] = None) -> str:
         pants_run = self.run_pants(["list", *(extra_args or ())])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         return pants_run.stdout
 
     def test_changed_exclude_root_targets_only(self):
@@ -242,7 +242,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
                         workdir=workdir,
                     )
 
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             for expected_item in expected_set:
                 self.assertIn(expected_item, pants_run.stdout)
 
@@ -273,7 +273,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
                         workdir=workdir,
                     )
 
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             for expected_item in expected_set:
                 self.assertIn(expected_item, pants_run.stdout)
 
@@ -292,14 +292,14 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, "src/python/sources/sources.py"))
             pants_run = self.run_pants(["list", "--changed-since=HEAD"])
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "src/python/sources")
 
     def test_changed_with_deleted_resource(self):
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, "src/python/sources/sources.txt"))
             pants_run = self.run_pants(["list", "--changed-since=HEAD"])
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "src/python/sources:text")
 
     @pytest.mark.skip(reason="Unskip after rewriting these tests to stop using testprojects.")
@@ -311,7 +311,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
             pants_run = self.run_pants(
                 ["list", "--changed-since=HEAD", "--changed-dependees=transitive"]
             )
-            self.assert_failure(pants_run)
+            pants_run.assert_failure()
             self.assertRegex(
                 pants_run.stderr, "src/resources/org/pantsbuild/resourceonly:.*did not exist"
             )
@@ -320,7 +320,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
         with create_isolated_git_repo() as worktree:
             create_file_in(worktree, "new-project/README.txt", "This is important.")
             pants_run = self.run_pants(["list", "--changed-since=HEAD"])
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "")
 
     @ensure_daemon
@@ -330,7 +330,7 @@ class ChangedIntegrationTest(PantsIntegrationTest, AbstractTestGenerator):
         with create_isolated_git_repo() as worktree:
             safe_delete(os.path.join(worktree, deleted_file))
             pants_run = self.run_pants(["--changed-since=HEAD", "list"])
-            self.assert_success(pants_run)
+            pants_run.assert_success()
             self.assertEqual(pants_run.stdout.strip(), "src/python/sources")
 
 

--- a/tests/python/pants_test/integration/goal_rule_integration_test.py
+++ b/tests/python/pants_test/integration/goal_rule_integration_test.py
@@ -7,45 +7,42 @@ import time
 import pytest
 
 from pants.base.build_environment import get_buildroot
-from pants.testutil.pants_integration_test import ensure_daemon
+from pants.testutil.pants_integration_test import ensure_daemon, run_pants, setup_tmpdir
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import fast_relpath, safe_file_dump
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
+@ensure_daemon
+def test_goal_validation():
+    result = run_pants(["blah", "::"])
+    result.assert_failure()
+    assert "Unknown goals: blah" in result.stdout
+
+
+def test_unimplemented_goals_noop() -> None:
+    # Running on a `files` target should usually fail, but it should no-op if no `run`
+    # implementations are activated.
+    with setup_tmpdir({"bad.txt": "", "BUILD": "files(sources=['f.txt')"}) as tmpdir:
+        run_pants(["run", tmpdir]).assert_success()
+        run_pants(["--backend-packages=['pants.backend.python']", "run", tmpdir]).assert_failure()
+
+
 @pytest.mark.skip(reason="Flaky test. https://github.com/pantsbuild/pants/issues/10478")
 class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
-
-    # TODO: Set hermetic=True after rewriting this test to stop using an example project.
     hermetic = False
-
-    target = "examples/src/python/example/hello::"
-
-    @ensure_daemon
-    def test_list(self):
-        result = self.run_pants(["list", self.target])
-        result.assert_success()
-        output_lines = result.stdout.splitlines()
-        self.assertEqual(len(output_lines), 4)
-        self.assertIn("examples/src/python/example/hello/main", output_lines)
 
     def test_list_does_not_cache(self):
         with self.pantsd_successful_run_context() as ctx:
 
             def run_list():
-                result = ctx.runner(["list", self.target])
+                result = ctx.runner(["list", "examples/src/python/example/hello::"])
                 ctx.checker.assert_started()
                 return result
 
             first_run = run_list().stdout.splitlines()
             second_run = run_list().stdout.splitlines()
             self.assertTrue(sorted(first_run), sorted(second_run))
-
-    @ensure_daemon
-    def test_goal_validation(self):
-        result = self.run_pants(["blah", "::"])
-        result.assert_failure()
-        self.assertIn("Unknown goals: blah", result.stdout)
 
     def test_list_loop(self):
         # Create a BUILD file in a nested temporary directory, and add additional targets to it.
@@ -82,14 +79,3 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
             assert [
                 f"{rel_tmpdir}:{name}" for name in ("one", "two", "three")
             ] == pants_result.stdout.splitlines()
-
-    def test_unimplemented_goals_noop(self) -> None:
-        # If the goal is actually run, it should fail because `run` expects a single target
-        # and will fail when given the glob `::`.
-        command_prefix = ["--pants-config-files=[]"]
-        target = "testprojects/tests/python/pants/dummies::"
-        self.run_pants([*command_prefix, "--backend-packages=[]", "run", target]).assert_success()
-
-        self.run_pants(
-            [*command_prefix, "--backend-packages='pants.backend.python'", "run", target]
-        ).assert_failure()

--- a/tests/python/pants_test/integration/goal_rule_integration_test.py
+++ b/tests/python/pants_test/integration/goal_rule_integration_test.py
@@ -24,7 +24,7 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
     @ensure_daemon
     def test_list(self):
         result = self.run_pants(["list", self.target])
-        self.assert_success(result)
+        result.assert_success()
         output_lines = result.stdout.splitlines()
         self.assertEqual(len(output_lines), 4)
         self.assertIn("examples/src/python/example/hello/main", output_lines)
@@ -37,14 +37,14 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
                 ctx.checker.assert_started()
                 return result
 
-            first_run = run_list().stdout_data.splitlines()
-            second_run = run_list().stdout_data.splitlines()
+            first_run = run_list().stdout.splitlines()
+            second_run = run_list().stdout.splitlines()
             self.assertTrue(sorted(first_run), sorted(second_run))
 
     @ensure_daemon
     def test_goal_validation(self):
         result = self.run_pants(["blah", "::"])
-        self.assert_failure(result)
+        result.assert_failure()
         self.assertIn("Unknown goals: blah", result.stdout)
 
     def test_list_loop(self):
@@ -78,7 +78,7 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
 
             # Verify that the three different target states were listed, and that the process exited.
             pants_result = handle.join()
-            self.assert_success(pants_result)
+            pants_result.assert_success()
             assert [
                 f"{rel_tmpdir}:{name}" for name in ("one", "two", "three")
             ] == pants_result.stdout.splitlines()
@@ -88,10 +88,8 @@ class TestGoalRuleIntegration(PantsDaemonIntegrationTestBase):
         # and will fail when given the glob `::`.
         command_prefix = ["--pants-config-files=[]"]
         target = "testprojects/tests/python/pants/dummies::"
-        result = self.run_pants([*command_prefix, "--backend-packages=[]", "run", target])
-        self.assert_success(result)
+        self.run_pants([*command_prefix, "--backend-packages=[]", "run", target]).assert_success()
 
-        result = self.run_pants(
+        self.run_pants(
             [*command_prefix, "--backend-packages='pants.backend.python'", "run", target]
-        )
-        self.assert_failure(result)
+        ).assert_failure()

--- a/tests/python/pants_test/integration/graph_integration_test.py
+++ b/tests/python/pants_test/integration/graph_integration_test.py
@@ -10,6 +10,7 @@ from typing import Iterator
 
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.util.contextutil import overwrite_file_content
 
 
 class GraphIntegrationTest(PantsIntegrationTest):
@@ -69,7 +70,7 @@ class GraphIntegrationTest(PantsIntegrationTest):
             )
             """
         )
-        with self.overwrite_file_content(build_path, f"{original_content}\n{new_content}"):
+        with overwrite_file_content(build_path, f"{original_content}\n{new_content}"):
             yield
 
     @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/8520")

--- a/tests/python/pants_test/integration/graph_integration_test.py
+++ b/tests/python/pants_test/integration/graph_integration_test.py
@@ -9,125 +9,126 @@ from textwrap import dedent
 from typing import Iterator
 
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 from pants.util.contextutil import overwrite_file_content
 
+_NO_BUILD_FILE_TARGET_BASE = "testprojects/src/python/no_build_file"
+_SOURCES_TARGET_BASE = "testprojects/src/python/sources"
 
-class GraphIntegrationTest(PantsIntegrationTest):
+_ERR_TARGETS = {
+    "testprojects/src/python/sources:some-missing-some-not": [
+        "['*.txt', '*.rs']",
+        "Snapshot(PathGlobs(globs=('testprojects/src/python/sources/*.txt', 'testprojects/src/python/sources/*.rs'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
+        'Unmatched glob from testprojects/src/python/sources:some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
+    ],
+    "testprojects/src/python/sources:missing-sources": [
+        "*.scala",
+        "Snapshot(PathGlobs(globs=('testprojects/src/python/sources/*.scala', '!testprojects/src/python/sources/*Test.scala', '!testprojects/src/python/sources/*Spec.scala'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
+        'Unmatched glob from testprojects/src/python/sources:missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
+    ],
+}
 
-    _NO_BUILD_FILE_TARGET_BASE = "testprojects/src/python/no_build_file"
-    _SOURCES_TARGET_BASE = "testprojects/src/python/sources"
 
-    _ERR_TARGETS = {
-        "testprojects/src/python/sources:some-missing-some-not": [
-            "['*.txt', '*.rs']",
-            "Snapshot(PathGlobs(globs=('testprojects/src/python/sources/*.txt', 'testprojects/src/python/sources/*.rs'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
-            'Unmatched glob from testprojects/src/python/sources:some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
-        ],
-        "testprojects/src/python/sources:missing-sources": [
-            "*.scala",
-            "Snapshot(PathGlobs(globs=('testprojects/src/python/sources/*.scala', '!testprojects/src/python/sources/*Test.scala', '!testprojects/src/python/sources/*Spec.scala'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
-            'Unmatched glob from testprojects/src/python/sources:missing-sources\'s `sources` field:: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]',
-        ],
+@contextmanager
+def setup_sources_targets() -> Iterator[None]:
+    build_path = Path(_SOURCES_TARGET_BASE, "BUILD")
+    original_content = build_path.read_text()
+    new_content = dedent(
+        """\
+        scala_library(
+          name='missing-sources',
+        )
+
+        resources(
+          name='missing-literal-files',
+          sources=[
+            'nonexistent_test_file.txt',
+            'another_nonexistent_file.txt',
+          ],
+        )
+
+        resources(
+          name='missing-globs',
+          sources=['*.a'],
+        )
+
+        resources(
+          name='missing-rglobs',
+          sources=['**/*.a'],
+        )
+
+        resources(
+          name='some-missing-some-not',
+          sources=['*.txt', '*.rs'],
+        )
+
+        resources(
+          name='overlapping-globs',
+          sources=['sources.txt', '*.txt'],
+        )
+        """
+    )
+    with overwrite_file_content(build_path, f"{original_content}\n{new_content}"):
+        yield
+
+
+@unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/8520")
+def test_missing_sources_warnings():
+    target_to_unmatched_globs = {
+        "missing-globs": ["*.a"],
+        "missing-rglobs": ["**/*.a"],
+        "missing-literal-files": ["another_nonexistent_file.txt", "nonexistent_test_file.txt"],
     }
-
-    @contextmanager
-    def setup_sources_targets(self) -> Iterator[None]:
-        build_path = Path(self._SOURCES_TARGET_BASE, "BUILD")
-        original_content = build_path.read_text()
-        new_content = dedent(
-            """\
-            scala_library(
-              name='missing-sources',
+    with setup_sources_targets():
+        for target in target_to_unmatched_globs:
+            target_full = f"{_SOURCES_TARGET_BASE}:{target}"
+            pants_run = run_pants(
+                ["filedeps", target_full],
+                config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
             )
-
-            resources(
-              name='missing-literal-files',
-              sources=[
-                'nonexistent_test_file.txt',
-                'another_nonexistent_file.txt',
-              ],
+            pants_run.assert_success()
+            unmatched_globs = target_to_unmatched_globs[target]
+            formatted_globs = ", ".join(
+                f'"{os.path.join(_SOURCES_TARGET_BASE, glob)}"' for glob in unmatched_globs
             )
-
-            resources(
-              name='missing-globs',
-              sources=['*.a'],
-            )
-
-            resources(
-              name='missing-rglobs',
-              sources=['**/*.a'],
-            )
-
-            resources(
-              name='some-missing-some-not',
-              sources=['*.txt', '*.rs'],
-            )
-
-            resources(
-              name='overlapping-globs',
-              sources=['sources.txt', '*.txt'],
-            )
-            """
-        )
-        with overwrite_file_content(build_path, f"{original_content}\n{new_content}"):
-            yield
-
-    @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/8520")
-    def test_missing_sources_warnings(self):
-        target_to_unmatched_globs = {
-            "missing-globs": ["*.a"],
-            "missing-rglobs": ["**/*.a"],
-            "missing-literal-files": ["another_nonexistent_file.txt", "nonexistent_test_file.txt"],
-        }
-        with self.setup_sources_targets():
-            for target in target_to_unmatched_globs:
-                target_full = f"{self._SOURCES_TARGET_BASE}:{target}"
-                pants_run = self.run_pants(
-                    ["filedeps", target_full],
-                    config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
+            error_origin = f"from {_SOURCES_TARGET_BASE}:{target}'s `sources` field"
+            if len(unmatched_globs) == 1:
+                assert (
+                    f"[WARN] Unmatched glob {error_origin}: {formatted_globs}" in pants_run.stderr
                 )
-                pants_run.assert_success()
-                unmatched_globs = target_to_unmatched_globs[target]
-                formatted_globs = ", ".join(
-                    f'"{os.path.join(self._SOURCES_TARGET_BASE, glob)}"' for glob in unmatched_globs
+            else:
+                assert (
+                    f"[WARN] Unmatched globs {error_origin}: [{formatted_globs}]"
+                    in pants_run.stderr
                 )
-                error_origin = f"from {self._SOURCES_TARGET_BASE}:{target}'s `sources` field"
-                if len(unmatched_globs) == 1:
-                    assert (
-                        f"[WARN] Unmatched glob {error_origin}: {formatted_globs}"
-                        in pants_run.stderr
-                    )
-                else:
-                    assert (
-                        f"[WARN] Unmatched globs {error_origin}: [{formatted_globs}]"
-                        in pants_run.stderr
-                    )
 
-    @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/8520")
-    def test_existing_sources(self):
-        target_full = f"{self._SOURCES_TARGET_BASE}:text"
-        pants_run = self.run_pants(
-            ["filedeps", target_full],
-            config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
-        )
-        pants_run.assert_success()
-        assert "[WARN] Unmatched glob" not in pants_run.stderr
 
-    def test_existing_directory_with_no_build_files_fails(self):
-        pants_run = self.run_pants(["list", f"{self._NO_BUILD_FILE_TARGET_BASE}::"])
-        pants_run.assert_failure()
-        self.assertIn("does not match any targets.", pants_run.stderr)
+@unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/8520")
+def test_existing_sources():
+    target_full = f"{_SOURCES_TARGET_BASE}:text"
+    pants_run = run_pants(
+        ["filedeps", target_full],
+        config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
+    )
+    pants_run.assert_success()
+    assert "[WARN] Unmatched glob" not in pants_run.stderr
 
-    @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/6787")
-    def test_error_message(self):
-        with self.setup_sources_targets():
-            for target in self._ERR_TARGETS:
-                expected_excerpts = self._ERR_TARGETS[target]
-                pants_run = self.run_pants(
-                    ["filedeps", target],
-                    config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "error"}},
-                )
-                pants_run.assert_failure()
-                for excerpt in expected_excerpts:
-                    self.assertIn(excerpt, pants_run.stderr)
+
+def test_existing_directory_with_no_build_files_fails():
+    pants_run = run_pants(["list", f"{_NO_BUILD_FILE_TARGET_BASE}::"])
+    pants_run.assert_failure()
+    assert "does not match any targets." in pants_run.stderr
+
+
+@unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/6787")
+def test_error_message():
+    with setup_sources_targets():
+        for target in _ERR_TARGETS:
+            expected_excerpts = _ERR_TARGETS[target]
+            pants_run = run_pants(
+                ["filedeps", target],
+                config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "error"}},
+            )
+            pants_run.assert_failure()
+            for excerpt in expected_excerpts:
+                assert excerpt in pants_run.stderr

--- a/tests/python/pants_test/integration/graph_integration_test.py
+++ b/tests/python/pants_test/integration/graph_integration_test.py
@@ -86,7 +86,7 @@ class GraphIntegrationTest(PantsIntegrationTest):
                     ["filedeps", target_full],
                     config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
                 )
-                self.assert_success(pants_run)
+                pants_run.assert_success()
                 unmatched_globs = target_to_unmatched_globs[target]
                 formatted_globs = ", ".join(
                     f'"{os.path.join(self._SOURCES_TARGET_BASE, glob)}"' for glob in unmatched_globs
@@ -110,12 +110,12 @@ class GraphIntegrationTest(PantsIntegrationTest):
             ["filedeps", target_full],
             config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "warn"}},
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         assert "[WARN] Unmatched glob" not in pants_run.stderr
 
     def test_existing_directory_with_no_build_files_fails(self):
         pants_run = self.run_pants(["list", f"{self._NO_BUILD_FILE_TARGET_BASE}::"])
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("does not match any targets.", pants_run.stderr)
 
     @unittest.skip("flaky: https://github.com/pantsbuild/pants/issues/6787")
@@ -127,6 +127,6 @@ class GraphIntegrationTest(PantsIntegrationTest):
                     ["filedeps", target],
                     config={GLOBAL_SCOPE_CONFIG_SECTION: {"files_not_found_behavior": "error"}},
                 )
-                self.assert_failure(pants_run)
+                pants_run.assert_failure()
                 for excerpt in expected_excerpts:
                     self.assertIn(excerpt, pants_run.stderr)

--- a/tests/python/pants_test/integration/list_integration_test.py
+++ b/tests/python/pants_test/integration/list_integration_test.py
@@ -1,35 +1,37 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import run_pants
 
 
-class ListIntegrationTest(PantsIntegrationTest):
-    def test_list_all(self) -> None:
-        pants_run = self.run_pants(["--backend-packages=pants.backend.python", "list", "::"])
-        pants_run.assert_success()
-        self.assertGreater(len(pants_run.stdout.strip().split()), 1)
+def test_list_all() -> None:
+    pants_run = run_pants(["--backend-packages=pants.backend.python", "list", "::"])
+    pants_run.assert_success()
+    assert len(pants_run.stdout.strip().split()) > 1
 
-    def test_list_none(self) -> None:
-        pants_run = self.run_pants(["list"])
-        pants_run.assert_success()
-        self.assertIn("WARNING: No targets were matched in", pants_run.stderr)
 
-    def test_list_invalid_dir(self) -> None:
-        pants_run = self.run_pants(["list", "abcde::"])
-        pants_run.assert_failure()
-        self.assertIn("ResolveError", pants_run.stderr)
+def test_list_none() -> None:
+    pants_run = run_pants(["list"])
+    pants_run.assert_success()
+    assert "WARNING: No targets were matched in" in pants_run.stderr
 
-    def test_list_testproject(self) -> None:
-        pants_run = self.run_pants(
-            [
-                "--backend-packages=pants.backend.python",
-                "list",
-                "testprojects/tests/python/pants/build_parsing::",
-            ]
-        )
-        pants_run.assert_success()
-        self.assertEqual(
-            pants_run.stdout.strip(),
-            "testprojects/tests/python/pants/build_parsing:test-nested-variable-access-in-function-call",
-        )
+
+def test_list_invalid_dir() -> None:
+    pants_run = run_pants(["list", "abcde::"])
+    pants_run.assert_failure()
+    assert "ResolveError" in pants_run.stderr
+
+
+def test_list_testproject() -> None:
+    pants_run = run_pants(
+        [
+            "--backend-packages=pants.backend.python",
+            "list",
+            "testprojects/tests/python/pants/build_parsing::",
+        ]
+    )
+    pants_run.assert_success()
+    assert (
+        pants_run.stdout.strip()
+        == "testprojects/tests/python/pants/build_parsing:test-nested-variable-access-in-function-call"
+    )

--- a/tests/python/pants_test/integration/list_integration_test.py
+++ b/tests/python/pants_test/integration/list_integration_test.py
@@ -7,17 +7,17 @@ from pants.testutil.pants_integration_test import PantsIntegrationTest
 class ListIntegrationTest(PantsIntegrationTest):
     def test_list_all(self) -> None:
         pants_run = self.run_pants(["--backend-packages=pants.backend.python", "list", "::"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertGreater(len(pants_run.stdout.strip().split()), 1)
 
     def test_list_none(self) -> None:
         pants_run = self.run_pants(["list"])
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertIn("WARNING: No targets were matched in", pants_run.stderr)
 
     def test_list_invalid_dir(self) -> None:
         pants_run = self.run_pants(["list", "abcde::"])
-        self.assert_failure(pants_run)
+        pants_run.assert_failure()
         self.assertIn("ResolveError", pants_run.stderr)
 
     def test_list_testproject(self) -> None:
@@ -28,7 +28,7 @@ class ListIntegrationTest(PantsIntegrationTest):
                 "testprojects/tests/python/pants/build_parsing::",
             ]
         )
-        self.assert_success(pants_run)
+        pants_run.assert_success()
         self.assertEqual(
             pants_run.stdout.strip(),
             "testprojects/tests/python/pants/build_parsing:test-nested-variable-access-in-function-call",

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -3,32 +3,31 @@
 
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
-class LogOutputIntegrationTest(PantsIntegrationTest):
-    def test_completed_log_output(self) -> None:
-        sources = {
-            "src/python/project/__init__.py": "",
-            "src/python/project/lib.py": dedent(
-                """\
-                def add(x: int, y: int) -> int:
-                    return x + y
-                """
-            ),
-            "src/python/project/BUILD": "python_library()",
-        }
-        with setup_tmpdir(sources) as tmpdir:
-            result = self.run_pants(
-                [
-                    "--no-dynamic-ui",
-                    "--backend-packages=['pants.backend.python', 'pants.backend.python.typecheck.mypy']",
-                    "-ldebug",
-                    "typecheck",
-                    f"{tmpdir}/src/python/project",
-                ]
-            )
+def test_completed_log_output() -> None:
+    sources = {
+        "src/python/project/__init__.py": "",
+        "src/python/project/lib.py": dedent(
+            """\
+            def add(x: int, y: int) -> int:
+                return x + y
+            """
+        ),
+        "src/python/project/BUILD": "python_library()",
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        result = run_pants(
+            [
+                "--no-dynamic-ui",
+                "--backend-packages=['pants.backend.python', 'pants.backend.python.typecheck.mypy']",
+                "-ldebug",
+                "typecheck",
+                f"{tmpdir}/src/python/project",
+            ]
+        )
 
-        result.assert_success()
-        assert "[DEBUG] Starting: Run MyPy on" in result.stderr
-        assert "[DEBUG] Completed: Run MyPy on" in result.stderr
+    result.assert_success()
+    assert "[DEBUG] Starting: Run MyPy on" in result.stderr
+    assert "[DEBUG] Completed: Run MyPy on" in result.stderr

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -3,7 +3,7 @@
 
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
 
 
 class LogOutputIntegrationTest(PantsIntegrationTest):
@@ -18,7 +18,7 @@ class LogOutputIntegrationTest(PantsIntegrationTest):
             ),
             "src/python/project/BUILD": "python_library()",
         }
-        with self.setup_tmpdir(sources) as tmpdir:
+        with setup_tmpdir(sources) as tmpdir:
             result = self.run_pants(
                 [
                     "--no-dynamic-ui",

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -29,5 +29,6 @@ class LogOutputIntegrationTest(PantsIntegrationTest):
                 ]
             )
 
+        result.assert_success()
         assert "[DEBUG] Starting: Run MyPy on" in result.stderr
         assert "[DEBUG] Completed: Run MyPy on" in result.stderr

--- a/tests/python/pants_test/integration/prelude_integration_test.py
+++ b/tests/python/pants_test/integration/prelude_integration_test.py
@@ -4,29 +4,28 @@
 import os
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
-class PreludeIntegrationTest(PantsIntegrationTest):
-    def test_build_file_prelude(self) -> None:
-        sources = {
-            "prelude.py": dedent(
-                """\
-                def make_binary_macro():
-                    python_binary(name="main", sources=["main.py"])
-                """
-            ),
-            "BUILD": "make_binary_macro()",
-            "main.py": "print('Hello world!')",
-        }
-        with setup_tmpdir(sources) as tmpdir:
-            run = self.run_pants(
-                [
-                    "--backend-packages=pants.backend.python",
-                    f"--build-file-prelude-globs={os.path.join(tmpdir, 'prelude.py')}",
-                    "run",
-                    f"{tmpdir}:main",
-                ]
-            )
-        run.assert_success()
-        assert "Hello world!" in run.stdout
+def test_build_file_prelude() -> None:
+    sources = {
+        "prelude.py": dedent(
+            """\
+            def make_binary_macro():
+                python_binary(name="main", sources=["main.py"])
+            """
+        ),
+        "BUILD": "make_binary_macro()",
+        "main.py": "print('Hello world!')",
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        run = run_pants(
+            [
+                "--backend-packages=pants.backend.python",
+                f"--build-file-prelude-globs={os.path.join(tmpdir, 'prelude.py')}",
+                "run",
+                f"{tmpdir}:main",
+            ]
+        )
+    run.assert_success()
+    assert "Hello world!" in run.stdout

--- a/tests/python/pants_test/integration/prelude_integration_test.py
+++ b/tests/python/pants_test/integration/prelude_integration_test.py
@@ -28,5 +28,5 @@ class PreludeIntegrationTest(PantsIntegrationTest):
                     f"{tmpdir}:main",
                 ]
             )
-        self.assert_success(run)
+        run.assert_success()
         assert "Hello world!" in run.stdout

--- a/tests/python/pants_test/integration/prelude_integration_test.py
+++ b/tests/python/pants_test/integration/prelude_integration_test.py
@@ -4,7 +4,7 @@
 import os
 from textwrap import dedent
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest
+from pants.testutil.pants_integration_test import PantsIntegrationTest, setup_tmpdir
 
 
 class PreludeIntegrationTest(PantsIntegrationTest):
@@ -19,7 +19,7 @@ class PreludeIntegrationTest(PantsIntegrationTest):
             "BUILD": "make_binary_macro()",
             "main.py": "print('Hello world!')",
         }
-        with self.setup_tmpdir(sources) as tmpdir:
+        with setup_tmpdir(sources) as tmpdir:
             run = self.run_pants(
                 [
                     "--backend-packages=pants.backend.python",

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -2,9 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_integration_tests(
-  name='tests',
   uses_pants_run=True,
   timeout=150,
 )
-
-python_library()

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -9,11 +9,15 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 
 def test_native_logging() -> None:
     expected_msg = r"\[DEBUG\] Launching \d+ root"
-    pants_run = run_pants(["-linfo", "list", "3rdparty::"])
+    pants_run = run_pants(
+        ["-linfo", "--backend-packages=pants.backend.python", "list", "3rdparty::"]
+    )
     pants_run.assert_success()
     assert not bool(re.search(expected_msg, pants_run.stderr))
 
-    pants_run = run_pants(["-ldebug", "list", "3rdparty::"])
+    pants_run = run_pants(
+        ["-ldebug", "--backend-packages=pants.backend.python", "list", "3rdparty::"]
+    )
     pants_run.assert_success()
     assert bool(re.search(expected_msg, pants_run.stderr))
 

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -1,20 +1,21 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.testutil.pants_integration_test import PantsIntegrationTest, read_pantsd_log
+import re
+
+from pants.testutil.pants_integration_test import read_pantsd_log, run_pants
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
-class NativeEngineLoggingTest(PantsIntegrationTest):
-    def test_native_logging(self) -> None:
-        expected_msg = r"\[DEBUG\] Launching \d+ root"
-        pants_run = self.run_pants(["-linfo", "list", "3rdparty::"])
-        pants_run.assert_success()
-        self.assertNotRegex(pants_run.stderr, expected_msg)
+def test_native_logging() -> None:
+    expected_msg = r"\[DEBUG\] Launching \d+ root"
+    pants_run = run_pants(["-linfo", "list", "3rdparty::"])
+    pants_run.assert_success()
+    assert not bool(re.search(expected_msg, pants_run.stderr))
 
-        pants_run = self.run_pants(["-ldebug", "list", "3rdparty::"])
-        pants_run.assert_success()
-        self.assertRegex(pants_run.stderr, expected_msg)
+    pants_run = run_pants(["-ldebug", "list", "3rdparty::"])
+    pants_run.assert_success()
+    assert bool(re.search(expected_msg, pants_run.stderr))
 
 
 class PantsdNativeLoggingTest(PantsDaemonIntegrationTestBase):

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -9,9 +9,11 @@ class NativeEngineLoggingTest(PantsIntegrationTest):
     def test_native_logging(self) -> None:
         expected_msg = r"\[DEBUG\] Launching \d+ root"
         pants_run = self.run_pants(["-linfo", "list", "3rdparty::"])
+        pants_run.assert_success()
         self.assertNotRegex(pants_run.stderr, expected_msg)
 
         pants_run = self.run_pants(["-ldebug", "list", "3rdparty::"])
+        pants_run.assert_success()
         self.assertRegex(pants_run.stderr, expected_msg)
 
 

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -63,19 +63,17 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     def test_pantsd_pantsd_runner_doesnt_die_after_failed_run(self):
         with self.pantsd_test_context() as (workdir, pantsd_config, checker):
             # Run target that throws an exception in pants.
-            self.assert_failure(
-                self.run_pants_with_workdir(
-                    ["lint", "testprojects/src/python/unicode/compilation_failure"],
-                    workdir=workdir,
-                    config=pantsd_config,
-                )
-            )
+            self.run_pants_with_workdir(
+                ["lint", "testprojects/src/python/unicode/compilation_failure"],
+                workdir=workdir,
+                config=pantsd_config,
+            ).assert_failure()
             checker.assert_started()
 
             # Assert pantsd is in a good functional state.
-            self.assert_success(
-                self.run_pants_with_workdir(["help"], workdir=workdir, config=pantsd_config)
-            )
+            self.run_pants_with_workdir(
+                ["help"], workdir=workdir, config=pantsd_config
+            ).assert_success()
             checker.assert_running()
 
     def test_pantsd_lifecycle_invalidation(self):
@@ -129,17 +127,13 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     def test_pantsd_lifecycle_shutdown_for_broken_scheduler(self):
         with self.pantsd_test_context() as (workdir, config, checker):
             # Run with valid options.
-            self.assert_success(
-                self.run_pants_with_workdir(["help"], workdir=workdir, config=config)
-            )
+            self.run_pants_with_workdir(["help"], workdir=workdir, config=config).assert_success()
             checker.assert_started()
 
             # And again with invalid scheduler-fingerprinted options that trigger a re-init.
-            self.assert_failure(
-                self.run_pants_with_workdir(
-                    ["--backend-packages=nonsensical", "help"], workdir=workdir, config=config
-                )
-            )
+            self.run_pants_with_workdir(
+                ["--backend-packages=nonsensical", "help"], workdir=workdir, config=config
+            ).assert_failure()
             checker.assert_stopped()
 
     def test_pantsd_aligned_output(self) -> None:
@@ -209,18 +203,16 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     def test_pantsd_launch_env_var_is_not_inherited_by_pantsd_runner_children(self):
         with self.pantsd_test_context() as (workdir, pantsd_config, checker):
             with environment_as(NO_LEAKS="33"):
-                self.assert_success(
-                    self.run_pants_with_workdir(["help"], workdir=workdir, config=pantsd_config)
-                )
+                self.run_pants_with_workdir(
+                    ["help"], workdir=workdir, config=pantsd_config
+                ).assert_success()
                 checker.assert_started()
 
-            self.assert_failure(
-                self.run_pants_with_workdir(
-                    ["run", "testprojects/src/python/print_env", "--", "NO_LEAKS"],
-                    workdir=workdir,
-                    config=pantsd_config,
-                )
-            )
+            self.run_pants_with_workdir(
+                ["run", "testprojects/src/python/print_env", "--", "NO_LEAKS"],
+                workdir=workdir,
+                config=pantsd_config,
+            ).assert_failure()
             checker.assert_running()
 
     def test_pantsd_touching_a_file_does_not_restart_daemon(self):
@@ -324,10 +316,10 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             # NB: This doesn't actually run against all testprojects, only those that are in the chroot,
             # i.e. explicitly declared in this test file's BUILD.
             cmd = ["list", "testprojects::"]
-            self.assert_success(ctx.runner(cmd))
+            ctx.runner(cmd).assert_success()
             initial_memory_usage = ctx.checker.current_memory_usage()
             for _ in range(number_of_runs):
-                self.assert_success(ctx.runner(cmd))
+                ctx.runner(cmd).assert_success()
                 ctx.checker.assert_running()
 
             final_memory_usage = ctx.checker.current_memory_usage()
@@ -438,8 +430,8 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
                 config=config,
             )
 
-            self.assert_success(creator_handle.join())
-            self.assert_success(waiter_handle.join())
+            creator_handle.join().assert_success()
+            waiter_handle.join().assert_success()
 
     def _assert_pantsd_keyboardinterrupt_signal(self, signum, regexps=[], quit_timeout=None):
         """Send a signal to the thin pailgun client and observe the error messaging.
@@ -477,7 +469,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             # This should kill the pantsd processes through the RemotePantsRunner signal handler.
             os.kill(client_pid, signum)
             waiter_run = waiter_handle.join()
-            self.assert_failure(waiter_run)
+            waiter_run.assert_failure()
 
             for regexp in regexps:
                 self.assertRegex(waiter_run.stderr, regexp)
@@ -604,14 +596,14 @@ Interrupted by user over pailgun client!
 
             # Send exit() to the repl, and exit it.
             result = first_run_handle.join(stdin_data="exit()")
-            self.assert_success(result)
+            result.assert_success()
             checker.assert_running()
 
     def test_pantsd_unicode_environment(self):
         with self.pantsd_successful_run_context(extra_env={"XXX": "¡"},) as ctx:
             result = ctx.runner(["help"])
             ctx.checker.assert_started()
-            self.assert_success(result)
+            result.assert_success()
 
     # This is a regression test for a bug where we would incorrectly detect a cycle if two targets swapped their
     # dependency relationship (#7404).
@@ -642,7 +634,7 @@ Interrupted by user over pailgun client!
                 def list_and_verify():
                     result = ctx.runner(["list", f"{directory}:"])
                     ctx.checker.assert_started()
-                    self.assert_success(result)
+                    result.assert_success()
                     expected_targets = {f"{directory}:{target}" for target in ("A", "B")}
                     self.assertEqual(expected_targets, set(result.stdout_data.strip().split("\n")))
 
@@ -660,8 +652,7 @@ Interrupted by user over pailgun client!
         config = {"GLOBAL": {"concurrent": True, "pantsd": True}}
         with self.temporary_workdir() as workdir:
             pants_run = self.run_pants_with_workdir(["goals"], workdir=workdir, config=config)
-            self.assert_success(pants_run)
-            # TODO migrate to pathlib when we cut 1.18.x
+            pants_run.assert_success()
             pantsd_log_location = os.path.join(workdir, "pantsd", "pantsd.log")
             self.assertFalse(os.path.exists(pantsd_log_location))
 
@@ -676,7 +667,7 @@ Interrupted by user over pailgun client!
         with self.pantsd_run_context(success=False) as ctx:
             result = ctx.runner(["run", "testprojects/src/python/bad_requirements:use_badreq"])
             ctx.checker.assert_running()
-            self.assert_failure(result)
+            result.assert_failure()
             # Assert that the desired exception has been triggered once.
             self.assertRegex(result.stderr_data, r"ERROR:.*badreq==99.99.99")
             # Assert that it has only been triggered once.

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 import pytest
 
-from pants.testutil.pants_integration_test import read_pantsd_log
+from pants.testutil.pants_integration_test import read_pantsd_log, temporary_workdir
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, safe_open, touch
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
@@ -650,7 +650,7 @@ Interrupted by user over pailgun client!
         """Tests that the --concurrent flag overrides the --pantsd flag, because we don't allow
         concurrent runs under pantsd."""
         config = {"GLOBAL": {"concurrent": True, "pantsd": True}}
-        with self.temporary_workdir() as workdir:
+        with temporary_workdir() as workdir:
             pants_run = self.run_pants_with_workdir(["goals"], workdir=workdir, config=config)
             pants_run.assert_success()
             pantsd_log_location = os.path.join(workdir, "pantsd", "pantsd.log")

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -187,9 +187,9 @@ class PantsDaemonIntegrationTestBase(PantsIntegrationTest):
         print(bold(cyan(f"\ncompleted in {elapsed} seconds")))
 
         if success:
-            self.assert_success(run)
+            run.assert_success()
         else:
-            self.assert_failure(run)
+            run.assert_failure()
 
         runs_created = self._run_count(workdir) - run_count
         self.assertEqual(


### PR DESCRIPTION
We've slowly been chipping away at using Pytest-style tests, meaning using `assert` rather than `self.assertX` and using top-level functions rather than test classes.

Now, integration tests can be written in Pytest style. We deprecate the old class-based style.

To land this change, we drop the ability to set the PANTS_PROFILE in an integration test. It appears that this was not used; the workaround is to run the test like you would on the command line.