### PR TITLE
Validate the names of directory children, and normalize output directory/file names

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -745,7 +745,6 @@ version = "0.0.1"
 dependencies = [
  "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "derivative 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2823,6 +2822,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
  "hashing 0.0.1",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
 ]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 bytes = "0.4.5"
-derivative = "2.1.1"
 dirs = "1"
 futures = "0.3"
 glob = "0.2.11"

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -33,9 +33,6 @@ mod glob_matching_tests;
 #[cfg(test)]
 mod posixfs_tests;
 
-#[macro_use]
-extern crate derivative;
-
 pub use crate::glob_matching::{
   ExpandablePathGlobs, GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB,
   SINGLE_STAR_GLOB,
@@ -43,6 +40,7 @@ pub use crate::glob_matching::{
 
 use std::cmp::min;
 use std::io::{self, Read};
+use std::ops::Deref;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -89,8 +87,7 @@ pub fn default_config_path() -> PathBuf {
   config_path.join("pants")
 }
 
-#[derive(Derivative, Clone, Debug, Eq)]
-#[derivative(PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct RelativePath(PathBuf);
 
 impl RelativePath {
@@ -133,15 +130,23 @@ impl RelativePath {
   }
 }
 
+impl Deref for RelativePath {
+  type Target = PathBuf;
+
+  fn deref(&self) -> &PathBuf {
+    &self.0
+  }
+}
+
 impl AsRef<Path> for RelativePath {
   fn as_ref(&self) -> &Path {
     self.0.as_path()
   }
 }
 
-impl Into<PathBuf> for RelativePath {
-  fn into(self) -> PathBuf {
-    self.0
+impl From<RelativePath> for PathBuf {
+  fn from(p: RelativePath) -> Self {
+    p.0
   }
 }
 

--- a/src/rust/engine/fs/src/tests.rs
+++ b/src/rust/engine/fs/src/tests.rs
@@ -16,3 +16,8 @@ fn relative_path_err() {
   assert!(RelativePath::new("../a").is_err());
   assert!(RelativePath::new("/a").is_err());
 }
+
+#[test]
+fn relative_path_normalize() {
+  assert_eq!(Some("a"), RelativePath::new("a/").unwrap().to_str());
+}

--- a/src/rust/engine/process_execution/bazel_protos/src/verification.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/verification.rs
@@ -1,16 +1,22 @@
 use crate::remote_execution;
 
+use hashing::Digest;
 use std::collections::HashSet;
 
-pub fn verify_directory_canonical(directory: &remote_execution::Directory) -> Result<(), String> {
+pub fn verify_directory_canonical(
+  digest: Digest,
+  directory: &remote_execution::Directory,
+) -> Result<(), String> {
   verify_no_unknown_fields(directory)?;
-  verify_nodes(directory.get_files(), |n| n.get_name(), |n| n.get_digest())?;
+  verify_nodes(directory.get_files(), |n| n.get_name(), |n| n.get_digest())
+    .map_err(|e| format!("Invalid file in {:?}: {}", digest, e))?;
   verify_nodes(
     directory.get_directories(),
     |n| n.get_name(),
     |n| n.get_digest(),
-  )?;
-  let file_names: HashSet<&str> = directory
+  )
+  .map_err(|e| format!("Invalid directory in {:?}: {}", digest, e))?;
+  let child_names: HashSet<&str> = directory
     .get_files()
     .iter()
     .map(remote_execution::FileNode::get_name)
@@ -21,10 +27,10 @@ pub fn verify_directory_canonical(directory: &remote_execution::Directory) -> Re
         .map(remote_execution::DirectoryNode::get_name),
     )
     .collect();
-  if file_names.len() != directory.get_files().len() + directory.get_directories().len() {
+  if child_names.len() != directory.get_files().len() + directory.get_directories().len() {
     return Err(format!(
-      "Children must be unique, but a path was both a file and a directory: {:?}",
-      directory
+      "Child paths must be unique, but a child path of {:?} was both a file and a directory: {:?}",
+      digest, directory
     ));
   }
   Ok(())
@@ -44,18 +50,24 @@ where
   for node in nodes {
     verify_no_unknown_fields(node)?;
     verify_no_unknown_fields(get_digest(node))?;
-    if get_name(node).contains('/') {
+    let name = get_name(node);
+    if name.is_empty() {
+      return Err(format!(
+        "A child name must not be empty, but {:?} had an empty name.",
+        get_digest(node),
+      ));
+    } else if name.contains('/') {
       return Err(format!(
         "All children must have one path segment, but found {}",
-        get_name(node)
+        name
       ));
     }
     if let Some(p) = prev {
-      if get_name(node) <= get_name(p) {
+      if name <= get_name(p) {
         return Err(format!(
           "Children must be sorted and unique, but {} was before {}",
           get_name(p),
-          get_name(node)
+          name,
         ));
       }
     }

--- a/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
@@ -1,5 +1,7 @@
 use crate::remote_execution::{Digest, Directory, DirectoryNode, FileNode};
 use crate::verify_directory_canonical;
+
+use hashing::EMPTY_DIGEST;
 use protobuf::Message;
 
 const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
@@ -12,7 +14,10 @@ const OTHER_DIRECTORY_SIZE: i64 = 0;
 
 #[test]
 fn empty_directory() {
-  assert_eq!(Ok(()), verify_directory_canonical(&Directory::new()));
+  assert_eq!(
+    Ok(()),
+    verify_directory_canonical(EMPTY_DIGEST, &Directory::new())
+  );
 }
 
 #[test]
@@ -62,14 +67,14 @@ fn canonical_directory() {
     });
     dir
   });
-  assert_eq!(Ok(()), verify_directory_canonical(&directory));
+  assert_eq!(Ok(()), verify_directory_canonical(EMPTY_DIGEST, &directory));
 }
 
 #[test]
 fn unknown_field() {
   let mut directory = Directory::new();
   directory.mut_unknown_fields().add_fixed32(42, 42);
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("unknown"),
     format!("Bad error message: {}", error)
@@ -93,7 +98,7 @@ fn unknown_field_in_file_node() {
     file
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("unknown"),
     format!("Bad error message: {}", error)
@@ -115,7 +120,7 @@ fn empty_child_name() {
     dir
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("A child name must not be empty"),
     format!("Bad error message: {}", error)
@@ -137,7 +142,7 @@ fn multiple_path_segments_in_directory() {
     dir
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("pets/cats"),
     format!("Bad error message: {}", error)
@@ -159,7 +164,7 @@ fn multiple_path_segments_in_file() {
     file
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("cats/roland"),
     format!("Bad error message: {}", error)
@@ -192,7 +197,7 @@ fn duplicate_path_in_directory() {
     dir
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("cats"),
     format!("Bad error message: {}", error)
@@ -225,7 +230,7 @@ fn duplicate_path_in_file() {
     file
   });
 
-  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("roland"),
     format!("Bad error message: {}", error)
@@ -258,7 +263,7 @@ fn duplicate_path_in_file_and_directory() {
     dir
   });
 
-  verify_directory_canonical(&directory).expect_err("Want error");
+  verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
 }
 
 #[test]

--- a/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/verification_tests.rs
@@ -101,6 +101,28 @@ fn unknown_field_in_file_node() {
 }
 
 #[test]
+fn empty_child_name() {
+  let mut directory = Directory::new();
+  directory.mut_directories().push({
+    let mut dir = DirectoryNode::new();
+    dir.set_name("".to_owned());
+    dir.set_digest({
+      let mut digest = Digest::new();
+      digest.set_size_bytes(DIRECTORY_SIZE);
+      digest.set_hash(DIRECTORY_HASH.to_owned());
+      digest
+    });
+    dir
+  });
+
+  let error = verify_directory_canonical(&directory).expect_err("Want error");
+  assert!(
+    error.contains("A child name must not be empty"),
+    format!("Bad error message: {}", error)
+  );
+}
+
+#[test]
 fn multiple_path_segments_in_directory() {
   let mut directory = Directory::new();
   directory.mut_directories().push({

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -12,6 +12,7 @@ use sharded_lmdb::{ShardedLmdb, DEFAULT_LEASE_TIME};
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::TestData;
+use testutil::relative_paths;
 use tokio::runtime::Handle;
 
 struct RoundtripResults {
@@ -85,7 +86,7 @@ fn create_script(script_exit_code: i8) -> (Process, PathBuf, TempDir) {
     testutil::path::find_bash(),
     format!("{}", script_path.display()),
   ])
-  .output_files(vec![PathBuf::from("roland")].into_iter().collect());
+  .output_files(relative_paths(&["roland"]).collect());
 
   (process, script_path, script_dir)
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -180,9 +180,9 @@ pub struct Process {
 
   pub input_files: hashing::Digest,
 
-  pub output_files: BTreeSet<PathBuf>,
+  pub output_files: BTreeSet<RelativePath>,
 
-  pub output_directories: BTreeSet<PathBuf>,
+  pub output_directories: BTreeSet<RelativePath>,
 
   pub timeout: Option<std::time::Duration>,
 
@@ -267,7 +267,7 @@ impl Process {
   ///
   /// Replaces the output files for this process.
   ///
-  pub fn output_files(mut self, output_files: BTreeSet<PathBuf>) -> Process {
+  pub fn output_files(mut self, output_files: BTreeSet<RelativePath>) -> Process {
     self.output_files = output_files;
     self
   }
@@ -275,7 +275,7 @@ impl Process {
   ///
   /// Replaces the output directories for this process.
   ///
-  pub fn output_directories(mut self, output_directories: BTreeSet<PathBuf>) -> Process {
+  pub fn output_directories(mut self, output_directories: BTreeSet<RelativePath>) -> Process {
     self.output_directories = output_directories;
     self
   }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
-use testutil::owned_string_vec;
 use testutil::path::find_bash;
+use testutil::{owned_string_vec, relative_paths};
 use tokio::runtime::Handle;
 
 #[derive(PartialEq, Debug)]
@@ -158,7 +158,7 @@ async fn output_files_one() {
       "-c".to_owned(),
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ])
-    .output_files(vec![PathBuf::from("roland")].into_iter().collect()),
+    .output_files(relative_paths(&["roland"]).collect()),
   )
   .await
   .unwrap();
@@ -186,8 +186,8 @@ async fn output_dirs() {
         TestData::catnip().string()
       ),
     ])
-    .output_files(vec![PathBuf::from("treats")].into_iter().collect())
-    .output_directories(vec![PathBuf::from("cats")].into_iter().collect()),
+    .output_files(relative_paths(&["treats"]).collect())
+    .output_directories(relative_paths(&["cats"]).collect()),
   )
   .await
   .unwrap();
@@ -214,11 +214,7 @@ async fn output_files_many() {
         TestData::catnip().string()
       ),
     ])
-    .output_files(
-      vec![PathBuf::from("cats/roland"), PathBuf::from("treats")]
-        .into_iter()
-        .collect(),
-    ),
+    .output_files(relative_paths(&["cats/roland", "treats"]).collect()),
   )
   .await
   .unwrap();
@@ -245,7 +241,7 @@ async fn output_files_execution_failure() {
         "roland"
       ),
     ])
-    .output_files(vec![PathBuf::from("roland")].into_iter().collect()),
+    .output_files(relative_paths(&["roland"]).collect()),
   )
   .await
   .unwrap();
@@ -269,7 +265,7 @@ async fn output_files_partial_output() {
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ])
     .output_files(
-      vec![PathBuf::from("roland"), PathBuf::from("susannah")]
+      relative_paths(&["roland", "susannah"])
         .into_iter()
         .collect(),
     ),
@@ -295,8 +291,8 @@ async fn output_overlapping_file_and_dir() {
       "-c".to_owned(),
       format!("echo -n {} > cats/roland", TestData::roland().string()),
     ])
-    .output_files(vec![PathBuf::from("cats/roland")].into_iter().collect())
-    .output_directories(vec![PathBuf::from("cats")].into_iter().collect()),
+    .output_files(relative_paths(&["cats/roland"]).collect())
+    .output_directories(relative_paths(&["cats"]).collect()),
   )
   .await
   .unwrap();
@@ -361,7 +357,7 @@ async fn test_directory_preservation() {
   let argv = vec![find_bash(), "-c".to_owned(), bash_contents.clone()];
 
   let result = run_command_locally_in_dir(
-    Process::new(argv.clone()).output_files(vec![PathBuf::from("roland")].into_iter().collect()),
+    Process::new(argv.clone()).output_files(relative_paths(&["roland"]).collect()),
     preserved_work_root.clone(),
     false,
     None,
@@ -434,8 +430,8 @@ async fn all_containing_directories_for_outputs_are_created() {
         TestData::roland().string()
       ),
     ])
-    .output_files(vec![PathBuf::from("cats/roland")].into_iter().collect())
-    .output_directories(vec![PathBuf::from("birds/falcons")].into_iter().collect()),
+    .output_files(relative_paths(&["cats/roland"]).collect())
+    .output_directories(relative_paths(&["birds/falcons"]).collect()),
   )
   .await
   .unwrap();
