### PR TITLE
Fix display of "Snapshotting" in dynamic UI

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -417,6 +417,12 @@ impl PathGlobs {
   }
 }
 
+impl fmt::Display for PathGlobs {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", self.globs.join(", "))
+  }
+}
+
 ///
 /// All Stats consumed or returned by this type are relative to the root.
 ///

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -322,7 +322,7 @@ impl GitignoreStyleExcludes {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum StrictGlobMatching {
   // NB: the Error and Warn variants store a description of the origin of the PathGlob
   // request so that we can make the error message more helpful to users when globs fail to match.
@@ -366,7 +366,7 @@ impl StrictGlobMatching {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum GlobExpansionConjunction {
   AllMatch,
   AnyMatch,
@@ -388,7 +388,7 @@ pub enum SymlinkBehavior {
   Oblivious,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct PathGlobs {
   globs: Vec<String>,
   strict_match_behavior: StrictGlobMatching,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1363,8 +1363,10 @@ fn capture_snapshots(
     .iter()
     .map(|value| {
       let root = PathBuf::from(externs::project_str(&value, "root"));
-      let path_globs =
-        nodes::Snapshot::lift_prepared_path_globs(&externs::project_ignoring_type(&value, "path_globs"));
+      let path_globs = nodes::Snapshot::lift_prepared_path_globs(&externs::project_ignoring_type(
+        &value,
+        "path_globs",
+      ));
       let digest_hint = {
         let maybe_digest = externs::project_ignoring_type(&value, "digest_hint");
         if maybe_digest == Value::from(externs::none()) {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1330,7 +1330,7 @@ fn match_path_globs(
 ) -> CPyResult<Vec<String>> {
   let matches = py
     .allow_threads(|| {
-      let path_globs = nodes::Snapshot::lift_path_globs(&path_globs.into())?;
+      let path_globs = nodes::Snapshot::lift_prepared_path_globs(&path_globs.into())?;
 
       Ok(
         paths
@@ -1364,7 +1364,7 @@ fn capture_snapshots(
     .map(|value| {
       let root = PathBuf::from(externs::project_str(&value, "root"));
       let path_globs =
-        nodes::Snapshot::lift_path_globs(&externs::project_ignoring_type(&value, "path_globs"));
+        nodes::Snapshot::lift_prepared_path_globs(&externs::project_ignoring_type(&value, "path_globs"));
       let digest_hint = {
         let maybe_digest = externs::project_ignoring_type(&value, "digest_hint");
         if maybe_digest == Value::from(externs::none()) {

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -305,7 +305,7 @@ fn path_globs_to_digest(
   let core = context.core.clone();
   async move {
     let key = externs::acquire_key_for(args.pop().unwrap())?;
-    let digest = context.get(Snapshot(key)).await?;
+    let digest = context.get(Snapshot::from_key(key)).await?;
     Ok(Snapshot::store_directory_digest(&core, &digest))
   }
   .boxed()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -304,8 +304,10 @@ fn path_globs_to_digest(
 ) -> BoxFuture<'static, NodeResult<Value>> {
   let core = context.core.clone();
   async move {
-    let key = externs::acquire_key_for(args.pop().unwrap())?;
-    let digest = context.get(Snapshot::from_key(key)).await?;
+    let val = args.pop().unwrap();
+    let path_globs = Snapshot::lift_path_globs(&val)
+      .map_err(|e| throw(&format!("Failed to parse PathGlobs: {}", e)))?;
+    let digest = context.get(Snapshot::from_path_globs(path_globs)).await?;
     Ok(Snapshot::store_directory_digest(&core, &digest))
   }
   .boxed()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -319,8 +319,10 @@ fn path_globs_to_paths(
 ) -> BoxFuture<'static, NodeResult<Value>> {
   let core = context.core.clone();
   async move {
-    let key = externs::acquire_key_for(args.pop().unwrap())?;
-    let paths = context.get(Paths(key)).await?;
+    let val = args.pop().unwrap();
+    let path_globs = Snapshot::lift_path_globs(&val)
+      .map_err(|e| throw(&format!("Failed to parse PathGlobs: {}", e)))?;
+    let paths = context.get(Paths::from_path_globs(path_globs)).await?;
     Paths::store_paths(&core, &paths).map_err(|e: String| throw(&e))
   }
   .boxed()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -381,7 +381,7 @@ fn digest_subset_to_digest(
   let store = context.core.store();
 
   async move {
-    let path_globs = Snapshot::lift_path_globs(&globs).map_err(|e| throw(&e))?;
+    let path_globs = Snapshot::lift_prepared_path_globs(&globs).map_err(|e| throw(&e))?;
     let original_digest =
       lift_digest(&externs::project_ignoring_type(&args[0], "digest")).map_err(|e| throw(&e))?;
     let subset_params = SubsetParams { globs: path_globs };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -560,9 +560,12 @@ impl From<SessionValues> for NodeKey {
 /// A Node that captures an store::Snapshot for a PathGlobs subject.
 ///
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Snapshot(pub Key);
+pub struct Snapshot(Key);
 
 impl Snapshot {
+  pub fn from_key(key: Key) -> Snapshot {
+    Snapshot(key)
+  }
   async fn create(context: Context, path_globs: PreparedPathGlobs) -> NodeResult<store::Snapshot> {
     // We rely on Context::expand_globs tracking dependencies for scandirs,
     // and store::Snapshot::from_path_stats tracking dependencies for file digests.


### PR DESCRIPTION
### Problem

A recent change to the string representation of the `Key` type affected the `user_facing_name` of the `Snapshot` variant of `NodeKey`, resulting in the dynamic UI displaying "Snapshotting: PathGlobs" rather than a useful path.

### Solution

Irrespective of the string representation of a, `Key`, the `Snapshot` variant of `NodeKey` doesn't need to contain a `Key` at all; it can contain a `PathGlobs` object. The code that ran a `Snapshot` Node was already parsing the `Key` into a `PathGlobs` (and handling potential errors in that process), so it was easy enough to move that parsing into the location where we create a `Snapshot` from a Python `Value`. Several traits had to be implemented on `PathGlobs` to maintain the trait implementations that `Snapshot` already had.

### Result

Restores the correct behavior for printing the path(s) in a `Snapshot` in the dynamic UI.
