### PR TITLE
Upgrade to Pex 2.1.14 (Cherry-pick of #10437)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -21,7 +21,7 @@ mypy==0.780
 Markdown==2.1.1
 packaging==20.3
 pathspec==0.8.0
-pex==2.1.12
+pex==2.1.14
 psutil==5.7.0
 Pygments==2.6.1
 pystache==0.5.4

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -21,12 +21,14 @@ from pants.python.python_setup import PythonSetup
 
 
 class PexBin(ExternalTool):
+    """The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."""
+
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.12"
+    default_version = "v2.1.14"
     default_known_versions = [
-        f"v2.1.12|{plat}|98cee30e00bfad8279159390139844f9154d9505f98cdbf35733f92412e26910|2631935"
-        for plat in ["darwin", "linux"]
+        f"v2.1.14|{plat}|12937da9ad5ad2c60564aa35cb4b3992ba3cc5ef7efedd44159332873da6fe46|2637138"
+        for plat in ["darwin", "linux "]
     ]
 
     def generate_url(self, plat: Platform) -> str:
@@ -97,8 +99,8 @@ class DownloadedPexBin(HermeticPex):
 
 @rule
 async def download_pex_bin(pex_binary_tool: PexBin) -> DownloadedPexBin:
-    downloaded_tool = await Get[DownloadedExternalTool](
-        ExternalToolRequest, pex_binary_tool.get_request(Platform.current)
+    downloaded_tool = await Get(
+        DownloadedExternalTool, ExternalToolRequest, pex_binary_tool.get_request(Platform.current)
     )
     return DownloadedPexBin(downloaded_tool)
 


### PR DESCRIPTION
This fixes a flaky issue with Pex that Pip would ask for interactive input, but there was no way to give the input, so it would error.

[ci skip-jvm-tests]
[ci skip-rust-tests]