### PR TITLE
Prepare 1.30.1

### DIFF
--- a/src/python/pants/notes/1.30.x.rst
+++ b/src/python/pants/notes/1.30.x.rst
@@ -5,6 +5,11 @@ This document describes releases leading up to the ``1.30.x`` ``stable`` series.
 
 See https://www.pantsbuild.org/v1.30/docs/release-notes-1-30 for an overview of the changes in this release.
 
+1.30.1 (9/23/2020)
+------------------
+
+The second stable release of the ``1.30.x`` series, with no changes since the previous release candidate.
+
 1.30.1rc2 (9/14/2020)
 ---------------------
 


### PR DESCRIPTION
We will have a 1.30.2 series with backports and bugfixes to help users upgrade to 2.0. But we want to check in this stable release instead of continually pushing it off.