### PR TITLE
Upgrade to Pex 2.1.16.

### DIFF
--- a/3rdparty/python/constraints.txt
+++ b/3rdparty/python/constraints.txt
@@ -13,7 +13,7 @@ mypy==0.782
 mypy-extensions==0.4.3
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.14
+pex==2.1.16
 pip==19.0.3
 psutil==5.7.0
 pycparser==2.20

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ mypy==0.782
 
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.14
+pex==2.1.16
 psutil==5.7.0
 pystache==0.5.4
 python-Levenshtein==0.12.0

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -172,14 +172,11 @@ class PexInheritPath(StringField):
 class PexZipSafe(BoolField):
     """Whether or not this binary is safe to run in compacted (zip-file) form.
 
-    If they are not zip safe, they will be written to disk prior to execution.
-
-    We default to False, because there are various gotchas with zipped pexes. Notably,
-    PEP420 implicit namespace packages don't appear to work in that environment.
+    If they are not zip safe, they will be written to disk prior to execution. iff
     """
 
     alias = "zip_safe"
-    default = False
+    default = True
     value: bool
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -20,7 +20,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import Get, collect_rules, rule
 from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
+from pants.util.meta import classproperty, frozen_after_init
 
 
 class PexBinary(ExternalTool):
@@ -28,11 +28,21 @@ class PexBinary(ExternalTool):
 
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.14"
-    default_known_versions = [
-        f"v2.1.14|{plat}|12937da9ad5ad2c60564aa35cb4b3992ba3cc5ef7efedd44159332873da6fe46|2637138"
-        for plat in ["darwin", "linux "]
-    ]
+    default_version = "v2.1.16"
+
+    @classproperty
+    def default_known_versions(cls):
+        return [
+            "|".join(
+                (
+                    cls.default_version,
+                    plat,
+                    "38712847654254088a23394728f9a5fb93c6c83631300e7ab427ec780a88f653",
+                    "2662638",
+                )
+            )
+            for plat in ["darwin", "linux "]
+        ]
 
     def generate_url(self, _: Platform) -> str:
         return f"https://github.com/pantsbuild/pex/releases/download/{self.version}/pex"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,7 +41,7 @@ class PexBinary(ExternalTool):
                     "2662638",
                 )
             )
-            for plat in ["darwin", "linux "]
+            for plat in ["darwin", "linux"]
         ]
 
     def generate_url(self, _: Platform) -> str:

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -53,6 +53,5 @@ python_binary(
   # dependency on setuptools (for namespace package support).
   emit_warnings=False,
   # To allow for loading `native_engine.so` when built as a pex, we set zip_safe=False.
-  # This is the default, but we set it here explicitly, for emphasis.
   zip_safe=False,
 )


### PR DESCRIPTION
Besides general improvements this picks up a fix for PEP-420 implicit
(namespace) packages in loose sources and resources added via `-D` and
`-R` which allows us to return to producing `zip_safe` PEXes by default
(see: #10608 which this change reverts).

2.1.16 release notes here:
https://github.com/pantsbuild/pex/blob/master/CHANGES.rst#2116

2.1.15 release notes here:
https://github.com/pantsbuild/pex/blob/master/CHANGES.rst#2115

[ci skip-rust]
[ci skip-build-wheels]
