### PR TITLE
Add `runtime_binary_dependencies` field to `python_tests` target

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -26,6 +26,7 @@ from pants.engine.target import (
     Sources,
     StringField,
     StringOrStringSequenceField,
+    StringSequenceField,
     Target,
 )
 from pants.option.subsystem import Subsystem
@@ -258,6 +259,16 @@ class PythonTestsDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
+class PythonRuntimeBinaryDependencies(StringSequenceField):
+    """Addresses to binary targets that will be built and included in this target at runtime.
+
+    These binary targets do not necessarily need to be `python_binary` targets; they can be any
+    targets accepted by `./pants binary`
+    """
+
+    alias = "runtime_binary_dependencies"
+
+
 class PythonTestsTimeout(IntField):
     """A timeout (in seconds) which covers the total runtime of all tests in this target.
 
@@ -307,6 +318,7 @@ class PythonTests(Target):
         *COMMON_PYTHON_FIELDS,
         PythonTestsSources,
         PythonTestsDependencies,
+        PythonRuntimeBinaryDependencies,
         PythonTestsTimeout,
     )
 


### PR DESCRIPTION
This improves on the mechanism introduced in https://github.com/pantsbuild/pants/pull/10744. It's not consistent that putting a `python_binary` in the `dependencies` field would result in actually building a binary during runtime. That only happened with `python_tests`, which is confusing.

It can also be surprising when Pants does this for you automatically, given how heavy-weight building a binary can be (e.g. resolving requirements). For example, as a result of #10744, all of our own integration tests would end up building `local_pants.pex`, which we did not want.

Now, you must explicitly enumerate every binary that you want built in the field `runtime_binary_dependencies`.

[ci skip-build-wheels]
[ci skip-rust]