### PR TITLE
Temporarily disable 3rd-party requirements support for MyPy

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -3,7 +3,6 @@
 
 import itertools
 from dataclasses import dataclass
-from pathlib import PurePath
 from textwrap import dedent
 from typing import Tuple
 
@@ -21,7 +20,6 @@ from pants.backend.python.util_rules.pex import (
     PexRequest,
     PexRequirements,
 )
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -197,13 +195,13 @@ async def mypy_typecheck(
             entry_point=mypy.entry_point,
         ),
     )
-    requirements_pex_request = Get(
-        Pex,
-        PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(
-            (field_set.address for field_set in request.field_sets), internal_only=True
-        ),
-    )
+    # requirements_pex_request = Get(
+    #     Pex,
+    #     PexFromTargetsRequest,
+    #     PexFromTargetsRequest.for_requirements(
+    #         (field_set.address for field_set in request.field_sets), internal_only=True
+    #     ),
+    # )
     runner_pex_request = Get(
         Pex,
         PexRequest(
@@ -211,13 +209,14 @@ async def mypy_typecheck(
             internal_only=True,
             sources=launcher_script,
             interpreter_constraints=PexInterpreterConstraints(tool_interpreter_constraints),
-            entry_point=PurePath(LAUNCHER_FILE.path).stem,
+            # entry_point=PurePath(LAUNCHER_FILE.path).stem,
+            entry_point=mypy.entry_point,
             additional_args=(
                 "--pex-path",
                 ":".join(
                     (
                         tool_pex_request.subject.output_filename,
-                        requirements_pex_request.subject.output_filename,
+                        # requirements_pex_request.subject.output_filename,
                     )
                 ),
             ),
@@ -237,14 +236,14 @@ async def mypy_typecheck(
         plugin_sources,
         typechecked_sources,
         tool_pex,
-        requirements_pex,
+        # requirements_pex,
         runner_pex,
         config_digest,
     ) = await MultiGet(
         plugin_sources_request,
         typechecked_sources_request,
         tool_pex_request,
-        requirements_pex_request,
+        # requirements_pex_request,
         runner_pex_request,
         config_digest_request,
     )
@@ -267,7 +266,7 @@ async def mypy_typecheck(
                 plugin_sources.source_files.snapshot.digest,
                 typechecked_srcs_snapshot.digest,
                 tool_pex.digest,
-                requirements_pex.digest,
+                # requirements_pex.digest,
                 runner_pex.digest,
                 config_digest,
             ]

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -197,6 +197,7 @@ def test_skip(rule_runner: RuleRunner) -> None:
     assert not result
 
 
+@pytest.mark.xfail(reason="Temporarily disabled 3rd-party support")
 def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file(
         "",
@@ -226,6 +227,7 @@ def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/itertools.py:3" in result[0].stdout
 
 
+@pytest.mark.xfail(reason="Temporarily disabled 3rd-party support")
 def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file(
         "",
@@ -367,6 +369,7 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
     assert "Success: no issues found" in result[0].stdout.strip()
 
 
+@pytest.mark.xfail(reason="Temporarily disabled 3rd-party support, and this plugin uses that")
 def test_source_plugin(rule_runner: RuleRunner) -> None:
     # NB: We make this source plugin fairly complex by having it use transitive dependencies.
     # This is to ensure that we can correctly support plugins with dependencies.


### PR DESCRIPTION
There is an issue with the Rich library when loaded up in Toolchain, that its module is registered twice. It's unclear why that's happening.

This does a light revert, rather than a full revert, as we will want to keep the majority of this code and only make small tweaks.

[ci skip-rust]
[ci skip-build-wheels]