### PR TITLE
Fix MyPy to work by default with Python 3.6+ code and Black with 3.8+ code

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -75,9 +75,6 @@ config = ["pyproject.toml", "examples/.isort.cfg"]
 
 [mypy]
 config = "build-support/mypy/mypy.ini"
-# TODO(John Sirois): Remove once proper interpreter selection is performed automatically as part of
-#  https://github.com/pantsbuild/pants/issues/10131
-interpreter_constraints=["CPython>=3.6"]
 
 [pants-releases]
 release_notes = """

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -30,7 +30,6 @@ from pants.backend.python.goals.setup_py import (
     get_owned_dependencies,
     get_requirements,
     get_sources,
-    is_python2,
     validate_args,
 )
 from pants.backend.python.macros.python_artifact import PythonArtifact
@@ -808,32 +807,3 @@ def test_declares_pkg_resources_namespace_package(python_src: str) -> None:
 )
 def test_does_not_declare_pkg_resources_namespace_package(python_src: str) -> None:
     assert not declares_pkg_resources_namespace_package(python_src)
-
-
-@pytest.mark.parametrize(
-    "constraints",
-    [
-        ["CPython>=2.7,<3"],
-        ["CPython>=2.7,<3", "CPython>=3.6"],
-        ["CPython>=2.7.13"],
-        ["CPython>=2.7.13,<2.7.16"],
-        ["CPython>=2.7.13,!=2.7.16"],
-        ["PyPy>=2.7,<3"],
-    ],
-)
-def test_is_python2(constraints):
-    assert is_python2(constraints)
-
-
-@pytest.mark.parametrize(
-    "constraints",
-    [
-        ["CPython>=3.6"],
-        ["CPython>=3.7"],
-        ["CPython>=3.6", "CPython>=3.8"],
-        ["CPython!=2.7.*"],
-        ["PyPy>=3.6"],
-    ],
-)
-def test_is_not_python2(constraints):
-    assert not is_python2(constraints)

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -129,7 +129,9 @@ async def bandit_lint_partition(
         report = LintReport(report_file_name, report_digest)
 
     return LintResult.from_fallible_process_result(
-        result, partition_description=str(sorted(partition.interpreter_constraints)), report=report
+        result,
+        partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
+        report=report,
     )
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -86,9 +86,12 @@ async def setup_black(
         python_setup,
     )
     tool_interpreter_constraints = PexInterpreterConstraints(
-        black.interpreter_constraints
-        if not all_interpreter_constraints.requires_python38_or_newer()
-        else ("CPython>=3.8",)
+        ("CPython>=3.8",)
+        if (
+            all_interpreter_constraints.requires_python38_or_newer()
+            and black.options.is_default("interpreter_constraints")
+        )
+        else black.interpreter_constraints
     )
 
     black_pex_request = Get(

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.python_fmt import PythonFmtRequest
-from pants.backend.python.target_types import PythonSources
+from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -26,6 +26,7 @@ from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
+from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -35,6 +36,7 @@ class BlackFieldSet(FieldSet):
     required_fields = (PythonSources,)
 
     sources: PythonSources
+    interpreter_constraints: PythonInterpreterCompatibility
 
 
 class BlackRequest(PythonFmtRequest, LintRequest):
@@ -71,14 +73,31 @@ def generate_args(*, source_files: SourceFiles, black: Black, check_only: bool) 
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_black(setup_request: SetupRequest, black: Black) -> Setup:
-    requirements_pex_request = Get(
+async def setup_black(
+    setup_request: SetupRequest, black: Black, python_setup: PythonSetup
+) -> Setup:
+    # Black requires 3.6+ but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6, and 3.7.
+    # However, typed-ast does not understand 3.8, so instead we must run Black with Python 3.8 when
+    # relevant. We only do this if if <3.8 can't be used, as we don't want a loose requirement like
+    # `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on the
+    # machine.
+    all_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
+        (field_set.interpreter_constraints for field_set in setup_request.request.field_sets),
+        python_setup,
+    )
+    tool_interpreter_constraints = PexInterpreterConstraints(
+        black.interpreter_constraints
+        if not all_interpreter_constraints.requires_python38_or_newer()
+        else ("CPython>=3.8",)
+    )
+
+    black_pex_request = Get(
         Pex,
         PexRequest(
             output_filename="black.pex",
             internal_only=True,
             requirements=PexRequirements(black.all_requirements),
-            interpreter_constraints=PexInterpreterConstraints(black.interpreter_constraints),
+            interpreter_constraints=tool_interpreter_constraints,
             entry_point=black.entry_point,
         ),
     )
@@ -97,8 +116,8 @@ async def setup_black(setup_request: SetupRequest, black: Black) -> Setup:
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    source_files, requirements_pex, config_digest = await MultiGet(
-        source_files_request, requirements_pex_request, config_digest_request
+    source_files, black_pex, config_digest = await MultiGet(
+        source_files_request, black_pex_request, config_digest_request
     )
     source_files_snapshot = (
         source_files.snapshot
@@ -108,13 +127,13 @@ async def setup_black(setup_request: SetupRequest, black: Black) -> Setup:
 
     input_digest = await Get(
         Digest,
-        MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
+        MergeDigests((source_files_snapshot.digest, black_pex.digest, config_digest)),
     )
 
     process = await Get(
         Process,
         PexProcess(
-            requirements_pex,
+            black_pex,
             argv=generate_args(
                 source_files=source_files, black=black, check_only=setup_request.check_only
             ),

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -130,7 +130,9 @@ async def flake8_lint_partition(
         report = LintReport(report_file_name, report_digest)
 
     return LintResult.from_fallible_process_result(
-        result, partition_description=str(sorted(partition.interpreter_constraints)), report=report
+        result,
+        partition_description=str(sorted(str(c) for c in partition.interpreter_constraints)),
+        report=report,
     )
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -232,7 +232,7 @@ async def pylint_lint_partition(partition: PylintPartition, pylint: Pylint) -> L
         ),
     )
     return LintResult.from_fallible_process_result(
-        result, partition_description=str(sorted(partition.interpreter_constraints))
+        result, partition_description=str(sorted(str(c) for c in partition.interpreter_constraints))
     )
 
 

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -180,7 +180,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert "invalid syntax (<string>, line 2) (syntax-error)" in batched_py2_result.stdout
 
     assert batched_py3_result.exit_code == 0
-    assert batched_py3_result.partition_description == "['CPython>=3.6,<3.8']"
+    assert batched_py3_result.partition_description == "['CPython<3.8,>=3.6']"
     assert "Your code has been rated at 10.00/10" in batched_py3_result.stdout.strip()
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -1,10 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.python.target_types import PythonSources
+from pants.backend.python.target_types import PythonInterpreterCompatibility, PythonSources
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
 from pants.backend.python.util_rules.pex import (
     Pex,
@@ -34,8 +35,11 @@ from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, TransitiveTargets
 from pants.engine.unions import UnionRule
+from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -60,13 +64,41 @@ def generate_args(mypy: MyPy, *, file_list_path: str) -> Tuple[str, ...]:
 
 # TODO(#10131): Improve performance, e.g. by leveraging the MyPy cache.
 # TODO(#10131): Support plugins and type stubs.
+# TODO(#10131): Support third-party requirements.
 @rule(desc="Typecheck using MyPy", level=LogLevel.DEBUG)
-async def mypy_typecheck(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
+async def mypy_typecheck(
+    request: MyPyRequest, mypy: MyPy, python_setup: PythonSetup
+) -> TypecheckResults:
     if mypy.skip:
         return TypecheckResults([], typechecker_name="MyPy")
 
     transitive_targets = await Get(
         TransitiveTargets, Addresses(fs.address for fs in request.field_sets)
+    )
+
+    # Interpreter constraints are tricky with MyPy:
+    #  * MyPy requires running with Python 3.5+. If run with Python 3.5 - 3.7, MyPy can understand
+    #     Python 2.7 and 3.4-3.7 thanks to the typed-ast library, but it can't understand 3.8+ If
+    #     run with Python 3.8, it can understand 2.7 and 3.4-3.8. So, we need to check if the user
+    #     has code that requires Python 3.8+, and if so, use a tighter requirement. We only do this
+    #     if <3.8 can't be used, as we don't want a loose requirement like `>=3.6` to result in
+    #     requiring Python 3.8, which would error if 3.8 is not installed on the machine.
+    #  * We must resolve third-party dependencies. This should use whatever the actual code's
+    #     constraints are, as the constraints for the tool can be different than for the
+    #     requirements.
+    #  * The runner Pex should use the same constraints as the tool Pex.
+    all_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
+        (
+            tgt[PythonInterpreterCompatibility]
+            for tgt in transitive_targets.closure
+            if tgt.has_field(PythonInterpreterCompatibility)
+        ),
+        python_setup,
+    )
+    tool_interpreter_constraints = PexInterpreterConstraints(
+        mypy.interpreter_constraints
+        if not all_interpreter_constraints.requires_python38_or_newer()
+        else ("CPython>=3.8",)
     )
 
     prepared_sources_request = Get(
@@ -79,12 +111,7 @@ async def mypy_typecheck(request: MyPyRequest, mypy: MyPy) -> TypecheckResults:
             output_filename="mypy.pex",
             internal_only=True,
             requirements=PexRequirements(mypy.all_requirements),
-            # NB: This only determines what MyPy is run with. The user can specify what version
-            # their code is with `--python-version`. See
-            # https://mypy.readthedocs.io/en/stable/config_file.html#platform-configuration. We do
-            # not auto-configure this for simplicity and to avoid Pants magically setting values for
-            # users.
-            interpreter_constraints=PexInterpreterConstraints(mypy.interpreter_constraints),
+            interpreter_constraints=tool_interpreter_constraints,
             entry_point=mypy.entry_point,
         ),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -39,8 +38,6 @@ from pants.python.python_setup import PythonSetup
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
-logger = logging.getLogger(__name__)
-
 
 @dataclass(frozen=True)
 class MyPyFieldSet(FieldSet):
@@ -77,7 +74,7 @@ async def mypy_typecheck(
     )
 
     # Interpreter constraints are tricky with MyPy:
-    #  * MyPy requires running with Python 3.5+. If run with Python 3.5 - 3.7, MyPy can understand
+    #  * MyPy requires running with Python 3.5+. If run with Python 3.5-3.7, MyPy can understand
     #     Python 2.7 and 3.4-3.7 thanks to the typed-ast library, but it can't understand 3.8+ If
     #     run with Python 3.8, it can understand 2.7 and 3.4-3.8. So, we need to check if the user
     #     has code that requires Python 3.8+, and if so, use a tighter requirement.
@@ -90,11 +87,11 @@ async def mypy_typecheck(
     #
     #     We only apply these optimizations if the user did not configure
     #     `--mypy-interpreter-constraints`, and if we are know that there are no Py35 or Py27
-    #     constraints, as we would assume that their code is compatible with those ASTs, and we
-    #     want looser constraints to make it more flexible to install MyPy.
+    #     constraints. If they use Py27 or Py35, this implies that they're not using Py36+ syntax,
+    #     so it's fine to use the Py35 parser. We want the loosest constraints possible to make it
+    #     more flexible to install MyPy.
     #  * We must resolve third-party dependencies. This should use whatever the actual code's
-    #     constraints are, as the constraints for the tool can be different than for the
-    #     requirements.
+    #     constraints are. The constraints for the tool can be different than for the requirements.
     #  * The runner Pex should use the same constraints as the tool Pex.
     all_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -13,6 +13,7 @@ class MyPy(PythonToolBase):
     options_scope = "mypy"
     default_version = "mypy==0.782"
     default_entry_point = "mypy"
+    # See `mypy/rules.py`. We only use these default constraints in some situations.
     default_interpreter_constraints = ["CPython>=3.5"]
 
     @classmethod

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import dataclasses
+import functools
 import itertools
 import logging
 from dataclasses import dataclass
@@ -10,12 +11,12 @@ from typing import (
     Iterable,
     List,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
     Set,
     Tuple,
     TypeVar,
+    Union,
 )
 
 from pkg_resources import Requirement
@@ -46,6 +47,7 @@ from pants.python.python_setup import PythonSetup
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
 
 
@@ -63,33 +65,6 @@ class PexRequirements(DeduplicatedCollection[str]):
         return PexRequirements({*field_requirements, *additional_requirements})
 
 
-def parse_interpreter_constraint(constraint: str) -> Requirement:
-    """Parse an interpreter constraint, e.g., CPython>=2.7,<3.
-
-    We allow shorthand such as `>=3.7`, which gets expanded to `CPython>=3.7`. See Pex's
-    interpreter.py's `parse_requirement()`.
-    """
-    try:
-        parsed_requirement = Requirement.parse(constraint)
-    except ValueError:
-        parsed_requirement = Requirement.parse(f"CPython{constraint}")
-    return parsed_requirement
-
-
-Spec = Tuple[str, str]  # e.g. (">=", "3.6")
-
-
-class ParsedConstraint(NamedTuple):
-    interpreter: str
-    specs: FrozenSet[Spec]
-
-    def __str__(self) -> str:
-        specs = ",".join(
-            f"{op}{version}" for op, version in sorted(self.specs, key=lambda spec: spec[1])
-        )
-        return f"{self.interpreter}{specs}"
-
-
 # This protocol allows us to work with any arbitrary FieldSet. See
 # https://mypy.readthedocs.io/en/stable/protocols.html.
 class FieldSetWithCompatibility(Protocol):
@@ -105,11 +80,29 @@ class FieldSetWithCompatibility(Protocol):
 _FS = TypeVar("_FS", bound=FieldSetWithCompatibility)
 
 
-class PexInterpreterConstraints(DeduplicatedCollection[str]):
-    sort_input = True
+# Normally we would subclass `DeduplicatedCollection`, but we want a custom constructor.
+class PexInterpreterConstraints(FrozenOrderedSet[Requirement]):
+    def __init__(self, constraints: Iterable[Union[str, Requirement]] = ()) -> None:
+        super().__init__(
+            v if isinstance(v, Requirement) else self.parse_constraint(v)
+            for v in sorted(constraints)
+        )
 
     @staticmethod
-    def merge_constraint_sets(constraint_sets: Iterable[Iterable[str]]) -> List[str]:
+    def parse_constraint(constraint: str) -> Requirement:
+        """Parse an interpreter constraint, e.g., CPython>=2.7,<3.
+
+        We allow shorthand such as `>=3.7`, which gets expanded to `CPython>=3.7`. See Pex's
+        interpreter.py's `parse_requirement()`.
+        """
+        try:
+            parsed_requirement = Requirement.parse(constraint)
+        except ValueError:
+            parsed_requirement = Requirement.parse(f"CPython{constraint}")
+        return parsed_requirement
+
+    @classmethod
+    def merge_constraint_sets(cls, constraint_sets: Iterable[Iterable[str]]) -> List[Requirement]:
         """Given a collection of constraints sets, merge by ORing within each individual constraint
         set and ANDing across each distinct constraint set.
 
