### PR TITLE
Only use `TestBase` for tests that run rules

### DIFF
--- a/build-support/migration-support/fix_deprecated_globs_usage_test.py
+++ b/build-support/migration-support/fix_deprecated_globs_usage_test.py
@@ -8,409 +8,413 @@ from typing import List, Optional, Tuple
 
 from fix_deprecated_globs_usage import SCRIPT_RESTRICTIONS, generate_possibly_new_build, warning_msg
 
-from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
 
 Result = Optional[List[str]]
 
 
-class ModernizeSourcesTest(TestBase):
-    @staticmethod
-    def run_on_build_file(content: str) -> Tuple[Result, Path]:
-        with temporary_dir() as tmpdir:
-            build = Path(tmpdir, "BUILD")
-            build.write_text(content)
-            result = generate_possibly_new_build(build)
-        return result, build
+def run_on_build_file(content: str) -> Tuple[Result, Path]:
+    with temporary_dir() as tmpdir:
+        build = Path(tmpdir, "BUILD")
+        build.write_text(content)
+        result = generate_possibly_new_build(build)
+    return result, build
 
-    def capture_warnings(self, *, build_file_content: str) -> Tuple[Result, Path, List[str]]:
-        with self.captured_logging() as captured:
-            result, build = self.run_on_build_file(build_file_content)
-        return result, build, captured.warnings()
 
