### PR TITLE
Simplify --print-exception-stacktrace logic

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -410,20 +410,20 @@ Exception message: {exception_message}{maybe_newline}
         # Generate an unhandled exception report fit to be printed to the terminal.
         logger.exception(exc)
 
-    _CATCHABLE_SIGNAL_ERROR_LOG_FORMAT = """\
-Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_traceback}
-"""
-
     @classmethod
     def _handle_signal_gracefully(cls, signum, signame, traceback_lines):
         """Signal handler for non-fatal signals which raises or logs an error."""
+
+        def gen_formatted(formatted_traceback: str) -> str:
+            return f"Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_traceback}"
+
         # Extract the stack, and format an entry to be written to the exception log.
         formatted_traceback = cls._format_traceback(
             traceback_lines=traceback_lines, should_print_backtrace=True
         )
-        signal_error_log_entry = cls._CATCHABLE_SIGNAL_ERROR_LOG_FORMAT.format(
-            signum=signum, signame=signame, formatted_traceback=formatted_traceback
-        )
+
+        signal_error_log_entry = gen_formatted(formatted_traceback)
+
         # TODO: determine the appropriate signal-safe behavior here (to avoid writing to our file
         # descriptors reentrantly, which raises an IOError).
         # This method catches any exceptions raised within it.
@@ -434,9 +434,9 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
             traceback_lines=traceback_lines,
             should_print_backtrace=cls._should_print_backtrace_to_terminal,
         )
-        terminal_log_entry = cls._CATCHABLE_SIGNAL_ERROR_LOG_FORMAT.format(
-            signum=signum, signame=signame, formatted_traceback=formatted_traceback_for_terminal
-        )
+
+        terminal_log_entry = gen_formatted(formatted_traceback_for_terminal)
+
         # Print the output via standard logging.
         logger.error(terminal_log_entry)
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -15,7 +15,6 @@ from typing import Callable, Dict, Iterator, Optional
 import setproctitle
 
 from pants.util.dirutil import safe_mkdir, safe_open
-from pants.util.meta import classproperty
 from pants.util.osutil import Pid
 
 logger = logging.getLogger(__name__)
@@ -104,9 +103,6 @@ class ExceptionSink:
     # Where to log stacktraces to in a SIGUSR2 handler.
     _interactive_output_stream = None
 
-    # Whether to print a stacktrace in any fatal error message printed to the terminal.
-    _should_print_backtrace_to_terminal = True
-
     # An instance of `SignalHandler` which is invoked to handle a static set of specific
     # nonfatal signals (these signal handlers are allowed to make pants exit, but unlike SIGSEGV they
     # don't need to exit immediately).
@@ -128,15 +124,6 @@ class ExceptionSink:
     @classmethod
     def signal_sent(cls) -> Optional[int]:
         return cls._signal_sent
-
-    @classmethod
-    def reset_should_print_backtrace_to_terminal(cls, should_print_backtrace):
-        """Set whether a backtrace gets printed to the terminal error stream on a fatal error.
-
-        Class state:
-        - Overwrites `cls._should_print_backtrace_to_terminal`.
-        """
-        cls._should_print_backtrace_to_terminal = should_print_backtrace
 
     # All reset_* methods are ~idempotent!
     @classmethod
@@ -221,10 +208,6 @@ class ExceptionSink:
             cls._log_exception(
                 "Cannot reset interactive_output_stream -- stream (probably stderr) is closed"
             )
-
-    @classproperty
-    def should_print_exception_stacktrace(cls):
-        return cls._should_print_backtrace_to_terminal
 
     @classmethod
     def exceptions_log_path(cls, for_pid=None, in_dir=None):
@@ -432,7 +415,7 @@ Exception message: {exception_message}{maybe_newline}
         # Create a potentially-abbreviated traceback for the terminal or other interactive stream.
         formatted_traceback_for_terminal = cls._format_traceback(
             traceback_lines=traceback_lines,
-            should_print_backtrace=cls._should_print_backtrace_to_terminal,
+            should_print_backtrace=True,
         )
 
         terminal_log_entry = gen_formatted(formatted_traceback_for_terminal)
@@ -454,12 +437,3 @@ ExceptionSink.reset_interactive_output_stream(sys.stderr.buffer)
 
 # Setup a default signal handler.
 ExceptionSink.reset_signal_handler(SignalHandler(pantsd_instance=False))
-
-# Set whether to print stacktraces on exceptions or signals during import time.
-# NB: This will be overridden by bootstrap options in PantsRunner, so we avoid printing out a full
-# stacktrace when a user presses control-c during import time unless the environment variable is set
-# to explicitly request it. The exception log will have any stacktraces regardless so this should
-# not hamper debugging.
-ExceptionSink.reset_should_print_backtrace_to_terminal(
-    should_print_backtrace=os.environ.get("PANTS_PRINT_EXCEPTION_STACKTRACE", "True") == "True"
-)

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -80,10 +80,6 @@ class PantsRunner:
         # Python logging.
         setup_logging(global_bootstrap_options)
 
-        ExceptionSink.reset_should_print_backtrace_to_terminal(
-            global_bootstrap_options.print_exception_stacktrace
-        )
-
         if self._should_run_with_pantsd(global_bootstrap_options):
             try:
                 remote_runner = RemotePantsRunner(self.args, self.env, options_bootstrapper)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -281,9 +281,6 @@ class PantsDaemon(PantsDaemonProcessManager):
 
             # Reset the log location and the backtrace preference from the global bootstrap options.
             global_bootstrap_options = self._bootstrap_options.for_global_scope()
-            ExceptionSink.reset_should_print_backtrace_to_terminal(
-                global_bootstrap_options.print_exception_stacktrace
-            )
             ExceptionSink.reset_log_location(global_bootstrap_options.pants_workdir)
 
             self._native.set_panic_handler()


### PR DESCRIPTION
Currently, we're using the value of the `--print-exception-stacktrace` option to set a class var on `ExceptionSink` early in the pants initialization process. The `ExceptionFormatter` class in the Python logging initialization code uses this value as its source of truth for whether or not to emit stacktrace output. There's also one code path in `ExceptionSink` that uses this value, namely the code that responds to SIGTERM and SIGQUIT.

I'm actually not sure if the SIGTERM/SIGQUIT handling code is actually doing anything right now - it seems like if those signals are actually sent to the pants process, the failure will actually happen in Rust engine code, and never touch that code path. In any case, since SIGQUIT and SIGTERM are only going to be sent to pants very deliberately, it should be fine to default to always printing a stack trace in that eventuality.

This means that the code around `ExceptionSink` that pays attention to this variable can be removed entirely, and the global `--print-exception-stacktrace` option can be the only source of truth for this value. 