### PR TITLE
Restore running internal only PEXes via discovered Python (#10779)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -396,7 +396,7 @@ class TwoStepPex:
 logger = logging.getLogger(__name__)
 
 
-@rule
+@rule(desc="Find Python interpreter for constraints", level=LogLevel.DEBUG)
 async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
     process = await Get(
         Process,
@@ -432,6 +432,7 @@ async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -
                     """
                 ),
             ),
+            level=LogLevel.DEBUG,
         ),
     )
     result = await Get(
@@ -475,8 +476,9 @@ async def create_pex(
         argv.extend(request.platforms.generate_pex_arg_list())
     else:
         # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
-        # interpreter constraints, and then will run the PEX with that specific interpreter.
-        # Otherwise, we let Pex resolve the constraints.
+        # interpreter constraints, and then will run the PEX with that specific interpreter. We
+        # will have already validated that there were no platforms. Otherwise, we let Pex resolve
+        # the constraints.
         if request.internal_only:
             python = await Get(
                 PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -474,13 +474,15 @@ async def create_pex(
         #  constraints.
         argv.extend(request.platforms.generate_pex_arg_list())
     else:
-        argv.extend(request.interpreter_constraints.generate_pex_arg_list())
-        # N.B: An internal-only PexRequest is validated to never have platforms set so we only need
-        # perform interpreter lookup in this branch.
+        # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
+        # interpreter constraints, and then will run the PEX with that specific interpreter.
+        # Otherwise, we let Pex resolve the constraints.
         if request.internal_only:
             python = await Get(
                 PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints
             )
+        else:
+            argv.extend(request.interpreter_constraints.generate_pex_arg_list())
 
     argv.append("--no-emit-warnings")
     verbosity = pex_runtime_environment.verbosity

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -20,6 +20,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import Get, collect_rules, rule
 from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
 from pants.util.meta import classproperty, frozen_after_init
 
 
@@ -61,6 +62,7 @@ class PexCliProcess:
     output_files: Optional[Tuple[str, ...]]
     output_directories: Optional[Tuple[str, ...]]
     python: Optional[PythonExecutable]
+    level: LogLevel
 
     def __init__(
         self,
@@ -72,6 +74,7 @@ class PexCliProcess:
         output_files: Optional[Iterable[str]] = None,
         output_directories: Optional[Iterable[str]] = None,
         python: Optional[PythonExecutable] = None,
+        level: LogLevel = LogLevel.INFO,
     ) -> None:
         self.argv = tuple(argv)
         self.description = description
@@ -80,6 +83,7 @@ class PexCliProcess:
         self.output_files = tuple(output_files) if output_files else None
         self.output_directories = tuple(output_directories) if output_directories else None
         self.python = python
+        self.level = level
         self.__post_init__()
 
     def __post_init__(self) -> None:
@@ -133,6 +137,7 @@ async def setup_pex_cli_process(
         output_files=request.output_files,
         output_directories=request.output_directories,
         append_only_caches={"pex_root": pex_root_path},
+        level=request.level,
     )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -10,7 +10,7 @@ from pants.core.util_rules import subprocess_environment
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.engine import process
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.process import BinaryPathRequest, BinaryPaths
+from pants.engine.process import BinaryPath, BinaryPathRequest, BinaryPaths, BinaryPathTest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup
@@ -90,17 +90,22 @@ class PexRuntimeEnvironment(Subsystem):
         return level
 
 
+class PythonExecutable(BinaryPath):
+    """The BinaryPath of a Python executable."""
+
+
 @dataclass(frozen=True)
 class PexEnvironment(EngineAwareReturnType):
     path: Tuple[str, ...]
     interpreter_search_paths: Tuple[str, ...]
     subprocess_environment_dict: FrozenDict[str, str]
-    bootstrap_python: Optional[str] = None
+    bootstrap_python: Optional[PythonExecutable] = None
 
     def create_argv(
-        self, pex_path: str, *args: str, always_use_shebang: bool = False
+        self, pex_path: str, *args: str, python: Optional[PythonExecutable] = None
     ) -> Iterable[str]:
-        argv = [self.bootstrap_python] if self.bootstrap_python and not always_use_shebang else []
+        python = python or self.bootstrap_python
+        argv = [python.path] if python else []
         argv.extend((pex_path, *args))
         return argv
 
@@ -138,13 +143,13 @@ async def find_pex_python(
     # interpreter. As such, we look for many Pythons usable by the PEX bootstrap code here for
     # maximum flexibility.
     all_python_binary_paths = await MultiGet(
-        [
-            Get(
-                BinaryPaths,
-                BinaryPathRequest(
-                    search_path=python_setup.interpreter_search_paths,
-                    binary_name=binary_name,
-                    test_args=[
+        Get(
+            BinaryPaths,
+            BinaryPathRequest(
+                search_path=python_setup.interpreter_search_paths,
+                binary_name=binary_name,
+                test=BinaryPathTest(
+                    args=[
                         "-c",
                         # N.B.: The following code snippet must be compatible with Python 2.7 and
                         # Python 3.5+.
@@ -175,16 +180,20 @@ async def find_pex_python(
                             """
                         ),
                     ],
