### PR TITLE
Refactor `core/util_rules/archive.py` to use `BinaryPaths`

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -2,11 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Tuple
 
-from pants.engine.fs import Digest, RemovePrefix, Snapshot
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.process import (
+    BinaryNotFoundError,
+    BinaryPath,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+    Process,
+    ProcessResult,
+)
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.logging import LogLevel
 
 
@@ -28,38 +36,83 @@ class ExtractedDigest:
     digest: Digest
 
 
-def get_extraction_cmd(archive_path: str, output_dir: str) -> Optional[Tuple[str, ...]]:
-    """Returns a shell command to run to extract the archive to the output directory."""
-    # Note that we assume that mkdir, unzip, and tar exist in the executing environment.
-    if archive_path.endswith(".zip"):
-        return ("unzip", "-q", archive_path, "-d", output_dir)
-    elif archive_path.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz")):
-        return ("mkdir", output_dir, "&&", "tar", "xf", archive_path, "-C", output_dir)
-    return None
+# TODO: Should this be configurable?
+SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
+
+
+class UnzipBinary(BinaryPath):
+    def extract_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
+        # Note that the `output_dir` does not need to already exist. The caller should also
+        # validate that it's a valid `.zip` file.
+        return (self.path, "-q", archive_path, "-d", output_dir)
 
 
 @rule(level=LogLevel.DEBUG)
-async def maybe_extract(extractable: MaybeExtractable) -> ExtractedDigest:
+async def find_unzip() -> UnzipBinary:
+    request = BinaryPathRequest(
+        binary_name="unzip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path
+    if not first_path:
+        raise BinaryNotFoundError(request, rationale="download the tools Pants needs to run")
+    return UnzipBinary(first_path.path, first_path.fingerprint)
+
+
+class TarBinary(BinaryPath):
+    def extract_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
+        # Note that the `output_dir` must already exist. The caller should also
+        # validate that it's a valid `.tar` file.
+        return (self.path, "xf", archive_path, "-C", output_dir)
+
+
+@rule(level=LogLevel.DEBUG)
+async def find_tar() -> TarBinary:
+    request = BinaryPathRequest(
+        binary_name="tar", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["--version"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path
+    if not first_path:
+        raise BinaryNotFoundError(request, rationale="download the tools Pants needs to run")
+    return TarBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(level=LogLevel.DEBUG)
+async def maybe_extract(
+    extractable: MaybeExtractable, tar_binary: TarBinary, unzip_binary: UnzipBinary
+) -> ExtractedDigest:
     """If digest contains a single archive file, extract it, otherwise return the input digest."""
-    digest = extractable.digest
-    snapshot = await Get(Snapshot, Digest, digest)
-    if len(snapshot.files) == 1:
-        output_dir = "out/"
-        extraction_cmd = get_extraction_cmd(snapshot.files[0], output_dir)
-        if extraction_cmd:
-            extraction_cmd_str = " ".join(extraction_cmd)
-            proc = Process(
-                argv=("/bin/bash", "-c", f"{extraction_cmd_str}"),
-                input_digest=digest,
-                description=f"Extract {snapshot.files[0]}",
-                level=LogLevel.DEBUG,
-                env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
-                output_directories=(output_dir,),
-            )
-            result = await Get(ProcessResult, Process, proc)
-            strip_output_dir = await Get(Digest, RemovePrefix(result.output_digest, output_dir))
-            return ExtractedDigest(strip_output_dir)
-    return ExtractedDigest(digest)
+    extractable_digest = extractable.digest
+    output_dir = "out/"
+    snapshot, output_dir_digest = await MultiGet(
+        Get(Snapshot, Digest, extractable_digest),
+        Get(Digest, CreateDigest([Directory(output_dir)])),
+    )
+    if len(snapshot.files) != 1:
+        return ExtractedDigest(extractable_digest)
+
+    input_digest = await Get(Digest, MergeDigests((extractable_digest, output_dir_digest)))
+    fp = snapshot.files[0]
+    if fp.endswith(".zip"):
+        argv = unzip_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+    elif fp.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz")):
+        argv = tar_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+    else:
+        return ExtractedDigest(extractable_digest)
+
+    result = await Get(
+        ProcessResult,
+        Process(
+            argv=argv,
+            input_digest=input_digest,
+            description=f"Extract {fp}",
+            level=LogLevel.DEBUG,
+            output_directories=(output_dir,),
+        ),
+    )
+    strip_output_dir = await Get(Digest, RemovePrefix(result.output_digest, output_dir))
+    return ExtractedDigest(strip_output_dir)
 
 
 def rules():

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -100,7 +101,7 @@ async def maybe_extract(
     elif fp.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz")):
         argv = tar_binary.extract_argv(archive_path=fp, output_dir=output_dir)
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
-        env = {"PATH": SEARCH_PATHS}
+        env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
     else:
         return ExtractedDigest(extractable_digest)
 

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -96,8 +96,11 @@ async def maybe_extract(
     fp = snapshot.files[0]
     if fp.endswith(".zip"):
         argv = unzip_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+        env = {}
     elif fp.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz")):
         argv = tar_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+        # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
+        env = {"PATH": SEARCH_PATHS}
     else:
         return ExtractedDigest(extractable_digest)
 
@@ -105,6 +108,7 @@ async def maybe_extract(
         ProcessResult,
         Process(
             argv=argv,
+            env=env,
             input_digest=input_digest,
             description=f"Extract {fp}",
             level=LogLevel.DEBUG,


### PR DESCRIPTION
At the time this code was added, we didn't have `BinaryPaths`. This change brings a couple improvements:

* We now use `CreateDigest` to create the empty directory, rather than `mkdir`.
* We no longer require `/bin/bash` existing.
* We use tests to verify that each binary is valid, e.g. not malicious, by running `--version`.
* The cache will be invalidated if the programs change.
    * Almost certainly, the output digest will still be the same, so downstream rules would not need to rerun. 
* We run via absolute paths, which is important for compliance with the RE spec.

This also unblocks some MyPy work, where we need to unzip a Pex.

[ci skip-build-wheels]
[ci skip-rust]

