### PR TITLE
Formalize support for VCS-style requirements via PEP 440

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -142,6 +142,13 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
               name='un_normalized',
               requirements=['Un-Normalized-Project>3', 'two_owners'],
             )
+
+            python_requirement_library(
+              name='direct_references',
+              requirements=[
+                'pip@ git+https://github.com/pypa/pip.git', 'local_dist@ file:///path/to/dist.whl',
+              ],
+            )
             """
         ),
     )
@@ -150,9 +157,11 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
     )
     assert result.mapping == FrozenDict(
         {
-            "colors": Address.parse("3rdparty/python:ansicolors"),
-            "req1": Address.parse("3rdparty/python:req1"),
-            "un_normalized_project": Address.parse("3rdparty/python:un_normalized"),
+            "colors": Address("3rdparty/python", target_name="ansicolors"),
+            "local_dist": Address("3rdparty/python", target_name="direct_references"),
+            "pip": Address("3rdparty/python", target_name="direct_references"),
+            "req1": Address("3rdparty/python", target_name="req1"),
+            "un_normalized_project": Address("3rdparty/python", target_name="un_normalized"),
         }
     )
 

--- a/src/python/pants/backend/python/macros/pipenv_requirements.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from json import load
+import json
 from pathlib import Path
 from typing import Iterable, Mapping, Optional
 
@@ -10,6 +10,8 @@ from pkg_resources import Requirement
 from pants.base.build_environment import get_buildroot
 
 
+# TODO(#10655): add support for PEP 440 direct references (aka VCS style).
+# TODO(#10655): differentiate between Pipfile vs. Pipfile.lock.
 class PipenvRequirements:
     """Translates a Pipenv.lock file into an equivalent set `python_requirement_library` targets.
 
@@ -46,13 +48,10 @@ class PipenvRequirements:
         if the requirements_relpath value is not in the current rel_path
         """
 
-        lock_info = {}
-
         requirements_path = Path(
             get_buildroot(), self._parse_context.rel_path, requirements_relpath
         )
-        with open(requirements_path, "r") as fp:
-            lock_info = load(fp)
+        lock_info = json.loads(requirements_path.read_text())
 
         if pipfile_target:
             requirements_dep = pipfile_target

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -6,6 +6,7 @@ from typing import Iterable, Mapping, Optional
 
 from pkg_resources import Requirement
 
+from pants.backend.python.target_types import format_invalid_requirement_string_error
 from pants.base.build_environment import get_buildroot
 
 
@@ -70,8 +71,13 @@ class PythonRequirements:
                 req = Requirement.parse(line)
             except Exception as e:
                 raise ValueError(
-                    f"Invalid requirement in {req_file.relative_to(get_buildroot())} at line "
-                    f"{i + 1} due to value '{line}'.\n\n{e}"
+                    format_invalid_requirement_string_error(
+                        line,
+                        e,
+                        description_of_origin=(
+                            f"{req_file.relative_to(get_buildroot())} at line {i + 1}"
+                        ),
+                    )
                 )
             requirements.append(req)
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -350,15 +350,15 @@ def format_invalid_requirement_string_error(
 
         Instead of this style:
 
-            git+https://github.com/django/django.git#egg=django
-            git+https://github.com/django/django.git@stable/2.1.x#egg=django
-            git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8#egg=django
+            git+https://github.com/django/django.git#egg=Django
+            git+https://github.com/django/django.git@stable/2.1.x#egg=Django
+            git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8#egg=Django
 
-        Use this style:
+        Use this style, where the first value is the name of the dependency:
 
-            django@ git+https://github.com/django/django.git
-            django@ git+https://github.com/django/django.git@stable/2.1.x
-            django@ git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8
+            Django@ git+https://github.com/django/django.git
+            Django@ git+https://github.com/django/django.git@stable/2.1.x
+            Django@ git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8
         """
     )
 


### PR DESCRIPTION
Since 2016, users have been asking for a way to install wheels from a URL, e.g. from Git.

There are two approaches to VCS-style requirements:

1) Pip's proprietary syntax, e.g. `git+https://github.com/pypa/pip.git#egg=pip`. This is what most people are familiar with. https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
2) PEP 440's standardized "direct references", e.g. `pip@ git+https://github.com/pypa/pip.git`.

Turns out, ever since we upgraded to Pex 2.0, approach #2 has worked to achieve this goal. But few users knew about it (including us), and approach #1 has continued to not work.

We use setuptools to parse our requirements before passing to Pex. Why? We need to normalize it to, for example, strip comments from `requirements.txt`; and because we need the parsed information to do things like create a module mapping for dependency inference. However, `pkg_resources.Requirement.parse()` chokes on Pip's VCS style, and only understands PEP 440.

Both the Pip VCS and PEP 440 approaches achieve the same end goal. We could use some custom libraries like https://github.com/sarugaku/requirementslib and https://github.com/davidfischer/requirements-parser to allow for Pip's proprietary format, but that adds new complexity to our project.

Nevertheless, few users are familiar with PEP 440, so we eagerly detect if they're trying to use the Pip style and have a nice error message for how to instead use PEP 440:

```
▶ ./pants list 3rdparty/python: --no-print-exception-stacktrace
13:25:59.67 [ERROR] 1 Exception encountered:

  MappingError: Failed to parse 3rdparty/python/BUILD:
Invalid requirement 'git+https://github.com/django/django.git#egg=django' in 3rdparty/python/requirements.txt at line 32: Parse error at "'+https:/'": Expected stringEnd

It looks like you're trying to use a pip VCS-style requirement?
Instead, use a direct reference (PEP 440).

Instead of this style:

    git+https://github.com/django/django.git#egg=django
    git+https://github.com/django/django.git@stable/2.1.x#egg=django
    git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8#egg=django

Use this style, where the first value is the name of the dependency:

    Django@ git+https://github.com/django/django.git
    Django@ git+https://github.com/django/django.git@stable/2.1.x
    Django@ git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8
```

Closes https://github.com/pantsbuild/pants/issues/3063.

### Additional benefit: doesn't allow `--editable`

With Pip VCS-style requirements, it's common to use `-e` or `--editable`, which changes how the distribution is downloaded so that the user can make edits to it. That is not sensible in Pants, and we are unlikely to ever support this feature.

PEP 440 style does not support `-e`, so, when users migrate to PEP 440, they won't have the opportunity to inadvertently use `-e` and for it to not work like they expect.

[ci skip-rust]
[ci skip-build-wheels]