### PR TITLE
Add `RuleRunner.get_target()`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -16,7 +16,6 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.engine.rules import QueryRule
-from pants.engine.target import WrappedTarget
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
@@ -40,7 +39,7 @@ def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, by
             "--source-root-patterns=src/python",
         ]
     )
-    target = rule_runner.request_product(WrappedTarget, [Address.parse(addr), bootstrapper]).target
+    target = rule_runner.get_target(Address.parse(addr), bootstrapper)
     created_awslambda = rule_runner.request_product(
         CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target), bootstrapper]
     )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -23,7 +23,7 @@ from pants.backend.python.target_types import (
 from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.rules import QueryRule, SubsystemRule
-from pants.engine.target import InferredDependencies, WrappedTarget
+from pants.engine.target import InferredDependencies
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
@@ -91,7 +91,7 @@ def test_infer_python_imports() -> None:
         if enable_string_imports:
             args.append("--python-infer-string-imports")
         options_bootstrapper = create_options_bootstrapper(args=args)
-        target = rule_runner.request_product(WrappedTarget, [address, options_bootstrapper]).target
+        target = rule_runner.get_target(address, options_bootstrapper)
         return rule_runner.request_product(
             InferredDependencies,
             [InferPythonDependencies(target[PythonSources]), options_bootstrapper],
@@ -152,7 +152,7 @@ def test_infer_python_inits() -> None:
     rule_runner.add_to_build_file("src/python/root/mid/leaf", "python_library()")
 
     def run_dep_inference(address: Address) -> InferredDependencies:
-        target = rule_runner.request_product(WrappedTarget, [address, options_bootstrapper]).target
+        target = rule_runner.get_target(address, options_bootstrapper)
         return rule_runner.request_product(
             InferredDependencies,
             [InferInitDependencies(target[PythonSources]), options_bootstrapper],
@@ -195,7 +195,7 @@ def test_infer_python_conftests() -> None:
     rule_runner.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
 
     def run_dep_inference(address: Address) -> InferredDependencies:
-        target = rule_runner.request_product(WrappedTarget, [address, options_bootstrapper]).target
+        target = rule_runner.get_target(address, options_bootstrapper)
         return rule_runner.request_product(
             InferredDependencies,
             [InferConftestDependencies(target[PythonSources]), options_bootstrapper],

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -15,7 +15,7 @@ from pants.core.goals.lint import LintResult, LintResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
-from pants.engine.target import Target, WrappedTarget
+from pants.engine.target import Target
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
@@ -71,13 +71,9 @@ def make_target(
             """
         ),
     )
-    return rule_runner.request_product(
-        WrappedTarget,
-        [
-            Address(package, target_name=name),
-            create_options_bootstrapper(args=GLOBAL_ARGS),
-        ],
-    ).target
+    return rule_runner.get_target(
+        Address(package, target_name=name), create_options_bootstrapper(args=GLOBAL_ARGS)
+    )
 
 
 def run_pylint(

--- a/src/python/pants/backend/python/pants_requirement_test.py
+++ b/src/python/pants/backend/python/pants_requirement_test.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import (
 from pants.base.build_environment import pants_version
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import WrappedTarget
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.frozendict import FrozenDict
@@ -36,13 +35,9 @@ def assert_pants_requirement(
     expected_module: str = "pants",
 ) -> None:
     rule_runner.add_to_build_file("3rdparty/python", f"{build_file_entry}\n")
-    target = rule_runner.request_product(
-        WrappedTarget,
-        [
-            Address("3rdparty/python", target_name=expected_target_name),
-            create_options_bootstrapper(),
-        ],
-    ).target
+    target = rule_runner.get_target(
+        Address("3rdparty/python", target_name=expected_target_name), create_options_bootstrapper()
+    )
     assert isinstance(target, PythonRequirementLibrary)
     assert target[PythonRequirementsField].value == (
         Requirement.parse(f"{expected_dist}=={pants_version()}"),

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -51,7 +51,7 @@ class PythonArtifact:
         return f"{self._name}=={self._version}"
 
     @property
-    def setup_py_keywords(self):
+    def kwargs(self):
         return self._kw
 
     @property

--- a/src/python/pants/backend/python/rules/run_setup_py.py
+++ b/src/python/pants/backend/python/rules/run_setup_py.py
@@ -62,7 +62,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership
 from pants.option.custom_types import shell_str
 from pants.python.python_setup import PythonSetup
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
@@ -177,15 +176,18 @@ class SetupPyKwargsRequest:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class SetupPyKwargs(FrozenDict):
+class SetupPyKwargs:
     """The keyword arguments to put in the setup.py file."""
 
     json_str: str
 
     def __init__(self, kwargs: Mapping[str, Any]) -> None:
         super().__init__()
-        # Note that we convert to a `str` so that this type can be hashable.
-        self.json_str = json.dumps(kwargs)
+        # We convert to a `str` so that this type can be hashable. We don't use `FrozenDict`
+        # because it would require that all values are immutable, and we may have lists and
+        # dictionaries as values. It's too difficult/clunky to convert those all, then to convert
+        # them back out of `FrozenDict`.
+        self.json_str = json.dumps(kwargs, sort_keys=True)
 
     @property
     def kwargs(self) -> Dict[str, Any]:

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import json
 import textwrap
 from typing import Iterable, Type
 
@@ -22,7 +23,6 @@ from pants.backend.python.rules.run_setup_py import (
     SetupPyChrootRequest,
     SetupPySources,
     SetupPySourcesRequest,
-    determine_setup_kwargs,
     generate_chroot,
     get_exporting_owner,
     get_owned_dependencies,
@@ -68,7 +68,6 @@ def create_setup_py_rule_runner(*, rules: Iterable) -> RuleRunner:
 def chroot_rule_runner() -> RuleRunner:
     return create_setup_py_rule_runner(
         rules=[
-            determine_setup_kwargs,
             generate_chroot,
             get_sources,
             get_requirements,
@@ -93,7 +92,7 @@ def assert_chroot(
     )
     snapshot = rule_runner.request_product(Snapshot, [chroot.digest])
     assert sorted(expected_files) == sorted(snapshot.files)
-    assert expected_setup_kwargs == chroot.setup_keywords.kwargs
+    assert expected_setup_kwargs == json.loads(chroot.setup_keywords_json)
 
 
 def assert_chroot_error(rule_runner: RuleRunner, addr: str, exc_cls: Type[Exception]) -> None:

--- a/src/python/pants/backend/python/rules/run_setup_py_test.py
+++ b/src/python/pants/backend/python/rules/run_setup_py_test.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import json
 import textwrap
 from typing import Iterable, Type
 
@@ -23,6 +22,7 @@ from pants.backend.python.rules.run_setup_py import (
     SetupPyChrootRequest,
     SetupPySources,
     SetupPySourcesRequest,
+    determine_setup_kwargs,
     generate_chroot,
     get_exporting_owner,
     get_owned_dependencies,
@@ -36,48 +36,39 @@ from pants.backend.python.target_types import (
     PythonLibrary,
     PythonRequirementLibrary,
 )
-from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.target_types import Files, Resources
-from pants.core.util_rules import source_files, stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
-from pants.engine.target import Target, Targets, WrappedTarget
+from pants.engine.target import Targets
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
-from pants.testutil.test_base import TestBase
+from pants.testutil.rule_runner import RuleRunner
 
 _namespace_decl = "__import__('pkg_resources').declare_namespace(__name__)"
 
 
-class TestSetupPyBase(TestBase):
-    @classmethod
-    def alias_groups(cls) -> BuildFileAliases:
-        return BuildFileAliases(objects={"setup_py": PythonArtifact})
-
-    @classmethod
-    def target_types(cls):
-        return [
+def create_setup_py_rule_runner(*, rules: Iterable) -> RuleRunner:
+    return RuleRunner(
+        rules=rules,
+        target_types=[
             PythonBinary,
             PythonDistribution,
             PythonLibrary,
             PythonRequirementLibrary,
             Resources,
             Files,
-        ]
-
-    def tgt(self, addr: str) -> Target:
-        return self.request_product(
-            WrappedTarget, [Address.parse(addr), create_options_bootstrapper()]
-        ).target
+        ],
+        objects={"setup_py": PythonArtifact},
+    )
 
 
-class TestGenerateChroot(TestSetupPyBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+@pytest.fixture
+def chroot_rule_runner() -> RuleRunner:
+    return create_setup_py_rule_runner(
+        rules=[
+            determine_setup_kwargs,
             generate_chroot,
             get_sources,
             get_requirements,
@@ -85,618 +76,640 @@ class TestGenerateChroot(TestSetupPyBase):
             get_exporting_owner,
             *python_sources.rules(),
             QueryRule(SetupPyChroot, (SetupPyChrootRequest, OptionsBootstrapper)),
-        )
+        ]
+    )
 
-    def assert_chroot(self, expected_files, expected_setup_kwargs, addr):
-        chroot = self.request_product(
+
+def assert_chroot(
+    rule_runner: RuleRunner, expected_files, expected_setup_kwargs, addr: str
+) -> None:
+    tgt = rule_runner.get_target(Address.parse(addr))
+    chroot = rule_runner.request_product(
+        SetupPyChroot,
+        [
+            SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
+            create_options_bootstrapper(),
+        ],
+    )
+    snapshot = rule_runner.request_product(Snapshot, [chroot.digest])
+    assert sorted(expected_files) == sorted(snapshot.files)
+    assert expected_setup_kwargs == chroot.setup_keywords.kwargs
+
+
+def assert_chroot_error(rule_runner: RuleRunner, addr: str, exc_cls: Type[Exception]) -> None:
+    tgt = rule_runner.get_target(Address.parse(addr))
+    with pytest.raises(ExecutionError) as excinfo:
+        rule_runner.request_product(
             SetupPyChroot,
             [
-                SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
+                SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
                 create_options_bootstrapper(),
             ],
         )
-        snapshot = self.request_product(Snapshot, [chroot.digest])
-        assert sorted(expected_files) == sorted(snapshot.files)
-        kwargs = json.loads(chroot.setup_keywords_json)
-        assert expected_setup_kwargs == kwargs
+    ex = excinfo.value
+    assert len(ex.wrapped_exceptions) == 1
+    assert type(ex.wrapped_exceptions[0]) == exc_cls
 
-    def assert_error(self, addr: str, exc_cls: Type[Exception]):
-        with pytest.raises(ExecutionError) as excinfo:
-            self.request_product(
-                SetupPyChroot,
-                [
-                    SetupPyChrootRequest(ExportedTarget(self.tgt(addr)), py2=False),
-                    create_options_bootstrapper(),
-                ],
-            )
-        ex = excinfo.value
-        assert len(ex.wrapped_exceptions) == 1
-        assert type(ex.wrapped_exceptions[0]) == exc_cls
 
-    def test_generate_chroot(self) -> None:
-        self.create_file(
-            "src/python/foo/bar/baz/BUILD",
-            textwrap.dedent(
-                """
-            python_distribution(
-                name="baz-dist",
-                dependencies=[':baz'],
-                provides=setup_py(
-                    name='baz',
-                    version='1.1.1'
-                )
-            )
-
-            python_library()
+def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo/bar/baz",
+        textwrap.dedent(
             """
-            ),
+        python_distribution(
+            name="baz-dist",
+            dependencies=[':baz'],
+            provides=setup_py(
+                name='baz',
+                version='1.1.1'
+            )
         )
-        self.create_file("src/python/foo/bar/baz/baz.py", "")
-        self.create_file(
-            "src/python/foo/qux/BUILD",
-            textwrap.dedent(
-                """
-                python_library()
 
-                python_binary(name="bin", entry_point="foo.qux.bin")
-                """
-            ),
-        )
-        self.create_file("src/python/foo/qux/__init__.py", "")
-        self.create_file("src/python/foo/qux/qux.py", "")
-        self.create_file("src/python/foo/resources/BUILD", 'resources(sources=["js/code.js"])')
-        self.create_file("src/python/foo/resources/js/code.js", "")
-        self.create_file("files/BUILD", 'files(sources=["README.txt"])')
-        self.create_file("files/README.txt", "")
-        self.create_file(
-            "src/python/foo/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='foo-dist',
-                    dependencies=[
-                        ':foo',
-                    ],
-                    provides=setup_py(
-                        name='foo', version='1.2.3'
-                    ).with_binaries(
-                        foo_main='src/python/foo/qux:bin'
-                    )
+        python_library()
+        """
+        ),
+    )
+    chroot_rule_runner.create_file("src/python/foo/bar/baz/baz.py", "")
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo/qux",
+        textwrap.dedent(
+            """
+            python_library()
+
+            python_binary(name="bin", entry_point="foo.qux.bin")
+            """
+        ),
+    )
+    chroot_rule_runner.create_file("src/python/foo/qux/__init__.py")
+    chroot_rule_runner.create_file("src/python/foo/qux/qux.py")
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo/resources", 'resources(sources=["js/code.js"])'
+    )
+    chroot_rule_runner.create_file("src/python/foo/resources/js/code.js")
+    chroot_rule_runner.add_to_build_file("files", 'files(sources=["README.txt"])')
+    chroot_rule_runner.create_file("files/README.txt")
+    chroot_rule_runner.add_to_build_file(
+        "src/python/foo",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='foo-dist',
+                dependencies=[
+                    ':foo',
+                ],
+                provides=setup_py(
+                    name='foo', version='1.2.3'
+                ).with_binaries(
+                    foo_main='src/python/foo/qux:bin'
                 )
+            )
 
-                python_library(
-                    dependencies=[
-                        'src/python/foo/bar/baz',
-                        'src/python/foo/qux',
-                        'src/python/foo/resources',
-                        'files',
-                    ]
-                )
-                """
-            ),
-        )
-        self.create_file("src/python/foo/__init__.py", _namespace_decl)
-        self.create_file("src/python/foo/foo.py", "")
-        self.assert_chroot(
-            [
-                "src/files/README.txt",
-                "src/foo/qux/__init__.py",
-                "src/foo/qux/qux.py",
-                "src/foo/resources/js/code.js",
-                "src/foo/__init__.py",
-                "src/foo/foo.py",
-                "setup.py",
-                "MANIFEST.in",
-            ],
-            {
-                "name": "foo",
-                "version": "1.2.3",
-                "package_dir": {"": "src"},
-                "packages": ["foo", "foo.qux"],
-                "namespace_packages": ["foo"],
-                "package_data": {"foo": ["resources/js/code.js"]},
-                "install_requires": ["baz==1.1.1"],
-                "entry_points": {"console_scripts": ["foo_main=foo.qux.bin"]},
-            },
-            "src/python/foo:foo-dist",
-        )
-
-    def test_invalid_binary(self) -> None:
-        self.create_file(
-            "src/python/invalid_binary/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='not_a_binary', sources=[])
-                python_binary(name='no_entrypoint')
-                python_distribution(
-                    name='invalid_bin1',
-                    provides=setup_py(
-                        name='invalid_bin1', version='1.1.1'
-                    ).with_binaries(foo=':not_a_binary')
-                )
-                python_distribution(
-                    name='invalid_bin2',
-                    provides=setup_py(
-                        name='invalid_bin2', version='1.1.1'
-                    ).with_binaries(foo=':no_entrypoint')
-                )
-                """
-            ),
-        )
-
-        self.assert_error("src/python/invalid_binary:invalid_bin1", InvalidEntryPoint)
-        self.assert_error("src/python/invalid_binary:invalid_bin2", InvalidEntryPoint)
+            python_library(
+                dependencies=[
+                    'src/python/foo/bar/baz',
+                    'src/python/foo/qux',
+                    'src/python/foo/resources',
+                    'files',
+                ]
+            )
+            """
+        ),
+    )
+    chroot_rule_runner.create_file("src/python/foo/__init__.py", _namespace_decl)
+    chroot_rule_runner.create_file("src/python/foo/foo.py")
+    assert_chroot(
+        chroot_rule_runner,
+        [
+            "src/files/README.txt",
+            "src/foo/qux/__init__.py",
+            "src/foo/qux/qux.py",
+            "src/foo/resources/js/code.js",
+            "src/foo/__init__.py",
+            "src/foo/foo.py",
+            "setup.py",
+            "MANIFEST.in",
+        ],
+        {
+            "name": "foo",
+            "version": "1.2.3",
+            "package_dir": {"": "src"},
+            "packages": ["foo", "foo.qux"],
+            "namespace_packages": ["foo"],
+            "package_data": {"foo": ["resources/js/code.js"]},
+            "install_requires": ["baz==1.1.1"],
+            "entry_points": {"console_scripts": ["foo_main=foo.qux.bin"]},
+        },
+        "src/python/foo:foo-dist",
+    )
 
 
-class TestGetSources(TestSetupPyBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
+    chroot_rule_runner.add_to_build_file(
+        "src/python/invalid_binary",
+        textwrap.dedent(
+            """
+            python_library(name='not_a_binary', sources=[])
+            python_binary(name='no_entrypoint')
+            python_distribution(
+                name='invalid_bin1',
+                provides=setup_py(
+                    name='invalid_bin1', version='1.1.1'
+                ).with_binaries(foo=':not_a_binary')
+            )
+            python_distribution(
+                name='invalid_bin2',
+                provides=setup_py(
+                    name='invalid_bin2', version='1.1.1'
+                ).with_binaries(foo=':no_entrypoint')
+            )
+            """
+        ),
+    )
+
+    assert_chroot_error(
+        chroot_rule_runner, "src/python/invalid_binary:invalid_bin1", InvalidEntryPoint
+    )
+    assert_chroot_error(
+        chroot_rule_runner, "src/python/invalid_binary:invalid_bin2", InvalidEntryPoint
+    )
+
+
+def test_get_sources() -> None:
+    rule_runner = create_setup_py_rule_runner(
+        rules=[
             get_sources,
-            *source_files.rules(),
-            *stripped_source_files.rules(),
             *python_sources.rules(),
             QueryRule(SetupPySources, (SetupPySourcesRequest, OptionsBootstrapper)),
-        )
+        ]
+    )
+
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar/baz",
+        textwrap.dedent(
+            """
+            python_library(name='baz1', sources=['baz1.py'])
+            python_library(name='baz2', sources=['baz2.py'])
+            """
+        ),
+    )
+    rule_runner.create_file("src/python/foo/bar/baz/baz1.py")
+    rule_runner.create_file("src/python/foo/bar/baz/baz2.py")
+    rule_runner.create_file("src/python/foo/bar/__init__.py", _namespace_decl)
+    rule_runner.add_to_build_file("src/python/foo/qux", "python_library()")
+    rule_runner.create_file("src/python/foo/qux/__init__.py")
+    rule_runner.create_file("src/python/foo/qux/qux.py")
+    rule_runner.add_to_build_file("src/python/foo/resources", 'resources(sources=["js/code.js"])')
+    rule_runner.create_file("src/python/foo/resources/js/code.js")
+    rule_runner.create_file("src/python/foo/__init__.py")
 
     def assert_sources(
-        self,
         expected_files,
         expected_packages,
         expected_namespace_packages,
         expected_package_data,
         addrs,
     ):
-        srcs = self.request_product(
+        targets = Targets(rule_runner.get_target(Address.parse(addr)) for addr in addrs)
+        srcs = rule_runner.request_product(
             SetupPySources,
-            [
-                SetupPySourcesRequest(Targets([self.tgt(addr) for addr in addrs]), py2=False),
-                create_options_bootstrapper(),
-            ],
+            [SetupPySourcesRequest(targets, py2=False), create_options_bootstrapper()],
         )
-        chroot_snapshot = self.request_product(Snapshot, [srcs.digest])
+        chroot_snapshot = rule_runner.request_product(Snapshot, [srcs.digest])
 
         assert sorted(expected_files) == sorted(chroot_snapshot.files)
         assert sorted(expected_packages) == sorted(srcs.packages)
         assert sorted(expected_namespace_packages) == sorted(srcs.namespace_packages)
         assert expected_package_data == dict(srcs.package_data)
 
-    def test_get_sources(self) -> None:
-        self.create_file(
-            "src/python/foo/bar/baz/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='baz1', sources=['baz1.py'])
-                python_library(name='baz2', sources=['baz2.py'])
-                """
-            ),
-        )
-        self.create_file("src/python/foo/bar/baz/baz1.py", "")
-        self.create_file("src/python/foo/bar/baz/baz2.py", "")
-        self.create_file("src/python/foo/bar/__init__.py", _namespace_decl)
-        self.create_file("src/python/foo/qux/BUILD", "python_library()")
-        self.create_file("src/python/foo/qux/__init__.py", "")
-        self.create_file("src/python/foo/qux/qux.py", "")
-        self.create_file("src/python/foo/resources/BUILD", 'resources(sources=["js/code.js"])')
-        self.create_file("src/python/foo/resources/js/code.js", "")
-        self.create_file("src/python/foo/__init__.py", "")
+    assert_sources(
+        expected_files=["foo/bar/baz/baz1.py", "foo/bar/__init__.py", "foo/__init__.py"],
+        expected_packages=["foo", "foo.bar", "foo.bar.baz"],
+        expected_namespace_packages=["foo.bar"],
+        expected_package_data={},
+        addrs=["src/python/foo/bar/baz:baz1"],
+    )
 