+                    fingerprint_stdout=False,  # We already emit a usable fingerprint to stdout.
                 ),
-            )
-            for binary_name in pex_runtime_env.bootstrap_interpreter_names
-        ]
+            ),
+        )
+        for binary_name in pex_runtime_env.bootstrap_interpreter_names
     )
 
-    def first_python_binary() -> Optional[str]:
+    def first_python_binary() -> Optional[PythonExecutable]:
         for binary_paths in all_python_binary_paths:
             if binary_paths.first_path:
-                return binary_paths.first_path.path
+                return PythonExecutable(
+                    path=binary_paths.first_path.path,
+                    fingerprint=binary_paths.first_path.fingerprint,
+                )
         return None
 
     return PexEnvironment(

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -90,8 +90,11 @@ class PexRuntimeEnvironment(Subsystem):
         return level
 
 
-class PythonExecutable(BinaryPath):
+class PythonExecutable(BinaryPath, EngineAwareReturnType):
     """The BinaryPath of a Python executable."""
+
+    def message(self) -> str:
+        return f"Selected {self.path} to run PEXes with."
 
 
 @dataclass(frozen=True)
@@ -129,7 +132,7 @@ class PexEnvironment(EngineAwareReturnType):
                 "`interpreter_search_paths` in the `[python-setup]` scope. Will attempt to run "
                 "PEXes directly."
             )
