### PR TITLE
Various ExceptionSink improvements

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -324,9 +324,12 @@ class ExceptionSink:
         is not enabled (if pantsd is enabled, the client will actually catch SIGINT and forward it
         to the server, so we don't want the server process to ignore it.
         """
-        cls._signal_handler._toggle_ignoring_sigint(True)
-        yield
-        cls._signal_handler._toggle_ignoring_sigint(False)
+
+        try:
+            cls._signal_handler._toggle_ignoring_sigint(True)
+            yield
+        finally:
+            cls._signal_handler._toggle_ignoring_sigint(False)
 
     @classmethod
     def _iso_timestamp_for_now(cls):

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -314,16 +314,19 @@ class ExceptionSink:
             cls.reset_signal_handler(previous_signal_handler)
 
     @classmethod
-    def toggle_ignoring_sigint(cls, toggle: bool) -> None:
-        """This method is used to temporarily disable responding to the SIGINT signal sent by a
-        Ctrl-C in the terminal.
+    @contextmanager
+    def ignoring_sigint(cls) -> Iterator[None]:
+        """This method provides a context that temporarily disables responding to the SIGINT signal
+        sent by a Ctrl-C in the terminal.
 
         We currently only use this to implement disabling catching SIGINT while an
         InteractiveProcess is running (where we want that process to catch it), and only when pantsd
         is not enabled (if pantsd is enabled, the client will actually catch SIGINT and forward it
         to the server, so we don't want the server process to ignore it.
         """
-        cls._signal_handler._toggle_ignoring_sigint(toggle)
+        cls._signal_handler._toggle_ignoring_sigint(True)
+        yield
+        cls._signal_handler._toggle_ignoring_sigint(False)
 
     @classmethod
     def _iso_timestamp_for_now(cls):

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -2,24 +2,51 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 import signal
 import time
 from textwrap import dedent
+from typing import List, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
-from pants.util.contextutil import environment_as, temporary_dir
+from pants.testutil.pants_integration_test import run_pants_with_workdir
+from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
-class ExceptionSinkIntegrationTest(PantsDaemonIntegrationTestBase):
-    hermetic = False
+def lifecycle_stub_cmdline() -> List[str]:
+    # Load the testprojects pants-plugins to get some testing tasks and subsystems.
+    testproject_backend_src_dir = os.path.join(
+        get_buildroot(), "testprojects/pants-plugins/src/python"
+    )
+    testproject_backend_pkg_name = "test_pants_plugin"
+    lifecycle_stub_cmdline = [
+        "--no-pantsd",
+        f"--pythonpath=+['{testproject_backend_src_dir}']",
+        f"--backend-packages=+['{testproject_backend_pkg_name}']",
+        # This task will always raise an exception.
+        "lifecycle-stub-goal",
+    ]
 
-    def _assert_unhandled_exception_log_matches(self, pid, file_contents, namespace):
-        self.assertRegex(
-            file_contents,
-            f"""\
+    return lifecycle_stub_cmdline
+
+
+def get_log_file_paths(workdir: str, pid: int) -> Tuple[str, str]:
+    pid_specific_log_file = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=workdir)
+    assert os.path.isfile(pid_specific_log_file)
+
+    shared_log_file = ExceptionSink.exceptions_log_path(in_dir=workdir)
+    assert os.path.isfile(shared_log_file)
+
+    assert pid_specific_log_file != shared_log_file
+
+    return (pid_specific_log_file, shared_log_file)
+
+
+def assert_unhandled_exception_log_matches(pid: int, file_contents: str, namespace: str) -> None:
+    regex_str = f"""\
 timestamp: ([^\n]+)
 process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
@@ -30,109 +57,99 @@ Exception caught: \\([^)]*\\)
 Exception message:.* 1 Exception encountered:
 
   ResolveError: 'this-target-does-not-exist' was not found in namespace '{namespace}'\\. Did you mean one of:
-""",
-        )
+"""
+    assert re.match(regex_str, file_contents)
 
-    def _get_log_file_paths(self, workdir, pid):
-        pid_specific_log_file = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=workdir)
-        self.assertTrue(os.path.isfile(pid_specific_log_file))
 
