### PR TITLE
Snapshots of single files store normalized paths.

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -139,6 +139,12 @@ impl AsRef<Path> for RelativePath {
   }
 }
 
+impl Into<PathBuf> for RelativePath {
+  fn into(self) -> PathBuf {
+    self.0
+  }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Stat {
   Link(Link),

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -303,7 +303,7 @@ impl Store {
   /// Store a digest under a given file path, returning a Snapshot
   pub async fn snapshot_of_one_file(
     &self,
-    name: PathBuf,
+    name: RelativePath,
     digest: hashing::Digest,
     is_executable: bool,
   ) -> Result<Snapshot, String> {
@@ -322,9 +322,9 @@ impl Store {
       self.clone(),
       Digester { digest },
       vec![fs::PathStat::File {
-        path: name.clone(),
+        path: name.clone().into(),
         stat: fs::File {
-          path: name,
+          path: name.into(),
           is_executable: is_executable,
         },
       }],


### PR DESCRIPTION
Previously we were not enforcing or normalizing relative paths. There
are two callers, `DownloadedFile::load_or_download` and the
`create_digest_to_digest` intrinsic. The former happens to always pass a
normalized relative path due to the parsing behavior of `Url` but the
latter did no validation or normalization taking a path string directly
via cpython. A normalized relative path is now enforced by demanding a
`RelativePath`.

[ci skip-build-wheels]
