### PR TITLE
Rename mypy subsystem to mypy-config and add standalone mypy task

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/register.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/register.py
@@ -6,5 +6,15 @@ from pants.goal.task_registrar import TaskRegistrar as task
 from pants.contrib.mypy.tasks.mypy_task import MypyTask
 
 
+class MypyStandalone(MypyTask):
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register('--skip', type=bool, default=False, help='Skip running mypy.')
+        register('--transitive', type=bool, default=False,
+                 help='Whether to run mypy on transitive dependencies of the given pythohn targets.')
+
+
 def register_goals():
     task(name="mypy", action=MypyTask).install("lint")
+    task(name="mypy", action=MypyStandalone).install()

--- a/contrib/mypy/src/python/pants/contrib/mypy/register.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/register.py
@@ -12,7 +12,7 @@ class MypyStandalone(MypyTask):
         super().register_options(register)
         register('--skip', type=bool, default=False, help='Skip running mypy.')
         register('--transitive', type=bool, default=False,
-                 help='Whether to run mypy on transitive dependencies of the given pythohn targets.')
+                 help='Whether to run mypy on transitive dependencies of the given python targets.')
 
 
 def register_goals():

--- a/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
@@ -6,7 +6,7 @@ from pants.option.custom_types import file_option, shell_str
 
 
 class MyPy(PythonToolBase):
-    options_scope = "mypy"
+    options_scope = "mypy-config"
     default_version = "mypy==0.761"
     default_entry_point = "mypy"
     default_interpreter_constraints = ["CPython>=3.5"]

--- a/pants.toml
+++ b/pants.toml
@@ -56,6 +56,7 @@ backend_packages.add = [
   "pants.contrib.googlejavaformat",
   "pants.contrib.jax_ws",
   "pants.contrib.scalajs",
+  "pants.contrib.mypy",
   "pants.contrib.node",
   "pants.contrib.python.checks",
   "pants.contrib.scrooge",


### PR DESCRIPTION
### Problem

We would like to be able to run the mypy task with the `mypy` goal. This goal is unfortunately incompatible with the specific subsystem `options_scope` we happened to choose at the time for the `MyPy` subsystem. Pants v2 has `--skip` and `--only` options which are used to select individual linters, avoiding the need to register a separate task and keeping option names relatively clean. This branch is not pants v2.

### Solution

- Rename `MyPy.options_scope = "mypy-config"`.
- In the mypy contrib backend's `register.py`, subclass `MyPyTask` to add the `--skip` and `--transitive` options.
  - Register this task as a standalone `mypy` goal.
- Edit the v1 mypy task to respect the `--skip` and `--transitive` options, which had not been used in the upstream pants CI and therefore were somewhat surprisingly (but reasonably) not supported.

### Result

The correct behavior can now be demonstrated in two pants runs below. Note that `--transitive` will check 2 source files, because `:memo` depends on `:meta`:
```bash
> ./pants mypy --whitelist-tag-name=type_checked --transitive src/python/pants/util:memo
...
12:05:26 00:08   [mypy]
12:05:26 00:08     [mypy]
12:05:26 00:08       [create_mypy_pex]
12:05:26 00:08       [check]
Success: no issues found in 2 source files
```

After applying this diff:
```diff
diff --git a/src/python/pants/util/BUILD b/src/python/pants/util/BUILD
index ad1d39243..80191b36f 100644
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -93,7 +93,7 @@ python_library(
   dependencies = [
     '3rdparty/python:dataclasses'
   ],
-  tags = {'type_checked'},
+  # tags = {'type_checked'},
 )

 python_library(
```
After applying the diff, we note that the `--verbose` flag will warn about unmarked dependencies regardless of the value of the `--transitive` flag, but that only 1 source file is checked:
```bash
> ./pants mypy --whitelist-tag-name=type_checked --verbose --no-transitive src/python/pants/util:memo
...
11:54:57 00:08   [mypy]
11:54:57 00:08     [mypy]
                   [WARNING]: The following targets are not marked with the tag name `type_checked`, but are dependencies of targets that are type checked. MyPy will check these dependencies, inferring `Any` where possible. You are encouraged to properly type check these dependencies.
                   src/python/pants/util:meta
11:54:57 00:08       [create_mypy_pex]
11:54:57 00:08       [check]
Success: no issues found in 1 source file
```
