### PR TITLE
Rename `TestBase.request_single_product` to `TestBase.request_product`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -40,13 +40,13 @@ class TestPythonAWSLambdaCreation(ExternalToolTestBase):
                 "--source-root-patterns=src/python",
             ]
         )
-        target = self.request_single_product(
+        target = self.request_product(
             WrappedTarget, Params(Address.parse(addr), bootstrapper)
         ).target
-        created_awslambda = self.request_single_product(
+        created_awslambda = self.request_product(
             CreatedAWSLambda, Params(PythonAwsLambdaFieldSet.create(target), bootstrapper)
         )
-        created_awslambda_digest_contents = self.request_single_product(
+        created_awslambda_digest_contents = self.request_product(
             DigestContents, created_awslambda.digest
         )
         assert len(created_awslambda_digest_contents) == 1

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -51,13 +51,11 @@ class ProtobufPythonIntegrationTest(ExternalToolTestBase):
                 f"--source-root-patterns={repr(source_roots)}",
             ]
         )
-        tgt = self.request_single_product(
-            WrappedTarget, Params(Address.parse(spec), bootstrapper)
-        ).target
-        protocol_sources = self.request_single_product(
+        tgt = self.request_product(WrappedTarget, Params(Address.parse(spec), bootstrapper)).target
+        protocol_sources = self.request_product(
             HydratedSources, Params(HydrateSourcesRequest(tgt[ProtobufSources]), bootstrapper),
         )
-        generated_sources = self.request_single_product(
+        generated_sources = self.request_product(
             GeneratedSources,
             Params(GeneratePythonFromProtobufRequest(protocol_sources.snapshot, tgt), bootstrapper),
         )

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -105,7 +105,7 @@ class ModuleMapperTest(TestBase):
         # not generate subtargets.
         self.create_file("tests/python/project_test/demo_test/__init__.py")
         self.add_to_build_file("tests/python/project_test/demo_test", "python_library()")
-        result = self.request_single_product(FirstPartyModuleToAddressMapping, options_bootstrapper)
+        result = self.request_product(FirstPartyModuleToAddressMapping, options_bootstrapper)
         assert result.mapping == FrozenDict(
             {
                 "project.util.dirutil": Address(
@@ -145,7 +145,7 @@ class ModuleMapperTest(TestBase):
                 """
             ),
         )
-        result = self.request_single_product(
+        result = self.request_product(
             ThirdPartyModuleToAddressMapping, Params(create_options_bootstrapper())
         )
         assert result.mapping == FrozenDict(
@@ -162,7 +162,7 @@ class ModuleMapperTest(TestBase):
         )
 
         def get_owner(module: str) -> Optional[Address]:
-            return self.request_single_product(
+            return self.request_product(
                 PythonModuleOwner, Params(PythonModule(module), options_bootstrapper)
             ).address
 

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -95,10 +95,10 @@ class PythonDependencyInferenceTest(TestBase):
             if enable_string_imports:
                 args.append("--python-infer-string-imports")
             options_bootstrapper = create_options_bootstrapper(args=args)
-            target = self.request_single_product(
+            target = self.request_product(
                 WrappedTarget, Params(address, options_bootstrapper)
             ).target
-            return self.request_single_product(
+            return self.request_product(
                 InferredDependencies,
                 Params(InferPythonDependencies(target[PythonSources]), options_bootstrapper),
             )
@@ -145,10 +145,10 @@ class PythonDependencyInferenceTest(TestBase):
         self.add_to_build_file("src/python/root/mid/leaf", "python_library()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
-            target = self.request_single_product(
+            target = self.request_product(
                 WrappedTarget, Params(address, options_bootstrapper)
             ).target
-            return self.request_single_product(
+            return self.request_product(
                 InferredDependencies,
                 Params(InferInitDependencies(target[PythonSources]), options_bootstrapper),
             )
@@ -177,10 +177,10 @@ class PythonDependencyInferenceTest(TestBase):
         self.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
 
         def run_dep_inference(address: Address) -> InferredDependencies:
-            target = self.request_single_product(
+            target = self.request_product(
                 WrappedTarget, Params(address, options_bootstrapper)
             ).target
-            return self.request_single_product(
+            return self.request_product(
                 InferredDependencies,
                 Params(InferConftestDependencies(target[PythonSources]), options_bootstrapper),
             )

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -57,7 +57,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
             args.append("--bandit-skip")
         if additional_args:
             args.extend(additional_args)
-        results = self.request_single_product(
+        results = self.request_product(
             LintResults,
             Params(
                 BanditRequest(BanditFieldSet.create(tgt) for tgt in targets),
@@ -180,7 +180,7 @@ class BanditIntegrationTest(ExternalToolTestBase):
         assert result[0].exit_code == 1
         assert result[0].stdout.strip() == ""
         assert result[0].report is not None
-        report_files = self.request_single_product(DigestContents, result[0].report.digest)
+        report_files = self.request_product(DigestContents, result[0].report.digest)
         assert len(report_files) == 1
         assert (
             "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5"

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -54,17 +54,17 @@ class BlackIntegrationTest(ExternalToolTestBase):
             args.append("--black-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
-        lint_results = self.request_single_product(
+        lint_results = self.request_product(
             LintResults, Params(BlackRequest(field_sets), options_bootstrapper)
         )
-        input_sources = self.request_single_product(
+        input_sources = self.request_product(
             SourceFiles,
             Params(
                 SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )
-        fmt_result = self.request_single_product(
+        fmt_result = self.request_product(
             FmtResult,
             Params(
                 BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -74,7 +74,7 @@ class BlackIntegrationTest(ExternalToolTestBase):
         return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
-        return self.request_single_product(Digest, CreateDigest(source_files))
+        return self.request_product(Digest, CreateDigest(source_files))
 
     def test_passing_source(self) -> None:
         target = self.make_target([self.good_source])

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -43,17 +43,17 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
             args.append("--docformatter-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [DocformatterFieldSet.create(tgt) for tgt in targets]
-        lint_results = self.request_single_product(
+        lint_results = self.request_product(
             LintResults, Params(DocformatterRequest(field_sets), options_bootstrapper)
         )
-        input_sources = self.request_single_product(
+        input_sources = self.request_product(
             SourceFiles,
             Params(
                 SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )
-        fmt_result = self.request_single_product(
+        fmt_result = self.request_product(
             FmtResult,
             Params(
                 DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -63,7 +63,7 @@ class DocformatterIntegrationTest(ExternalToolTestBase):
         return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
-        return self.request_single_product(Digest, CreateDigest(source_files))
+        return self.request_product(Digest, CreateDigest(source_files))
 
     def test_passing_source(self) -> None:
         target = self.make_target([self.good_source])

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -56,7 +56,7 @@ class Flake8IntegrationTest(ExternalToolTestBase):
             args.append("--flake8-skip")
         if additional_args:
             args.extend(additional_args)
-        results = self.request_single_product(
+        results = self.request_product(
             LintResults,
             Params(
                 Flake8Request(Flake8FieldSet.create(tgt) for tgt in targets),
@@ -168,6 +168,6 @@ class Flake8IntegrationTest(ExternalToolTestBase):
         assert result[0].exit_code == 1
         assert result[0].stdout.strip() == ""
         assert result[0].report is not None
-        report_files = self.request_single_product(DigestContents, result[0].report.digest)
+        report_files = self.request_product(DigestContents, result[0].report.digest)
         assert len(report_files) == 1
         assert "bad.py:1:1: F401" in report_files[0].content.decode()

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -61,17 +61,17 @@ class IsortIntegrationTest(ExternalToolTestBase):
             args.append("--isort-skip")
         options_bootstrapper = create_options_bootstrapper(args=args)
         field_sets = [IsortFieldSet.create(tgt) for tgt in targets]
-        lint_results = self.request_single_product(
+        lint_results = self.request_product(
             LintResults, Params(IsortRequest(field_sets), options_bootstrapper)
         )
-        input_sources = self.request_single_product(
+        input_sources = self.request_product(
             SourceFiles,
             Params(
                 SourceFilesRequest(field_set.sources for field_set in field_sets),
                 options_bootstrapper,
             ),
         )
-        fmt_result = self.request_single_product(
+        fmt_result = self.request_product(
             FmtResult,
             Params(
                 IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -81,7 +81,7 @@ class IsortIntegrationTest(ExternalToolTestBase):
         return lint_results.results, fmt_result
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
-        return self.request_single_product(Digest, CreateDigest(source_files))
+        return self.request_product(Digest, CreateDigest(source_files))
 
     def test_passing_source(self) -> None:
         target = self.make_target_with_origin([self.good_source])

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -69,7 +69,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
                 """
             ),
         )
-        return self.request_single_product(
+        return self.request_product(
             WrappedTarget,
             Params(
                 Address(package, target_name=name),
@@ -96,7 +96,7 @@ class PylintIntegrationTest(ExternalToolTestBase):
             args.append("--pylint-skip")
         if additional_args:
             args.extend(additional_args)
-        results = self.request_single_product(
+        results = self.request_product(
             LintResults,
             Params(
                 PylintRequest(PylintFieldSet.create(tgt) for tgt in targets),

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -44,13 +44,13 @@ class PythonFmtIntegrationTest(ExternalToolTestBase):
             "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
             *(extra_args or []),
         ]
-        results = self.request_single_product(
+        results = self.request_product(
             LanguageFmtResults, Params(targets, create_options_bootstrapper(args=args)),
         )
         return results
 
     def get_digest(self, source_files: List[FileContent]) -> Digest:
-        return self.request_single_product(Digest, CreateDigest(source_files))
+        return self.request_product(Digest, CreateDigest(source_files))
 
     def test_multiple_formatters_changing_the_same_file(self) -> None:
         original_source = FileContent(

--- a/src/python/pants/backend/python/pants_requirement_test.py
+++ b/src/python/pants/backend/python/pants_requirement_test.py
@@ -41,7 +41,7 @@ class PantsRequirementTest(TestBase):
         expected_module: str = "pants",
     ) -> None:
         self.add_to_build_file("3rdparty/python", f"{build_file_entry}\n")
-        target = self.request_single_product(
+        target = self.request_product(
             WrappedTarget,
             Params(
                 Address("3rdparty/python", target_name=expected_target_name),

--- a/src/python/pants/backend/python/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/pipenv_requirements_test.py
@@ -40,7 +40,7 @@ class PipenvRequirementsTest(TestBase):
     ) -> None:
         self.add_to_build_file("", f"{build_file_entry}\n")
         self.create_file(pipfile_lock_relpath, dumps(pipfile_lock))
-        targets = self.request_single_product(
+        targets = self.request_product(
             Targets,
             Params(
                 Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),

--- a/src/python/pants/backend/python/python_requirements_test.py
+++ b/src/python/pants/backend/python/python_requirements_test.py
@@ -41,7 +41,7 @@ class PantsRequirementTest(TestBase):
     ) -> None:
         self.add_to_build_file("", f"{build_file_entry}\n")
         self.create_file(requirements_txt_relpath, requirements_txt)
-        targets = self.request_single_product(
+        targets = self.request_product(
             Targets,
             Params(
                 Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),

--- a/src/python/pants/backend/python/rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/rules/ancestor_files_test.py
@@ -43,10 +43,10 @@ class InjectAncestorFilesTest(TestBase):
             "__init__.py", self.make_snapshot({fp: "# declared" for fp in original_declared_files}),
         )
         bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
-        result = self.request_single_product(AncestorFiles, Params(request, bootstrapper)).snapshot
+        result = self.request_product(AncestorFiles, Params(request, bootstrapper)).snapshot
         assert list(result.files) == sorted(expected_discovered)
 
-        materialized_result = self.request_single_product(DigestContents, result.digest)
+        materialized_result = self.request_product(DigestContents, result.digest)
         for file_content in materialized_result:
             path = file_content.path
             if not path.endswith("__init__.py"):

--- a/src/python/pants/backend/python/rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/rules/pex_from_targets_test.py
@@ -83,7 +83,7 @@ class PexTest(TestBase):
                 args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")
             if constraints_file:
                 args.append(f"--python-setup-requirement-constraints={constraints_file}")
-            return self.request_single_product(
+            return self.request_product(
                 PexRequest, Params(request, create_options_bootstrapper(args=args))
             )
 

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -211,7 +211,7 @@ class PexTest(ExternalToolTestBase):
             additional_inputs=additional_inputs,
             additional_args=additional_pex_args,
         )
-        pex = self.request_single_product(
+        pex = self.request_product(
             Pex,
             Params(
                 request,
@@ -258,7 +258,7 @@ class PexTest(ExternalToolTestBase):
         )
 
     def test_pex_execution(self) -> None:
-        sources = self.request_single_product(
+        sources = self.request_product(
             Digest,
             CreateDigest(
                 (
@@ -284,7 +284,7 @@ class PexTest(ExternalToolTestBase):
             input_digest=pex_output["pex"].digest,
             description="Run the pex and make sure it works",
         )
-        result = self.request_single_product(ProcessResult, process)
+        result = self.request_product(ProcessResult, process)
         assert result.stdout == b"from main\n"
 
     def test_resolves_dependencies(self) -> None:
@@ -355,7 +355,7 @@ class PexTest(ExternalToolTestBase):
         # This verifies that the file was indeed provided as additional input to the pex call.
         preamble_file = "custom_preamble.txt"
         preamble = "#!CUSTOM PREAMBLE\n"
-        additional_inputs = self.request_single_product(
+        additional_inputs = self.request_product(
             Digest, CreateDigest([FileContent(path=preamble_file, content=preamble.encode())])
         )
         additional_pex_args = (f"--preamble-file={preamble_file}",)

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -154,8 +154,8 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
             PythonTestFieldSet.create(PythonTests({}, address=address)),
             create_options_bootstrapper(args=args),
         )
-        test_result = self.request_single_product(TestResult, params)
-        debug_request = self.request_single_product(TestDebugRequest, params)
+        test_result = self.request_product(TestResult, params)
+        debug_request = self.request_product(TestDebugRequest, params)
         if debug_request.process is not None:
             debug_result = InteractiveRunner(self.scheduler).run(debug_request.process)
             assert test_result.exit_code == debug_result.exit_code
@@ -341,7 +341,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert result.exit_code == 0
         assert f"{self.package}/test_good.py ." in result.stdout
         assert result.xml_results is not None
-        digest_contents = self.request_single_product(DigestContents, result.xml_results)
+        digest_contents = self.request_product(DigestContents, result.xml_results)
         assert len(digest_contents) == 1
         file = digest_contents[0]
         assert file.path.startswith("dist/test-results")

--- a/src/python/pants/backend/python/rules/python_sources_test.py
+++ b/src/python/pants/backend/python/rules/python_sources_test.py
@@ -62,7 +62,7 @@ class PythonSourceFilesTest(ExternalToolTestBase):
         source_roots: Optional[List[str]] = None,
         extra_args: Optional[List[str]] = None,
     ) -> StrippedPythonSourceFiles:
-        return self.request_single_product(
+        return self.request_product(
             StrippedPythonSourceFiles,
             Params(
                 PythonSourceFilesRequest(
@@ -87,7 +87,7 @@ class PythonSourceFilesTest(ExternalToolTestBase):
         source_roots: Optional[List[str]] = None,
         extra_args: Optional[List[str]] = None,
     ) -> PythonSourceFiles:
-        return self.request_single_product(
+        return self.request_product(
             PythonSourceFiles,
             Params(
                 PythonSourceFilesRequest(

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -69,7 +69,7 @@ class TestSetupPyBase(TestBase):
         ]
 
     def tgt(self, addr: str) -> Target:
-        return self.request_single_product(
+        return self.request_product(
             WrappedTarget, Params(Address.parse(addr), create_options_bootstrapper())
         ).target
 
@@ -88,21 +88,21 @@ class TestGenerateChroot(TestSetupPyBase):
         ]
 
     def assert_chroot(self, expected_files, expected_setup_kwargs, addr):
-        chroot = self.request_single_product(
+        chroot = self.request_product(
             SetupPyChroot,
             Params(
                 SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
                 create_options_bootstrapper(),
             ),
         )
-        snapshot = self.request_single_product(Snapshot, Params(chroot.digest))
+        snapshot = self.request_product(Snapshot, Params(chroot.digest))
         assert sorted(expected_files) == sorted(snapshot.files)
         kwargs = json.loads(chroot.setup_keywords_json)
         assert expected_setup_kwargs == kwargs
 
     def assert_error(self, addr: str, exc_cls: Type[Exception]):
         with pytest.raises(ExecutionError) as excinfo:
-            self.request_single_product(
+            self.request_product(
                 SetupPyChroot,
                 Params(
                     SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
@@ -248,14 +248,14 @@ class TestGetSources(TestSetupPyBase):
         expected_package_data,
         addrs,
     ):
-        srcs = self.request_single_product(
+        srcs = self.request_product(
             SetupPySources,
             Params(
                 SetupPySourcesRequest(Targets([self.tgt(addr) for addr in addrs]), py2=False),
                 create_options_bootstrapper(),
             ),
         )
-        chroot_snapshot = self.request_single_product(Snapshot, Params(srcs.digest))
+        chroot_snapshot = self.request_product(Snapshot, Params(srcs.digest))
 
         assert sorted(expected_files) == sorted(chroot_snapshot.files)
         assert sorted(expected_packages) == sorted(srcs.packages)
@@ -354,7 +354,7 @@ class TestGetRequirements(TestSetupPyBase):
         ]
 
     def assert_requirements(self, expected_req_strs, addr):
-        reqs = self.request_single_product(
+        reqs = self.request_product(
             ExportedTargetRequirements,
             Params(DependencyOwner(ExportedTarget(self.tgt(addr))), create_options_bootstrapper()),
         )
@@ -440,7 +440,7 @@ class TestGetOwnedDependencies(TestSetupPyBase):
     def assert_owned(self, owned: Iterable[str], exported: str):
         assert sorted(owned) == sorted(
             od.target.address.spec
-            for od in self.request_single_product(
+            for od in self.request_product(
                 OwnedDependencies,
                 Params(
                     DependencyOwner(ExportedTarget(self.tgt(exported))),
@@ -533,7 +533,7 @@ class TestGetExportingOwner(TestSetupPyBase):
     def assert_is_owner(self, owner: str, owned: str):
         assert (
             owner
-            == self.request_single_product(
+            == self.request_product(
                 ExportedTarget,
                 Params(OwnedDependency(self.tgt(owned)), create_options_bootstrapper()),
             ).target.address.spec
@@ -541,7 +541,7 @@ class TestGetExportingOwner(TestSetupPyBase):
 
     def assert_error(self, owned: str, exc_cls: Type[Exception]):
         with pytest.raises(ExecutionError) as excinfo:
-            self.request_single_product(
+            self.request_product(
                 ExportedTarget,
                 Params(OwnedDependency(self.tgt(owned)), create_options_bootstrapper()),
             )

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -46,7 +46,7 @@ class TestTimeout(TestBase):
             args.append(f"--pytest-timeout-default={global_default}")
         if global_max is not None:
             args.append(f"--pytest-timeout-maximum={global_max}")
-        pytest = self.request_single_product(PyTest, create_options_bootstrapper(args=args))
+        pytest = self.request_product(PyTest, create_options_bootstrapper(args=args))
         field = PythonTestsTimeout(field_value, address=Address.parse(":tests"))
         assert field.calculate_from_global_options(pytest) == expected
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -99,7 +99,7 @@ class MyPyIntegrationTest(ExternalToolTestBase):
                 """
             ),
         )
-        return self.request_single_product(
+        return self.request_product(
             WrappedTarget,
             Params(
                 Address(package, target_name=name),
@@ -126,7 +126,7 @@ class MyPyIntegrationTest(ExternalToolTestBase):
             args.append("--mypy-skip")
         if additional_args:
             args.extend(additional_args)
-        result = self.request_single_product(
+        result = self.request_product(
             TypecheckResults,
             Params(
                 MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets),

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -24,7 +24,7 @@ from pants.testutil.test_base import TestBase
 
 class RunTest(TestBase):
     def create_mock_run_request(self, program_text: bytes) -> RunRequest:
-        digest = self.request_single_product(
+        digest = self.request_product(
             Digest,
             CreateDigest(
                 [FileContent(path="program.py", content=program_text, is_executable=True)]

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -90,7 +90,7 @@ class ConditionallySucceedsFieldSet(MockTestFieldSet):
 
 class TestTest(TestBase):
     def make_interactive_process(self) -> InteractiveProcess:
-        digest = self.request_single_product(
+        digest = self.request_product(
             Digest, CreateDigest((FileContent(path="program.py", content=b"def test(): pass"),))
         )
         return InteractiveProcess(["/usr/bin/python", "program.py"], input_digest=digest)

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -34,13 +34,11 @@ class ArchiveTest(TestBase):
                 zf.writestr(name, content)
         io.flush()
         input_snapshot = self.make_snapshot({"test.zip": io.getvalue()})
-        extracted_digest = self.request_single_product(
+        extracted_digest = self.request_product(
             ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
-        digest_contents = self.request_single_product(
-            DigestContents, Params(extracted_digest.digest)
-        )
+        digest_contents = self.request_product(DigestContents, Params(extracted_digest.digest))
         assert self.expected_digest_contents == digest_contents
 
     def test_extract_zip_stored(self) -> None:
@@ -61,13 +59,11 @@ class ArchiveTest(TestBase):
                 tf.addfile(tarinfo, BytesIO(content))
         ext = f"tar.{compression}" if compression else "tar"
         input_snapshot = self.make_snapshot({f"test.{ext}": io.getvalue()})
-        extracted_digest = self.request_single_product(
+        extracted_digest = self.request_product(
             ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
-        digest_contents = self.request_single_product(
-            DigestContents, Params(extracted_digest.digest)
-        )
+        digest_contents = self.request_product(DigestContents, Params(extracted_digest.digest))
         assert self.expected_digest_contents == digest_contents
 
     def test_extract_tar(self) -> None:
@@ -84,11 +80,9 @@ class ArchiveTest(TestBase):
 
     def test_non_archive(self) -> None:
         input_snapshot = self.make_snapshot({"test.sh": b"# A shell script"})
-        extracted_digest = self.request_single_product(
+        extracted_digest = self.request_product(
             ExtractedDigest, Params(MaybeExtractable(input_snapshot.digest))
         )
 
-        digest_contents = self.request_single_product(
-            DigestContents, Params(extracted_digest.digest)
-        )
+        digest_contents = self.request_product(DigestContents, Params(extracted_digest.digest))
         assert DigestContents([FileContent("test.sh", b"# A shell script")]) == digest_contents

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -40,7 +40,7 @@ class FilterEmptySourcesTest(TestBase):
             empty_addr, Sources(None, address=empty_addr), Tags(None, address=empty_addr)
         )
 
-        result = self.request_single_product(
+        result = self.request_product(
             FieldSetsWithSources,
             Params(
                 FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
@@ -65,7 +65,7 @@ class FilterEmptySourcesTest(TestBase):
         empty_tgt = MockTarget({}, address=Address("", target_name="empty"))
         invalid_tgt = MockTargetWithNoSourcesField({}, address=Address("", target_name="invalid"))
 
-        result = self.request_single_product(
+        result = self.request_product(
             TargetsWithSources,
             Params(
                 TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt]),

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -55,7 +55,7 @@ class SourceFilesTest(TestBase):
         expected: Iterable[TargetSources],
         expected_unrooted: Iterable[str] = (),
     ) -> None:
-        result = self.request_single_product(
+        result = self.request_product(
             SourceFiles, Params(SourceFilesRequest(sources_fields), create_options_bootstrapper()),
         )
         assert list(result.snapshot.files) == sorted(

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -39,7 +39,7 @@ class StrippedSourceFilesTest(TestBase):
         if not has_source_root_patterns:
             source_root_patterns = ["src/python", "src/java", "tests/python"]
             args.append(f"--source-root-patterns={json.dumps(source_root_patterns)}")
-        result = self.request_single_product(
+        result = self.request_product(
             StrippedSourceFiles, Params(request, create_options_bootstrapper(args=args)),
         )
         return list(result.snapshot.files)

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -138,7 +138,7 @@ class BuildFileIntegrationTest(TestBase):
 
     def test_resolve_address(self) -> None:
         def assert_is_expected(address_input: AddressInput, expected: Address) -> None:
-            assert self.request_single_product(Address, address_input) == expected
+            assert self.request_product(Address, address_input) == expected
 
         self.create_file("a/b/c.txt")
         assert_is_expected(
@@ -165,7 +165,7 @@ class BuildFileIntegrationTest(TestBase):
         assert_is_expected(AddressInput("", target_component="t"), Address("", target_name="t"))
 
         with pytest.raises(ExecutionError) as exc:
-            self.request_single_product(Address, AddressInput("a/b/fake"))
+            self.request_product(Address, AddressInput("a/b/fake"))
         assert "'a/b/fake' does not exist on disk" in str(exc.value)
 
     def test_target_adaptor_parsed_correctly(self) -> None:
@@ -188,7 +188,7 @@ class BuildFileIntegrationTest(TestBase):
             ),
         )
         addr = Address("helloworld")
-        target_adaptor = self.request_single_product(
+        target_adaptor = self.request_product(
             TargetAdaptor, Params(addr, create_options_bootstrapper())
         )
         assert target_adaptor.name == "helloworld"
@@ -206,7 +206,7 @@ class BuildFileIntegrationTest(TestBase):
     def test_target_adaptor_not_found(self) -> None:
         bootstrapper = create_options_bootstrapper()
         with pytest.raises(ExecutionError) as exc:
-            self.request_single_product(TargetAdaptor, Params(Address("helloworld"), bootstrapper))
+            self.request_product(TargetAdaptor, Params(Address("helloworld"), bootstrapper))
         assert "Directory \\'helloworld\\' does not contain any BUILD files" in str(exc)
 
         self.add_to_build_file("helloworld", "mock_tgt(name='other_tgt')")
@@ -214,7 +214,7 @@ class BuildFileIntegrationTest(TestBase):
             "'helloworld' was not found in namespace 'helloworld'. Did you mean one of:\n  :other_tgt"
         )
         with pytest.raises(ExecutionError, match=expected_rx_str):
-            self.request_single_product(TargetAdaptor, Params(Address("helloworld"), bootstrapper))
+            self.request_product(TargetAdaptor, Params(Address("helloworld"), bootstrapper))
 
     def test_build_file_address(self) -> None:
         self.create_file("helloworld/BUILD.ext", "mock_tgt()")
@@ -222,9 +222,9 @@ class BuildFileIntegrationTest(TestBase):
 
         def assert_bfa_resolved(address: Address) -> None:
             expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", address=address)
-            bfa = self.request_single_product(BuildFileAddress, Params(address, bootstrapper))
+            bfa = self.request_product(BuildFileAddress, Params(address, bootstrapper))
             assert bfa == expected_bfa
-            bfas = self.request_single_product(
+            bfas = self.request_product(
                 BuildFileAddresses, Params(Addresses([address]), bootstrapper)
             )
             assert bfas == BuildFileAddresses([bfa])
@@ -236,7 +236,7 @@ class BuildFileIntegrationTest(TestBase):
     def resolve_address_specs(
         self, specs: Iterable[AddressSpec], bootstrapper: Optional[OptionsBootstrapper] = None
     ) -> Set[AddressWithOrigin]:
-        result = self.request_single_product(
+        result = self.request_product(
             AddressesWithOrigins,
             Params(
                 Specs(AddressSpecs(specs, filter_by_global_options=True), FilesystemSpecs([])),

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -667,7 +667,7 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            result = self.request_single_product(ProcessResult, stdout_process)
+            result = self.request_product(ProcessResult, stdout_process)
 
         assert tracker.finished
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -696,7 +696,7 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            result = self.request_single_product(ProcessResult, stderr_process)
+            result = self.request_product(ProcessResult, stderr_process)
 
         assert tracker.finished
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -749,4 +749,4 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            self.request_single_product(ProcessResult, stdout_process)
+            self.request_product(ProcessResult, stdout_process)

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -51,7 +51,7 @@ class TestEngineOptionsParsing(TestBase):
 
         def parse(ob):
             params = Params(Scope(str(GLOBAL_SCOPE)), ob)
-            return self.request_single_product(ScopedOptions, params)
+            return self.request_product(ScopedOptions, params)
 
         # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
         one_opts = ob()

--- a/src/python/pants/engine/internals/uuid_test.py
+++ b/src/python/pants/engine/internals/uuid_test.py
@@ -19,11 +19,11 @@ class UUIDTest(TestBase):
         )
 
     def test_distinct_uuids(self):
-        uuid1 = self.request_single_product(UUID, UUIDRequest())
-        uuid2 = self.request_single_product(UUID, UUIDRequest())
+        uuid1 = self.request_product(UUID, UUIDRequest())
+        uuid2 = self.request_product(UUID, UUIDRequest())
         assert uuid1 != uuid2
 
     def test_identical_uuids(self):
-        uuid1 = self.request_single_product(UUID, UUIDRequest(randomizer=0.0))
-        uuid2 = self.request_single_product(UUID, UUIDRequest(randomizer=0.0))
+        uuid1 = self.request_product(UUID, UUIDRequest(randomizer=0.0))
+        uuid2 = self.request_product(UUID, UUIDRequest(randomizer=0.0))
         assert uuid1 == uuid2

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -14,6 +14,6 @@ class PlatformTest(TestBase):
         process = Process(
             argv=("/bin/echo", "test"), description="Run some program that will exit cleanly."
         )
-        result = self.request_single_product(FallibleProcessResultWithPlatform, process)
+        result = self.request_product(FallibleProcessResultWithPlatform, process)
         assert result.exit_code == 0
         assert result.platform == this_platform

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -60,7 +60,7 @@ class WorkspaceTest(TestBase):
         # TODO(#8336): at some point, this test should require that Workspace only be invoked from
         #  an @goal_rule
         workspace = Workspace(self.scheduler)
-        digest = self.request_single_product(
+        digest = self.request_product(
             Digest,
             CreateDigest([FileContent("a.txt", b"hello"), FileContent("subdir/b.txt", b"goodbye")]),
         )

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -25,7 +25,7 @@ class FilespecTest(TestBase):
                 self.create_dir(expected_match)
             else:
                 self.create_file(expected_match)
-        snapshot = self.request_single_product(Snapshot, PathGlobs([glob]))
+        snapshot = self.request_product(Snapshot, PathGlobs([glob]))
         if should_match:
             assert sorted(paths) == sorted(snapshot.files)
         else:

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -277,7 +277,7 @@ class SourceRootsRequestTest(TestBase):
             files=(PurePath("src/python/foo/bar.py"), PurePath("tests/python/foo/bar_test.py")),
             dirs=(PurePath("src/python/foo"), PurePath("src/python/baz/qux")),
         )
-        res = self.request_single_product(
+        res = self.request_product(
             SourceRootsResult,
             Params(
                 req,

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -48,7 +48,7 @@ class PluginResolverTest(TestBase):
         )
 
     def _create_pex(self) -> Pex:
-        return self.request_single_product(
+        return self.request_product(
             Pex,
             Params(
                 PexRequest(
@@ -64,7 +64,7 @@ class PluginResolverTest(TestBase):
         self, plugin: str, version: str, setup_py_args: Iterable[str], install_dir: str
     ) -> None:
         pex_obj = self._create_pex()
-        source_digest = self.request_single_product(
+        source_digest = self.request_product(
             Digest,
             CreateDigest(
                 [
@@ -81,9 +81,7 @@ class PluginResolverTest(TestBase):
                 ]
             ),
         )
-        merged_digest = self.request_single_product(
-            Digest, MergeDigests([pex_obj.digest, source_digest])
-        )
+        merged_digest = self.request_product(Digest, MergeDigests([pex_obj.digest, source_digest]))
 
         process = Process(
             argv=("python", "setup-py-runner.pex", "setup.py") + tuple(setup_py_args),
@@ -94,8 +92,8 @@ class PluginResolverTest(TestBase):
             description="Run setup.py",
             output_directories=("dist/",),
         )
-        result = self.request_single_product(ProcessResult, process)
-        result_snapshot = self.request_single_product(Snapshot, result.output_digest)
+        result = self.request_product(ProcessResult, process)
+        result_snapshot = self.request_product(Snapshot, result.output_digest)
         self.scheduler.write_digest(result.output_digest, path_prefix="output")
         safe_mkdir(install_dir)
         for path in result_snapshot.files:

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -8,6 +8,7 @@ from typing import Iterator
 from pants.fs.fs import safe_filename_from_path
 from pants.init.util import init_workdir
 from pants.option.option_value_container import OptionValueContainer
+from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
 
@@ -16,9 +17,9 @@ class UtilTest(TestBase):
     @contextmanager
     def physical_workdir_base(self) -> Iterator[OptionValueContainer]:
         with temporary_dir(cleanup=False) as physical_workdir_base:
-            bootstrap_options = self.get_bootstrap_options(
-                [f"--pants-physical-workdir-base={physical_workdir_base}"]
-            )
+            bootstrap_options = create_options_bootstrapper(
+                args=[f"--pants-physical-workdir-base={physical_workdir_base}"]
+            ).bootstrap_options.for_global_scope()
             yield bootstrap_options
 
     def assert_exists(self, path):


### PR DESCRIPTION
Originally, we used "single" to distinguish from the batched `scheduler.product_request`. However, we no longer use the synchronous API outside of tests and special startup code - end users should never see `scheduler.product_request`.

Further, we don't care that `TestBase.request_product()` is only one-product-at-a-time. That's fine for tests, where we don't care about the speed of batching. We care more about readability with tests.

[ci skip-build-wheels]
[ci skip-rust]