### PR TITLE
Default to `[python-infer].inits = false`

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -57,14 +57,16 @@ class PythonInference(Subsystem):
         )
         register(
             "--inits",
-            default=True,
+            default=False,
             type=bool,
             help=(
                 "Infer a target's dependencies on any __init__.py files existing for the packages "
-                "it is located in (recursively upward in the directory structure). Regardless of "
-                "whether inference is disabled, empty ancestor __init__.py files will still be "
-                "included even without an explicit dependency, but ones containing any code (even "
-                "just comments) will not, and must be brought in via an explicit dependency."
+                "it is located in (recursively upward in the directory structure). Even if this is "
+                "disabled, Pants will still include any ancestor __init__.py files, only they will "
+                "not be 'proper' dependencies, e.g. they will not show up in "
+                "`./pants dependencies` and their own dependencies will not be used. If you have "
+                "empty `__init__.py` files, it's safe to leave this option off; otherwise, you "
+                "should enable this option."
             ),
         )
         register(

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -138,6 +138,7 @@ def test_infer_python_inits() -> None:
     options_bootstrapper = create_options_bootstrapper(
         args=[
             "--backend-packages=pants.backend.python",
+            "--python-infer-inits",
             "--source-root-patterns=src/python",
         ]
     )

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -1,4 +1,0 @@
-# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-python_library()


### PR DESCRIPTION
The default behavior for most Python repos is to have empty `__init__.py` files.

If you have empty `__init__.py` files, while it is more correct to declare "proper" dependencies, it brings several downsides:

* If you have an explicit dep in the owning target, _all_ downstream files will now have that same dep. This is subtle. Usually, `__init__.py` gets included due to default source globs. It's surprising that adding something like `3rdparty/python:numpy` to `src/python/BUILD` will cause _every single file_ in the project to now depend on NumPy.
* This causes issues with interpreter constraints. Every single ancestor `__init__.py` file must be compatible with your constraints, even if those files are completely empty.

This feature is really nice and powerful, but should only be used if you actually have content in `__init__.py` files. So, we will document this as something that users may want to enable.

[ci skip-rust]
[ci skip-build-wheels]