### PR TITLE
Run internal only pexes via discovered python.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -45,7 +45,13 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.process import MultiPlatformProcess, Process, ProcessResult, UncacheableProcess
+from pants.engine.process import (
+    MultiPlatformProcess,
+    Process,
+    ProcessResult,
+    ProcessScope,
+    UncacheableProcess,
+)
 from pants.engine.rules import Get, collect_rules, rule
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -428,7 +434,9 @@ async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -
             ),
         ),
     )
-    result = await Get(ProcessResult, UncacheableProcess(process))
+    result = await Get(
+        ProcessResult, UncacheableProcess(process=process, scope=ProcessScope.PER_SESSION)
+    )
     path, fingerprint = result.stdout.decode().strip().splitlines()
     return PythonExecutable(path=path, fingerprint=fingerprint)
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -6,6 +6,7 @@ import functools
 import itertools
 import logging
 from dataclasses import dataclass
+from textwrap import dedent
 from typing import (
     FrozenSet,
     Iterable,
@@ -27,7 +28,11 @@ from pants.backend.python.target_types import PythonPlatforms as PythonPlatforms
 from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli
 from pants.backend.python.util_rules.pex_cli import PexCliProcess
-from pants.backend.python.util_rules.pex_environment import PexEnvironment, PexRuntimeEnvironment
+from pants.backend.python.util_rules.pex_environment import (
+    PexEnvironment,
+    PexRuntimeEnvironment,
+    PythonExecutable,
+)
 from pants.engine.addresses import Address
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import (
@@ -336,6 +341,15 @@ class PexRequest:
         self.entry_point = entry_point
         self.additional_args = tuple(additional_args)
         self.description = description
+        self.__post_init__()
+
+    def __post_init__(self):
+        if self.internal_only and self.platforms:
+            raise ValueError(
+                "Internal only PEXes can only constrain interpreters with interpreter_constraints."
+                f"Given platform constraints {self.platforms} for internal only pex request: "
+                f"{self}."
+            )
 
 
 @dataclass(frozen=True)
@@ -359,7 +373,7 @@ class Pex:
 
     digest: Digest
     name: str
-    internal_only: bool
+    python: Optional[PythonExecutable]
 
 
 @dataclass(frozen=True)
@@ -374,6 +388,49 @@ class TwoStepPex:
 
 
 logger = logging.getLogger(__name__)
+
+
+@rule
+async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
+    process = await Get(
+        Process,
+        PexCliProcess(
+            description=f"Find interpreter for constraints: {interpreter_constraints}",
+            # Here we run the Pex CLI with no requirements which just selects an interpreter and
+            # normally starts an isolated repl. By passing `--` we force the repl to instead act as
+            # an interpreter (the selected one) and tell us about itself. The upshot is we run the
+            # Pex interpreter selection logic unperturbed but without resolving any distributions.
+            argv=(
+                *interpreter_constraints.generate_pex_arg_list(),
+                "--",
+                "-c",
+                # N.B.: The following code snippet must be compatible with Python 2.7 and
+                # Python 3.5+.
+                dedent(
+                    """\
+                    import hashlib
+                    import os
+                    import sys
+
+                    python = os.path.realpath(sys.executable)
+                    print(python)
+
+                    hasher = hashlib.sha256()
+                    with open(python, "rb") as fp:
+                      # We pick 8192 for efficiency of reads and fingerprint updates
+                      # (writes) since it's a common OS buffer size and an even
+                      # multiple of the hash block size.
+                      for chunk in iter(lambda: fp.read(8192), b""):
+                          hasher.update(chunk)
+                    print(hasher.hexdigest())
+                    """
+                ),
+            ),
+        ),
+    )
+    result = await Get(ProcessResult, UncacheableProcess(process))
+    path, fingerprint = result.stdout.decode().strip().splitlines()
+    return PythonExecutable(path=path, fingerprint=fingerprint)
 
 
 @rule(level=LogLevel.DEBUG)
@@ -399,14 +456,15 @@ async def create_pex(
         *request.additional_args,
     ]
 
-    if request.internal_only:
-        # This will result in a faster build, but worse compatibility at runtime.
-        argv.append("--use-first-matching-interpreter")
-
     # NB: If `--platform` is specified, this signals that the PEX should not be built locally.
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
     # flags are mutually exclusive. See https://github.com/pantsbuild/pex/issues/957.
-    if request.platforms:
+    python: Optional[PythonExecutable] = None
+    if request.internal_only:
+        python = await Get(
+            PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints
+        )
+    elif request.platforms:
         # TODO(#9560): consider validating that these platforms are valid with the interpreter
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())
@@ -479,6 +537,7 @@ async def create_pex(
     process = await Get(
         Process,
         PexCliProcess(
+            python=python,
             argv=argv,
             additional_input_digest=merged_digest,
             description=description,
@@ -501,11 +560,7 @@ async def create_pex(
         if log_output:
             logger.info("%s", log_output)
 
-    return Pex(
-        digest=result.output_digest,
-        name=request.output_filename,
-        internal_only=request.internal_only,
-    )
+    return Pex(digest=result.output_digest, name=request.output_filename, python=python)
 
 
 @rule(level=LogLevel.DEBUG)
@@ -599,9 +654,7 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
     argv = pex_environment.create_argv(
         f"./{request.pex.name}",
         *request.argv,
-        # If the Pex isn't distributed to users, then we must use the shebang because we will have
-        # used the flag `--use-first-matching-interpreter`, which requires running via shebang.
-        always_use_shebang=request.pex.internal_only,
+        python=request.pex.python,
     )
     env = {**pex_environment.environment_dict, **(request.extra_env or {})}
     process = Process(

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -7,7 +7,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.util_rules import pex_environment
-from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -50,6 +50,7 @@ class PexCliProcess:
     extra_env: Optional[FrozenDict[str, str]]
     output_files: Optional[Tuple[str, ...]]
     output_directories: Optional[Tuple[str, ...]]
+    python: Optional[PythonExecutable]
 
     def __init__(
         self,
@@ -60,6 +61,7 @@ class PexCliProcess:
         extra_env: Optional[Mapping[str, str]] = None,
         output_files: Optional[Iterable[str]] = None,
         output_directories: Optional[Iterable[str]] = None,
+        python: Optional[PythonExecutable] = None,
     ) -> None:
         self.argv = tuple(argv)
         self.description = description
@@ -67,6 +69,7 @@ class PexCliProcess:
         self.extra_env = FrozenDict(extra_env) if extra_env else None
         self.output_files = tuple(output_files) if output_files else None
         self.output_directories = tuple(output_directories) if output_directories else None
+        self.python = python
         self.__post_init__()
 
     def __post_init__(self) -> None:
@@ -95,7 +98,9 @@ async def setup_pex_cli_process(
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     pex_root_path = ".cache/pex_root"
-    argv = pex_env.create_argv(downloaded_pex_bin.exe, *request.argv, "--pex-root", pex_root_path)
+    argv = pex_env.create_argv(
+        downloaded_pex_bin.exe, *request.argv, "--pex-root", pex_root_path, python=request.python
+    )
     env = {
         # Ensure Pex and its subprocesses create temporary files in the the process execution
         # sandbox. It may make sense to do this generally for Processes, but in the short term we

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -10,7 +10,7 @@ from pants.core.util_rules import subprocess_environment
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.engine import process
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.process import BinaryPathRequest, BinaryPaths
+from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
@@ -90,17 +90,22 @@ class PexRuntimeEnvironment(Subsystem):
         return level
 
 
+class PythonExecutable(BinaryPath):
+    """The BinaryPath of a Python executable."""
+
+
 @dataclass(frozen=True)
 class PexEnvironment(EngineAwareReturnType):
     path: Tuple[str, ...]
     interpreter_search_paths: Tuple[str, ...]
     subprocess_environment_dict: FrozenDict[str, str]
-    bootstrap_python: Optional[str] = None
+    bootstrap_python: Optional[PythonExecutable] = None
 
     def create_argv(
-        self, pex_path: str, *args: str, always_use_shebang: bool = False
+        self, pex_path: str, *args: str, python: Optional[PythonExecutable] = None
     ) -> Iterable[str]:
-        argv = [self.bootstrap_python] if self.bootstrap_python and not always_use_shebang else []
+        python = python or self.bootstrap_python
+        argv = [python.path] if python else []
         argv.extend((pex_path, *args))
         return argv
 
@@ -138,13 +143,13 @@ async def find_pex_python(
     # interpreter. As such, we look for many Pythons usable by the PEX bootstrap code here for
     # maximum flexibility.
     all_python_binary_paths = await MultiGet(
-        [
-            Get(
-                BinaryPaths,
-                BinaryPathRequest(
-                    search_path=python_setup.interpreter_search_paths,
-                    binary_name=binary_name,
-                    test_args=[
+        Get(
+            BinaryPaths,
+            BinaryPathRequest(
+                search_path=python_setup.interpreter_search_paths,
+                binary_name=binary_name,
+                test=BinaryPathTest(
+                    args=[
                         "-c",
                         # N.B.: The following code snippet must be compatible with Python 2.7 and
                         # Python 3.5+.
@@ -175,16 +180,20 @@ async def find_pex_python(
                             """
                         ),
                     ],
+                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
                 ),
-            )
-            for binary_name in pex_runtime_env.bootstrap_interpreter_names
-        ]
+            ),
+        )
+        for binary_name in pex_runtime_env.bootstrap_interpreter_names
     )
 
-    def first_python_binary() -> Optional[str]:
+    def first_python_binary() -> Optional[PythonExecutable]:
         for binary_paths in all_python_binary_paths:
             if binary_paths.first_path:
-                return binary_paths.first_path.path
+                return PythonExecutable(
+                    path=binary_paths.first_path.path,
+                    fingerprint=binary_paths.first_path.fingerprint,
+                )
         return None
 
     return PexEnvironment(

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -337,10 +337,11 @@ def create_pex_and_get_all_data(
     additional_inputs: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
+    internal_only: bool = True,
 ) -> Dict:
     request = PexRequest(
         output_filename="test.pex",
-        internal_only=True,
+        internal_only=internal_only,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
         platforms=platforms,
@@ -383,6 +384,7 @@ def create_pex_and_get_pex_info(
     sources: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
+    internal_only: bool = True,
 ) -> Dict:
     return cast(
         Dict,
@@ -395,6 +397,7 @@ def create_pex_and_get_pex_info(
             sources=sources,
             additional_pants_args=additional_pants_args,
             additional_pex_args=additional_pex_args,
+            internal_only=internal_only,
         )["info"],
     )
 
@@ -534,6 +537,7 @@ def test_platforms(rule_runner: RuleRunner) -> None:
         requirements=PexRequirements(["cryptography==2.9"]),
         platforms=platforms,
         interpreter_constraints=constraints,
+        internal_only=False,  # Internal only PEXes do not support (foreign) platforms.
     )
     assert any(
         "cryptography-2.9-cp27-cp27mu-manylinux2010_x86_64.whl" in fp for fp in pex_output["files"]


### PR DESCRIPTION
Since shebangs record information about the host system it is incorrect
to ever rely on these when present in a binary stored in the CAS. A
shebang that worked in the past can fail in the future even though a viable
alternative interpreter may be discoverable.

As such, convert all local internal-only PEX creation and execution to
using a freshly discovered interpreter.

Fixes #10648

[ci skip-rust]
[ci skip-build-wheels]