### PR TITLE
Filter log levels by target

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from typing import Dict, Iterable, List, Tuple, Union, cast
+from typing import Dict, Iterable, List, Mapping, Tuple, Union, cast
 
 from typing_extensions import Protocol
 
@@ -137,7 +137,7 @@ class Native(metaclass=SingletonMetaclass):
         log_show_rust_3rdparty: bool,
         use_color: bool,
         show_target: bool,
-        log_levels_by_target: Dict[str, LogLevel],
+        log_levels_by_target: Mapping[str, LogLevel],
     ):
         log_levels_as_ints = {k: v.level for k, v in log_levels_by_target.items()}
         return self.lib.init_logging(

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -26,6 +26,7 @@ from pants.engine.internals.native_engine import (
 )
 from pants.engine.rules import Get
 from pants.engine.unions import union
+from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import SingletonMetaclass
 
@@ -131,9 +132,17 @@ class Native(metaclass=SingletonMetaclass):
         return self.lib.decompress_tarball(tarfile_path, dest_dir)
 
     def init_rust_logging(
-        self, level, log_show_rust_3rdparty: bool, use_color: bool, show_target: bool
+        self,
+        level: int,
+        log_show_rust_3rdparty: bool,
+        use_color: bool,
+        show_target: bool,
+        log_levels_by_target: Dict[str, LogLevel],
     ):
-        return self.lib.init_logging(level, log_show_rust_3rdparty, use_color, show_target)
+        log_levels_as_ints = {k: v.level for k, v in log_levels_by_target.items()}
+        return self.lib.init_logging(
+            level, log_show_rust_3rdparty, use_color, show_target, log_levels_as_ints
+        )
 
     def default_cache_path(self) -> str:
         return cast(str, self.lib.default_cache_path())

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -130,8 +130,10 @@ class Native(metaclass=SingletonMetaclass):
     def decompress_tarball(self, tarfile_path, dest_dir):
         return self.lib.decompress_tarball(tarfile_path, dest_dir)
 
-    def init_rust_logging(self, level, log_show_rust_3rdparty: bool, use_color: bool):
-        return self.lib.init_logging(level, log_show_rust_3rdparty, use_color)
+    def init_rust_logging(
+        self, level, log_show_rust_3rdparty: bool, use_color: bool, show_target: bool
+    ):
+        return self.lib.init_logging(level, log_show_rust_3rdparty, use_color, show_target)
 
     def default_cache_path(self) -> str:
         return cast(str, self.lib.default_cache_path())

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -21,8 +21,10 @@ logging.addLevelName(logging.WARNING, "WARN")
 logging.addLevelName(pants_logging.TRACE, "TRACE")
 
 
-def init_rust_logger(log_level: LogLevel, log_show_rust_3rdparty: bool, use_color: bool) -> None:
-    Native().init_rust_logging(log_level.level, log_show_rust_3rdparty, use_color)
+def init_rust_logger(
+    log_level: LogLevel, log_show_rust_3rdparty: bool, use_color: bool, show_target: bool
+) -> None:
+    Native().init_rust_logging(log_level.level, log_show_rust_3rdparty, use_color, show_target)
 
 
 class NativeHandler(StreamHandler):
@@ -38,9 +40,7 @@ class NativeHandler(StreamHandler):
             self.native.setup_stderr_logger()
 
     def emit(self, record: LogRecord) -> None:
-        self.native.write_log(
-            msg=self.format(record), level=record.levelno, target=f"{record.name}:pid={os.getpid()}"
-        )
+        self.native.write_log(msg=self.format(record), level=record.levelno, target=record.name)
 
     def flush(self) -> None:
         self.native.flush_log()
@@ -114,8 +114,9 @@ def setup_logging(global_bootstrap_options):
 
     log_show_rust_3rdparty = global_bootstrap_options.log_show_rust_3rdparty
     use_color = global_bootstrap_options.colors
+    show_target = global_bootstrap_options.show_log_target
 
-    init_rust_logger(global_level, log_show_rust_3rdparty, use_color)
+    init_rust_logger(global_level, log_show_rust_3rdparty, use_color, show_target)
     setup_logging_to_stderr(global_level, warnings_filter_regexes=ignores)
     if log_dir:
         setup_logging_to_file(global_level, log_dir=log_dir, warnings_filter_regexes=ignores)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -6,11 +6,12 @@ import logging
 import os
 import warnings
 from logging import Formatter, Handler, LogRecord, StreamHandler
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pants.util.logging as pants_logging
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.internals.native import Native
+from pants.option.option_value_container import OptionValueContainer
 from pants.util.dirutil import safe_mkdir
 from pants.util.logging import LogLevel
 
@@ -22,9 +23,15 @@ logging.addLevelName(pants_logging.TRACE, "TRACE")
 
 
 def init_rust_logger(
-    log_level: LogLevel, log_show_rust_3rdparty: bool, use_color: bool, show_target: bool
+    log_level: LogLevel,
+    log_show_rust_3rdparty: bool,
+    use_color: bool,
+    show_target: bool,
+    log_levels_by_target: Dict[str, LogLevel] = {},
 ) -> None:
-    Native().init_rust_logging(log_level.level, log_show_rust_3rdparty, use_color, show_target)
+    Native().init_rust_logging(
+        log_level.level, log_show_rust_3rdparty, use_color, show_target, log_levels_by_target
+    )
 
 
 class NativeHandler(StreamHandler):
@@ -115,11 +122,27 @@ def setup_logging(global_bootstrap_options):
     log_show_rust_3rdparty = global_bootstrap_options.log_show_rust_3rdparty
     use_color = global_bootstrap_options.colors
     show_target = global_bootstrap_options.show_log_target
+    log_levels_by_target = get_log_levels_by_target(global_bootstrap_options)
 
-    init_rust_logger(global_level, log_show_rust_3rdparty, use_color, show_target)
+    init_rust_logger(
+        global_level, log_show_rust_3rdparty, use_color, show_target, log_levels_by_target
+    )
     setup_logging_to_stderr(global_level, warnings_filter_regexes=ignores)
     if log_dir:
         setup_logging_to_file(global_level, log_dir=log_dir, warnings_filter_regexes=ignores)
+
+
+def get_log_levels_by_target(global_bootstrap_options: OptionValueContainer) -> Dict[str, LogLevel]:
+    raw_levels = global_bootstrap_options.log_levels_by_target
+    levels: Dict[str, LogLevel] = {}
+    for key, value in raw_levels.items():
+        if not isinstance(key, str):
+            raise ValueError("keys for log_domain_levels must be strings")
+        if not isinstance(value, str):
+            raise ValueError("values for log_domain_levels must be strings")
+        log_level = LogLevel[value.upper()]
+        levels[key] = log_level
+    return levels
 
 
 def setup_logging_to_stderr(

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -42,7 +42,7 @@ class NativeHandler(StreamHandler):
         super().__init__(None)
         self.native = Native()
         self.native_filename = native_filename
-        self.setLevel(log_level.level)
+        self.setLevel(pants_logging.TRACE)
         if not self.native_filename:
             self.native.setup_stderr_logger()
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -137,9 +137,13 @@ def get_log_levels_by_target(global_bootstrap_options: OptionValueContainer) -> 
     levels: Dict[str, LogLevel] = {}
     for key, value in raw_levels.items():
         if not isinstance(key, str):
-            raise ValueError("keys for log_domain_levels must be strings")
+            raise ValueError(
+                "Keys for log_domain_levels must be strings, but was given the key: {key} with type {type(key)}."
+            )
         if not isinstance(value, str):
-            raise ValueError("values for log_domain_levels must be strings")
+            raise ValueError(
+                "Values for log_domain_levels must be strings, but was given the value: {value} with type {type(value)}."
+            )
         log_level = LogLevel[value.upper()]
         levels[key] = log_level
     return levels

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -168,7 +168,8 @@ class GlobalOptions(Subsystem):
             "--level",
             type=LogLevel,
             default=LogLevel.INFO,
-            help="Set the logging level.",
+            help="Set the logging level. The logging levels are one of: "
+            '"error", "warn", "info", "debug", "trace".',
         )
         register(
             "--show-log-target",
@@ -176,6 +177,16 @@ class GlobalOptions(Subsystem):
             default=False,
             advanced=True,
             help="Display the target where a log message originates in that log message's output.",
+        )
+
+        register(
+            "--log-levels-by-target",
+            type=dict,
+            default={},
+            advanced=True,
+            help="Set a more specific logging level for one or more logging targets. "
+            "The logging levels are one of: "
+            '"error", "warn", "info", "debug", "trace".',
         )
 
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -170,6 +170,13 @@ class GlobalOptions(Subsystem):
             default=LogLevel.INFO,
             help="Set the logging level.",
         )