-        self.assert_sources(
-            expected_files=["foo/bar/baz/baz1.py", "foo/bar/__init__.py", "foo/__init__.py"],
-            expected_packages=["foo", "foo.bar", "foo.bar.baz"],
-            expected_namespace_packages=["foo.bar"],
-            expected_package_data={},
-            addrs=["src/python/foo/bar/baz:baz1"],
-        )
+    assert_sources(
+        expected_files=["foo/bar/baz/baz2.py", "foo/bar/__init__.py", "foo/__init__.py"],
+        expected_packages=["foo", "foo.bar", "foo.bar.baz"],
+        expected_namespace_packages=["foo.bar"],
+        expected_package_data={},
+        addrs=["src/python/foo/bar/baz:baz2"],
+    )
 
-        self.assert_sources(
-            expected_files=["foo/bar/baz/baz2.py", "foo/bar/__init__.py", "foo/__init__.py"],
-            expected_packages=["foo", "foo.bar", "foo.bar.baz"],
-            expected_namespace_packages=["foo.bar"],
-            expected_package_data={},
-            addrs=["src/python/foo/bar/baz:baz2"],
-        )
+    assert_sources(
+        expected_files=["foo/qux/qux.py", "foo/qux/__init__.py", "foo/__init__.py"],
+        expected_packages=["foo", "foo.qux"],
+        expected_namespace_packages=[],
+        expected_package_data={},
+        addrs=["src/python/foo/qux"],
+    )
 