@@ -120,29 +113,26 @@ class PexInterpreterConstraints(DeduplicatedCollection[str]):
         # identical top-level parsed constraint sets.
         if not constraint_sets:
             return []
-        parsed_constraint_sets: Set[FrozenSet[ParsedConstraint]] = set()
+        parsed_constraint_sets: Set[FrozenSet[Requirement]] = set()
         for constraint_set in constraint_sets:
             # Each element (a ParsedConstraint) will get ORed.
-            parsed_constraint_set: Set[ParsedConstraint] = set()
-            for constraint in constraint_set:
-                parsed_requirement = parse_interpreter_constraint(constraint)
-                interpreter = parsed_requirement.project_name
-                specs = frozenset(parsed_requirement.specs)
-                parsed_constraint_set.add(ParsedConstraint(interpreter, specs))
-            parsed_constraint_sets.add(frozenset(parsed_constraint_set))
+            parsed_constraint_set = frozenset(
+                cls.parse_constraint(constraint) for constraint in constraint_set
+            )
+            parsed_constraint_sets.add(parsed_constraint_set)
 
-        def and_constraints(parsed_constraints: Sequence[ParsedConstraint]) -> ParsedConstraint:
-            merged_specs: Set[Spec] = set()
-            expected_interpreter = parsed_constraints[0][0]
+        def and_constraints(parsed_constraints: Sequence[Requirement]) -> Requirement:
+            merged_specs: Set[Tuple[str, str]] = set()
+            expected_interpreter = parsed_constraints[0].project_name
             for parsed_constraint in parsed_constraints:
