### PR TITLE
Useful equality for relevant options types

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-import os
 from dataclasses import dataclass
 from typing import Mapping, Optional, Tuple
 
@@ -146,9 +145,6 @@ class LocalPantsRunner:
         )
 
     def _set_start_time(self, start_time: float) -> None:
-        # Propagates parent_build_id to pants runs that may be called from this pants run.
-        os.environ["PANTS_PARENT_BUILD_ID"] = self._run_tracker.run_id
-
         self._run_tracker.start(self.options, run_start_time=start_time)
 
         spec_parser = SpecsParser(get_buildroot())

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -33,11 +33,6 @@ class PantsRunner:
         return not frozenset(self.args).isdisjoint(_DAEMON_KILLING_GOALS)
 
     def _should_run_with_pantsd(self, global_bootstrap_options: OptionValueContainer) -> bool:
-        # The parent_build_id option is set only for pants commands (inner runs)
-        # that were called by other pants command.
-        # Inner runs should never be run with pantsd.
-        # See https://github.com/pantsbuild/pants/issues/7881 for context.
-        is_inner_run = global_bootstrap_options.parent_build_id is not None
         terminate_pantsd = self.will_terminate_pantsd()
 
         if terminate_pantsd:
@@ -48,7 +43,6 @@ class PantsRunner:
             global_bootstrap_options.pantsd
             and not terminate_pantsd
             and not global_bootstrap_options.concurrent
-            and not is_inner_run
         )
 
     @staticmethod

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -244,8 +244,6 @@ class RunTracker(Subsystem):
         self.run_info = RunInfo(os.path.join(self.run_info_dir, "info"))
         self.run_info.add_basic_info(self.run_id, self._run_timestamp)
         self.run_info.add_info("cmd_line", self._cmd_line)
-        if self.options.parent_build_id:
-            self.run_info.add_info("parent_build_id", self.options.parent_build_id)
 
         # Create a 'latest' symlink, after we add_infos, so we're guaranteed that the file exists.
         link_to_latest = os.path.join(os.path.dirname(self.run_info_dir), "latest")

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -8,7 +8,7 @@ from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
-from pants.option.option_value_container import OptionValueContainer
+from pants.option.option_value_container import OptionValueContainerBuilder
 from pants.option.parser import OptionValueHistory, Parser
 from pants.option.ranked_value import Rank, RankedValue
 
@@ -64,7 +64,9 @@ class OptionHelpFormatterTest(unittest.TestCase):
         )
         parser.register(*args, **kwargs)
         # Force a parse to generate the derivation history.
-        parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainer(), lambda: [], []))
+        parser.parse_args(
+            Parser.ParseArgsRequest((), OptionValueContainerBuilder(), lambda: [], [])
+        )
         oshi = HelpInfoExtracter("").get_option_scope_help_info("", parser, False)
         return HelpFormatter(
             show_advanced=show_advanced, show_deprecated=show_deprecated, color=False

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -528,19 +528,6 @@ class GlobalOptions(Subsystem):
             "Enabling this option requires parallel Pants invocations to block on the first",
         )
 
-        # Calling pants command (inner run) from other pants command is unusual behaviour,
-        # and most users should never set this flag.
-        # It is automatically set by pants when an inner run is detected.
-        # Currently, pants commands with this option set don't use pantsd,
-        # but this effect should not be relied upon.
-        # This option allows us to know who was the parent of pants inner runs for informational purposes.
-        register(
-            "--parent-build-id",
-            advanced=True,
-            default=None,
-            help="The build ID of the other Pants run which spawned this one, if any.",
-        )
-
         # NB: We really don't want this option to invalidate the daemon, because different clients might have
         # different needs. For instance, an IDE might have a very long timeout because it only wants to refresh
         # a project in the background, while a user might want a shorter timeout for interactivity.

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import copy
+from dataclasses import dataclass
 from typing import Dict, Iterator, List, Optional
 
 from pants.option.ranked_value import Rank, RankedValue, Value
@@ -9,6 +10,40 @@ from pants.option.ranked_value import Rank, RankedValue, Value
 Key = str
 
 
