### PR TITLE
Fix the `testutil` wheel's imports not working due to namespace packages

### DIFF
--- a/build-support/bin/check_inits.py
+++ b/build-support/bin/check_inits.py
@@ -21,11 +21,17 @@ def main() -> None:
     files = itertools.chain.from_iterable(
         [Path().glob(f"{d}/**/__init__.py") for d in DIRS_TO_CHECK]
     )
-    bad_inits = [f for f in files if bool(f.read_text())]
-    if bad_inits:
+    root_init = Path("src/python/pants/__init__.py")
+    if '__import__("pkg_resources").declare_namespace(__name__)' not in root_init.read_text():
+        die(
+            f"{root_init} must have the line "
+            '`__import__("pkg_resources").declare_namespace(__name__)` in it.'
+        )
+    non_empty_inits = [f for f in files if bool(f.read_text()) and f != root_init]
+    if non_empty_inits:
         die(
             "All `__init__.py` file should be empty, but the following had content: "
-            f"{', '.join(str(f) for f in bad_inits)}"
+            f"{', '.join(str(f) for f in non_empty_inits)}"
         )
 
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -116,7 +116,7 @@ function pkg_testutil_install_test() {
   shift
   local PIP_ARGS=("$@")
   pip install "${PIP_ARGS[@]}" "pantsbuild.pants.testutil==${version}" && \
-  python -c "import pants.testutil"
+  python -c "import pants.testutil.option_util"
 }
 
 #

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -25,7 +25,6 @@ python_distribution(
   provides=setup_py(
     name='pantsbuild.pants',
     description='A scalable build tool for large, complex, heterogeneous repos.',
-    namespace_packages=['pants', 'pants.backend'],
     # NB: by setting `ext_modules`, we signal to setup_py and bdist_wheel that this library
     # has native code. As a consequence, bdist_wheel pins the ABI (application binary interface)
     # used when creating the wheel, which is a good thing. We should be setting this ABI to ensure

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,1 +1,3 @@
+# NB: We need to declare a namespace package because we have the dists `pantsbuild.pants` and
+# `pantsbuild.pants.testutil`, which both have the module `pants`.
 __import__("pkg_resources").declare_namespace(__name__)

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -200,7 +200,14 @@ class SetupKwargs:
             raise ValueError(f"Missing a `version` kwarg in the `provides` field for {address}.")
 
         if not _allow_banned_keys:
-            for arg in {"data_files", "package_dir", "package_data", "packages"}:
+            for arg in {
+                "data_files",
+                "namespace_packages",
+                "package_dir",
+                "package_data",
+                "packages",
+                "install_requires",
+            }:
                 if arg in kwargs:
                     raise ValueError(
                         f"{arg} cannot be set in the `provides` field for {address}, but it was "

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -218,7 +218,7 @@ class SetupKwargs:
         # would require that all values are immutable, and we may have lists and dictionaries as
         # values. It's too difficult/clunky to convert those all, then to convert them back out of
         # `FrozenDict`. We don't use JSON because it does not preserve data types like `tuple`.
-        self._pickled_bytes = pickle.dumps({k: v for k, v in sorted(kwargs.items())})
+        self._pickled_bytes = pickle.dumps({k: v for k, v in sorted(kwargs.items())}, protocol=4)
 
     @memoized_property
     def kwargs(self) -> Dict[str, Any]:

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -531,13 +531,19 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     target = exported_target.target
     resolved_setup_kwargs = await Get(SetupKwargs, ExportedTarget, exported_target)
     setup_kwargs = resolved_setup_kwargs.kwargs.copy()
+    # NB: We are careful to not overwrite these values, but we also don't expect them to have been
+    # set. The user must have have gone out of their way to use a `SetupKwargs` plugin, and to have
+    # specified `SetupKwargs(_allow_banned_keys=True)`.
     setup_kwargs.update(
         {
-            "package_dir": {"": CHROOT_SOURCE_ROOT},
-            "packages": sources.packages,
-            "namespace_packages": sources.namespace_packages,
-            "package_data": dict(sources.package_data),
-            "install_requires": tuple(requirements),
+            "package_dir": {"": CHROOT_SOURCE_ROOT, **setup_kwargs.get("package_dir", {})},
+            "packages": (*sources.packages, *(setup_kwargs.get("packages", []))),
+            "namespace_packages": (
+                *sources.namespace_packages,
+                *setup_kwargs.get("namespace_packages", []),
+            ),
+            "package_data": {**dict(sources.package_data), **setup_kwargs.get("package_data", {})},
+            "install_requires": (*requirements, *setup_kwargs.get("install_requires", [])),
         }
     )
     key_to_binary_spec = exported_target.provides.binaries

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -10,7 +10,6 @@ python_distribution(
   provides=setup_py(
     name='pantsbuild.pants.testutil',
     description='Test support for writing Pants plugins.',
-    namespace_packages=['pants.testutil'],
     classifiers=[
       'Topic :: Software Development :: Testing',
     ]


### PR DESCRIPTION
Imports stopped working for `testutil` in 2.0.0.dev2 because we removed the line `__import__("pkg_resources").declare_namespace(__name__)` from `src/python/pants/__init__.py`, so we were no longer using namespace packages and we had two dists with the same namespace.

This PR also fixes the `setup-py` goal to error if users are manually setting `namespace_packages` and `install_requires`. Pants manages that for users. Before, we were silently overwriting values they set, which was confusing.

[ci skip-rust]
[ci skip-build-wheels]