### PR TITLE
Fix invalid shebang for `BinaryPaths` script

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -350,9 +350,12 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     #  depend on either /bin/bash being available on the Process host.
     # TODO(#10507): Running the script directly from a shebang sometimes results in a "Text file
     #  busy" error.
+    #
+    # Note: the backslash after the """ marker ensures that the shebang is at the start of the
+    # script file. Many OSs will not see the shebang if there is intervening whitespace.
     script_path = "./script.sh"
     script_content = dedent(
-        """
+        """\
         #!/usr/bin/env bash
 
         set -euo pipefail
@@ -363,7 +366,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             command -v $1
         fi
         """
-    ).lstrip()
+    )
     script_digest = await Get(
         Digest,
         CreateDigest([FileContent(script_path, script_content.encode(), is_executable=True)]),

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -363,7 +363,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
             command -v $1
         fi
         """
-    )
+    ).lstrip()
     script_digest = await Get(
         Digest,
         CreateDigest([FileContent(script_path, script_content.encode(), is_executable=True)]),


### PR DESCRIPTION
### Problem

The code in https://github.com/pantsbuild/pants/blob/master/src/python/pants/engine/process.py, which uses a shell script to probe where Python interpreters are located, puts a newline in front of the shebang which can error out when remote execution environments try to execute the script. Unix/Linux requires that the shebang be the very first bytes in the file.

### Solution

Strip whitespace off the front of the script. This removes the newline just after the `"""` marker.

### Result

Remote execution in Buildbarn should pass.

[ci skip-rust]

[ci skip-build-wheels]