### PR TITLE
Backport `--test-extra-env-vars` feature (from #10715)

### DIFF
--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -26,6 +26,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/python',
     'src/python/pants/source:source',
+    'src/python/pants/util:frozendict',
     'src/python/pants/util:logging',
     'src/python/pants/util:meta',
     'src/python/pants/util:memo',

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -21,6 +21,7 @@ from pants.core.util_rules import (
     distdir,
     external_tool,
     filter_empty_sources,
+    pants_environment,
     strip_source_roots,
 )
 from pants.source import source_root
@@ -42,6 +43,7 @@ def rules():
         *strip_source_roots.rules(),
         *archive.rules(),
         *external_tool.rules(),
+        *pants_environment.rules(),
         *source_root.rules(),
     ]
 

--- a/src/python/pants/core/util_rules/pants_environment.py
+++ b/src/python/pants/core/util_rules/pants_environment.py
@@ -1,0 +1,85 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, Sequence
+
+from pants.engine.rules import RootRule
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+
+logger = logging.getLogger(__name__)
+
+name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
+shorthand_re = re.compile(r"([A-Za-z_]\w*)")
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class PantsEnvironment:
+    """PantsEnvironment is a representation of the environment variables the currently-executing
+    pants process was invoked with.
+
+    Since the exact contents of the environment are very specific to a given invocation of pants,
+    this type is marked as side-effecting, and can only be requested as an input to an uncacheable
+    rule. An uncacheable rule should accept this type as an input, and use `get_subset` to filter
+    the environment rules down to only the ones other rules care about as inputs, in order to avoid
+    a lot of cache invalidation if the environment changes spuriously.
+    """
+
+    env: FrozenDict[str, str]
+
+    def __init__(self, env: Optional[Mapping[str, str]] = None):
+        """Initialize a `PantsEnvironment` with the current contents of the environment.
+
+        Explicitly specify the env argument to create a mock environment for testing.
+        """
+
+        self.env = FrozenDict(env if env else os.environ)
+
+    def get_subset(
+        self, requested: Sequence[str], allowed: Optional[Sequence[str]] = None
+    ) -> FrozenDict[str, str]:
+        """Extract a subset of named env vars.
+
+        Given a list of extra environment variable specifiers as strings, filter the contents of
+        the pants environment to only those variables.
+
+        Each variable can be specified either as a name or as a name=value pair.
+        In the former case, the value for that name is taken from this env. In the latter
+        case the specified value overrides the value in this env.
+
+        If `allowed` is specified, variable names must be in that list, or an error will be raised.
+        """
+        allowed_set = None if allowed is None else set(allowed)
+        env_var_subset: Dict[str, str] = {}
+
+        def check_and_set(name: str, value: Optional[str]):
+            if allowed_set is not None and name not in allowed_set:
+                raise ValueError(
+                    f"{name} is not in the list of variable names that are allowed to be set. "
+                    f"Must be one of {','.join(sorted(allowed_set))}."
+                )
+            if value is not None:
+                env_var_subset[name] = value
+
+        for env_var in requested:
+            name_value_match = name_value_re.match(env_var)
+            if name_value_match:
+                check_and_set(name_value_match[1], name_value_match[2])
+            elif shorthand_re.match(env_var):
+                check_and_set(env_var, self.env.get(env_var))
+            else:
+                raise ValueError(
+                    f"An invalid variable was requested via the --test-extra-env-var "
+                    f"mechanism: {env_var}"
+                )
+
+        return FrozenDict(env_var_subset)
+
+
+def rules():
+    return [RootRule(PantsEnvironment)]

--- a/src/python/pants/core/util_rules/pants_environment_test.py
+++ b/src/python/pants/core/util_rules/pants_environment_test.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Dict, List
+
+import pytest
+
+from pants.core.util_rules.pants_environment import PantsEnvironment
+
+
+@pytest.mark.parametrize(
+    "input_strs, expected",
+    [
+        # Test explicit variable and variable read from Pants' enivronment.
+        (["A=unrelated", "B"], {"A": "unrelated", "B": "b"}),
+        # Test multi-word string.
+        (["A=unrelated", "C=multi word"], {"A": "unrelated", "C": "multi word"}),
+        # Test emtpy string.
+        (["A="], {"A": ""}),
+        # Test string with " literal.
+        (['A=has a " in it'], {"A": 'has a " in it'}),
+    ],
+)
+def test_pants_environment(input_strs: List[str], expected: Dict[str, str]) -> None:
+    pants_env = PantsEnvironment({"A": "a", "B": "b", "C": "c"})
+
+    subset = pants_env.get_subset(input_strs)
+    assert dict(subset) == expected
+
+
+def test_invalid_variable() -> None:
+    pants_env = PantsEnvironment()
+
+    with pytest.raises(ValueError) as exc:
+        pants_env.get_subset(["3INVALID=doesn't matter"])
+    assert (
+        "An invalid variable was requested via the --test-extra-env-var mechanism: 3INVALID"
+        in str(exc)
+    )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -22,6 +22,7 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.remote_sources import RemoteSources
 from pants.build_graph.target import Target as TargetV1
+from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine import interactive_process, process, target
 from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
@@ -231,6 +232,7 @@ class LegacyGraphSession:
 
         workspace = Workspace(self.scheduler_session)
         interactive_runner = InteractiveRunner(self.scheduler_session)
+        pants_environment = PantsEnvironment()
 
         for goal in goals:
             goal_product = self.goal_map[goal]
@@ -249,6 +251,7 @@ class LegacyGraphSession:
                 self.console,
                 workspace,
                 interactive_runner,
+                pants_environment,
             )
             logger.debug(f"requesting {goal_product} to satisfy execution of `{goal}` goal")
             try:


### PR DESCRIPTION
From https://github.com/pantsbuild/pants/pull/10715.

This feature is necessary, understandably, for some users to switch to the v2 test runner. By backporting, we make it a little easier to upgrade from 1.30 to 2.0.

This is not as robust as the 2.0 implementation: we do not have `@_uncachable_rule`, so this is treated like a normal rule. This means that with Pantsd, we won't pick up changes to your environment. You must restart Pantsd (or not use Pantsd).