+class OptionValueContainerBuilder:
+    def __init__(self, value_map: Optional[Dict[Key, RankedValue]] = None) -> None:
+        self._value_map: Dict[Key, RankedValue] = value_map if value_map else {}
+
+    def update(self, other: "OptionValueContainerBuilder") -> None:
+        """Set other's values onto this object.
+
+        For each key, highest ranked value wins. In a tie, other's value wins.
+        """
+        for k, v in other._value_map.items():
+            self._set(k, v)
+
+    def _set(self, key: Key, value: RankedValue) -> None:
+        if not isinstance(value, RankedValue):
+            raise AttributeError(f"Value must be of type RankedValue: {value}")
+
+        existing_value = self._value_map.get(key)
+        existing_rank = existing_value.rank if existing_value is not None else Rank.NONE
+        if value.rank >= existing_rank:
+            # We set values from outer scopes before values from inner scopes, so
+            # in case of equal rank we overwrite. That way that the inner scope value wins.
+            self._value_map[key] = value
+
+    # Support attribute setting, e.g., opts.foo = RankedValue(Rank.HARDCODED, 42).
+    def __setattr__(self, key: Key, value: RankedValue) -> None:
+        if key == "_value_map":
+            return super().__setattr__(key, value)
+        self._set(key, value)
+
+    def build(self) -> "OptionValueContainer":
+        return OptionValueContainer(copy.copy(self._value_map))
+
+
+@dataclass(frozen=True)
 class OptionValueContainer:
     """A container for option values.
 
@@ -23,8 +58,7 @@ class OptionValueContainer:
        See ranked_value.py for more details.
     """
 