-        self.assert_sources(
-            expected_files=["foo/qux/qux.py", "foo/qux/__init__.py", "foo/__init__.py"],
-            expected_packages=["foo", "foo.qux"],
-            expected_namespace_packages=[],
-            expected_package_data={},
-            addrs=["src/python/foo/qux"],
-        )
+    assert_sources(
+        expected_files=[
+            "foo/bar/baz/baz1.py",
+            "foo/bar/__init__.py",
+            "foo/qux/qux.py",
+            "foo/qux/__init__.py",
+            "foo/__init__.py",
+            "foo/resources/js/code.js",
+        ],
+        expected_packages=["foo", "foo.bar", "foo.bar.baz", "foo.qux"],
+        expected_namespace_packages=["foo.bar"],
+        expected_package_data={"foo": ("resources/js/code.js",)},
+        addrs=["src/python/foo/bar/baz:baz1", "src/python/foo/qux", "src/python/foo/resources"],
+    )
 
-        self.assert_sources(
-            expected_files=[
-                "foo/bar/baz/baz1.py",
-                "foo/bar/__init__.py",
-                "foo/qux/qux.py",
-                "foo/qux/__init__.py",
-                "foo/__init__.py",
-                "foo/resources/js/code.js",
-            ],
-            expected_packages=["foo", "foo.bar", "foo.bar.baz", "foo.qux"],
-            expected_namespace_packages=["foo.bar"],
-            expected_package_data={"foo": ("resources/js/code.js",)},
-            addrs=["src/python/foo/bar/baz:baz1", "src/python/foo/qux", "src/python/foo/resources"],
-        )
-
-        self.assert_sources(
-            expected_files=[
-                "foo/bar/baz/baz1.py",
-                "foo/bar/baz/baz2.py",
-                "foo/bar/__init__.py",
-                "foo/qux/qux.py",
-                "foo/qux/__init__.py",
-                "foo/__init__.py",
-                "foo/resources/js/code.js",
-            ],
-            expected_packages=["foo", "foo.bar", "foo.bar.baz", "foo.qux"],
-            expected_namespace_packages=["foo.bar"],
-            expected_package_data={"foo": ("resources/js/code.js",)},
-            addrs=[
-                "src/python/foo/bar/baz:baz1",
-                "src/python/foo/bar/baz:baz2",
-                "src/python/foo/qux",
-                "src/python/foo/resources",
-            ],
-        )
+    assert_sources(
+        expected_files=[
+            "foo/bar/baz/baz1.py",
+            "foo/bar/baz/baz2.py",
+            "foo/bar/__init__.py",
+            "foo/qux/qux.py",
+            "foo/qux/__init__.py",
+            "foo/__init__.py",
+            "foo/resources/js/code.js",
+        ],
+        expected_packages=["foo", "foo.bar", "foo.bar.baz", "foo.qux"],
+        expected_namespace_packages=["foo.bar"],
+        expected_package_data={"foo": ("resources/js/code.js",)},
+        addrs=[
+            "src/python/foo/bar/baz:baz1",
+            "src/python/foo/bar/baz:baz2",
+            "src/python/foo/qux",
+            "src/python/foo/resources",
+        ],
+    )
 
 
-class TestGetRequirements(TestSetupPyBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+def test_get_requirements() -> None:
+    rule_runner = create_setup_py_rule_runner(
+        rules=[
             get_requirements,
             get_owned_dependencies,
             get_exporting_owner,
             QueryRule(ExportedTargetRequirements, (DependencyOwner, OptionsBootstrapper)),
-        )
+        ]
+    )
+    rule_runner.add_to_build_file(
+        "3rdparty",
+        textwrap.dedent(
+            """
+            python_requirement_library(
+                name='ext1',
+                requirements=['ext1==1.22.333'],
+            )
+            python_requirement_library(
+                name='ext2',
+                requirements=['ext2==4.5.6'],
+            )
+            python_requirement_library(
+                name='ext3',
+                requirements=['ext3==0.0.1'],
+            )
+            """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar/baz",
+        "python_library(dependencies=['3rdparty:ext1'], sources=[])",
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar/qux",
+        "python_library(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'], sources=[])",
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='bar-dist',
+                dependencies=[':bar'],
+                provides=setup_py(name='bar', version='9.8.7'),
+            )
 
-    def assert_requirements(self, expected_req_strs, addr):
-        reqs = self.request_product(
+            python_library(
+                sources=[],
+                dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
+            )
+          """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/corge",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='corge-dist',
+                # Tests having a 3rdparty requirement directly on a python_distribution.
+                dependencies=[':corge', '3rdparty:ext3'],
+                provides=setup_py(name='corge', version='2.2.2'),
+            )
+
+            python_library(
+                sources=[],
+                dependencies=['src/python/foo/bar'],
+            )
+            """
+        ),
+    )
+
+    def assert_requirements(expected_req_strs, addr):
+        tgt = rule_runner.get_target(Address.parse(addr))
+        reqs = rule_runner.request_product(
             ExportedTargetRequirements,
-            [DependencyOwner(ExportedTarget(self.tgt(addr))), create_options_bootstrapper()],
+            [DependencyOwner(ExportedTarget(tgt)), create_options_bootstrapper()],
         )
         assert sorted(expected_req_strs) == list(reqs)
 
