### PR TITLE
Replace `cloc` with `count-loc`, using much faster SCC program

### DIFF
--- a/src/python/pants/backend/project_info/cloc.py
+++ b/src/python/pants/backend/project_info/cloc.py
@@ -92,16 +92,16 @@ async def run_cloc(
     if not sources_snapshot.snapshot.files:
         return CountLinesOfCode(exit_code=0)
 
-    downloaded_cloc_binary = await Get(
+    scc_program = await Get(
         DownloadedExternalTool, ExternalToolRequest, cloc_binary.get_request(Platform.current)
     )
     input_digest = await Get(
-        Digest, MergeDigests((downloaded_cloc_binary.digest, sources_snapshot.snapshot.digest))
+        Digest, MergeDigests((scc_program.digest, sources_snapshot.snapshot.digest))
     )
     result = await Get(
         ProcessResult,
         Process(
-            argv=(downloaded_cloc_binary.exe, *cloc_subsystem.args),
+            argv=(scc_program.exe, *cloc_subsystem.args),
             input_digest=input_digest,
             description=(
                 f"Count lines of code for {pluralize(len(sources_snapshot.snapshot.files), 'file')}"

--- a/src/python/pants/backend/project_info/cloc_test.py
+++ b/src/python/pants/backend/project_info/cloc_test.py
@@ -34,16 +34,16 @@ def assert_counts(
         (
             line
             for line in stdout.splitlines()
-            if len(line.split()) == 5 and line.split()[0] == lang
+            if len(line.split()) in (6, 7) and line.split()[0] == lang
         ),
         None,
     )
-    assert summary_line is not None, f"Found no output line for {lang}"
+    assert summary_line is not None, f"Found no output line for {lang} given stdout:\n {stdout}"
     fields = summary_line.split()
     assert num_files == int(fields[1])
-    assert blank == int(fields[2])
-    assert comment == int(fields[3])
-    assert code == int(fields[4])
+    assert blank == int(fields[3])
+    assert comment == int(fields[4])
+    assert code == int(fields[5])
 
 
 def test_cloc(rule_runner: RuleRunner) -> None:
@@ -67,33 +67,18 @@ def test_cloc(rule_runner: RuleRunner) -> None:
     assert_counts(result.stdout, "Elixir", comment=1, code=1)
 
 
-def test_ignored(rule_runner: RuleRunner) -> None:
-    py_dir = "src/py/foo"
-    rule_runner.create_file(f"{py_dir}/foo.py", "print('some code')")
-    rule_runner.create_file(f"{py_dir}/empty.py", "")
-    rule_runner.add_to_build_file(py_dir, "python_library()")
-
-    result = rule_runner.run_goal_rule(CountLinesOfCode, args=[py_dir, "--cloc-ignored"])
+def test_passthrough_args(rule_runner: RuleRunner) -> None:
+    rule_runner.create_file("foo.py", "print('hello world!')\n")
+    rule_runner.add_to_build_file("", "python_library(name='foo')")
+    result = rule_runner.run_goal_rule(CountLinesOfCode, args=["--args='--no-cocomo'", "//:foo"])
     assert result.exit_code == 0
-    assert "Ignored the following files:" in result.stderr
-    assert "empty.py: zero sized file" in result.stderr
+    assert_counts(result.stdout, "Python", code=1)
+    assert "Estimated Cost to Develop" not in result.stdout
 
 
-def test_filesystem_specs_with_owners(rule_runner: RuleRunner) -> None:
-    """Even if a file belongs to a target which has multiple sources, we should only run over the
-    specified file."""
-    py_dir = "src/py/foo"
-    rule_runner.create_file(f"{py_dir}/foo.py", "print('some code')")
-    rule_runner.create_file(f"{py_dir}/bar.py", "print('some code')\nprint('more code')")
-    rule_runner.add_to_build_file(py_dir, "python_library()")
-    result = rule_runner.run_goal_rule(CountLinesOfCode, args=[f"{py_dir}/foo.py"])
-    assert result.exit_code == 0
-    assert_counts(result.stdout, "Python", num_files=1, code=1)
-
-
-def test_filesystem_specs_without_owners(rule_runner: RuleRunner) -> None:
-    """Unlike most goals, cloc works on any readable file in the build root, regardless of whether
-    it's declared in a BUILD file."""
+def test_files_without_owners(rule_runner: RuleRunner) -> None:
+    """cloc works on any readable file in the build root, regardless of whether it's declared in a
+    BUILD file."""
     rule_runner.create_file("test/foo.ex", 'IO.puts("im a free thinker!")')
     rule_runner.create_file("test/foo.hs", 'main = putStrLn "Whats Pants, precious?"')
     result = rule_runner.run_goal_rule(CountLinesOfCode, args=["test/foo.*"])

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -21,30 +21,14 @@ from pants.util.strutil import pluralize
 
 
 class SuccinctCodeCounter(ExternalTool):
-    """The Succinct Code Counter (https://github.com/boyter/scc)."""
+    """The Succinct Code Counter, aka `scc` (https://github.com/boyter/scc)."""
 
-    options_scope = "succinct-code-counter"
+    options_scope = "scc"
     default_version = "2.12.0"
     default_known_versions = [
         "2.12.0|darwin|70b7002cd1e4541cb37b7b9cbc0eeedd13ceacb49628e82ab46332bb2e65a5a6|1842530",
         "2.12.0|linux|8eca3e98fe8a78d417d3779a51724515ac4459760d3ec256295f80954a0da044|1753059",
     ]
-
-    def generate_url(self, plat: Platform) -> str:
-        plat_str = match(plat, {Platform.darwin: "apple-darwin", Platform.linux: "unknown-linux"})
-        return (
-            f"https://github.com/boyter/scc/releases/download/v{self.version}/scc-{self.version}-"
-            f"x86_64-{plat_str}.zip"
-        )
-
-    def generate_exe(self, _: Platform) -> str:
-        return "./scc"
-
-
-class CountLinesOfCodeSubsystem(GoalSubsystem):
-    """Count lines of code using Succinct Code Counter (https://github.com/boyter/scc)."""
-
-    name = "count-loc"
 
     @classmethod
     def register_options(cls, register) -> None:
@@ -64,6 +48,22 @@ class CountLinesOfCodeSubsystem(GoalSubsystem):
     def args(self) -> Tuple[str, ...]:
         return tuple(self.options.args)
 
+    def generate_url(self, plat: Platform) -> str:
+        plat_str = match(plat, {Platform.darwin: "apple-darwin", Platform.linux: "unknown-linux"})
+        return (
+            f"https://github.com/boyter/scc/releases/download/v{self.version}/scc-{self.version}-"
+            f"x86_64-{plat_str}.zip"
+        )
+
+    def generate_exe(self, _: Platform) -> str:
+        return "./scc"
+
+
+class CountLinesOfCodeSubsystem(GoalSubsystem):
+    """Count lines of code using `scc` (Succinct Code Counter, https://github.com/boyter/scc)."""
+
+    name = "count-loc"
+
 
 class CountLinesOfCode(Goal):
     subsystem_cls = CountLinesOfCodeSubsystem
@@ -72,7 +72,6 @@ class CountLinesOfCode(Goal):
 @goal_rule
 async def count_loc(
     console: Console,
-    count_loc_subsystem: CountLinesOfCodeSubsystem,
     succinct_code_counter: SuccinctCodeCounter,
     sources_snapshot: SourcesSnapshot,
 ) -> CountLinesOfCode:
@@ -90,7 +89,7 @@ async def count_loc(
     result = await Get(
         ProcessResult,
         Process(
-            argv=(scc_program.exe, *count_loc_subsystem.args),
+            argv=(scc_program.exe, *succinct_code_counter.args),
             input_digest=input_digest,
             description=(
                 f"Count lines of code for {pluralize(len(sources_snapshot.snapshot.files), 'file')}"

--- a/src/python/pants/backend/project_info/count_loc_test.py
+++ b/src/python/pants/backend/project_info/count_loc_test.py
@@ -71,7 +71,7 @@ def test_count_loc(rule_runner: RuleRunner) -> None:
 def test_passthrough_args(rule_runner: RuleRunner) -> None:
     rule_runner.create_file("foo.py", "print('hello world!')\n")
     rule_runner.add_to_build_file("", "python_library(name='foo')")
-    result = rule_runner.run_goal_rule(CountLinesOfCode, args=["--args='--no-cocomo'", "//:foo"])
+    result = rule_runner.run_goal_rule(CountLinesOfCode, args=["//:foo", "--", "--no-cocomo"])
     assert result.exit_code == 0
     assert_counts(result.stdout, "Python", code=1)
     assert "Estimated Cost to Develop" not in result.stdout

--- a/src/python/pants/backend/project_info/count_loc_test.py
+++ b/src/python/pants/backend/project_info/count_loc_test.py
@@ -3,8 +3,8 @@
 
 import pytest
 
-from pants.backend.project_info import cloc
-from pants.backend.project_info.cloc import CountLinesOfCode
+from pants.backend.project_info import count_loc
+from pants.backend.project_info.count_loc import CountLinesOfCode
 from pants.backend.python.target_types import PythonLibrary
 from pants.core.util_rules import external_tool
 from pants.engine.target import Sources, Target
@@ -23,7 +23,8 @@ class ElixirTarget(Target):
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[*cloc.rules(), *external_tool.rules()], target_types=[PythonLibrary, ElixirTarget]
+        rules=[*count_loc.rules(), *external_tool.rules()],
+        target_types=[PythonLibrary, ElixirTarget],
     )
 
 
@@ -46,7 +47,7 @@ def assert_counts(
     assert code == int(fields[5])
 
 
-def test_cloc(rule_runner: RuleRunner) -> None:
+def test_count_loc(rule_runner: RuleRunner) -> None:
     py_dir = "src/py/foo"
     rule_runner.create_file(
         f"{py_dir}/foo.py", '# A comment.\n\nprint("some code")\n# Another comment.'

--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -4,7 +4,7 @@
 """Information on your project, such as listing the targets in your project."""
 
 from pants.backend.project_info import (
-    cloc,
+    count_loc,
     dependees,
     dependencies,
     filedeps,
@@ -17,7 +17,7 @@ from pants.backend.project_info import (
 
 def rules():
     return [
-        *cloc.rules(),
+        *count_loc.rules(),
         *dependees.rules(),
         *dependencies.rules(),
         *filedeps.rules(),


### PR DESCRIPTION
The `cloc` Perl script is not great for performance. There are several modern replacements, including Tokei (Rust), Loc (Rust), and SCC (Go). Loc has recommended that people now use SCC. Tokei looks promising, but SCC has better benchmarks https://boyter.org/posts/sloc-cloc-code-performance-update/. SCC is very well maintained with several maintainers https://github.com/boyter/scc, and they have several blogs on how they achieved such impressive performance https://boyter.org/posts/sloc-cloc-code-performance/. 

This also allows us to simplify our implementation. We are now nothing more than a light wrapper around SCC, in line with our general philosophy with Pants 2.0 and the v2 engine. We expose a new option `--args` which allows users to customize the tool as they want, e.g. `./pants count-loc '**' -- --no-complexity -v`.

Sample run on Pants:

```

───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
Python                     526     77465     6835      5246    65384       3197
Rust                       105     37940     3609      3394    30937       1392
Markdown                    34      1457      287         0     1170          0
ReStructuredText            34     18759     6164         0    12595          0
TOML                        33       921       76        88      757          0
Shell                       29      1645      272       250     1123        159
Protocol Buffers            21      4970      517      3400     1053          0
Plain Text                   7       119        7         0      112          0
BASH                         6       468       83       129      256         60
Dockerfile                   4       205       34        42      129          4
License                      4       646      104         0      542          0
gitignore                    4        75        0         6       69          0
Mustache                     2        55        9         0       46          0
YAML                         2      1006        6        11      989          0
C                            1         0        0         0        0          0
Cargo Lock                   1      3801      367         2     3432          0
XML                          1         7        0         0        7          0
───────────────────────────────────────────────────────────────────────────────
Total                      814    149539    18370     12568   118601       4812
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop $4,068,066
Estimated Schedule Effort 26.149191 months
Estimated People Required 18.428267
───────────────────────────────────────────────────────────────────────────────
```

### Benchmark on Pants codebase
Both benchmarks use our UUID hack to force rerunning the Cloc process, but use the cache for downloading the program.

Before:

```
1: ./pants --no-pantsd cloc '**'
            Mean        Std.Dev.    Min         Median      Max
real        3.560       0.045       3.492       3.568       3.650
user        3.337       0.029       3.287       3.336       3.386
sys         1.258       0.033       1.199       1.263       1.292
```

After:

```
1: ./pants --no-pantsd count-loc '**'
            Mean        Std.Dev.    Min         Median      Max
real        1.949       0.069       1.838       1.951       2.094
user        1.833       0.032       1.797       1.828       1.910
sys         1.136       0.026       1.088       1.134       1.177
```

Almost all of the time is now from Pants.

[ci skip-rust]
[ci skip-build-wheels]