-                if parsed_constraint.interpreter != expected_interpreter:
+                if parsed_constraint.project_name != expected_interpreter:
                     attempted_interpreters = {
                         interp: sorted(
                             str(parsed_constraint) for parsed_constraint in parsed_constraints
                         )
                         for interp, parsed_constraints in itertools.groupby(
                             parsed_constraints,
-                            key=lambda pc: pc.interpreter,
+                            key=lambda pc: pc.project_name,
                         )
                     }
                     raise ValueError(
@@ -151,13 +141,23 @@ class PexInterpreterConstraints(DeduplicatedCollection[str]):
                         f"{attempted_interpreters}."
                     )
                 merged_specs.update(parsed_constraint.specs)
-            return ParsedConstraint(expected_interpreter, frozenset(merged_specs))
+
+            formatted_specs = ",".join(f"{op}{version}" for op, version in merged_specs)
+            return Requirement.parse(f"{expected_interpreter}{formatted_specs}")
+
+        def cmp_constraints(req1: Requirement, req2: Requirement) -> int:
+            if req1.project_name != req2.project_name:
+                return -1 if req1.project_name < req2.project_name else 1
+            if req1.specs == req2.specs:
+                return 0
+            return -1 if req1.specs < req2.specs else 1
 
         return sorted(
             {
-                str(and_constraints(constraints_product))
+                and_constraints(constraints_product)
                 for constraints_product in itertools.product(*parsed_constraint_sets)
-            }
+            },
+            key=functools.cmp_to_key(cmp_constraints),
         )
 
     @classmethod