-        return f"Selected {self.bootstrap_python} to bootstrap PEXes with."
+        return f"Selected {self.bootstrap_python.path} to bootstrap PEXes with."
 
 
 @rule(desc="Find PEX Python", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -518,7 +518,9 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
 
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
     constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
-    pex_info = create_pex_and_get_pex_info(rule_runner, interpreter_constraints=constraints)
+    pex_info = create_pex_and_get_pex_info(
+        rule_runner, interpreter_constraints=constraints, internal_only=False
+    )
     assert set(pex_info["interpreter_constraints"]) == {str(c) for c in constraints}
 
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -518,9 +518,7 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
 
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
     constraints = PexInterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
-    pex_info = create_pex_and_get_pex_info(
-        rule_runner, interpreter_constraints=constraints, internal_only=False
-    )
+    pex_info = create_pex_and_get_pex_info(rule_runner, interpreter_constraints=constraints)
     assert set(pex_info["interpreter_constraints"]) == {str(c) for c in constraints}
 
 
@@ -539,6 +537,7 @@ def test_platforms(rule_runner: RuleRunner) -> None:
         requirements=PexRequirements(["cryptography==2.9"]),
         platforms=platforms,
         interpreter_constraints=constraints,
+        internal_only=False,  # Internal only PEXes do not support (foreign) platforms.
     )
     assert any(
         "cryptography-2.9-cp27-cp27mu-manylinux2010_x86_64.whl" in fp for fp in pex_output["files"]

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -5,15 +5,16 @@ import dataclasses
 import hashlib
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from textwrap import dedent
-from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Tuple, Union, cast
 from uuid import UUID
 
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import MultiGet
-from pants.engine.internals.uuid import UUIDRequest
+from pants.engine.internals.uuid import UUIDRequest, UUIDScope
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import Get, collect_rules, rule, side_effecting
 from pants.util.frozendict import FrozenDict
@@ -315,32 +316,43 @@ class InteractiveRunner:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
+class BinaryPathTest:
+    args: Tuple[str, ...]
+    fingerprint_stdout: bool
+
+    def __init__(self, args: Iterable[str], fingerprint_stdout: bool = True) -> None:
+        self.args = tuple(args)
+        self.fingerprint_stdout = fingerprint_stdout
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class BinaryPathRequest:
     """Request to find a binary of a given name.
 
-    If `test_args` are specified all binaries that are found will be executed with these args and
+    If a `test` is specified all binaries that are found will be executed with the test args and
     only those binaries whose test executions exit with return code 0 will be retained.
     Additionally, if test execution includes stdout content, that will be used to fingerprint the
     binary path so that upgrades and downgrades can be detected. A reasonable test for many programs
-    might be to pass `["--version"]` for `test_args` since it will both ensure the program runs and
+    might be `BinaryPathTest(args=["--version"])` since it will both ensure the program runs and
     also produce stdout text that changes upon upgrade or downgrade of the binary at the discovered
     path.
     """
 
     search_path: Tuple[str, ...]
     binary_name: str
-    test_args: Optional[Tuple[str, ...]]
+    test: Optional[BinaryPathTest]
 
     def __init__(
         self,
         *,
         search_path: Iterable[str],
         binary_name: str,
-        test_args: Optional[Iterable[str]] = None,
+        test: Optional[BinaryPathTest] = None,
     ) -> None:
         self.search_path = tuple(OrderedSet(search_path))
         self.binary_name = binary_name
-        self.test_args = tuple(test_args or ())
+        self.test = test
 
 
 @frozen_after_init
@@ -389,16 +401,27 @@ class BinaryPaths(EngineAwareReturnType):
         return next(iter(self.paths), None)
 
 
+class ProcessScope(Enum):
+    PER_CALL = UUIDScope.PER_CALL
+    PER_SESSION = UUIDScope.PER_SESSION
+
+
 @dataclass(frozen=True)
 class UncacheableProcess:
-    """Ensures the wrapped Process will always be run and its results never re-used."""
+    """Ensures the wrapped Process will be run once per scope and its results never re-used.
+
+    By default the scope is PER_CALL which ensures the Process is re-run on every call.
+    """
 
     process: Process
+    scope: ProcessScope = ProcessScope.PER_CALL
 
 
 @rule
 async def make_process_uncacheable(uncacheable_process: UncacheableProcess) -> Process:
-    uuid = await Get(UUID, UUIDRequest())
+    uuid = await Get(
+        UUID, UUIDRequest, UUIDRequest.scoped(cast(UUIDScope, uncacheable_process.scope.value))
+    )
 
     process = uncacheable_process.process
     env = dict(process.env)
@@ -455,7 +478,8 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 input_digest=script_digest,
                 argv=[script_path, request.binary_name],
                 env={"PATH": search_path},
-            )
+            ),
+            scope=ProcessScope.PER_SESSION,
         ),
     )
 
@@ -464,7 +488,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
         return binary_paths
 
     found_paths = result.stdout.decode().splitlines()
-    if not request.test_args:
+    if not request.test:
         return dataclasses.replace(binary_paths, paths=[BinaryPath(path) for path in found_paths])
 
     results = await MultiGet(
@@ -474,8 +498,9 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
                 Process(
                     description=f"Test binary {path}.",
                     level=LogLevel.DEBUG,
-                    argv=[path, *request.test_args],
-                )
+                    argv=[path, *request.test.args],
+                ),
+                scope=ProcessScope.PER_SESSION,
             ),
         )
         for path in found_paths
@@ -484,6 +509,8 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
         binary_paths,
         paths=[
             BinaryPath.fingerprinted(path, result.stdout)
+            if request.test.fingerprint_stdout
+            else BinaryPath(path, result.stdout.decode())
             for path, result in zip(found_paths, results)
             if result.exit_code == 0
         ],

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -508,9 +508,11 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
     return dataclasses.replace(
         binary_paths,
         paths=[
-            BinaryPath.fingerprinted(path, result.stdout)
-            if request.test.fingerprint_stdout
-            else BinaryPath(path, result.stdout.decode())
+            (
+                BinaryPath.fingerprinted(path, result.stdout)
+                if request.test.fingerprint_stdout
+                else BinaryPath(path, result.stdout.decode())
+            )
             for path, result in zip(found_paths, results)
             if result.exit_code == 0
         ],


### PR DESCRIPTION
Restores https://github.com/pantsbuild/pants/pull/10779 with a bug fix that we were incorrectly setting interpreter constraints, which caused Pex to ignore our interpreter and look for a new one.

Also, fixes an issue with logging at INFO when we want DEBUG.

Finally, this improves our logging to log (at Debug level) which interpreter we chose for particular interpreter constraints.