### PR TITLE
avoid creating invalid input root with relative path in filename

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -350,7 +350,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     #  depend on either /bin/bash being available on the Process host.
     # TODO(#10507): Running the script directly from a shebang sometimes results in a "Text file
     #  busy" error.
-    script_path = "./script.sh"
+    script_path = "script.sh"
     script_content = dedent(
         """
         #!/usr/bin/env bash
@@ -377,7 +377,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             description=f"Searching for `{request.binary_name}` on PATH={search_path}",
             level=LogLevel.DEBUG,
             input_digest=script_digest,
-            argv=[script_path, request.binary_name],
+            argv=[f"./{script_path}", request.binary_name],
             env={"PATH": search_path},
         ),
     )


### PR DESCRIPTION
### Problem

The `find_binary` rule generates a digest where `.` is an entry in the Directory. In remote execution, this causes Buildbarn to reject the request with the following error:

```
Exception: Error from remote execution: 3-INVALID_ARGUMENT: "Failed to create input directory \".\": Invalid filename: \".\""
```

(Reported to Buildbarn as https://github.com/buildbarn/bb-remote-execution/issues/70. They noted it is probably a Pants bug.)

### Solution

Do not use a multi-component path when generating the digest.

Do use the `./script.sh` form when running in local execution because the local executor was unable to find the script without the leading `./`.

### Result

Buildbarn should accept the valid input root. I still need to test with Buildbarn (but since I am using the remote-apis-testing framework, this PR will need to land and be consumable via `PANTS_SHA` before I can actually do that).

[ci skip-build-wheels]

[ci skip-rust]