-    def assert_rewrite(
-        self, *, original: str, expected: str, include_field_after_sources: bool = True,
-    ) -> None:
-        template = dedent(
+def assert_rewrite(
+    *, original: str, expected: str, include_field_after_sources: bool = True
+) -> None:
+    template = dedent(
+        """\
+        # A stray comment
+
+        python_library(
+          name="lib",
+          {sources_field}
+          {dependencies_field}
+        )
+
+        python_binary(
+          name="bin",
+          dependencies=[
+            ':lib',
+          ],
+        )
+        """
+    )
+    dependencies_field = (
+        dedent(
             """\
-            # A stray comment
+            dependencies=[
+              'src/python/pants/util',
+            ],
+            """
+        )
+        if include_field_after_sources
+        else ""
+    )
+    result, _ = run_on_build_file(
+        template.format(sources_field=original, dependencies_field=dependencies_field),
+    )
+    if original == expected:
+        assert result is None
+    else:
+        assert (
+            result
+            == template.format(
+                sources_field=expected, dependencies_field=dependencies_field
+            ).splitlines()
+        )
 
-            python_library(
-              name="lib",
-              {sources_field}
-              {dependencies_field}
+
+def assert_warning_raised(
+    caplog,
+    *,
+    warning_num: int,
+    build_file_content: str,
+    line_number: int,
+    field_name: str,
+    replacement: str,
+    script_restriction: str,
+) -> None:
+    result, build = run_on_build_file(build_file_content)
+    assert result is None  # i.e., the script will not change the BUILD
+    assert caplog.records[warning_num].msg == warning_msg(
+        build_file=build,
+        lineno=line_number,
+        field_name=field_name,
+        replacement=replacement,
+        script_restriction=script_restriction,
+    )
+
+
+def test_no_op_when_already_valid() -> None:
+    valid_entries = [
+        "sources=['foo.py'],",
+        "sources=['!ignore.py'],",
+        "sources=[],",
+        "sources=['foo.py', '!ignore.py'],",
+    ]
+    for entry in valid_entries:
+        assert_rewrite(original=entry, expected=entry)
+
+
+def test_includes() -> None:
+    assert_rewrite(original="sources=globs(),", expected="sources=[],")
+    assert_rewrite(original="sources=zglobs(),", expected="sources=[],")
+    assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
+    assert_rewrite(original="sources=zglobs('foo.py'),", expected="sources=['foo.py'],")
+    assert_rewrite(
+        original="sources=globs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
+    )
+    assert_rewrite(
+        original="sources=zglobs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
+    )
+
+
+def test_excludes() -> None:
+    assert_rewrite(original="sources=globs(exclude=[]),", expected="sources=[],")
+
+    # `exclude` elements are strings
+    assert_rewrite(
+        original="sources=globs(exclude=['ignore.py']),", expected="sources=['!ignore.py'],"
+    )
+    assert_rewrite(
+        original="sources=globs(exclude=['ignore.py', 'ignore2.py']),",
+        expected="sources=['!ignore.py', '!ignore2.py'],",
+    )
+
+    # `exclude` elements are globs
+    assert_rewrite(
+        original="sources=globs(exclude=[globs('ignore.py')]),", expected="sources=['!ignore.py'],",
+    )
+    assert_rewrite(
+        original="sources=globs(exclude=[globs('ignore.py'), globs('ignore2.py')]),",
+        expected="sources=['!ignore.py', '!ignore2.py'],",
+    )
+
+    # `exclude` elements are lists
+    assert_rewrite(
+        original="sources=globs(exclude=[['ignore.py']]),", expected="sources=['!ignore.py'],"
+    )
+    assert_rewrite(
+        original="sources=globs(exclude=[[globs('ignore.py')]]),",
+        expected="sources=['!ignore.py'],",
+    )
+
+    # `exclude` elements are all of the above
+    assert_rewrite(
+        original="sources=globs(exclude=['ignore1.py', globs('ignore2.py'), ['ignore3.py'], [globs('ignore4.py')]]),",
+        expected="sources=['!ignore1.py', '!ignore2.py', '!ignore3.py', '!ignore4.py'],",
+    )
+
+    # check that `exclude` plays nicely with includes
+    assert_rewrite(
+        original="sources=globs('foo.py', 'bar.py', exclude=['ignore1.py', 'ignore2.py']),",
+        expected="sources=['foo.py', 'bar.py', '!ignore1.py', '!ignore2.py'],",
+    )
+
+
+def test_normalizes_rglobs() -> None:
+    # Expand when the path component starts with a `*`
+    assert_rewrite(original="sources=rglobs('*'),", expected="sources=['**/*'],")
+    assert_rewrite(original="sources=rglobs('*.txt'),", expected="sources=['**/*.txt'],")
+    assert_rewrite(original="sources=rglobs('test/*.txt'),", expected="sources=['test/**/*.txt'],")
+    assert_rewrite(original="sources=rglobs('*/*/*.txt'),", expected="sources=['**/*/*/**/*.txt'],")
+
+    # Don't expand in these cases
+    assert_rewrite(original="sources=rglobs('foo.py'),", expected="sources=['foo.py'],")
+    assert_rewrite(original="sources=rglobs('test_*'),", expected="sources=['test_*'],")
+    assert_rewrite(original="sources=rglobs('**/*'),", expected="sources=['**/*'],")
+
+    # Check the intersection with the `exclude` clause
+    assert_rewrite(
+        original="sources=rglobs('foo.py', exclude=['*']),", expected="sources=['foo.py', '!*'],",
+    )
+    assert_rewrite(
+        original="sources=globs('foo.py', exclude=[rglobs('*')]),",
+        expected="sources=['foo.py', '!**/*'],",
+    )
+
+
+def test_correctly_formats_rewrite() -> None:
+    # Preserve the original `sources` prefix, including whitespace
+    assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
+    assert_rewrite(original="sources = globs('foo.py'),", expected="sources = ['foo.py'],")
+    assert_rewrite(original="sources =globs('foo.py'),", expected="sources =['foo.py'],")
+    assert_rewrite(original="sources= globs('foo.py'),", expected="sources= ['foo.py'],")
+    assert_rewrite(original="sources  = globs('foo.py'),", expected="sources  = ['foo.py'],")
+    assert_rewrite(original="sources =  globs('foo.py'),", expected="sources =  ['foo.py'],")
+    assert_rewrite(original="  sources=globs('foo.py'),", expected="  sources=['foo.py'],")
+
+    # Strip stray trailing whitespace
+    assert_rewrite(original="sources=globs('foo.py'),      ", expected="sources=['foo.py'],")
+
+    # Preserve whether the original used single quotes or double quotes
+    assert_rewrite(original="""sources=globs("foo.py"),""", expected="""sources=["foo.py"],""")
+    assert_rewrite(
+        original="""sources=globs("double.py", "foo.py", 'single.py'),""",
+        expected="""sources=["double.py", "foo.py", "single.py"],""",
+    )
+
+    # Always use a trailing comma
+    assert_rewrite(
+        original="sources=globs('foo.py')",
+        expected="sources=['foo.py'],",
+        include_field_after_sources=False,
+    )
+
+    # Maintain insertion order for includes
+    assert_rewrite(
+        original="sources=globs('dog.py', 'cat.py'),", expected="sources=['dog.py', 'cat.py'],",
+    )
+
+
+def test_warns_when_sources_shares_a_line(caplog) -> None:
+    assert_warning = partial(
+        assert_warning_raised,
+        caplog,
+        field_name="sources",
+        replacement="['foo.py']",
+        script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_distinct_line"],
+    )
+    assert_warning(
+        build_file_content="files(sources=globs('foo.py'))", warning_num=0, line_number=1,
+    )
+    assert_warning(
+        build_file_content=dedent(
+            """\
+            files(
+              name='bad', sources=globs('foo.py'),
             )
+            """
+        ),
+        warning_num=1,
+        line_number=2,
+    )
 
-            python_binary(
-              name="bin",
-              dependencies=[
-                ':lib',
+
+def test_warns_when_sources_is_multiline(caplog) -> None:
+    assert_warning = partial(
+        assert_warning_raised,
+        caplog,
+        field_name="sources",
+        replacement='["foo.py", "bar.py"]',
+        script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_single_line"],
+        line_number=3,
+    )
+    assert_warning(
+        build_file_content=dedent(
+            """\
+            files(
+              name='bad',
+              sources=globs(
+                "foo.py",
+                "bar.py",
+              ),
+            )
+            """
+        ),
+        warning_num=0,
+        # We can't easily infer whether to use single vs. double quotes
+        replacement='["foo.py", "bar.py"]',
+    )
+    assert_warning(
+        build_file_content=dedent(
+            """\
+            files(
+              name='bad',
+              sources=globs('foo.py',
+                            'bar.py'),
+            )
+            """
+        ),
+        warning_num=1,
+        replacement="['foo.py', 'bar.py']",
+    )
+
+
+def test_warns_on_comments(caplog) -> None:
+    assert_warning_raised(
+        caplog,
+        build_file_content=dedent(
+            """\
+            files(
+              sources=globs('foo.py'),  # a comment
+            )
+            """
+        ),
+        warning_num=0,
+        line_number=2,
+        replacement="['foo.py']",
+        field_name="sources",
+        script_restriction=SCRIPT_RESTRICTIONS["no_comments"],
+    )
+
+
+def test_warns_on_bundles(caplog) -> None:
+    def assert_no_op(build_file_content: str) -> None:
+        result, _ = run_on_build_file(build_file_content)
+        assert result is None
+
+    assert_no_op(
+        dedent(
+            """\
+            jvm_app(
+              bundles=[],
+            )
+            """
+        )
+    )
+    assert_no_op(
+        dedent(
+            """\
+            jvm_app(
+              bundles=[
+                bundle(fileset=[]),
               ],
             )
             """
         )
-        dependencies_field = (
-            dedent(
-                """\
-                dependencies=[
-                  'src/python/pants/util',
-                ],
-                """
+    )
+    assert_no_op(
+        dedent(
+            """\
+            jvm_app(
+              bundles=[
+                bundle(fileset=['foo.java', '!ignore.java']),
+              ],
             )
-            if include_field_after_sources
-            else ""
+            """
         )
-        result, _ = self.run_on_build_file(
-            template.format(sources_field=original, dependencies_field=dependencies_field),
-        )
-        if original == expected:
-            assert result is None
-        else:
-            assert (
-                result
-                == template.format(
-                    sources_field=expected, dependencies_field=dependencies_field
-                ).splitlines()
-            )
+    )
 
-    def assert_warning_raised(
-        self,
-        *,
+    assert_warning_raised(
+        caplog,
+        build_file_content=dedent(
+            """\
+            jvm_app(
+              bundles=[
+                bundle(fileset=globs('foo.java')),
+              ],
+            )
+            """
+        ),
+        warning_num=0,
+        field_name="bundle(fileset=)",
+        line_number=3,
+        replacement="['foo.java']",
+        script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
+    )
+
+    def check_multiple_bad_bundle_entries(
         build_file_content: str,
-        line_number: int,
-        field_name: str,
-        replacement: str,
-        script_restriction: str,
+        warning_slice: slice,
+        *,
+        replacements_and_line_numbers: List[Tuple[str, int]],
     ) -> None:
-        result, build, warnings = self.capture_warnings(build_file_content=build_file_content)
-        assert result is None  # i.e., the script will not change the BUILD
-        assert len(warnings) == 1
-        assert warnings[0] == "root: " + warning_msg(
-            build_file=build,
-            lineno=line_number,
-            field_name=field_name,
-            replacement=replacement,
-            script_restriction=script_restriction,
-        )
-
-    def test_no_op_when_already_valid(self) -> None:
-        valid_entries = [
-            "sources=['foo.py'],",
-            "sources=['!ignore.py'],",
-            "sources=[],",
-            "sources=['foo.py', '!ignore.py'],",
-        ]
-        for entry in valid_entries:
-            self.assert_rewrite(original=entry, expected=entry)
-
-    def test_includes(self) -> None:
-        self.assert_rewrite(original="sources=globs(),", expected="sources=[],")
-        self.assert_rewrite(original="sources=zglobs(),", expected="sources=[],")
-        self.assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
-        self.assert_rewrite(original="sources=zglobs('foo.py'),", expected="sources=['foo.py'],")
-        self.assert_rewrite(
-            original="sources=globs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
-        )
-        self.assert_rewrite(
-            original="sources=zglobs('foo.py', 'bar.py'),", expected="sources=['foo.py', 'bar.py'],"
-        )
-
-    def test_excludes(self) -> None:
-        self.assert_rewrite(original="sources=globs(exclude=[]),", expected="sources=[],")
-
-        # `exclude` elements are strings
-        self.assert_rewrite(
-            original="sources=globs(exclude=['ignore.py']),", expected="sources=['!ignore.py'],"
-        )
-        self.assert_rewrite(
-            original="sources=globs(exclude=['ignore.py', 'ignore2.py']),",
-            expected="sources=['!ignore.py', '!ignore2.py'],",
-        )
-
-        # `exclude` elements are globs
-        self.assert_rewrite(
-            original="sources=globs(exclude=[globs('ignore.py')]),",
-            expected="sources=['!ignore.py'],",
-        )
-        self.assert_rewrite(
-            original="sources=globs(exclude=[globs('ignore.py'), globs('ignore2.py')]),",
-            expected="sources=['!ignore.py', '!ignore2.py'],",
-        )
-
-        # `exclude` elements are lists
-        self.assert_rewrite(
-            original="sources=globs(exclude=[['ignore.py']]),", expected="sources=['!ignore.py'],"
-        )
-        self.assert_rewrite(
-            original="sources=globs(exclude=[[globs('ignore.py')]]),",
-            expected="sources=['!ignore.py'],",
-        )
-
-        # `exclude` elements are all of the above
-        self.assert_rewrite(
-            original="sources=globs(exclude=['ignore1.py', globs('ignore2.py'), ['ignore3.py'], [globs('ignore4.py')]]),",
-            expected="sources=['!ignore1.py', '!ignore2.py', '!ignore3.py', '!ignore4.py'],",
-        )
-
-        # check that `exclude` plays nicely with includes
-        self.assert_rewrite(
-            original="sources=globs('foo.py', 'bar.py', exclude=['ignore1.py', 'ignore2.py']),",
-            expected="sources=['foo.py', 'bar.py', '!ignore1.py', '!ignore2.py'],",
-        )
-
-    def test_normalizes_rglobs(self) -> None:
-        # Expand when the path component starts with a `*`
-        self.assert_rewrite(original="sources=rglobs('*'),", expected="sources=['**/*'],")
-        self.assert_rewrite(original="sources=rglobs('*.txt'),", expected="sources=['**/*.txt'],")
-        self.assert_rewrite(
-            original="sources=rglobs('test/*.txt'),", expected="sources=['test/**/*.txt'],"
-        )
-        self.assert_rewrite(
-            original="sources=rglobs('*/*/*.txt'),", expected="sources=['**/*/*/**/*.txt'],"
-        )
-
-        # Don't expand in these cases
-        self.assert_rewrite(original="sources=rglobs('foo.py'),", expected="sources=['foo.py'],")
-        self.assert_rewrite(original="sources=rglobs('test_*'),", expected="sources=['test_*'],")
-        self.assert_rewrite(original="sources=rglobs('**/*'),", expected="sources=['**/*'],")
-
-        # Check the intersection with the `exclude` clause
-        self.assert_rewrite(
-            original="sources=rglobs('foo.py', exclude=['*']),",
-            expected="sources=['foo.py', '!*'],",
-        )
-        self.assert_rewrite(
-            original="sources=globs('foo.py', exclude=[rglobs('*')]),",
-            expected="sources=['foo.py', '!**/*'],",
-        )
-
-    def test_correctly_formats_rewrite(self) -> None:
-        # Preserve the original `sources` prefix, including whitespace
-        self.assert_rewrite(original="sources=globs('foo.py'),", expected="sources=['foo.py'],")
-        self.assert_rewrite(original="sources = globs('foo.py'),", expected="sources = ['foo.py'],")
-        self.assert_rewrite(original="sources =globs('foo.py'),", expected="sources =['foo.py'],")
-        self.assert_rewrite(original="sources= globs('foo.py'),", expected="sources= ['foo.py'],")
-        self.assert_rewrite(
-            original="sources  = globs('foo.py'),", expected="sources  = ['foo.py'],"
-        )
-        self.assert_rewrite(
-            original="sources =  globs('foo.py'),", expected="sources =  ['foo.py'],"
-        )
-        self.assert_rewrite(original="  sources=globs('foo.py'),", expected="  sources=['foo.py'],")
-
-        # Strip stray trailing whitespace
-        self.assert_rewrite(
-            original="sources=globs('foo.py'),      ", expected="sources=['foo.py'],"
-        )
-
-        # Preserve whether the original used single quotes or double quotes
-        self.assert_rewrite(
-            original="""sources=globs("foo.py"),""", expected="""sources=["foo.py"],"""
-        )
-        self.assert_rewrite(
-            original="""sources=globs("double.py", "foo.py", 'single.py'),""",
-            expected="""sources=["double.py", "foo.py", "single.py"],""",
-        )
-
-        # Always use a trailing comma
-        self.assert_rewrite(
-            original="sources=globs('foo.py')",
-            expected="sources=['foo.py'],",
-            include_field_after_sources=False,
-        )
-
-        # Maintain insertion order for includes
-        self.assert_rewrite(
-            original="sources=globs('dog.py', 'cat.py'),", expected="sources=['dog.py', 'cat.py'],",
-        )
-
-    def test_warns_when_sources_shares_a_line(self) -> None:
-        assert_warning = partial(
-            self.assert_warning_raised,
-            field_name="sources",
-            replacement="['foo.py']",
-            script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_distinct_line"],
-        )
-        assert_warning(
-            build_file_content="files(sources=globs('foo.py'))", line_number=1,
-        )
-        assert_warning(
-            build_file_content=dedent(
-                """\
-                files(
-                  name='bad', sources=globs('foo.py'),
-                )
-                """
-            ),
-            line_number=2,
-        )
-
-    def test_warns_when_sources_is_multiline(self) -> None:
-        assert_warning = partial(
-            self.assert_warning_raised,
-            field_name="sources",
-            replacement='["foo.py", "bar.py"]',
-            script_restriction=SCRIPT_RESTRICTIONS["sources_must_be_single_line"],
-            line_number=3,
-        )
-        assert_warning(
-            build_file_content=dedent(
-                """\
-                files(
-                  name='bad',
-                  sources=globs(
-                    "foo.py",
-                    "bar.py",
-                  ),
-                )
-                """
-            ),
-            # We can't easily infer whether to use single vs. double quotes
-            replacement='["foo.py", "bar.py"]',
-        )
-        assert_warning(
-            build_file_content=dedent(
-                """\
-                files(
-                  name='bad',
-                  sources=globs('foo.py',
-                                'bar.py'),
-                )
-                """
-            ),
-            replacement="['foo.py', 'bar.py']",
-        )
-
-    def test_warns_on_comments(self) -> None:
-        self.assert_warning_raised(
-            build_file_content=dedent(
-                """\
-                files(
-                  sources=globs('foo.py'),  # a comment
-                )
-                """
-            ),
-            line_number=2,
-            replacement="['foo.py']",
-            field_name="sources",
-            script_restriction=SCRIPT_RESTRICTIONS["no_comments"],
-        )
-
-    def test_warns_on_bundles(self) -> None:
-        def assert_no_op(build_file_content: str) -> None:
-            result, _ = self.run_on_build_file(build_file_content)
-            assert result is None
-
-        assert_no_op(
-            dedent(
-                """\
-                jvm_app(
-                  bundles=[],
-                )
-                """
-            )
-        )
-        assert_no_op(
-            dedent(
-                """\
-                jvm_app(
-                  bundles=[
-                    bundle(fileset=[]),
-                  ],
-                )
-                """
-            )
-        )
-        assert_no_op(
-            dedent(
-                """\
-                jvm_app(
-                  bundles=[
-                    bundle(fileset=['foo.java', '!ignore.java']),
-                  ],
-                )
-                """
-            )
-        )
-
-        self.assert_warning_raised(
-            build_file_content=dedent(
-                """\
-                jvm_app(
-                  bundles=[
-                    bundle(fileset=globs('foo.java')),
-                  ],
-                )
-                """
-            ),
-            field_name="bundle(fileset=)",
-            line_number=3,
-            replacement="['foo.java']",
-            script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
-        )
-
-        def check_multiple_bad_bundle_entries(
-            build_file_content: str, *, replacements_and_line_numbers: List[Tuple[str, int]]
-        ) -> None:
-            result, build, warnings = self.capture_warnings(build_file_content=build_file_content)
-            assert result is None
-            for warning, replacement_and_line_number in zip(
-                warnings, replacements_and_line_numbers
-            ):
-                replacement, line_number = replacement_and_line_number
-                assert warning == "root: " + warning_msg(
-                    build_file=build,
-                    lineno=line_number,
-                    field_name="bundle(fileset=)",
-                    replacement=replacement,
-                    script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
-                )
-
-        check_multiple_bad_bundle_entries(
-            dedent(
-                """\
-                jvm_app(
-                  bundles=[
-                    bundle(fileset=globs('foo.java')),
-                    bundle(fileset=globs('bar.java')),
-                  ],
-                )
-                """
-            ),
-            replacements_and_line_numbers=[("['foo.java']", 3), ("['bar.java']", 4)],
-        )
-        check_multiple_bad_bundle_entries(
-            dedent(
-                """\
-                jvm_app(
-                  bundles=[bundle(fileset=globs('foo.java')), bundle(fileset=globs('bar.java'))],
-                )
-                """
-            ),
-            replacements_and_line_numbers=[("['foo.java']", 2), ("['bar.java']", 2)],
-        )
-
-    def test_warns_on_variables(self) -> None:
-        result, build, warnings = self.capture_warnings(
-            build_file_content=dedent(
-                """\
-                files(
-                  sources=globs(VARIABLE, VAR2),
-                )
-                """
-            )
-        )
+        result, build = run_on_build_file(build_file_content)
         assert result is None
-        assert f"Could not parse the globs in {build} at line 2." in warnings[0]
-
-        result, build, warnings = self.capture_warnings(
-            build_file_content=dedent(
-                """\
-                files(
-                  sources=globs('foo.py', exclude=[VAR1, [VAR2], glob(VAR3)]),
-                )
-                """
+        for record, replacement_and_line_number in zip(
+            caplog.records[warning_slice], replacements_and_line_numbers
+        ):
+            replacement, line_number = replacement_and_line_number
+            assert record.message == warning_msg(
+                build_file=build,
+                lineno=line_number,
+                field_name="bundle(fileset=)",
+                replacement=replacement,
+                script_restriction=SCRIPT_RESTRICTIONS["no_bundles"],
             )
+
+    check_multiple_bad_bundle_entries(
+        dedent(
+            """\
+            jvm_app(
+              bundles=[
+                bundle(fileset=globs('foo.java')),
+                bundle(fileset=globs('bar.java')),
+              ],
+            )
+            """
+        ),
+        warning_slice=slice(1, 3),
+        replacements_and_line_numbers=[("['foo.java']", 3), ("['bar.java']", 4)],
+    )
+    check_multiple_bad_bundle_entries(
+        dedent(
+            """\
+            jvm_app(
+              bundles=[bundle(fileset=globs('foo.java')), bundle(fileset=globs('bar.java'))],
+            )
+            """
+        ),
+        warning_slice=slice(3, 5),
+        replacements_and_line_numbers=[("['foo.java']", 2), ("['bar.java']", 2)],
+    )
+
+
+def test_warns_on_variables(caplog) -> None:
+    result, build = run_on_build_file(
+        dedent(
+            """\
+            files(
+              sources=globs(VARIABLE, VAR2),
+            )
+            """
         )
-        assert result is None
-        assert f"Could not parse the exclude globs in {build} at line 2." in warnings[0]
+    )
+    assert result is None
+    assert f"Could not parse the globs in {build} at line 2." in caplog.records[0].message
+
+    result, build = run_on_build_file(
+        dedent(
+            """\
+            files(
+              sources=globs('foo.py', exclude=[VAR1, [VAR2], glob(VAR3)]),
+            )
+            """
+        )
+    )
+    assert result is None
+    assert f"Could not parse the exclude globs in {build} at line 2." in caplog.records[1].message

--- a/src/python/pants/backend/python/rules/coverage_test.py
+++ b/src/python/pants/backend/python/rules/coverage_test.py
@@ -10,126 +10,127 @@ from pants.backend.python.rules.coverage import CoverageSubsystem, create_covera
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, PathGlobs
 from pants.testutil.engine_util import MockGet, run_rule
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.test_base import TestBase
 
 
-class TestCoverageConfig(TestBase):
-    def run_create_coverage_config_rule(self, coverage_config: Optional[str]) -> str:
-        coverage = create_subsystem(
-            CoverageSubsystem, config="some_file" if coverage_config else None
+def run_create_coverage_config_rule(coverage_config: Optional[str]) -> str:
+    coverage = create_subsystem(CoverageSubsystem, config="some_file" if coverage_config else None)
+    resolved_config: List[str] = []
+
+    def mock_handle_config(request: CreateDigest) -> Digest:
+        assert len(request) == 1
+        assert request[0].path == ".coveragerc"
+        assert request[0].is_executable is False
+        resolved_config.append(request[0].content.decode())
+        return Digest("jerry", 30)
+
+    def mock_read_config(_: PathGlobs) -> DigestContents:
+        # This shouldn't be called if no config file provided.
+        assert coverage_config is not None
+        return DigestContents(
+            [FileContent(path="/dev/null/prelude", content=coverage_config.encode())]
         )
-        resolved_config: List[str] = []
 
-        def mock_handle_config(request: CreateDigest) -> Digest:
-            assert len(request) == 1
-            assert request[0].path == ".coveragerc"
-            assert request[0].is_executable is False
-            resolved_config.append(request[0].content.decode())
-            return Digest("jerry", 30)
+    mock_gets = [
+        MockGet(product_type=DigestContents, subject_type=PathGlobs, mock=mock_read_config),
+        MockGet(product_type=Digest, subject_type=CreateDigest, mock=mock_handle_config),
+    ]
 
-        def mock_read_config(_: PathGlobs) -> DigestContents:
-            # This shouldn't be called if no config file provided.
-            assert coverage_config is not None
-            return DigestContents(
-                [FileContent(path="/dev/null/prelude", content=coverage_config.encode())]
-            )
+    result = run_rule(create_coverage_config, rule_args=[coverage], mock_gets=mock_gets)
+    assert result.digest.fingerprint == "jerry"
+    assert len(resolved_config) == 1
+    return resolved_config[0]
 
-        mock_gets = [
-            MockGet(product_type=DigestContents, subject_type=PathGlobs, mock=mock_read_config),
-            MockGet(product_type=Digest, subject_type=CreateDigest, mock=mock_handle_config),
-        ]
 
-        result = run_rule(create_coverage_config, rule_args=[coverage], mock_gets=mock_gets)
-        assert result.digest.fingerprint == "jerry"
-        assert len(resolved_config) == 1
-        return resolved_config[0]
+def test_default_no_config() -> None:
+    resolved_config = run_create_coverage_config_rule(coverage_config=None)
+    assert resolved_config == dedent(
+        """\
+            [run]
+            relative_files = True
+            omit = 
+            \ttest_runner.pex/*
 
-    def test_default_no_config(self) -> None:
-        resolved_config = self.run_create_coverage_config_rule(coverage_config=None)
-        assert resolved_config == dedent(
-            """\
-                [run]
-                relative_files = True
-                omit = 
-                \ttest_runner.pex/*
+        """  # noqa: W291
+    )
+
+
+def test_simple_config() -> None:
+    config = dedent(
+        """
+      [run]
+      branch = False
+      relative_files = True
+      jerry = HELLO
+      """
+    )
+    resolved_config = run_create_coverage_config_rule(coverage_config=config)
+    assert resolved_config == dedent(
+        """\
+            [run]
+            branch = False
+            relative_files = True
+            jerry = HELLO
+            omit = 
+            \ttest_runner.pex/*
 
             """  # noqa: W291
-        )
+    )
 
-    def test_simple_config(self) -> None:
-        config = dedent(
-            """
-          [run]
-          branch = False
-          relative_files = True
-          jerry = HELLO
-          """
-        )
-        resolved_config = self.run_create_coverage_config_rule(coverage_config=config)
-        assert resolved_config == dedent(
-            """\
-                [run]
-                branch = False
-                relative_files = True
-                jerry = HELLO
-                omit = 
-                \ttest_runner.pex/*
 
-                """  # noqa: W291
-        )
+def test_config_no_run_section() -> None:
+    config = dedent(
+        """
+      [report]
+      ignore_errors = True
+      """
+    )
+    resolved_config = run_create_coverage_config_rule(coverage_config=config)
+    assert resolved_config == dedent(
+        """\
+            [report]
+            ignore_errors = True
 
-    def test_config_no_run_section(self) -> None:
-        config = dedent(
-            """
-          [report]
-          ignore_errors = True
-          """
-        )
-        resolved_config = self.run_create_coverage_config_rule(coverage_config=config)
-        assert resolved_config == dedent(
-            """\
-                [report]
-                ignore_errors = True
+            [run]
+            relative_files = True
+            omit = 
+            \ttest_runner.pex/*
 
-                [run]
-                relative_files = True
-                omit = 
-                \ttest_runner.pex/*
+            """  # noqa: W291
+    )
 
-                """  # noqa: W291
-        )
 
-    def test_append_omits(self) -> None:
-        config = dedent(
-            """
-          [run]
-          omit =
-            jerry/seinfeld/*.py
-            # I find tinsel distracting
-            festivus/tinsel/*.py
-          """
-        )
-        resolved_config = self.run_create_coverage_config_rule(coverage_config=config)
-        assert resolved_config == dedent(
-            """\
-                [run]
-                omit = 
-                \tjerry/seinfeld/*.py
-                \tfestivus/tinsel/*.py
-                \ttest_runner.pex/*
-                relative_files = True
+def test_append_omits() -> None:
+    config = dedent(
+        """
+      [run]
+      omit =
+        jerry/seinfeld/*.py
+        # I find tinsel distracting
+        festivus/tinsel/*.py
+      """
+    )
+    resolved_config = run_create_coverage_config_rule(coverage_config=config)
+    assert resolved_config == dedent(
+        """\
+            [run]
+            omit = 
+            \tjerry/seinfeld/*.py
+            \tfestivus/tinsel/*.py
+            \ttest_runner.pex/*
+            relative_files = True
 
-                """  # noqa: W291
-        )
+            """  # noqa: W291
+    )
 
-    def test_invalid_relative_files_setting(self) -> None:
-        config = dedent(
-            """
-          [run]
-          relative_files = False
-          """
-        )
-        with pytest.raises(
-            ValueError, match="relative_files under the 'run' section must be set to True"
-        ):
-            self.run_create_coverage_config_rule(coverage_config=config)
+
+def test_invalid_relative_files_setting() -> None:
+    config = dedent(
+        """
+      [run]
+      relative_files = False
+      """
+    )
+    with pytest.raises(
+        ValueError, match="relative_files under the 'run' section must be set to True"
+    ):
+        run_create_coverage_config_rule(coverage_config=config)

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -13,27 +13,21 @@ from pants.backend.python.target_types import (
     PythonTestsTimeout,
 )
 from pants.engine.addresses import Address
-from pants.engine.rules import SubsystemRule
 from pants.engine.target import InvalidFieldException, InvalidFieldTypeException
 from pants.python.python_requirement import PythonRequirement
-from pants.testutil.option_util import create_options_bootstrapper
-from pants.testutil.test_base import TestBase
+from pants.testutil.option_util import create_subsystem
 
 
-class TestTimeout(TestBase):
-    @classmethod
-    def rules(cls):
-        return [*super().rules(), SubsystemRule(PyTest)]
+def test_timeout_validation() -> None:
+    with pytest.raises(InvalidFieldException):
+        PythonTestsTimeout(-100, address=Address.parse(":tests"))
+    with pytest.raises(InvalidFieldException):
+        PythonTestsTimeout(0, address=Address.parse(":tests"))
+    assert PythonTestsTimeout(5, address=Address.parse(":tests")).value == 5
 
-    def test_timeout_validation(self) -> None:
-        with pytest.raises(InvalidFieldException):
-            PythonTestsTimeout(-100, address=Address.parse(":tests"))
-        with pytest.raises(InvalidFieldException):
-            PythonTestsTimeout(0, address=Address.parse(":tests"))
-        assert PythonTestsTimeout(5, address=Address.parse(":tests")).value == 5
 
+def test_timeout_calculation() -> None:
     def assert_timeout_calculated(
-        self,
         *,
         field_value: Optional[int],
         expected: Optional[int],
@@ -41,34 +35,21 @@ class TestTimeout(TestBase):
         global_max: Optional[int] = None,
         timeouts_enabled: bool = True,
     ) -> None:
-        args = ["--backend-packages=pants.backend.python", f"--pytest-timeouts={timeouts_enabled}"]
-        if global_default is not None:
-            args.append(f"--pytest-timeout-default={global_default}")
-        if global_max is not None:
-            args.append(f"--pytest-timeout-maximum={global_max}")
-        pytest = self.request_product(PyTest, create_options_bootstrapper(args=args))
         field = PythonTestsTimeout(field_value, address=Address.parse(":tests"))
+        pytest = create_subsystem(
+            PyTest,
+            timeouts=timeouts_enabled,
+            timeout_default=global_default,
+            timeout_maximum=global_max,
+        )
         assert field.calculate_from_global_options(pytest) == expected
 
-    def test_valid_field_timeout(self) -> None:
-        self.assert_timeout_calculated(field_value=10, expected=10)
-
-    def test_field_timeout_greater_than_max(self) -> None:
-        self.assert_timeout_calculated(field_value=20, global_max=10, expected=10)
-
-    def test_no_field_timeout_uses_default(self) -> None:
-        self.assert_timeout_calculated(field_value=None, global_default=20, expected=20)
-
-    def test_no_field_timeout_and_no_default(self) -> None:
-        self.assert_timeout_calculated(field_value=None, expected=None)
-
-    def test_no_field_timeout_and_default_greater_than_max(self) -> None:
-        self.assert_timeout_calculated(
-            field_value=None, global_default=20, global_max=10, expected=10
-        )
-
-    def test_timeouts_disabled(self) -> None:
-        self.assert_timeout_calculated(field_value=10, timeouts_enabled=False, expected=None)
+    assert_timeout_calculated(field_value=10, expected=10)
+    assert_timeout_calculated(field_value=20, global_max=10, expected=10)
+    assert_timeout_calculated(field_value=None, global_default=20, expected=20)
+    assert_timeout_calculated(field_value=None, expected=None)
+    assert_timeout_calculated(field_value=None, global_default=20, global_max=10, expected=10)
+    assert_timeout_calculated(field_value=10, timeouts_enabled=False, expected=None)
 
 
 def test_translate_source_file_to_entry_point() -> None:

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -24,267 +24,275 @@ from pants.base.deprecated import (
 )
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.ranked_value import Rank, RankedValue
-from pants.testutil.test_base import TestBase
 from pants.util.collections import assert_single_element
 
 _FAKE_CUR_VERSION = "2.0.0.dev0"
+FUTURE_VERSION = "9999.9.9.dev0"
 
 
-class DeprecatedTest(TestBase):
-    FUTURE_VERSION = "9999.9.9.dev0"
+@contextmanager
+def assert_deprecation(deprecation_expected=True):
+    with warnings.catch_warnings(record=True) as seen_warnings:
 
-    @contextmanager
-    def _test_deprecation(self, deprecation_expected=True):
-        with warnings.catch_warnings(record=True) as seen_warnings:
+        def assert_deprecation_warning():
+            if deprecation_expected:
+                warning = assert_single_element(seen_warnings)
+                assert warning.category == DeprecationWarning
+                return warning.message
+            else:
+                assert len(seen_warnings) == 0
 
-            def assert_deprecation_warning():
-                if deprecation_expected:
-                    warning = assert_single_element(seen_warnings)
-                    self.assertEqual(warning.category, DeprecationWarning)
-                    return warning.message
-                else:
-                    self.assertEqual(0, len(seen_warnings))
+        warnings.simplefilter("always")
+        assert len(seen_warnings) == 0
+        yield assert_deprecation_warning
+        assert_deprecation_warning()
 
-            warnings.simplefilter("always")
-            self.assertEqual(0, len(seen_warnings))
-            yield assert_deprecation_warning
-            assert_deprecation_warning()
 
-    def test_deprecated_function(self):
-        expected_return = "deprecated_function"
+def test_deprecated_function():
+    expected_return = "deprecated_function"
 
-        @deprecated(self.FUTURE_VERSION)
-        def deprecated_function():
+    @deprecated(FUTURE_VERSION)
+    def deprecated_function():
+        return expected_return
+
+    with assert_deprecation():
+        assert deprecated_function() == expected_return
+
+
+def test_deprecated_method():
+    expected_return = "deprecated_method"
+
+    class Test:
+        @deprecated(FUTURE_VERSION)
+        def deprecated_method(self):
             return expected_return
 
-        with self._test_deprecation():
-            self.assertEqual(expected_return, deprecated_function())
+    with assert_deprecation():
+        assert Test().deprecated_method() == expected_return
 
-    def test_deprecated_method(self):
-        expected_return = "deprecated_method"
+
+def test_deprecated_conditional_true():
+    predicate = lambda: True
+    with assert_deprecation():
+        deprecated_conditional(predicate, FUTURE_VERSION, "test hint message", stacklevel=0)
+
+
+def test_deprecated_conditional_false():
+    predicate = lambda: False
+    with assert_deprecation(deprecation_expected=False):
+        deprecated_conditional(predicate, FUTURE_VERSION, "test hint message", stacklevel=0)
+
+
+def test_deprecated_property():
+    expected_return = "deprecated_property"
+
+    class Test:
+        @property
+        @deprecated(FUTURE_VERSION)
+        def deprecated_property(self):
+            return expected_return
+
+    with assert_deprecation():
+        assert Test().deprecated_property == expected_return
+
+
+def test_deprecated_module():
+    with assert_deprecation() as extract_deprecation_warning:
+        # Note: Attempting to import here a dummy module that just calls deprecated_module() does not
+        # properly trigger the deprecation, due to a bad interaction with pytest that I've not fully
+        # understood.  But we trust python to correctly execute modules on import, so just testing a
+        # direct call of deprecated_module() here is fine.
+        deprecated_module(FUTURE_VERSION, hint_message="Do not use me.")
+        warning_message = str(extract_deprecation_warning())
+        assert "module will be removed" in warning_message
+        assert "Do not use me" in warning_message
+
+
+def test_deprecation_hint():
+    hint_message = "Find the foos, fast!"
+    expected_return = "deprecated_function"
+
+    @deprecated(FUTURE_VERSION, hint_message=hint_message)
+    def deprecated_function():
+        return expected_return
+
+    with assert_deprecation() as extract_deprecation_warning:
+        assert deprecated_function() == expected_return
+        assert hint_message in str(extract_deprecation_warning())
+
+
+def test_deprecation_subject():
+    subject = "`./pants blah`"
+    expected_return = "deprecated_function"
+
+    @deprecated(FUTURE_VERSION, subject=subject)
+    def deprecated_function():
+        return expected_return
+
+    with assert_deprecation() as extract_deprecation_warning:
+        assert deprecated_function() == expected_return
+        assert subject in str(extract_deprecation_warning())
+
+
+def test_removal_version_required():
+    with pytest.raises(MissingSemanticVersionError):
+
+        @deprecated(None)
+        def test_func():
+            pass
+
+
+def test_removal_version_bad():
+    with pytest.raises(BadSemanticVersionError):
+        warn_or_error("a.a.a", "dummy description")
+
+    with pytest.raises(BadSemanticVersionError):
+
+        @deprecated("a.a.a")
+        def test_func0():
+            pass
+
+    with pytest.raises(BadSemanticVersionError):
+        warn_or_error(1.0, "dummy description")
+
+    with pytest.raises(BadSemanticVersionError):
+
+        @deprecated(1.0)
+        def test_func1():
+            pass
+
+    with pytest.raises(BadSemanticVersionError):
+        warn_or_error("1.a.0", "dummy description")
+
+    with pytest.raises(BadSemanticVersionError):
+
+        @deprecated("1.a.0")
+        def test_func1a():
+            pass
+
+
+def test_removal_version_non_dev():
+    with pytest.raises(NonDevSemanticVersionError):
+
+        @deprecated("1.0.0")
+        def test_func1a():
+            pass
+
+
+@unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
+def test_removal_version_same():
+    with pytest.raises(CodeRemovedError):
+        warn_or_error(_FAKE_CUR_VERSION, "dummy description")
+
+    @deprecated(_FAKE_CUR_VERSION)
+    def test_func():
+        pass
+
+    with pytest.raises(CodeRemovedError):
+        test_func()
+
+
+def test_removal_version_lower():
+    with pytest.raises(CodeRemovedError):
+        warn_or_error("0.0.27.dev0", "dummy description")
+
+    @deprecated("0.0.27.dev0")
+    def test_func():
+        pass
+
+    with pytest.raises(CodeRemovedError):
+        test_func()
+
+
+def test_bad_decorator_nesting():
+    with pytest.raises(BadDecoratorNestingError):
 
         class Test:
-            @deprecated(self.FUTURE_VERSION)
-            def deprecated_method(self):
-                return expected_return
-
-        with self._test_deprecation():
-            self.assertEqual(expected_return, Test().deprecated_method())
-
-    def test_deprecated_conditional_true(self):
-        predicate = lambda: True
-        with self._test_deprecation():
-            deprecated_conditional(
-                predicate, self.FUTURE_VERSION, "test hint message", stacklevel=0
-            )
-
-    def test_deprecated_conditional_false(self):
-        predicate = lambda: False
-        with self._test_deprecation(deprecation_expected=False):
-            deprecated_conditional(
-                predicate, self.FUTURE_VERSION, "test hint message", stacklevel=0
-            )
-
-    def test_deprecated_property(self):
-        expected_return = "deprecated_property"
-
-        class Test:
+            @deprecated(FUTURE_VERSION)
             @property
-            @deprecated(self.FUTURE_VERSION)
-            def deprecated_property(self):
-                return expected_return
-
-        with self._test_deprecation():
-            self.assertEqual(expected_return, Test().deprecated_property)
-
-    def test_deprecated_module(self):
-        with self._test_deprecation() as extract_deprecation_warning:
-            # Note: Attempting to import here a dummy module that just calls deprecated_module() does not
-            # properly trigger the deprecation, due to a bad interaction with pytest that I've not fully
-            # understood.  But we trust python to correctly execute modules on import, so just testing a
-            # direct call of deprecated_module() here is fine.
-            deprecated_module(self.FUTURE_VERSION, hint_message="Do not use me.")
-            warning_message = str(extract_deprecation_warning())
-            self.assertIn("module will be removed", warning_message)
-            self.assertIn("Do not use me", warning_message)
-
-    def test_deprecation_hint(self):
-        hint_message = "Find the foos, fast!"
-        expected_return = "deprecated_function"
-
-        @deprecated(self.FUTURE_VERSION, hint_message=hint_message)
-        def deprecated_function():
-            return expected_return
-
-        with self._test_deprecation() as extract_deprecation_warning:
-            self.assertEqual(expected_return, deprecated_function())
-            self.assertIn(hint_message, str(extract_deprecation_warning()))
-
-    def test_deprecation_subject(self):
-        subject = "`./pants blah`"
-        expected_return = "deprecated_function"
-
-        @deprecated(self.FUTURE_VERSION, subject=subject)
-        def deprecated_function():
-            return expected_return
-
-        with self._test_deprecation() as extract_deprecation_warning:
-            self.assertEqual(expected_return, deprecated_function())
-            self.assertIn(subject, str(extract_deprecation_warning()))
-
-    def test_removal_version_required(self):
-        with self.assertRaises(MissingSemanticVersionError):
-
-            @deprecated(None)
-            def test_func():
+            def test_prop(this):
                 pass
 
-    def test_removal_version_bad(self):
-        with self.assertRaises(BadSemanticVersionError):
-            warn_or_error("a.a.a", "dummy description")
 
-        with self.assertRaises(BadSemanticVersionError):
-
-            @deprecated("a.a.a")
-            def test_func0():
-                pass
-
-        with self.assertRaises(BadSemanticVersionError):
-            warn_or_error(1.0, "dummy description")
-
-        with self.assertRaises(BadSemanticVersionError):
-
-            @deprecated(1.0)
-            def test_func1():
-                pass
-
-        with self.assertRaises(BadSemanticVersionError):
-            warn_or_error("1.a.0", "dummy description")
-
-        with self.assertRaises(BadSemanticVersionError):
-
-            @deprecated("1.a.0")
-            def test_func1a():
-                pass
-
-    def test_removal_version_non_dev(self):
-        with self.assertRaises(NonDevSemanticVersionError):
-
-            @deprecated("1.0.0")
-            def test_func1a():
-                pass
-
-    @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
-    def test_removal_version_same(self):
-        with self.assertRaises(CodeRemovedError):
-            warn_or_error(_FAKE_CUR_VERSION, "dummy description")
-
-        @deprecated(_FAKE_CUR_VERSION)
-        def test_func():
-            pass
-
-        with self.assertRaises(CodeRemovedError):
-            test_func()
-
-    def test_removal_version_lower(self):
-        with self.assertRaises(CodeRemovedError):
-            warn_or_error("0.0.27.dev0", "dummy description")
-
-        @deprecated("0.0.27.dev0")
-        def test_func():
-            pass
-
-        with self.assertRaises(CodeRemovedError):
-            test_func()
-
-    def test_bad_decorator_nesting(self):
-        with self.assertRaises(BadDecoratorNestingError):
-
-            class Test:
-                @deprecated(self.FUTURE_VERSION)
-                @property
-                def test_prop(this):
-                    pass
-
-    def test_deprecation_start_version_validation(self):
-        with self.assertRaises(BadSemanticVersionError):
-            warn_or_error(
-                removal_version="1.0.0.dev0",
-                deprecated_entity_description="dummy",
-                deprecation_start_version="1.a.0",
-            )
-
-        with self.assertRaises(InvalidSemanticVersionOrderingError):
-            warn_or_error(
-                removal_version="0.0.0.dev0",
-                deprecated_entity_description="dummy",
-                deprecation_start_version="1.0.0.dev0",
-            )
-
-    @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
-    def test_deprecation_start_period(self):
-        with self.assertRaises(CodeRemovedError):
-            warn_or_error(
-                removal_version=_FAKE_CUR_VERSION,
-                deprecated_entity_description="dummy",
-                deprecation_start_version="1.0.0.dev0",
-            )
-
-        with self.warnings_catcher() as w:
-            warn_or_error(
-                removal_version="999.999.999.dev999",
-                deprecated_entity_description="dummy",
-                deprecation_start_version=_FAKE_CUR_VERSION,
-            )
-            self.assertWarning(
-                w,
-                DeprecationWarning,
-                "DEPRECATED: dummy will be removed in version 999.999.999.dev999.",
-            )
-
-        self.assertIsNone(
-            warn_or_error(
-                removal_version="999.999.999.dev999",
-                deprecated_entity_description="dummy",
-                deprecation_start_version="500.0.0.dev0",
-            )
+def test_deprecation_start_version_validation():
+    with pytest.raises(BadSemanticVersionError):
+        warn_or_error(
+            removal_version="1.0.0.dev0",
+            deprecated_entity_description="dummy",
+            deprecation_start_version="1.a.0",
         )
 
-    def test_resolve_conflicting_options(self) -> None:
-        resolve_options = partial(
-            resolve_conflicting_options,
-            old_option="my_opt",
-            new_option="my_opt",
-            old_scope="old-scope",
-            new_scope="new-scope",
+    with pytest.raises(InvalidSemanticVersionOrderingError):
+        warn_or_error(
+            removal_version="0.0.0.dev0",
+            deprecated_entity_description="dummy",
+            deprecation_start_version="1.0.0.dev0",
         )
-        old_val = "ancient"
-        new_val = "modern"
-        old_default_rv = RankedValue(Rank.HARDCODED, old_val)
-        new_default_rv = RankedValue(Rank.HARDCODED, new_val)
-        old_configured_rv = RankedValue(Rank.FLAG, old_val)
-        new_configured_rv = RankedValue(Rank.FLAG, new_val)
 
-        def assert_option_resolved(
-            *, old_configured: bool = False, new_configured: bool = False, expected: str,
-        ) -> None:
-            old_container, new_container = OptionValueContainer(), OptionValueContainer()
-            old_container.my_opt = old_configured_rv if old_configured else old_default_rv
-            new_container.my_opt = new_configured_rv if new_configured else new_default_rv
-            assert (
-                resolve_options(old_container=old_container, new_container=new_container)
-                == expected
-            )
 
-        assert_option_resolved(expected=new_val)
-        assert_option_resolved(old_configured=True, expected=old_val)
-        assert_option_resolved(new_configured=True, expected=new_val)
+@unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
+def test_deprecation_start_period():
+    with pytest.raises(CodeRemovedError):
+        warn_or_error(
+            removal_version=_FAKE_CUR_VERSION,
+            deprecated_entity_description="demo",
+            deprecation_start_version="1.0.0.dev0",
+        )
 
-        # both configured -> raise an error
+    warnings.simplefilter("always")
+    with pytest.warns(None) as record:
+        warn_or_error(
+            removal_version="999.999.999.dev999",
+            deprecated_entity_description="demo",
+            deprecation_start_version=_FAKE_CUR_VERSION,
+        )
+    assert len(record) == 1
+    assert (
+        str(record[0].message) == "DEPRECATED: demo will be removed in version 999.999.999.dev999."
+    )
+
+    assert (
+        warn_or_error(
+            removal_version="999.999.999.dev999",
+            deprecated_entity_description="demo",
+            deprecation_start_version="500.0.0.dev0",
+        )
+        is None
+    )
+
+
+def test_resolve_conflicting_options() -> None:
+    resolve_options = partial(
+        resolve_conflicting_options,
+        old_option="my_opt",
+        new_option="my_opt",
+        old_scope="old-scope",
+        new_scope="new-scope",
+    )
+    old_val = "ancient"
+    new_val = "modern"
+    old_default_rv = RankedValue(Rank.HARDCODED, old_val)
+    new_default_rv = RankedValue(Rank.HARDCODED, new_val)
+    old_configured_rv = RankedValue(Rank.FLAG, old_val)
+    new_configured_rv = RankedValue(Rank.FLAG, new_val)
+
+    def assert_option_resolved(
+        *, old_configured: bool = False, new_configured: bool = False, expected: str,
+    ) -> None:
         old_container, new_container = OptionValueContainer(), OptionValueContainer()
-        old_container.my_opt = old_configured_rv
-        new_container.my_opt = new_configured_rv
-        with pytest.raises(ValueError) as e:
-            resolve_options(old_container=old_container, new_container=new_container)
-        assert "--old-scope-my-opt" in str(e.value)
-        assert "--new-scope-my-opt" in str(e.value)
+        old_container.my_opt = old_configured_rv if old_configured else old_default_rv
+        new_container.my_opt = new_configured_rv if new_configured else new_default_rv
+        assert resolve_options(old_container=old_container, new_container=new_container) == expected
+
+    assert_option_resolved(expected=new_val)
+    assert_option_resolved(old_configured=True, expected=old_val)
+    assert_option_resolved(new_configured=True, expected=new_val)
+
+    # both configured -> raise an error
+    old_container, new_container = OptionValueContainer(), OptionValueContainer()
+    old_container.my_opt = old_configured_rv
+    new_container.my_opt = new_configured_rv
+    with pytest.raises(ValueError) as e:
+        resolve_options(old_container=old_container, new_container=new_container)
+    assert "--old-scope-my-opt" in str(e.value)
+    assert "--new-scope-my-opt" in str(e.value)

--- a/src/python/pants/base/exception_sink_test.py
+++ b/src/python/pants/base/exception_sink_test.py
@@ -1,128 +1,127 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
 import os
 import re
 import unittest.mock
 
+import pytest
+
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.platform import Platform
-from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
 from pants.util.enums import match
 
 
-class TestExceptionSink(TestBase):
-    def _gen_sink_subclass(self):
-        # Avoid modifying global state by generating a subclass.
-        class AnonymousSink(ExceptionSink):
-            pass
+def _gen_sink_subclass():
+    # Avoid modifying global state by generating a subclass.
+    class AnonymousSink(ExceptionSink):
+        pass
 
-        return AnonymousSink
+    return AnonymousSink
 
-    def test_default_log_location(self):
-        sink = self._gen_sink_subclass()
-        self.assertEqual(os.getcwd(), sink._log_dir)
 
-    def test_reset_log_location(self):
-        sink = self._gen_sink_subclass()
+def test_default_log_location():
+    sink = _gen_sink_subclass()
+    assert os.getcwd() == sink._log_dir
 
-        with temporary_dir() as tmpdir:
-            sink.reset_log_location(tmpdir)
-            self.assertEqual(tmpdir, sink._log_dir)
 
-    def test_set_invalid_log_location(self):
-        self.assertFalse(os.path.isdir("/does/not/exist"))
-        sink = self._gen_sink_subclass()
-        with self.assertRaisesWithMessageContaining(
-            ExceptionSink.ExceptionSinkError,
-            "The provided log location path at '/does/not/exist' is not writable or could not be created",
-        ):
-            sink.reset_log_location("/does/not/exist")
+def test_reset_log_location():
+    sink = _gen_sink_subclass()
+    with temporary_dir() as tmpdir:
+        sink.reset_log_location(tmpdir)
+        assert tmpdir == sink._log_dir
 
-        # NB: This target is marked with 'platform_specific_behavior' because OSX errors out here at
-        # creating a new directory with safe_mkdir(), Linux errors out trying to create the directory
-        # for its log files with safe_open(). This may be due to differences in the filesystems.
-        # TODO: figure out why we error out at different points here!
-        err_str = match(
-            Platform.current,
-            {
-                Platform.darwin: "The provided log location path at '/' is not writable or could not be created: [Errno 21] Is a directory: '/'.",
-                Platform.linux: "Error opening fatal error log streams for log location '/': [Errno 13] Permission denied: '/.pids'",
-            },
-        )
-        with self.assertRaisesWithMessageContaining(ExceptionSink.ExceptionSinkError, err_str):
-            sink.reset_log_location("/")
 
-    def test_log_exception(self):
-        fake_process_title = "fake_title"
-        msg = "XXX"
-        sink = self._gen_sink_subclass()
+def test_set_invalid_log_location():
+    assert os.path.isdir("/does/not/exist") is False
+    sink = _gen_sink_subclass()
+    with pytest.raises(ExceptionSink.ExceptionSinkError) as exc:
+        sink.reset_log_location("/does/not/exist")
+    assert (
+        "The provided log location path at '/does/not/exist' is not writable or could not be "
+        "created"
+    ) in str(exc.value)
+
+    # NB: This target is marked with 'platform_specific_behavior' because OSX errors out here at
+    # creating a new directory with safe_mkdir(), Linux errors out trying to create the directory
+    # for its log files with safe_open(). This may be due to differences in the filesystems.
+    # TODO: figure out why we error out at different points here!
+    with pytest.raises(ExceptionSink.ExceptionSinkError) as exc:
+        sink.reset_log_location("/")
+    err_str = {
+        Platform.darwin: (
+            "The provided log location path at '/' is not writable or could not be created: "
+            "[Errno 21] Is a directory: '/'."
+        ),
+        Platform.linux: (
+            "Error opening fatal error log streams for log location '/': [Errno 13] Permission "
+            "denied: '/.pids'"
+        ),
+    }
+    assert match(Platform.current, err_str) in str(exc.value)
+
+
+def test_log_exception():
+    sink = _gen_sink_subclass()
+
+    with temporary_dir() as tmpdir:
+        # Check that tmpdir exists, and log an exception into that directory.
+        sink.reset_log_location(tmpdir)
         pid = os.getpid()
 
-        with temporary_dir() as tmpdir:
-            # Check that tmpdir exists, and log an exception into that directory.
-            sink.reset_log_location(tmpdir)
+        with unittest.mock.patch(
+            "setproctitle.getproctitle", autospec=True, spec_set=True
+        ) as getproctitle_mock:
+            getproctitle_mock.return_value = "fake_title"
+            sink._log_exception("XXX")
+            getproctitle_mock.assert_called_once()
 
-            with unittest.mock.patch(
-                "setproctitle.getproctitle", autospec=True, spec_set=True
-            ) as getproctitle_mock:
-                getproctitle_mock.return_value = fake_process_title
-                sink._log_exception(msg)
-                getproctitle_mock.assert_called_once()
+        # This should have created two log files, one specific to the current pid.
+        assert os.listdir(tmpdir) == [".pids"]
 
-            # This should have created two log files, one specific to the current pid.
-            self.assertEqual(os.listdir(tmpdir), [".pids"])
+        cur_process_error_log_path = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=tmpdir)
+        assert os.path.isfile(cur_process_error_log_path) is True
 
-            cur_process_error_log_path = ExceptionSink.exceptions_log_path(
-                for_pid=pid, in_dir=tmpdir
-            )
-            self.assertTrue(os.path.isfile(cur_process_error_log_path))
+        shared_error_log_path = ExceptionSink.exceptions_log_path(in_dir=tmpdir)
+        assert os.path.isfile(shared_error_log_path) is True
+        # Ensure we're creating two separate files.
+        assert cur_process_error_log_path != shared_error_log_path
 
-            shared_error_log_path = ExceptionSink.exceptions_log_path(in_dir=tmpdir)
-            self.assertTrue(os.path.isfile(shared_error_log_path))
-            # Ensure we're creating two separate files.
-            self.assertNotEqual(cur_process_error_log_path, shared_error_log_path)
-
-            # We only logged a single error, so the files should both contain only that single log entry.
-            err_rx = """\
+        # We only logged a single error, so the files should both contain only that single log entry.
+        err_rx = f"""\
 timestamp: ([^\n]+)
-process title: {fake_process_title}
+process title: fake_title
 sys.argv: ([^\n]+)
 pid: {pid}
-{msg}
-""".format(
-                fake_process_title=re.escape(fake_process_title), pid=pid, msg=msg
+XXX
+"""
+        with open(cur_process_error_log_path, "r") as cur_pid_file:
+            assert bool(re.search(err_rx, cur_pid_file.read()))
+        with open(shared_error_log_path, "r") as shared_log_file:
+            assert bool(re.search(err_rx, shared_log_file.read()))
+
+
+def test_backup_logging_on_fatal_error(caplog):
+    sink = _gen_sink_subclass()
+    with temporary_dir() as tmpdir:
+        sink.reset_log_location(tmpdir)
+        with unittest.mock.patch.object(sink, "_try_write_with_flush", autospec=sink) as mock_write:
+            mock_write.side_effect = ExceptionSink.ExceptionSinkError("fake write failure")
+            sink._log_exception("XXX")
+
+    errors = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert len(errors) == 2
+
+    def assert_log(log_file_type: str, log):
+        assert bool(
+            re.search(
+                fr"Error logging the message 'XXX' to the {log_file_type} file handle for .* at "
+                fr"pid {os.getpid()}",
+                log.msg,
             )
-            with open(cur_process_error_log_path, "r") as cur_pid_file:
-                self.assertRegex(cur_pid_file.read(), err_rx)
-            with open(shared_error_log_path, "r") as shared_log_file:
-                self.assertRegex(shared_log_file.read(), err_rx)
+        )
+        assert log.filename == "exception_sink.py"
 
-    def test_backup_logging_on_fatal_error(self):
-        sink = self._gen_sink_subclass()
-        with self.captured_logging(level=logging.ERROR) as captured:
-            with temporary_dir() as tmpdir:
-                sink.reset_log_location(tmpdir)
-                with unittest.mock.patch.object(
-                    sink, "_try_write_with_flush", autospec=sink
-                ) as mock_write:
-                    mock_write.side_effect = ExceptionSink.ExceptionSinkError("fake write failure")
-                    sink._log_exception("XXX")
-        errors = list(captured.errors())
-        self.assertEqual(2, len(errors))
-
-        def format_log_rx(log_file_type):
-            return ".*".join(
-                re.escape(s)
-                for s in [
-                    "pants.base.exception_sink: Error logging the message 'XXX' to the {log_file_type} file "
-                    "handle for".format(log_file_type=log_file_type),
-                    "at pid {pid}".format(pid=os.getpid()),
-                    "\nfake write failure",
-                ]
-            )
-
-        self.assertRegex(str(errors[0]), format_log_rx("pid-specific"))
-        self.assertRegex(str(errors[1]), format_log_rx("shared"))
+    assert_log("pid-specific", errors[0])
+    assert_log("shared", errors[1])

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -231,10 +231,9 @@ class SchedulerTest(TestBase):
             remove_locations_from_traceback(consumes_a_and_b(a, transitive_b_c(c))),
         )
 
-        # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to the
-        # existence of transitive_b_c().
-        with self.assertDoesNotRaise():
-            _ = self.request_product(D, Params(c))
+        # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to
+        # the existence of transitive_b_c().
+        self.request_product(D, Params(c))
 
     def test_consumed_types(self):
         assert {A, B, C, str} == set(
@@ -258,10 +257,8 @@ class SchedulerTest(TestBase):
             yield
 
     def test_union_rules(self):
-        with self.assertDoesNotRaise():
-            _ = self.request_product(A, Params(UnionWrapper(UnionA())))
-        with self.assertDoesNotRaise():
-            _ = self.request_product(A, Params(UnionWrapper(UnionB())))
+        self.request_product(A, Params(UnionWrapper(UnionA())))
+        self.request_product(A, Params(UnionWrapper(UnionB())))
         # Fails due to no union relationship from A -> UnionBase.
         with self._assert_execution_error("Type A is not a member of the UnionBase @union"):
             self.request_product(A, Params(UnionWrapper(A())))

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -258,8 +258,9 @@ class TestInputFileCreation(TestBase):
             argv=("./echo.sh",), input_digest=digest, description="cat the contents of this file",
         )
 
-        with self.assertRaisesWithMessageContaining(ExecutionError, "Permission"):
+        with pytest.raises(ExecutionError) as exc:
             self.request_product(ProcessResult, req)
+        assert "Permission" in str(exc.value)
 
     def test_executable(self):
         file_name = "echo.sh"

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -421,15 +421,13 @@ class RuleTest(TestBase):
         assert "pants.util.meta.Console" in error_str
 
 
-class RuleIndexTest(TestBase):
-    def test_creation_fails_with_bad_declaration_type(self):
-        with self.assertRaisesWithMessage(
-            TypeError,
-            "Rule entry A() had an unexpected type: <class "
-            "'pants.engine.rules_test.A'>. Rules either extend Rule or UnionRule, or "
-            "are static functions decorated with @rule.",
-        ):
-            RuleIndex.create([A()])
+def test_rule_index_creation_fails_with_bad_declaration_type():
+    with pytest.raises(TypeError) as exc:
+        RuleIndex.create([A()])
+    assert str(exc.value) == (
+        "Rule entry A() had an unexpected type: <class 'pants.engine.rules_test.A'>. Rules "
+        "either extend Rule or UnionRule, or are static functions decorated with @rule."
+    )
 
 
 class RuleArgumentAnnotationTest(unittest.TestCase):
@@ -513,25 +511,27 @@ class GraphVertexTypeAnnotationTest(unittest.TestCase):
                 return False
 
 
-class GoalRuleValidation(TestBase):
-    def test_not_properly_marked_goal_rule(self) -> None:
-        with self.assertRaisesWithMessage(
-            TypeError,
-            "An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`.",
-        ):
+def test_goal_rule_not_properly_marked_goal_rule() -> None:
+    with pytest.raises(TypeError) as exc:
 
-            @rule
-            def normal_rule_trying_to_return_a_goal() -> Example:
-                return Example(0)
+        @rule
+        def normal_rule_trying_to_return_a_goal() -> Example:
+            return Example(0)
 
-    def test_goal_rule_not_returning_a_goal(self) -> None:
-        with self.assertRaisesWithMessage(
-            TypeError, "An `@goal_rule` must return a subclass of `engine.goal.Goal`."
-        ):
+    assert (
+        str(exc.value)
+        == "An `@rule` that returns a `Goal` must instead be declared with `@goal_rule`."
+    )
 
-            @goal_rule
-            def goal_rule_returning_a_non_goal() -> int:
-                return 0
+
+def test_goal_rule_not_returning_a_goal() -> None:
+    with pytest.raises(TypeError) as exc:
+
+        @goal_rule
+        def goal_rule_returning_a_non_goal() -> int:
+            return 0
+
+    assert str(exc.value) == "An `@goal_rule` must return a subclass of `engine.goal.Goal`."
 
 
 class RuleGraphTest(TestBase):

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -81,16 +81,15 @@ class WorkspaceTest(TestBase):
         assert Path(self.build_root, "prefix", path2).is_file()
 
 
-class IsChildOfTest(TestBase):
-    def test_is_child_of(self):
-        mock_build_root = Path("/mock/build/root")
+def test_is_child_of() -> None:
+    mock_build_root = Path("/mock/build/root")
 
-        assert is_child_of(Path("/mock/build/root/dist/dir"), mock_build_root)
-        assert is_child_of(Path("dist/dir"), mock_build_root)
-        assert is_child_of(Path("./dist/dir"), mock_build_root)
-        assert is_child_of(Path("../root/dist/dir"), mock_build_root)
-        assert is_child_of(Path(""), mock_build_root)
-        assert is_child_of(Path("./"), mock_build_root)
+    assert is_child_of(Path("/mock/build/root/dist/dir"), mock_build_root)
+    assert is_child_of(Path("dist/dir"), mock_build_root)
+    assert is_child_of(Path("./dist/dir"), mock_build_root)
+    assert is_child_of(Path("../root/dist/dir"), mock_build_root)
+    assert is_child_of(Path(""), mock_build_root)
+    assert is_child_of(Path("./"), mock_build_root)
 
-        assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
-        assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)
+    assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
+    assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import configparser
+import unittest
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Dict
@@ -9,7 +10,6 @@ from typing import Dict
 import pytest
 
 from pants.option.config import Config, TomlSerializer
-from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_file
 from pants.util.ordered_set import OrderedSet
 
@@ -114,26 +114,26 @@ FILE_2 = ConfigFile(
 )
 
 
-class ConfigeTest(TestBase):
-    def _setup_config(self) -> Config:
-        with temporary_file(binary_mode=False, suffix=".toml") as config1, temporary_file(
-            binary_mode=False, suffix=".toml"
-        ) as config2:
-            config1.write(FILE_1.content)
-            config1.close()
-            config2.write(FILE_2.content)
-            config2.close()
-            parsed_config = Config.load(
-                config_paths=[config1.name, config2.name],
-                seed_values={"buildroot": self.build_root},
-            )
-            assert [config1.name, config2.name] == parsed_config.sources()
-        return parsed_config
+def _setup_config() -> Config:
+    with temporary_file(binary_mode=False, suffix=".toml") as config1, temporary_file(
+        binary_mode=False, suffix=".toml"
+    ) as config2:
+        config1.write(FILE_1.content)
+        config1.close()
+        config2.write(FILE_2.content)
+        config2.close()
+        parsed_config = Config.load(
+            config_paths=[config1.name, config2.name], seed_values={"buildroot": "fake_buildroot"},
+        )
+        assert [config1.name, config2.name] == parsed_config.sources()
+    return parsed_config
 
+
+class ConfigTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.config = self._setup_config()
+        self.config = _setup_config()
         self.default_seed_values = Config._determine_seed_values(
-            seed_values={"buildroot": self.build_root},
+            seed_values={"buildroot": "fake_buildroot"},
         )
         self.expected_combined_values = {
             **FILE_1.expected_options,

--- a/src/python/pants/util/osutil_test.py
+++ b/src/python/pants/util/osutil_test.py
@@ -1,10 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
 from typing import Optional
 
-from pants.testutil.test_base import TestBase
 from pants.util.osutil import (
     OS_ALIASES,
     get_closest_mac_host_platform_pair,
@@ -13,68 +11,62 @@ from pants.util.osutil import (
 )
 
 
-class OsutilTest(TestBase):
-    def test_alias_normalization(self) -> None:
-        for normal_os, aliases in OS_ALIASES.items():
-            for alias in aliases:
-                self.assertEqual(normal_os, normalize_os_name(alias))
+def test_alias_normalization() -> None:
+    for normal_os, aliases in OS_ALIASES.items():
+        for alias in aliases:
+            assert normal_os == normalize_os_name(alias)
 
-    def test_keys_in_aliases(self) -> None:
-        for key in OS_ALIASES.keys():
-            self.assertIn(key, known_os_names())
 
-    def test_no_warnings_on_known_names(self) -> None:
-        for name in known_os_names():
-            with self.captured_logging(logging.WARNING) as captured:
-                normalize_os_name(name)
-                self.assertEqual(
-                    0,
-                    len(captured.warnings()),
-                    f"Received unexpected warnings: {captured.warnings()}",
-                )
+def test_keys_in_aliases() -> None:
+    for key in OS_ALIASES.keys():
+        assert key in known_os_names()
 
-    def test_warnings_on_unknown_names(self) -> None:
-        name = "I really hope no one ever names an operating system with this string."
-        with self.captured_logging(logging.WARNING) as captured:
-            normalize_os_name(name)
-            self.assertEqual(
-                1,
-                len(captured.warnings()),
-                f"Expected exactly one warning, but got: {captured.warnings()}",
-            )
 
-    def test_get_closest_mac_host_platform_pair(self) -> None:
-        # Note the gaps in darwin versions.
-        platform_name_map = {
-            ("linux", "x86_64"): ("linux", "x86_64"),
-            ("linux", "amd64"): ("linux", "x86_64"),
-            ("darwin", "10"): ("mac", "10.6"),
-            ("darwin", "13"): ("mac", "10.9"),
-            ("darwin", "14"): ("mac", "10.10"),
-            ("darwin", "16"): ("mac", "10.12"),
-            ("darwin", "17"): ("mac", "10.13"),
-        }
+def test_no_warnings_on_known_names(caplog) -> None:
+    for name in known_os_names():
+        normalize_os_name(name)
+        assert len(caplog.records) == 0
 
-        def get_macos_version(darwin_version: Optional[str]) -> Optional[str]:
-            host, version = get_closest_mac_host_platform_pair(
-                darwin_version, platform_name_map=platform_name_map
-            )
-            if host is not None:
-                self.assertEqual("mac", host)
-            return version
 
-        self.assertEqual("10.13", get_macos_version("19"))
-        self.assertEqual("10.13", get_macos_version("18"))
-        self.assertEqual("10.13", get_macos_version("17"))
-        self.assertEqual("10.12", get_macos_version("16"))
-        self.assertEqual("10.10", get_macos_version("15"))
-        self.assertEqual("10.10", get_macos_version("14"))
-        self.assertEqual("10.9", get_macos_version("13"))
-        self.assertEqual("10.6", get_macos_version("12"))
-        self.assertEqual("10.6", get_macos_version("11"))
-        self.assertEqual("10.6", get_macos_version("10"))
-        self.assertEqual(None, get_macos_version("9"))
+def test_warnings_on_unknown_names(caplog) -> None:
+    name = "I really hope no one ever names an operating system with this string."
+    normalize_os_name(name)
+    assert len(caplog.records) == 1
+    assert "Unknown operating system name" in caplog.text
 
-        # When a version bound of `None` is provided, it should select the most recent OSX platform
-        # available.
-        self.assertEqual("10.13", get_macos_version(None))
+
+def test_get_closest_mac_host_platform_pair() -> None:
+    # Note the gaps in darwin versions.
+    platform_name_map = {
+        ("linux", "x86_64"): ("linux", "x86_64"),
+        ("linux", "amd64"): ("linux", "x86_64"),
+        ("darwin", "10"): ("mac", "10.6"),
+        ("darwin", "13"): ("mac", "10.9"),
+        ("darwin", "14"): ("mac", "10.10"),
+        ("darwin", "16"): ("mac", "10.12"),
+        ("darwin", "17"): ("mac", "10.13"),
+    }
+
+    def get_macos_version(darwin_version: Optional[str]) -> Optional[str]:
+        host, version = get_closest_mac_host_platform_pair(
+            darwin_version, platform_name_map=platform_name_map
+        )
+        if host is not None:
+            assert "mac" == host
+        return version
+
+    assert "10.13" == get_macos_version("19")
+    assert "10.13" == get_macos_version("18")
+    assert "10.13" == get_macos_version("17")
+    assert "10.12" == get_macos_version("16")
+    assert "10.10" == get_macos_version("15")
+    assert "10.10" == get_macos_version("14")
+    assert "10.9" == get_macos_version("13")
+    assert "10.6" == get_macos_version("12")
+    assert "10.6" == get_macos_version("11")
+    assert "10.6" == get_macos_version("10")
+    assert get_macos_version("9") is None
+
+    # When a version bound of `None` is provided, it should select the most recent OSX platform
+    # available.
+    assert "10.13" == get_macos_version(None)

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -3,6 +3,7 @@
 
 python_tests(
   sources=['test_*.py'],
+  dependencies=["//:build_root"],
 )
 
 python_library(

--- a/tests/python/pants_test/pantsd/service/test_pants_service.py
+++ b/tests/python/pants_test/pantsd/service/test_pants_service.py
@@ -3,8 +3,9 @@
 
 import threading
 
+import pytest
+
 from pants.pantsd.service.pants_service import PantsService
-from pants.testutil.test_base import TestBase
 
 
 class RunnableTestService(PantsService):
@@ -12,42 +13,46 @@ class RunnableTestService(PantsService):
         pass
 
 
-class TestPantsService(TestBase):
-    def setUp(self):
-        super().setUp()
-        self.service = RunnableTestService()
+@pytest.fixture
+def service() -> RunnableTestService:
+    return RunnableTestService()
 
-    def test_init(self):
-        self.assertTrue(self.service.name)
 
-    def test_run_abstract(self):
-        with self.assertRaises(TypeError):
-            PantsService()
+def test_init(service: RunnableTestService) -> None:
+    assert bool(service.name) is True
 
-    def test_terminate(self):
-        self.service.terminate()
-        assert self.service._state.is_terminating
 
-    def test_maybe_pause(self):
-        # Confirm that maybe_pause with/without a timeout does not deadlock when we are not
-        # marked Pausing/Paused.
-        self.service._state.maybe_pause(timeout=None)
-        self.service._state.maybe_pause(timeout=0.5)
+def test_run_abstract() -> None:
+    with pytest.raises(TypeError):
+        PantsService()  # type: ignore[abstract]
 
-    def test_pause_and_resume(self):
-        self.service.mark_pausing()
-        # Confirm that we don't transition to Paused without a service thread to maybe_pause.
-        self.assertFalse(self.service._state.await_paused(timeout=0.5))
-        # Spawn a thread to call maybe_pause.
-        t = threading.Thread(target=self.service._state.maybe_pause)
-        t.daemon = True
-        t.start()
-        # Confirm that we observe the pause from the main thread, and that the child thread pauses
-        # there without exiting.
-        self.assertTrue(self.service._state.await_paused(timeout=5))
-        t.join(timeout=0.5)
-        self.assertTrue(t.is_alive())
-        # Resume the service, and confirm that the child thread exits.
-        self.service.resume()
-        t.join(timeout=5)
-        self.assertFalse(t.is_alive())
+
+def test_terminate(service: RunnableTestService) -> None:
+    service.terminate()
+    assert service._state.is_terminating
+
+
+def test_maybe_pause(service: RunnableTestService) -> None:
+    # Confirm that maybe_pause with/without a timeout does not deadlock when we are not
+    # marked Pausing/Paused.
+    service._state.maybe_pause(timeout=None)
+    service._state.maybe_pause(timeout=0.5)
+
+
+def test_pause_and_resume(service: RunnableTestService) -> None:
+    service.mark_pausing()
+    # Confirm that we don't transition to Paused without a service thread to maybe_pause.
+    assert service._state.await_paused(timeout=0.5) is False
+    # Spawn a thread to call maybe_pause.
+    t = threading.Thread(target=service._state.maybe_pause)
+    t.daemon = True
+    t.start()
+    # Confirm that we observe the pause from the main thread, and that the child thread pauses
+    # there without exiting.
+    assert service._state.await_paused(timeout=5) is True
+    t.join(timeout=0.5)
+    assert t.is_alive() is True
+    # Resume the service, and confirm that the child thread exits.
+    service.resume()
+    t.join(timeout=5)
+    assert t.is_alive() is False

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -9,65 +9,62 @@ from pants.engine.internals.native import Native
 from pants.pantsd.pants_daemon import PantsDaemon, _LoggerStream
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices
-from pants.testutil.test_base import TestBase
 from pants.util.contextutil import stdio_as
 
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
-class LoggerStreamTest(TestBase):
-
-    TEST_LOG_LEVEL = logging.INFO
-
-    def test_write(self):
-        mock_logger = unittest.mock.Mock()
-        _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write("testing 1 2 3")
-        mock_logger.log.assert_called_once_with(self.TEST_LOG_LEVEL, "testing 1 2 3")
-
-    def test_write_multiline(self):
-        mock_logger = unittest.mock.Mock()
-        _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write("testing\n1\n2\n3\n\n")
-        mock_logger.log.assert_has_calls(
-            [
-                unittest.mock.call(self.TEST_LOG_LEVEL, "testing"),
-                unittest.mock.call(self.TEST_LOG_LEVEL, "1"),
-                unittest.mock.call(self.TEST_LOG_LEVEL, "2"),
-                unittest.mock.call(self.TEST_LOG_LEVEL, "3"),
-            ]
-        )
-
-    def test_flush(self):
-        _LoggerStream(unittest.mock.Mock(), self.TEST_LOG_LEVEL, None).flush()
+TEST_LOG_LEVEL = logging.INFO
 
 
-class PantsDaemonTest(TestBase):
-    def setUp(self):
-        super().setUp()
-        mock_options = unittest.mock.Mock()
-        mock_options_values = unittest.mock.Mock()
-        mock_options.for_global_scope.return_value = mock_options_values
-        mock_options_values.pants_subprocessdir = "non_existent_dir"
-        mock_server = unittest.mock.Mock()
+def test_logger_stream_write():
+    mock_logger = unittest.mock.Mock()
+    _LoggerStream(mock_logger, TEST_LOG_LEVEL, None).write("testing 1 2 3")
+    mock_logger.log.assert_called_once_with(TEST_LOG_LEVEL, "testing 1 2 3")
 
-        def create_services(bootstrap_options, legacy_graph_scheduler):
-            return PantsServices()
 
-        self.pantsd = PantsDaemon(
-            native=Native(),
-            work_dir="test_work_dir",
-            log_level=logging.INFO,
-            server=mock_server,
-            core=PantsDaemonCore(create_services),
-            metadata_base_dir="/tmp/pants_test_metadata_dir",
-            bootstrap_options=mock_options,
-        )
+def test_logger_stream_write_multiline():
+    mock_logger = unittest.mock.Mock()
+    _LoggerStream(mock_logger, TEST_LOG_LEVEL, None).write("testing\n1\n2\n3\n\n")
+    mock_logger.log.assert_has_calls(
+        [
+            unittest.mock.call(TEST_LOG_LEVEL, "testing"),
+            unittest.mock.call(TEST_LOG_LEVEL, "1"),
+            unittest.mock.call(TEST_LOG_LEVEL, "2"),
+            unittest.mock.call(TEST_LOG_LEVEL, "3"),
+        ]
+    )
 
-    @unittest.mock.patch("os.close", **PATCH_OPTS)
-    def test_close_stdio(self, mock_close):
-        with stdio_as(-1, -1, -1):
-            handles = (sys.stdin, sys.stdout, sys.stderr)
-            fds = [h.fileno() for h in handles]
-            self.pantsd._close_stdio()
-            mock_close.assert_has_calls(unittest.mock.call(x) for x in fds)
-            for handle in handles:
-                self.assertTrue(handle.closed, f"{handle} was not closed")
+
+def test_logger_stream_flush():
+    _LoggerStream(unittest.mock.Mock(), TEST_LOG_LEVEL, None).flush()
+
+
+@unittest.mock.patch("os.close", **PATCH_OPTS)
+def test_close_stdio(mock_close):
+    mock_options = unittest.mock.Mock()
+    mock_options_values = unittest.mock.Mock()
+    mock_options.for_global_scope.return_value = mock_options_values
+    mock_options_values.pants_subprocessdir = "non_existent_dir"
+    mock_server = unittest.mock.Mock()
+
+    def create_services(bootstrap_options, legacy_graph_scheduler):
+        return PantsServices()
+
+    pantsd = PantsDaemon(
+        native=Native(),
+        work_dir="test_work_dir",
+        log_level=logging.INFO,
+        server=mock_server,
+        core=PantsDaemonCore(create_services),
+        metadata_base_dir="/tmp/pants_test_metadata_dir",
+        bootstrap_options=mock_options,
+    )
+
+    with stdio_as(-1, -1, -1):
+        handles = (sys.stdin, sys.stdout, sys.stderr)
+        fds = [h.fileno() for h in handles]
+        pantsd._close_stdio()
+        mock_close.assert_has_calls(unittest.mock.call(x) for x in fds)
+        for handle in handles:
+            assert handle.closed is True

--- a/tests/python/pants_test/pantsd/test_pants_daemon_core.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon_core.py
@@ -4,18 +4,16 @@
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices
 from pants.testutil.option_util import create_options_bootstrapper
-from pants.testutil.test_base import TestBase
 
 
-class PantsDaemonCoreTest(TestBase):
-    def test_prepare_scheduler(self):
-        # A core with no services.
-        def create_services(bootstrap_options, legacy_graph_scheduler):
-            return PantsServices()
+def test_prepare_scheduler():
+    # A core with no services.
+    def create_services(bootstrap_options, legacy_graph_scheduler):
+        return PantsServices()
 
-        core = PantsDaemonCore(create_services)
+    core = PantsDaemonCore(create_services)
 
-        first_scheduler = core.prepare_scheduler(create_options_bootstrapper(args=["-ldebug"]))
-        second_scheduler = core.prepare_scheduler(create_options_bootstrapper(args=["-lwarn"]))
+    first_scheduler = core.prepare_scheduler(create_options_bootstrapper(args=["-ldebug"]))
+    second_scheduler = core.prepare_scheduler(create_options_bootstrapper(args=["-lwarn"]))
 
-        assert first_scheduler is not second_scheduler
+    assert first_scheduler is not second_scheduler

--- a/tests/python/pants_test/reporting/test_json_reporter.py
+++ b/tests/python/pants_test/reporting/test_json_reporter.py
@@ -4,7 +4,6 @@
 from pants.base.workunit import WorkUnit
 from pants.reporting.json_reporter import JsonReporter
 from pants.reporting.report import Report
-from pants.testutil.test_base import TestBase
 
 
 class FakeRunTracker:
@@ -57,159 +56,158 @@ def generate_callbacks(workunit_data, reporter, parent=None):
     reporter.end_workunit(workunit)
 
 
-class JsonReporterTest(TestBase):
-    def _check_callbacks(self, root_workunit_dict, reporter):
-        generate_callbacks(root_workunit_dict, reporter)
-        self.assertDictEqual(root_workunit_dict, reporter.results[root_workunit_dict["id"]])
+def _check_callbacks(root_workunit_dict, reporter):
+    generate_callbacks(root_workunit_dict, reporter)
+    assert root_workunit_dict == reporter.results[root_workunit_dict["id"]]
 
-    def test_nested_grandchild(self):
-        expected = {
-            "name": "root",
-            "id": "root_id",
-            "parent_name": "",
-            "parent_id": "",
-            "labels": ["IAMROOT"],
-            "cmd": "",
-            "start_time": -5419800.0,
-            "outputs": {},
-            "children": [
-                {
-                    "name": "child1",
-                    "id": "child1_id",
-                    "parent_name": "root",
-                    "parent_id": "root_id",
-                    "labels": [],
-                    "cmd": "",
-                    "start_time": 31564800.0,
-                    "outputs": {},
-                    "children": [
-                        {
-                            "name": "grandchild",
-                            "id": "grandchild_id",
-                            "parent_name": "child1",
-                            "parent_id": "child1_id",
-                            "labels": ["LABEL1"],
-                            "cmd": "",
-                            "start_time": 479721600.0,
-                            "outputs": {},
-                            "children": [],
-                            "log_entries": [],
-                            "outcome": "SUCCESS",
-                            "end_time": 479721610.0,
-                            "unaccounted_time": 0,
-                        }
-                    ],
-                    "log_entries": [],
-                    "outcome": "SUCCESS",
-                    "end_time": 31564810.0,
-                    "unaccounted_time": 0,
-                },
-                {
-                    "name": "child2",
-                    "id": "child2_id",
-                    "parent_name": "root",
-                    "parent_id": "root_id",
-                    "labels": [],
-                    "cmd": "",
-                    "start_time": 684140400.0,
-                    "outputs": {},
-                    "children": [],
-                    "log_entries": [],
-                    "outcome": "SUCCESS",
-                    "end_time": 684140410.0,
-                    "unaccounted_time": 0,
-                },
-            ],
-            "log_entries": [],
-            "outcome": "SUCCESS",
-            "end_time": -5419790.0,
-            "unaccounted_time": 0,
-        }
 
-        reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(log_level=Report.INFO))
+def test_nested_grandchild():
+    expected = {
+        "name": "root",
+        "id": "root_id",
+        "parent_name": "",
+        "parent_id": "",
+        "labels": ["IAMROOT"],
+        "cmd": "",
+        "start_time": -5419800.0,
+        "outputs": {},
+        "children": [
+            {
+                "name": "child1",
+                "id": "child1_id",
+                "parent_name": "root",
+                "parent_id": "root_id",
+                "labels": [],
+                "cmd": "",
+                "start_time": 31564800.0,
+                "outputs": {},
+                "children": [
+                    {
+                        "name": "grandchild",
+                        "id": "grandchild_id",
+                        "parent_name": "child1",
+                        "parent_id": "child1_id",
+                        "labels": ["LABEL1"],
+                        "cmd": "",
+                        "start_time": 479721600.0,
+                        "outputs": {},
+                        "children": [],
+                        "log_entries": [],
+                        "outcome": "SUCCESS",
+                        "end_time": 479721610.0,
+                        "unaccounted_time": 0,
+                    }
+                ],
+                "log_entries": [],
+                "outcome": "SUCCESS",
+                "end_time": 31564810.0,
+                "unaccounted_time": 0,
+            },
+            {
+                "name": "child2",
+                "id": "child2_id",
+                "parent_name": "root",
+                "parent_id": "root_id",
+                "labels": [],
+                "cmd": "",
+                "start_time": 684140400.0,
+                "outputs": {},
+                "children": [],
+                "log_entries": [],
+                "outcome": "SUCCESS",
+                "end_time": 684140410.0,
+                "unaccounted_time": 0,
+            },
+        ],
+        "log_entries": [],
+        "outcome": "SUCCESS",
+        "end_time": -5419790.0,
+        "unaccounted_time": 0,
+    }
 
-        self._check_callbacks(expected, reporter)
+    reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(log_level=Report.INFO))
+    _check_callbacks(expected, reporter)
 
-    def test_nested_great_grandchildren(self):
-        expected = {
-            "name": "root",
-            "id": "root_id",
-            "parent_name": "",
-            "parent_id": "",
-            "labels": [],
-            "cmd": "",
-            "start_time": -5419800.0,
-            "outputs": {},
-            "children": [
-                {
-                    "name": "child",
-                    "id": "child_id",
-                    "parent_name": "root",
-                    "parent_id": "root_id",
-                    "labels": [],
-                    "cmd": "",
-                    "start_time": 31564800.0,
-                    "outputs": {},
-                    "children": [
-                        {
-                            "name": "grandchild",
-                            "id": "grandchild_id",
-                            "parent_name": "child",
-                            "parent_id": "child_id",
-                            "labels": ["LABEL1"],
-                            "cmd": "",
-                            "start_time": 479721600.0,
-                            "outputs": {},
-                            "children": [
-                                {
-                                    "name": "great_grandchild1",
-                                    "id": "great_grandchild1_id",
-                                    "parent_name": "grandchild",
-                                    "parent_id": "grandchild_id",
-                                    "labels": [],
-                                    "cmd": "",
-                                    "start_time": 684140400.0,
-                                    "outputs": {},
-                                    "children": [],
-                                    "log_entries": [],
-                                    "outcome": "SUCCESS",
-                                    "end_time": 684140410.0,
-                                    "unaccounted_time": 0,
-                                },
-                                {
-                                    "name": "great_grandchild2",
-                                    "id": "great_grandchild2_id",
-                                    "parent_name": "grandchild",
-                                    "parent_id": "grandchild_id",
-                                    "labels": ["TURTLES"],
-                                    "cmd": "",
-                                    "start_time": 1234.0,
-                                    "outputs": {},
-                                    "children": [],
-                                    "log_entries": [],
-                                    "outcome": "SUCCESS",
-                                    "end_time": 1244.0,
-                                    "unaccounted_time": 0,
-                                },
-                            ],
-                            "log_entries": [],
-                            "outcome": "SUCCESS",
-                            "end_time": 479721610.0,
-                            "unaccounted_time": 0,
-                        }
-                    ],
-                    "log_entries": [],
-                    "outcome": "SUCCESS",
-                    "end_time": 31564810.0,
-                    "unaccounted_time": 0,
-                },
-            ],
-            "log_entries": [],
-            "outcome": "SUCCESS",
-            "end_time": -5419790.0,
-            "unaccounted_time": 0,
-        }
 
-        reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(log_level=Report.INFO))
+def test_nested_great_grandchildren():
+    expected = {
+        "name": "root",
+        "id": "root_id",
+        "parent_name": "",
+        "parent_id": "",
+        "labels": [],
+        "cmd": "",
+        "start_time": -5419800.0,
+        "outputs": {},
+        "children": [
+            {
+                "name": "child",
+                "id": "child_id",
+                "parent_name": "root",
+                "parent_id": "root_id",
+                "labels": [],
+                "cmd": "",
+                "start_time": 31564800.0,
+                "outputs": {},
+                "children": [
+                    {
+                        "name": "grandchild",
+                        "id": "grandchild_id",
+                        "parent_name": "child",
+                        "parent_id": "child_id",
+                        "labels": ["LABEL1"],
+                        "cmd": "",
+                        "start_time": 479721600.0,
+                        "outputs": {},
+                        "children": [
+                            {
+                                "name": "great_grandchild1",
+                                "id": "great_grandchild1_id",
+                                "parent_name": "grandchild",
+                                "parent_id": "grandchild_id",
+                                "labels": [],
+                                "cmd": "",
+                                "start_time": 684140400.0,
+                                "outputs": {},
+                                "children": [],
+                                "log_entries": [],
+                                "outcome": "SUCCESS",
+                                "end_time": 684140410.0,
+                                "unaccounted_time": 0,
+                            },
+                            {
+                                "name": "great_grandchild2",
+                                "id": "great_grandchild2_id",
+                                "parent_name": "grandchild",
+                                "parent_id": "grandchild_id",
+                                "labels": ["TURTLES"],
+                                "cmd": "",
+                                "start_time": 1234.0,
+                                "outputs": {},
+                                "children": [],
+                                "log_entries": [],
+                                "outcome": "SUCCESS",
+                                "end_time": 1244.0,
+                                "unaccounted_time": 0,
+                            },
+                        ],
+                        "log_entries": [],
+                        "outcome": "SUCCESS",
+                        "end_time": 479721610.0,
+                        "unaccounted_time": 0,
+                    }
+                ],
+                "log_entries": [],
+                "outcome": "SUCCESS",
+                "end_time": 31564810.0,
+                "unaccounted_time": 0,
+            },
+        ],
+        "log_entries": [],
+        "outcome": "SUCCESS",
+        "end_time": -5419790.0,
+        "unaccounted_time": 0,
+    }
 
-        self._check_callbacks(expected, reporter)
+    reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(log_level=Report.INFO))
+    _check_callbacks(expected, reporter)


### PR DESCRIPTION
`TestBase` was being used for many tests that didn't need it. There's a cost to using `TestBase`, including a slower test startup time and far more frequent cache invalidation due to `TestBase` dependencies.

More importantly, we want to move away from unittest-style tests to Pytest-style tests. By making these changes, we are able to remove several util functions on `TestBase` that will make it a little bit easier to convert `TestBase` into a Pytest-style fixture.

[ci skip-rust]
