### PR TITLE
Support adding arbitrary env vars to test processes

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -324,7 +324,7 @@ class TestSubsystem(GoalSubsystem):
             member_type=str,
             default=[],
             help="Specify a list additional environment variables to include in test processes. Entries are strings "
-            "in the form `ENV_VAR=value` to use explicitly; or just `ENV_VAR` to copy the value of a variable in Pants' "
+            "in the form `ENV_VAR=value` to use explicitly; or just `ENV_VAR` to copy the value of a variable in Pants's "
             "own environment. `value` may be a string with spaces in it such as `ENV_VAR=has some spaces`. `ENV_VAR=` sets "
             "a variable to be the empty string.",
         )

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -27,6 +27,7 @@ from pants.core.util_rules.filter_empty_sources import (
     FieldSetsWithSources,
     FieldSetsWithSourcesRequest,
 )
+from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests, Workspace
@@ -121,9 +122,11 @@ def run_test_rule(
         debug=debug,
         use_coverage=use_coverage,
         output=output,
+        extra_env_vars=[],
     )
     interactive_runner = InteractiveRunner(rule_runner.scheduler)
     workspace = Workspace(rule_runner.scheduler)
+    pants_environment = PantsEnvironment()
     union_membership = UnionMembership(
         {TestFieldSet: [field_set], CoverageDataCollection: [MockCoverageDataCollection]}
     )
