### PR TITLE
Change Display impl of Key

### DIFF
--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -209,7 +209,7 @@ impl hash::Hash for Key {
 
 impl fmt::Display for Key {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", externs::type_to_str(self.type_id))
+    write!(f, "{}", externs::key_to_str(self))
   }
 }
 


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/10665 , the `Display` implementation for `Key` was changed from printing the Python `__repr__` of the Python object contained within that `Key`, to just printing the name of the Python type. This is undesirable, since there are cases where we do want to be able to log a ` Key` and get more information about the underlying Python object than just its type. This commit restores the use of `key_to_str` instead of `key_to_type`.