### PR TITLE
Better Ctrl-C handling in the `test --debug` case

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -315,7 +315,9 @@ async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
     if field_set.is_conftest():
         return TestDebugRequest(None)
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
-    return TestDebugRequest(InteractiveProcess.from_process(setup.process))
+    return TestDebugRequest(
+        InteractiveProcess.from_process(setup.process, forward_signals_to_process=False)
+    )
 
 
 def rules():

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -12,6 +12,7 @@ import traceback
 from contextlib import contextmanager
 from typing import Callable, Dict, Iterator, Optional
 
+import psutil
 import setproctitle
 
 from pants.util.dirutil import safe_mkdir, safe_open
@@ -59,6 +60,12 @@ class SignalHandler:
                 self._ignoring_sigint = toggle
 
     def handle_sigint(self, signum: int, _frame):
+        self_process = psutil.Process()
+        children = self_process.children()
+        logger.debug(f"Sending SIGINT to child processes: {children}")
+        for child_process in children:
+            child_process.send_signal(signal.SIGINT)
+
         ExceptionSink._signal_sent = signum
         raise KeyboardInterrupt("User interrupted execution with control-c!")
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -266,6 +266,7 @@ class InteractiveProcess:
     input_digest: Digest
     run_in_workspace: bool
     hermetic_env: bool
+    forward_signals_to_process: bool
 
     def __init__(
         self,
@@ -275,6 +276,7 @@ class InteractiveProcess:
         input_digest: Digest = EMPTY_DIGEST,
         run_in_workspace: bool = False,
         hermetic_env: bool = True,
+        forward_signals_to_process: bool = True,
     ) -> None:
         """Request to run a subprocess in the foreground, similar to subprocess.run().
 
@@ -282,12 +284,17 @@ class InteractiveProcess:
 
         To run the process, request `InteractiveRunner` in a `@goal_rule`, then use
         `interactive_runner.run()`.
+
+        `forward_signals_to_process` controls whether pants will allow a SIGINT signal
+        sent to a process by hitting Ctrl-C in the terminal to actually reach the process,
+        or capture that signal itself, blocking it from the process.
         """
         self.argv = tuple(argv)
         self.env = FrozenDict(env or {})
         self.input_digest = input_digest
         self.run_in_workspace = run_in_workspace
         self.hermetic_env = hermetic_env
+        self.forward_signals_to_process = forward_signals_to_process
         self.__post_init__()
 
     def __post_init__(self):
@@ -298,12 +305,15 @@ class InteractiveProcess:
             )
 
     @classmethod
-    def from_process(cls, process: Process, *, hermetic_env: bool = True) -> "InteractiveProcess":
+    def from_process(
+        cls, process: Process, *, hermetic_env: bool = True, forward_signals_to_process: bool = True
+    ) -> "InteractiveProcess":
         return InteractiveProcess(
             argv=process.argv,
             env=process.env,
             input_digest=process.input_digest,
             hermetic_env=hermetic_env,
+            forward_signals_to_process=forward_signals_to_process,
         )
 
 
@@ -313,8 +323,11 @@ class InteractiveRunner:
     _scheduler: "SchedulerSession"
 
     def run(self, request: InteractiveProcess) -> InteractiveProcessResult:
-        with ExceptionSink.ignoring_sigint():
-            return self._scheduler.run_local_interactive_process(request)
+        if request.forward_signals_to_process:
+            with ExceptionSink.ignoring_sigint():
+                return self._scheduler.run_local_interactive_process(request)
+
+        return self._scheduler.run_local_interactive_process(request)
 
 
 @frozen_after_init


### PR DESCRIPTION
### Problem
 
Currently when a user hits Ctrl-C while running the `test` goal with the `--debug` flag (which runs test runner process(es) such as `pytest` foregrounded in the terminal using the `InteractiveProcess` mechanism), pants ends up not cleanly exiting the current test runner process, which continues to run in the background. This is due to two slightly-different problems, depending on whether or not pantsd is running. 

If pantsd is not running, then pants successfully ignores the SIGINT signal sent by a terminal Ctrl-C, and forwards that signal to the test process. This is fine if there is exactly one test process being run by the `test` goal; the test runner process will receive the SIGINT, respond to it (in the case of pytest and probably any other reasonable test runner, by exiting), and that is that. However, if there is more than one test source file associated with a test target, or if more than one test target is specified, another test runner subprocess will be started. It is therefore necessary to keep hitting Ctrl-C until all the test runner subprocesses have been manually killed.

If pantsd is running, then pants fails to ignore the SIGINT signal, captures it, and exits, without doing anything to the test runner process, which `InteractiveProcess` has spawned as a separate child process. So, the test runner process continues to run and print data to the terminal until it is finished.

### Solution

In order to fix the no-pantsd case, we add a new flag `forward_signals_to_process` to the `InteractiveProcess` dataclass to make it possible for clients of `InteractiveProcess` to toggle the signal-capturing behavior. We set this flag to False when running debug-mode tests, and leave it as True for other uses of `InteractiveProcess` such as `run` and `repl`, where we do want the subprocess pants is running to handle SIGINT.

In order to fix the pantsd case, we also add logic that sends a SIGINT signal to any subprocesses of pants, when pantsd handles a signal and is shutting down.

### Result

Hitting Ctrl-C when running `test --debug` cleanly exits the running process and gets back to a working terminal.