### PR TITLE
Signal handling fixes

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -79,6 +79,12 @@ class SignalHandler:
             self.traceback_lines = traceback.format_stack()
             super(SignalHandler.SignalHandledNonLocalExit, self).__init__()
 
+            if "I/O operation on closed file" in self.traceback_lines:
+                logger.debug(
+                    "SignalHandledNonLocalExit: unexpected appearance of "
+                    "'I/O operation on closed file' in traceback"
+                )
+
     def handle_sigquit(self, signum, _frame):
         ExceptionSink._signal_sent = signum
         raise self.SignalHandledNonLocalExit(signum, "SIGQUIT")

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -100,11 +100,16 @@ class ExceptionSink:
     # NB: see the bottom of this file where we call reset_log_location() and other mutators in order
     # to properly setup global state.
     _log_dir = None
+
     # Where to log stacktraces to in a SIGUSR2 handler.
     _interactive_output_stream = None
+
     # Whether to print a stacktrace in any fatal error message printed to the terminal.
     _should_print_backtrace_to_terminal = True
 
+    # An instance of `SignalHandler` which is invoked to handle a static set of specific
+    # nonfatal signals (these signal handlers are allowed to make pants exit, but unlike SIGSEGV they
+    # don't need to exit immediately).
     _signal_handler: SignalHandler = SignalHandler(pantsd_instance=False)
 
     # These persistent open file descriptors are kept so the signal handler can do almost no work

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -32,8 +32,6 @@ Exception message:.* 1 Exception encountered:
   ResolveError: 'this-target-does-not-exist' was not found in namespace '{namespace}'\\. Did you mean one of:
 """,
         )
-        # Ensure we write all output such as stderr and reporting files before closing any streams.
-        self.assertNotIn("Exception message: I/O operation on closed file.", file_contents)
 
     def _get_log_file_paths(self, workdir, pid):
         pid_specific_log_file = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=workdir)
@@ -135,8 +133,6 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
                 pid=pid, signum=signum, signame=signame
             ),
         )
-        # Ensure we write all output such as stderr and reporting files before closing any streams.
-        self.assertNotIn("Exception message: I/O operation on closed file.", contents)
 
     def test_dumps_logs_on_signal(self):
         """Send signals which are handled, but don't get converted into a KeyboardInterrupt."""

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -34,7 +34,7 @@ class PailgunClientSignalHandler(SignalHandler):
         )
         self._pailgun_client.set_exit_timeout(
             timeout=self._timeout,
-            reason=KeyboardInterrupt("Interrupted by user over pailgun client!"),
+            reason=KeyboardInterrupt("Sending user interrupt to pantsd"),
         )
         self._pailgun_client.maybe_send_signal(signum)
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -481,7 +481,7 @@ class SchedulerSession:
             ),
         )
 
-        ExceptionSink.toggle_ignoring_sigint_v2_engine(False)
+        ExceptionSink.toggle_ignoring_sigint(False)
 
         self._maybe_visualize()
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -314,9 +314,20 @@ class Scheduler:
         return {"started": result[0], "completed": result[1]}
 
     def _run_and_return_roots(self, session, execution_request):
+        def python_signal() -> bool:
+            """This function checks to see whether the main Python thread has responded to a signal.
+
+            It is invoked by the Rust scheduler, and if it returns true, the scheduler will
+            gracefully shut down.
+            """
+            return ExceptionSink.signal_sent() is not None
+
         try:
             raw_roots = self._native.lib.scheduler_execute(
-                self._scheduler, session, execution_request
+                self._scheduler,
+                session,
+                execution_request,
+                python_signal,
             )
         except self._native.lib.PollTimeout:
             raise ExecutionTimeoutError("Timed out")

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -309,7 +309,7 @@ class InteractiveRunner:
     _scheduler: "SchedulerSession"
 
     def run(self, request: InteractiveProcess) -> InteractiveProcessResult:
-        ExceptionSink.toggle_ignoring_sigint_v2_engine(True)
+        ExceptionSink.toggle_ignoring_sigint(True)
         return self._scheduler.run_local_interactive_process(request)
 
 

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -43,7 +43,7 @@ class NailgunClientSession(NailgunProtocol, NailgunProtocol.TimeoutProvider):
         self._exit_timeout = None
         self._exit_reason = None
 