-    def test_get_requirements(self) -> None:
-        self.create_file(
-            "3rdparty/BUILD",
-            textwrap.dedent(
-                """
-                python_requirement_library(
-                    name='ext1',
-                    requirements=['ext1==1.22.333'],
-                )
-                python_requirement_library(
-                    name='ext2',
-                    requirements=['ext2==4.5.6'],
-                )
-                python_requirement_library(
-                    name='ext3',
-                    requirements=['ext3==0.0.1'],
-                )
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/bar/baz/BUILD",
-            "python_library(dependencies=['3rdparty:ext1'], sources=[])",
-        )
-        self.create_file(
-            "src/python/foo/bar/qux/BUILD",
-            "python_library(dependencies=['3rdparty:ext2', 'src/python/foo/bar/baz'], sources=[])",
-        )
-        self.create_file(
-            "src/python/foo/bar/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='bar-dist',
-                    dependencies=[':bar'],
-                    provides=setup_py(name='bar', version='9.8.7'),
-                )
-
-                python_library(
-                    sources=[],
-                    dependencies=['src/python/foo/bar/baz', 'src/python/foo/bar/qux'],
-                )
-              """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/corge/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='corge-dist',
-                    # Tests having a 3rdparty requirement directly on a python_distribution.
-                    dependencies=[':corge', '3rdparty:ext3'],
-                    provides=setup_py(name='corge', version='2.2.2'),
-                )
-
-                python_library(
-                    sources=[],
-                    dependencies=['src/python/foo/bar'],
-                )
-                """
-            ),
-        )
-
-        self.assert_requirements(["ext1==1.22.333", "ext2==4.5.6"], "src/python/foo/bar:bar-dist")
-        self.assert_requirements(["ext3==0.0.1", "bar==9.8.7"], "src/python/foo/corge:corge-dist")
+    assert_requirements(["ext1==1.22.333", "ext2==4.5.6"], "src/python/foo/bar:bar-dist")
+    assert_requirements(["ext3==0.0.1", "bar==9.8.7"], "src/python/foo/corge:corge-dist")
 
 
-class TestGetOwnedDependencies(TestSetupPyBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+def test_owned_dependencies() -> None:
+    rule_runner = create_setup_py_rule_runner(
+        rules=[
             get_owned_dependencies,
             get_exporting_owner,
             QueryRule(OwnedDependencies, (DependencyOwner, OptionsBootstrapper)),
-        )
+        ]
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar/baz",
+        textwrap.dedent(
+            """
+            python_library(name='baz1', sources=[])
+            python_library(name='baz2', sources=[])
+            """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo/bar",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='bar1-dist',
+                dependencies=[':bar1'],
+                provides=setup_py(name='bar1', version='1.1.1'),
+            )
 
-    def assert_owned(self, owned: Iterable[str], exported: str):
+            python_library(
+                name='bar1',
+                sources=[],
+                dependencies=['src/python/foo/bar/baz:baz1'],
+            )
+
+            python_library(
+                name='bar2',
+                sources=[],
+                dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
+            )
+            resources(name='bar-resources', sources=[])
+            """
+        ),
+    )
+    rule_runner.add_to_build_file(
+        "src/python/foo",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='foo-dist',
+                dependencies=[':foo'],
+                provides=setup_py(name='foo', version='3.4.5'),
+            )
+
+            python_library(
+                sources=[],
+                dependencies=['src/python/foo/bar:bar1', 'src/python/foo/bar:bar2'],
+            )
+            """
+        ),
+    )
+
+    def assert_owned(owned: Iterable[str], exported: str):
+        tgt = rule_runner.get_target(Address.parse(exported))
         assert sorted(owned) == sorted(
             od.target.address.spec
-            for od in self.request_product(
+            for od in rule_runner.request_product(
                 OwnedDependencies,
                 [
-                    DependencyOwner(ExportedTarget(self.tgt(exported))),
+                    DependencyOwner(ExportedTarget(tgt)),
                     create_options_bootstrapper(),
                 ],
             )
         )
 
-    def test_owned_dependencies(self) -> None:
-        self.create_file(
-            "src/python/foo/bar/baz/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='baz1', sources=[])
-                python_library(name='baz2', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/bar/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='bar1-dist',
-                    dependencies=[':bar1'],
-                    provides=setup_py(name='bar1', version='1.1.1'),
-                )
-
-                python_library(
-                    name='bar1',
-                    sources=[],
-                    dependencies=['src/python/foo/bar/baz:baz1'],
-                )
-
-                python_library(
-                    name='bar2',
-                    sources=[],
-                    dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
-                )
-                resources(name='bar-resources', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='foo-dist',
-                    dependencies=[':foo'],
-                    provides=setup_py(name='foo', version='3.4.5'),
-                )
-
-                python_library(
-                    sources=[],
-                    dependencies=['src/python/foo/bar:bar1', 'src/python/foo/bar:bar2'],
-                )
-                """
-            ),
-        )
-
-        self.assert_owned(
-            [
-                "src/python/foo/bar:bar1",
-                "src/python/foo/bar:bar1-dist",
-                "src/python/foo/bar/baz:baz1",
-            ],
-            "src/python/foo/bar:bar1-dist",
-        )
-        self.assert_owned(
-            [
-                "src/python/foo",
-                "src/python/foo:foo-dist",
-                "src/python/foo/bar:bar2",
-                "src/python/foo/bar:bar-resources",
-                "src/python/foo/bar/baz:baz2",
-            ],
+    assert_owned(
+        ["src/python/foo/bar:bar1", "src/python/foo/bar:bar1-dist", "src/python/foo/bar/baz:baz1"],
+        "src/python/foo/bar:bar1-dist",
+    )
+    assert_owned(
+        [
+            "src/python/foo",
             "src/python/foo:foo-dist",
-        )
+            "src/python/foo/bar:bar2",
+            "src/python/foo/bar:bar-resources",
+            "src/python/foo/bar/baz:baz2",
+        ],
+        "src/python/foo:foo-dist",
+    )
 
 
-class TestGetExportingOwner(TestSetupPyBase):
-    @classmethod
-    def rules(cls):
-        return (
-            *super().rules(),
+@pytest.fixture
+def exporting_owner_rule_runner() -> RuleRunner:
+    return create_setup_py_rule_runner(
+        rules=[
             get_exporting_owner,
             QueryRule(ExportedTarget, (OwnedDependency, OptionsBootstrapper)),
-        )
+        ]
+    )
 
