### PR TITLE
Fix `find_binary` rule to not use the cache

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional, cast
-from uuid import UUID
 
 from pants.backend.python.goals.coverage_py import (
     CoverageConfig,
@@ -42,7 +41,7 @@ from pants.core.goals.test import (
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
-from pants.engine.internals.uuid import UUIDRequest
+from pants.engine.internals.uuid import UUID, UUIDRequest
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSetsPerTarget, FieldSetsPerTargetRequest, TransitiveTargets

--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -4,6 +4,7 @@
 import random
 import uuid
 from dataclasses import dataclass, field
+from uuid import UUID as UUID
 
 from pants.engine.rules import _uncacheable_rule, collect_rules
 
@@ -14,7 +15,7 @@ class UUIDRequest:
 
 
 @_uncacheable_rule
-async def generate_uuid(_: UUIDRequest) -> uuid.UUID:
+async def generate_uuid(_: UUIDRequest) -> UUID:
     """A rule to generate a UUID.
 
     Useful primarily to force a rule to re-run: a rule that `await Get`s on a UUIDRequest will be

--- a/src/python/pants/engine/internals/uuid_test.py
+++ b/src/python/pants/engine/internals/uuid_test.py
@@ -1,11 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from uuid import UUID
-
 import pytest
 
-from pants.engine.internals.uuid import UUIDRequest
+from pants.engine.internals.uuid import UUID, UUIDRequest
 from pants.engine.internals.uuid import rules as uuid_rules
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner


### PR DESCRIPTION
Because this rule depends entirely on the state of the external environment, it's more correct to not cache it. For example, if a user uninstalls a program or installs a new one, Pants needs to detect that automatically.

This does not fix every issue. The original motivation for this PR is Pyenv, where we want `pyenv global 2.7.15` to cause invalidation for most Pex processes. Unfortunately, this does not fix it because Pyenv uses a single folder `.shims/`, so the output of this rule is simply `path/to/.shims` and things stay the same. But, this PR still improves the situation.

[ci skip-rust]
[ci skip-build-wheels]