### PR TITLE
Revert "Run internal only pexes via discovered python. (#10779)"

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -6,7 +6,6 @@ import functools
 import itertools
 import logging
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import (
     FrozenSet,
     Iterable,
@@ -28,11 +27,7 @@ from pants.backend.python.target_types import PythonPlatforms as PythonPlatforms
 from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli
 from pants.backend.python.util_rules.pex_cli import PexCliProcess
-from pants.backend.python.util_rules.pex_environment import (
-    PexEnvironment,
-    PexRuntimeEnvironment,
-    PythonExecutable,
-)
+from pants.backend.python.util_rules.pex_environment import PexEnvironment, PexRuntimeEnvironment
 from pants.engine.addresses import Address
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import (
@@ -45,13 +40,7 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.platform import Platform, PlatformConstraint
-from pants.engine.process import (
-    MultiPlatformProcess,
-    Process,
-    ProcessResult,
-    ProcessScope,
-    UncacheableProcess,
-)
+from pants.engine.process import MultiPlatformProcess, Process, ProcessResult, UncacheableProcess
 from pants.engine.rules import Get, collect_rules, rule
 from pants.python.python_repos import PythonRepos
 from pants.python.python_setup import PythonSetup
@@ -347,15 +336,6 @@ class PexRequest:
         self.entry_point = entry_point
         self.additional_args = tuple(additional_args)
         self.description = description
-        self.__post_init__()
-
-    def __post_init__(self):
-        if self.internal_only and self.platforms:
-            raise ValueError(
-                "Internal only PEXes can only constrain interpreters with interpreter_constraints."
-                f"Given platform constraints {self.platforms} for internal only pex request: "
-                f"{self}."
-            )
 
 
 @dataclass(frozen=True)
@@ -379,7 +359,7 @@ class Pex:
 
     digest: Digest
     name: str
-    python: Optional[PythonExecutable]
+    internal_only: bool
 
 
 @dataclass(frozen=True)
@@ -394,51 +374,6 @@ class TwoStepPex:
 
 
 logger = logging.getLogger(__name__)
-
-
-@rule
-async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
-    process = await Get(
-        Process,
-        PexCliProcess(
-            description=f"Find interpreter for constraints: {interpreter_constraints}",
-            # Here we run the Pex CLI with no requirements which just selects an interpreter and
-            # normally starts an isolated repl. By passing `--` we force the repl to instead act as
-            # an interpreter (the selected one) and tell us about itself. The upshot is we run the
-            # Pex interpreter selection logic unperturbed but without resolving any distributions.
-            argv=(
-                *interpreter_constraints.generate_pex_arg_list(),
-                "--",
-                "-c",
-                # N.B.: The following code snippet must be compatible with Python 2.7 and
-                # Python 3.5+.
-                dedent(
-                    """\
-                    import hashlib
-                    import os
-                    import sys
-
-                    python = os.path.realpath(sys.executable)
-                    print(python)
-
-                    hasher = hashlib.sha256()
-                    with open(python, "rb") as fp:
-                      # We pick 8192 for efficiency of reads and fingerprint updates
-                      # (writes) since it's a common OS buffer size and an even
-                      # multiple of the hash block size.
-                      for chunk in iter(lambda: fp.read(8192), b""):
-                          hasher.update(chunk)
-                    print(hasher.hexdigest())
-                    """
-                ),
-            ),
-        ),
-    )
-    result = await Get(
-        ProcessResult, UncacheableProcess(process=process, scope=ProcessScope.PER_SESSION)
-    )
-    path, fingerprint = result.stdout.decode().strip().splitlines()
-    return PythonExecutable(path=path, fingerprint=fingerprint)
 
 
 @rule(level=LogLevel.DEBUG)
@@ -464,7 +399,9 @@ async def create_pex(
         *request.additional_args,
     ]
 
-    python: Optional[PythonExecutable] = None
+    if request.internal_only:
+        # This will result in a faster build, but worse compatibility at runtime.
+        argv.append("--use-first-matching-interpreter")
 
     # NB: If `--platform` is specified, this signals that the PEX should not be built locally.
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
@@ -475,12 +412,6 @@ async def create_pex(
         argv.extend(request.platforms.generate_pex_arg_list())
     else:
         argv.extend(request.interpreter_constraints.generate_pex_arg_list())
-        # N.B: An internal-only PexRequest is validated to never have platforms set so we only need
-        # perform interpreter lookup in this branch.
-        if request.internal_only:
-            python = await Get(
-                PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints
-            )
 
     argv.append("--no-emit-warnings")
     verbosity = pex_runtime_environment.verbosity
@@ -548,7 +479,6 @@ async def create_pex(
     process = await Get(
         Process,
         PexCliProcess(
-            python=python,
             argv=argv,
             additional_input_digest=merged_digest,
             description=description,
@@ -571,7 +501,11 @@ async def create_pex(
         if log_output:
             logger.info("%s", log_output)
 
-    return Pex(digest=result.output_digest, name=request.output_filename, python=python)
+    return Pex(
+        digest=result.output_digest,
+        name=request.output_filename,
+        internal_only=request.internal_only,
+    )
 
 
 @rule(level=LogLevel.DEBUG)
@@ -665,7 +599,9 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
     argv = pex_environment.create_argv(
         f"./{request.pex.name}",
         *request.argv,
-        python=request.pex.python,
+        # If the Pex isn't distributed to users, then we must use the shebang because we will have
+        # used the flag `--use-first-matching-interpreter`, which requires running via shebang.
+        always_use_shebang=request.pex.internal_only,
     )
     env = {**pex_environment.environment_dict, **(request.extra_env or {})}
     process = Process(

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -7,7 +7,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.util_rules import pex_environment
-from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
+from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -60,7 +60,6 @@ class PexCliProcess:
     extra_env: Optional[FrozenDict[str, str]]
     output_files: Optional[Tuple[str, ...]]
     output_directories: Optional[Tuple[str, ...]]
-    python: Optional[PythonExecutable]
 
     def __init__(
         self,
@@ -71,7 +70,6 @@ class PexCliProcess:
         extra_env: Optional[Mapping[str, str]] = None,
         output_files: Optional[Iterable[str]] = None,
         output_directories: Optional[Iterable[str]] = None,
-        python: Optional[PythonExecutable] = None,
     ) -> None:
         self.argv = tuple(argv)
         self.description = description
@@ -79,7 +77,6 @@ class PexCliProcess:
         self.extra_env = FrozenDict(extra_env) if extra_env else None
         self.output_files = tuple(output_files) if output_files else None
         self.output_directories = tuple(output_directories) if output_directories else None
-        self.python = python
         self.__post_init__()
 
     def __post_init__(self) -> None:
@@ -108,9 +105,7 @@ async def setup_pex_cli_process(
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     pex_root_path = ".cache/pex_root"
-    argv = pex_env.create_argv(
-        downloaded_pex_bin.exe, *request.argv, "--pex-root", pex_root_path, python=request.python
-    )
+    argv = pex_env.create_argv(downloaded_pex_bin.exe, *request.argv, "--pex-root", pex_root_path)
     env = {
         # Ensure Pex and its subprocesses create temporary files in the the process execution
         # sandbox. It may make sense to do this generally for Processes, but in the short term we

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -10,7 +10,7 @@ from pants.core.util_rules import subprocess_environment
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.engine import process
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
+from pants.engine.process import BinaryPathRequest, BinaryPaths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
@@ -90,22 +90,17 @@ class PexRuntimeEnvironment(Subsystem):
         return level
 
 
-class PythonExecutable(BinaryPath):
-    """The BinaryPath of a Python executable."""
-
-
 @dataclass(frozen=True)
 class PexEnvironment(EngineAwareReturnType):
     path: Tuple[str, ...]
     interpreter_search_paths: Tuple[str, ...]
     subprocess_environment_dict: FrozenDict[str, str]
-    bootstrap_python: Optional[PythonExecutable] = None
+    bootstrap_python: Optional[str] = None
 
     def create_argv(
-        self, pex_path: str, *args: str, python: Optional[PythonExecutable] = None
+        self, pex_path: str, *args: str, always_use_shebang: bool = False
     ) -> Iterable[str]:
-        python = python or self.bootstrap_python
-        argv = [python.path] if python else []
+        argv = [self.bootstrap_python] if self.bootstrap_python and not always_use_shebang else []
         argv.extend((pex_path, *args))
         return argv
 
@@ -143,13 +138,13 @@ async def find_pex_python(
     # interpreter. As such, we look for many Pythons usable by the PEX bootstrap code here for
     # maximum flexibility.
     all_python_binary_paths = await MultiGet(
-        Get(
-            BinaryPaths,
-            BinaryPathRequest(
-                search_path=python_setup.interpreter_search_paths,
-                binary_name=binary_name,
-                test=BinaryPathTest(
-                    args=[
+        [
+            Get(
+                BinaryPaths,
+                BinaryPathRequest(
+                    search_path=python_setup.interpreter_search_paths,
+                    binary_name=binary_name,
+                    test_args=[
                         "-c",
                         # N.B.: The following code snippet must be compatible with Python 2.7 and
                         # Python 3.5+.
@@ -180,20 +175,16 @@ async def find_pex_python(
                             """
                         ),
                     ],
-                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
                 ),
-            ),
-        )
-        for binary_name in pex_runtime_env.bootstrap_interpreter_names
+            )
+            for binary_name in pex_runtime_env.bootstrap_interpreter_names
+        ]
     )
 
-    def first_python_binary() -> Optional[PythonExecutable]:
+    def first_python_binary() -> Optional[str]:
         for binary_paths in all_python_binary_paths:
             if binary_paths.first_path:
-                return PythonExecutable(
-                    path=binary_paths.first_path.path,
-                    fingerprint=binary_paths.first_path.fingerprint,
-                )
+                return binary_paths.first_path.path
         return None
 
     return PexEnvironment(

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -337,11 +337,10 @@ def create_pex_and_get_all_data(
     additional_inputs: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
-    internal_only: bool = True,
 ) -> Dict:
     request = PexRequest(
         output_filename="test.pex",
-        internal_only=internal_only,
+        internal_only=True,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
         platforms=platforms,
@@ -384,7 +383,6 @@ def create_pex_and_get_pex_info(
     sources: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
-    internal_only: bool = True,
 ) -> Dict:
     return cast(
         Dict,
@@ -397,7 +395,6 @@ def create_pex_and_get_pex_info(
             sources=sources,
             additional_pants_args=additional_pants_args,
             additional_pex_args=additional_pex_args,
-            internal_only=internal_only,
         )["info"],
     )
 
@@ -537,7 +534,6 @@ def test_platforms(rule_runner: RuleRunner) -> None:
         requirements=PexRequirements(["cryptography==2.9"]),
         platforms=platforms,
         interpreter_constraints=constraints,
-        internal_only=False,  # Internal only PEXes do not support (foreign) platforms.
     )
     assert any(
         "cryptography-2.9-cp27-cp27mu-manylinux2010_x86_64.whl" in fp for fp in pex_output["files"]

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -337,10 +337,11 @@ def create_pex_and_get_all_data(
     additional_inputs: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
+    internal_only: bool = True,
 ) -> Dict:
     request = PexRequest(
         output_filename="test.pex",
-        internal_only=True,
+        internal_only=internal_only,
         requirements=requirements,
         interpreter_constraints=interpreter_constraints,
         platforms=platforms,
@@ -383,6 +384,7 @@ def create_pex_and_get_pex_info(
     sources: Optional[Digest] = None,
     additional_pants_args: Tuple[str, ...] = (),
     additional_pex_args: Tuple[str, ...] = (),
+    internal_only: bool = True,
 ) -> Dict:
     return cast(
         Dict,
@@ -395,6 +397,7 @@ def create_pex_and_get_pex_info(
             sources=sources,
             additional_pants_args=additional_pants_args,
             additional_pex_args=additional_pex_args,
+            internal_only=internal_only,
         )["info"],
     )
 
@@ -515,7 +518,9 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
 
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
     constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
-    pex_info = create_pex_and_get_pex_info(rule_runner, interpreter_constraints=constraints)
+    pex_info = create_pex_and_get_pex_info(
+        rule_runner, interpreter_constraints=constraints, internal_only=False
+    )
     assert set(pex_info["interpreter_constraints"]) == {str(c) for c in constraints}
 
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -5,16 +5,15 @@ import dataclasses
 import hashlib
 import logging
 from dataclasses import dataclass
-from enum import Enum
 from textwrap import dedent
-from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Tuple, Union
 from uuid import UUID
 
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import MultiGet
-from pants.engine.internals.uuid import UUIDRequest, UUIDScope
+from pants.engine.internals.uuid import UUIDRequest
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import Get, collect_rules, rule, side_effecting
 from pants.util.frozendict import FrozenDict
@@ -316,43 +315,32 @@ class InteractiveRunner:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class BinaryPathTest:
-    args: Tuple[str, ...]
-    fingerprint_stdout: bool
-
-    def __init__(self, args: Iterable[str], fingerprint_stdout: bool = True) -> None:
-        self.args = tuple(args)
-        self.fingerprint_stdout = fingerprint_stdout
-
-
-@frozen_after_init
-@dataclass(unsafe_hash=True)
 class BinaryPathRequest:
     """Request to find a binary of a given name.
 
-    If a `test` is specified all binaries that are found will be executed with the test args and
+    If `test_args` are specified all binaries that are found will be executed with these args and
     only those binaries whose test executions exit with return code 0 will be retained.
     Additionally, if test execution includes stdout content, that will be used to fingerprint the
     binary path so that upgrades and downgrades can be detected. A reasonable test for many programs
-    might be `BinaryPathTest(args=["--version"])` since it will both ensure the program runs and
+    might be to pass `["--version"]` for `test_args` since it will both ensure the program runs and
     also produce stdout text that changes upon upgrade or downgrade of the binary at the discovered
     path.
     """
 
     search_path: Tuple[str, ...]
     binary_name: str
-    test: Optional[BinaryPathTest]
+    test_args: Optional[Tuple[str, ...]]
 
     def __init__(
         self,
         *,
         search_path: Iterable[str],
         binary_name: str,
-        test: Optional[BinaryPathTest] = None,
+        test_args: Optional[Iterable[str]] = None,
     ) -> None:
         self.search_path = tuple(OrderedSet(search_path))
         self.binary_name = binary_name
-        self.test = test
+        self.test_args = tuple(test_args or ())
 
 
 @frozen_after_init
@@ -401,27 +389,16 @@ class BinaryPaths(EngineAwareReturnType):
         return next(iter(self.paths), None)
 
 
-class ProcessScope(Enum):
-    PER_CALL = UUIDScope.PER_CALL
-    PER_SESSION = UUIDScope.PER_SESSION
-
-
 @dataclass(frozen=True)
 class UncacheableProcess:
-    """Ensures the wrapped Process will be run once per scope and its results never re-used.
-
-    By default the scope is PER_CALL which ensures the Process is re-run on every call.
-    """
+    """Ensures the wrapped Process will always be run and its results never re-used."""
 
     process: Process
-    scope: ProcessScope = ProcessScope.PER_CALL
 
 
 @rule
 async def make_process_uncacheable(uncacheable_process: UncacheableProcess) -> Process:
-    uuid = await Get(
-        UUID, UUIDRequest, UUIDRequest.scoped(cast(UUIDScope, uncacheable_process.scope.value))
-    )
+    uuid = await Get(UUID, UUIDRequest())
 
     process = uncacheable_process.process
     env = dict(process.env)
@@ -478,8 +455,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 input_digest=script_digest,
                 argv=[script_path, request.binary_name],
                 env={"PATH": search_path},
-            ),
-            scope=ProcessScope.PER_SESSION,
+            )
         ),
     )
 
@@ -488,7 +464,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
         return binary_paths
 
     found_paths = result.stdout.decode().splitlines()
-    if not request.test:
+    if not request.test_args:
         return dataclasses.replace(binary_paths, paths=[BinaryPath(path) for path in found_paths])
 
     results = await MultiGet(
@@ -498,9 +474,8 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 Process(
                     description=f"Test binary {path}.",
                     level=LogLevel.DEBUG,
-                    argv=[path, *request.test.args],
-                ),
-                scope=ProcessScope.PER_SESSION,
+                    argv=[path, *request.test_args],
+                )
             ),
         )
         for path in found_paths
@@ -509,8 +484,6 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
         binary_paths,
         paths=[
             BinaryPath.fingerprinted(path, result.stdout)
-            if request.test.fingerprint_stdout
-            else BinaryPath(path, result.stdout.decode())
             for path, result in zip(found_paths, results)
             if result.exit_code == 0
         ],


### PR DESCRIPTION
This reverts commit ca7e2c268cbf9857110069dcc2b9ccf6feb97bcc.

Unfortunately, this is resulting in Pex using macOS's System Python 3.7 to run Pip, which is botched. This is happening even though Pants is correctly choosing the interpreter and is passing those interpreters to Pex. See https://github.com/pantsbuild/pants/issues/10648#issuecomment-692964125.

[ci skip-rust]
[ci skip-build-wheels]