-    def assert_is_owner(self, owner: str, owned: str):
-        assert (
-            owner
-            == self.request_product(
-                ExportedTarget,
-                [OwnedDependency(self.tgt(owned)), create_options_bootstrapper()],
-            ).target.address.spec
-        )
 
-    def assert_error(self, owned: str, exc_cls: Type[Exception]):
-        with pytest.raises(ExecutionError) as excinfo:
-            self.request_product(
-                ExportedTarget,
-                [OwnedDependency(self.tgt(owned)), create_options_bootstrapper()],
+def assert_is_owner(rule_runner: RuleRunner, owner: str, owned: str):
+    tgt = rule_runner.get_target(Address.parse(owned))
+    assert (
+        owner
+        == rule_runner.request_product(
+            ExportedTarget,
+            [OwnedDependency(tgt), create_options_bootstrapper()],
+        ).target.address.spec
+    )
+
+
+def assert_owner_error(rule_runner, owned: str, exc_cls: Type[Exception]):
+    tgt = rule_runner.get_target(Address.parse(owned))
+    with pytest.raises(ExecutionError) as excinfo:
+        rule_runner.request_product(
+            ExportedTarget,
+            [OwnedDependency(tgt), create_options_bootstrapper()],
+        )
+    ex = excinfo.value
+    assert len(ex.wrapped_exceptions) == 1
+    assert type(ex.wrapped_exceptions[0]) == exc_cls
+
+
+def assert_no_owner(rule_runner: RuleRunner, owned: str):
+    assert_owner_error(rule_runner, owned, NoOwnerError)
+
+
+def assert_ambiguous_owner(rule_runner: RuleRunner, owned: str):
+    assert_owner_error(rule_runner, owned, AmbiguousOwnerError)
+
+
+def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/foo/bar/baz",
+        textwrap.dedent(
+            """
+            python_library(name='baz1', sources=[])
+            python_library(name='baz2', sources=[])
+            """
+        ),
+    )
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/foo/bar",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='bar1',
+                dependencies=['src/python/foo/bar/baz:baz1'],
+                provides=setup_py(name='bar1', version='1.1.1'),
             )