@@ -158,7 +161,14 @@ def run_test_rule(
 
     result: Test = run_rule_with_mocks(
         run_tests,
-        rule_args=[console, test_subsystem, interactive_runner, workspace, union_membership],
+        rule_args=[
+            console,
+            test_subsystem,
+            interactive_runner,
+            workspace,
+            union_membership,
+            pants_environment,
+        ],
         mock_gets=[
             MockGet(
                 product_type=TargetsToValidFieldSets,

--- a/src/python/pants/core/util_rules/pants_environment.py
+++ b/src/python/pants/core/util_rules/pants_environment.py
@@ -13,6 +13,9 @@ from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
 
+name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
+shorthand_re = re.compile(r"([A-Za-z_]\w*)")
+
 
 @side_effecting
 @frozen_after_init
@@ -27,9 +30,6 @@ class PantsEnvironment:
     the environment rules down to only the ones other rules care about as inputs, in order to avoid
     a lot of cache invalidation if the environment changes spuriously.
     """
-
-    name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
-    shorthand_re = re.compile(r"([A-Za-z_]\w*)")
 
     env: FrozenDict[str, str]
 
@@ -49,10 +49,10 @@ class PantsEnvironment:
         env_var_subset: Dict[str, Optional[str]] = {}
 
         for env_var in requested:
-            name_value_match = self.name_value_re.match(env_var)
+            name_value_match = name_value_re.match(env_var)
             if name_value_match:
                 env_var_subset[name_value_match[1]] = name_value_match[2]
-            elif self.shorthand_re.match(env_var):
+            elif shorthand_re.match(env_var):
                 env_var_subset[env_var] = self.env.get(env_var)
             else:
                 raise ValueError(

--- a/src/python/pants/core/util_rules/pants_environment.py
+++ b/src/python/pants/core/util_rules/pants_environment.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, Sequence
+
+from pants.engine.rules import side_effecting
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+
+logger = logging.getLogger(__name__)
+
+
+@side_effecting
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class PantsEnvironment:
+    """PantsEnvironment is a representation of the environment variables the currently-executing
+    pants process was invoked with.
+
+    Since the exact contents of the environment are very specific to a given invocation of pants,
+    this type is marked as side-effecting, and can only be requested as an input to an uncacheable
+    rule. An uncacheable rule should accept this type as an input, and use `get_subset` to filter
+    the environment rules down to only the ones other rules care about as inputs, in order to avoid
+    a lot of cache invalidation if the environment changes spuriously.
+    """
+
+    env: FrozenDict[str, str]
+
+    def __init__(self, env: Optional[Mapping[str, str]] = None):
+        """Initialize a `PantsEnvironment` with the current contents of the environment.
+
+        Explicitly specify the env argument to create a mock environment for testing.
+        """
+
+        self.env = FrozenDict(env if env else dict(os.environ))
+
+    def get_subset(self, requested: Sequence[str]) -> FrozenDict[str, Optional[str]]:
+        """Given a list of extra environment variable specifiers as strings, filter the contents of
+        the pants environment to only the variables that were specified as a pants configuration
+        option."""
+
+        name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
+        shorthand_re = re.compile(r"([A-Za-z_]\w*)")
+
+        env_var_subset: Dict[str, Optional[str]] = {}
+
+        for env_var in requested:
+            logger.warning(f"ENV_VAR: {env_var}")
+            name_value_match = name_value_re.match(env_var)
+            if name_value_match:
+                env_var_subset[name_value_match[1]] = name_value_match[2]
+            elif shorthand_re.match(env_var):
+                env_var_subset[env_var] = self.env.get(env_var)
+            else:
+                logger.warning(f"Invalid extra env var: {env_var}, skipping")
+
+        return FrozenDict(env_var_subset)

--- a/src/python/pants/core/util_rules/pants_environment_test.py
+++ b/src/python/pants/core/util_rules/pants_environment_test.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Dict, List
+
+import pytest
+
+from pants.core.util_rules.pants_environment import PantsEnvironment
+
+
+@pytest.mark.parametrize(
+    "input_strs, expected",
+    [
+        # Test explicit variable and variable read from Pants' enivronment.
+        (["A=unrelated", "B"], {"A": "unrelated", "B": "b"}),
+        # Test multi-word string.
+        (["A=unrelated", "C=multi word"], {"A": "unrelated", "C": "multi word"}),
+        # Test emtpy string.
+        (["A="], {"A": ""}),
+        # Test string with " literal.
+        (['A=has a " in it'], {"A": 'has a " in it'}),
+        # An invalid variable name should be skipped.
+        (["3INVALID=doesn't matter"], {}),
+    ],
+)
+def test_pants_environment(input_strs: List[str], expected: Dict[str, str]) -> None:
+    pants_env = PantsEnvironment({"A": "a", "B": "b", "C": "c"})
+
+    subset = pants_env.get_subset(input_strs)
+    assert dict(subset) == expected

--- a/src/python/pants/core/util_rules/pants_environment_test.py
+++ b/src/python/pants/core/util_rules/pants_environment_test.py
@@ -19,8 +19,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
         (["A="], {"A": ""}),
         # Test string with " literal.
         (['A=has a " in it'], {"A": 'has a " in it'}),
-        # An invalid variable name should be skipped.
-        (["3INVALID=doesn't matter"], {}),
     ],
 )
 def test_pants_environment(input_strs: List[str], expected: Dict[str, str]) -> None:
@@ -28,3 +26,14 @@ def test_pants_environment(input_strs: List[str], expected: Dict[str, str]) -> N
 
     subset = pants_env.get_subset(input_strs)
     assert dict(subset) == expected
+
+
+def test_invalid_variable() -> None:
+    pants_env = PantsEnvironment()
+
+    with pytest.raises(ValueError) as exc:
+        pants_env.get_subset(["3INVALID=doesn't matter"])
+    assert (
+        "An invalid variable was requested via the --test-extra-env-var mechanism: 3INVALID"
+        in str(exc)
+    )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -11,6 +11,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
 from pants.build_graph.build_configuration import BuildConfiguration
+from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine import desktop, fs, process
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
@@ -70,6 +71,7 @@ class GraphSession:
         InteractiveRunner,
         OptionsBootstrapper,
         Workspace,
+        PantsEnvironment,
     )
 
     def goal_consumed_subsystem_scopes(self, goal_name: str) -> Tuple[str, ...]:
@@ -110,6 +112,7 @@ class GraphSession:
 
         workspace = Workspace(self.scheduler_session)
         interactive_runner = InteractiveRunner(self.scheduler_session)
+        pants_environment = PantsEnvironment()
 
         for goal in goals:
             goal_product = self.goal_map[goal]
@@ -123,7 +126,12 @@ class GraphSession:
                 continue
             # NB: Keep this in sync with the property `goal_param_types`.
             params = Params(
-                specs, options_bootstrapper, self.console, workspace, interactive_runner
+                specs,
+                options_bootstrapper,
+                self.console,
+                workspace,
+                interactive_runner,
+                pants_environment,
             )
             logger.debug(f"requesting {goal_product} to satisfy execution of `{goal}` goal")
             try:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -27,6 +27,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
@@ -174,6 +175,7 @@ class RuleRunner:
                 options_bootstrapper,
                 Workspace(self.scheduler),
                 InteractiveRunner(self.scheduler),
+                PantsEnvironment(),
             ),
         )
 

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -28,6 +28,7 @@ from pants.base.deprecated import warn_or_error
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
@@ -139,6 +140,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
                 options_bootstrapper,
                 Workspace(self.scheduler),
                 InteractiveRunner(self.scheduler),
+                PantsEnvironment(),
             ),
         )
 


### PR DESCRIPTION
### Problem

cf. https://github.com/pantsbuild/pants/issues/10644 , we would like to be able to specify additional environment variables that can be made available to test processes, both explicitly specified and with a "shorthand" option that can read the value of an environment variable from Pants' own execution environment. 

### Solution

This commit introduces a new type `PantsEnvironment` that contains a copy of the environment variables a pants process was invoked with. Since this type contains an exact copy of the environment, we expect that its values might change spuriously, so we cannot use it directly as the input to rules without risking frequent needless cache invalidations. Instead, we mark this type
as side-effecting so it can only be included in a non-cacheable rule, and add some logic to prune the environment to only the variables explicitly requested by a (new) `--test-extra-env-vars` option.

`PantsEnvironment` is a general mechanism that can be used in any rule that needs to be aware of pants' own environment. The remaining work in this commit is to hook up the pruned result from `PantsEnvironment` into a new `TestExtraEnv` mechanism, and wire that up to the test process execution framework.
