### PR TITLE
remoting: output directories in action results reference trees

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -451,7 +451,7 @@ impl Store {
       (Some(value_result), _) => value_result.map(|res| Some((res, LoadMetadata::Local))),
       (None, None) => Ok(None),
       (None, Some(remote)) => {
-        let maybe_bytes = remote.load_bytes_with(entry_type, digest, Ok).await?;
+        let maybe_bytes = remote.load_bytes_with(digest, Ok).await?;
 
         match maybe_bytes {
           Some(bytes) => {
@@ -615,7 +615,7 @@ impl Store {
     };
 
     let tree_opt = remote
-      .load_bytes_with(EntryType::Directory, tree_digest, |b| {
+      .load_bytes_with(tree_digest, |b| {
         let mut tree = Tree::new();
         tree
           .merge_from_bytes(&b)

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -427,7 +427,7 @@ impl Store {
   /// two functions f_local and f_remote. These functions are any validation or transformations you
   /// want to perform on the bytes received from the local and remote cas (if remote is configured).
   ///
-  async fn load_bytes_with<
+  pub async fn load_bytes_with<
     T: Send + 'static,
     FLocal: Fn(&[u8]) -> Result<T, String> + Send + Sync + 'static,
     FRemote: Fn(Bytes) -> Result<T, String> + Send + Sync + 'static,
@@ -678,6 +678,7 @@ impl Store {
                   .await?;
                 Ok(Either::Right(reachable))
               }
+              Ok(Some(EntryType::Tree)) => unimplemented!(),
               Ok(None) => {
                 if allow_missing {
                   Ok(Either::Right(HashMap::new()))
@@ -1052,6 +1053,7 @@ impl StoreWrapper for Store {
 pub enum EntryType {
   Directory,
   File,
+  Tree, // multiple Directories encoded together
 }
 
 #[cfg(test)]

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -24,6 +24,7 @@ struct InnerStore {
   //  2. It's nice to know whether we should be able to parse something as a proto.
   file_dbs: Result<Arc<ShardedLmdb>, String>,
   directory_dbs: Result<Arc<ShardedLmdb>, String>,
+  tree_dbs: Result<Arc<ShardedLmdb>, String>,
   executor: task_executor::Executor,
 }
 
@@ -43,6 +44,7 @@ impl ByteStore {
     let root = path.as_ref();
     let files_root = root.join("files");
     let directories_root = root.join("directories");
+    let trees_root = root.join("trees");
     Ok(ByteStore {
       inner: Arc::new(InnerStore {
         // We want these stores to be allowed to grow very large, in case we are on a system with
@@ -63,6 +65,8 @@ impl ByteStore {
           lease_time,
         )
         .map(Arc::new),
+        tree_dbs: ShardedLmdb::new(trees_root, 2 * GIGABYTES, executor.clone(), lease_time)
+          .map(Arc::new),
         executor,
       }),
     })
@@ -103,6 +107,7 @@ impl ByteStore {
       let dbs = match entry_type {
         EntryType::File => self.inner.file_dbs.clone(),
         EntryType::Directory => self.inner.directory_dbs.clone(),
+        EntryType::Tree => self.inner.tree_dbs.clone(),
       };
       dbs?
         .lease(digest.0)
@@ -149,6 +154,7 @@ impl ByteStore {
       let lmdbs = match aged_fingerprint.entry_type {
         EntryType::File => self.inner.file_dbs.clone(),
         EntryType::Directory => self.inner.directory_dbs.clone(),
+        EntryType::Tree => self.inner.tree_dbs.clone(),
       };
       let (env, database, lease_database) = lmdbs.clone()?.get(&aged_fingerprint.fingerprint);
       {
@@ -190,6 +196,7 @@ impl ByteStore {
     let database = match entry_type {
       EntryType::File => self.inner.file_dbs.clone(),
       EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::Tree => self.inner.tree_dbs.clone(),
     };
 
     for &(ref env, ref database, ref lease_database) in &database?.all_lmdbs() {
@@ -248,6 +255,7 @@ impl ByteStore {
     let dbs = match entry_type {
       EntryType::Directory => self.inner.directory_dbs.clone(),
       EntryType::File => self.inner.file_dbs.clone(),
+      EntryType::Tree => self.inner.tree_dbs.clone(),
     };
     let bytes2 = bytes.clone();
     let digest = self
@@ -284,6 +292,7 @@ impl ByteStore {
     let dbs = match entry_type {
       EntryType::Directory => self.inner.directory_dbs.clone(),
       EntryType::File => self.inner.file_dbs.clone(),
+      EntryType::Tree => self.inner.tree_dbs.clone(),
     };
 
     dbs?.load_bytes_with(digest.0, move |bytes| {
@@ -299,6 +308,7 @@ impl ByteStore {
     let database = match entry_type {
       EntryType::File => self.inner.file_dbs.clone(),
       EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::Tree => self.inner.tree_dbs.clone(),
     };
     let mut digests = vec![];
     for &(ref env, ref database, ref _lease_database) in &database?.all_lmdbs() {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -230,7 +230,7 @@ impl ByteStore {
 
   pub async fn load_bytes_with<
     T: Send + 'static,
-    F: Fn(Bytes) -> T + Send + Sync + Clone + 'static,
+    F: Fn(Bytes) -> Result<T, String> + Send + Sync + Clone + 'static,
   >(
     &self,
     _entry_type: EntryType,
@@ -291,7 +291,10 @@ impl ByteStore {
           }
         };
 
-        Ok(maybe_bytes.map(f))
+        match maybe_bytes {
+          Some(b) => f(b).map(Some),
+          None => Ok(None),
+        }
       }
     });
 

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -16,7 +16,7 @@ use log::Level;
 use serverset::{retry, Serverset};
 use workunit_store::with_workunit;
 
-use super::{BackoffConfig, EntryType};
+use super::BackoffConfig;
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -233,7 +233,6 @@ impl ByteStore {
     F: Fn(Bytes) -> Result<T, String> + Send + Sync + Clone + 'static,
   >(
     &self,
-    _entry_type: EntryType,
     digest: Digest,
     f: F,
   ) -> Result<Option<T>, String> {

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -376,5 +376,5 @@ async fn load_bytes(
   entry_type: EntryType,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(entry_type, digest, |b| b).await
+  store.load_bytes_with(entry_type, digest, |b| Ok(b)).await
 }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -1,5 +1,5 @@
 use crate::remote::ByteStore;
-use crate::{EntryType, MEGABYTES};
+use crate::MEGABYTES;
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
 use hashing::Digest;
@@ -361,20 +361,16 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
 }
 
 pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::File, digest).await
+  load_bytes(&store, digest).await
 }
 
 pub async fn load_directory_proto_bytes(
   store: &ByteStore,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::Directory, digest).await
+  load_bytes(&store, digest).await
 }
 
-async fn load_bytes(
-  store: &ByteStore,
-  entry_type: EntryType,
-  digest: Digest,
-) -> Result<Option<Bytes>, String> {
-  store.load_bytes_with(entry_type, digest, |b| Ok(b)).await
+async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
+  store.load_bytes_with(digest, |b| Ok(b)).await
 }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -120,6 +120,7 @@ impl CommandRunner {
         execute_response.get_result(),
         vec![],
         platform,
+        true,
       )
       .map(Some)
       .compat()

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2450,7 +2450,7 @@ async fn extract_output_files_from_response(
   let executor = task_executor::Executor::new(Handle::current());
   let store_dir = TempDir::new().unwrap();
   let store = make_store(store_dir.path(), &cas, executor.clone());
-  crate::remote::extract_output_files(store, execute_response.get_result())
+  crate::remote::extract_output_files(store, execute_response.get_result(), false)
     .compat()
     .await
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -19,7 +19,7 @@ use spectral::prelude::*;
 use spectral::{assert_that, string::StrAssertions};
 use store::Store;
 use tempfile::TempDir;
-use testutil::data::{TestData, TestDirectory};
+use testutil::data::{TestData, TestDirectory, TestTree};
 use testutil::owned_string_vec;
 use tokio::runtime::Handle;
 use workunit_store::{Level, SpanId, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
@@ -1955,6 +1955,7 @@ async fn extract_output_files_from_response_one_file() {
   output_file.set_path("roland".into());
   output_file.set_digest((&TestData::roland().digest()).into());
   output_file.set_is_executable(false);
+
   let mut output_files = protobuf::RepeatedField::new();
   output_files.push(output_file);
 
@@ -1983,6 +1984,7 @@ async fn extract_output_files_from_response_two_files_not_nested() {
   output_file_2.set_path("treats".into());
   output_file_2.set_digest((&TestData::catnip().digest()).into());
   output_file_2.set_is_executable(false);
+
   let mut output_files = protobuf::RepeatedField::new();
   output_files.push(output_file_1);
   output_files.push(output_file_2);
@@ -2012,6 +2014,7 @@ async fn extract_output_files_from_response_two_files_nested() {
   output_file_2.set_path("treats".into());
   output_file_2.set_digest((&TestData::catnip().digest()).into());
   output_file_2.set_is_executable(false);
+
   let mut output_files = protobuf::RepeatedField::new();
   output_files.push(output_file_1);
   output_files.push(output_file_2);
@@ -2034,7 +2037,9 @@ async fn extract_output_files_from_response_two_files_nested() {
 async fn extract_output_files_from_response_just_directory() {
   let mut output_directory = bazel_protos::remote_execution::OutputDirectory::new();
   output_directory.set_path("cats".into());
-  output_directory.set_tree_digest((&TestDirectory::containing_roland().digest()).into());
+  let tree: TestTree = TestDirectory::containing_roland().into();
+  output_directory.set_tree_digest(tree.digest().into());
+
   let mut output_directories = protobuf::RepeatedField::new();
   output_directories.push(output_directory);
 
@@ -2059,16 +2064,18 @@ async fn extract_output_files_from_response_directories_and_files() {
   // /pets/dogs/robin
 
   let mut output_directories = protobuf::RepeatedField::new();
+
   output_directories.push({
     let mut output_directory = bazel_protos::remote_execution::OutputDirectory::new();
     output_directory.set_path("pets/cats".into());
-    output_directory.set_tree_digest((&TestDirectory::containing_roland().digest()).into());
+    output_directory.set_tree_digest((&TestTree::roland_at_root().digest()).into());
     output_directory
   });
+
   output_directories.push({
     let mut output_directory = bazel_protos::remote_execution::OutputDirectory::new();
     output_directory.set_path("pets/dogs".into());
-    output_directory.set_tree_digest((&TestDirectory::containing_robin().digest()).into());
+    output_directory.set_tree_digest((&TestTree::robin_at_root().digest()).into());
     output_directory
   });
 
@@ -2106,7 +2113,7 @@ async fn extract_output_files_from_response_directories_and_files() {
 async fn extract_output_files_from_response_no_prefix() {
   let mut output_directory = bazel_protos::remote_execution::OutputDirectory::new();
   output_directory.set_path(String::new());
-  output_directory.set_tree_digest((&TestDirectory::containing_roland().digest()).into());
+  output_directory.set_tree_digest((&TestTree::roland_at_root().digest()).into());
 
   let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
   execute_response.set_result({
@@ -2352,6 +2359,7 @@ async fn run_command_remote(
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())
+    .tree(&TestTree::roland_at_root())
     .build();
   let (command_runner, store) = create_command_runner(address, &cas, Platform::Linux);
   let original = command_runner.run(request, Context::default()).await?;
@@ -2436,6 +2444,8 @@ async fn extract_output_files_from_response(
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())
+    .tree(&TestTree::roland_at_root())
+    .tree(&TestTree::robin_at_root())
     .build();
   let executor = task_executor::Executor::new(Handle::current());
   let store_dir = TempDir::new().unwrap();

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -26,7 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-#![type_length_limit = "1076749"]
+#![type_length_limit = "1076799"]
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -26,7 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-#![type_length_limit = "1076799"]
+#![type_length_limit = "1100709"]
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -7,7 +7,7 @@ use futures01::{Future, IntoFuture, Stream};
 use grpcio::RpcContext;
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
-use testutil::data::{TestData, TestDirectory};
+use testutil::data::{TestData, TestDirectory, TestTree};
 
 ///
 /// Implements the ContentAddressableStorage gRPC API, answering read requests with either known
@@ -68,6 +68,11 @@ impl StubCASBuilder {
     self
       .content
       .insert(directory.fingerprint(), directory.bytes());
+    self
+  }
+
+  pub fn tree(mut self, tree: &TestTree) -> Self {
+    self.content.insert(tree.fingerprint(), tree.bytes());
     self
   }
 

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -309,3 +309,39 @@ impl TestDirectory {
     hashing::Digest::of_bytes(&self.bytes())
   }
 }
+
+pub struct TestTree {
+  pub tree: bazel_protos::remote_execution::Tree,
+}
+
+impl TestTree {
+  pub fn roland_at_root() -> TestTree {
+    TestDirectory::containing_roland().into()
+  }
+
+  pub fn robin_at_root() -> TestTree {
+    TestDirectory::containing_robin().into()
+  }
+}
+
+impl TestTree {
+  pub fn bytes(&self) -> bytes::Bytes {
+    bytes::Bytes::from(self.tree.write_to_bytes().expect("Error serializing proto"))
+  }
+
+  pub fn fingerprint(&self) -> hashing::Fingerprint {
+    self.digest().0
+  }
+
+  pub fn digest(&self) -> hashing::Digest {
+    hashing::Digest::of_bytes(&self.bytes())
+  }
+}
+
+impl From<TestDirectory> for TestTree {
+  fn from(dir: TestDirectory) -> Self {
+    let mut tree = bazel_protos::remote_execution::Tree::new();
+    tree.set_root(dir.directory);
+    TestTree { tree }
+  }
+}


### PR DESCRIPTION
### Problem

The `tree_digest` field of `OutputDirectory` protos embedded in an `ActionResult` is a digest pointing to a `Tree` and not a `Directory`. The RE client, however, wrongly assumes that it is a `Directory` message. Thus, Pants is unable to decode `ActionResult` protos that have output directory responses.

>  // The digest of the encoded
  // [Tree][build.bazel.remote.execution.v2.Tree] proto containing the
  // directory's contents.
  Digest tree_digest = 3;

[See the Remote Execution spec for more details.](https://github.com/bazelbuild/remote-apis/blob/5a7b1a472165a0ea47b9060089855385fe351193/build/bazel/remote/execution/v2/remote_execution.proto#L1097-L1100)

### Solution

Rewrite the parsing of action results so that the client decodes the `Tree` referenced in the `ActionResult` and hashes the embedded root `Directory` for the applicable `OutputDirectory`.

### Result

Tests pass.