### PR TITLE
Switch the backend of AsyncSemaphore to tokio's Semaphore.

### DIFF
--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 
 [dependencies]
 parking_lot = "0.11"
+# TODO: See #10291.
+tokio = { version = "=0.2.20", features = ["sync"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -437,10 +437,6 @@ pub trait CommandRunner: Send + Sync {
   /// first candidate that will be run if the multi platform request is submitted to
   /// `fn run(..)`
   fn extract_compatible_request(&self, req: &MultiPlatformProcess) -> Option<Process>;
-
-  fn num_waiters(&self) -> usize {
-    panic!("This method is abstract and not implemented for this type")
-  }
 }
 
 // TODO(#8513) possibly move to the MEPR struct, or to the hashing crate?
@@ -481,10 +477,6 @@ impl BoundedCommandRunner {
 
 #[async_trait]
 impl CommandRunner for BoundedCommandRunner {
-  fn num_waiters(&self) -> usize {
-    self.inner.1.num_waiters()
-  }
-
   async fn run(
     &self,
     mut req: MultiPlatformProcess,

--- a/src/rust/engine/process_execution/src/speculate.rs
+++ b/src/rust/engine/process_execution/src/speculate.rs
@@ -4,7 +4,7 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::future::{self, Either, FutureExt};
-use log::{debug, trace};
+use log::debug;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::delay_for;
@@ -34,11 +34,6 @@ impl SpeculatingCommandRunner {
     req: MultiPlatformProcess,
     context: Context,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
-    trace!(
-      "Primary command runner queue length: {:?}",
-      self.primary.num_waiters()
-    );
-
     let secondary_request = {
       let command_runner = self.clone();
       let req = req.clone();
@@ -46,10 +41,6 @@ impl SpeculatingCommandRunner {
       async move {
         delay_for(self.speculation_timeout).await;
 
-        trace!(
-          "Secondary command runner queue length: {:?}",
-          command_runner.secondary.num_waiters()
-        );
         command_runner.secondary.run(req, context).await
       }
     };


### PR DESCRIPTION
### Problem

Our `AsyncSemaphore` was created before tokio's existed, and has needed patches to fix various issues over the intervening time. We're currently seeing an issue that we believe might be starvation of an `AsyncSemaphore`.

### Solution

Switch to tokio's `Semaphore` behind the `AsyncSemaphore` facade.

### Result

Less code to maintain!

[ci skip-build-wheels]