### PR TITLE
Add support for junit xml file for mypy runs

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -237,3 +237,13 @@ class MyPyIntegrationTest(ExternalToolTestBase):
         assert len(result) == 1
         assert result[0].exit_code == 1
         assert f"{self.package}/math/add.py:5" in result[0].stdout
+
+    def test_failing_source_with_junit_xml(self) -> None:
+        target = self.make_target([self.bad_source])
+        result = self.run_mypy([target], additional_args=["--mypy-junit-xml-dir=dist"])
+        assert len(result) == 1
+        assert result[0].exit_code == 1
+        assert f"{self.package}/bad.py:4" in result[0].stdout
+        assert result[0].report is not None
+        assert result[0].report.digest.serialized_bytes_length > 0
+        assert result[0].report.path.as_posix() == "dist/mypy_junit_results.xml"

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pathlib import Path
 from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
@@ -39,6 +40,14 @@ class MyPy(PythonToolBase):
             advanced=True,
             help="Path to `mypy.ini` or alternative MyPy config file",
         )
+        register(
+            "--junit-xml-dir",
+            type=str,
+            metavar="<DIR>",
+            default=None,
+            advanced=True,
+            help="Directory for a Junit XML result document(s) with type checking results.",
+        )
 
     @property
     def skip(self) -> bool:
@@ -51,3 +60,7 @@ class MyPy(PythonToolBase):
     @property
     def config(self) -> Optional[str]:
         return cast(Optional[str], self.options.config)
+
+    @property
+    def junit_xml(self) -> Optional[Path]:
+        return Path(self.options.junit_xml_dir) if self.options.junit_xml_dir else None

--- a/src/python/pants/core/goals/typecheck_test.py
+++ b/src/python/pants/core/goals/typecheck_test.py
@@ -17,6 +17,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSourcesRequest,
 )
 from pants.engine.addresses import Address
+from pants.engine.fs import Workspace
 from pants.engine.target import FieldSet, Sources, Target, Targets
 from pants.engine.unions import UnionMembership
 from pants.testutil.rule_runner import MockConsole, MockGet, run_rule_with_mocks
@@ -117,18 +118,19 @@ class TypecheckTest(TestBase):
             address = Address.parse(":tests")
         return MockTarget({}, address=address)
 
-    @staticmethod
     def run_typecheck_rule(
+        self,
         *,
         request_types: List[Type[TypecheckRequest]],
         targets: List[Target],
         include_sources: bool = True,
     ) -> Tuple[int, str]:
         console = MockConsole(use_colors=False)
+        workspace = Workspace(self.scheduler)
         union_membership = UnionMembership({TypecheckRequest: request_types})
         result: Typecheck = run_rule_with_mocks(
             typecheck,
-            rule_args=[console, Targets(targets), union_membership],
+            rule_args=[console, Targets(targets), workspace, union_membership],
             mock_gets=[
                 MockGet(
                     product_type=TypecheckResults,


### PR DESCRIPTION
### Problem

Mypy can write reports in various formats (including code-coverage like reports), but the pants wrapper doesn't currently support any of those.

### Solution

This is the first PR, adding support for writing JUnit XML reports for mypy runs, which is something that mypy supports nativly.
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-junit-xml