### PR TITLE
Fix  --pants-ignore-warnings behavior

### DIFF
--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -11,6 +11,7 @@ from typing import Dict, Iterable, Optional, Tuple
 import pants.util.logging as pants_logging
 from pants.engine.internals.native import Native
 from pants.option.option_value_container import OptionValueContainer
+from pants.option.options import Options
 from pants.util.dirutil import safe_mkdir
 from pants.util.logging import LogLevel
 
@@ -35,8 +36,11 @@ def init_rust_logger(
 
 def setup_warning_filtering(warnings_filter_regexes: Iterable[str]) -> None:
     """Sets up regex-based ignores for messages using the Python warnings system."""
+    warnings.resetwarnings()
     for message_regexp in warnings_filter_regexes or ():
         warnings.filterwarnings(action="ignore", message=message_regexp)
+
+    Options.toggle_option_warning_suppression(False)
 
 
 class NativeHandler(StreamHandler):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -68,11 +68,11 @@ class Options:
     # This is a class-wide toggle for whether Python warnings (using the warnings module) should
     # be emitted during the options-parsing process. We want to initially set this to `True` and
     # then set it to `False` after we have done the initial options parsing.
-    suppress_warnings = True
+    _suppress_warnings = True
 
     @classmethod
     def toggle_option_warning_suppression(cls, toggle: bool) -> None:
-        cls.suppress_warnings = toggle
+        cls._suppress_warnings = toggle
 
     class FrozenOptionsError(Exception):
         """Options are frozen and can't be mutated."""
@@ -448,7 +448,7 @@ class Options:
             namespace=values_builder,
             get_all_scoped_flag_names=lambda: self._all_scoped_flag_names_for_fuzzy_matching,
             passthrough_args=self._passthru,
-            suppress_warnings=self.suppress_warnings,
+            suppress_warnings=self._suppress_warnings,
         )
 
         values = self._parser_hierarchy.get_parser_by_scope(scope).parse_args(parse_args_request)

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1138,6 +1138,7 @@ class OptionsTest(unittest.TestCase):
             env: Optional[Dict[str, str]] = None,
             config: Optional[Dict[str, Dict[str, str]]] = None,
         ) -> None:
+            Options.toggle_option_warning_suppression(False)
             warnings.simplefilter("always")
             with pytest.warns(DeprecationWarning) as record:
                 options = self._parse(flags=flags, env=env, config=config)
@@ -1211,6 +1212,7 @@ class OptionsTest(unittest.TestCase):
 
     @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))
     def test_delayed_deprecated_option(self) -> None:
+        Options.toggle_option_warning_suppression(False)
         warnings.simplefilter("always")
         with pytest.warns(None) as record:
             delayed_deprecation_option_value = (

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -345,9 +345,10 @@ class Parser:
                     f"Error computing value for {args_str} in {self._scope_str()} (may also be from PANTS_* environment variables).\nCaused by:\n{traceback.format_exc()}"
                 )
 
-            # If the option is explicitly given, check deprecation and mutual exclusion.
+            # If the option is explicitly given, check deprecation (unless suppressed) and mutual exclusion.
+
+            print_warning = parse_args_request.suppress_warnings is False
             if val.rank > Rank.HARDCODED:
-                print_warning = not parse_args_request.suppress_warnings
                 self._check_deprecated(dest, kwargs, print_warning=print_warning)
 
                 mutex_dest = kwargs.get("mutually_exclusive_group")

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -226,6 +226,7 @@ class Parser:
         namespace: OptionValueContainerBuilder
         get_all_scoped_flag_names: FlagNameProvider
         passthrough_args: List[str]
+        suppress_warnings: bool
 
         def __init__(
             self,
@@ -233,6 +234,7 @@ class Parser:
             namespace: OptionValueContainerBuilder,
             get_all_scoped_flag_names: FlagNameProvider,
             passthrough_args: List[str],
+            suppress_warnings: bool = False,
         ) -> None:
             """
             :param flags_in_scope: Iterable of arg strings to parse into flag values.
@@ -246,6 +248,7 @@ class Parser:
             self.namespace = namespace
             self.get_all_scoped_flag_names = get_all_scoped_flag_names
             self.passthrough_args = passthrough_args
+            self.suppress_warnings = suppress_warnings
 
         @staticmethod
         def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, List[Optional[str]]]:
@@ -344,7 +347,8 @@ class Parser:
 
             # If the option is explicitly given, check deprecation and mutual exclusion.
             if val.rank > Rank.HARDCODED:
-                self._check_deprecated(dest, kwargs)
+                print_warning = not parse_args_request.suppress_warnings
+                self._check_deprecated(dest, kwargs, print_warning=print_warning)
 
                 mutex_dest = kwargs.get("mutually_exclusive_group")
                 if mutex_dest:


### PR DESCRIPTION
### Problem

cf. https://github.com/pantsbuild/pants/issues/9938 , the infrastructure for ignoring warnings with the `--pants-ignore-warnings` option is broken in the pantsd case, not correctly filtering warnings that are triggered in options initialization code (and also printing multiple instances of the same warning, regardless of whether or not pantsd is running). 

### Solution

The root cause of these problems are that the ignore filters set up by `--pants-ignore-warnings` can only be configured after bootstrap option parsing has already happened, so any warnings set up before this will be printed. It's also necessary to make sure that *after* `setup_warning_filtering` has been called with the bootstrap options, options are parsed again in order to have warnings there have a chance to either be emitted or filtered.

This commit adds a novel class level option `suppress_warnings` to the `Option` class, which controls whether or not warnings are emitted via the `print_warning` flag on the `_check_deprecated` method that already existed. This option is initially set to `True` when the `Options` class is created in the Python runtime, and then toggled to off by `setup_warning_filtering`. This gets the correct behavior in the no-pantsd case.

In the pantsd case, it is additionally necessary to make sure that `setup_warning_filtering` is called again (and the warning filterings reset) in the `pants_daemon_core.py` code that triggers reinitialization when pantsd's options change (since one of the options that has changed might well be `--pants-ignore-warnings`).