-    def __init__(self) -> None:
-        self._value_map: Dict[Key, RankedValue] = {}
+    _value_map: Dict[Key, RankedValue]
 
     def get_explicit_keys(self) -> List[Key]:
         """Returns the keys for any values that were set explicitly (via flag, config, or env
@@ -78,16 +112,11 @@ class OptionValueContainer:
             return default
         return self._get_underlying_value(key)
 
-    def update(self, other: "OptionValueContainer") -> None:
-        """Set other's values onto this object.
-
-        For each key, highest ranked value wins. In a tie, other's value wins.
-        """
-        for k, v in other._value_map.items():
-            self._set(k, v)
-
     def as_dict(self) -> Dict[Key, Value]:
         return {key: self.get(key) for key in self._value_map}
+
+    def to_builder(self) -> OptionValueContainerBuilder:
+        return OptionValueContainerBuilder(copy.copy(self._value_map))
 
     def _get_underlying_value(self, key: Key):
         # Note that the key may exist with a value of None, so we can't just
@@ -97,33 +126,16 @@ class OptionValueContainer:
         ranked_val = self._value_map[key]
         return ranked_val.value
 
-    def _set(self, key: Key, value: RankedValue) -> None:
-        if not isinstance(value, RankedValue):
-            raise AttributeError(f"Value must be of type RankedValue: {value}")
-
-        existing_value = self._value_map.get(key)
-        existing_rank = existing_value.rank if existing_value is not None else Rank.NONE
-        if value.rank >= existing_rank:
-            # We set values from outer scopes before values from inner scopes, so
-            # in case of equal rank we overwrite. That way that the inner scope value wins.
-            self._value_map[key] = value
-
     # Support natural dynamic access, e.g., opts[foo] is more idiomatic than getattr(opts, 'foo').
     def __getitem__(self, key: Key):
         return self.__getattr__(key)
-
-    # Support attribute setting, e.g., opts.foo = RankedValue(Rank.HARDCODED, 42).
-    def __setattr__(self, key: Key, value: RankedValue) -> None:
-        if key == "_value_map":
-            return super().__setattr__(key, value)
-        self._set(key, value)
 
     # Support attribute getting, e.g., foo = opts.foo.
     # Note: Called only if regular attribute lookup fails,
     # so method and member access will be handled the normal way.
     def __getattr__(self, key: Key):
         if key == "_value_map":
-            # In case we get called in copy/deepcopy, which don't invoke the ctor.
+            # In case we get called in copy, which don't invoke the ctor.
             raise AttributeError(key)
         return self._get_underlying_value(key)
 
@@ -131,9 +143,3 @@ class OptionValueContainer:
         """Returns an iterator over all option names, in lexicographical order."""
         for name in sorted(self._value_map.keys()):
             yield name
-
-    def __copy__(self) -> "OptionValueContainer":
-        """Ensure that a shallow copy has its own value map."""
-        ret = type(self)()
-        ret._value_map = copy.copy(self._value_map)
-        return ret

--- a/src/python/pants/option/option_value_container_test.py
+++ b/src/python/pants/option/option_value_container_test.py
@@ -1,57 +1,62 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import copy
 import unittest
 
-from pants.option.option_value_container import OptionValueContainer
+from pants.option.option_value_container import OptionValueContainerBuilder
 from pants.option.ranked_value import Rank, RankedValue
 
 
 class OptionValueContainerTest(unittest.TestCase):
     def test_unknown_values(self) -> None:
-        o = OptionValueContainer()
-        o.foo = RankedValue(Rank.HARDCODED, 1)
+        ob = OptionValueContainerBuilder()
+        ob.foo = RankedValue(Rank.HARDCODED, 1)
+        o = ob.build()
         self.assertEqual(1, o.foo)
 
         with self.assertRaises(AttributeError):
             o.bar
 
     def test_value_ranking(self) -> None:
-        o = OptionValueContainer()
-        o.foo = RankedValue(Rank.CONFIG, 11)
+        ob = OptionValueContainerBuilder()
+        ob.foo = RankedValue(Rank.CONFIG, 11)
+        o = ob.build()
         self.assertEqual(11, o.foo)
         self.assertEqual(Rank.CONFIG, o.get_rank("foo"))
-        o.foo = RankedValue(Rank.HARDCODED, 22)
+        ob.foo = RankedValue(Rank.HARDCODED, 22)
+        o = ob.build()
         self.assertEqual(11, o.foo)
         self.assertEqual(Rank.CONFIG, o.get_rank("foo"))
-        o.foo = RankedValue(Rank.ENVIRONMENT, 33)
+        ob.foo = RankedValue(Rank.ENVIRONMENT, 33)
+        o = ob.build()
         self.assertEqual(33, o.foo)
         self.assertEqual(Rank.ENVIRONMENT, o.get_rank("foo"))
-        o.foo = RankedValue(Rank.FLAG, 44)
+        ob.foo = RankedValue(Rank.FLAG, 44)
+        o = ob.build()
         self.assertEqual(44, o.foo)
         self.assertEqual(Rank.FLAG, o.get_rank("foo"))
 
     def test_is_flagged(self) -> None:
-        o = OptionValueContainer()
+        ob = OptionValueContainerBuilder()
 
-        o.foo = RankedValue(Rank.NONE, 11)
-        self.assertFalse(o.is_flagged("foo"))
+        ob.foo = RankedValue(Rank.NONE, 11)
+        self.assertFalse(ob.build().is_flagged("foo"))
 
-        o.foo = RankedValue(Rank.CONFIG, 11)
-        self.assertFalse(o.is_flagged("foo"))
+        ob.foo = RankedValue(Rank.CONFIG, 11)
+        self.assertFalse(ob.build().is_flagged("foo"))
 
-        o.foo = RankedValue(Rank.ENVIRONMENT, 11)
-        self.assertFalse(o.is_flagged("foo"))
+        ob.foo = RankedValue(Rank.ENVIRONMENT, 11)
+        self.assertFalse(ob.build().is_flagged("foo"))
 
-        o.foo = RankedValue(Rank.FLAG, 11)
-        self.assertTrue(o.is_flagged("foo"))
+        ob.foo = RankedValue(Rank.FLAG, 11)
+        self.assertTrue(ob.build().is_flagged("foo"))
 
     def test_indexing(self) -> None:
-        o = OptionValueContainer()
-        o.foo = RankedValue(Rank.CONFIG, 1)
-        self.assertEqual(1, o["foo"])
+        ob = OptionValueContainerBuilder()
+        ob.foo = RankedValue(Rank.CONFIG, 1)
+        o = ob.build()
 
+        self.assertEqual(1, o["foo"])
         self.assertEqual(1, o.get("foo"))
         self.assertEqual(1, o.get("foo", 2))
         self.assertIsNone(o.get("unknown"))
@@ -61,45 +66,29 @@ class OptionValueContainerTest(unittest.TestCase):
             o["bar"]
 
     def test_iterator(self) -> None:
-        o = OptionValueContainer()
-        o.a = RankedValue(Rank.FLAG, 3)
-        o.b = RankedValue(Rank.FLAG, 2)
-        o.c = RankedValue(Rank.FLAG, 1)
+        ob = OptionValueContainerBuilder()
+        ob.a = RankedValue(Rank.FLAG, 3)
+        ob.b = RankedValue(Rank.FLAG, 2)
+        ob.c = RankedValue(Rank.FLAG, 1)
+        o = ob.build()
+
         names = list(iter(o))
         self.assertListEqual(["a", "b", "c"], names)
 
     def test_copy(self) -> None:
         # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
-        o = OptionValueContainer()
-        o.foo = RankedValue(Rank.FLAG, 1)
-        o.bar = RankedValue(Rank.FLAG, {"a": 111})
+        ob = OptionValueContainerBuilder()
+        ob.foo = RankedValue(Rank.FLAG, 1)
+        ob.bar = RankedValue(Rank.FLAG, {"a": 111})
 
-        p = copy.copy(o)
+        p = ob.build()
+        z = ob.build()
 
         # Verify that the result is in fact a copy.
         self.assertEqual(1, p.foo)  # Has original attribute.
-        o.baz = RankedValue(Rank.FLAG, 42)
+        ob.baz = RankedValue(Rank.FLAG, 42)
         self.assertFalse(hasattr(p, "baz"))  # Does not have attribute added after the copy.
 
         # Verify that it's a shallow copy by modifying a referent in o and reading it in p.
-        # TODO: add type hints to ranked_value.py and option_value_container.py so that this works.
-        o.bar["b"] = 222  # type: ignore[index]
-        self.assertEqual({"a": 111, "b": 222}, p.bar)
-
-    def test_deepcopy(self) -> None:
-        # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
-        o = OptionValueContainer()
-        o.foo = RankedValue(Rank.FLAG, 1)
-        o.bar = RankedValue(Rank.FLAG, {"a": 111})
-
-        p = copy.deepcopy(o)
-
-        # Verify that the result is in fact a copy.
-        self.assertEqual(1, p.foo)  # Has original attribute.
-        o.baz = RankedValue(Rank.FLAG, 42)
-        self.assertFalse(hasattr(p, "baz"))  # Does not have attribute added after the copy.
-
-        # Verify that it's a deep copy by modifying a referent in o and reading it in p.
-        # TODO: add type hints to ranked_value.py and option_value_container.py so that this works.
-        o.bar["b"] = 222  # type: ignore[index]
-        self.assertEqual({"a": 111}, p.bar)
+        p.bar["b"] = 222
+        self.assertEqual({"a": 111, "b": 222}, z.bar)

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -34,7 +34,7 @@ class OptionableFactory(ABC):
 
     @property
     @abstractmethod
-    def options_scope(self):
+    def options_scope(self) -> str:
         """The scope from which the ScopedOptions for the target Optionable will be parsed."""
 
     @classmethod
@@ -66,9 +66,6 @@ class OptionableFactory(ABC):
 
 class Optionable(OptionableFactory, metaclass=ABCMeta):
     """A mixin for classes that can register options on some scope."""
-
-    # Subclasses must override.
-    options_scope: Optional[str] = None
 
     # Subclasses may override these to specify a deprecated former name for this Optionable's scope.
     # Option values can be read from the deprecated scope, but a deprecation warning will be issued.
@@ -145,16 +142,3 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
         Subclasses should not generally need to override this method.
         """
         cls.register_options(options.registration_function_for_optionable(cls))
