### PR TITLE
OptionsBootstrapper is provided via a new SessionValues facility rather than a Param

### DIFF
--- a/pants-plugins/internal_plugins/rules_for_testing/register.py
+++ b/pants-plugins/internal_plugins/rules_for_testing/register.py
@@ -5,7 +5,6 @@ from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import QueryRule, collect_rules, goal_rule
-from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 class ListAndDieForTestingSubsystem(GoalSubsystem):
@@ -29,5 +28,5 @@ def rules():
     return [
         *collect_rules(),
         # NB: Would be unused otherwise.
-        QueryRule(ListAndDieForTestingSubsystem, [OptionsBootstrapper]),
+        QueryRule(ListAndDieForTestingSubsystem, []),
     ]

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -16,7 +16,6 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -26,9 +25,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *awslambda_python_rules(),
-            QueryRule(
-                CreatedAWSLambda, (PythonAwsLambdaFieldSet, OptionsBootstrapper, PantsEnvironment)
-            ),
+            QueryRule(CreatedAWSLambda, (PythonAwsLambdaFieldSet, PantsEnvironment)),
         ],
         target_types=[PythonAWSLambda, PythonLibrary],
     )

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -19,7 +19,6 @@ from pants.engine.target import (
     HydrateSourcesRequest,
     WrappedTarget,
 )
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.source.source_root import NoSourceRootError
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
 from pants.testutil.option_util import create_options_bootstrapper
@@ -39,8 +38,8 @@ class ProtobufPythonIntegrationTest(ExternalToolTestBase):
             *additional_fields.rules(),
             *source_files.rules(),
             *stripped_source_files.rules(),
-            QueryRule(HydratedSources, (HydrateSourcesRequest, OptionsBootstrapper)),
-            QueryRule(GeneratedSources, (GeneratePythonFromProtobufRequest, OptionsBootstrapper)),
+            QueryRule(HydratedSources, (HydrateSourcesRequest,)),
+            QueryRule(GeneratedSources, (GeneratePythonFromProtobufRequest,)),
         )
 
     def assert_files_generated(

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -17,7 +17,6 @@ from pants.backend.python.dependency_inference.module_mapper import rules as mod
 from pants.backend.python.target_types import PythonLibrary, PythonRequirementLibrary
 from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.frozendict import FrozenDict
@@ -75,9 +74,9 @@ def rule_runner() -> RuleRunner:
         rules=[
             *stripped_source_files.rules(),
             *module_mapper_rules(),
-            QueryRule(FirstPartyModuleToAddressMapping, (OptionsBootstrapper,)),
-            QueryRule(ThirdPartyModuleToAddressMapping, (OptionsBootstrapper,)),
-            QueryRule(PythonModuleOwner, (PythonModule, OptionsBootstrapper)),
+            QueryRule(FirstPartyModuleToAddressMapping, ()),
+            QueryRule(ThirdPartyModuleToAddressMapping, ()),
+            QueryRule(PythonModuleOwner, (PythonModule,)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -24,7 +24,6 @@ from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.rules import SubsystemRule
 from pants.engine.target import InferredDependencies
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -36,7 +35,7 @@ def test_infer_python_imports() -> None:
             *module_mapper.rules(),
             infer_python_dependencies,
             SubsystemRule(PythonInference),
-            QueryRule(InferredDependencies, (InferPythonDependencies, OptionsBootstrapper)),
+            QueryRule(InferredDependencies, (InferPythonDependencies,)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )
@@ -131,7 +130,7 @@ def test_infer_python_inits() -> None:
             *ancestor_files.rules(),
             infer_python_init_dependencies,
             SubsystemRule(PythonInference),
-            QueryRule(InferredDependencies, (InferInitDependencies, OptionsBootstrapper)),
+            QueryRule(InferredDependencies, (InferInitDependencies,)),
         ],
         target_types=[PythonLibrary],
     )
@@ -174,7 +173,7 @@ def test_infer_python_conftests() -> None:
             *ancestor_files.rules(),
             infer_python_conftest_dependencies,
             SubsystemRule(PythonInference),
-            QueryRule(InferredDependencies, (InferConftestDependencies, OptionsBootstrapper)),
+            QueryRule(InferredDependencies, (InferConftestDependencies,)),
         ],
         target_types=[PythonTests],
     )

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -27,7 +27,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.process import InteractiveRunner
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -45,10 +44,8 @@ def rule_runner() -> RuleRunner:
             *binary.rules(),
             *create_python_binary.rules(),
             get_filtered_environment,
