### PR TITLE
Fix --pants-ignore-warnings behavior

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import warnings
 from dataclasses import dataclass
 from typing import List, Mapping
 
@@ -62,8 +63,9 @@ class PantsRunner:
         options_bootstrapper = OptionsBootstrapper.create(
             env=self.env, args=self.args, allow_pantsrc=True
         )
-        bootstrap_options = options_bootstrapper.bootstrap_options
-        global_bootstrap_options = bootstrap_options.for_global_scope()
+        with warnings.catch_warnings(record=True):
+            bootstrap_options = options_bootstrapper.bootstrap_options
+            global_bootstrap_options = bootstrap_options.for_global_scope()
 
         # Initialize the workdir early enough to ensure that logging has a destination.
         workdir_src = init_workdir(global_bootstrap_options)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -35,6 +35,8 @@ def init_rust_logger(
 
 def setup_warning_filtering(warnings_filter_regexes: Iterable[str]) -> None:
     """Sets up regex-based ignores for messages using the Python warnings system."""
+
+    warnings.resetwarnings()
     for message_regexp in warnings_filter_regexes or ():
         warnings.filterwarnings(action="ignore", message=message_regexp)
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import time
+import warnings
 from contextlib import contextmanager
 from typing import Any, Iterator
 
@@ -45,8 +46,9 @@ class PantsDaemon(PantsDaemonProcessManager):
     @classmethod
     def create(cls, options_bootstrapper: OptionsBootstrapper) -> "PantsDaemon":
 
-        bootstrap_options = options_bootstrapper.bootstrap_options
-        bootstrap_options_values = bootstrap_options.for_global_scope()
+        with warnings.catch_warnings(record=True):
+            bootstrap_options = options_bootstrapper.bootstrap_options
+            bootstrap_options_values = bootstrap_options.for_global_scope()
 
         setup_warning_filtering(bootstrap_options_values.ignore_pants_warnings or [])
 

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.init.logging import setup_warning_filtering
 import logging
 import threading
 from typing import Optional
@@ -9,6 +8,7 @@ from typing import Optional
 from typing_extensions import Protocol
 
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
+from pants.init.logging import setup_warning_filtering
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.init.logging import setup_warning_filtering
 import logging
 import threading
 from typing import Optional
@@ -76,6 +77,8 @@ class PantsDaemonCore:
             build_config = BuildConfigInitializer.get(options_bootstrapper)
             self._scheduler = EngineInitializer.setup_graph(options_bootstrapper, build_config)
             bootstrap_options_values = options_bootstrapper.bootstrap_options.for_global_scope()
+            setup_warning_filtering(bootstrap_options_values.ignore_pants_warnings or [])
+
             self._services = self._services_constructor(bootstrap_options_values, self._scheduler)
             self._fingerprint = options_fingerprint
             logger.info("pantsd initialized.")


### PR DESCRIPTION
### Problem

cf. https://github.com/pantsbuild/pants/issues/9938 , the infrastructure for ignoring warnings with the `--pants-ignore-warnings` option is broken in the pantsd case, not correctly filtering warnings that are triggered in options initialization code (and also printing multiple instances of the same warning, regardless of whether or not pantsd is running). 

### Solution

The root cause of these problems are that the ignore filters set up by `--pants-ignore-warnings` can only be configured after bootstrap option parsing has already happened, so any warnings set up before this are currently being printed. This commit makes use of the `warnings.catch_warnings` context manager, which suppresses warning messages within the context, to temporarily suppress the unwanted emissions of warning message before `setup_warning_filtering` is called. Additionally it is necessary to add a call to `setup_warning_filtering`, which has been modified to reset warning filters before (re)configuring them, in the pantsd core code. This commit also removes the no-longer-used `ensure_stderr` option from `warn_or_error`.