### PR TITLE
Fix usage of PathGlobs in python code coverage config again.

### DIFF
--- a/src/python/pants/backend/python/rules/coverage.py
+++ b/src/python/pants/backend/python/rules/coverage.py
@@ -170,7 +170,7 @@ async def create_coverage_config(coverage: CoverageSubsystem) -> CoverageConfig:
         config_contents = await Get(
             DigestContents,
             PathGlobs(
-                globs=tuple(coverage.config,),
+                globs=(coverage.config,),
                 glob_match_error_behavior=GlobMatchErrorBehavior.error,
                 description_of_origin=f"the option `--{coverage.options_scope}-config`",
             ),


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/10670
double derp... tested it this time


### Problem

PathGlob glob param expects a collection (iterable) of strings, passing it a string prevents it from working properly

### Solution

Pass the correct param type