@@ -458,7 +454,7 @@ async fn output_empty_dir() {
       "-c".to_owned(),
       "/bin/mkdir falcons".to_string(),
     ])
-    .output_directories(vec![PathBuf::from("falcons")].into_iter().collect()),
+    .output_directories(relative_paths(&["falcons"]).collect()),
   )
   .await
   .unwrap();

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -20,7 +20,7 @@ use spectral::{assert_that, string::StrAssertions};
 use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory, TestTree};
-use testutil::owned_string_vec;
+use testutil::{owned_string_vec, relative_paths};
 use tokio::runtime::Handle;
 use workunit_store::{Level, SpanId, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
@@ -74,14 +74,8 @@ async fn make_execute_request() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: vec!["path/to/file", "other/file"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
-    output_directories: vec!["directory/name"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
+    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
     level: log::Level::Info,
@@ -161,14 +155,8 @@ async fn make_execute_request_with_instance_name() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: vec!["path/to/file", "other/file"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
-    output_directories: vec!["directory/name"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
+    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
     level: log::Level::Info,
@@ -261,14 +249,8 @@ async fn make_execute_request_with_cache_key_gen_version() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: vec!["path/to/file", "other/file"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
-    output_directories: vec!["directory/name"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
+    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: None,
     description: "some description".to_owned(),
     level: log::Level::Info,
@@ -510,14 +492,8 @@ async fn make_execute_request_with_timeout() {
     working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
-    output_files: vec!["path/to/file", "other/file"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
-    output_directories: vec!["directory/name"]
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
+    output_files: relative_paths(&["path/to/file", "other/file"]).collect(),
+    output_directories: relative_paths(&["directory/name"]).collect(),
     timeout: one_second(),
     description: "some description".to_owned(),
     level: log::Level::Info,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -276,12 +276,18 @@ async fn main() {
   let server_arg = args.value_of("server");
   let remote_instance_arg = args.value_of("remote-instance-name").map(str::to_owned);
   let output_files = if let Some(values) = args.values_of("output-file-path") {
-    values.map(PathBuf::from).collect()
+    values
+      .map(RelativePath::new)
+      .collect::<Result<BTreeSet<_>, _>>()
+      .unwrap()
   } else {
     BTreeSet::new()
   };
   let output_directories = if let Some(values) = args.values_of("output-directory-path") {
-    values.map(PathBuf::from).collect()
+    values
+      .map(RelativePath::new)
+      .collect::<Result<BTreeSet<_>, _>>()
+      .unwrap()
   } else {
     BTreeSet::new()
   };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -243,13 +243,13 @@ impl MultiPlatformExecuteProcess {
 
     let output_files = externs::project_multi_strs(&value, "output_files")
       .into_iter()
-      .map(PathBuf::from)
-      .collect();
+      .map(RelativePath::new)
+      .collect::<Result<_, _>>()?;
 
     let output_directories = externs::project_multi_strs(&value, "output_directories")
       .into_iter()
-      .map(PathBuf::from)
-      .collect();
+      .map(RelativePath::new)
+      .collect::<Result<_, _>>()?;
 
     let timeout_in_seconds = externs::project_f64(&value, "timeout_seconds");
 

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 [dependencies]
 bazel_protos = { path = "../process_execution/bazel_protos" }
 bytes = "0.4.5"
+fs = { path = "../fs" }
 hashing = { path = "../hashing" }
 protobuf = { version = "2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -32,12 +32,18 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use fs::RelativePath;
+
 pub mod data;
 pub mod file;
 pub mod path;
 
 pub fn owned_string_vec(args: &[&str]) -> Vec<String> {
   args.iter().map(<&str>::to_string).collect()
+}
+
+pub fn relative_paths<'a>(paths: &'a [&str]) -> impl Iterator<Item = RelativePath> + 'a {
+  paths.iter().map(|p| RelativePath::new(p).unwrap())
 }
 
 pub fn as_byte_owned_vec(str: &str) -> Vec<u8> {


### PR DESCRIPTION
### Problem

As explained in https://github.com/pantsbuild/pants/issues/10802#issuecomment-697922102, Pants does not currently normalize `Process::{output_files,output_directories}` as relative paths, which caused us to send an [invalid path](https://github.com/bazelbuild/remote-apis/blob/f54876595da9f2c2d66c98c318d00b60fd64900b/build/bazel/remote/execution/v2/remote_execution.proto#L507-L508) to the server. Additionally, the server managed to return a "nearly valid" output where a child path for a directory had an empty name, which we should validate for in order to fail faster.

### Solution

In two commits: 1) validate that `Directory` protos returned by remoting do not contain empty child names, 2) switch the `Process::{output_files,output_directories}` fields to holding `RelativePath`s, which are normalized to strip trailing slashes, and validated as not escaping their root.

### Result

Fixes #10802. Opened https://github.com/bazelbuild/remote-apis/issues/175 to track upstreaming the additional "must be non-empty" constraint.

[ci skip-build-wheels]