-        shared_log_file = ExceptionSink.exceptions_log_path(in_dir=workdir)
-        self.assertTrue(os.path.isfile(shared_log_file))
-
-        self.assertNotEqual(pid_specific_log_file, shared_log_file)
-
-        return (pid_specific_log_file, shared_log_file)
-
-    def test_fails_ctrl_c_ffi_extern(self):
-        with temporary_dir() as tmpdir:
-            with environment_as(_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS="True"):
-                pants_run = self.run_pants_with_workdir(
-                    self._lifecycle_stub_cmdline(), workdir=tmpdir
-                )
-                pants_run.assert_failure()
-
-                self.assertIn(
-                    "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!",
-                    pants_run.stderr,
-                )
-
-                pid_specific_log_file, shared_log_file = self._get_log_file_paths(
-                    tmpdir, pants_run.pid
-                )
-
-                self.assertIn(
-                    "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!",
-                    read_file(pid_specific_log_file),
-                )
-                self.assertIn(
-                    "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!",
-                    read_file(shared_log_file),
-                )
-
-    def test_fails_ctrl_c_on_import(self):
-        with temporary_dir() as tmpdir:
-            with environment_as(_RAISE_KEYBOARDINTERRUPT_ON_IMPORT="True"):
-                # TODO: figure out the cwd of the pants subprocess, not just the "workdir"!
-                pants_run = self.run_pants_with_workdir(
-                    self._lifecycle_stub_cmdline(), workdir=tmpdir
-                )
-                pants_run.assert_failure()
-
-                self.assertIn(
-                    dedent(
-                        """\
-                        Interrupted by user:
-                        ctrl-c during import!
-                        """
-                    ),
-                    pants_run.stderr,
-                )
-
-                pid_specific_log_file, shared_log_file = self._get_log_file_paths(
-                    tmpdir, pants_run.pid
-                )
-
-                self.assertEqual("", read_file(pid_specific_log_file))
-                self.assertEqual("", read_file(shared_log_file))
-
-    def test_logs_unhandled_exception(self):
-        directory = "examples/src/python/example/hello/main"
-        with temporary_dir() as tmpdir:
-            pants_run = self.run_pants_with_workdir(
-                ["--no-pantsd", "list", f"{directory}:this-target-does-not-exist"],
-                workdir=tmpdir,
-                # The backtrace should be omitted when --print-exception-stacktrace=False.
-                print_exception_stacktrace=False,
-            )
-            pants_run.assert_failure()
-            self.assertRegex(
-                pants_run.stderr,
-                f"""\
-'this-target-does-not-exist' was not found in namespace '{directory}'\\. Did you mean one of:
-""",
-            )
-            pid_specific_log_file, shared_log_file = self._get_log_file_paths(tmpdir, pants_run.pid)
-            self._assert_unhandled_exception_log_matches(
-                pants_run.pid, read_file(pid_specific_log_file), namespace=directory
-            )
-            self._assert_unhandled_exception_log_matches(
-                pants_run.pid, read_file(shared_log_file), namespace=directory
-            )
-
-    def _assert_graceful_signal_log_matches(self, pid, signum, signame, contents):
-        self.assertRegex(
-            contents,
-            """\
+def assert_graceful_signal_log_matches(pid: int, signum, signame, contents: str) -> None:
+    regex_str = """\
 timestamp: ([^\n]+)
 process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
 pid: {pid}
 Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
 """.format(
-                pid=pid, signum=signum, signame=signame
-            ),
+        pid=pid, signum=signum, signame=signame
+    )
+    assert re.search(regex_str, contents)
+
+
+def test_logs_unhandled_exception() -> None:
+    directory = "examples/src/python/example/hello/main"
+    with temporary_dir() as tmpdir:
+        pants_run = run_pants_with_workdir(
+            ["--no-pantsd", "list", f"{directory}:this-target-does-not-exist"],
+            workdir=tmpdir,
+            # The backtrace should be omitted when --print-exception-stacktrace=False.
+            print_exception_stacktrace=False,
+            hermetic=False,
         )
+
+        pants_run.assert_failure()
+
+        regex = f"'this-target-does-not-exist' was not found in namespace '{directory}'\\. Did you mean one of:"
+        assert re.search(regex, pants_run.stderr)
+
+        pid_specific_log_file, shared_log_file = get_log_file_paths(tmpdir, pants_run.pid)
+        assert_unhandled_exception_log_matches(
+            pants_run.pid, read_file(pid_specific_log_file), namespace=directory
+        )
+        assert_unhandled_exception_log_matches(
+            pants_run.pid, read_file(shared_log_file), namespace=directory
+        )
+
+
+def test_fails_ctrl_c_on_import() -> None:
+    with temporary_dir() as tmpdir:
+        # TODO: figure out the cwd of the pants subprocess, not just the "workdir"!
+        pants_run = run_pants_with_workdir(
+            lifecycle_stub_cmdline(),
+            workdir=tmpdir,
+            extra_env={"_RAISE_KEYBOARDINTERRUPT_ON_IMPORT": "True"},
+        )
+        pants_run.assert_failure()
+
+        assert (
+            dedent(
+                """\
+                Interrupted by user:
+                ctrl-c during import!
+                """
+            )
+            in pants_run.stderr
+        )
+
+        pid_specific_log_file, shared_log_file = get_log_file_paths(tmpdir, pants_run.pid)
+
+        assert "" == read_file(pid_specific_log_file)
+        assert "" == read_file(shared_log_file)
+
+
+def test_fails_ctrl_c_ffi_extern() -> None:
+    with temporary_dir() as tmpdir:
+        pants_run = run_pants_with_workdir(
+            command=lifecycle_stub_cmdline(),
+            workdir=tmpdir,
+            extra_env={"_RAISE_KEYBOARDINTERRUPT_IN_EXTERNS": "True"},
+        )
+        pants_run.assert_failure()
+
+        assert (
+            "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in pants_run.stderr
+        )
+
+        pid_specific_log_file, shared_log_file = get_log_file_paths(tmpdir, pants_run.pid)
+
+        assert "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in read_file(
+            pid_specific_log_file
+        )
+        assert "KeyboardInterrupt: ctrl-c interrupted execution of a ffi method!" in read_file(
+            shared_log_file
+        )
+
+
+class ExceptionSinkIntegrationTest(PantsDaemonIntegrationTestBase):
+    hermetic = False
 
     def test_dumps_logs_on_signal(self):
         """Send signals which are handled, but don't get converted into a KeyboardInterrupt."""
@@ -149,13 +166,11 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
                 time.sleep(5)
 
                 # Check that the logs show a graceful exit by signal.
-                pid_specific_log_file, shared_log_file = self._get_log_file_paths(ctx.workdir, pid)
-                self._assert_graceful_signal_log_matches(
+                pid_specific_log_file, shared_log_file = get_log_file_paths(ctx.workdir, pid)
+                assert_graceful_signal_log_matches(
                     pid, signum, signame, read_file(pid_specific_log_file)
                 )
-                self._assert_graceful_signal_log_matches(
-                    pid, signum, signame, read_file(shared_log_file)
-                )
+                assert_graceful_signal_log_matches(pid, signum, signame, read_file(shared_log_file))
 
     def test_dumps_traceback_on_sigabrt(self):
         # SIGABRT sends a traceback to the log file for the current process thanks to
@@ -168,15 +183,15 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
             time.sleep(5)
 
             # Check that the logs show an abort signal and the beginning of a traceback.
-            pid_specific_log_file, shared_log_file = self._get_log_file_paths(ctx.workdir, pid)
-            self.assertRegex(
-                read_file(pid_specific_log_file),
-                """\
+            pid_specific_log_file, shared_log_file = get_log_file_paths(ctx.workdir, pid)
+            regex_str = """\
 Fatal Python error: Aborted
 
 Thread [^\n]+ \\(most recent call first\\):
-""",
-            )
+"""
+
+            assert re.search(regex_str, read_file(pid_specific_log_file))
+
             # faulthandler.enable() only allows use of a single logging file at once for fatal tracebacks.
             self.assertEqual("", read_file(shared_log_file))
 
@@ -189,25 +204,6 @@ Thread [^\n]+ \\(most recent call first\\):
             time.sleep(5)
 
             ctx.checker.assert_running()
-            self.assertRegex(
-                read_file(os.path.join(ctx.workdir, "pantsd", "pantsd.log")),
-                """\
-Current thread [^\n]+ \\(most recent call first\\):
-""",
-            )
-
-    def _lifecycle_stub_cmdline(self):
-        # Load the testprojects pants-plugins to get some testing tasks and subsystems.
-        testproject_backend_src_dir = os.path.join(
-            get_buildroot(), "testprojects/pants-plugins/src/python"
-        )
-        testproject_backend_pkg_name = "test_pants_plugin"
-        lifecycle_stub_cmdline = [
-            "--no-pantsd",
-            f"--pythonpath=+['{testproject_backend_src_dir}']",
-            f"--backend-packages=+['{testproject_backend_pkg_name}']",
-            # This task will always raise an exception.
-            "lifecycle-stub-goal",
-        ]
-
-        return lifecycle_stub_cmdline
+            regex_str = r"Current thread [^\n]+ \(most recent call first\):"
+            file_contents = read_file(os.path.join(ctx.workdir, "pantsd", "pantsd.log"))
+            assert re.search(regex_str, file_contents)

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -492,8 +492,6 @@ class SchedulerSession:
             ),
         )
 
-        ExceptionSink.toggle_ignoring_sigint(False)
-
         self._maybe_visualize()
 
         logger.debug(

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -310,8 +310,8 @@ class InteractiveRunner:
     _scheduler: "SchedulerSession"
 
     def run(self, request: InteractiveProcess) -> InteractiveProcessResult:
-        ExceptionSink.toggle_ignoring_sigint(True)
-        return self._scheduler.run_local_interactive_process(request)
+        with ExceptionSink.ignoring_sigint():
+            return self._scheduler.run_local_interactive_process(request)
 
 
 @frozen_after_init


### PR DESCRIPTION
This commit has a couple of pure refactoring changes to code around the `ExceptionSink` code:

* using a Python `contextmanager` for the functionality that temporarily ignores SIGINT for interactive processes
* moving many but not all of the `ExceptionSink` integration tests to the new top-level-function style