### PR TITLE
Un-revert Add cache_failures option to Process type

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -51,6 +51,7 @@ class Process:
     jdk_home: Optional[str]
     is_nailgunnable: bool
     execution_slot_variable: Optional[str]
+    cache_failures: bool
 
     def __init__(
         self,
@@ -68,6 +69,7 @@ class Process:
         jdk_home: Optional[str] = None,
         is_nailgunnable: bool = False,
         execution_slot_variable: Optional[str] = None,
+        cache_failures: bool = False,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -106,6 +108,7 @@ class Process:
         self.jdk_home = jdk_home
         self.is_nailgunnable = is_nailgunnable
         self.execution_slot_variable = execution_slot_variable
+        self.cache_failures = cache_failures
 
 
 @frozen_after_init

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -231,11 +231,13 @@ impl<N: Node> Entry<N> {
   }
 
   pub(crate) fn cacheable_with_output(&self, output: Option<&N::Item>) -> bool {
-    (if let Some(item) = output {
+    let output_cacheable = if let Some(item) = output {
       self.node.cacheable_item(item)
     } else {
       false
-    }) && self.node.cacheable()
+    };
+
+    output_cacheable && self.node.cacheable()
   }
 
   ///

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -230,6 +230,14 @@ impl<N: Node> Entry<N> {
     &self.node
   }
 
+  pub(crate) fn cacheable_with_output(&self, output: Option<&N::Item>) -> bool {
+    (if let Some(item) = output {
+      self.node.cacheable_item(item)
+    } else {
+      false
+    }) && self.node.cacheable()
+  }
+
   ///
   /// If this Node is currently complete and clean with the given Generation, then waits for it to
   /// be changed in any way. If the node is not clean, or the generation mismatches, returns
@@ -434,7 +442,7 @@ impl<N: Node> Entry<N> {
             entry_id,
             run_token,
             generation,
-            if self.node.cacheable() {
+            if self.cacheable_with_output(Some(result.as_ref())) {
               Some(dep_generations)
             } else {
               None
@@ -506,7 +514,7 @@ impl<N: Node> Entry<N> {
             }
           }
           Some(Ok(result)) => {
-            let next_result: EntryResult<N> = if !self.node.cacheable() {
+            let next_result: EntryResult<N> = if !self.cacheable_with_output(Some(&result)) {
               EntryResult::Uncacheable(result, context.session_id().clone())
             } else if has_weak_deps {
               EntryResult::Dirty(result)

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -863,7 +863,11 @@ impl<N: Node> Graph<N> {
             // This is to allow for the behaviour that an uncacheable Node should always have "dirty"
             // (marked as UncacheableDependencies) dependents, transitively.
             let entry = inner.entry_for_id(edge_ref.target()).unwrap();
-            if !entry.node().cacheable() || entry.has_uncacheable_deps() {
+            let result_item = match result {
+              Some(Ok(ref item)) => Some(item),
+              _ => None,
+            };
+            if !entry.cacheable_with_output(result_item) || entry.has_uncacheable_deps() {
               has_uncacheable_deps = true;
             }
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -863,11 +863,7 @@ impl<N: Node> Graph<N> {
             // This is to allow for the behaviour that an uncacheable Node should always have "dirty"
             // (marked as UncacheableDependencies) dependents, transitively.
             let entry = inner.entry_for_id(edge_ref.target()).unwrap();
-            let result_item = match result {
-              Some(Ok(ref item)) => Some(item),
-              _ => None,
-            };
-            if !entry.cacheable_with_output(result_item) || entry.has_uncacheable_deps() {
+            if entry.has_uncacheable_deps() {
               has_uncacheable_deps = true;
             }
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -30,9 +30,16 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   async fn run(self, context: Self::Context) -> Result<Self::Item, Self::Error>;
 
   ///
-  /// If the node result is cacheable, return true.
+  /// If a node's output is cacheable based solely on properties of the node, and not the output,
+  /// return true.
   ///
   fn cacheable(&self) -> bool;
+
+  /// A Node may want to compute cacheability differently based on properties of the Node's item.
+  /// The output of this method will be and'd with `cacheable` to compute overall cacheability.
+  fn cacheable_item(&self, _item: &Self::Item) -> bool {
+    self.cacheable()
+  }
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -77,8 +77,10 @@ impl crate::CommandRunner for CommandRunner {
       }
     }
 
+    let cache_failures = req.0.values().any(|process| process.cache_failures);
+
     let result = command_runner.underlying.run(req, context).await?;
-    if result.exit_code == 0 {
+    if result.exit_code == 0 || cache_failures {
       if let Err(err) = command_runner.store(key, &result).await {
         warn!(
           "Error storing process execution result to local cache: {} - ignoring and continuing",

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -221,6 +221,8 @@ pub struct Process {
   pub target_platform: PlatformConstraint,
 
   pub is_nailgunnable: bool,
+
+  pub cache_failures: bool,
 }
 
 impl Process {
@@ -250,6 +252,7 @@ impl Process {
       target_platform: PlatformConstraint::None,
       is_nailgunnable: false,
       execution_slot_variable: None,
+      cache_failures: false,
     }
   }
 

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -65,6 +65,7 @@ fn construct_nailgun_server_request(
     target_platform: platform_constraint,
     is_nailgunnable: true,
     execution_slot_variable: None,
+    cache_failures: false,
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -90,6 +90,7 @@ async fn make_execute_request() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -176,6 +177,7 @@ async fn make_execute_request_with_instance_name() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -275,6 +277,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();
@@ -523,6 +526,7 @@ async fn make_execute_request_with_timeout() {
     target_platform: PlatformConstraint::None,
     is_nailgunnable: false,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let mut want_command = bazel_protos::remote_execution::Command::new();

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -367,6 +367,7 @@ async fn main() {
     target_platform: target_platform,
     is_nailgunnable,
     execution_slot_variable: None,
+    cache_failures: false,
   };
 
   let runner: Box<dyn process_execution::CommandRunner> = match server_arg {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1127,7 +1127,6 @@ impl NodeKey {
       NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
       NodeKey::Snapshot(ref s) => Some(format!("Snapshotting: {}", s.0)),
       NodeKey::Paths(ref s) => Some(format!("Finding files: {}", s.0)),
-      //NodeKey::MultiPlatformExecuteProcess(mp_epr) => Some(mp_epr.0.user_facing_name()),
       NodeKey::MultiPlatformExecuteProcess(mp_epr) => Some(mp_epr.process.user_facing_name()),
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))


### PR DESCRIPTION
After https://github.com/pantsbuild/pants/pull/10433 (Add cache_failures option to Process type) was merged, it was noted that that change caused failing tests to repeat ( https://github.com/pantsbuild/pants/issues/10129#issuecomment-667774204 ), and the original commit was reverted. I spent some time digging into the `graph` crate to try to figure out the cause of the problem, but was unsuccessful. 

However, as of today, we found that we could no longer reproduce the original bug. There have been some significant changes to `rule_graph` and several other deep parts of the Rust engine's codebase since the original revert, so it's very possible that the condition that originally triggered the bug is no longer relevant. Consequently, this commit restores the original commit.