### PR TITLE
Local process cache validates that digests exist locally before hitting

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -346,7 +346,7 @@ class Scheduler:
     def lease_files_in_graph(self, session):
         self._native.lib.lease_files_in_graph(self._scheduler, session)
 
-    def garbage_collect_store(self, target_size_bytes: int):
+    def garbage_collect_store(self, target_size_bytes: int) -> None:
         self._native.lib.garbage_collect_store(self._scheduler, target_size_bytes)
 
     def new_session(
@@ -659,5 +659,5 @@ class SchedulerSession:
     def lease_files_in_graph(self):
         self._scheduler.lease_files_in_graph(self._session)
 
-    def garbage_collect_store(self, target_size_bytes: int):
+    def garbage_collect_store(self, target_size_bytes: int) -> None:
         self._scheduler.garbage_collect_store(target_size_bytes)

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -346,8 +346,8 @@ class Scheduler:
     def lease_files_in_graph(self, session):
         self._native.lib.lease_files_in_graph(self._scheduler, session)
 
-    def garbage_collect_store(self):
-        self._native.lib.garbage_collect_store(self._scheduler)
+    def garbage_collect_store(self, target_size_bytes: int):
+        self._native.lib.garbage_collect_store(self._scheduler, target_size_bytes)
 
     def new_session(
         self,
@@ -659,5 +659,5 @@ class SchedulerSession:
     def lease_files_in_graph(self):
         self._scheduler.lease_files_in_graph(self._session)
 
-    def garbage_collect_store(self):
-        self._scheduler.garbage_collect_store()
+    def garbage_collect_store(self, target_size_bytes: int):
+        self._scheduler.garbage_collect_store(target_size_bytes)

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -663,13 +663,14 @@ impl Store {
     match self.local.shrink(target_size_bytes, shrink_behavior) {
       Ok(size) => {
         if size > target_size_bytes {
-          Err(format!(
-            "Garbage collection attempted to target {} bytes but could only shrink to {} bytes",
-            target_size_bytes, size
-          ))
-        } else {
-          Ok(())
+          log::warn!(
+            "Garbage collection attempted to shrink the store to {} bytes but {} bytes \
+            are currently in use.",
+            target_size_bytes,
+            size
+          )
         }
+        Ok(())
       }
       Err(err) => Err(format!("Garbage collection failed: {:?}", err)),
     }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -287,6 +287,13 @@ impl Store {
   }
 
   ///
+  /// Remove a file locally, returning true if it existed, or false otherwise.
+  ///
+  pub async fn remove_file(&self, digest: Digest) -> Result<bool, String> {
+    self.local.remove(EntryType::File, digest).await
+  }
+
+  ///
   /// Store a file locally.
   ///
   pub async fn store_file_bytes(

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -239,6 +239,14 @@ impl ByteStore {
     Ok(())
   }
 
+  pub async fn remove(&self, entry_type: EntryType, digest: Digest) -> Result<bool, String> {
+    let dbs = match entry_type {
+      EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::File => self.inner.file_dbs.clone(),
+    };
+    dbs?.remove(digest.0).await
+  }
+
   pub async fn store_bytes(
     &self,
     entry_type: EntryType,

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
-use futures01::Future;
+use futures::{future as future03, FutureExt};
 use log::{debug, warn};
 use protobuf::Message;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ impl crate::CommandRunner for CommandRunner {
     match self.lookup(key).await {
       Ok(Some(result)) => return Ok(result),
       Err(err) => {
-        warn!(
+        debug!(
           "Error loading process execution result from local cache: {} - continuing to execute",
           err
         );
@@ -80,7 +80,7 @@ impl crate::CommandRunner for CommandRunner {
     let result = command_runner.underlying.run(req, context).await?;
     if result.exit_code == 0 {
       if let Err(err) = command_runner.store(key, &result).await {
-        debug!(
+        warn!(
           "Error storing process execution result to local cache: {} - ignoring and continuing",
           err
         );
@@ -97,6 +97,7 @@ impl CommandRunner {
   ) -> Result<Option<FallibleProcessResultWithPlatform>, String> {
     use bazel_protos::remote_execution::ExecuteResponse;
 
+    // See whether there is a cache entry.
     let maybe_execute_response: Option<(ExecuteResponse, Platform)> = self
       .process_execution_store
       .load_bytes_with(fingerprint, move |bytes| {
@@ -114,7 +115,8 @@ impl CommandRunner {
       })
       .await?;
 
-    if let Some((execute_response, platform)) = maybe_execute_response {
+    // Deserialize the cache entry if it existed.
+    let result = if let Some((execute_response, platform)) = maybe_execute_response {
       crate::remote::populate_fallible_execution_result(
         self.file_store.clone(),
         execute_response.get_result(),
@@ -122,12 +124,31 @@ impl CommandRunner {
         platform,
         true,
       )
-      .map(Some)
       .compat()
-      .await
+      .await?
     } else {
-      Ok(None)
-    }
+      return Ok(None);
+    };
+
+    // Ensure that all digests in the result are loadable, erroring if any are not.
+    let _ = future03::try_join_all(vec![
+      self
+        .file_store
+        .ensure_local_has_file(result.stdout_digest)
+        .boxed(),
+      self
+        .file_store
+        .ensure_local_has_file(result.stderr_digest)
+        .boxed(),
+      self
+        .file_store
+        .ensure_local_has_recursive_directory(result.output_directory)
+        .compat()
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(Some(result))
   }
 
   async fn store(

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use sharded_lmdb::{ShardedLmdb, DEFAULT_LEASE_TIME};
 use store::Store;
@@ -17,41 +16,27 @@ struct RoundtripResults {
   maybe_cached: Result<FallibleProcessResultWithPlatform, String>,
 }
 
-async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
+fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
   let runtime = task_executor::Executor::new(Handle::current());
-  let work_dir = TempDir::new().unwrap();
-  let named_cache_dir = TempDir::new().unwrap();
-  let store_dir = TempDir::new().unwrap();
-  let store = Store::local_only(runtime.clone(), store_dir.path()).unwrap();
-  let local = crate::local::CommandRunner::new(
+  let base_dir = TempDir::new().unwrap();
+  let named_cache_dir = base_dir.path().join("named_cache_dir");
+  let store_dir = base_dir.path().join("store_dir");
+  let store = Store::local_only(runtime.clone(), store_dir).unwrap();
+  let runner = Box::new(crate::local::CommandRunner::new(
     store.clone(),
     runtime.clone(),
-    work_dir.path().to_owned(),
-    NamedCaches::new(named_cache_dir.path().to_owned()),
+    base_dir.path().to_owned(),
+    NamedCaches::new(named_cache_dir),
     true,
-  );
+  ));
+  (runner, store, base_dir)
+}
 
-  let script_dir = TempDir::new().unwrap();
-  let script_path = script_dir.path().join("script");
-  std::fs::File::create(&script_path)
-    .and_then(|mut file| {
-      writeln!(
-        file,
-        "echo -n {} > roland && echo Hello && echo >&2 World; exit {}",
-        TestData::roland().string(),
-        script_exit_code
-      )
-    })
-    .unwrap();
-
-  let request = Process::new(vec![
-    testutil::path::find_bash(),
-    format!("{}", script_path.display()),
-  ])
-  .output_files(vec![PathBuf::from("roland")].into_iter().collect());
-
-  let local_result = local.run(request.clone().into(), Context::default()).await;
-
+fn create_cached_runner(
+  local: Box<dyn CommandRunnerTrait>,
+  store: Store,
+) -> (Box<dyn CommandRunnerTrait>, TempDir) {
+  let runtime = task_executor::Executor::new(Handle::current());
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
 
@@ -69,15 +54,49 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     platform_properties: vec![],
   };
 
-  let caching = crate::cache::CommandRunner::new(
-    Arc::new(local),
+  let runner = Box::new(crate::cache::CommandRunner::new(
+    local.into(),
     process_execution_store,
-    store.clone(),
+    store,
     metadata,
-  );
+  ));
+
+  (runner, cache_dir)
+}
+
+fn create_script(script_exit_code: i8) -> (Process, PathBuf, TempDir) {
+  let script_dir = TempDir::new().unwrap();
+  let script_path = script_dir.path().join("script");
+  std::fs::File::create(&script_path)
+    .and_then(|mut file| {
+      writeln!(
+        file,
+        "echo -n {} > roland && echo Hello && echo >&2 World; exit {}",
+        TestData::roland().string(),
+        script_exit_code
+      )
+    })
+    .unwrap();
+
+  let process = Process::new(vec![
+    testutil::path::find_bash(),
+    format!("{}", script_path.display()),
+  ])
+  .output_files(vec![PathBuf::from("roland")].into_iter().collect());
+
+  (process, script_path, script_dir)
+}
+
+async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
+  let (local, store, _local_runner_dir) = create_local_runner();
+  let (process, script_path, _script_dir) = create_script(script_exit_code);
+
+  let local_result = local.run(process.clone().into(), Context::default()).await;
+
+  let (caching, _cache_dir) = create_cached_runner(local, store.clone());
 
   let uncached_result = caching
-    .run(request.clone().into(), Context::default())
+    .run(process.clone().into(), Context::default())
     .await;
 
   assert_eq!(local_result, uncached_result);
@@ -86,7 +105,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   // fail due to a FileNotFound error. So, If the second run succeeds, that implies that the
   // cache was successfully used.
   std::fs::remove_file(&script_path).unwrap();
-  let maybe_cached_result = caching.run(request.into(), Context::default()).await;
+  let maybe_cached_result = caching.run(process.into(), Context::default()).await;
 
   RoundtripResults {
     uncached: uncached_result,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -197,7 +197,7 @@ py_module_initializer!(native_engine, |py, m| {
   m.add(
     py,
     "garbage_collect_store",
-    py_fn!(py, garbage_collect_store(a: PyScheduler)),
+    py_fn!(py, garbage_collect_store(a: PyScheduler, b: usize)),
   )?;
   m.add(
     py,
@@ -1282,13 +1282,17 @@ fn set_panic_handler(_: Python) -> PyUnitResult {
   Ok(None)
 }
 
-fn garbage_collect_store(py: Python, scheduler_ptr: PyScheduler) -> PyUnitResult {
+fn garbage_collect_store(
+  py: Python,
+  scheduler_ptr: PyScheduler,
+  target_size_bytes: usize,
+) -> PyUnitResult {
   with_scheduler(py, scheduler_ptr, |scheduler| {
     py.allow_threads(|| {
-      scheduler.core.store().garbage_collect(
-        store::DEFAULT_LOCAL_STORE_GC_TARGET_BYTES,
-        store::ShrinkBehavior::Fast,
-      )
+      scheduler
+        .core
+        .store()
+        .garbage_collect(target_size_bytes, store::ShrinkBehavior::Fast)
     })
     .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
     .map(|()| None)


### PR DESCRIPTION
### Problem

#10719 likely describes two different variants of "we hit the local process cache, but then failed to actually use the result because it had been garbage collected". In one of the cases it is crystal clear that the result was collected, because it is the stdout of the process that is missing. In the other case, the failure occurs while attempting to merge directories produced by process runs.

### Solution

When hitting the local process cache, ensure that all of the process outputs exist (and as a sideffect, that they are downloaded locally if a remote cache is configured). Added and fixed a test for this case.

An alternative implementation would have been to guarantee that a cache entry must exist only if all of the digests it requires are transitively reachable. But the local cache and the filesystem store use two different LMDB stores, which means that we cannot transactionally update them in a way that would rule out a cache entry existing even though its file content had been garbage collected... and it's not clear that merging those stores is desirable.

### Result

Fixes #10719. In addition to the test, I lowered the lease time and garbage collection times and validated that the case described on #10719 is no longer reproducible.