### PR TITLE
work around trailing slash issue with protobuf codegen

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -85,7 +85,7 @@ async def maybe_extract(
 ) -> ExtractedDigest:
     """If digest contains a single archive file, extract it, otherwise return the input digest."""
     extractable_digest = extractable.digest
-    output_dir = "out/"
+    output_dir = "out"
     snapshot, output_dir_digest = await MultiGet(
         Get(Snapshot, Digest, extractable_digest),
         Get(Digest, CreateDigest([Directory(output_dir)])),


### PR DESCRIPTION
### Problem

See https://github.com/pantsbuild/pants/issues/10802 for an issue with protobuf generation and remote execution. As it turns out, sending the output directory as `out/` with a trailing slash caused BuildBarn to generate a Directory proto with a empty directory name in it.

The trailing slash is forbidden by the REAPI spec in any event: https://github.com/bazelbuild/remote-apis/blob/f54876595da9f2c2d66c98c318d00b60fd64900b/build/bazel/remote/execution/v2/remote_execution.proto#L507-L508

### Solution

This solution is just a short-term work around. A better fix would provide better validation of REAPI requests.

### Result

The example-python repository is buildable in remote execution with BuildBarn.