### PR TITLE
Temporarily disable protobuf support.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -18,3 +18,11 @@ def rules():
 
 def target_types():
     return [ProtobufLibrary]
+
+
+raise Exception(
+    "The pants.backend.codege.protobuf.python backend is temporarily disabled for this 2.0 alpha "
+    "release, due to performance issues. If you require protobuf support, please do not use this "
+    "Pants release.  This is a very temporary measure, to allow alpha testing to proceed on other "
+    "features. Protobuf support will be fully restored before the 2.0 release."
+)


### PR DESCRIPTION
This is so we can get the alpha release out, to allow
testing of other features.  Restoring protobuf support
is our highest priority prior to the 2.0 release.

[ci skip-rust]

[ci skip-build-wheels]