-            QueryRule(TestResult, (PythonTestFieldSet, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(
-                TestDebugRequest, (PythonTestFieldSet, OptionsBootstrapper, PantsEnvironment)
-            ),
+            QueryRule(TestResult, (PythonTestFieldSet, PantsEnvironment)),
+            QueryRule(TestDebugRequest, (PythonTestFieldSet, PantsEnvironment)),
         ],
         target_types=[PythonBinary, PythonLibrary, PythonTests, PythonRequirementLibrary],
     )

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -47,7 +47,6 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionRule
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -96,7 +95,7 @@ def chroot_rule_runner() -> RuleRunner:
             *python_sources.rules(),
             setup_kwargs_plugin,
             UnionRule(SetupKwargsRequest, PluginSetupKwargsRequest),
-            QueryRule(SetupPyChroot, (SetupPyChrootRequest, OptionsBootstrapper)),
+            QueryRule(SetupPyChroot, (SetupPyChrootRequest,)),
         ]
     )
 
@@ -261,7 +260,7 @@ def test_get_sources() -> None:
         rules=[
             get_sources,
             *python_sources.rules(),
-            QueryRule(SetupPySources, (SetupPySourcesRequest, OptionsBootstrapper)),
+            QueryRule(SetupPySources, (SetupPySourcesRequest,)),
         ]
     )
 
@@ -371,7 +370,7 @@ def test_get_requirements() -> None:
             get_requirements,
             get_owned_dependencies,
             get_exporting_owner,
-            QueryRule(ExportedTargetRequirements, (DependencyOwner, OptionsBootstrapper)),
+            QueryRule(ExportedTargetRequirements, (DependencyOwner,)),
         ]
     )
     rule_runner.add_to_build_file(
@@ -454,7 +453,7 @@ def test_owned_dependencies() -> None:
         rules=[
             get_owned_dependencies,
             get_exporting_owner,
-            QueryRule(OwnedDependencies, (DependencyOwner, OptionsBootstrapper)),
+            QueryRule(OwnedDependencies, (DependencyOwner,)),
         ]
     )
     rule_runner.add_to_build_file(
@@ -543,7 +542,7 @@ def exporting_owner_rule_runner() -> RuleRunner:
     return create_setup_py_rule_runner(
         rules=[
             get_exporting_owner,
-            QueryRule(ExportedTarget, (OwnedDependency, OptionsBootstrapper)),
+            QueryRule(ExportedTarget, (OwnedDependency,)),
         ]
     )
 

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -24,7 +23,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *bandit_rules(),
-            QueryRule(LintResults, (BanditRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (BanditRequest, PantsEnvironment)),
         ],
     )
 

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -16,7 +16,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python38_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -27,9 +26,9 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *black_rules(),
-            QueryRule(LintResults, (BlackRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(FmtResult, (BlackRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(SourceFiles, (SourceFilesRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (BlackRequest, PantsEnvironment)),
+            QueryRule(FmtResult, (BlackRequest, PantsEnvironment)),
+            QueryRule(SourceFiles, (SourceFilesRequest, PantsEnvironment)),
         ],
         target_types=[PythonLibrary],
     )

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -15,7 +15,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -25,9 +24,9 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *docformatter_rules(),
-            QueryRule(LintResults, (DocformatterRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(FmtResult, (DocformatterRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(SourceFiles, (SourceFilesRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (DocformatterRequest, PantsEnvironment)),
+            QueryRule(FmtResult, (DocformatterRequest, PantsEnvironment)),
+            QueryRule(SourceFiles, (SourceFilesRequest, PantsEnvironment)),
         ]
     )
 

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -24,7 +23,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *flake8_rules(),
-            QueryRule(LintResults, (Flake8Request, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (Flake8Request, PantsEnvironment)),
         ]
     )
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -15,7 +15,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -25,9 +24,9 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *isort_rules(),
-            QueryRule(LintResults, (IsortRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(FmtResult, (IsortRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(SourceFiles, (SourceFilesRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (IsortRequest, PantsEnvironment)),
+            QueryRule(FmtResult, (IsortRequest, PantsEnvironment)),
+            QueryRule(SourceFiles, (SourceFilesRequest, PantsEnvironment)),
         ]
     )
 

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -16,7 +16,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -27,7 +26,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pylint_rules(),
-            QueryRule(LintResults, (PylintRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(LintResults, (PylintRequest, PantsEnvironment)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary, PylintSourcePlugin],
     )

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -14,7 +14,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Targets
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -26,9 +25,7 @@ def rule_runner() -> RuleRunner:
             format_python_target,
             *black_rules(),
             *isort_rules(),
-            QueryRule(
-                LanguageFmtResults, (PythonFmtTargets, OptionsBootstrapper, PantsEnvironment)
-            ),
+            QueryRule(LanguageFmtResults, (PythonFmtTargets, PantsEnvironment)),
         ]
     )
 

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import PythonRequirementLibrary, PythonRe
 from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs, Specs
 from pants.engine.addresses import Address
 from pants.engine.target import Targets
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -21,7 +20,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(Targets, (OptionsBootstrapper, Specs))],
+        rules=[QueryRule(Targets, (Specs,))],
         target_types=[PythonRequirementLibrary, PythonRequirementsFile],
         context_aware_object_factories={"pipenv_requirements": PipenvRequirements},
     )

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -13,7 +13,6 @@ from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs,
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Targets
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -21,7 +20,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(Targets, (OptionsBootstrapper, Specs))],
+        rules=[QueryRule(Targets, (Specs,))],
         target_types=[PythonRequirementLibrary, PythonRequirementsFile],
         context_aware_object_factories={"python_requirements": PythonRequirements},
     )

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -18,7 +18,6 @@ from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python38_present
 from pants.testutil.rule_runner import RuleRunner
@@ -30,7 +29,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *mypy_rules(),
             *dependency_inference_rules.rules(),  # Used for import inference.
-            QueryRule(TypecheckResults, (MyPyRequest, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(TypecheckResults, (MyPyRequest, PantsEnvironment)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary, MyPySourcePlugin],
     )

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.ancestor_files import (
     identify_missing_ancestor_files,
 )
 from pants.engine.fs import DigestContents
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -22,7 +21,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *ancestor_files.rules(),
-            QueryRule(AncestorFiles, (AncestorFilesRequest, OptionsBootstrapper)),
+            QueryRule(AncestorFiles, (AncestorFilesRequest,)),
         ]
     )
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.pex import PexRequest, PexRequirements
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.build_graph.address import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.python.python_setup import ResolveAllConstraintsOption
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -23,7 +22,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_from_targets.rules(),
-            QueryRule(PexRequest, (PexFromTargetsRequest, OptionsBootstrapper)),
+            QueryRule(PexRequest, (PexFromTargetsRequest,)),
         ],
         target_types=[PythonLibrary, PythonRequirementLibrary],
     )

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -26,7 +26,6 @@ from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
 from pants.engine.target import FieldSet
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.python.python_setup import PythonSetup
 from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -318,8 +317,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_rules(),
