### PR TITLE
Remove reset_interactive_output_stream

### DIFF
--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -194,16 +194,3 @@ Thread [^\n]+ \\(most recent call first\\):
 
             # faulthandler.enable() only allows use of a single logging file at once for fatal tracebacks.
             self.assertEqual("", read_file(shared_log_file))
-
-    def test_prints_traceback_on_sigusr2(self):
-        with self.pantsd_successful_run_context() as ctx:
-            ctx.runner(["help"])
-            pid = ctx.checker.assert_started()
-            os.kill(pid, signal.SIGUSR2)
-
-            time.sleep(5)
-
-            ctx.checker.assert_running()
-            regex_str = r"Current thread [^\n]+ \(most recent call first\):"
-            file_contents = read_file(os.path.join(ctx.workdir, "pantsd", "pantsd.log"))
-            assert re.search(regex_str, file_contents)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -9,7 +9,6 @@ from logging import Formatter, Handler, LogRecord, StreamHandler
 from typing import Dict, Iterable, Optional, Tuple
 
 import pants.util.logging as pants_logging
-from pants.base.exception_sink import ExceptionSink
 from pants.engine.internals.native import Native
 from pants.option.option_value_container import OptionValueContainer
 from pants.util.dirutil import safe_mkdir
@@ -187,8 +186,7 @@ def setup_logging_to_file(
     safe_mkdir(log_dir)
     log_path = os.path.join(log_dir, log_filename)
 
-    fd = native.setup_pantsd_logger(log_path)
-    ExceptionSink.reset_interactive_output_stream(os.fdopen(os.dup(fd), "a"))
+    native.setup_pantsd_logger(log_path)
     handler = NativeHandler(level, native_filename=log_path)
 
     logger.addHandler(handler)

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -4,7 +4,6 @@
 import os
 
 from pants.base.deprecated import warn_or_error
-from pants.base.exception_sink import ExceptionSink
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import collect_rules, goal_rule
 from pants.option.custom_types import file_option
@@ -53,7 +52,6 @@ async def run_lifecycle_stubs(opts: LifecycleStubsSubsystem) -> LifecycleStubsGo
     output_file = opts.options.new_interactive_stream_output_file
     if output_file:
         file_stream = open(output_file, "wb")
-        ExceptionSink.reset_interactive_output_stream(file_stream, output_file)
     raise Exception("erroneous!")
 
 


### PR DESCRIPTION
### Problem

`ExceptionSink.reset_interactive_output_stream` is a legacy codepath that touches some class variables in `ExceptionSink` as well as pants initialization code in both the pantsd and no-pantsd cases. The only case where this code is relevant is in the custom singal handler for SIGUSR2, where the python standard library `faulthandler` module was being used to optionally print a Python stack trace when that signal was received (which is also an undocumented piece of functionality).

### Solution

This commit removes that code path entirely, which allows us to simplify `ExceptionSink` and remove a dependency on `ExceptionSink` in several places. 

cf. https://github.com/pantsbuild/pants/issues/10792 , we may want to re-introduce the functionality to send pants some kind of signal to output a live stack trace. However, if we do this, we should re-implement the feature in a way that is aware of the Rust engine (and useful for debugging Rust as well as Python issues), and make sure that we document it.