@@ -187,8 +187,53 @@ class PexInterpreterConstraints(DeduplicatedCollection[str]):
     def generate_pex_arg_list(self) -> List[str]:
         args = []
         for constraint in self:
-            args.extend(["--interpreter-constraint", constraint])
+            args.extend(["--interpreter-constraint", str(constraint)])
         return args
+
+    def includes_python2(self) -> bool:
+        """Checks if any of the constraints include Python 2.
+
+        This will return True even if the code works with Python 3 too, so long as at least one of
+        the constraints works with Python 2.
+        """
+        py27_patch_versions = list(
+            reversed(range(0, 18))
+        )  # The last python 2.7 version was 2.7.18.
+        for req in self:
+            if any(
+                req.specifier.contains(f"2.7.{p}") for p in py27_patch_versions  # type: ignore[attr-defined]
+            ):
+                return True
+        return False
+
+    def requires_python38_or_newer(self) -> bool:
+        """Checks if the constraints are all for Python 3.8+.
+
+        This will return False if Python 3.8 is allowed, but prior versions like 3.7 are also
+        allowed.
+        """
+        # Assume any 3.x release has no more than 13 releases. The max is currently 10.
+        patch_versions = list(reversed(range(0, 13)))
+        # We only need to look at Python 3.7. If using something like `>=3.5`, Py37 will be
+        # included. `==3.6.*,!=3.7.*,==3.8.*` is extremely unlikely, and even that will work
+        # correctly as it's an invalid constraint so setuptools returns False always.
+        # `['==2.7.*', '==3.8.*']` will fail because not every single constraint is exclusively 3.8.
+        py37_versions = [f"3.7.{v}" for v in patch_versions]
+        py38_versions = [f"3.8.{v}" for v in patch_versions]
+        py39_versions = [f"3.9.{v}" for v in patch_versions]
+        for req in self:
+            if any(
+                req.specifier.contains(py37_version) for py37_version in py37_versions  # type: ignore[attr-defined]
+            ):
+                return False
+            works_with_py38_or_py39 = any(
+                req.specifier.contains(py38_version) for py38_version in py38_versions  # type: ignore[attr-defined]
+            ) or any(
+                req.specifier.contains(py39_version) for py39_version in py39_versions  # type: ignore[attr-defined]
+            )
+            if not works_with_py38_or_py39:
+                return False
+        return True
 
 
 class PexPlatforms(DeduplicatedCollection[str]):

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -162,6 +162,72 @@ def test_interpreter_constraints_do_not_include_python2(constraints):
 @pytest.mark.parametrize(
     "constraints",
     [
+        ["CPython==3.6.*"],
+        ["CPython==3.6.1"],
+        ["CPython==3.7.1"],
+        ["CPython==3.8.2"],
+        ["CPython==3.9.1"],
+        ["CPython>=3.6"],
+        ["CPython>=3.7"],
+        ["CPython==3.6.*", "CPython==3.7.*"],
+        ["PyPy>=3.6"],
+    ],
+)
+def test_interpreter_constraints_require_python36(constraints) -> None:
+    assert PexInterpreterConstraints(constraints).requires_python36_or_newer() is True
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        ["CPython==3.5.*"],
+        ["CPython==3.5.3"],
+        ["CPython>=3.5"],
+        ["CPython==3.5.*", "CPython==3.6.*"],
+        ["CPython==3.5.3", "CPython==3.6.3"],
+        ["PyPy>=3.5"],
+    ],
+)
+def test_interpreter_constraints_do_not_require_python36(constraints):
+    assert PexInterpreterConstraints(constraints).requires_python36_or_newer() is False
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        ["CPython==3.7.*"],
+        ["CPython==3.7.1"],
+        ["CPython==3.8.1"],
+        ["CPython==3.9.1"],
+        ["CPython>=3.7"],
+        ["CPython>=3.8"],
+        ["CPython==3.7.*", "CPython==3.8.*"],
+        ["PyPy>=3.7"],
+    ],
+)
+def test_interpreter_constraints_require_python37(constraints) -> None:
+    assert PexInterpreterConstraints(constraints).requires_python37_or_newer() is True
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        ["CPython==3.5.*"],
+        ["CPython==3.6.*"],
+        ["CPython==3.6.3"],
+        ["CPython>=3.6"],
+        ["CPython==3.6.*", "CPython==3.7.*"],
+        ["CPython==3.6.3", "CPython==3.7.3"],
+        ["PyPy>=3.6"],
+    ],
+)
+def test_interpreter_constraints_do_not_require_python37(constraints):
+    assert PexInterpreterConstraints(constraints).requires_python37_or_newer() is False
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
         ["CPython==3.8.*"],
         ["CPython==3.8.1"],
         ["CPython==3.9.1"],