-            QueryRule(Pex, (PexRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(Process, (PexProcess, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(Pex, (PexRequest, PantsEnvironment)),
+            QueryRule(Process, (PexProcess, PantsEnvironment)),
             QueryRule(ProcessResult, (Process,)),
         ]
     )

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -16,7 +16,6 @@ from pants.backend.python.util_rules.python_sources import rules as python_sourc
 from pants.core.target_types import Files, Resources
 from pants.engine.addresses import Address
 from pants.engine.target import Sources, Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.external_tool_test_base import ExternalToolTestBase
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule
@@ -39,8 +38,8 @@ class PythonSourceFilesTest(ExternalToolTestBase):
             *super().rules(),
             *python_sources_rules(),
             *protobuf_rules(),
-            QueryRule(PythonSourceFiles, (PythonSourceFilesRequest, OptionsBootstrapper)),
-            QueryRule(StrippedPythonSourceFiles, (PythonSourceFilesRequest, OptionsBootstrapper)),
+            QueryRule(PythonSourceFiles, (PythonSourceFilesRequest,)),
+            QueryRule(StrippedPythonSourceFiles, (PythonSourceFilesRequest,)),
         )
 
     @classmethod

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -14,6 +14,7 @@ from pants.base.workunit import WorkUnit
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.native import Native
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.session import SessionValues
 from pants.engine.unions import UnionMembership
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_info_extracter import HelpInfoExtracter
@@ -84,6 +85,7 @@ class LocalPantsRunner:
             dynamic_ui=dynamic_ui,
             use_colors=use_colors,
             should_report_workunits=stream_workunits,
+            session_values=SessionValues({OptionsBootstrapper: options_bootstrapper}),
         )
 
     @classmethod

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -129,9 +129,10 @@ class BuildConfiguration:
                 raise TypeError("The rules must be an iterable, given {!r}".format(rules))
 
             # "Index" the rules to normalize them and expand their dependencies.
