### PR TITLE
Fix `test --debug` to be hermetic, but keep `run` and `repl` non-hermetic

### DIFF
--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -36,9 +36,11 @@ async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) 
     )
 
     chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
-    env = {**pex_env.environment_dict, "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)}
+    extra_env = {**pex_env.environment_dict, "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)}
 
-    return ReplRequest(digest=merged_digest, args=(repl.in_chroot(requirements_pex.name),), env=env)
+    return ReplRequest(
+        digest=merged_digest, args=(repl.in_chroot(requirements_pex.name),), extra_env=extra_env
+    )
 
 
 class IPythonRepl(ReplImplementation):
@@ -91,13 +93,13 @@ async def create_ipython_repl_request(
         args.append("--ignore-cwd")
 
     chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
-    env = {
+    extra_env = {
         **pex_env.environment_dict,
         "PEX_PATH": repl.in_chroot(requirements_pex_request.output_filename),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 
-    return ReplRequest(digest=merged_digest, args=args, env=env)
+    return ReplRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/repl.py
+++ b/src/python/pants/backend/python/rules/repl.py
@@ -1,9 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
-
 from pants.backend.python.rules.pex import Pex, PexRequest, PexRequirements
+from pants.backend.python.rules.pex_environment import PexEnvironment
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.subsystems.ipython import IPython
@@ -20,7 +19,7 @@ class PythonRepl(ReplImplementation):
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_python_repl_request(repl: PythonRepl) -> ReplRequest:
+async def create_python_repl_request(repl: PythonRepl, pex_env: PexEnvironment) -> ReplRequest:
     requirements_request = Get(
         Pex,
         PexFromTargetsRequest,
@@ -35,12 +34,11 @@ async def create_python_repl_request(repl: PythonRepl) -> ReplRequest:
     merged_digest = await Get(
         Digest, MergeDigests((requirements_pex.digest, sources.source_files.snapshot.digest))
     )
+
     chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
-    return ReplRequest(
-        digest=merged_digest,
-        args=(repl.in_chroot(requirements_pex.name),),
-        env={"PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)},
-    )
+    env = {**pex_env.environment_dict, "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)}
+
+    return ReplRequest(digest=merged_digest, args=(repl.in_chroot(requirements_pex.name),), env=env)
 
 
 class IPythonRepl(ReplImplementation):
@@ -48,7 +46,9 @@ class IPythonRepl(ReplImplementation):
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> ReplRequest:
+async def create_ipython_repl_request(
+    repl: IPythonRepl, ipython: IPython, pex_env: PexEnvironment
+) -> ReplRequest:
     # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
     # so that we can get the interpreter constraints for use in ipython_request.
     requirements_pex_request = await Get(
@@ -85,18 +85,19 @@ async def create_ipython_repl_request(repl: IPythonRepl, ipython: IPython) -> Re
             (requirements_pex.digest, sources.source_files.snapshot.digest, ipython_pex.digest)
         ),
     )
-    chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
-    args: Tuple[str, ...] = (repl.in_chroot(ipython_pex.name),)
+
+    args = [repl.in_chroot(ipython_pex.name)]
     if ipython.options.ignore_cwd:
-        args = args + ("--ignore-cwd",)
-    return ReplRequest(
-        digest=merged_digest,
-        args=args,
-        env={
-            "PEX_PATH": repl.in_chroot(requirements_pex_request.output_filename),
-            "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
-        },
-    )
+        args.append("--ignore-cwd")
+
+    chrooted_source_roots = [repl.in_chroot(sr) for sr in sources.source_roots]
+    env = {
+        **pex_env.environment_dict,
+        "PEX_PATH": repl.in_chroot(requirements_pex_request.output_filename),
+        "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
+    }
+
+    return ReplRequest(digest=merged_digest, args=args, env=env)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -90,14 +90,16 @@ async def create_python_binary_run_request(
         return os.path.join("{chroot}", relpath)
 
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
-    env = {
+    extra_env = {
         **pex_env.environment_dict,
         "PEX_PATH": in_chroot(requirements_pex_request.output_filename),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 
     return RunRequest(
-        digest=merged_digest, args=(in_chroot(runner_pex.name), "-m", entry_point), env=env
+        digest=merged_digest,
+        args=(in_chroot(runner_pex.name), "-m", entry_point),
+        extra_env=extra_env,
     )
 
 

--- a/src/python/pants/backend/python/rules/run_python_binary.py
+++ b/src/python/pants/backend/python/rules/run_python_binary.py
@@ -5,6 +5,7 @@ import os
 
 from pants.backend.python.rules.create_python_binary import PythonBinaryFieldSet
 from pants.backend.python.rules.pex import Pex, PexRequest
+from pants.backend.python.rules.pex_environment import PexEnvironment
 from pants.backend.python.rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.rules.python_sources import PythonSourceFiles, PythonSourceFilesRequest
 from pants.backend.python.target_types import PythonBinaryDefaults, PythonBinarySources
@@ -26,7 +27,9 @@ from pants.util.logging import LogLevel
 
 @rule(level=LogLevel.DEBUG)
 async def create_python_binary_run_request(
-    field_set: PythonBinaryFieldSet, python_binary_defaults: PythonBinaryDefaults
+    field_set: PythonBinaryFieldSet,
+    python_binary_defaults: PythonBinaryDefaults,
+    pex_env: PexEnvironment,
 ) -> RunRequest:
     entry_point = field_set.entry_point.value
     if entry_point is None:
@@ -87,16 +90,16 @@ async def create_python_binary_run_request(
         return os.path.join("{chroot}", relpath)
 
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
-    pex_path = in_chroot(requirements_pex_request.output_filename)
+    env = {
+        **pex_env.environment_dict,
+        "PEX_PATH": in_chroot(requirements_pex_request.output_filename),
+        "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
+    }
+
     return RunRequest(
-        digest=merged_digest,
-        args=(in_chroot(runner_pex.name), "-m", entry_point),
-        env={"PEX_PATH": pex_path, "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots)},
+        digest=merged_digest, args=(in_chroot(runner_pex.name), "-m", entry_point), env=env
     )
 
 
 def rules():
-    return [
-        *collect_rules(),
-        UnionRule(RunFieldSet, PythonBinaryFieldSet),
-    ]
+    return [*collect_rules(), UnionRule(RunFieldSet, PythonBinaryFieldSet)]

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -4,7 +4,7 @@ import os
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Dict, Mapping, Optional, Tuple, Type, cast
+from typing import ClassVar, Dict, Iterable, Mapping, Optional, Tuple, Type, cast
 
 from pants.base.build_root import BuildRoot
 from pants.engine.console import Console
@@ -72,11 +72,11 @@ class ReplRequest:
         self,
         *,
         digest: Digest,
-        args: Tuple[str, ...],
+        args: Iterable[str],
         env: Optional[Mapping[str, str]] = None,
     ) -> None:
         self.digest = digest
-        self.args = args
+        self.args = tuple(args)
         self.env = FrozenDict(env or {})
 
 
@@ -117,7 +117,9 @@ async def run_repl(
             request.digest, path_prefix=PurePath(tmpdir).relative_to(build_root.path).as_posix()
         )
         result = interactive_runner.run(
-            InteractiveProcess(argv=request.args, env=request.env, run_in_workspace=True)
+            InteractiveProcess(
+                argv=request.args, env=request.env, run_in_workspace=True, hermetic_env=False
+            )
         )
     return Repl(result.exit_code)
 

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -66,18 +66,18 @@ class Repl(Goal):
 class ReplRequest:
     digest: Digest
     args: Tuple[str, ...]
-    env: FrozenDict[str, str]
+    extra_env: FrozenDict[str, str]
 
     def __init__(
         self,
         *,
         digest: Digest,
         args: Iterable[str],
-        env: Optional[Mapping[str, str]] = None,
+        extra_env: Optional[Mapping[str, str]] = None,
     ) -> None:
         self.digest = digest
         self.args = tuple(args)
-        self.env = FrozenDict(env or {})
+        self.extra_env = FrozenDict(extra_env or {})
 
 
 @goal_rule
@@ -118,7 +118,7 @@ async def run_repl(
         )
         result = interactive_runner.run(
             InteractiveProcess(
-                argv=request.args, env=request.env, run_in_workspace=True, hermetic_env=False
+                argv=request.args, env=request.extra_env, run_in_workspace=True, hermetic_env=False
             )
         )
     return Repl(result.exit_code)

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -107,14 +107,15 @@ async def run(
 
         args = (arg.format(chroot=tmpdir) for arg in request.args)
         env = {k: v.format(chroot=tmpdir) for k, v in request.env.items()}
-
-        process = InteractiveProcess(
-            argv=(*args, *run_subsystem.args),
-            env=env,
-            run_in_workspace=True,
-        )
         try:
-            result = interactive_runner.run(process)
+            result = interactive_runner.run(
+                InteractiveProcess(
+                    argv=(*args, *run_subsystem.args),
+                    env=env,
+                    run_in_workspace=True,
+                    hermetic_env=False,
+                )
+            )
             exit_code = result.exit_code
         except Exception as e:
             console.print_stderr(f"Exception when attempting to run {field_set.address}: {e!r}")

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -33,18 +33,18 @@ class RunRequest:
     # Values in args and in env can contain the format specifier "{chroot}", which will
     # be substituted with the (absolute) chroot path.
     args: Tuple[str, ...]
-    env: FrozenDict[str, str]
+    extra_env: FrozenDict[str, str]
 
     def __init__(
         self,
         *,
         digest: Digest,
         args: Iterable[str],
-        env: Optional[Mapping[str, str]] = None,
+        extra_env: Optional[Mapping[str, str]] = None,
     ) -> None:
         self.digest = digest
         self.args = tuple(args)
-        self.env = FrozenDict(env or {})
+        self.extra_env = FrozenDict(extra_env or {})
 
 
 class RunSubsystem(GoalSubsystem):
@@ -106,12 +106,12 @@ async def run(
         )
 
         args = (arg.format(chroot=tmpdir) for arg in request.args)
-        env = {k: v.format(chroot=tmpdir) for k, v in request.env.items()}
+        extra_env = {k: v.format(chroot=tmpdir) for k, v in request.extra_env.items()}
         try:
             result = interactive_runner.run(
                 InteractiveProcess(
                     argv=(*args, *run_subsystem.args),
-                    env=env,
+                    env=extra_env,
                     run_in_workspace=True,
                     hermetic_env=False,
                 )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -13,10 +13,10 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
 )
-from pants.engine import desktop
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.console import Console
+from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
@@ -405,8 +405,7 @@ async def run_tests(
         console.print_stderr(f"{sigil} {result.address} {status}.")
 
     merged_xml_results = await Get(
-        Digest,
-        MergeDigests(result.xml_results for result in results if result.xml_results),
+        Digest, MergeDigests(result.xml_results for result in results if result.xml_results)
     )
     workspace.write_digest(merged_xml_results)
 
@@ -437,7 +436,11 @@ async def run_tests(
             coverage_report_files.extend(report_files)
 
         if coverage_report_files and test_subsystem.open_coverage:
-            desktop.ui_open(console, interactive_runner, coverage_report_files)
+            open_files = await Get(
+                OpenFiles, OpenFilesRequest(coverage_report_files, error_if_open_not_found=False)
+            )
+            for process in open_files.processes:
+                interactive_runner.run(process)
 
     return Test(exit_code)
 

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -26,6 +26,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
+from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.target import (
@@ -185,6 +186,11 @@ class TestTest(TestBase):
                     product_type=CoverageReports,
                     subject_type=CoverageDataCollection,
                     mock=mock_coverage_report_generation,
+                ),
+                MockGet(
+                    product_type=OpenFiles,
+                    subject_type=OpenFilesRequest,
+                    mock=lambda _: OpenFiles(()),
                 ),
             ],
             union_membership=union_membership,

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -1,83 +1,67 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC
+import logging
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Iterable, Iterator
+from typing import Iterable, Tuple
 
-from pants.engine.console import Console
-from pants.engine.process import InteractiveProcess, InteractiveRunner
-from pants.util.osutil import get_os_name
-from pants.util.strutil import safe_shlex_join
+from pants.engine.platform import Platform
+from pants.engine.process import BinaryPathRequest, BinaryPaths, InteractiveProcess
+from pants.engine.rules import Get, collect_rules, rule
+from pants.util.meta import frozen_after_init
+
+logger = logging.getLogger(__name__)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class OpenFilesRequest:
+    files: Tuple[PurePath, ...]
+    error_if_open_not_found: bool
+
+    def __init__(self, files: Iterable[PurePath], *, error_if_open_not_found: bool = True) -> None:
+        self.files = tuple(files)
+        self.error_if_open_not_found = error_if_open_not_found
 
 
 @dataclass(frozen=True)
-class _Opener(ABC):
-    console: Console
-    runner: InteractiveRunner
-
-    program: ClassVar[str]
-
-    def _iter_openers(self, files: Iterable[PurePath]) -> Iterator[InteractiveProcess]:
-        # N.B.: We cannot mark this method @abc.abstractmethod due to:
-        #   https://github.com/python/mypy/issues/5374
-        raise NotImplementedError()
-
-    def open(self, files: Iterable[PurePath]) -> None:
-        for request in self._iter_openers(files):
-            open_command = safe_shlex_join(request.argv)
-            try:
-                result = self.runner.run(request)
-                if result.exit_code != 0:
-                    self.console.print_stderr(
-                        f"Failed to open files for viewing using `{open_command}` - received exit "
-                        f"code {result.exit_code}."
-                    )
-            except Exception as e:
-                self.console.print_stderr(
-                    f"Failed to open files for viewing using " f"`{open_command}`: {e}"
-                )
-                self.console.print_stderr(
-                    f"Ensure {self.program} is installed on your `PATH` and " f"re-run this goal."
-                )
+class OpenFiles:
+    processes: Tuple[InteractiveProcess, ...]
 
 
-class _DarwinOpener(_Opener):
-    program = "open"
-
-    def _iter_openers(self, files: Iterable[PurePath]) -> Iterator[InteractiveProcess]:
-        yield InteractiveProcess(
-            argv=(self.program, *(str(f) for f in files)), run_in_workspace=True
+@rule
+async def find_open_program(request: OpenFilesRequest, plat: Platform) -> OpenFiles:
+    open_program_name = "open" if plat == Platform.darwin else "xdg-open"
+    open_program_paths = await Get(
+        BinaryPaths,
+        BinaryPathRequest(binary_name=open_program_name, search_path=("/bin", "/usr/bin")),
+    )
+    if not open_program_paths.first_path:
+        error = (
+            f"Could not find the program '{open_program_name}' on `/bin` or `/usr/bin`, so cannot "
+            f"open the files {sorted(request.files)}."
         )
+        if request.error_if_open_not_found:
+            raise OSError(error)
+        logger.error(error)
+        return OpenFiles(())
+
+    if plat == Platform.darwin:
+        processes = [
+            InteractiveProcess(
+                argv=(open_program_paths.first_path, *(str(f) for f in request.files)),
+                run_in_workspace=True,
+            )
+        ]
+    else:
+        processes = [
+            InteractiveProcess(argv=(open_program_paths.first_path, str(f)), run_in_workspace=True)
+            for f in request.files
+        ]
+
+    return OpenFiles(tuple(processes))
 
 
-class _LinuxOpener(_Opener):
-    program = "xdg-open"
-
-    def _iter_openers(self, files: Iterable[PurePath]) -> Iterator[InteractiveProcess]:
-        for f in files:
-            yield InteractiveProcess(argv=(self.program, str(f)), run_in_workspace=True)
-
-
-_OPENERS_BY_OSNAME = {"darwin": _DarwinOpener, "linux": _LinuxOpener}
-
-
-def ui_open(console: Console, runner: InteractiveRunner, files: Iterable[PurePath]) -> None:
-    """Opens the given files with the appropriate application for the current operating system.
-
-    Any failures to either locate an appropriate application to open the files with or else execute
-    that program are reported to the console stderr.
-    """
-    osname = get_os_name()
-    opener_type = _OPENERS_BY_OSNAME.get(osname)
-    if opener_type is None:
-        console.print_stderr(f"Could not open {' '.join(map(str, files))} for viewing.")
-        console.print_stderr(
-            f"Opening files for viewing is currently not supported for the "
-            f"{osname} operating system."
-        )
-        return
-
-    opener = opener_type(console, runner)
-    opener.open(files)
+def rules():
+    return collect_rules()

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -257,6 +257,7 @@ class InteractiveProcess:
     env: FrozenDict[str, str]
     input_digest: Digest
     run_in_workspace: bool
+    hermetic_env: bool
 
     def __init__(
         self,
@@ -265,6 +266,7 @@ class InteractiveProcess:
         env: Optional[Mapping[str, str]] = None,
         input_digest: Digest = EMPTY_DIGEST,
         run_in_workspace: bool = False,
+        hermetic_env: bool = True,
     ) -> None:
         """Request to run a subprocess in the foreground, similar to subprocess.run().
 
@@ -277,6 +279,7 @@ class InteractiveProcess:
         self.env = FrozenDict(env or {})
         self.input_digest = input_digest
         self.run_in_workspace = run_in_workspace
+        self.hermetic_env = hermetic_env
         self.__post_init__()
 
     def __post_init__(self):
@@ -285,6 +288,15 @@ class InteractiveProcess:
                 "InteractiveProcessRequest should use the Workspace API to materialize any needed "
                 "files when it runs in the workspace"
             )
+
+    @classmethod
+    def from_process(cls, process: Process, *, hermetic_env: bool = True) -> "InteractiveProcess":
+        return InteractiveProcess(
+            argv=process.argv,
+            env=process.env,
+            input_digest=process.input_digest,
+            hermetic_env=hermetic_env,
+        )
 
 
 @side_effecting

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -11,7 +11,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine import fs, process
+from pants.engine import desktop, fs, process
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
 from pants.engine.goal import Goal
@@ -241,6 +241,7 @@ class EngineInitializer:
                 *collect_rules(locals()),
                 *build_files.rules(),
                 *fs.rules(),
+                *desktop.rules(),
                 *graph.rules(),
                 *uuid.rules(),
                 *options_parsing.rules(),

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1576,10 +1576,12 @@ fn run_local_interactive_process(
             command.current_dir(tempdir.path());
           }
 
-          let env = externs::project_frozendict(&value, "env");
-          for (key, value) in env.iter() {
-            command.env(key, value);
+          let hermetic_env = externs::project_bool(&value, "hermetic_env");
+          if hermetic_env {
+            command.env_clear();
           }
+          let env = externs::project_frozendict(&value, "env");
+          command.envs(env);
 
           let mut subprocess = command.spawn().map_err(|e| format!("Error executing interactive process: {}", e.to_string()))?;
           let exit_status = subprocess.wait().map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Problem

See https://github.com/pantsbuild/pants/pull/10668 for the original implementation, which ended up getting reverted.

As pointed out there and in https://github.com/pantsbuild/pants/issues/10644, there's an argument to keeping `run` and `repl` non-hermetic, i.e. using the env for the parent `./pants` process. Neither of those goals are cached. REPL is designed for experimentation. Run's analog is `binary`; when producing a `binary` and then running it, the `binary` would end up having the env of the host platform, rather than what Pants sets.

However, we do want `test --debug` to be hermetic so that `test` and `test --debug` behave the same.

## Solution

Add the argument `hermetic_env: bool` to the `InteractiveProcess` constructor, which controls whether the env gets stripped or not. We default this to `True` as, generally, hermiticity is a good default.

`run.py` and `repl.py` ensure that `hermetic_env` is always set to False.

### Nuance: env var may be still be overridden

If the `InteractiveProcess` includes an env var that is already set in the parent process's env, then we will override the env var with Pants's value.

Tangibly, the Python implementations for `repl` and `run` will override the `$PATH` to whatever is set via `--pex-executable-search-paths`.

[ci skip-build-wheels]