### PR TITLE
Fix retrieval of bytes from artifacts in StreamingWorkunitHandler

### DIFF
--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -267,7 +267,7 @@ async def run_python_test(
         if xml_results_snapshot.files == (setup.results_file_name,):
             xml_results_snapshot = await Get(
                 Snapshot,
-                AddPrefix(xml_results_snapshot.digest, setup.xml_dir),  # type: ignore[arg-type]
+                AddPrefix(xml_results_snapshot.digest, pytest.options.junit_xml_dir),
             )
         else:
             logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")
@@ -277,7 +277,6 @@ async def run_python_test(
         address=field_set.address,
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
-        address=field_set.address,
     )
 
 

--- a/src/python/pants/backend/python/rules/pytest_runner.py
+++ b/src/python/pants/backend/python/rules/pytest_runner.py
@@ -259,15 +259,15 @@ async def run_python_test(
         else:
             logger.warning(f"Failed to generate coverage data for {field_set.address}.")
 
-    xml_results_digest = None
+    xml_results_snapshot = None
     if setup.results_file_name:
         xml_results_snapshot = await Get(
             Snapshot, DigestSubset(result.output_digest, PathGlobs([setup.results_file_name]))
         )
         if xml_results_snapshot.files == (setup.results_file_name,):
-            xml_results_digest = await Get(
-                Digest,
-                AddPrefix(xml_results_snapshot.digest, pytest.options.junit_xml_dir),
+            xml_results_snapshot = await Get(
+                Snapshot,
+                AddPrefix(xml_results_snapshot.digest, setup.xml_dir),  # type: ignore[arg-type]
             )
         else:
             logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")
@@ -276,7 +276,8 @@ async def run_python_test(
         result,
         address=field_set.address,
         coverage_data=coverage_data,
-        xml_results=xml_results_digest,
+        xml_results=xml_results_snapshot,
+        address=field_set.address,
     )
 
 

--- a/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/pytest_runner_integration_test.py
@@ -342,7 +342,7 @@ class PytestRunnerIntegrationTest(ExternalToolTestBase):
         assert result.exit_code == 0
         assert f"{self.package}/test_good.py ." in result.stdout
         assert result.xml_results is not None
-        digest_contents = self.request_product(DigestContents, [result.xml_results])
+        digest_contents = self.request_product(DigestContents, [result.xml_results.digest])
         file = digest_contents[0]
         assert file.path.startswith("dist/test-results")
         assert b"pants_test.test_good" in file.content

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -112,7 +112,7 @@ class EnrichedTestResult(EngineAwareReturnType):
     def artifacts(self) -> Optional[Dict[str, Snapshot]]:
         if not self.xml_results:
             return None
-        return {"xml_results_digest": self.xml_results}
+        return {"xml_results": self.xml_results}
 
     def level(self) -> LogLevel:
         if self.skipped:

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -405,7 +405,8 @@ async def run_tests(
         console.print_stderr(f"{sigil} {result.address} {status}.")
 
     merged_xml_results = await Get(
-        Digest, MergeDigests(result.xml_results.digest for result in results if result.xml_results),
+        Digest,
+        MergeDigests(result.xml_results.digest for result in results if result.xml_results),
     )
     workspace.write_digest(merged_xml_results)
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -18,7 +18,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.fs import Digest, MergeDigests, Workspace
+from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
@@ -61,7 +61,7 @@ class TestResult:
     stderr: str
     address: Address
     coverage_data: Optional["CoverageData"] = None
-    xml_results: Optional[Digest] = None
+    xml_results: Optional[Snapshot] = None
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -77,7 +77,7 @@ class TestResult:
         address: Address,
         *,
         coverage_data: Optional["CoverageData"] = None,
-        xml_results: Optional[Digest] = None,
+        xml_results: Optional[Snapshot] = None,
     ) -> "TestResult":
         return cls(
             exit_code=process_result.exit_code,
@@ -97,7 +97,7 @@ class EnrichedTestResult(EngineAwareReturnType):
     address: Address
     output_setting: "ShowOutput"
     coverage_data: Optional["CoverageData"] = None
-    xml_results: Optional[Digest] = None
+    xml_results: Optional[Snapshot] = None
 
     @property
     def skipped(self) -> bool:
@@ -109,7 +109,7 @@ class EnrichedTestResult(EngineAwareReturnType):
             and not self.xml_results
         )
 
-    def artifacts(self) -> Optional[Dict[str, Digest]]:
+    def artifacts(self) -> Optional[Dict[str, Snapshot]]:
         if not self.xml_results:
             return None
         return {"xml_results_digest": self.xml_results}
@@ -200,7 +200,7 @@ class CoverageReport(ABC):
         """
         ...
 
-    def get_artifact(self) -> Optional[Tuple[str, Digest]]:
+    def get_artifact(self) -> Optional[Tuple[str, Snapshot]]:
         return None
 
 
@@ -219,22 +219,22 @@ class ConsoleCoverageReport(CoverageReport):
 class FilesystemCoverageReport(CoverageReport):
     """Materializes a code coverage report to disk."""
 
-    result_digest: Digest
+    result_snapshot: Snapshot
     directory_to_materialize_to: PurePath
     report_file: Optional[PurePath]
     report_type: CoverageReportType
 
     def materialize(self, console: Console, workspace: Workspace) -> Optional[PurePath]:
         workspace.write_digest(
-            self.result_digest, path_prefix=str(self.directory_to_materialize_to)
+            self.result_snapshot.digest, path_prefix=str(self.directory_to_materialize_to)
         )
         console.print_stderr(
             f"\nWrote {self.report_type.report_name} coverage report to `{self.directory_to_materialize_to}`"
         )
         return self.report_file
 
-    def get_artifact(self) -> Optional[Tuple[str, Digest]]:
-        return self.report_type.value, self.result_digest
+    def get_artifact(self) -> Optional[Tuple[str, Snapshot]]:
+        return self.report_type.value, self.result_snapshot
 
 
 @dataclass(frozen=True)
@@ -249,7 +249,7 @@ class CoverageReports(EngineAwareReturnType):
                 report_paths.append(report_path)
         return tuple(report_paths)
 
-    def artifacts(self) -> Optional[Dict[str, Digest]]:
+    def artifacts(self) -> Optional[Dict[str, Snapshot]]:
         artifacts = {}
         for report in self.reports:
             artifact = report.get_artifact()
@@ -405,7 +405,7 @@ async def run_tests(
         console.print_stderr(f"{sigil} {result.address} {status}.")
 
     merged_xml_results = await Get(
-        Digest, MergeDigests(result.xml_results for result in results if result.xml_results)
+        Digest, MergeDigests(result.xml_results.digest for result in results if result.xml_results),
     )
     workspace.write_digest(merged_xml_results)
 

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -4,7 +4,7 @@
 from abc import ABC
 from typing import Dict, Optional
 
-from pants.engine.fs import Digest
+from pants.engine.fs import Digest, Snapshot
 from pants.util.logging import LogLevel
 
 
@@ -49,10 +49,10 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def artifacts(self) -> Optional[Dict[str, Digest]]:
+    def artifacts(self) -> Optional[Dict[str, Snapshot]]:
         """If implemented, this sets the `artifacts` entry for the workunit of any `@rule`'s that
         return the annotated type.
 
-        `artifacts` is a mapping of arbitrary string keys to `Digest`s.
+        `artifacts` is a mapping of arbitrary string keys to `Snapshot`s.
         """
         return None

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -4,7 +4,7 @@
 from abc import ABC
 from typing import Dict, Optional
 
-from pants.engine.fs import Digest, Snapshot
+from pants.engine.fs import Snapshot
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -610,10 +610,8 @@ class MoreComplicatedEngineAware(TestBase, SchedulerTestBase):
         artifacts = workunit["artifacts"]
         output_digest = artifacts["some_arbitrary_key"]
 
-        print(f"Output digest: {output_digest}")
-        output_bytes = streaming_workunit_context.digests_to_bytes([output_digest])
-        print(f"Ouput bytes: {output_bytes}")
-        assert 1 == 2
+        output_bytes = streaming_workunit_context.snapshot_digests_to_bytes([output_digest])
+        assert output_bytes == (b"alpha",)
 
 
 class StreamingWorkunitProcessTests(TestBase):

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -14,6 +14,7 @@ from pants.engine.fs import (
     EMPTY_SNAPSHOT,
     CreateDigest,
     Digest,
+    DigestContents,
     FileContent,
     Snapshot,
 )
@@ -584,7 +585,7 @@ def a_rule(snapshot: Snapshot) -> Output:
     return Output(val=snapshot)
 
 
-class MoreComplicatedEngineAware(TestBase, SchedulerTestBase):
+class MoreComplicatedEngineAware(TestBase):
     @classmethod
     def rules(cls):
         return (
@@ -621,8 +622,9 @@ class MoreComplicatedEngineAware(TestBase, SchedulerTestBase):
 
         output_contents = streaming_workunit_context.snapshots_to_file_contents([output_digest])[0]
         assert len(output_contents) == 1
-        assert isinstance(output_contents[0], FileContent)
-        assert output_contents[0].content == b"alpha"
+        assert isinstance(output_contents[0], DigestContents)
+        file_contents = tuple(output_contents[0])[0]
+        assert file_contents.content == b"alpha"
 
 
 class StreamingWorkunitProcessTests(TestBase):

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -9,10 +9,16 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, EMPTY_SNAPSHOT, Snapshot
 from pants.engine.internals.engine_testutil import (
     assert_equal_with_printing,
     remove_locations_from_traceback,
+from pants.engine.fs import (
+    EMPTY_DIGEST,
+    EMPTY_SNAPSHOT,
+    CreateDigest,
+    Digest,
+    FileContent,
+    Snapshot,
 )
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -703,7 +703,7 @@ class StreamingWorkunitProcessTests(TestBase):
             # in rust.
             assert str(e) == "Cannot ensure remote has blobs without a remote"
 
-        byte_outputs = self._scheduler.digests_to_bytes([stdout_digest, stderr_digest])
+        byte_outputs = self._scheduler.single_file_digests_to_bytes([stdout_digest, stderr_digest])
         assert byte_outputs[0] == result.stdout
         assert byte_outputs[1] == result.stderr
 
@@ -718,7 +718,7 @@ class StreamingWorkunitProcessTests(TestBase):
             for workunit in completed_workunits:
                 if "artifacts" in workunit and "stdout_digest" in workunit["artifacts"]:
                     digest = workunit["artifacts"]["stdout_digest"]
-                    output = context.digests_to_bytes([digest])
+                    output = context.single_file_digests_to_bytes([digest])
                     assert output == (b"stdout output\n",)
 
         handler = StreamingWorkunitHandler(

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -9,9 +9,6 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.internals.engine_testutil import (
-    assert_equal_with_printing,
-    remove_locations_from_traceback,
 from pants.engine.fs import (
     EMPTY_DIGEST,
     EMPTY_SNAPSHOT,
@@ -19,6 +16,10 @@ from pants.engine.fs import (
     Digest,
     FileContent,
     Snapshot,
+)
+from pants.engine.internals.engine_testutil import (
+    assert_equal_with_printing,
+    remove_locations_from_traceback,
 )
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.scheduler_test_base import SchedulerTestBase

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from typing import List, Optional
 
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, DigestContents, FileContent
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.engine.internals.engine_testutil import (
     assert_equal_with_printing,
     remove_locations_from_traceback,
@@ -610,8 +610,10 @@ class MoreComplicatedEngineAware(TestBase, SchedulerTestBase):
         artifacts = workunit["artifacts"]
         output_digest = artifacts["some_arbitrary_key"]
 
-        output_bytes = streaming_workunit_context.snapshot_digests_to_bytes([output_digest])
-        assert output_bytes == (b"alpha",)
+        output_contents = streaming_workunit_context.snapshot_digests_to_bytes([output_digest])[0]
+        assert len(output_contents) == 1
+        assert isinstance(output_contents[0], FileContent)
+        assert output_contents[0].content == b"alpha"
 
 
 class StreamingWorkunitProcessTests(TestBase):

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -567,7 +567,7 @@ class StreamingWorkunitTests(unittest.TestCase, SchedulerTestBase):
             item for item in finished if item["name"] == "pants.engine.internals.engine_test.a_rule"
         )
         artifacts = workunit["artifacts"]
-        assert artifacts["some_arbitrary_key"] == EMPTY_DIGEST
+        assert artifacts["some_arbitrary_key"] == EMPTY_SNAPSHOT
 
 
 @dataclass(frozen=True)
@@ -618,7 +618,7 @@ class MoreComplicatedEngineAware(TestBase, SchedulerTestBase):
         artifacts = workunit["artifacts"]
         output_digest = artifacts["some_arbitrary_key"]
 
-        output_contents = streaming_workunit_context.snapshot_digests_to_bytes([output_digest])[0]
+        output_contents = streaming_workunit_context.snapshots_to_file_contents([output_digest])[0]
         assert len(output_contents) == 1
         assert isinstance(output_contents[0], FileContent)
         assert output_contents[0].content == b"alpha"

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -628,8 +628,14 @@ class SchedulerSession:
     def snapshots_to_file_contents(
         self, snapshots: Sequence[Snapshot]
     ) -> Tuple[DigestContents, ...]:
+        """For each input `Snapshot`, yield a single `DigestContents` containing all the
+        `FileContent`s corresponding to the file(s) contained within that `Snapshot`.
+
+        Note that we cannot currently use a parallelized version of `self.product_request` since
+        each snapshot needs to yield a separate `DigestContents`.
+        """
         return tuple(
-            cast(DigestContents, self.product_request(DigestContents, [snapshot.digest]))
+            cast(DigestContents, self.product_request(DigestContents, [snapshot.digest])[0])
             for snapshot in snapshots
         )
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -614,11 +614,15 @@ class SchedulerSession:
             self._scheduler._scheduler, self._session, _DirectoryDigests(digests)
         )
 
-    def digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
+    def single_file_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
         sched_pointer = self._scheduler._scheduler
         return cast(
             Tuple[bytes],
-            tuple(self._scheduler._native.lib.digests_to_bytes(sched_pointer, list(digests))),
+            tuple(
+                self._scheduler._native.lib.single_file_digests_to_bytes(
+                    sched_pointer, list(digests)
+                )
+            ),
         )
 
     def snapshots_to_file_contents(

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -623,15 +623,10 @@ class SchedulerSession:
 
     def snapshots_to_file_contents(
         self, snapshots: Sequence[Snapshot]
-    ) -> Tuple[Tuple[FileContent]]:
-        sched_pointer = self._scheduler._scheduler
-        return cast(
-            Tuple[Tuple[FileContent]],
-            tuple(
-                self._scheduler._native.lib.snapshots_to_file_contents(
-                    sched_pointer, list(snapshots)
-                )
-            ),
+    ) -> Tuple[DigestContents, ...]:
+        return tuple(
+            cast(DigestContents, self.product_request(DigestContents, [snapshot.digest]))
+            for snapshot in snapshots
         )
 
     def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -621,6 +621,15 @@ class SchedulerSession:
             tuple(self._scheduler._native.lib.digests_to_bytes(sched_pointer, list(digests))),
         )
 
+    def snapshot_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
+        sched_pointer = self._scheduler._scheduler
+        return cast(
+            Tuple[bytes],
+            tuple(
+                self._scheduler._native.lib.snapshot_digests_to_bytes(sched_pointer, list(digests))
+            ),
+        )
+
     def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:
         sched_pointer = self._scheduler._scheduler
         self._scheduler._native.lib.ensure_remote_has_recursive(sched_pointer, list(digests))

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -621,12 +621,16 @@ class SchedulerSession:
             tuple(self._scheduler._native.lib.digests_to_bytes(sched_pointer, list(digests))),
         )
 
-    def snapshot_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
+    def snapshots_to_file_contents(
+        self, snapshots: Sequence[Snapshot]
+    ) -> Tuple[Tuple[FileContent]]:
         sched_pointer = self._scheduler._scheduler
         return cast(
-            Tuple[bytes],
+            Tuple[Tuple[FileContent]],
             tuple(
-                self._scheduler._native.lib.snapshot_digests_to_bytes(sched_pointer, list(digests))
+                self._scheduler._native.lib.snapshots_to_file_contents(
+                    sched_pointer, list(snapshots)
+                )
             ),
         )
 

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Tuple
 
-from pants.engine.fs import Digest
+from pants.engine.fs import Digest, FileContent, Snapshot
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.util.logging import LogLevel
 
@@ -20,10 +20,12 @@ class StreamingWorkunitContext:
         Digests in sequence."""
         return self._scheduler.digests_to_bytes(digests)
 
-    def snapshot_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
-        """Given a list of Digest objects representing the digest from a Snapshot, return a list of
-        the bytes corresponding to each of those Digests in sequence."""
-        return self._scheduler.snapshot_digests_to_bytes(digests)
+    def snapshots_to_file_contents(
+        self, snapshots: Sequence[Snapshot]
+    ) -> Tuple[Tuple[FileContent]]:
+        """Given a sequence of Snapshot objects, return a tuple of the FileContents representing the
+        files contained in those `Snapshot`s in sequence."""
+        return self._scheduler.snapshots_to_file_contents(snapshots)
 
     def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:
         """Invoke the internal ensure_remote_has_recursive function, which ensures that a remote

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Tuple
 
-from pants.engine.fs import Digest, FileContent, Snapshot
+from pants.engine.fs import Digest, DigestContents, Snapshot
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.util.logging import LogLevel
 
@@ -22,8 +22,8 @@ class StreamingWorkunitContext:
 
     def snapshots_to_file_contents(
         self, snapshots: Sequence[Snapshot]
-    ) -> Tuple[Tuple[FileContent]]:
-        """Given a sequence of Snapshot objects, return a tuple of the FileContents representing the
+    ) -> Tuple[DigestContents, ...]:
+        """Given a sequence of Snapshot objects, return a tuple of DigestContents representing the
         files contained in those `Snapshot`s in sequence."""
         return self._scheduler.snapshots_to_file_contents(snapshots)
 

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -20,6 +20,11 @@ class StreamingWorkunitContext:
         Digests in sequence."""
         return self._scheduler.digests_to_bytes(digests)
 
+    def snapshot_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
+        """Given a list of Digest objects representing the digest from a Snapshot, return a list of
+        the bytes corresponding to each of those Digests in sequence."""
+        return self._scheduler.snapshot_digests_to_bytes(digests)
+
     def ensure_remote_has_recursive(self, digests: Sequence[Digest]) -> None:
         """Invoke the internal ensure_remote_has_recursive function, which ensures that a remote
         ByteStore, if it exists, has a copy of the files fingerprinted by each Digest."""

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -15,10 +15,10 @@ from pants.util.logging import LogLevel
 class StreamingWorkunitContext:
     _scheduler: SchedulerSession
 
-    def digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
-        """Given a list of Digest objects, return a list of the bytes corresponding to each of those
-        Digests in sequence."""
-        return self._scheduler.digests_to_bytes(digests)
+    def single_file_digests_to_bytes(self, digests: Sequence[Digest]) -> Tuple[bytes]:
+        """Given a list of Digest objects, each representing the contents of a single file, return a
+        list of the bytes corresponding to each of those Digests in sequence."""
+        return self._scheduler.single_file_digests_to_bytes(digests)
 
     def snapshots_to_file_contents(
         self, snapshots: Sequence[Snapshot]

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -49,7 +49,13 @@ impl EngineAwareInformation for Artifacts {
   type MaybeOutput = Vec<(String, Digest)>;
 
   fn retrieve(value: &Value) -> Option<Self::MaybeOutput> {
-    let artifacts_val: Value = externs::call_method(&value, "artifacts", &[]).ok()?;
+    let artifacts_val: Value = match externs::call_method(&value, "artifacts", &[]) {
+      Ok(value) => value,
+      Err(e) => {
+        log::error!("Error calling `artifacts` method: {}", e);
+        return None;
+      }
+    };
     let artifacts_val: Value = externs::check_for_python_none(artifacts_val)?;
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -4,7 +4,7 @@
 use crate::core::Value;
 use crate::externs;
 use crate::nodes::lift_digest;
-use cpython::{PyDict, PyString, Python};
+use cpython::{PyDict, PyObject, PyString, Python};
 use hashing::Digest;
 use workunit_store::Level;
 
@@ -73,7 +73,12 @@ impl EngineAwareInformation for Artifacts {
           return None;
         }
       };
-      let digest = match lift_digest(&Value::new(value)) {
+      let digest_value: PyObject = externs::getattr(&Value::new(value), "digest")
+        .map_err(|e| {
+          log::error!("Error in EngineAware.artifacts() - no `digest` attr: {}", e);
+        })
+        .ok()?;
+      let digest = match lift_digest(&Value::new(digest_value)) {
         Ok(digest) => digest,
         Err(e) => {
           log::error!("Error in EngineAware.artifacts() implementation: {}", e);

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -359,8 +359,8 @@ py_module_initializer!(native_engine, |py, m| {
 
   m.add(
     py,
-    "digests_to_bytes",
-    py_fn!(py, digests_to_bytes(a: PyScheduler, b: PyList)),
+    "single_file_digests_to_bytes",
+    py_fn!(py, single_file_digests_to_bytes(a: PyScheduler, b: PyList)),
   )?;
 
   m.add(
@@ -1488,8 +1488,9 @@ fn ensure_remote_has_recursive(
   })
 }
 
-//Assumes a digest that comes from a snapshot - i.e. it is a directory with a single file in it
-fn digests_to_bytes(
+/// This functions assumes that the Digest in question represents the contents of a single File rather than a Directory,
+/// and will fail on Digests representing a Directory.
+fn single_file_digests_to_bytes(
   py: Python,
   scheduler_ptr: PyScheduler,
   py_digests: PyList,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -365,8 +365,8 @@ py_module_initializer!(native_engine, |py, m| {
 
   m.add(
     py,
-    "snapshot_digests_to_bytes",
-    py_fn!(py, snapshot_digests_to_bytes(a: PyScheduler, b: PyList)),
+    "snapshots_to_file_contents",
+    py_fn!(py, snapshots_to_file_contents(a: PyScheduler, b: PyList)),
   )?;
 
   m.add(
@@ -1527,7 +1527,7 @@ fn digests_to_bytes(
   })
 }
 
-fn snapshot_digests_to_bytes(
+fn snapshots_to_file_contents(
   py: Python,
   scheduler_ptr: PyScheduler,
   py_digests: PyList,
@@ -1537,7 +1537,10 @@ fn snapshot_digests_to_bytes(
     let core = scheduler.core.clone();
     let digests: Vec<Digest> = py_digests
       .iter(py)
-      .map(|item| crate::nodes::lift_digest(&item.into()))
+      .map(|item| {
+        let digest: Value = externs::getattr(&item.into(), "digest").unwrap();
+        crate::nodes::lift_digest(&digest)
+      })
       .collect::<Result<Vec<Digest>, _>>()
       .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))?;
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -573,9 +573,12 @@ impl Snapshot {
     }
   }
 
-  fn store_file_content(context: &Context, item: &FileContent) -> Result<Value, String> {
+  pub fn store_file_content(
+    types: &crate::types::Types,
+    item: &FileContent,
+  ) -> Result<Value, String> {
     Ok(externs::unsafe_call(
-      context.core.types.file_content,
+      types.file_content,
       &[
         Self::store_path(&item.path)?,
         externs::store_bytes(&item.content),
@@ -587,7 +590,7 @@ impl Snapshot {
   pub fn store_digest_contents(context: &Context, item: &[FileContent]) -> Result<Value, String> {
     let entries = item
       .iter()
-      .map(|e| Self::store_file_content(context, e))
+      .map(|e| Self::store_file_content(&context.core.types, e))
       .collect::<Result<Vec<_>, _>>()?;
     Ok(externs::unsafe_call(
       context.core.types.digest_contents,


### PR DESCRIPTION
### Problem

The `digests_to_bytes` method, used to allow the StreamingWorkunitHandler to get the raw bytes associated with a `Digest` item on a workunit, works correctly for the `stdout_digest` and `stderr_digest` items. These effectively represent nameless files whose content is the stdout and stderr stream of a process, and the `Digest`s attached to the workunit yield the bytes the user expects. 

However, `digests_to_bytes` fails for other `Digest`s provided as workunit artifacts, because these generally come from a `Snapshot` that was the output of some `@rule`. The `Digest` contained within a `Snapshot` is generally a directory containing a single named file; trying to transform this kind of `Digest` into bytes with `digests_to_bytes` fails at the `store` level and produces a Python-level error.

### Solution

This commit adds a new method on `StreamingWorkunitContext` called `snapshots_to_file_contents`. This method can convert a sequence of `Snapshot`s into a sequence of sequences of `FileContent` representing the files contained within that snapshot, which in turn contain the byte values of those files. As well, the various python code flows that pass `Digest`s around to be used on the `artifacts` method have been modified to now pass around `Snapshot`s. 

A plugin that receives streaming workunits can now use the `snapshots_to_file_contents` context method to correctly retrieve the bytes of artifacts on a workunit, which are now more-correctly represented as a `Snapshot` rather than a `Digest`. And since an artifact is now a `Snapshot`, in principle any number of discrete files can now constitute a single artifact.