### PR TITLE
Deprecate `--interpreter-constraints` option where it no-ops

### DIFF
--- a/src/python/pants/backend/awslambda/python/lambdex.py
+++ b/src/python/pants/backend/awslambda/python/lambdex.py
@@ -12,5 +12,6 @@ class Lambdex(PythonToolBase):
     # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
     # https://github.com/wickman/lambdex/issues/6 fixed.
     default_extra_requirements = ["setuptools>=50.3.0,<50.4"]
+    register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.5"]
     default_entry_point = "lambdex.bin.lambdex"

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -98,6 +98,7 @@ class CoverageSubsystem(PythonToolBase):
     options_scope = "coverage-py"
     default_version = "coverage>=5.0.3,<5.1"
     default_entry_point = "coverage"
+    register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
 
     @classmethod

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -68,10 +68,7 @@ async def bandit_lint_partition(
             output_filename="bandit.pex",
             internal_only=True,
             requirements=PexRequirements(bandit.all_requirements),
-            interpreter_constraints=(
-                partition.interpreter_constraints
-                or PexInterpreterConstraints(bandit.interpreter_constraints)
-            ),
+            interpreter_constraints=partition.interpreter_constraints,
             entry_point=bandit.entry_point,
         ),
     )

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -15,7 +15,6 @@ class Bandit(PythonToolBase):
     # `setuptools<45` is for Python 2 support. `stevedore` is because the 3.0 release breaks Bandit.
     default_extra_requirements = ["setuptools<45", "stevedore<3"]
     default_entry_point = "bandit"
-    default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.5"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -14,6 +14,7 @@ class Black(PythonToolBase):
     default_version = "black==20.8b1"
     default_extra_requirements = ["setuptools"]
     default_entry_point = "black:patched_main"
+    register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
 
     @classmethod

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -13,6 +13,8 @@ class Docformatter(PythonToolBase):
     options_scope = "docformatter"
     default_version = "docformatter>=1.3.1,<1.4"
     default_entry_point = "docformatter:main"
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython==2.7.*", "CPython>=3.4,<3.9"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -68,10 +68,7 @@ async def flake8_lint_partition(
             output_filename="flake8.pex",
             internal_only=True,
             requirements=PexRequirements(flake8.all_requirements),
-            interpreter_constraints=(
-                partition.interpreter_constraints
-                or PexInterpreterConstraints(flake8.interpreter_constraints)
-            ),
+            interpreter_constraints=partition.interpreter_constraints,
             entry_point=flake8.entry_point,
         ),
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -14,7 +14,6 @@ class Flake8(PythonToolBase):
     default_version = "flake8>=3.7.9,<3.9"
     default_extra_requirements = ["setuptools<45"]  # NB: `<45` is for Python 2 support
     default_entry_point = "flake8"
-    default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -13,6 +13,7 @@ class Isort(PythonToolBase):
     options_scope = "isort"
     default_version = "isort[pyproject]>=5.5.1,<5.6"
     default_extra_requirements = ["setuptools"]
+    register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.6"]
     default_entry_point = "isort.main"
 

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -14,7 +14,6 @@ class Pylint(PythonToolBase):
     options_scope = "pylint"
     default_version = "pylint>=2.4.4,<2.5"
     default_entry_point = "pylint"