-    def _set_exit_timeout(self, timeout, reason):
+    def _set_exit_timeout(self, timeout: float, reason: type) -> None:
         """Set a timeout for the remainder of the session, along with an exception to raise. which
         is implemented by NailgunProtocol.
 
@@ -245,7 +245,7 @@ class NailgunClient:
         else:
             return sock
 
-    def set_exit_timeout(self, timeout, reason):
+    def set_exit_timeout(self, timeout: float, reason: type) -> None:
         """Expose the inner session object's exit timeout setter."""
         self._session._set_exit_timeout(timeout, reason)
 

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -58,6 +58,12 @@ pub fn is_union(ty: TypeId) -> bool {
   })
 }
 
+pub fn is_truthy(value: &PyObject) -> bool {
+  let gil = Python::acquire_gil();
+  let py = gil.python();
+  value.is_true(py).unwrap()
+}
+
 pub fn equals(h1: &PyObject, h2: &PyObject) -> bool {
   let gil = Python::acquire_gil();
   let py = gil.python();

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -337,12 +337,17 @@ pub fn call_method(value: &Value, method: &str, args: &[Value]) -> Result<Value,
     .map_err(|py_err| Failure::from_py_err(gil.python(), py_err))
 }
 
-pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
+pub fn call_function(func: &Value, args: &[Value]) -> Result<PyObject, PyErr> {
   let arg_handles: Vec<PyObject> = args.iter().map(|v| v.clone().into()).collect();
   let gil = Python::acquire_gil();
   let args_tuple = PyTuple::new(gil.python(), &arg_handles);
-  func
-    .call(gil.python(), args_tuple, None)
+  func.call(gil.python(), args_tuple, None)
+}
+
+pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
+  let output = call_function(func, args);
+  let gil = Python::acquire_gil();
+  output
     .map(Value::from)
     .map_err(|py_err| Failure::from_py_err(gil.python(), py_err))
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -346,10 +346,10 @@ pub fn call_function(func: &Value, args: &[Value]) -> Result<PyObject, PyErr> {
 
 pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
   let output = call_function(func, args);
-  let gil = Python::acquire_gil();
-  output
-    .map(Value::from)
-    .map_err(|py_err| Failure::from_py_err(gil.python(), py_err))
+  output.map(Value::from).map_err(|py_err| {
+    let gil = Python::acquire_gil();
+    Failure::from_py_err(gil.python(), py_err)
+  })
 }
 
 pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorResponse, Failure> {

--- a/tests/python/pants_test/logging/native_engine_logging_integration_test.py
+++ b/tests/python/pants_test/logging/native_engine_logging_integration_test.py
@@ -32,4 +32,4 @@ class PantsdNativeLoggingTest(PantsDaemonIntegrationTestBase):
             assert "[DEBUG] connecting to pantsd on port" in daemon_run.stderr_data
 
             pantsd_log = "\n".join(read_pantsd_log(ctx.workdir))
-            assert "[DEBUG] logging initialized" in pantsd_log
+            assert "[DEBUG] Logging reinitialized in pantsd context" in pantsd_log


### PR DESCRIPTION
### Problem

Ideally, pants should exit promptly when a user hits Ctrl-C in the terminal, regardless of how it is configured to run or what it is running. cf. https://github.com/pantsbuild/pants/issues/10051 and other general observations made while using pants, there are still a few cases where pants does not respond quickly to a Ctrl-C and hangs or otherwise takes a while to quit. This commit is an attempt to fix these cases.

### Solution

In the `--debug` case, the problem turned out to be that we were explicitly disabling SIGINT handling in the case where pants was running an `InteractiveProcess`. For the non-pantsd case, this is desirable - we use the `InteractiveProcess` abstraction for `test --debug` and a few other cases where we legitimately want a pants subprocess to take over the terminal and do its own signal handling. But when pantsd is running, we don't want to explicitly disable SIGINT handling, because that means that pantsd will ignore a signal from its own client process. This commit solves the problem by adding a flag to `SignalHandler` to indicate whether this is a pantsd run, and doesn't ignore SIGINT if it is.

Some other instances of pants ignoring prompt signal handling are caused by rust code not heeding the Python interrupt state triggered by SIGINT, resulting in pants not quitting until execution returns to the Python main thread. This commit works around this by having the Python signal handling infrastructure set a flag on `ExceptionSink` once it has handled a signal that would cause pants to terminate. A python helper function is passed into the main execution loop in `scheduler.rs` that checks for the presence of this flag, and breaks the loop to terminate the engine if it finds that the flag is set. 

### Result

Ctrl-C should now work in the `test --debug` case with pantsd, and work in the `--no-pantsd` case when any kind of test is running. It still does seem to take more than one hit of Ctrl-C to fully quit pants in some cases, though, which will be addressed in followup commits.