### PR TITLE
Fix `setup_py.with_binaries()` to automatically inject `dependencies`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/codegen/protobuf/target_types_test.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types_test.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.backend.codegen.protobuf.target_types import (
+    InjectProtobufDependencies,
+    ProtobufDependencies,
+    ProtobufLibrary,
+)
+from pants.backend.codegen.protobuf.target_types import rules as target_type_rules
+from pants.core.target_types import Files
+from pants.engine.addresses import Address
+from pants.engine.target import InjectedDependencies
+from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.testutil.option_util import create_options_bootstrapper
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_inject_dependencies() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *target_type_rules(),
+            QueryRule(InjectedDependencies, (InjectProtobufDependencies, OptionsBootstrapper)),
+        ],
+        target_types=[ProtobufLibrary, Files],
+    )
+    # Note that injected deps can be any target type for `--protobuf-runtime-targets`.
+    rule_runner.add_to_build_file(
+        "protos",
+        dedent(
+            """\
+            protobuf_library()
+            files(name="injected_dep", sources=[])
+            """
+        ),
+    )
+    tgt = rule_runner.get_target(Address("protos"))
+    injected = rule_runner.request(
+        InjectedDependencies,
+        [
+            InjectProtobufDependencies(tgt[ProtobufDependencies]),
+            create_options_bootstrapper(
+                args=[
+                    "--backend-packages=pants.backend.codegen.protobuf.python",
+                    "--protoc-runtime-targets=protos:injected_dep",
+                ]
+            ),
+        ],
+    )
+    assert injected == InjectedDependencies([Address("protos", target_name="injected_dep")])

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -28,6 +28,7 @@ from pants.backend.python.target_types import (
     PythonRequirementsFile,
     PythonTests,
 )
+from pants.backend.python.target_types import rules as target_type_rules
 from pants.backend.python.util_rules import (
     ancestor_files,
     pex,
@@ -70,6 +71,7 @@ def rules():
         *python_native_code.rules(),
         *repl.rules(),
         *run_python_binary.rules(),
+        *target_type_rules(),
         *setup_py.rules(),
     )
 

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -131,7 +131,6 @@ def test_python_distribution_dependency_injection() -> None:
         target_types=[PythonDistribution, PythonBinary],
         objects={"setup_py": PythonArtifact},
     )
-    # Note that injected deps can be any target type for `--protobuf-runtime-targets`.
     rule_runner.add_to_build_file(
         "project",
         dedent(

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -1,21 +1,34 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from textwrap import dedent
 from typing import Optional
 
 import pytest
 from pkg_resources import Requirement
 
+from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
+    InjectPythonDistributionDependencies,
+    PythonBinary,
     PythonBinarySources,
+    PythonDistribution,
+    PythonDistributionDependencies,
     PythonRequirementsField,
     PythonTestsTimeout,
 )
+from pants.backend.python.target_types import rules as target_type_rules
 from pants.engine.addresses import Address
-from pants.engine.target import InvalidFieldException, InvalidFieldTypeException
+from pants.engine.target import (
+    InjectedDependencies,
+    InvalidFieldException,
+    InvalidFieldTypeException,
+)
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.python.python_requirement import PythonRequirement
-from pants.testutil.option_util import create_subsystem
+from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
 def test_timeout_validation() -> None:
@@ -104,3 +117,41 @@ def test_requirements_field() -> None:
         ).value
         == parsed_value
     )
+
+
+def test_python_distribution_dependency_injection() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *target_type_rules(),
+            QueryRule(
+                InjectedDependencies,
+                (InjectPythonDistributionDependencies, OptionsBootstrapper),
+            ),
+        ],
+        target_types=[PythonDistribution, PythonBinary],
+        objects={"setup_py": PythonArtifact},
+    )
+    # Note that injected deps can be any target type for `--protobuf-runtime-targets`.
+    rule_runner.add_to_build_file(
+        "project",
+        dedent(
+            """\
+            python_binary(name="my_binary")
+            python_distribution(
+                name="dist",
+                provides=setup_py(
+                    name='my-dist'
+                ).with_binaries({"my_cmd": ":my_binary"})
+            )
+            """
+        ),
+    )
+    tgt = rule_runner.get_target(Address("project", target_name="dist"))
+    injected = rule_runner.request(
+        InjectedDependencies,
+        [
+            InjectPythonDistributionDependencies(tgt[PythonDistributionDependencies]),
+            create_options_bootstrapper(),
+        ],
+    )
+    assert injected == InjectedDependencies([Address("project", target_name="my_binary")])


### PR DESCRIPTION
If you have a `python_binary` target in `setup_py().with_binaries()`, it's clear that you intend to depend on the target and for its files to be included in the result.

Right now, you must explicitly add it to the `dependencies` field too, otherwise you will have the right `setup.py` entry, but missing files.

This uses dependency injection (not inference) to automatically inject the dependencies for a `python_distribution` target. This approach is more robust than special casing in `setup_py.py`. For example, this ensures that our invalidation will work properly in all contexts, and that `./pants dependencies` includes it.

[ci skip-rust]
[ci skip-build-wheels]