-            rules, union_rules = RuleIndex.create(rules).normalized_rules()
-            self._rules.update(rules)
-            self._union_rules.update(union_rules)
+            rule_index = RuleIndex.create(rules)
+            self._rules.update(rule_index.rules)
+            self._rules.update(rule_index.queries)
+            self._union_rules.update(rule_index.union_rules)
             self.register_optionables(
                 rule.output_type for rule in self._rules if issubclass(rule.output_type, Optionable)
             )

--- a/src/python/pants/core/goals/repl_integration_test.py
+++ b/src/python/pants/core/goals/repl_integration_test.py
@@ -12,7 +12,6 @@ from pants.core.goals.repl import Repl
 from pants.core.goals.repl import rules as repl_rules
 from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.process import Process
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -23,7 +22,7 @@ def rule_runner() -> RuleRunner:
             *repl_rules(),
             *python_repl.rules(),
             *pex_from_targets.rules(),
-            QueryRule(Process, (PexProcess, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(Process, (PexProcess, PantsEnvironment)),
         ],
         target_types=[PythonLibrary, ProtobufLibrary],
     )

--- a/src/python/pants/core/goals/typecheck.py
+++ b/src/python/pants/core/goals/typecheck.py
@@ -16,7 +16,6 @@ from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, goal_rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionMembership, union
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
@@ -177,5 +176,5 @@ def rules():
     return [
         *collect_rules(),
         # NB: Would be unused otherwise.
-        QueryRule(TypecheckSubsystem, [OptionsBootstrapper]),
+        QueryRule(TypecheckSubsystem, []),
     ]

--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pants.base.build_root import BuildRoot
 from pants.engine.rules import collect_rules, rule
 from pants.fs.fs import is_child_of
-from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.global_options import GlobalOptions
 
 
 class InvalidDistDir(Exception):
@@ -22,9 +22,8 @@ class DistDir:
 
 
 @rule
-async def get_distdir(options_bootstrapper: OptionsBootstrapper, buildroot: BuildRoot) -> DistDir:
-    global_options = options_bootstrapper.bootstrap_options.for_global_scope()
-    return validate_distdir(Path(global_options.pants_distdir), buildroot.pathlib_path)
+async def get_distdir(global_options: GlobalOptions, buildroot: BuildRoot) -> DistDir:
+    return validate_distdir(Path(global_options.options.pants_distdir), buildroot.pathlib_path)
 
 
 def validate_distdir(distdir: Path, buildroot: Path) -> DistDir:

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -14,7 +14,6 @@ from pants.core.util_rules.filter_empty_sources import (
 from pants.core.util_rules.filter_empty_sources import rules as filter_empty_sources_rules
 from pants.engine.addresses import Address
 from pants.engine.target import FieldSet, Sources, Tags, Target
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -24,8 +23,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *filter_empty_sources_rules(),
-            QueryRule(FieldSetsWithSources, (FieldSetsWithSourcesRequest, OptionsBootstrapper)),
-            QueryRule(TargetsWithSources, (TargetsWithSourcesRequest, OptionsBootstrapper)),
+            QueryRule(FieldSetsWithSources, (FieldSetsWithSourcesRequest,)),
+            QueryRule(TargetsWithSources, (TargetsWithSourcesRequest,)),
         ]
     )
 

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
 from pants.engine.target import Sources as SourcesField
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -23,7 +22,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *source_files_rules(),
-            QueryRule(SourceFiles, (SourceFilesRequest, OptionsBootstrapper)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
 

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -11,7 +11,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -21,8 +20,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *stripped_source_files.rules(),
-            QueryRule(SourceFiles, (SourceFilesRequest, OptionsBootstrapper)),
-            QueryRule(StrippedSourceFiles, (SourceFiles, OptionsBootstrapper)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+            QueryRule(StrippedSourceFiles, (SourceFiles,)),
         ]
     )
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -156,9 +156,7 @@ def test_resolve_address() -> None:
 
 @pytest.fixture
 def target_adaptor_rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[QueryRule(TargetAdaptor, (Address, OptionsBootstrapper))], target_types=[MockTgt]
-    )
+    return RuleRunner(rules=[QueryRule(TargetAdaptor, (Address,))], target_types=[MockTgt])
 
 
 def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner) -> None:
