### PR TITLE
Simplify logging initialization

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -107,13 +107,13 @@ class DaemonPantsRunner(RawFdRunner):
         try:
             clear_logging_handlers()
             Native().override_thread_logging_destination_to_just_stderr()
-            setup_logging(global_bootstrap_options)
+            setup_logging(global_bootstrap_options, stderr_logging=True)
             yield
         finally:
             Native().override_thread_logging_destination_to_just_pantsd()
             set_logging_handlers(handlers)
 
-    def _run(self, working_dir: str) -> ExitCode:
+    def single_daemonized_run(self, working_dir: str) -> ExitCode:
         """Run a single daemonized run of Pants.
 
         All aspects of the `sys` global should already have been replaced in `__call__`, so this
@@ -172,6 +172,6 @@ class DaemonPantsRunner(RawFdRunner):
             # this function, where they will be logged to the pantsd.log by the server.
             logger.info(f"handling request: `{' '.join(args)}`")
             try:
-                return self._run(working_directory.decode())
+                return self.single_daemonized_run(working_directory.decode())
             finally:
                 logger.info(f"request completed: `{' '.join(args)}`")

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -78,7 +78,7 @@ class PantsRunner:
         setup_warning_filtering(global_bootstrap_options.ignore_pants_warnings or [])
         # We enable logging here, and everything before it will be routed through regular
         # Python logging.
-        setup_logging(global_bootstrap_options)
+        setup_logging(global_bootstrap_options, stderr_logging=True)
 
         if self._should_run_with_pantsd(global_bootstrap_options):
             try:

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -111,7 +111,7 @@ def _common_logging_setup(level: LogLevel) -> None:
         requests_logger.propagate = True
 
 
-def setup_logging(global_bootstrap_options):
+def setup_logging(global_bootstrap_options: OptionValueContainer, stderr_logging: bool) -> None:
     """Sets up logging for a Pants run.
 
     This is called in two contexts: 1) PantsRunner, 2) DaemonPantsRunner. In the latter case, the
@@ -134,7 +134,8 @@ def setup_logging(global_bootstrap_options):
     )
 
     print_exception_stacktrace = global_bootstrap_options.print_exception_stacktrace
-    setup_logging_to_stderr(global_level, print_exception_stacktrace)
+    if stderr_logging:
+        setup_logging_to_stderr(global_level, print_exception_stacktrace)
 
     if log_dir:
         setup_logging_to_file(global_level, log_dir=log_dir)

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -6,7 +6,7 @@ import sys
 import unittest.mock
 
 from pants.engine.internals.native import Native
-from pants.pantsd.pants_daemon import PantsDaemon, _LoggerStream
+from pants.pantsd.pants_daemon import PantsDaemon
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices
 from pants.util.contextutil import stdio_as
@@ -15,29 +15,6 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
 TEST_LOG_LEVEL = logging.INFO
-
-
-def test_logger_stream_write():
-    mock_logger = unittest.mock.Mock()
-    _LoggerStream(mock_logger, TEST_LOG_LEVEL, None).write("testing 1 2 3")
-    mock_logger.log.assert_called_once_with(TEST_LOG_LEVEL, "testing 1 2 3")
-
-
-def test_logger_stream_write_multiline():
-    mock_logger = unittest.mock.Mock()
-    _LoggerStream(mock_logger, TEST_LOG_LEVEL, None).write("testing\n1\n2\n3\n\n")
-    mock_logger.log.assert_has_calls(
-        [
-            unittest.mock.call(TEST_LOG_LEVEL, "testing"),
-            unittest.mock.call(TEST_LOG_LEVEL, "1"),
-            unittest.mock.call(TEST_LOG_LEVEL, "2"),
-            unittest.mock.call(TEST_LOG_LEVEL, "3"),
-        ]
-    )
-
-
-def test_logger_stream_flush():
-    _LoggerStream(unittest.mock.Mock(), TEST_LOG_LEVEL, None).flush()
 
 
 @unittest.mock.patch("os.close", **PATCH_OPTS)


### PR DESCRIPTION
This PR attempts to simplify the code paths around log initialization in the several places in the pants codebase where we do so. It also removes the `_LoggerStream` replacement for `sys.stdout` and `sys.stderr`, since code in pantsd should be using the Python logging abstraction rather than trying to write to stdout/stderr and then having that be directed to the log.