-
-    def __init__(self) -> None:
-        # Check that the instance's class defines options_scope.
-        # Note: It is a bit odd to validate a class when instantiating an object of it. but checking
-        # the class itself (e.g., via metaclass magic) turns out to be complicated, because
-        # non-instantiable subclasses (such as TaskBase, Task, Subsystem and other domain-specific
-        # intermediate classes) don't define options_scope, so we can only apply this check to
-        # instantiable classes. And the easiest way to know if a class is instantiable is to hook into
-        # its __init__, as we do here. We usually only create a single instance of an Optionable
-        # subclass anyway.
-        cls = type(self)
-        if not isinstance(cls.options_scope, str):
-            raise NotImplementedError(f"{cls} must set an options_scope class-level property.")

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -11,20 +11,9 @@ class OptionableTest(unittest.TestCase):
         class NoScope(Optionable):
             pass
 
-        with self.assertRaises(NotImplementedError):
-            NoScope()
-
-        class NoneScope(Optionable):
-            options_scope = None
-
-        with self.assertRaises(NotImplementedError):
-            NoneScope()
-
-        class NonStringScope(Optionable):
-            options_scope = 42  # type: ignore[assignment]
-
-        with self.assertRaises(NotImplementedError):
-            NonStringScope()
+        with self.assertRaises(TypeError) as cm:
+            NoScope()  # type: ignore[abstract]
+        assert ("with abstract methods options_scope") in str(cm.exception)
 
         class StringScope(Optionable):
             options_scope = "good"

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -448,7 +448,9 @@ class Options:
 
         # Check for any deprecation conditions, which are evaluated using `self._flag_matchers`.
         if inherit_from_enclosing_scope:
