### PR TITLE
Add product type to the Rule trait to simplify unit testing

### DIFF
--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -30,7 +30,7 @@
 mod builder;
 mod rules;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::io;
 
 pub use crate::builder::Builder;
@@ -243,10 +243,7 @@ fn entry_with_deps_str<R: Rule>(entry: &EntryWithDeps<R>) -> String {
 }
 
 impl<R: Rule> RuleGraph<R> {
-  pub fn new(
-    rules: &BTreeMap<R::TypeId, Vec<R>>,
-    queries: Vec<Query<R>>,
-  ) -> Result<RuleGraph<R>, String> {
+  pub fn new(rules: Vec<R>, queries: Vec<Query<R>>) -> Result<RuleGraph<R>, String> {
     Builder::new(rules, queries).graph()
   }
 

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -78,6 +78,11 @@ pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + DisplayForGraph + 
   type DependencyKey: DependencyKey<TypeId = Self::TypeId>;
 
   ///
+  /// Returns the product (output) type for this Rule.
+  ///
+  fn product(&self) -> Self::TypeId;
+
+  ///
   /// Return keys for the dependencies of this Rule.
   ///
   fn dependency_keys(&self) -> Vec<Self::DependencyKey>;

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -250,7 +250,7 @@ impl Core {
     let graph = Arc::new(InvalidatableGraph(Graph::new()));
 
     let http_client = reqwest::Client::new();
-    let rule_graph = RuleGraph::new(tasks.as_map(), tasks.queries().clone())?;
+    let rule_graph = RuleGraph::new(tasks.rules().clone(), tasks.queries().clone())?;
 
     let gitignore_file = if use_gitignore {
       let gitignore_path = build_root.join(".gitignore");


### PR DESCRIPTION
### Problem

The `Rule` trait did not require that a `Rule` declare its own return type, which was ... strange. It also made unit testing more awkward, because rules needed to be declared in a type->rules map rather than a flat list.

### Solution

Add `Rule::product`, and simplify tests.

[ci skip-build-wheels]