-        ex = excinfo.value
-        assert len(ex.wrapped_exceptions) == 1
-        assert type(ex.wrapped_exceptions[0]) == exc_cls
+            python_library(
+                name='bar2',
+                sources=[],
+                dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
+            )
+            resources(name='bar-resources', sources=[])
+            """
+        ),
+    )
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/foo",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='foo1',
+                dependencies=['src/python/foo/bar/baz:baz2'],
+                provides=setup_py(name='foo1', version='0.1.2'),
+            )
+            python_library(name='foo2', sources=[])
+            python_distribution(
+                name='foo3',
+                dependencies=['src/python/foo/bar:bar2'],
+                provides=setup_py(name='foo3', version='3.4.5'),
+            )
+            """
+        ),
+    )
 
-    def assert_no_owner(self, owned: str):
-        self.assert_error(owned, NoOwnerError)
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/foo/bar:bar1", "src/python/foo/bar:bar1"
+    )
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/foo/bar:bar1", "src/python/foo/bar/baz:baz1"
+    )
 
-    def assert_ambiguous_owner(self, owned: str):
-        self.assert_error(owned, AmbiguousOwnerError)
+    assert_is_owner(exporting_owner_rule_runner, "src/python/foo:foo1", "src/python/foo:foo1")
 
-    def test_get_owner_simple(self) -> None:
-        self.create_file(
-            "src/python/foo/bar/baz/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='baz1', sources=[])
-                python_library(name='baz2', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/bar/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='bar1',
-                    dependencies=['src/python/foo/bar/baz:baz1'],
-                    provides=setup_py(name='bar1', version='1.1.1'),
-                )
-                python_library(
-                    name='bar2',
-                    sources=[],
-                    dependencies=[':bar-resources', 'src/python/foo/bar/baz:baz2'],
-                )
-                resources(name='bar-resources', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/foo/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='foo1',
-                    dependencies=['src/python/foo/bar/baz:baz2'],
-                    provides=setup_py(name='foo1', version='0.1.2'),
-                )
-                python_library(name='foo2', sources=[])
-                python_distribution(
-                    name='foo3',
-                    dependencies=['src/python/foo/bar:bar2'],
-                    provides=setup_py(name='foo3', version='3.4.5'),
-                )
-                """
-            ),
-        )
+    assert_is_owner(exporting_owner_rule_runner, "src/python/foo:foo3", "src/python/foo:foo3")
+    assert_is_owner(exporting_owner_rule_runner, "src/python/foo:foo3", "src/python/foo/bar:bar2")
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/foo:foo3", "src/python/foo/bar:bar-resources"
+    )
 
-        self.assert_is_owner("src/python/foo/bar:bar1", "src/python/foo/bar:bar1")
-        self.assert_is_owner("src/python/foo/bar:bar1", "src/python/foo/bar/baz:baz1")
+    assert_no_owner(exporting_owner_rule_runner, "src/python/foo:foo2")
+    assert_ambiguous_owner(exporting_owner_rule_runner, "src/python/foo/bar/baz:baz2")
 
-        self.assert_is_owner("src/python/foo:foo1", "src/python/foo:foo1")
 
-        self.assert_is_owner("src/python/foo:foo3", "src/python/foo:foo3")
-        self.assert_is_owner("src/python/foo:foo3", "src/python/foo/bar:bar2")
-        self.assert_is_owner("src/python/foo:foo3", "src/python/foo/bar:bar-resources")
+def test_get_owner_siblings(exporting_owner_rule_runner: RuleRunner) -> None:
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/siblings",
+        textwrap.dedent(
+            """
+            python_library(name='sibling1', sources=[])
+            python_distribution(
+                name='sibling2',
+                dependencies=['src/python/siblings:sibling1'],
+                provides=setup_py(name='siblings', version='2.2.2'),
+            )
+            """
+        ),
+    )
 
-        self.assert_no_owner("src/python/foo:foo2")
-        self.assert_ambiguous_owner("src/python/foo/bar/baz:baz2")
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/siblings:sibling2", "src/python/siblings:sibling1"
+    )
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/siblings:sibling2", "src/python/siblings:sibling2"
+    )
 
-    def test_get_owner_siblings(self) -> None:
-        self.create_file(
-            "src/python/siblings/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='sibling1', sources=[])
-                python_distribution(
-                    name='sibling2',
-                    dependencies=['src/python/siblings:sibling1'],
-                    provides=setup_py(name='siblings', version='2.2.2'),
-                )
-                """
-            ),
-        )
 