+        register(
+            "--show-log-target",
+            type=bool,
+            default=False,
+            advanced=True,
+            help="Display the target where a log message originates in that log message's output.",
+        )
 
         register(
             "--log-show-rust-3rdparty",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -176,7 +176,8 @@ class GlobalOptions(Subsystem):
             type=bool,
             default=False,
             advanced=True,
-            help="Display the target where a log message originates in that log message's output.",
+            help="Display the target where a log message originates in that log message's output. "
+            "This can be helpful when paired with --log-levels-by-target.",
         )
 
         register(
@@ -184,9 +185,12 @@ class GlobalOptions(Subsystem):
             type=dict,
             default={},
             advanced=True,
-            help="Set a more specific logging level for one or more logging targets. "
+            help="Set a more specific logging level for one or more logging targets. The names of "
+            "logging targets are specified in log strings when the --show-log-target option is set. "
             "The logging levels are one of: "
-            '"error", "warn", "info", "debug", "trace".',
+            '"error", "warn", "info", "debug", "trace". '
+            "All logging targets not specified here use the global log level set with --level. For example, "
+            'you can set `--log-levels-by-target=\'{"workunit_store": "info", "pants.engine.rules": "warn"}\'` ',
         )
 
         register(

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -214,8 +214,15 @@ class PantsDaemon(PantsDaemonProcessManager):
         # for further forks.
         with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
             # Reinitialize logging for the daemon context.
-            use_color = self._bootstrap_options.for_global_scope().colors
-            init_rust_logger(self._log_level, self._log_show_rust_3rdparty, use_color=use_color)
+            global_options = self._bootstrap_options.for_global_scope()
+            use_color = global_options.colors
+            show_target = global_options.show_log_target
+            init_rust_logger(
+                self._log_level,
+                self._log_show_rust_3rdparty,
+                use_color=use_color,
+                show_target=show_target,
+            )
 
             level = self._log_level
             ignores = self._bootstrap_options.for_global_scope().ignore_pants_warnings
@@ -249,6 +256,7 @@ class PantsDaemon(PantsDaemonProcessManager):
 
         # Write the pidfile. The SchedulerService will monitor it after a grace period.
         pid = os.getpid()
+        self._logger.debug(f"pantsd running with PID: {pid}")
         self.write_pid(pid=pid)
         self.write_metadata_by_name(
             "pantsd", self.FINGERPRINT_KEY, ensure_text(self.options_fingerprint)

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -26,6 +26,7 @@
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
+#![type_length_limit = "1880979"]
 
 use std::convert::TryInto;
 use std::io::{self, Write};

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -87,7 +87,7 @@ py_module_initializer!(native_engine, |py, m| {
   m.add(
     py,
     "init_logging",
-    py_fn!(py, init_logging(a: u64, b: bool, c: bool)),
+    py_fn!(py, init_logging(a: u64, b: bool, c: bool, d: bool)),
   )?;
   m.add(
     py,
@@ -1689,8 +1689,9 @@ fn init_logging(
   level: u64,
   show_rust_3rdparty_logs: bool,
   use_color: bool,
+  show_target: bool,
 ) -> PyUnitResult {
-  Logger::init(level, show_rust_3rdparty_logs, use_color);
+  Logger::init(level, show_rust_3rdparty_logs, use_color, show_target);
   Ok(None)
 }
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -25,6 +25,7 @@ class LoggingTest(TestBase):
             level=LogLevel.INFO.level,  # Tests assume a log level of INFO
             log_show_rust_3rdparty=False,
             use_color=False,
+            show_target=False,
         )
 
     @contextmanager

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -26,6 +26,7 @@ class LoggingTest(TestBase):
             log_show_rust_3rdparty=False,
             use_color=False,
             show_target=False,
+            log_levels_by_target={},
         )
 
     @contextmanager

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -2,103 +2,63 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from contextlib import contextmanager
-from logging import Logger
 from pathlib import Path
-from typing import Iterator, Tuple
 
 from pants.engine.internals.native import Native
-from pants.init.logging import NativeHandler, setup_logging_to_file
-from pants.testutil.test_base import TestBase
+from pants.init.logging import setup_logging_to_file
 from pants.util.contextutil import temporary_dir
 from pants.util.logging import LogLevel
 
 
-class LoggingTest(TestBase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        # NB: We must set this up at the class level, rather than per-test level, because
-        # `init_rust_logging` must never be called more than once. The Rust logger is global and static,
-        # and initializing it twice in the same test class results in a SIGABRT.
-        Native().init_rust_logging(
-            level=LogLevel.INFO.level,  # Tests assume a log level of INFO
-            log_show_rust_3rdparty=False,
-            use_color=False,
-            show_target=False,
-            log_levels_by_target={},
-        )
+def test_file_logging() -> None:
+    native = Native()
+    native.init_rust_logging(
+        level=LogLevel.INFO.level,  # Tests assume a log level of INFO
+        log_show_rust_3rdparty=False,
+        use_color=False,
+        show_target=False,
+        log_levels_by_target={},
+    )
+    logger = logging.getLogger("my_file_logger")
+    with temporary_dir() as tmpdir:
+        setup_logging_to_file(LogLevel.INFO, log_dir=tmpdir)
+        log_file = Path(tmpdir, "pants.log")
 
-    @contextmanager
-    def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
-        native = self.scheduler._scheduler._native
-        # TODO(gregorys) - if this line isn't here this test fails with no stdout. Figure out why.
-        print(f"Native: {native}")
-        logger = logging.getLogger("my_file_logger")
-        with temporary_dir() as tmpdir:
-            handler = setup_logging_to_file(log_level, log_dir=tmpdir)
-            log_file = Path(tmpdir, "pants.log")
-            yield logger, handler, log_file
+        cat = "🐈"
+        logger.warning("this is a warning")
+        logger.info("this is some info")
+        logger.debug("this is some debug info")
+        logger.info(f"unicode: {cat}")
 
-    def test_utf8_logging(self) -> None:
-        with self.logger(LogLevel.INFO) as (file_logger, log_handler, log_file):
-            cat = "🐈"
-            file_logger.info(cat)
-            log_handler.flush()
-            self.assertIn(cat, log_file.read_text())
-
-    def test_file_logging(self) -> None:
-        with self.logger(LogLevel.INFO) as (file_logger, log_handler, log_file):
-            file_logger.warning("this is a warning")
-            file_logger.info("this is some info")
-            file_logger.debug("this is some debug info")
-            log_handler.flush()
-
-            loglines = log_file.read_text().splitlines()
-            self.assertEqual(2, len(loglines))
-            self.assertIn("[WARN] this is a warning", loglines[0])
-            self.assertIn("[INFO] this is some info", loglines[1])
+        loglines = log_file.read_text().splitlines()
+        print(loglines)
+        assert len(loglines) == 3
+        assert "[WARN] this is a warning" in loglines[0]
+        assert "[INFO] this is some info" in loglines[1]
+        assert f"[INFO] unicode: {cat}" in loglines[2]
 
 
-class AdvancedLoggingTest(TestBase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        # NB: We must set this up at the class level, rather than per-test level, because
-        # `init_rust_logging` must never be called more than once. The Rust logger is global and static,
-        # and initializing it twice in the same test class results in a SIGABRT.
-        Native().init_rust_logging(
-            level=LogLevel.INFO.level,  # Tests assume a log level of INFO
-            log_show_rust_3rdparty=False,
-            use_color=False,
-            show_target=True,
-            log_levels_by_target={
-                "debug_target": LogLevel.DEBUG,
-            },
-        )
+def test_log_filtering_by_rule() -> None:
+    native = Native()
+    native.init_rust_logging(
+        level=LogLevel.INFO.level,
+        log_show_rust_3rdparty=False,
+        use_color=False,
+        show_target=True,
+        log_levels_by_target={
+            "debug_target": LogLevel.DEBUG,
+        },
+    )
+    with temporary_dir() as tmpdir:
+        setup_logging_to_file(LogLevel.INFO, log_dir=tmpdir)
+        log_file = Path(tmpdir, "pants.log")
 
-    @contextmanager
-    def logger(self, log_level: LogLevel) -> Iterator[Tuple[Logger, NativeHandler, Path]]:
-        native = self.scheduler._scheduler._native
-        # TODO(gregorys) - if this line isn't here this test fails with no stdout. Figure out why.
-        print(f"Native: {native}")
-        logger = logging.getLogger("my_file_logger")
-        with temporary_dir() as tmpdir:
-            handler = setup_logging_to_file(log_level, log_dir=tmpdir)
-            log_file = Path(tmpdir, "pants.log")
-            yield logger, handler, log_file
+        native.write_log(msg="log msg one", level=LogLevel.INFO.level, target="some.target")
+        native.write_log(msg="log msg two", level=LogLevel.DEBUG.level, target="some.other.target")
+        native.write_log(msg="log msg three", level=LogLevel.DEBUG.level, target="debug_target")
 
-    def test_log_filtering(self) -> None:
-        with self.logger(LogLevel.INFO) as (file_logger, log_handler, log_file):
-            native = Native()
-            native.write_log(msg="log msg one", level=LogLevel.INFO.level, target="some.target")
-            native.write_log(
-                msg="log msg two", level=LogLevel.DEBUG.level, target="some.other.target"
-            )
-            native.write_log(msg="log msg three", level=LogLevel.DEBUG.level, target="debug_target")
+        loglines = log_file.read_text().splitlines()
 
-            loglines = log_file.read_text().splitlines()
-
-            assert "[INFO] (some.target) log msg one" in loglines[0]
-            assert "[DEBUG] (debug_target) log msg three" in loglines[1]
-            assert len(loglines) == 2
+        assert "[INFO] (some.target) log msg one" in loglines[0]
+        assert "[DEBUG] (debug_target) log msg three" in loglines[1]
+        assert len(loglines) == 2

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -36,12 +36,6 @@ def test_completed_log_output() -> None:
 def test_log_filtering_by_target() -> None:
     sources = {
         "src/python/project/__init__.py": "",
-        "src/python/project/lib.py": dedent(
-            """\
-            def add(x: int, y: int) -> int:
-                return x + y
-            """
-        ),
         "src/python/project/BUILD": "python_library()",
     }
     with setup_tmpdir(sources) as tmpdir:

--- a/tests/python/pants_test/integration/log_output_integration_test.py
+++ b/tests/python/pants_test/integration/log_output_integration_test.py
@@ -31,3 +31,31 @@ def test_completed_log_output() -> None:
     result.assert_success()
     assert "[DEBUG] Starting: Run MyPy on" in result.stderr
     assert "[DEBUG] Completed: Run MyPy on" in result.stderr
+
+
+def test_log_filtering_by_target() -> None:
+    sources = {
+        "src/python/project/__init__.py": "",
+        "src/python/project/lib.py": dedent(
+            """\
+            def add(x: int, y: int) -> int:
+                return x + y
+            """
+        ),
+        "src/python/project/BUILD": "python_library()",
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        result = run_pants(
+            [
+                "--no-pantsd",
+                "--backend-packages=['pants.backend.python']",
+                "--no-dynamic-ui",
+                "--level=info",
+                "--show-log-target",
+                '--log-levels-by-target={"workunit_store": "debug"}',
+                "list",
+                f"{tmpdir}/src/python/project",
+            ]
+        )
+
+        assert "[DEBUG] (workunit_store) Starting: `list` goal" in result.stderr


### PR DESCRIPTION
### Problem

Pants's logging, particularly on the DEBUG and TRACE levels, is too verbose to make effective use of. We would like to be able to selectively enable more verbose logging for specific areas of the pants codebase where we think a problem we're trying to debug might lie, while leaving others at the default logging level.

### Solution

The Rust and Python logging frameworks that Pants uses already have the concept of a *target*, that is, a name associated with a log object that comes from the area of the codebase where that log is emitted. For Python logs, that target name is a fully-qualified Python module (e.g. `pants.pantsd.service.pants_service`) and for Rust logs it is the name of the Rust module (e.g. `workunit_store`). 

This commit adds a new global option `--log-levels-by-target` that expects a dictionary mapping strings representing these target names to the string representation of a Pants log level. By this mechanism, a user can specify that logs originating in a given part of the pants codebase will be subject to less filtering than other logs. Log targets not explicitly specified in this option are filtered according to the global log level specified with `--level`. 

This commit also adds another new global option `--show-log-target` that simply adds the target name to log messages without doing any filtering, to make it easier for users casually inspecting logs to see what log targets might be relevant for further debugging.