### PR TITLE
Support binary dependencies in tests.

### DIFF
--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -40,7 +40,7 @@ class Binary(Goal):
 
 @goal_rule
 async def create_binary(workspace: Workspace, dist_dir: DistDir) -> Binary:
-    targets_to_valid_field_sets = await Get(
+    target_roots_to_field_sets = await Get(
         TargetRootsToFieldSets,
         TargetRootsToFieldSetsRequest(
             BinaryFieldSet,
@@ -50,7 +50,7 @@ async def create_binary(workspace: Workspace, dist_dir: DistDir) -> Binary:
     )
     binaries = await MultiGet(
         Get(CreatedBinary, BinaryFieldSet, field_set)
-        for field_set in targets_to_valid_field_sets.field_sets
+        for field_set in target_roots_to_field_sets.field_sets
     )
     merged_snapshot = await Get(Snapshot, MergeDigests(binary.digest for binary in binaries))
     workspace.write_digest(merged_snapshot.digest, path_prefix=str(dist_dir.relpath))

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -854,6 +854,10 @@ class FieldSetsPerTarget(Generic[_AFS]):
     def __init__(self, collection: Iterable[Iterable[_AFS]]):
         self.collection = tuple(tuple(iterable) for iterable in collection)
 
+    @memoized_property
+    def field_sets(self) -> Tuple[_AFS, ...]:
+        return tuple(itertools.chain.from_iterable(self.collection))
+
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)


### PR DESCRIPTION
A test can now depend on a binary target (python or otherwise)
and the built binary will be present in the test's chroot.

Note that this supports a user's immediate use case, but doesn't
address some wider questions of what it means to depend on a binary
target. For example, if a binary depends on another binary, should
that second binary be embedded as a resource inside the first one?
But until we figure out what the general principle might be,
this is useful in a real-world case.

[ci skip-rust]

[ci skip-build-wheels]