@@ -213,7 +211,7 @@ def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> Non
 
 def test_build_file_address() -> None:
     rule_runner = RuleRunner(
-        rules=[QueryRule(BuildFileAddress, (Address, OptionsBootstrapper))], target_types=[MockTgt]
+        rules=[QueryRule(BuildFileAddress, (Address,))], target_types=[MockTgt]
     )
     rule_runner.create_file("helloworld/BUILD.ext", "mock_tgt()")
     bootstrapper = create_options_bootstrapper()
@@ -231,7 +229,7 @@ def test_build_file_address() -> None:
 @pytest.fixture
 def address_specs_rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(AddressesWithOrigins, (AddressSpecs, OptionsBootstrapper))],
+        rules=[QueryRule(AddressesWithOrigins, (AddressSpecs,))],
         target_types=[MockTgt],
     )
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -90,8 +90,8 @@ class MockTarget(Target):
 def transitive_targets_rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            QueryRule(Targets, (DependenciesRequest, OptionsBootstrapper)),
-            QueryRule(TransitiveTargets, (Addresses, OptionsBootstrapper)),
+            QueryRule(Targets, (DependenciesRequest,)),
+            QueryRule(TransitiveTargets, (Addresses,)),
         ],
         target_types=[MockTarget],
     )
@@ -338,7 +338,7 @@ def test_resolve_sources_snapshot() -> None:
       so that the file only shows up once.
     """
     rule_runner = RuleRunner(
-        rules=[QueryRule(SourcesSnapshot, (Specs, OptionsBootstrapper))], target_types=[MockTarget]
+        rules=[QueryRule(SourcesSnapshot, (Specs,))], target_types=[MockTarget]
     )
     rule_runner.create_files("demo", ["f1.txt", "f2.txt"])
     rule_runner.add_to_build_file("demo", "target(sources=['*.txt'])")
@@ -351,9 +351,7 @@ def test_resolve_sources_snapshot() -> None:
 
 @pytest.fixture
 def owners_rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[QueryRule(Owners, (OwnersRequest, OptionsBootstrapper))], target_types=[MockTarget]
-    )
+    return RuleRunner(rules=[QueryRule(Owners, (OwnersRequest,))], target_types=[MockTarget])
 
 
 def assert_owners(
@@ -449,7 +447,7 @@ def test_owners_build_file(owners_rule_runner: RuleRunner) -> None:
 @pytest.fixture
 def specs_rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(AddressesWithOrigins, (FilesystemSpecs, OptionsBootstrapper))],
+        rules=[QueryRule(AddressesWithOrigins, (FilesystemSpecs,))],
         target_types=[MockTarget],
     )
 
@@ -532,7 +530,7 @@ def test_filesystem_specs_no_owner(specs_rule_runner: RuleRunner) -> None:
 def test_resolve_addresses_from_specs() -> None:
     """This tests that we correctly handle resolving from both address and filesystem specs."""
     rule_runner = RuleRunner(
-        rules=[QueryRule(AddressesWithOrigins, (Specs, OptionsBootstrapper))],
+        rules=[QueryRule(AddressesWithOrigins, (Specs,))],
         target_types=[MockTarget],
     )
     rule_runner.create_file("fs_spec/f.txt")
@@ -687,9 +685,7 @@ def test_find_valid_field_sets() -> None:
 
 @pytest.fixture
 def sources_rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[QueryRule(HydratedSources, (HydrateSourcesRequest, OptionsBootstrapper))]
-    )
+    return RuleRunner(rules=[QueryRule(HydratedSources, (HydrateSourcesRequest,))])
 
 
 def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
@@ -881,8 +877,8 @@ class TestCodegen(TestBase):
             *super().rules(),
             generate_smalltalk_from_avro,
             QueryRule(UnionMembership, ()),
-            QueryRule(HydratedSources, (HydrateSourcesRequest, OptionsBootstrapper)),
-            QueryRule(GeneratedSources, (GenerateSmalltalkFromAvroRequest, OptionsBootstrapper)),
+            QueryRule(HydratedSources, (HydrateSourcesRequest,)),
+            QueryRule(GeneratedSources, (GenerateSmalltalkFromAvroRequest,)),
             UnionRule(GenerateSourcesRequest, GenerateSmalltalkFromAvroRequest),
         )
 
@@ -1123,7 +1119,7 @@ def dependencies_rule_runner() -> RuleRunner:
             inject_smalltalk_deps,
             inject_custom_smalltalk_deps,
             infer_smalltalk_dependencies,
-            QueryRule(Addresses, (DependenciesRequest, OptionsBootstrapper)),
+            QueryRule(Addresses, (DependenciesRequest,)),
             UnionRule(InjectDependenciesRequest, InjectSmalltalkDependencies),
             UnionRule(InjectDependenciesRequest, InjectCustomSmalltalkDependencies),
             UnionRule(InferDependenciesRequest, InferSmalltalkDependencies),

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -25,6 +25,7 @@ from pants.engine.internals.native_engine import (
     PyTypes,
 )
 from pants.engine.rules import Get
+from pants.engine.session import SessionValues
 from pants.engine.unions import union
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
@@ -207,12 +208,14 @@ class Native(metaclass=SingletonMetaclass):
         dynamic_ui: bool,
         build_id,
         should_report_workunits: bool,
+        session_values: SessionValues,
     ) -> PySession:
         return PySession(
             scheduler,
             dynamic_ui,
             build_id,
             should_report_workunits,
+            session_values,
         )
 
     def new_scheduler(

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -4,7 +4,6 @@
 import pytest
 
 from pants.engine.rules import SubsystemRule
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import GLOBAL_SCOPE, Scope, ScopedOptions
 from pants.python.python_setup import PythonSetup
 from pants.testutil.option_util import create_options_bootstrapper
@@ -14,9 +13,7 @@ from pants.util.logging import LogLevel
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=[SubsystemRule(PythonSetup), QueryRule(ScopedOptions, (Scope, OptionsBootstrapper))]
-    )
+    return RuleRunner(rules=[SubsystemRule(PythonSetup), QueryRule(ScopedOptions, (Scope,))])
 
 
 def test_options_parse_scoped(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -186,12 +186,8 @@ class Scheduler:
 
         tasks = self._native.new_tasks()
 
-        for output_type, rules in rule_index.rules.items():
-            for rule in rules:
-                if isinstance(rule, TaskRule):
-                    self._register_task(tasks, output_type, rule, union_membership)
-                else:
-                    raise ValueError(f"Unexpected Rule type: {rule}")
+        for rule in rule_index.rules:
+            self._register_task(tasks, rule, union_membership)
         for query in rule_index.queries:
             self._native.lib.tasks_query_add(
                 tasks,
@@ -200,15 +196,13 @@ class Scheduler:
             )
         return tasks
 
-    def _register_task(
-        self, tasks, output_type: Type, rule: TaskRule, union_membership: UnionMembership
-    ) -> None:
+    def _register_task(self, tasks, rule: TaskRule, union_membership: UnionMembership) -> None:
         """Register the given TaskRule with the native scheduler."""
         self._native.lib.tasks_task_begin(
             tasks,
             rule.func,
-            output_type,
-            issubclass(output_type, EngineAwareReturnType),
+            rule.output_type,
+            issubclass(rule.output_type, EngineAwareReturnType),
             rule.cacheable,
             rule.canonical_name,
             rule.desc or "",

--- a/src/python/pants/engine/session.py
+++ b/src/python/pants/engine/session.py
@@ -1,0 +1,19 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Type
+
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+
+
+@frozen_after_init
+@dataclass
+class SessionValues:
+    """Values set for the Session, and exposed to @rules."""
+
+    values: FrozenDict[Type, Any]
+
+    def __init__(self, values: Optional[Mapping[Type, Any]] = None) -> None:
+        self.values = FrozenDict(values or {})

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -73,7 +73,6 @@ class GraphSession:
         Specs,
         Console,
         InteractiveRunner,
-        OptionsBootstrapper,
         Workspace,
         PantsEnvironment,
     )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -24,6 +24,7 @@ from pants.engine.internals.selectors import Params
 from pants.engine.platform import create_platform_rules
 from pants.engine.process import InteractiveRunner
 from pants.engine.rules import QueryRule, collect_rules, rule
+from pants.engine.session import SessionValues
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
 from pants.init import specs_calculator
@@ -50,8 +51,11 @@ class GraphScheduler:
         dynamic_ui: bool = False,
         use_colors=True,
         should_report_workunits=False,
+        session_values: Optional[SessionValues] = None,
     ) -> "GraphSession":
-        session = self.scheduler.new_session(build_id, dynamic_ui, should_report_workunits)
+        session = self.scheduler.new_session(
+            build_id, dynamic_ui, should_report_workunits, session_values=session_values
+        )
         console = Console(use_colors=use_colors, session=session if dynamic_ui else None)
         return GraphSession(session, console, self.goal_map)
 

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -83,5 +83,5 @@ def calculate_specs(
 
 def rules():
     return [
-        QueryRule(ChangedAddresses, [ChangedRequest, OptionsBootstrapper]),
+        QueryRule(ChangedAddresses, [ChangedRequest]),
     ]

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -9,7 +9,6 @@ import pytest
 
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import QueryRule
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.source.source_root import (
     OptionalSourceRoot,
     SourceRoot,
@@ -286,7 +285,7 @@ def test_source_roots_request() -> None:
     rule_runner = RuleRunner(
         rules=[
             *source_root_rules(),
-            QueryRule(SourceRootsResult, (SourceRootsRequest, OptionsBootstrapper)),
+            QueryRule(SourceRootsResult, (SourceRootsRequest,)),
         ]
     )
     req = SourceRootsRequest(

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -38,6 +38,7 @@ from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
 from pants.engine.process import InteractiveRunner
 from pants.engine.rules import QueryRule
+from pants.engine.session import SessionValues
 from pants.engine.target import Target, WrappedTarget
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.util import clean_global_runtime_state
@@ -104,9 +105,17 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     _O = TypeVar("_O")
 
     def request(self, output_type: Type["TestBase._O"], inputs: Iterable[Any]) -> "TestBase._O":
-        result = assert_single_element(
-            self.scheduler.product_request(output_type, [Params(*inputs)])
-        )
+        # TODO: Update all callsites to pass this explicitly via session values.
+        session = self.scheduler
+        for value in inputs:
+            if type(value) == OptionsBootstrapper:
+                session = self.scheduler.scheduler.new_session(
+                    build_id="buildid_for_test",
+                    should_report_workunits=True,
+                    session_values=SessionValues({OptionsBootstrapper: value}),
+                )
+
+        result = assert_single_element(session.product_request(output_type, [Params(*inputs)]))
         return cast(TestBase._O, result)
 
     def run_goal_rule(
@@ -130,12 +139,17 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr)
 
-        exit_code = self.scheduler.run_goal_rule(
+        session = self.scheduler.scheduler.new_session(
+            build_id="buildid_for_test",
+            should_report_workunits=True,
+            session_values=SessionValues({OptionsBootstrapper: options_bootstrapper}),
+        )
+
+        exit_code = session.run_goal_rule(
             goal,
             Params(
                 specs,
                 console,
-                options_bootstrapper,
                 Workspace(self.scheduler),
                 InteractiveRunner(self.scheduler),
                 PantsEnvironment(),
@@ -218,7 +232,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     def rules(cls):
         return [
             *source_root.rules(),
-            QueryRule(WrappedTarget, (Address, OptionsBootstrapper)),
+            QueryRule(WrappedTarget, (Address,)),
         ]
 
     @classmethod

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -412,6 +412,7 @@ py_class!(class PyTypes |py| {
       multi_platform_process: PyType,
       process_result: PyType,
       coroutine: PyType,
+      session_values: PyType,
       interactive_process_result: PyType,
       engine_aware_parameter: PyType
   ) -> CPyResult<Self> {
@@ -434,6 +435,7 @@ py_class!(class PyTypes |py| {
         multi_platform_process: externs::type_for(multi_platform_process),
         process_result: externs::type_for(process_result),
         coroutine: externs::type_for(coroutine),
+        session_values: externs::type_for(session_values),
         interactive_process_result: externs::type_for(interactive_process_result),
         engine_aware_parameter: externs::type_for(engine_aware_parameter),
     })),
@@ -538,13 +540,15 @@ py_class!(class PySession |py| {
           scheduler_ptr: PyScheduler,
           should_render_ui: bool,
           build_id: String,
-          should_report_workunits: bool
+          should_report_workunits: bool,
+          session_values: PyObject
     ) -> CPyResult<Self> {
       Self::create_instance(py, Session::new(
           scheduler_ptr.scheduler(py),
           should_render_ui,
           build_id,
           should_report_workunits,
+          session_values.into(),
         )
       )
     }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -2,7 +2,7 @@ use crate::context::Context;
 use crate::core::{throw, Value};
 use crate::externs;
 use crate::nodes::MultiPlatformExecuteProcess;
-use crate::nodes::{lift_digest, DownloadedFile, NodeResult, Paths, Snapshot};
+use crate::nodes::{lift_digest, DownloadedFile, NodeResult, Paths, SessionValues, Snapshot};
 use crate::tasks::Intrinsic;
 use crate::types::Types;
 
@@ -100,6 +100,13 @@ impl Intrinsics {
         inputs: vec![types.digest_subset],
       },
       Box::new(digest_subset_to_digest),
+    );
+    intrinsics.insert(
+      Intrinsic {
+        product: types.session_values,
+        inputs: vec![],
+      },
+      Box::new(session_values),
     );
     Intrinsics { intrinsics }
   }
@@ -385,4 +392,8 @@ fn digest_subset_to_digest(
     Ok(Snapshot::store_directory_digest(&context.core, &digest))
   }
   .boxed()
+}
+
+fn session_values(context: Context, _args: Vec<Value>) -> BoxFuture<'static, NodeResult<Value>> {
+  async move { context.get(SessionValues).await }.boxed()
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -64,6 +64,8 @@ struct InnerSession {
   workunit_store: WorkunitStore,
   // The unique id for this Session: used for metrics gathering purposes.
   build_id: String,
+  // Per-Session values that have been set for this session.
+  session_values: Mutex<Value>,
   // An id used to control the visibility of uncacheable rules. Generally this is identical for an
   // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
   // same Session while still observing new values for uncacheable rules like Goals.
@@ -84,6 +86,7 @@ impl Session {
     should_render_ui: bool,
     build_id: String,
     should_report_workunits: bool,
+    session_values: Value,
   ) -> Session {
     let workunit_store = WorkunitStore::new(should_render_ui);
     let display = if should_render_ui {
@@ -101,6 +104,7 @@ impl Session {
       display,
       workunit_store,
       build_id,
+      session_values: Mutex::new(session_values),
       run_id: Mutex::new(Uuid::new_v4()),
       should_report_workunits,
     };
@@ -126,6 +130,10 @@ impl Session {
   fn root_nodes(&self) -> Vec<NodeKey> {
     let roots = self.0.roots.lock();
     roots.keys().map(|r| r.clone().into()).collect()
+  }
+
+  pub fn session_values(&self) -> Value {
+    self.0.session_values.lock().clone()
   }
 
   pub fn preceding_graph_size(&self) -> usize {

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -20,6 +20,7 @@ pub struct Types {
   pub multi_platform_process: TypeId,
   pub process_result: TypeId,
   pub coroutine: TypeId,
+  pub session_values: TypeId,
   pub interactive_process_result: TypeId,
   pub engine_aware_parameter: TypeId,
 }

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -44,8 +44,8 @@ class PluginResolverTest(TestBase):
             *pex.rules(),
             *external_tool.rules(),
             *archive.rules(),
-            QueryRule(Pex, (PexRequest, OptionsBootstrapper, PantsEnvironment)),
-            QueryRule(Process, (PexProcess, OptionsBootstrapper, PantsEnvironment)),
+            QueryRule(Pex, (PexRequest, PantsEnvironment)),
+            QueryRule(Process, (PexProcess, PantsEnvironment)),
             QueryRule(ProcessResult, (Process,)),
         )
 


### PR DESCRIPTION
### Problem

As described on #10062: any change to options values (including the CLI specs and passthrough args) currently completely invalidate all `@rules` that consume `Subsystem`s, because the "identities" (memoization keys) of the involved `@rules` change. As more heavy lifting has begun to depend on options, this has become more obvious and problematic.

### Solution

As sketched in https://github.com/pantsbuild/pants/issues/10062#issuecomment-696389789, move to providing the `OptionsBootstrapper` (and in future, perhaps much smaller wrappers around the "args" and "env" instead) via a new uncacheable `SessionValues` intrinsic.

More generally, the combination of `Params` for values that _should_ affect the identity of a `@rule`, and `SessionValues` for values that should _not_ affect the identity of a `@rule` seems to be a sufficient solution to the problem described on #6845. The vast majority of values consumed by `@rule`s should be computed from `Params`, so it's possible that the env/args will be the only values we ever provide via `SessionValues`: TBD.

### Result

The case described in https://github.com/pantsbuild/pants/issues/10062#issuecomment-689790026 no longer invalidates the consumers of `Subsystem`s, and in general, only the `Subsystem`s that are affected by an option change should be invalidated in memory (although: #10834).

Fixes #10062 and fixes #6845.

[ci skip-build-wheels]