### PR TITLE
Fix `DictStringToStringField` not working with default values

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import collections.abc
 import dataclasses
 import itertools
 import os.path
@@ -1149,7 +1150,7 @@ class DictStringToStringField(PrimitiveField, metaclass=ABCMeta):
         invalid_type_exception = InvalidFieldTypeException(
             address, cls.alias, raw_value, expected_type="a dictionary of string -> string"
         )
-        if not isinstance(value_or_default, dict):
+        if not isinstance(value_or_default, collections.abc.Mapping):
             raise invalid_type_exception
         if not all(isinstance(k, str) and isinstance(v, str) for k, v in value_or_default.items()):
             raise invalid_type_exception
@@ -1173,7 +1174,7 @@ class DictStringToStringSequenceField(PrimitiveField, metaclass=ABCMeta):
             raw_value,
             expected_type="a dictionary of string -> an iterable of strings",
         )
-        if not isinstance(value_or_default, dict):
+        if not isinstance(value_or_default, collections.abc.Mapping):
             raise invalid_type_exception
         result = {}
         for k, v in value_or_default.items():

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -659,8 +659,10 @@ def test_dict_string_to_string_field() -> None:
     class Example(DictStringToStringField):
         alias = "example"
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
 
+    assert Example(None, address=addr).value is None
+    assert Example({}, address=addr).value == FrozenDict()
     assert Example({"hello": "world"}, address=addr).value == FrozenDict({"hello": "world"})
 
     def assert_invalid_type(raw_value: Any) -> None:
@@ -669,6 +671,14 @@ def test_dict_string_to_string_field() -> None:
 
     for v in [0, object(), "hello", ["hello"], {"hello": 0}, {0: "world"}]:
         assert_invalid_type(v)
+
+    # Regression test that a default can be set.
+    class ExampleDefault(DictStringToStringField):
+        alias = "example"
+        # Note that we use `FrozenDict` so that the object can be hashable.
+        default = FrozenDict({"default": "val"})
+
+    assert ExampleDefault(None, address=addr).value == FrozenDict({"default": "val"})
 
 
 def test_dict_string_to_string_sequence_field() -> None:
@@ -698,6 +708,14 @@ def test_dict_string_to_string_sequence_field() -> None:
         {0: ["world"]},
     ]:
         assert_invalid_type(v)
+
+    # Regression test that a default can be set.
+    class ExampleDefault(DictStringToStringSequenceField):
+        alias = "example"
+        # Note that we use `FrozenDict` so that the object can be hashable.
+        default = FrozenDict({"default": ("val",)})
+
+    assert ExampleDefault(None, address=addr).value == FrozenDict({"default": ("val",)})
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
The default must be a `FrozenDict` so that the object is hashable, as the class property must be hashable. But then, this results in the sanitization logic complaining that it's not a `dict`. We only care that the `raw_value_or_default` is a `Mapping`.

[ci skip-rust]
[ci skip-build-wheels]