@@ -178,12 +244,14 @@ def test_interpreter_constraints_require_python38(constraints) -> None:
 @pytest.mark.parametrize(
     "constraints",
     [
+        ["CPython==3.5.*"],
+        ["CPython==3.6.*"],
         ["CPython==3.7.*"],
         ["CPython==3.7.3"],
-        ["CPython>=3.6"],
+        ["CPython>=3.7"],
         ["CPython==3.7.*", "CPython==3.8.*"],
         ["CPython==3.5.3", "CPython==3.8.3"],
-        ["PyPy>=3.6"],
+        ["PyPy>=3.7"],
     ],
 )
 def test_interpreter_constraints_do_not_require_python38(constraints):

--- a/src/python/pants/testutil/python_interpreter_selection.py
+++ b/src/python/pants/testutil/python_interpreter_selection.py
@@ -11,6 +11,7 @@ PY_3 = "3"
 PY_27 = "2.7"
 PY_36 = "3.6"
 PY_37 = "3.7"
+PY_38 = "3.8"
 
 
 def has_python_version(version):
@@ -71,6 +72,16 @@ def skip_unless_python3_present(func):
 def skip_unless_python36_present(func):
     """A test skip decorator that only runs a test method if python3.6 is present."""
     return skip_unless_all_pythons_present(PY_36)(func)