-    default_interpreter_constraints = ["CPython>=3.5"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -1,8 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List
-
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 
@@ -11,9 +9,7 @@ class IPython(PythonToolBase):
 
     options_scope = "ipython"
     default_version = "ipython==7.16.1"  # The last version to support Python 3.6.
-    default_extra_requirements: List[str] = []
     default_entry_point = "IPython:start_ipython"
-    default_interpreter_constraints = ["CPython>=3.6"]
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional, Sequence, Tuple, cast
+from typing import ClassVar, Optional, Sequence, Tuple, cast
 
 from pants.option.subsystem import Subsystem
 
@@ -10,11 +10,12 @@ class PythonToolBase(Subsystem):
     """Base class for subsystems that configure a python tool to be invoked out-of-process."""
 
     # Subclasses must set.
-    default_version: Optional[str] = None
-    default_entry_point: Optional[str] = None
+    default_version: ClassVar[Optional[str]] = None
+    default_entry_point: ClassVar[Optional[str]] = None
     # Subclasses do not need to override.
-    default_extra_requirements: Sequence[str] = []
-    default_interpreter_constraints: Sequence[str] = []
+    default_extra_requirements: ClassVar[Sequence[str]] = []
+    default_interpreter_constraints: ClassVar[Sequence[str]] = []
+    register_interpreter_constraints: ClassVar[bool] = False
 
     @classmethod
     def register_options(cls, register):
@@ -37,14 +38,6 @@ class PythonToolBase(Subsystem):
             "a certain version.",
         )
         register(
-            "--interpreter-constraints",
-            type=list,
-            advanced=True,
-            default=cls.default_interpreter_constraints,
-            help="Python interpreter constraints for this tool. An empty list uses the default "
-            "interpreter constraints for the repo.",
-        )
-        register(
             "--entry-point",
             type=str,
             advanced=True,
@@ -53,6 +46,40 @@ class PythonToolBase(Subsystem):
             "must provide it explicitly on invocation, or it can use the tool as a "
             "library, invoked by a wrapper script.",
         )
+
+        if cls.default_interpreter_constraints and not cls.register_interpreter_constraints:
+            raise ValueError(
+                f"`default_interpreter_constraints` are configured for `{cls.options_scope}`, but "
+                "`register_interpreter_constraints` is not set to `True`, so the "
+                "`--interpreter-constraints` option will not be registered. Did you mean to set "
+                "this?"
+            )
+        interpreter_constraints_help = (
+            "Python interpreter constraints for this tool. An empty list uses the default "
+            "interpreter constraints for the repo."
+        )
+        if cls.register_interpreter_constraints:
+            register(
+                "--interpreter-constraints",
+                type=list,
+                advanced=True,
+                default=cls.default_interpreter_constraints,
+                help=interpreter_constraints_help,
+            )
+        else:
+            register(
+                "--interpreter-constraints",
+                type=list,
+                advanced=True,
+                default=[],
+                help=interpreter_constraints_help,
+                removal_version="2.1.0.dev0",
+                removal_hint=(
+                    "This option no longer does anything, as Pants auto-configures the interpreter "
+                    f"constraints for {cls.options_scope} based on your code's interpreter "
+                    "constraints."
+                ),
+            )
 
     @property
     def version(self) -> Optional[str]:

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -12,3 +12,5 @@ class Setuptools(PythonToolBase):
     options_scope = "setuptools"
     default_version = "setuptools>=50.3.0,<50.4"
     default_extra_requirements = ["wheel==0.35.1"]
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython>=3.5"]

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -224,8 +224,7 @@ class PythonBinary(Target):
     """A Python target that can be converted into an executable PEX file.
 
     PEX files are self-contained executable files that contain a complete Python environment capable
-    of running the target. For more information about PEX files, see
-    https://www.pantsbuild.org/docs/pex-files.
+    of running the target. For more information, see https://www.pantsbuild.org/docs/pex-files.
     """
 
     alias = "python_binary"

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -15,6 +15,7 @@ class MyPy(PythonToolBase):
     default_version = "mypy==0.782"
     default_entry_point = "mypy"
     # See `mypy/rules.py`. We only use these default constraints in some situations.
+    register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.5"]
 
     @classmethod


### PR DESCRIPTION
There are several places now where `--interpreter-constraints` is never used, or it's exceedingly rare to be used so it's misleading to have as an option.

This also fixes Pylint to ensure that no matter what, the tool Pex uses the same constraints as the requirements Pex. It looks like this was happening in practice, but it's important to enforce to avoid a Pex runtime error about "Missing Wheels".

Finally, this fixes `setuptools` to have default constraints, which it needs.

[ci skip-build-wheels]
[ci skip-rust]