-            self._check_and_apply_deprecations(scope, values)
+            values_builder = values.to_builder()
+            self._check_and_apply_deprecations(scope, values_builder)
+            values = values_builder.build()
 
         return values
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -67,7 +67,7 @@ from pants.option.errors import (
     Shadowing,
 )
 from pants.option.option_util import flatten_shlexed_list, is_dict_option, is_list_option
-from pants.option.option_value_container import OptionValueContainer
+from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.ranked_value import Rank, RankedValue
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
 from pants.util.meta import frozen_after_init
@@ -223,14 +223,14 @@ class Parser:
                 ...
 
         flag_value_map: Dict[str, List[Any]]
-        namespace: OptionValueContainer
+        namespace: OptionValueContainerBuilder
         get_all_scoped_flag_names: FlagNameProvider
         passthrough_args: List[str]
 
         def __init__(
             self,
             flags_in_scope: Iterable[str],
-            namespace: OptionValueContainer,
+            namespace: OptionValueContainerBuilder,
             get_all_scoped_flag_names: FlagNameProvider,
             passthrough_args: List[str],
         ) -> None:
@@ -368,7 +368,7 @@ class Parser:
                 max_edit_distance=2,
             )
 
-        return namespace
+        return namespace.build()
 
     def _raise_error_for_invalid_flag_names(
         self,

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -5,7 +5,20 @@ import importlib
 import inspect
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from pants.base.deprecated import deprecated
 from pants.option.option_value_container import OptionValueContainer
@@ -58,6 +71,7 @@ class SubsystemDependency(OptionableFactory):
 _S = TypeVar("_S", bound="Subsystem")
 
 
+@dataclass(frozen=True)
 class Subsystem(Optionable):
     """A separable piece of functionality that may be reused across multiple tasks or other code.
 
@@ -80,6 +94,20 @@ class Subsystem(Optionable):
 
     :API: public
     """
+
+    scope: str
+    options: OptionValueContainer
+
+    # TODO: The full Options object for this pants run for use by `global_instance` and
+    # `scoped_instance`.
+    _options: ClassVar[Optional[Options]] = None
+
+    # TODO: A cache of (cls, scope) -> the instance of cls tied to that scope.
+    # NB: it would be ideal to use `_S` rather than `Subsystem`, but we can't do this because
+    # MyPy complains that `_S` would not be properly constrained. Specifically, it suggests that we'd
+    # have to use typing.Generic or typing.Protocol to properly constrain the type var, which we
+    # don't want to do.
+    _scoped_instances: ClassVar[Dict[Tuple[Type["Subsystem"], str], "Subsystem"]] = {}
 
     class UninitializedSubsystemError(SubsystemError):
         def __init__(self, class_name, scope):
@@ -108,10 +136,6 @@ class Subsystem(Optionable):
         else:
             return ScopeInfo(cls.subscope(subscope), cls)
 
-    # The full Options object for this pants run.  Will be set after options are parsed.
-    # TODO: A less clunky way to make option values available?
-    _options: Optional[Options] = None
-
     @classmethod
     def set_options(cls, options: Options) -> None:
         cls._options = options
@@ -119,13 +143,6 @@ class Subsystem(Optionable):
     @classmethod
     def is_initialized(cls) -> bool:
         return cls._options is not None
-
-    # A cache of (cls, scope) -> the instance of cls tied to that scope.
-    # NB: it would be ideal to use `_S` rather than `Subsystem`, but we can't do this because
-    # MyPy complains that `_S` would not be properly constrained. Specifically, it suggests that we'd
-    # have to use typing.Generic or typing.Protocol to properly constrain the type var, which we
-    # don't want to do.
-    _scoped_instances: Dict[Tuple[Type["Subsystem"], str], "Subsystem"] = {}
 
     @classmethod
     def global_instance(cls: Type[_S]) -> _S:
@@ -176,33 +193,12 @@ class Subsystem(Optionable):
             cls._options = None
         cls._scoped_instances = {}
 
-    def __init__(self, scope: str, scoped_options: OptionValueContainer) -> None:
-        """Note: A subsystem has no access to options in scopes other than its own.
-
-        Code should call scoped_instance() or global_instance() to get a subsystem instance.
-        It should not invoke this constructor directly.
-
-        :API: public
-        """
-        super().__init__()
-        self._scope = scope
-        self._scoped_options = scoped_options
-        self._fingerprint = None
-
     # It's safe to override the signature from Optionable because we validate
     # that every Optionable has `options_scope` defined as a `str` in the __init__. This code is
     # complex, though, and may be worth refactoring.
     @property
     def options_scope(self) -> str:  # type: ignore[override]
-        return self._scope
-
-    @property
-    def options(self) -> OptionValueContainer:
-        """Returns the option values for this subsystem's scope.
-
-        :API: public
-        """
-        return self._scoped_options
+        return self.scope
 
     @deprecated(
         removal_version="2.1.0.dev0", hint_message="Use the property `self.options` instead."
@@ -212,7 +208,7 @@ class Subsystem(Optionable):
 
         :API: public
         """
-        return self._scoped_options
+        return self.options
 
     @staticmethod
     def get_streaming_workunit_callbacks(subsystem_names: Iterable[str]) -> List[Callable]:

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -71,7 +71,6 @@ class SubsystemDependency(OptionableFactory):
 _S = TypeVar("_S", bound="Subsystem")
 
 
-@dataclass(frozen=True)
 class Subsystem(Optionable):
     """A separable piece of functionality that may be reused across multiple tasks or other code.
 
@@ -193,12 +192,10 @@ class Subsystem(Optionable):
             cls._options = None
         cls._scoped_instances = {}
 
-    # It's safe to override the signature from Optionable because we validate
-    # that every Optionable has `options_scope` defined as a `str` in the __init__. This code is
-    # complex, though, and may be worth refactoring.
-    @property
-    def options_scope(self) -> str:  # type: ignore[override]
-        return self.scope
+    def __init__(self, scope: str, options: OptionValueContainer) -> None:
+        super().__init__()
+        self.scope = scope
+        self.options = options
 
     @deprecated(
         removal_version="2.1.0.dev0", hint_message="Use the property `self.options` instead."
@@ -383,3 +380,8 @@ class Subsystem(Optionable):
 
         collect_scope_infos(cls, GLOBAL_SCOPE)
         return known_scope_infos
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) != type(other):
+            return False
+        return bool(self.scope == other.scope and self.options == other.options)

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -69,8 +69,11 @@ def test_invalid_subsystem_class():
         pass
 
     NoScopeSubsystem._options = DummyOptions()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TypeError) as exc:
         NoScopeSubsystem.global_instance()
+    assert str(exc.value) == (
+        "Can't instantiate abstract class NoScopeSubsystem with abstract methods options_scope"
+    )
 
 
 def test_scoping_simple() -> None:

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -49,7 +49,7 @@ def create_goal_subsystem(
     """
     return goal_subsystem_type(
         scope=goal_subsystem_type.name,
-        scoped_options=_create_scoped_options(default_rank, **options),
+        options=_create_scoped_options(default_rank, **options),
     )
 
 
@@ -68,5 +68,5 @@ def create_subsystem(
     options_scope = cast(str, subsystem_type.options_scope)
     return subsystem_type(
         scope=options_scope,
-        scoped_options=_create_scoped_options(default_rank, **options),
+        options=_create_scoped_options(default_rank, **options),
     )

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -4,7 +4,7 @@
 from typing import Iterable, Mapping, Optional, Type, TypeVar, Union, cast
 
 from pants.engine.goal import GoalSubsystem
-from pants.option.option_value_container import OptionValueContainer
+from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.ranked_value import Rank, RankedValue, Value
 from pants.option.subsystem import Subsystem
@@ -25,7 +25,7 @@ def create_options_bootstrapper(
 def _create_scoped_options(
     default_rank: Rank, **options: Union[RankedValue, Value]
 ) -> OptionValueContainer:
-    scoped_options = OptionValueContainer()
+    scoped_options = OptionValueContainerBuilder().build()
     for key, value in options.items():
         if not isinstance(value, RankedValue):
             value = RankedValue(default_rank, value)

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -25,12 +25,12 @@ def create_options_bootstrapper(
 def _create_scoped_options(
     default_rank: Rank, **options: Union[RankedValue, Value]
 ) -> OptionValueContainer:
-    scoped_options = OptionValueContainerBuilder().build()
+    scoped_options = OptionValueContainerBuilder()
     for key, value in options.items():
         if not isinstance(value, RankedValue):
             value = RankedValue(default_rank, value)
         setattr(scoped_options, key, value)
-    return scoped_options
+    return scoped_options.build()
 
 
 _GS = TypeVar("_GS", bound=GoalSubsystem)


### PR DESCRIPTION
### Problem

In order to resolve #10062, we're planning to remove the `OptionsBootstrapper` `Param`, and instead compute it using an uncacheable `@rule`. Doing so performantly relies on successfully "cleaning" (see #10798) all of the nodes above options parsing in cases where the output has not changed, but experimentation and inspection of the types involved in [construct_scope_*](https://github.com/pantsbuild/pants/blob/dadbcc5b7cb08493ff8f5b0c7f88e896e20a7d7e/src/python/pants/option/optionable.py#L40-L64) and [scope_options](https://github.com/pantsbuild/pants/blob/dadbcc5b7cb08493ff8f5b0c7f88e896e20a7d7e/src/python/pants/engine/internals/options_parsing.py#L23-L37) showed that there were missing equals implementations that prevented cleaning.

### Solution

Give `Subsystem` and `OptionsValueContainer` structural implementations of `__eq__`. Because they will only be used as return values / positional args (ie, the rust side `Value` struct), they don't need `__hash__`.

Additionally, remove `--parent-build-id`, which is not currently consumed for metrics, and which causes lots of invalidation, because every run ends up with new options values. If this facility needs to be revived, it's likely that it should be set only in the context of the `InteractiveProcess` intrinsic, rather than globally... and perhaps not using the options system at all.
 
### Result

Together with #10814 and another PR to follow, `Subsystem` nodes above an uncacheable `@rule` that computes the `OptionsBootstrapper` can be successfully cleaned, which causes early cutoff that allows the rest of the graph to be cleaned with a minimum number of nodes re-running.