+
+
+def skip_unless_python37_present(func):
+    """A test skip decorator that only runs a test method if python3.7 is present."""
+    return skip_unless_all_pythons_present(PY_37)(func)
+
+
+def skip_unless_python38_present(func):
+    """A test skip decorator that only runs a test method if python3.8 is present."""
+    return skip_unless_all_pythons_present(PY_38)(func)
 
 
 def skip_unless_python27_and_python3_present(func):


### PR DESCRIPTION
### Problem

MyPy and Black both use typed-ast for parsing, just like we use it for dependency inference. Typed-ast understands Py27 and 34-37, but not Py38. For Py38, you instead must run with a Python 3.8 interpreter (which also understands 27 and 34-37).

This meant that our default Black and MyPy installations would break if encountering Py38 syntax like the walrus operator. You had to explicitly set `--black-interpreter-constrains` and `--mypy-interpreter-constraints`, which is not at all obvious.

### Solution

Detect if the user has constraints for 3.8+. If so, use the constraints `>=3.8` for the tools. Otherwise, use the tool's default constraints.

We check that the constraints do not include anything less than 3.8, such as 3.7. Why? If they need to support 3.7, then a user won't be using 3.8 syntax. We don't want to constraint to `>=3.8` because this would mean that they must have 3.8 on their machine, even though 3.7 would do just fine.

To facilitate this, we change `PexInterpreterConstraints` to store parsed `Requirement` objects.

#### Also fixes MyPy handing of Python 3.6 and Python 3.7

If the user leaves off `python_version`, MyPy defaults to the version of the interpreter used to run. MyPy also tells the AST parser to target this specific `python_version`. So, if you're running with our minimum requirement of Python 3.5, it will fail to parse any Python 3.6+ code like f-strings, unless you specifically set `python_version` in `mypy.ini`.

We apply the same fix as above so that MyPy now also works "out of the box" with Python 3.6-only and 3.7-only codebases. If users set `python_version` in `mypy.ini`, MyPy will respect this - we only influence the default behavior.

### Result

Toolchain's Python 3.8 codebase now works "out of the box" with Pants, i.e. without extra settings.

[ci skip-rust]
[ci skip-build-wheels]