### PR TITLE
Fix `internal_only` PEXes runtime interpreter diverging from buildtime

### DIFF
--- a/src/python/pants/backend/python/goals/run_python_binary.py
+++ b/src/python/pants/backend/python/goals/run_python_binary.py
@@ -92,18 +92,18 @@ async def create_python_binary_run_request(
     def in_chroot(relpath: str) -> str:
         return os.path.join("{chroot}", relpath)
 
+    args = pex_env.create_argv(
+        in_chroot(runner_pex.name), "-m", entry_point, python=runner_pex.python
+    )
+
     chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
-        **pex_env.environment_dict,
+        **pex_env.environment_dict(python_configured=runner_pex.python is not None),
         "PEX_PATH": in_chroot(requirements_pex_request.output_filename),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
     }
 
-    return RunRequest(
-        digest=merged_digest,
-        args=(in_chroot(runner_pex.name), "-m", entry_point),
-        extra_env=extra_env,
-    )
+    return RunRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -403,10 +403,11 @@ async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -
         Process,
         PexCliProcess(
             description=f"Find interpreter for constraints: {formatted_constraints}",
-            # Here we run the Pex CLI with no requirements which just selects an interpreter and
-            # normally starts an isolated repl. By passing `--` we force the repl to instead act as
-            # an interpreter (the selected one) and tell us about itself. The upshot is we run the
-            # Pex interpreter selection logic unperturbed but without resolving any distributions.
+            # Here, we run the Pex CLI with no requirements, which just selects an interpreter.
+            # Normally, this would start an isolated repl. By passing `--`, we force the repl to
+            # instead act as an interpreter (the selected one) and tell us about itself. The upshot
+            # is we run the Pex interpreter selection logic unperturbed but without resolving any
+            # distributions.
             argv=(
                 *interpreter_constraints.generate_pex_arg_list(),
                 "--",
@@ -478,8 +479,8 @@ async def create_pex(
     else:
         # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
         # interpreter constraints, and then will run the PEX with that specific interpreter. We
-        # will have already validated that there were no platforms. Otherwise, we let Pex resolve
-        # the constraints.
+        # will have already validated that there were no platforms.
+        # Otherwise, we let Pex resolve the constraints.
         if request.internal_only:
             python = await Get(
                 PythonExecutable, PexInterpreterConstraints, request.interpreter_constraints
@@ -672,7 +673,10 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
         *request.argv,
         python=request.pex.python,
     )
-    env = {**pex_environment.environment_dict, **(request.extra_env or {})}
+    env = {
+        **pex_environment.environment_dict(python_configured=request.pex.python is not None),
+        **(request.extra_env or {}),
+    }
     process = Process(
         argv,
         description=request.description,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -122,7 +122,7 @@ async def setup_pex_cli_process(
         # a remoting implementation has to allow for processes producing large binaries in a
         # sandbox to support reasonable workloads.
         "TMPDIR": tmpdir,
-        **pex_env.environment_dict,
+        **pex_env.environment_dict(python_configured=request.python is not None),
         **python_native_code.environment_dict,
         **(request.extra_env or {}),
     }


### PR DESCRIPTION
If you set `PEX_PYTHON_PATH`, Pex may choose a new interpreter, even if you use a specific Python interpreter to run the Pex initially. This was causing several instances of the runtime interpreter diverging from the buildtime interpreter for our `internal_only` PEXes.

```
$ pex --python='/Users/eric/.pyenv/versions/3.7.7/bin/python3.7' --output-file=bandit.pex bandit

$ ./bandit.pex
Python 3.7.7 (default, May 12 2020, 19:45:03)

$ /Users/eric/.pyenv/versions/3.7.7/bin/python3.7 bandit.pex
Python 3.7.7 (default, May 12 2020, 19:45:03)

$ PEX_PYTHON_PATH=/Users/eric/.pyenv/versions/3.8.5/bin/python3.8 /Users/eric/.pyenv/versions/3.7.7/bin/python3.7 ./bandit.pex
Failed to execute PEX file. Needed macosx_10_15_x86_64-cp-38-cp38 compatible dependencies for:
 1: pyyaml
    But this pex only contains:
      PyYAML-5.3.1-cp37-cp37m-macosx_10_15_x86_64.whl
 2: PyYAML>=3.13
    Required by:
      bandit==1.6.2
    But this pex only contains:
      PyYAML-5.3.1-cp37-cp37m-macosx_10_15_x86_64.whl
```
Fixes https://github.com/pantsbuild/example-python/issues/43.

This also fixes `run` and `repl`. They had bit rot from https://github.com/pantsbuild/pants/pull/10788 and were not using Pants's pre-selected interpreter.

[ci skip-rust]
[ci skip-build-wheels]