### PR TITLE
Fix UUIDRequest scoping.

### DIFF
--- a/src/python/pants/engine/internals/uuid.py
+++ b/src/python/pants/engine/internals/uuid.py
@@ -18,6 +18,11 @@ class UUIDScope(Enum):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class UUIDRequest:
+    scope: str
+
+    def __init__(self, scope: Optional[str] = None) -> None:
+        self.scope = scope if scope is not None else self._to_scope_name(UUIDScope.PER_CALL)
+
     @staticmethod
     def _to_scope_name(scope: UUIDScope) -> str:
         if scope == UUIDScope.PER_CALL:
@@ -27,11 +32,6 @@ class UUIDRequest:
     @classmethod
     def scoped(cls, scope: UUIDScope) -> "UUIDRequest":
         return cls(cls._to_scope_name(scope))
-
-    scope: str
-
-    def __init__(self, scope: Optional[str] = None) -> None:
-        self.scope = scope if scope is not None else self._to_scope_name(UUIDScope.PER_CALL)
 
 
 @rule

--- a/src/python/pants/engine/internals/uuid_test.py
+++ b/src/python/pants/engine/internals/uuid_test.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import pytest
 
-from pants.engine.internals.uuid import UUIDRequest
+from pants.engine.internals.uuid import UUIDRequest, UUIDScope
 from pants.engine.internals.uuid import rules as uuid_rules
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -16,13 +16,33 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(rules=[*uuid_rules(), QueryRule(UUID, (UUIDRequest,))])
 
 
-def test_distinct_uuids(rule_runner: RuleRunner) -> None:
+def test_distinct_uuids_default_scope(rule_runner: RuleRunner) -> None:
     uuid1 = rule_runner.request_product(UUID, [UUIDRequest()])
     uuid2 = rule_runner.request_product(UUID, [UUIDRequest()])
     assert uuid1 != uuid2
 
 
-def test_identical_uuids(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest(randomizer=0.0)])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(randomizer=0.0)])
+def test_distinct_uuids_different_scopes(rule_runner: RuleRunner) -> None:
+    uuid1 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
+    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="that")])
+    assert uuid1 != uuid2
+
+
+def test_identical_uuids_same_scope(rule_runner: RuleRunner) -> None:
+    uuid1 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
+    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
+    assert uuid1 == uuid2
+
+
+def test_distinct_uuids_call_scope(rule_runner: RuleRunner) -> None:
+    uuid1 = rule_runner.request_product(UUID, [UUIDRequest()])
+    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="bob")])
+    uuid3 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
+    uuid4 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
+    assert uuid1 != uuid2 != uuid3 != uuid4
+
+
+def test_identical_uuids_session_scope(rule_runner: RuleRunner) -> None:
+    uuid1 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
+    uuid2 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
     assert uuid1 == uuid2


### PR DESCRIPTION
Even though the scoping test previously passed, tests in the wild
confirm A fixed scope would generate a new UUID on each ./pants
invocation against a stable pantsd. This is fixed with an arguably
simpler model that doubles down on UUIDs while we're there.

[ci skip-rust]
[ci skip-build-wheels]
