### PR TITLE
Use "output" and "input" instead of "product" and "subject"

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -44,10 +44,10 @@ def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, by
         ]
     )
     target = rule_runner.get_target(Address.parse(addr), bootstrapper)
-    created_awslambda = rule_runner.request_product(
+    created_awslambda = rule_runner.request(
         CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target), bootstrapper, PantsEnvironment()]
     )
-    created_awslambda_digest_contents = rule_runner.request_product(
+    created_awslambda_digest_contents = rule_runner.request(
         DigestContents, [created_awslambda.digest]
     )
     assert len(created_awslambda_digest_contents) == 1

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -52,11 +52,11 @@ class ProtobufPythonIntegrationTest(ExternalToolTestBase):
                 f"--source-root-patterns={repr(source_roots)}",
             ]
         )
-        tgt = self.request_product(WrappedTarget, [Address.parse(spec), bootstrapper]).target
-        protocol_sources = self.request_product(
+        tgt = self.request(WrappedTarget, [Address.parse(spec), bootstrapper]).target
+        protocol_sources = self.request(
             HydratedSources, [HydrateSourcesRequest(tgt[ProtobufSources]), bootstrapper]
         )
-        generated_sources = self.request_product(
+        generated_sources = self.request(
             GeneratedSources,
             [GeneratePythonFromProtobufRequest(protocol_sources.snapshot, tgt), bootstrapper],
         )

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -41,8 +41,8 @@ def run_goal(
         ],
         mock_gets=[
             MockGet(
-                product_type=UnexpandedTargets,
-                subject_type=Addresses,
+                output_type=UnexpandedTargets,
+                input_type=Addresses,
                 mock=lambda _: UnexpandedTargets(targets),
             )
         ],

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -100,7 +100,7 @@ def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
     # not generate subtargets.
     rule_runner.create_file("tests/python/project_test/demo_test/__init__.py")
     rule_runner.add_to_build_file("tests/python/project_test/demo_test", "python_library()")
-    result = rule_runner.request_product(FirstPartyModuleToAddressMapping, [options_bootstrapper])
+    result = rule_runner.request(FirstPartyModuleToAddressMapping, [options_bootstrapper])
     assert result.mapping == FrozenDict(
         {
             "project.util.dirutil": Address(
@@ -152,9 +152,7 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    result = rule_runner.request_product(
-        ThirdPartyModuleToAddressMapping, [create_options_bootstrapper()]
-    )
+    result = rule_runner.request(ThirdPartyModuleToAddressMapping, [create_options_bootstrapper()])
     assert result.mapping == FrozenDict(
         {
             "colors": Address("3rdparty/python", target_name="ansicolors"),
@@ -172,7 +170,7 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
     )
 
     def get_owner(module: str) -> Optional[Address]:
-        return rule_runner.request_product(
+        return rule_runner.request(
             PythonModuleOwner, [PythonModule(module), options_bootstrapper]
         ).address
 

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -92,7 +92,7 @@ def test_infer_python_imports() -> None:
             args.append("--python-infer-string-imports")
         options_bootstrapper = create_options_bootstrapper(args=args)
         target = rule_runner.get_target(address, options_bootstrapper)
-        return rule_runner.request_product(
+        return rule_runner.request(
             InferredDependencies,
             [InferPythonDependencies(target[PythonSources]), options_bootstrapper],
         )
@@ -153,7 +153,7 @@ def test_infer_python_inits() -> None:
 
     def run_dep_inference(address: Address) -> InferredDependencies:
         target = rule_runner.get_target(address, options_bootstrapper)
-        return rule_runner.request_product(
+        return rule_runner.request(
             InferredDependencies,
             [InferInitDependencies(target[PythonSources]), options_bootstrapper],
         )
@@ -196,7 +196,7 @@ def test_infer_python_conftests() -> None:
 
     def run_dep_inference(address: Address) -> InferredDependencies:
         target = rule_runner.get_target(address, options_bootstrapper)
-        return rule_runner.request_product(
+        return rule_runner.request(
             InferredDependencies,
             [InferConftestDependencies(target[PythonSources]), options_bootstrapper],
         )

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -31,8 +31,8 @@ def run_create_coverage_config_rule(coverage_config: Optional[str]) -> str:
         )
 
     mock_gets = [
-        MockGet(product_type=DigestContents, subject_type=PathGlobs, mock=mock_read_config),
-        MockGet(product_type=Digest, subject_type=CreateDigest, mock=mock_handle_config),
+        MockGet(output_type=DigestContents, input_type=PathGlobs, mock=mock_read_config),
+        MockGet(output_type=Digest, input_type=CreateDigest, mock=mock_handle_config),
     ]
 
     result = run_rule_with_mocks(create_coverage_config, rule_args=[coverage], mock_gets=mock_gets)

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -156,8 +156,8 @@ async def setup_pytest_for_target(
                 # `pytest:main` or the tests themselves break between the two versions.
                 ":".join(
                     (
-                        pytest_pex_request.subject.output_filename,
-                        requirements_pex_request.subject.output_filename,
+                        pytest_pex_request.input.output_filename,
+                        requirements_pex_request.input.output_filename,
                     )
                 ),
             ),

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -173,8 +173,8 @@ def run_pytest(
         pants_environment,
         create_options_bootstrapper(args=args),
     ]
-    test_result = rule_runner.request_product(TestResult, subjects)
-    debug_request = rule_runner.request_product(TestDebugRequest, subjects)
+    test_result = rule_runner.request(TestResult, subjects)
+    debug_request = rule_runner.request(TestDebugRequest, subjects)
     if debug_request.process is not None:
         debug_result = InteractiveRunner(rule_runner.scheduler).run(debug_request.process)
         assert test_result.exit_code == debug_result.exit_code
@@ -371,7 +371,7 @@ def test_junit(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
     assert f"{PACKAGE}/test_good.py ." in result.stdout
     assert result.xml_results is not None
-    digest_contents = rule_runner.request_product(DigestContents, [result.xml_results.digest])
+    digest_contents = rule_runner.request(DigestContents, [result.xml_results.digest])
     file = digest_contents[0]
     assert file.path.startswith("dist/test-results")
     assert b"pants_test.test_good" in file.content

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -105,14 +105,14 @@ def assert_chroot(
     rule_runner: RuleRunner, expected_files, expected_setup_kwargs, addr: str
 ) -> None:
     tgt = rule_runner.get_target(Address.parse(addr))
-    chroot = rule_runner.request_product(
+    chroot = rule_runner.request(
         SetupPyChroot,
         [
             SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
             create_options_bootstrapper(),
         ],
     )
-    snapshot = rule_runner.request_product(Snapshot, [chroot.digest])
+    snapshot = rule_runner.request(Snapshot, [chroot.digest])
     assert sorted(expected_files) == sorted(snapshot.files)
     assert expected_setup_kwargs == chroot.setup_kwargs.kwargs
 
@@ -120,7 +120,7 @@ def assert_chroot(
 def assert_chroot_error(rule_runner: RuleRunner, addr: str, exc_cls: Type[Exception]) -> None:
     tgt = rule_runner.get_target(Address.parse(addr))
     with pytest.raises(ExecutionError) as excinfo:
-        rule_runner.request_product(
+        rule_runner.request(
             SetupPyChroot,
             [
                 SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
@@ -292,11 +292,11 @@ def test_get_sources() -> None:
         addrs,
     ):
         targets = Targets(rule_runner.get_target(Address.parse(addr)) for addr in addrs)
-        srcs = rule_runner.request_product(
+        srcs = rule_runner.request(
             SetupPySources,
             [SetupPySourcesRequest(targets, py2=False), create_options_bootstrapper()],
         )
-        chroot_snapshot = rule_runner.request_product(Snapshot, [srcs.digest])
+        chroot_snapshot = rule_runner.request(Snapshot, [srcs.digest])
 
         assert sorted(expected_files) == sorted(chroot_snapshot.files)
         assert sorted(expected_packages) == sorted(srcs.packages)
@@ -439,7 +439,7 @@ def test_get_requirements() -> None:
 
     def assert_requirements(expected_req_strs, addr):
         tgt = rule_runner.get_target(Address.parse(addr))
-        reqs = rule_runner.request_product(
+        reqs = rule_runner.request(
             ExportedTargetRequirements,
             [DependencyOwner(ExportedTarget(tgt)), create_options_bootstrapper()],
         )
@@ -513,7 +513,7 @@ def test_owned_dependencies() -> None:
         tgt = rule_runner.get_target(Address.parse(exported))
         assert sorted(owned) == sorted(
             od.target.address.spec
-            for od in rule_runner.request_product(
+            for od in rule_runner.request(
                 OwnedDependencies,
                 [
                     DependencyOwner(ExportedTarget(tgt)),
@@ -552,7 +552,7 @@ def assert_is_owner(rule_runner: RuleRunner, owner: str, owned: str):
     tgt = rule_runner.get_target(Address.parse(owned))
     assert (
         owner
-        == rule_runner.request_product(
+        == rule_runner.request(
             ExportedTarget,
             [OwnedDependency(tgt), create_options_bootstrapper()],
         ).target.address.spec
@@ -562,7 +562,7 @@ def assert_is_owner(rule_runner: RuleRunner, owner: str, owned: str):
 def assert_owner_error(rule_runner, owned: str, exc_cls: Type[Exception]):
     tgt = rule_runner.get_target(Address.parse(owned))
     with pytest.raises(ExecutionError) as excinfo:
-        rule_runner.request_product(
+        rule_runner.request(
             ExportedTarget,
             [OwnedDependency(tgt), create_options_bootstrapper()],
         )

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -69,7 +69,7 @@ def run_bandit(
         args.append("--bandit-skip")
     if additional_args:
         args.extend(additional_args)
-    results = rule_runner.request_product(
+    results = rule_runner.request(
         LintResults,
         [
             BanditRequest(BanditFieldSet.create(tgt) for tgt in targets),
@@ -202,7 +202,7 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     assert result[0].exit_code == 1
     assert result[0].stdout.strip() == ""
     assert result[0].report is not None
-    report_files = rule_runner.request_product(DigestContents, [result[0].report.digest])
+    report_files = rule_runner.request(DigestContents, [result[0].report.digest])
     assert len(report_files) == 1
     assert (
         "Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5" in report_files[0].content.decode()

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -78,10 +78,10 @@ def run_black(
     options_bootstrapper = create_options_bootstrapper(args=args)
     field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request_product(
+    lint_results = rule_runner.request(
         LintResults, [BlackRequest(field_sets), options_bootstrapper, pants_env]
     )
-    input_sources = rule_runner.request_product(
+    input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -89,7 +89,7 @@ def run_black(
             pants_env,
         ],
     )
-    fmt_result = rule_runner.request_product(
+    fmt_result = rule_runner.request(
         FmtResult,
         [
             BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -101,7 +101,7 @@ def run_black(
 
 
 def get_digest(rule_runner: RuleRunner, source_files: List[FileContent]) -> Digest:
-    return rule_runner.request_product(Digest, [CreateDigest(source_files)])
+    return rule_runner.request(Digest, [CreateDigest(source_files)])
 
 
 def test_passing_source(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -59,10 +59,10 @@ def run_docformatter(
     options_bootstrapper = create_options_bootstrapper(args=args)
     field_sets = [DocformatterFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request_product(
+    lint_results = rule_runner.request(
         LintResults, [DocformatterRequest(field_sets), options_bootstrapper, pants_env]
     )
-    input_sources = rule_runner.request_product(
+    input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -70,7 +70,7 @@ def run_docformatter(
             pants_env,
         ],
     )
-    fmt_result = rule_runner.request_product(
+    fmt_result = rule_runner.request(
         FmtResult,
         [
             DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -82,7 +82,7 @@ def run_docformatter(
 
 
 def get_digest(rule_runner: RuleRunner, source_files: List[FileContent]) -> Digest:
-    return rule_runner.request_product(Digest, [CreateDigest(source_files)])
+    return rule_runner.request(Digest, [CreateDigest(source_files)])
 
 
 def test_passing_source(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -68,7 +68,7 @@ def run_flake8(
         args.append("--flake8-skip")
     if additional_args:
         args.extend(additional_args)
-    results = rule_runner.request_product(
+    results = rule_runner.request(
         LintResults,
         [
             Flake8Request(Flake8FieldSet.create(tgt) for tgt in targets),
@@ -191,6 +191,6 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     assert result[0].exit_code == 1
     assert result[0].stdout.strip() == ""
     assert result[0].report is not None
-    report_files = rule_runner.request_product(DigestContents, [result[0].report.digest])
+    report_files = rule_runner.request(DigestContents, [result[0].report.digest])
     assert len(report_files) == 1
     assert "bad.py:1:1: F401" in report_files[0].content.decode()

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -73,10 +73,10 @@ def run_isort(
     options_bootstrapper = create_options_bootstrapper(args=args)
     field_sets = [IsortFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request_product(
+    lint_results = rule_runner.request(
         LintResults, [IsortRequest(field_sets), options_bootstrapper, pants_env]
     )
-    input_sources = rule_runner.request_product(
+    input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
@@ -84,7 +84,7 @@ def run_isort(
             pants_env,
         ],
     )
-    fmt_result = rule_runner.request_product(
+    fmt_result = rule_runner.request(
         FmtResult,
         [
             IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
@@ -96,7 +96,7 @@ def run_isort(
 
 
 def get_digest(rule_runner: RuleRunner, source_files: List[FileContent]) -> Digest:
-    return rule_runner.request_product(Digest, [CreateDigest(source_files)])
+    return rule_runner.request(Digest, [CreateDigest(source_files)])
 
 
 def test_passing_source(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -99,7 +99,7 @@ def run_pylint(
         args.append("--pylint-skip")
     if additional_args:
         args.extend(additional_args)
-    results = rule_runner.request_product(
+    results = rule_runner.request(
         LintResults,
         [
             PylintRequest(PylintFieldSet.create(tgt) for tgt in targets),

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -48,14 +48,14 @@ def run_black_and_isort(
         "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
         *(extra_args or []),
     ]
-    results = rule_runner.request_product(
+    results = rule_runner.request(
         LanguageFmtResults, [targets, create_options_bootstrapper(args=args), PantsEnvironment()]
     )
     return results
 
 
 def get_digest(rule_runner: RuleRunner, source_files: List[FileContent]) -> Digest:
-    return rule_runner.request_product(Digest, [CreateDigest(source_files)])
+    return rule_runner.request(Digest, [CreateDigest(source_files)])
 
 
 def test_multiple_formatters_changing_the_same_file(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -39,7 +39,7 @@ def assert_pipenv_requirements(
 ) -> None:
     rule_runner.add_to_build_file("", f"{build_file_entry}\n")
     rule_runner.create_file(pipfile_lock_relpath, dumps(pipfile_lock))
-    targets = rule_runner.request_product(
+    targets = rule_runner.request(
         Targets,
         [
             Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -39,7 +39,7 @@ def assert_python_requirements(
 ) -> None:
     rule_runner.add_to_build_file("", f"{build_file_entry}\n")
     rule_runner.create_file(requirements_txt_relpath, requirements_txt)
-    targets = rule_runner.request_product(
+    targets = rule_runner.request(
         Targets,
         [
             Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -215,7 +215,7 @@ async def mypy_typecheck(
                 "--pex-path",
                 ":".join(
                     (
-                        tool_pex_request.subject.output_filename,
+                        tool_pex_request.input.output_filename,
                         # requirements_pex_request.subject.output_filename,
                     )
                 ),

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -127,7 +127,7 @@ def run_mypy(
         args.append("--mypy-skip")
     if additional_args:
         args.extend(additional_args)
-    result = rule_runner.request_product(
+    result = rule_runner.request(
         TypecheckResults,
         [
             MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets),

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -43,10 +43,10 @@ def assert_injected(
         rule_runner.make_snapshot({fp: "# declared" for fp in original_declared_files}),
     )
     bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
-    result = rule_runner.request_product(AncestorFiles, [request, bootstrapper]).snapshot
+    result = rule_runner.request(AncestorFiles, [request, bootstrapper]).snapshot
     assert list(result.files) == sorted(expected_discovered)
 
-    materialized_result = rule_runner.request_product(DigestContents, [result.digest])
+    materialized_result = rule_runner.request(DigestContents, [result.digest])
     for file_content in materialized_result:
         path = file_content.path
         if not path.endswith("__init__.py"):

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -82,9 +82,7 @@ def test_constraints_validation(rule_runner: RuleRunner) -> None:
             args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")
         if constraints_file:
             args.append(f"--python-setup-requirement-constraints={constraints_file}")
-        return rule_runner.request_product(
-            PexRequest, [request, create_options_bootstrapper(args=args)]
-        )
+        return rule_runner.request(PexRequest, [request, create_options_bootstrapper(args=args)])
 
     pex_req1 = get_pex_request("constraints1.txt", ResolveAllConstraintsOption.NEVER)
     assert pex_req1.requirements == PexRequirements(["foo-bar>=0.1.2", "bar==5.5.5", "baz"])

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -350,7 +350,7 @@ def create_pex_and_get_all_data(
         additional_inputs=additional_inputs,
         additional_args=additional_pex_args,
     )
-    pex = rule_runner.request_product(
+    pex = rule_runner.request(
         Pex,
         [
             request,
@@ -403,7 +403,7 @@ def create_pex_and_get_pex_info(
 
 
 def test_pex_execution(rule_runner: RuleRunner) -> None:
-    sources = rule_runner.request_product(
+    sources = rule_runner.request(
         Digest,
         [
             CreateDigest(
@@ -430,12 +430,12 @@ def test_pex_execution(rule_runner: RuleRunner) -> None:
         input_digest=pex_output["pex"].digest,
         description="Run the pex and make sure it works",
     )
-    result = rule_runner.request_product(ProcessResult, [process])
+    result = rule_runner.request(ProcessResult, [process])
     assert result.stdout == b"from main\n"
 
 
 def test_pex_environment(rule_runner: RuleRunner) -> None:
-    sources = rule_runner.request_product(
+    sources = rule_runner.request(
         Digest,
         [
             CreateDigest(
@@ -456,7 +456,7 @@ def test_pex_environment(rule_runner: RuleRunner) -> None:
     )
     pex_output = create_pex_and_get_all_data(rule_runner, entry_point="main", sources=sources)
 
-    process = rule_runner.request_product(
+    process = rule_runner.request(
         Process,
         [
             PexProcess(
@@ -475,7 +475,7 @@ def test_pex_environment(rule_runner: RuleRunner) -> None:
         ],
     )
 
-    result = rule_runner.request_product(ProcessResult, [process])
+    result = rule_runner.request(ProcessResult, [process])
     assert b"LANG=es_PY.UTF-8" in result.stdout
     assert b"ftp_proxy=dummyproxy" in result.stdout
 
@@ -555,7 +555,7 @@ def test_additional_inputs(rule_runner: RuleRunner) -> None:
     # This verifies that the file was indeed provided as additional input to the pex call.
     preamble_file = "custom_preamble.txt"
     preamble = "#!CUSTOM PREAMBLE\n"
-    additional_inputs = rule_runner.request_product(
+    additional_inputs = rule_runner.request(
         Digest, [CreateDigest([FileContent(path=preamble_file, content=preamble.encode())])]
     )
     additional_pex_args = (f"--preamble-file={preamble_file}",)

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -63,7 +63,7 @@ class PythonSourceFilesTest(ExternalToolTestBase):
         source_roots: Optional[List[str]] = None,
         extra_args: Optional[List[str]] = None,
     ) -> StrippedPythonSourceFiles:
-        return self.request_product(
+        return self.request(
             StrippedPythonSourceFiles,
             [
                 PythonSourceFilesRequest(
@@ -88,7 +88,7 @@ class PythonSourceFilesTest(ExternalToolTestBase):
         source_roots: Optional[List[str]] = None,
         extra_args: Optional[List[str]] = None,
     ) -> PythonSourceFiles:
-        return self.request_product(
+        return self.request(
             PythonSourceFiles,
             [
                 PythonSourceFilesRequest(

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -162,20 +162,20 @@ class FmtTest(TestBase):
             ],
             mock_gets=[
                 MockGet(
-                    product_type=LanguageFmtResults,
-                    subject_type=LanguageFmtTargets,
+                    output_type=LanguageFmtResults,
+                    input_type=LanguageFmtTargets,
                     mock=lambda language_targets_collection: language_targets_collection.language_fmt_results(
                         result_digest
                     ),
                 ),
                 MockGet(
-                    product_type=TargetsWithSources,
-                    subject_type=TargetsWithSourcesRequest,
+                    output_type=TargetsWithSources,
+                    input_type=TargetsWithSourcesRequest,
                     mock=lambda tgts: TargetsWithSources(tgts if include_sources else ()),
                 ),
                 MockGet(
-                    product_type=Digest,
-                    subject_type=MergeDigests,
+                    output_type=Digest,
+                    input_type=MergeDigests,
                     mock=lambda _: result_digest,
                 ),
             ],

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -134,16 +134,16 @@ def run_lint_rule(
         ],
         mock_gets=[
             MockGet(
-                product_type=LintResults,
-                subject_type=LintRequest,
+                output_type=LintResults,
+                input_type=LintRequest,
                 mock=lambda field_set_collection: field_set_collection.lint_results,
             ),
             MockGet(
-                product_type=FieldSetsWithSources,
-                subject_type=FieldSetsWithSourcesRequest,
+                output_type=FieldSetsWithSources,
+                input_type=FieldSetsWithSourcesRequest,
                 mock=lambda field_sets: FieldSetsWithSources(field_sets if include_sources else ()),
             ),
-            MockGet(product_type=Digest, subject_type=MergeDigests, mock=lambda _: EMPTY_DIGEST),
+            MockGet(output_type=Digest, input_type=MergeDigests, mock=lambda _: EMPTY_DIGEST),
         ],
         union_membership=union_membership,
     )

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -29,7 +29,7 @@ def rule_runner() -> RuleRunner:
 
 
 def create_mock_run_request(rule_runner: RuleRunner, program_text: bytes) -> RunRequest:
-    digest = rule_runner.request_product(
+    digest = rule_runner.request(
         Digest,
         [CreateDigest([FileContent(path="program.py", content=program_text, is_executable=True)])],
     )
@@ -72,13 +72,13 @@ def single_target_run(
         ],
         mock_gets=[
             MockGet(
-                product_type=TargetRootsToFieldSets,
-                subject_type=TargetRootsToFieldSetsRequest,
+                output_type=TargetRootsToFieldSets,
+                input_type=TargetRootsToFieldSetsRequest,
                 mock=lambda _: TargetRootsToFieldSets({target_with_origin: [field_set]}),
             ),
             MockGet(
-                product_type=RunRequest,
-                subject_type=TestRunFieldSet,
+                output_type=RunRequest,
+                input_type=TestRunFieldSet,
                 mock=lambda _: create_mock_run_request(rule_runner, program_text),
             ),
         ],

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -142,7 +142,7 @@ def run_test_rule(
         )
 
     def mock_debug_request(_: TestFieldSet) -> TestDebugRequest:
-        digest = rule_runner.request_product(
+        digest = rule_runner.request(
             Digest, [CreateDigest((FileContent(path="program.py", content=b"def test(): pass"),))]
         )
         process = InteractiveProcess(["/usr/bin/python", "program.py"], input_digest=digest)
@@ -168,39 +168,39 @@ def run_test_rule(
         ],
         mock_gets=[
             MockGet(
-                product_type=TargetRootsToFieldSets,
-                subject_type=TargetRootsToFieldSetsRequest,
+                output_type=TargetRootsToFieldSets,
+                input_type=TargetRootsToFieldSetsRequest,
                 mock=mock_find_valid_field_sets,
             ),
             MockGet(
-                product_type=EnrichedTestResult,
-                subject_type=TestFieldSet,
+                output_type=EnrichedTestResult,
+                input_type=TestFieldSet,
                 mock=lambda fs: fs.test_result,
             ),
             MockGet(
-                product_type=TestDebugRequest,
-                subject_type=TestFieldSet,
+                output_type=TestDebugRequest,
+                input_type=TestFieldSet,
                 mock=mock_debug_request,
             ),
             MockGet(
-                product_type=FieldSetsWithSources,
-                subject_type=FieldSetsWithSourcesRequest,
+                output_type=FieldSetsWithSources,
+                input_type=FieldSetsWithSourcesRequest,
                 mock=lambda field_sets: FieldSetsWithSources(field_sets if include_sources else ()),
             ),
             # Merge XML results.
             MockGet(
-                product_type=Digest,
-                subject_type=MergeDigests,
+                output_type=Digest,
+                input_type=MergeDigests,
                 mock=lambda _: EMPTY_DIGEST,
             ),
             MockGet(
-                product_type=CoverageReports,
-                subject_type=CoverageDataCollection,
+                output_type=CoverageReports,
+                input_type=CoverageDataCollection,
                 mock=mock_coverage_report_generation,
             ),
             MockGet(
-                product_type=OpenFiles,
-                subject_type=OpenFilesRequest,
+                output_type=OpenFiles,
+                input_type=OpenFilesRequest,
                 mock=lambda _: OpenFiles(()),
             ),
         ],

--- a/src/python/pants/core/goals/typecheck_test.py
+++ b/src/python/pants/core/goals/typecheck_test.py
@@ -128,13 +128,13 @@ def run_typecheck_rule(
         rule_args=[console, Targets(targets), union_membership],
         mock_gets=[
             MockGet(
-                product_type=TypecheckResults,
-                subject_type=TypecheckRequest,
+                output_type=TypecheckResults,
+                input_type=TypecheckRequest,
                 mock=lambda field_set_collection: field_set_collection.typecheck_results,
             ),
             MockGet(
-                product_type=FieldSetsWithSources,
-                subject_type=FieldSetsWithSourcesRequest,
+                output_type=FieldSetsWithSources,
+                input_type=FieldSetsWithSourcesRequest,
                 mock=lambda field_sets: FieldSetsWithSources(field_sets if include_sources else ()),
             ),
         ],

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -33,11 +33,11 @@ def test_extract_zip(rule_runner: RuleRunner, compression: int) -> None:
             zf.writestr(name, content)
     io.flush()
     input_snapshot = rule_runner.make_snapshot({"test.zip": io.getvalue()})
-    extracted_digest = rule_runner.request_product(
+    extracted_digest = rule_runner.request(
         ExtractedDigest, [MaybeExtractable(input_snapshot.digest)]
     )
 
-    digest_contents = rule_runner.request_product(DigestContents, [extracted_digest.digest])
+    digest_contents = rule_runner.request(DigestContents, [extracted_digest.digest])
     assert digest_contents == EXPECTED_DIGEST_CONTENTS
 
 
@@ -52,19 +52,19 @@ def test_extract_tar(rule_runner: RuleRunner, compression: str) -> None:
             tf.addfile(tarinfo, BytesIO(content))
     ext = f"tar.{compression}" if compression else "tar"
     input_snapshot = rule_runner.make_snapshot({f"test.{ext}": io.getvalue()})
-    extracted_digest = rule_runner.request_product(
+    extracted_digest = rule_runner.request(
         ExtractedDigest, [MaybeExtractable(input_snapshot.digest)]
     )
 
-    digest_contents = rule_runner.request_product(DigestContents, [extracted_digest.digest])
+    digest_contents = rule_runner.request(DigestContents, [extracted_digest.digest])
     assert digest_contents == EXPECTED_DIGEST_CONTENTS
 
 
 def test_non_archive(rule_runner: RuleRunner) -> None:
     input_snapshot = rule_runner.make_snapshot({"test.sh": b"# A shell script"})
-    extracted_digest = rule_runner.request_product(
+    extracted_digest = rule_runner.request(
         ExtractedDigest, [MaybeExtractable(input_snapshot.digest)]
     )
 
-    digest_contents = rule_runner.request_product(DigestContents, [extracted_digest.digest])
+    digest_contents = rule_runner.request(DigestContents, [extracted_digest.digest])
     assert DigestContents([FileContent("test.sh", b"# A shell script")]) == digest_contents

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -49,7 +49,7 @@ def test_filter_field_sets(rule_runner: RuleRunner) -> None:
         empty_addr, Sources(None, address=empty_addr), Tags(None, address=empty_addr)
     )
 
-    result = rule_runner.request_product(
+    result = rule_runner.request(
         FieldSetsWithSources,
         [
             FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
@@ -73,7 +73,7 @@ def test_filter_targets(rule_runner: RuleRunner) -> None:
     empty_tgt = MockTarget({}, address=Address("", target_name="empty"))
     invalid_tgt = MockTargetWithNoSourcesField({}, address=Address("", target_name="invalid"))
 
-    result = rule_runner.request_product(
+    result = rule_runner.request(
         TargetsWithSources,
         [
             TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt]),

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -65,7 +65,7 @@ def assert_sources_resolved(
     expected: Iterable[TargetSources],
     expected_unrooted: Iterable[str] = (),
 ) -> None:
-    result = rule_runner.request_product(
+    result = rule_runner.request(
         SourceFiles,
         [SourceFilesRequest(sources_fields), create_options_bootstrapper()],
     )

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -43,7 +43,7 @@ def get_stripped_files(
     if not has_source_root_patterns:
         source_root_patterns = ["src/python", "src/java", "tests/python"]
         args.append(f"--source-root-patterns={json.dumps(source_root_patterns)}")
-    result = rule_runner.request_product(
+    result = rule_runner.request(
         StrippedSourceFiles,
         [request, create_options_bootstrapper(args=args)],
     )

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -615,16 +615,16 @@ class MoreComplicatedEngineAware(TestBase):
                     FileContent(path="b.txt", content=b"beta"),
                 )
             )
-            digest_1 = self.request_product(Digest, [input_1])
-            snapshot_1 = self.request_product(Snapshot, [digest_1])
+            digest_1 = self.request(Digest, [input_1])
+            snapshot_1 = self.request(Snapshot, [digest_1])
 
             input_2 = CreateDigest((FileContent(path="g.txt", content=b"gamma"),))
-            digest_2 = self.request_product(Digest, [input_2])
-            snapshot_2 = self.request_product(Snapshot, [digest_2])
+            digest_2 = self.request(Digest, [input_2])
+            snapshot_2 = self.request(Snapshot, [digest_2])
 
             input = ComplicatedInput(snapshot_1=snapshot_1, snapshot_2=snapshot_2)
 
-            self.request_product(Output, [input])
+            self.request(Output, [input])
 
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
         workunit = next(
@@ -678,7 +678,7 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            result = self.request_product(ProcessResult, [stdout_process])
+            result = self.request(ProcessResult, [stdout_process])
 
         assert tracker.finished
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -707,7 +707,7 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            result = self.request_product(ProcessResult, [stderr_process])
+            result = self.request(ProcessResult, [stderr_process])
 
         assert tracker.finished
         finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -760,4 +760,4 @@ class StreamingWorkunitProcessTests(TestBase):
         )
 
         with handler.session():
-            self.request_product(ProcessResult, [stdout_process])
+            self.request(ProcessResult, [stdout_process])

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -70,9 +70,9 @@ class Externs:
             if isinstance(res, Get):
                 # Get.
                 return PyGeneratorResponseGet(
-                    res.product_type,
-                    res.subject_declared_type,
-                    res.subject,
+                    res.output_type,
+                    res.input_type,
+                    res.input,
                     res.weak,
                 )
             elif type(res) in (tuple, list):
@@ -80,9 +80,9 @@ class Externs:
                 return PyGeneratorResponseGetMulti(
                     tuple(
                         PyGeneratorResponseGet(
-                            get.product_type,
-                            get.subject_declared_type,
-                            get.subject,
+                            get.output_type,
+                            get.input_type,
+                            get.input,
                             get.weak,
                         )
                         for get in res

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -23,10 +23,8 @@ def test_options_parse_scoped(rule_runner: RuleRunner) -> None:
     options_bootstrapper = create_options_bootstrapper(
         args=["-ldebug"], env=dict(PANTS_PANTSD="True", PANTS_BUILD_IGNORE='["ignoreme/"]')
     )
-    global_options = rule_runner.request_product(
-        ScopedOptions, [Scope(GLOBAL_SCOPE), options_bootstrapper]
-    )
-    python_setup_options = rule_runner.request_product(
+    global_options = rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE), options_bootstrapper])
+    python_setup_options = rule_runner.request(
         ScopedOptions, [Scope("python-setup"), options_bootstrapper]
     )
 
@@ -40,7 +38,7 @@ def test_options_parse_memoization(rule_runner: RuleRunner) -> None:
     # Confirm that re-executing with a new-but-identical Options object results in memoization.
 
     def parse(ob):
-        return rule_runner.request_product(ScopedOptions, [Scope(GLOBAL_SCOPE), ob])
+        return rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE), ob])
 
     # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
     one_opts = create_options_bootstrapper()

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -221,14 +221,14 @@ class Scheduler:
             self._native.lib.tasks_add_get(tasks, product, subject)
 
         for the_get in rule.input_gets:
-            if union.is_instance(the_get.subject_declared_type):
+            if union.is_instance(the_get.input_type):
                 # If the registered subject type is a union, add Get edges to all registered
                 # union members.
-                for union_member in union_membership.get(the_get.subject_declared_type):
-                    add_get_edge(the_get.product_type, union_member)
+                for union_member in union_membership.get(the_get.input_type):
+                    add_get_edge(the_get.output_type, union_member)
             else:
                 # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.
-                add_get_edge(the_get.product_type, the_get.subject_declared_type)
+                add_get_edge(the_get.output_type, the_get.input_type)
 
         self._native.lib.tasks_task_end(tasks)
 

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -207,23 +207,23 @@ class SchedulerTest(TestBase):
     def test_use_params(self):
         # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
         a, b = A(), B()
-        result_str = self.request_product(str, [a, b])
+        result_str = self.request(str, [a, b])
         self.assertEqual(result_str, consumes_a_and_b(a, b))
 
         # And confirm that a superset of Params is also accepted.
-        result_str = self.request_product(str, [a, b, self])
+        result_str = self.request(str, [a, b, self])
         self.assertEqual(result_str, consumes_a_and_b(a, b))
 
         # But not a subset.
         expected_msg = "No installed QueryRules can compute str given input Params(A), but"
         with self.assertRaisesRegex(Exception, re.escape(expected_msg)):
-            self.request_product(str, [a])
+            self.request(str, [a])
 
     def test_transitive_params(self):
         # Test that C can be provided and implicitly converted into a B with transitive_b_c() to satisfy
         # the selectors of consumes_a_and_b().
         a, c = A(), C()
-        result_str = self.request_product(str, [a, c])
+        result_str = self.request(str, [a, c])
         self.assertEqual(
             remove_locations_from_traceback(result_str),
             remove_locations_from_traceback(consumes_a_and_b(a, transitive_b_c(c))),
@@ -231,7 +231,7 @@ class SchedulerTest(TestBase):
 
         # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to
         # the existence of transitive_b_c().
-        self.request_product(D, [c])
+        self.request(D, [c])
 
     def test_consumed_types(self):
         assert {A, B, C, str} == set(
@@ -243,11 +243,11 @@ class SchedulerTest(TestBase):
         # engine that behavior would be surprising, and would cause both of these Params to intern
         # to the same value, triggering an error. Instead, the engine additionally includes the
         # type of a value in equality.
-        assert A() == self.request_product(A, [1, True])
+        assert A() == self.request(A, [1, True])
 
     def test_weak_gets(self):
-        assert {True, False} == set(self.request_product(BooleanDeps, [True]))
-        assert {True, False} == set(self.request_product(BooleanDeps, [False]))
+        assert {True, False} == set(self.request(BooleanDeps, [True]))
+        assert {True, False} == set(self.request(BooleanDeps, [False]))
 
     @contextmanager
     def _assert_execution_error(self, expected_msg):
@@ -255,15 +255,15 @@ class SchedulerTest(TestBase):
             yield
 
     def test_union_rules(self):
-        self.request_product(A, [UnionWrapper(UnionA())])
-        self.request_product(A, [UnionWrapper(UnionB())])
+        self.request(A, [UnionWrapper(UnionA())])
+        self.request(A, [UnionWrapper(UnionB())])
         # Fails due to no union relationship from A -> UnionBase.
         with self._assert_execution_error("Type A is not a member of the UnionBase @union"):
-            self.request_product(A, [UnionWrapper(A())])
+            self.request(A, [UnionWrapper(A())])
 
     def test_union_rules_no_docstring(self):
         with self._assert_execution_error("specific error message for UnionA instance"):
-            self.request_product(UnionX, [UnionWrapper(UnionA())])
+            self.request(UnionX, [UnionWrapper(UnionA())])
 
 
 class SchedulerWithNestedRaiseTest(TestBase):
@@ -285,7 +285,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
 
         with self.assertRaises(ExecutionError) as cm:
             # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
-            self.request_product(A, [TypeCheckFailWrapper(A())])
+            self.request(A, [TypeCheckFailWrapper(A())])
 
         expected_regex = "WithDeps.*did not declare a dependency on JustGet"
         self.assertRegex(str(cm.exception), expected_regex)
@@ -294,13 +294,13 @@ class SchedulerWithNestedRaiseTest(TestBase):
         """Test that unhashable root params result in a structured error."""
         # This will fail at the rust boundary, before even entering the engine.
         with self.assertRaisesRegex(TypeError, "unhashable type: 'list'"):
-            self.request_product(C, [CollectionType([1, 2, 3])])
+            self.request(C, [CollectionType([1, 2, 3])])
 
     def test_unhashable_get_params_failure(self):
         """Test that unhashable Get(...) params result in a structured error."""
         # This will fail inside of `c_unhashable_dataclass`.
         with self.assertRaisesRegex(ExecutionError, "unhashable type: 'list'"):
-            self.request_product(C, [CollectionType(tuple())])
+            self.request(C, [CollectionType(tuple())])
 
     def test_trace_includes_rule_exception_traceback(self):
         # Execute a request that will trigger the nested raise, and then directly inspect its trace.

--- a/src/python/pants/engine/internals/uuid_test.py
+++ b/src/python/pants/engine/internals/uuid_test.py
@@ -17,32 +17,32 @@ def rule_runner() -> RuleRunner:
 
 
 def test_distinct_uuids_default_scope(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest()])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest()])
+    uuid1 = rule_runner.request(UUID, [UUIDRequest()])
+    uuid2 = rule_runner.request(UUID, [UUIDRequest()])
     assert uuid1 != uuid2
 
 
 def test_distinct_uuids_different_scopes(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="that")])
+    uuid1 = rule_runner.request(UUID, [UUIDRequest(scope="this")])
+    uuid2 = rule_runner.request(UUID, [UUIDRequest(scope="that")])
     assert uuid1 != uuid2
 
 
 def test_identical_uuids_same_scope(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="this")])
+    uuid1 = rule_runner.request(UUID, [UUIDRequest(scope="this")])
+    uuid2 = rule_runner.request(UUID, [UUIDRequest(scope="this")])
     assert uuid1 == uuid2
 
 
 def test_distinct_uuids_call_scope(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest()])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest(scope="bob")])
-    uuid3 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
-    uuid4 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
+    uuid1 = rule_runner.request(UUID, [UUIDRequest()])
+    uuid2 = rule_runner.request(UUID, [UUIDRequest(scope="bob")])
+    uuid3 = rule_runner.request(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
+    uuid4 = rule_runner.request(UUID, [UUIDRequest.scoped(UUIDScope.PER_CALL)])
     assert uuid1 != uuid2 != uuid3 != uuid4
 
 
 def test_identical_uuids_session_scope(rule_runner: RuleRunner) -> None:
-    uuid1 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
-    uuid2 = rule_runner.request_product(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
+    uuid1 = rule_runner.request(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
+    uuid2 = rule_runner.request(UUID, [UUIDRequest.scoped(UUIDScope.PER_SESSION)])
     assert uuid1 == uuid2

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -13,6 +13,6 @@ def test_platform_on_local_epr_result() -> None:
     process = Process(
         argv=("/bin/echo", "test"), description="Run some program that will exit cleanly."
     )
-    result = rule_runner.request_product(FallibleProcessResultWithPlatform, [process])
+    result = rule_runner.request(FallibleProcessResultWithPlatform, [process])
     assert result.exit_code == 0
     assert result.platform == this_platform

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -65,7 +65,7 @@ class _RuleVisitor(ast.NodeVisitor):
     def visit_Call(self, call_node: ast.Call) -> None:
         get_args = self.maybe_extract_get_args(call_node)
         if get_args is not None:
-            product_str, subject_str = GetConstraints.parse_product_and_subject_types(
+            product_str, subject_str = GetConstraints.parse_input_and_output_types(
                 get_args, source_file_name=self.source_file_name
             )
             get = GetConstraints(self.resolve_type(product_str), self.resolve_type(subject_str))

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -113,8 +113,8 @@ class RuleVisitorTest(unittest.TestCase):
             A=str,
             B=int,
         )
-        assert get.product_type == str
-        assert get.subject_declared_type == int
+        assert get.output_type == str
+        assert get.input_type == int
 
     def test_multiple_gets(self) -> None:
         gets = self._parse_rule_gets(
@@ -134,11 +134,11 @@ class RuleVisitorTest(unittest.TestCase):
         assert len(gets) == 2
         get_a, get_c = gets
 
-        assert get_a.product_type == str
-        assert get_a.subject_declared_type == int
+        assert get_a.output_type == str
+        assert get_a.input_type == int
 
-        assert get_c.product_type == bool
-        assert get_c.subject_declared_type == str
+        assert get_c.output_type == bool
+        assert get_c.input_type == str
 
     def test_multiget_homogeneous(self) -> None:
         get = self._parse_single_get(
@@ -151,8 +151,8 @@ class RuleVisitorTest(unittest.TestCase):
             A=str,
             B=int,
         )
-        assert get.product_type == str
-        assert get.subject_declared_type == int
+        assert get.output_type == str
+        assert get.input_type == int
 
     def test_multiget_heterogeneous(self) -> None:
         gets = self._parse_rule_gets(
@@ -169,11 +169,11 @@ class RuleVisitorTest(unittest.TestCase):
         assert len(gets) == 2
         get_a, get_b = gets
 
-        assert get_a.product_type == str
-        assert get_a.subject_declared_type == int
+        assert get_a.output_type == str
+        assert get_a.input_type == int
 
-        assert get_b.product_type == int
-        assert get_b.subject_declared_type == str
+        assert get_b.output_type == int
+        assert get_b.input_type == str
 
     def test_get_no_index_call_no_subject_call_allowed(self) -> None:
         gets = self._parse_rule_gets("get_type: type = Get")
@@ -397,7 +397,7 @@ class RuleTest(TestBase):
         res = run_rule_with_mocks(
             a_goal_rule_generator,
             rule_args=[Console()],
-            mock_gets=[MockGet(product_type=A, subject_type=str, mock=lambda _: A())],
+            mock_gets=[MockGet(output_type=A, input_type=str, mock=lambda _: A())],
         )
         self.assertEqual(res, Example(0))
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -234,8 +234,8 @@ def test_async_field() -> None:
             rule_args=[FortranSourcesRequest(sources_field)],
             mock_gets=[
                 MockGet(
-                    product_type=Snapshot,
-                    subject_type=PathGlobs,
+                    output_type=Snapshot,
+                    input_type=PathGlobs,
                     mock=lambda _: Snapshot(EMPTY_DIGEST, files=hydrated_source_files, dirs=()),
                 )
             ],

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -50,7 +50,7 @@ def test_write_digest() -> None:
     # TODO(#8336): at some point, this test should require that Workspace only be invoked from
     #  an @goal_rule
     workspace = Workspace(rule_runner.scheduler)
-    digest = rule_runner.request_product(
+    digest = rule_runner.request(
         Digest,
         [CreateDigest([FileContent("a.txt", b"hello"), FileContent("subdir/b.txt", b"goodbye")])],
     )

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -59,7 +59,7 @@ class OptionableFactory(ABC):
             output_type=cls.optionable_cls,
             input_selectors=(),
             func=partial_construct_optionable,
-            input_gets=(GetConstraints(product_type=ScopedOptions, subject_declared_type=Scope),),
+            input_gets=(GetConstraints(output_type=ScopedOptions, input_type=Scope),),
             canonical_name=name,
         )
 

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -31,7 +31,7 @@ def assert_rule_match(
             rule_runner.create_dir(expected_match)
         else:
             rule_runner.create_file(expected_match)
-    snapshot = rule_runner.request_product(Snapshot, [PathGlobs([glob])])
+    snapshot = rule_runner.request(Snapshot, [PathGlobs([glob])])
     if should_match:
         assert sorted(paths) == sorted(snapshot.files)
     else:

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -53,11 +53,11 @@ def _find_root(
                 rule_args=[src_root_req, source_root_config],
                 mock_gets=[
                     MockGet(
-                        product_type=OptionalSourceRoot,
-                        subject_type=SourceRootRequest,
+                        output_type=OptionalSourceRoot,
+                        input_type=SourceRootRequest,
                         mock=_do_find_root,
                     ),
-                    MockGet(product_type=Paths, subject_type=PathGlobs, mock=_mock_fs_check),
+                    MockGet(output_type=Paths, input_type=PathGlobs, mock=_mock_fs_check),
                 ],
             ),
         )
@@ -233,10 +233,10 @@ def test_all_roots() -> None:
         all_roots,
         rule_args=[source_root_config],
         mock_gets=[
-            MockGet(product_type=Paths, subject_type=PathGlobs, mock=provider_rule),
+            MockGet(output_type=Paths, input_type=PathGlobs, mock=provider_rule),
             MockGet(
-                product_type=OptionalSourceRoot,
-                subject_type=SourceRootRequest,
+                output_type=OptionalSourceRoot,
+                input_type=SourceRootRequest,
                 mock=source_root_mock_rule,
             ),
         ],
@@ -271,10 +271,10 @@ def test_all_roots_with_root_at_buildroot() -> None:
         all_roots,
         rule_args=[source_root_config],
         mock_gets=[
-            MockGet(product_type=Paths, subject_type=PathGlobs, mock=provider_rule),
+            MockGet(output_type=Paths, input_type=PathGlobs, mock=provider_rule),
             MockGet(
-                product_type=OptionalSourceRoot,
-                subject_type=SourceRootRequest,
+                output_type=OptionalSourceRoot,
+                input_type=SourceRootRequest,
                 mock=lambda req: OptionalSourceRoot(SourceRoot(".")),
             ),
         ],
@@ -293,7 +293,7 @@ def test_source_roots_request() -> None:
         files=(PurePath("src/python/foo/bar.py"), PurePath("tests/python/foo/bar_test.py")),
         dirs=(PurePath("src/python/foo"), PurePath("src/python/baz/qux")),
     )
-    res = rule_runner.request_product(
+    res = rule_runner.request(
         SourceRootsResult,
         [
             req,

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -101,15 +101,13 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
     _scheduler: Optional[SchedulerSession] = None
 
-    _P = TypeVar("_P")
+    _O = TypeVar("_O")
 
-    def request_product(
-        self, product_type: Type["TestBase._P"], subjects: Iterable[Any]
-    ) -> "TestBase._P":
+    def request(self, output_type: Type["TestBase._O"], inputs: Iterable[Any]) -> "TestBase._O":
         result = assert_single_element(
-            self.scheduler.product_request(product_type, [Params(*subjects)])
+            self.scheduler.product_request(output_type, [Params(*inputs)])
         )
-        return cast(TestBase._P, result)
+        return cast(TestBase._O, result)
 
     def run_goal_rule(
         self,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1075,19 +1075,19 @@ fn tasks_task_begin(
   })
 }
 
-fn tasks_add_get(py: Python, tasks_ptr: PyTasks, product: PyType, subject: PyType) -> PyUnitResult {
+fn tasks_add_get(py: Python, tasks_ptr: PyTasks, output: PyType, input: PyType) -> PyUnitResult {
   with_tasks(py, tasks_ptr, |tasks| {
-    let product = externs::type_for(product);
-    let subject = externs::type_for(subject);
-    tasks.add_get(product, subject);
+    let output = externs::type_for(output);
+    let input = externs::type_for(input);
+    tasks.add_get(output, input);
     Ok(None)
   })
 }
 
-fn tasks_add_select(py: Python, tasks_ptr: PyTasks, product: PyType) -> PyUnitResult {
+fn tasks_add_select(py: Python, tasks_ptr: PyTasks, selector: PyType) -> PyUnitResult {
   with_tasks(py, tasks_ptr, |tasks| {
-    let product = externs::type_for(product);
-    tasks.add_select(product);
+    let selector = externs::type_for(selector);
+    tasks.add_select(selector);
     Ok(None)
   })
 }

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -500,20 +500,20 @@ py_class!(pub class PyGeneratorResponseGetMulti |py| {
 
 #[derive(Debug)]
 pub struct Get {
-  pub product: TypeId,
-  pub subject: Key,
-  pub declared_subject: Option<TypeId>,
+  pub output: TypeId,
+  pub input: Key,
+  pub input_type: Option<TypeId>,
   pub weak: bool,
 }
 
 impl Get {
   fn new(py: Python, interns: &mut Interns, get: &PyGeneratorResponseGet) -> Result<Get, Failure> {
     Ok(Get {
-      product: interns.type_insert(py, get.product(py).clone_ref(py)),
-      subject: interns
+      output: interns.type_insert(py, get.product(py).clone_ref(py)),
+      input: interns
         .key_insert(py, get.subject(py).clone_ref(py).into())
         .map_err(|e| Failure::from_py_err(py, e))?,
-      declared_subject: Some(interns.type_insert(py, get.declared_subject(py).clone_ref(py))),
+      input_type: Some(interns.type_insert(py, get.declared_subject(py).clone_ref(py))),
       weak: get.weak(py).is_true(),
     })
   }
@@ -524,8 +524,8 @@ impl fmt::Display for Get {
     write!(
       f,
       "Get({}, {})",
-      type_to_str(self.product),
-      key_to_str(&self.subject)
+      type_to_str(self.output),
+      key_to_str(&self.input)
     )
   }
 }

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -7,13 +7,13 @@ use crate::core::TypeId;
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialOrd, Hash, PartialEq)]
 pub struct Get {
-  pub product: TypeId,
-  pub subject: TypeId,
+  pub output: TypeId,
+  pub input: TypeId,
 }
 
 impl fmt::Display for Get {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-    write!(f, "Get({}, {})", self.product, self.subject)
+    write!(f, "Get({}, {})", self.output, self.input)
   }
 }
 
@@ -39,7 +39,7 @@ impl fmt::Debug for Select {
 ///
 #[derive(Clone, Copy, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub enum DependencyKey {
-  // A Get for a particular product/subject pair.
+  // A Get for a particular output/input pair.
   JustGet(Get),
   // A bare select with no projection.
   JustSelect(Select),
@@ -60,14 +60,14 @@ impl rule_graph::DependencyKey for DependencyKey {
 
   fn product(&self) -> TypeId {
     match self {
-      DependencyKey::JustGet(ref g) => g.product,
+      DependencyKey::JustGet(ref g) => g.output,
       DependencyKey::JustSelect(ref s) => s.product,
     }
   }
 
   fn provided_param(&self) -> Option<TypeId> {
     match self {
-      DependencyKey::JustGet(ref g) => Some(g.subject),
+      DependencyKey::JustGet(ref g) => Some(g.input),
       DependencyKey::JustSelect(_) => None,
     }
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -239,22 +239,22 @@ impl Tasks {
     });
   }
 
-  pub fn add_get(&mut self, product: TypeId, subject: TypeId) {
+  pub fn add_get(&mut self, output: TypeId, input: TypeId) {
     self
       .preparing
       .as_mut()
       .expect("Must `begin()` a task creation before adding gets!")
       .gets
-      .push(Get { product, subject });
+      .push(Get { output, input });
   }
 
-  pub fn add_select(&mut self, product: TypeId) {
+  pub fn add_select(&mut self, selector: TypeId) {
     self
       .preparing
       .as_mut()
       .expect("Must `begin()` a task creation before adding clauses!")
       .clause
-      .push(product);
+      .push(selector);
   }
 
   pub fn task_end(&mut self) {

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -50,7 +50,7 @@ class PluginResolverTest(TestBase):
         )
 
     def _create_pex(self) -> Pex:
-        return self.request_product(
+        return self.request(
             Pex,
             [
                 PexRequest(
@@ -67,7 +67,7 @@ class PluginResolverTest(TestBase):
         self, plugin: str, version: str, setup_py_args: Iterable[str], install_dir: str
     ) -> None:
         pex_obj = self._create_pex()
-        source_digest = self.request_product(
+        source_digest = self.request(
             Digest,
             [
                 CreateDigest(
@@ -86,9 +86,7 @@ class PluginResolverTest(TestBase):
                 )
             ],
         )
-        merged_digest = self.request_product(
-            Digest, [MergeDigests([pex_obj.digest, source_digest])]
-        )
+        merged_digest = self.request(Digest, [MergeDigests([pex_obj.digest, source_digest])])
 
         process = Process(
             argv=("python", "setup-py-runner.pex", "setup.py") + tuple(setup_py_args),
@@ -99,8 +97,8 @@ class PluginResolverTest(TestBase):
             description="Run setup.py",
             output_directories=("dist/",),
         )
-        result = self.request_product(ProcessResult, [process])
-        result_snapshot = self.request_product(Snapshot, [result.output_digest])
+        result = self.request(ProcessResult, [process])
+        result_snapshot = self.request(Snapshot, [result.output_digest])
         self.scheduler.write_digest(result.output_digest, path_prefix="output")
         safe_mkdir(install_dir)
         for path in result_snapshot.files:


### PR DESCRIPTION
These terms are easier to understand than "product" and "subject": they describe well what's going on, without introducing any new domain-specific language.

These terms do leak, such as into our test util code, so it's important to get right before the Plugin API is too widely used.

[ci skip-build-wheels]