### PR TITLE
Fix `./pants help $goal` showing the goal in "related subsystems"

### DIFF
--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -175,14 +175,14 @@ class HelpPrinter:
         formatted_lines = help_formatter.format_options(oshi)
         goal_info = self._all_help_info.name_to_goal_info.get(scope)
         if goal_info:
-            related_scopes = sorted(set(goal_info.consumed_scopes) - {GLOBAL_SCOPE})
+            related_scopes = sorted(set(goal_info.consumed_scopes) - {GLOBAL_SCOPE, goal_info.name})
             if related_scopes:
                 related_subsystems_label = "Related subsystems:"
                 if self._use_color:
                     related_subsystems_label = green(related_subsystems_label)
                 formatted_lines.append(f"{related_subsystems_label} {', '.join(related_scopes)}")
                 formatted_lines.append("")
-        return "\n".join(formatted_lines)
+        return "\n".join(formatted_lines).rstrip()
 
     def _get_help_json(self) -> str:
         """Return a JSON object containing all the help info we have, for every scope."""


### PR DESCRIPTION
Before:

```
▶ ./pants help target-types

`target-types` goal options
---------------------------

List all the registered target types, including custom plugin types.

Config section: [target-types]

...
  --target-types-details=<target_type>
  PANTS_TARGET_TYPES_DETAILS
  details
      default: None
      current value: None
      List all of the target type's registered fields.


Related subsystems: target-types
```

After:

```
▶ ./pants help target-types

`target-types` goal options
---------------------------

List all the registered target types, including custom plugin types.

Config section: [target-types]

...

  --target-types-details=<target_type>
  PANTS_TARGET_TYPES_DETAILS
  details
      default: None
      current value: None
      List all of the target type's registered fields.
```

[ci skip-build-wheels]
[ci skip-rust]