-        self.assert_is_owner("src/python/siblings:sibling2", "src/python/siblings:sibling1")
-        self.assert_is_owner("src/python/siblings:sibling2", "src/python/siblings:sibling2")
+def test_get_owner_not_an_ancestor(exporting_owner_rule_runner: RuleRunner) -> None:
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/notanancestor/aaa",
+        textwrap.dedent(
+            """
+            python_library(name='aaa', sources=[])
+            """
+        ),
+    )
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/notanancestor/bbb",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='bbb',
+                dependencies=['src/python/notanancestor/aaa'],
+                provides=setup_py(name='bbb', version='11.22.33'),
+            )
+            """
+        ),
+    )
 
-    def test_get_owner_not_an_ancestor(self) -> None:
-        self.create_file(
-            "src/python/notanancestor/aaa/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='aaa', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/notanancestor/bbb/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='bbb',
-                    dependencies=['src/python/notanancestor/aaa'],
-                    provides=setup_py(name='bbb', version='11.22.33'),
-                )
-                """
-            ),
-        )
+    assert_no_owner(exporting_owner_rule_runner, "src/python/notanancestor/aaa")
+    assert_is_owner(
+        exporting_owner_rule_runner, "src/python/notanancestor/bbb", "src/python/notanancestor/bbb"
+    )
 
-        self.assert_no_owner("src/python/notanancestor/aaa")
-        self.assert_is_owner("src/python/notanancestor/bbb", "src/python/notanancestor/bbb")
 
