### PR TITLE
Refactor find_valid_field_sets.

### DIFF
--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -10,7 +10,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
+from pants.engine.target import FieldSet, TargetRootsToFieldSets, TargetRootsToFieldSetsRequest
 from pants.engine.unions import union
 
 
@@ -49,11 +49,11 @@ async def create_awslambda(
     workspace: Workspace,
 ) -> AWSLambdaGoal:
     targets_to_valid_field_sets = await Get(
-        TargetsToValidFieldSets,
-        TargetsToValidFieldSetsRequest(
+        TargetRootsToFieldSets,
+        TargetRootsToFieldSetsRequest(
             AWSLambdaFieldSet,
             goal_description="the `awslambda` goal",
-            error_if_no_valid_targets=True,
+            error_if_no_applicable_targets=True,
         ),
     )
     awslambdas = await MultiGet(

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -740,13 +740,16 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
                 sibling = next(exported_ancestor_iter, None)
             if sibling_owners:
                 raise AmbiguousOwnerError(
-                    f"Exporting owners for {target.address} are "
-                    f"ambiguous. Found {exported_ancestor.address} and "
-                    f"{len(sibling_owners)} others: "
+                    f"python_distribution target owning {target.address} is ambiguous. "
+                    f"Found {exported_ancestor.address} and {len(sibling_owners)} others: "
                     f'{", ".join(so.address.spec for so in sibling_owners)}'
                 )
             return ExportedTarget(owner)
-    raise NoOwnerError(f"No exported target owner found for {target.address}")
+    raise NoOwnerError(
+        f"No python_distribution target found to own {target.address}. Note that "
+        f"the owner must be in or above the owned target's directory, and must "
+        f"depend on it (directly or indirectly)."
+    )
 
 
 @rule(desc="Set up setuptools")

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -9,7 +9,7 @@ from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
+from pants.engine.target import FieldSet, TargetRootsToFieldSets, TargetRootsToFieldSetsRequest
 from pants.engine.unions import union
 
 logger = logging.getLogger(__name__)
@@ -41,9 +41,11 @@ class Binary(Goal):
 @goal_rule
 async def create_binary(workspace: Workspace, dist_dir: DistDir) -> Binary:
     targets_to_valid_field_sets = await Get(
-        TargetsToValidFieldSets,
-        TargetsToValidFieldSetsRequest(
-            BinaryFieldSet, goal_description="the `binary` goal", error_if_no_valid_targets=True
+        TargetRootsToFieldSets,
+        TargetRootsToFieldSetsRequest(
+            BinaryFieldSet,
+            goal_description="the `binary` goal",
+            error_if_no_applicable_targets=True,
         ),
     )
     binaries = await MultiGet(

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -12,7 +12,7 @@ from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.rules import Get, collect_rules, goal_rule
-from pants.engine.target import FieldSet, TargetsToValidFieldSets, TargetsToValidFieldSetsRequest
+from pants.engine.target import FieldSet, TargetRootsToFieldSets, TargetRootsToFieldSetsRequest
 from pants.engine.unions import union
 from pants.option.custom_types import shell_str
 from pants.option.global_options import GlobalOptions
@@ -89,11 +89,11 @@ async def run(
     build_root: BuildRoot,
 ) -> Run:
     targets_to_valid_field_sets = await Get(
-        TargetsToValidFieldSets,
-        TargetsToValidFieldSetsRequest(
+        TargetRootsToFieldSets,
+        TargetRootsToFieldSetsRequest(
             RunFieldSet,
             goal_description="the `run` goal",
-            error_if_no_valid_targets=True,
+            error_if_no_applicable_targets=True,
             expect_single_field_set=True,
         ),
     )

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -14,8 +14,8 @@ from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.target import (
     Target,
-    TargetsToValidFieldSets,
-    TargetsToValidFieldSetsRequest,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
     TargetWithOrigin,
 )
 from pants.option.global_options import GlobalOptions
@@ -72,9 +72,9 @@ def single_target_run(
         ],
         mock_gets=[
             MockGet(
-                product_type=TargetsToValidFieldSets,
-                subject_type=TargetsToValidFieldSetsRequest,
-                mock=lambda _: TargetsToValidFieldSets({target_with_origin: [field_set]}),
+                product_type=TargetRootsToFieldSets,
+                subject_type=TargetRootsToFieldSetsRequest,
+                mock=lambda _: TargetRootsToFieldSets({target_with_origin: [field_set]}),
             ),
             MockGet(
                 product_type=RunRequest,

--- a/src/python/pants/core/goals/style_request.py
+++ b/src/python/pants/core/goals/style_request.py
@@ -7,10 +7,10 @@ from typing import ClassVar, Generic, Iterable, Optional, Type, TypeVar
 
 from pants.engine.collection import Collection
 from pants.engine.fs import Snapshot
-from pants.engine.target import FieldSetWithOrigin
+from pants.engine.target import FieldSet
 from pants.util.meta import frozen_after_init
 
-_FS = TypeVar("_FS", bound=FieldSetWithOrigin)
+_FS = TypeVar("_FS", bound=FieldSet)
 
 
 @frozen_after_init

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -26,8 +26,8 @@ from pants.engine.rules import Get, MultiGet, _uncacheable_rule, collect_rules, 
 from pants.engine.target import (
     FieldSet,
     Sources,
-    TargetsToValidFieldSets,
-    TargetsToValidFieldSetsRequest,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership, union
 from pants.util.frozendict import FrozenDict
@@ -376,9 +376,9 @@ async def run_tests(
 ) -> Test:
     if test_subsystem.debug:
         targets_to_valid_field_sets = await Get(
-            TargetsToValidFieldSets,
-            TargetsToValidFieldSetsRequest(
-                TestFieldSet, goal_description="`test --debug`", error_if_no_valid_targets=True
+            TargetRootsToFieldSets,
+            TargetRootsToFieldSetsRequest(
+                TestFieldSet, goal_description="`test --debug`", error_if_no_applicable_targets=True
             ),
         )
         debug_requests = await MultiGet(
@@ -395,11 +395,11 @@ async def run_tests(
         return Test(exit_code)
 
     targets_to_valid_field_sets = await Get(
-        TargetsToValidFieldSets,
-        TargetsToValidFieldSetsRequest(
+        TargetRootsToFieldSets,
+        TargetRootsToFieldSetsRequest(
             TestFieldSet,
             goal_description=f"the `{test_subsystem.name}` goal",
-            error_if_no_valid_targets=False,
+            error_if_no_applicable_targets=False,
         ),
     )
     field_sets_with_sources = await Get(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -35,8 +35,8 @@ from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.target import (
     Sources,
     Target,
-    TargetsToValidFieldSets,
-    TargetsToValidFieldSetsRequest,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
     TargetWithOrigin,
 )
 from pants.engine.unions import UnionMembership
@@ -132,11 +132,11 @@ def run_test_rule(
     )
 
     def mock_find_valid_field_sets(
-        _: TargetsToValidFieldSetsRequest,
-    ) -> TargetsToValidFieldSets:
+        _: TargetRootsToFieldSetsRequest,
+    ) -> TargetRootsToFieldSets:
         if not valid_targets:
-            return TargetsToValidFieldSets({})
-        return TargetsToValidFieldSets(
+            return TargetRootsToFieldSets({})
+        return TargetRootsToFieldSets(
             {
                 tgt_with_origin: [field_set.create(tgt_with_origin.target)]
                 for tgt_with_origin in targets
@@ -171,8 +171,8 @@ def run_test_rule(
         ],
         mock_gets=[
             MockGet(
-                product_type=TargetsToValidFieldSets,
-                subject_type=TargetsToValidFieldSetsRequest,
+                product_type=TargetRootsToFieldSets,
+                subject_type=TargetRootsToFieldSetsRequest,
                 mock=mock_find_valid_field_sets,
             ),
             MockGet(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -55,9 +55,9 @@ from pants.engine.target import (
     Sources,
     Subtargets,
     Target,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
     Targets,
-    TargetsToValidFieldSets,
-    TargetsToValidFieldSetsRequest,
     TargetsWithOrigins,
     TargetWithOrigin,
     TransitiveTargets,
@@ -664,7 +664,7 @@ class TransitiveExcludesNotSupportedError(ValueError):
         registered_target_types: Sequence[Type[Target]],
         union_membership: UnionMembership,
     ) -> None:
-        valid_target_types = sorted(
+        applicable_target_types = sorted(
             target_type.alias
             for target_type in registered_target_types
             if (
@@ -678,7 +678,7 @@ class TransitiveExcludesNotSupportedError(ValueError):
             f"Bad value '{bad_value}' in the `dependencies` field for {address}. "
             "Transitive excludes with `!!` are not supported for this target type. Did you mean "
             "to use a single `!` for a direct exclude?\n\nTransitive excludes work with these "
-            f"target types: {valid_target_types}"
+            f"target types: {applicable_target_types}"
         )
 
 
@@ -795,32 +795,32 @@ async def resolve_dependencies(
     return Addresses(sorted(result))
 
 
-# TODO: Rephrase "valid" to "applicable" in the below.
-
 # -----------------------------------------------------------------------------------------------
-# Find valid field sets
+# Find applicable field sets
 # -----------------------------------------------------------------------------------------------
 
 
-class NoValidTargetsException(Exception):
+class NoApplicableTargetsException(Exception):
     def __init__(
         self,
         targets_with_origins: TargetsWithOrigins,
         *,
-        valid_target_types: Iterable[Type[Target]],
+        applicable_target_types: Iterable[Type[Target]],
         goal_description: str,
     ) -> None:
-        valid_target_aliases = sorted({target_type.alias for target_type in valid_target_types})
-        invalid_target_aliases = sorted({tgt.alias for tgt in targets_with_origins.targets})
+        applicable_target_aliases = sorted(
+            {target_type.alias for target_type in applicable_target_types}
+        )
+        inapplicable_target_aliases = sorted({tgt.alias for tgt in targets_with_origins.targets})
         specs = sorted(
             {str(target_with_origin.origin) for target_with_origin in targets_with_origins}
         )
         bulleted_list_sep = "\n  * "
         super().__init__(
             f"{goal_description.capitalize()} only works with the following target types:"
-            f"{bulleted_list_sep}{bulleted_list_sep.join(valid_target_aliases)}\n\n"
+            f"{bulleted_list_sep}{bulleted_list_sep.join(applicable_target_aliases)}\n\n"
             f"You specified `{' '.join(specs)}`, which only included the following target types:"
-            f"{bulleted_list_sep}{bulleted_list_sep.join(invalid_target_aliases)}"
+            f"{bulleted_list_sep}{bulleted_list_sep.join(inapplicable_target_aliases)}"
         )
 
     @classmethod
@@ -832,17 +832,17 @@ class NoValidTargetsException(Exception):
         goal_description: str,
         union_membership: UnionMembership,
         registered_target_types: RegisteredTargetTypes,
-    ) -> "NoValidTargetsException":
-        valid_target_types = {
+    ) -> "NoApplicableTargetsException":
+        applicable_target_types = {
             target_type
             for field_set_type in field_set_types
-            for target_type in field_set_type.valid_target_types(
+            for target_type in field_set_type.applicable_target_types(
                 registered_target_types.types, union_membership=union_membership
             )
         }
         return cls(
             targets_with_origins,
-            valid_target_types=valid_target_types,
+            applicable_target_types=applicable_target_types,
             goal_description=goal_description,
         )
 
@@ -859,8 +859,7 @@ class TooManyTargetsException(Exception):
 
 
 class AmbiguousImplementationsException(Exception):
-    """Exception for when a single target has multiple valid FieldSets, but the goal only expects
-    there to be one FieldSet."""
+    """A target has multiple valid FieldSets, but a goal expects there to be one FieldSet."""
 
     def __init__(
         self,
@@ -883,11 +882,11 @@ class AmbiguousImplementationsException(Exception):
 
 @rule
 async def find_valid_field_sets_for_target_roots(
-    request: TargetsToValidFieldSetsRequest,
+    request: TargetRootsToFieldSetsRequest,
     targets_with_origins: TargetsWithOrigins,
     union_membership: UnionMembership,
     registered_target_types: RegisteredTargetTypes,
-) -> TargetsToValidFieldSets:
+) -> TargetRootsToFieldSets:
     field_sets_per_target = await Get(
         FieldSetsPerTarget,
         FieldSetsPerTargetRequest(
@@ -898,15 +897,15 @@ async def find_valid_field_sets_for_target_roots(
     for tgt_with_origin, field_sets in zip(targets_with_origins, field_sets_per_target.collection):
         if field_sets:
             targets_to_valid_field_sets[tgt_with_origin] = field_sets
-    if request.error_if_no_valid_targets and not targets_to_valid_field_sets:
-        raise NoValidTargetsException.create_from_field_sets(
+    if request.error_if_no_applicable_targets and not targets_to_valid_field_sets:
+        raise NoApplicableTargetsException.create_from_field_sets(
             TargetsWithOrigins(targets_with_origins),
             field_set_types=union_membership.union_rules[request.field_set_superclass],
             goal_description=request.goal_description,
             union_membership=union_membership,
             registered_target_types=registered_target_types,
         )
-    result = TargetsToValidFieldSets(targets_to_valid_field_sets)
+    result = TargetRootsToFieldSets(targets_to_valid_field_sets)
     if not request.expect_single_field_set:
         return result
     if len(result.targets) > 1:

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -50,7 +50,6 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     FieldSet,
-    FieldSetWithOrigin,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -610,15 +609,6 @@ def test_find_valid_field_sets() -> None:
 
         sources: FortranSources
 
-    @union
-    class FieldSetSuperclassWithOrigin(FieldSetWithOrigin):
-        pass
-
-    class FieldSetSubclassWithOrigin(FieldSetSuperclassWithOrigin):
-        required_fields = (FortranSources,)
-
-        sources: FortranSources
-
     rule_runner = RuleRunner(
         rules=[
             QueryRule(
@@ -626,7 +616,6 @@ def test_find_valid_field_sets() -> None:
             ),
             UnionRule(FieldSetSuperclass, FieldSetSubclass1),
             UnionRule(FieldSetSuperclass, FieldSetSubclass2),
-            UnionRule(FieldSetSuperclassWithOrigin, FieldSetSubclassWithOrigin),
         ],
         target_types=[FortranTarget, InvalidTarget],
     )
@@ -694,15 +683,6 @@ def test_find_valid_field_sets() -> None:
             FieldSetSuperclass, [invalid_tgt_with_origin], error_if_no_valid_targets=True
         )
     assert NoValidTargetsException.__name__ in str(exc.value)
-
-    valid_with_origin = find_valid_field_sets(
-        FieldSetSuperclassWithOrigin, [valid_tgt_with_origin, invalid_tgt_with_origin]
-    )
-    assert valid_with_origin.targets == (valid_tgt,)
-    assert valid_with_origin.targets_with_origins == (valid_tgt_with_origin,)
-    assert valid_with_origin.field_sets == (
-        FieldSetSubclassWithOrigin.create(valid_tgt_with_origin),
-    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -37,7 +37,7 @@ from pants.engine.internals.graph import (
     AmbiguousCodegenImplementationsException,
     AmbiguousImplementationsException,
     CycleException,
-    NoValidTargetsException,
+    NoApplicableTargetsException,
     Owners,
     OwnersRequest,
     TooManyTargetsException,
@@ -61,9 +61,9 @@ from pants.engine.target import (
     Sources,
     Tags,
     Target,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
     Targets,
-    TargetsToValidFieldSets,
-    TargetsToValidFieldSetsRequest,
     TargetsWithOrigins,
     TargetWithOrigin,
     TransitiveTargets,
@@ -611,9 +611,7 @@ def test_find_valid_field_sets() -> None:
 
     rule_runner = RuleRunner(
         rules=[
-            QueryRule(
-                TargetsToValidFieldSets, (TargetsToValidFieldSetsRequest, TargetsWithOrigins)
-            ),
+            QueryRule(TargetRootsToFieldSets, (TargetRootsToFieldSetsRequest, TargetsWithOrigins)),
             UnionRule(FieldSetSuperclass, FieldSetSubclass1),
             UnionRule(FieldSetSuperclass, FieldSetSubclass2),
         ],
@@ -630,17 +628,17 @@ def test_find_valid_field_sets() -> None:
         superclass: Type,
         targets_with_origins: Iterable[TargetWithOrigin],
         *,
-        error_if_no_valid_targets: bool = False,
+        error_if_no_applicable_targets: bool = False,
         expect_single_config: bool = False,
-    ) -> TargetsToValidFieldSets:
-        request = TargetsToValidFieldSetsRequest(
+    ) -> TargetRootsToFieldSets:
+        request = TargetRootsToFieldSetsRequest(
             superclass,
             goal_description="fake",
-            error_if_no_valid_targets=error_if_no_valid_targets,
+            error_if_no_applicable_targets=error_if_no_applicable_targets,
             expect_single_field_set=expect_single_config,
         )
         return rule_runner.request_product(
-            TargetsToValidFieldSets,
+            TargetRootsToFieldSets,
             [request, TargetsWithOrigins(targets_with_origins)],
         )
 
@@ -680,9 +678,9 @@ def test_find_valid_field_sets() -> None:
 
     with pytest.raises(ExecutionError) as exc:
         find_valid_field_sets(
-            FieldSetSuperclass, [invalid_tgt_with_origin], error_if_no_valid_targets=True
+            FieldSetSuperclass, [invalid_tgt_with_origin], error_if_no_applicable_targets=True
         )
-    assert NoValidTargetsException.__name__ in str(exc.value)
+    assert NoApplicableTargetsException.__name__ in str(exc.value)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -722,7 +722,7 @@ class _AbstractFieldSet(ABC):
 
     @final
     @classmethod
-    def valid_target_types(
+    def applicable_target_types(
         cls, target_types: Iterable[Type[Target]], *, union_membership: UnionMembership
     ) -> Tuple[Type[Target], ...]:
         return tuple(
@@ -794,12 +794,9 @@ class FieldSet(_AbstractFieldSet, metaclass=ABCMeta):
 _AFS = TypeVar("_AFS", bound=_AbstractFieldSet)
 
 
-# TODO: Rephrase "valid" to "applicable" in the below.
-
-
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TargetsToValidFieldSets(Generic[_AFS]):
+class TargetRootsToFieldSets(Generic[_AFS]):
     mapping: FrozenDict[TargetWithOrigin, Tuple[_AFS, ...]]
 
     def __init__(self, mapping: Mapping[TargetWithOrigin, Iterable[_AFS]]) -> None:
@@ -826,10 +823,10 @@ class TargetsToValidFieldSets(Generic[_AFS]):
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class TargetsToValidFieldSetsRequest(Generic[_AFS]):
+class TargetRootsToFieldSetsRequest(Generic[_AFS]):
     field_set_superclass: Type[_AFS]
     goal_description: str
-    error_if_no_valid_targets: bool
+    error_if_no_applicable_targets: bool
     expect_single_field_set: bool
     # TODO: Add a `require_sources` field. To do this, figure out the dependency cycle with
     #  `util_rules/filter_empty_sources.py`.
@@ -839,12 +836,12 @@ class TargetsToValidFieldSetsRequest(Generic[_AFS]):
         field_set_superclass: Type[_AFS],
         *,
         goal_description: str,
-        error_if_no_valid_targets: bool,
+        error_if_no_applicable_targets: bool,
         expect_single_field_set: bool = False,
     ) -> None:
         self.field_set_superclass = field_set_superclass
         self.goal_description = goal_description
-        self.error_if_no_valid_targets = error_if_no_valid_targets
+        self.error_if_no_applicable_targets = error_if_no_applicable_targets
         self.expect_single_field_set = expect_single_field_set
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import pytest
 from typing_extensions import final
 
-from pants.base.specs import FilesystemLiteralSpec
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, PathGlobs, Snapshot
 from pants.engine.rules import Get, rule
@@ -20,7 +19,6 @@ from pants.engine.target import (
     DictStringToStringField,
     DictStringToStringSequenceField,
     FieldSet,
-    FieldSetWithOrigin,
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
@@ -34,7 +32,6 @@ from pants.engine.target import (
     StringSequenceField,
     Tags,
     Target,
-    TargetWithOrigin,
     generate_subtarget,
     generate_subtarget_address,
 )
@@ -512,7 +509,7 @@ def test_field_set() -> None:
         unrelated_field: UnrelatedField
 
     @dataclass(frozen=True)
-    class UnrelatedFieldSet(FieldSetWithOrigin):
+    class UnrelatedFieldSet(FieldSet):
         required_fields = ()
 
         unrelated_field: UnrelatedField
@@ -537,16 +534,8 @@ def test_field_set() -> None:
     with pytest.raises(KeyError):
         FortranFieldSet.create(unrelated_tgt)
 
-    origin = FilesystemLiteralSpec("f.txt")
-    assert UnrelatedFieldSet.create(TargetWithOrigin(fortran_tgt, origin)).origin == origin
-    assert (
-        UnrelatedFieldSet.create(TargetWithOrigin(unrelated_tgt, origin)).unrelated_field.value
-        == "configured"
-    )
-    assert (
-        UnrelatedFieldSet.create(TargetWithOrigin(no_fields_tgt, origin)).unrelated_field.value
-        == UnrelatedField.default
-    )
+    assert UnrelatedFieldSet.create(unrelated_tgt).unrelated_field.value == "configured"
+    assert UnrelatedFieldSet.create(no_fields_tgt).unrelated_field.value == UnrelatedField.default
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Now it's possible to get the FieldSets that subclass some
  given superclass for any arbitrary set of targets.
- The previous logic, that applies this specifically to the 
  target roots, now uses this new logic.
- Removes FieldSetWithOrigin, which was unused,
  and would have complicated the refactoring.
- Also improves error messages in setup_py.py, that
  are unrelated to this change but didn't merit their
  own change.

[ci skip-rust]

[ci skip-build-wheels]

