### PR TITLE
Default to setting `LC_ALL` and `LANG` in subprocesses again

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -52,9 +52,6 @@ root_patterns = [
   "/pants-plugins",
 ]
 
-[subprocess-environment]
-env_vars = ["LANG", "LC_ALL"]
-
 [python-setup]
 requirement_constraints = "3rdparty/python/constraints.txt"
 resolve_all_constraints = "nondeployables"

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -398,7 +398,7 @@ logger = logging.getLogger(__name__)
 
 @rule(desc="Find Python interpreter for constraints", level=LogLevel.DEBUG)
 async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
-    formatted_constraints = ' OR '.join(str(constraint) for constraint in interpreter_constraints)
+    formatted_constraints = " OR ".join(str(constraint) for constraint in interpreter_constraints)
     process = await Get(
         Process,
         PexCliProcess(

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -398,10 +398,11 @@ logger = logging.getLogger(__name__)
 
 @rule(desc="Find Python interpreter for constraints", level=LogLevel.DEBUG)
 async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
+    formatted_constraints = ' OR '.join(str(constraint) for constraint in interpreter_constraints)
     process = await Get(
         Process,
         PexCliProcess(
-            description=f"Find interpreter for constraints: {interpreter_constraints}",
+            description=f"Find interpreter for constraints: {formatted_constraints}",
             # Here we run the Pex CLI with no requirements which just selects an interpreter and
             # normally starts an isolated repl. By passing `--` we force the repl to instead act as
             # an interpreter (the selected one) and tell us about itself. The upshot is we run the

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -10,7 +10,6 @@ from pants.engine.rules import _uncacheable_rule, collect_rules
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 
-
 # Names of env vars that can be set on all subprocesses via config.
 SETTABLE_ENV_VARS = (
     # Customarily used to control i18n settings.

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -1,17 +1,14 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
 import os
 from dataclasses import dataclass
-from typing import List
+from typing import Tuple
 
 from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.rules import _uncacheable_rule, collect_rules
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
-
-logger = logging.getLogger(__name__)
 
 
 # Names of env vars that can be set on all subprocesses via config.
@@ -67,7 +64,7 @@ class SubprocessEnvironment(Subsystem):
             "--env-vars",
             type=list,
             member_type=str,
-            default=[],
+            default=["LANG", "LC_CTYPE", "LC_ALL"],
             advanced=True,
             help=(
                 "Environment variables to set for process invocations. "
@@ -80,27 +77,38 @@ class SubprocessEnvironment(Subsystem):
         )
 
     @property
-    def env_vars_to_pass_to_subprocesses(self) -> List[str]:
-        ret: List[str] = list(self.options.env_vars)
+    def env_vars_to_pass_to_subprocesses(self) -> Tuple[str, ...]:
+        ret = set(self.options.env_vars)
 
-        # Inject values from the old --lang, --lc-all options if set.
+        # Inject values from the old --lang, --lc-all options if explicitly set, rather than the
+        # default.
         env_var_names = {env_var.split("=", 1)[0] for env_var in self.options.env_vars}
 
         def handle_deprecated(env_var_name: str):
-            val = self.options[env_var_name.lower()]
-            if env_var_name not in env_var_names and val:
-                logger.warning(
-                    f"Setting {env_var_name}={val} on subprocesses due to use of deprecated option "
-                    f"[{self.options_scope}].{env_var_name.lower()}. If you wish to continue to "
-                    f"set this option, do so by adding '{env_var_name}=value' (or '{env_var_name}' "
-                    f"to take the value from Pants's environment) to the "
-                    f"[{self.options_scope}].env_vars option."
+            old_configured = not self.options.is_default(env_var_name.lower())
+            new_configured = env_var_name in env_var_names and not self.options.is_default(
+                "env_vars"
+            )
+            if old_configured and new_configured:
+                raise ValueError(
+                    "Conflicting options used. You used the new, preferred "
+                    f"[{self.options_scope}].env_vars option, but also used the deprecated "
+                    f"[{self.options_scope}].{env_var_name.lower()}.\n\nPlease use only one of "
+                    "these."
                 )
+            if old_configured:
+                val = self.options[env_var_name.lower()]
+                # NB: We will have already validated that the user did not override `env_vars`,
+                # which means that they will be using the default values where we only use the env
+                # var name, and not a value, e.g. `LANG`.
+                if env_var_name in env_var_names:
+                    ret.discard(env_var_name)
+                ret.add(f"{env_var_name}={val}")
 
         handle_deprecated("LANG")
         handle_deprecated("LC_ALL")
 
-        return ret
+        return tuple(sorted(ret))
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -94,7 +94,7 @@ class SubprocessEnvironment(Subsystem):
                     f"[{self.options_scope}].{env_var_name.lower()}. If you wish to continue to "
                     f"set this option, do so by adding '{env_var_name}=value' (or '{env_var_name}' "
                     f"to take the value from Pants's environment) to the "
-                    f"[{self.options_scope}].env_var option."
+                    f"[{self.options_scope}].env_vars option."
                 )
 
         handle_deprecated("LANG")


### PR DESCRIPTION
These are sensible defaults. Without these set, many builds will fail. If user's don't like what we set, they can use the options system to override it.

Also improve formatting of the dynamic UI description for finding an interpreter based on constraints.

[ci skip-rust]
[ci skip-build-wheels]