-    def test_get_owner_multiple_ancestor_generations(self) -> None:
-        self.create_file(
-            "src/python/aaa/bbb/ccc/BUILD",
-            textwrap.dedent(
-                """
-                python_library(name='ccc', sources=[])
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/aaa/bbb/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='bbb',
-                    dependencies=['src/python/aaa/bbb/ccc'],
-                    provides=setup_py(name='bbb', version='1.1.1'),
-                )
-                """
-            ),
-        )
-        self.create_file(
-            "src/python/aaa/BUILD",
-            textwrap.dedent(
-                """
-                python_distribution(
-                    name='aaa',
-                    dependencies=['src/python/aaa/bbb/ccc'],
-                    provides=setup_py(name='aaa', version='2.2.2'),
-                )
-                """
-            ),
-        )
+def test_get_owner_multiple_ancestor_generations(exporting_owner_rule_runner: RuleRunner) -> None:
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/aaa/bbb/ccc",
+        textwrap.dedent(
+            """
+            python_library(name='ccc', sources=[])
+            """
+        ),
+    )
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/aaa/bbb",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='bbb',
+                dependencies=['src/python/aaa/bbb/ccc'],
+                provides=setup_py(name='bbb', version='1.1.1'),
+            )
+            """
+        ),
+    )
+    exporting_owner_rule_runner.add_to_build_file(
+        "src/python/aaa",
+        textwrap.dedent(
+            """
+            python_distribution(
+                name='aaa',
+                dependencies=['src/python/aaa/bbb/ccc'],
+                provides=setup_py(name='aaa', version='2.2.2'),
+            )
+            """
+        ),
+    )
 
-        self.assert_is_owner("src/python/aaa/bbb", "src/python/aaa/bbb/ccc")
-        self.assert_is_owner("src/python/aaa/bbb", "src/python/aaa/bbb")
-        self.assert_is_owner("src/python/aaa", "src/python/aaa")
+    assert_is_owner(exporting_owner_rule_runner, "src/python/aaa/bbb", "src/python/aaa/bbb/ccc")
+    assert_is_owner(exporting_owner_rule_runner, "src/python/aaa/bbb", "src/python/aaa/bbb")
+    assert_is_owner(exporting_owner_rule_runner, "src/python/aaa", "src/python/aaa")
 
 
 def test_validate_args() -> None:

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -15,7 +15,7 @@ from pants.core.goals.typecheck import TypecheckResult, TypecheckResults
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
-from pants.engine.target import Target, WrappedTarget
+from pants.engine.target import Target
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
@@ -98,13 +98,9 @@ def make_target(
             """
         ),
     )
-    return rule_runner.request_product(
-        WrappedTarget,
-        [
-            Address(package, target_name=name),
-            create_options_bootstrapper(args=GLOBAL_ARGS),
-        ],
-    ).target
+    return rule_runner.get_target(
+        Address(package, target_name=name), create_options_bootstrapper(args=GLOBAL_ARGS)
+    )
 
 
 def run_mypy(

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -115,9 +115,9 @@ def test_transitive_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     bootstrapper = create_options_bootstrapper()
 
     def get_target(name: str) -> Target:
-        return transitive_targets_rule_runner.request_product(
-            WrappedTarget, [Address("", target_name=name), bootstrapper]
-        ).target
+        return transitive_targets_rule_runner.get_target(
+            Address("", target_name=name), bootstrapper
+        )
 
     t1 = get_target("t1")
     t2 = get_target("t2")
@@ -156,9 +156,9 @@ def test_transitive_targets_transitive_exclude(transitive_targets_rule_runner: R
     bootstrapper = create_options_bootstrapper()
 
     def get_target(name: str) -> Target:
-        return transitive_targets_rule_runner.request_product(
-            WrappedTarget, [Address("", target_name=name), bootstrapper]
-        ).target
+        return transitive_targets_rule_runner.get_target(
+            Address("", target_name=name), bootstrapper
+        )
 
     base = get_target("base")
     intermediate = get_target("intermediate")
@@ -322,9 +322,9 @@ def test_resolve_generated_subtarget() -> None:
     rule_runner = RuleRunner(target_types=[MockTarget])
     rule_runner.add_to_build_file("demo", "target(sources=['f1.txt', 'f2.txt'])")
     generated_target_address = Address("demo", relative_file_path="f1.txt", target_name="demo")
-    generated_target = rule_runner.request_product(
-        WrappedTarget, [generated_target_address, create_options_bootstrapper()]
-    ).target
+    generated_target = rule_runner.get_target(
+        generated_target_address, create_options_bootstrapper()
+    )
     assert generated_target == MockTarget(
         {Sources.alias: ["f1.txt"]}, address=generated_target_address
     )
@@ -1166,7 +1166,7 @@ def assert_dependencies_resolved(
     expected: Iterable[Address],
 ) -> None:
     bootstrapper = create_options_bootstrapper()
-    target = rule_runner.request_product(WrappedTarget, [requested_address, bootstrapper]).target
+    target = rule_runner.get_target(requested_address, bootstrapper)
     result = rule_runner.request_product(
         Addresses,
         [DependenciesRequest(target[Dependencies]), bootstrapper],

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -261,6 +261,18 @@ class RuleRunner:
         """
         return self.make_snapshot({fp: "" for fp in files})
 
+    def get_target(
+        self, address: Address, options_bootstrapper: Optional[OptionsBootstrapper] = None
+    ) -> Target:
+        """Find the target for a given address.
+
+        This requires that the target actually exists, i.e. that you called
+        `rule_runner.add_to_build_file()`.
+        """
+        return self.request_product(
+            WrappedTarget, [address, options_bootstrapper or create_options_bootstrapper()]
+        ).target
+
 
 # -----------------------------------------------------------------------------------------------
 # `run_rule_with_mocks()`


### PR DESCRIPTION
We often request a target in tests for some address. This is common enough to be worth factoring up.

We also port `run_setup_py_test.py` to use Pytest style, and to use this new util. In addition, we make some small improvements to `run_setup_py.py`. This is prework for https://github.com/pantsbuild/pants/issues/10633.