### PR TITLE
Consolidate "runner" PEXes into "tool" PEXes

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -140,6 +140,8 @@ async def setup_pytest_for_target(
                 # by importlib_metadata and then by Pytest). See
                 # https://github.com/jaraco/zipp/pull/26.
                 "--not-zip-safe",
+                # TODO(John Sirois): Support shading python binaries:
+                #   https://github.com/pantsbuild/pants/issues/9206
                 "--pex-path",
                 requirements_pex_request.input.output_filename,
             ),

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -62,7 +62,7 @@ def generate_args(
 async def bandit_lint_partition(
     partition: BanditPartition, bandit: Bandit, lint_subsystem: LintSubsystem
 ) -> LintResult:
-    requirements_pex_request = Get(
+    bandit_pex_request = Get(
         Pex,
         PexRequest(
             output_filename="bandit.pex",
@@ -86,12 +86,12 @@ async def bandit_lint_partition(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
-    requirements_pex, config_digest, source_files = await MultiGet(
-        requirements_pex_request, config_digest_request, source_files_request
+    bandit_pex, config_digest, source_files = await MultiGet(
+        bandit_pex_request, config_digest_request, source_files_request
     )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files.snapshot.digest, requirements_pex.digest, config_digest))
+        Digest, MergeDigests((source_files.snapshot.digest, bandit_pex.digest, config_digest))
     )
 
     report_file_name = "bandit_report.txt" if lint_subsystem.reports_dir else None
@@ -99,7 +99,7 @@ async def bandit_lint_partition(
     result = await Get(
         FallibleProcessResult,
         PexProcess(
-            requirements_pex,
+            bandit_pex,
             argv=generate_args(
                 source_files=source_files, bandit=bandit, report_file_name=report_file_name
             ),

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -59,7 +59,7 @@ def generate_args(
 
 @rule(level=LogLevel.DEBUG)
 async def setup_docformatter(setup_request: SetupRequest, docformatter: Docformatter) -> Setup:
-    requirements_pex_request = Get(
+    docformatter_pex_request = Get(
         Pex,
         PexRequest(
             output_filename="docformatter.pex",
@@ -75,7 +75,7 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    source_files, requirements_pex = await MultiGet(source_files_request, requirements_pex_request)
+    source_files, docformatter_pex = await MultiGet(source_files_request, docformatter_pex_request)
 
     source_files_snapshot = (
         source_files.snapshot
@@ -84,13 +84,13 @@ async def setup_docformatter(setup_request: SetupRequest, docformatter: Docforma
     )
 
     input_digest = await Get(
-        Digest, MergeDigests((source_files_snapshot.digest, requirements_pex.digest))
+        Digest, MergeDigests((source_files_snapshot.digest, docformatter_pex.digest))
     )
 
     process = await Get(
         Process,
         PexProcess(
-            requirements_pex,
+            docformatter_pex,
             argv=generate_args(
                 source_files=source_files,
                 docformatter=docformatter,

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -62,7 +62,7 @@ def generate_args(
 async def flake8_lint_partition(
     partition: Flake8Partition, flake8: Flake8, lint_subsystem: LintSubsystem
 ) -> LintResult:
-    requirements_pex_request = Get(
+    flake8_pex_request = Get(
         Pex,
         PexRequest(
             output_filename="flake8.pex",
@@ -86,13 +86,13 @@ async def flake8_lint_partition(
         SourceFiles, SourceFilesRequest(field_set.sources for field_set in partition.field_sets)
     )
 
-    requirements_pex, config_digest, source_files = await MultiGet(
-        requirements_pex_request, config_digest_request, source_files_request
+    flake8_pex, config_digest, source_files = await MultiGet(
+        flake8_pex_request, config_digest_request, source_files_request
     )
 
     input_digest = await Get(
         Digest,
-        MergeDigests((source_files.snapshot.digest, requirements_pex.digest, config_digest)),
+        MergeDigests((source_files.snapshot.digest, flake8_pex.digest, config_digest)),
     )
 
     report_file_name = "flake8_report.txt" if lint_subsystem.reports_dir else None
@@ -100,7 +100,7 @@ async def flake8_lint_partition(
     result = await Get(
         FallibleProcessResult,
         PexProcess(
-            requirements_pex,
+            flake8_pex,
             argv=generate_args(
                 source_files=source_files, flake8=flake8, report_file_name=report_file_name
             ),

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -70,7 +70,7 @@ def generate_args(*, source_files: SourceFiles, isort: Isort, check_only: bool) 
 
 @rule(level=LogLevel.DEBUG)
 async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
-    requirements_pex_request = Get(
+    isort_pex_request = Get(
         Pex,
         PexRequest(
             output_filename="isort.pex",
@@ -96,8 +96,8 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
         SourceFilesRequest(field_set.sources for field_set in setup_request.request.field_sets),
     )
 
-    source_files, requirements_pex, config_digest = await MultiGet(
-        source_files_request, requirements_pex_request, config_digest_request
+    source_files, isort_pex, config_digest = await MultiGet(
+        source_files_request, isort_pex_request, config_digest_request
     )
     source_files_snapshot = (
         source_files.snapshot
@@ -107,13 +107,13 @@ async def setup_isort(setup_request: SetupRequest, isort: Isort) -> Setup:
 
     input_digest = await Get(
         Digest,
-        MergeDigests((source_files_snapshot.digest, requirements_pex.digest, config_digest)),
+        MergeDigests((source_files_snapshot.digest, isort_pex.digest, config_digest)),
     )
 
     process = await Get(
         Process,
         PexProcess(
-            requirements_pex,
+            isort_pex,
             argv=generate_args(
                 source_files=source_files, isort=isort, check_only=setup_request.check_only
             ),

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -159,8 +159,6 @@ async def mypy_typecheck(
     #     Python 2 wheels and they are not compatible with Python 3, then Pex will error about
     #     missing wheels. So, in this case, we set `PEX_IGNORE_ERRORS`, which will avoid erroring,
     #     but may result in MyPy complaining that it cannot find certain distributions.
-    #
-    #  * The runner Pex should use the same constraints as the tool Pex.
     code_interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
         (
             tgt[PythonInterpreterCompatibility]


### PR DESCRIPTION
Starting in https://github.com/pantsbuild/pants/pull/9208, we've been using a pattern of separting out a "tool Pex" (the tool's requirements), a "requirements Pex" (user's requirements), and a "runner Pex" (the entry-point). These get combined via `--pex-path`.

There doesn't seem to be a particularly compelling reason to separate the tool Pex from the runner Pex. It's fine to put the entry point on the tool Pex, as that entry point barely ever changes. When tool requirements do change, it's trivial for the new Pex to include the entry point in its setup.

This results in less code and also a less confusing UX, as users no longer have to question why we have both a `mypy.pex` and `mypy_runner.pex`.
 
[ci skip-rust]
[ci skip-build-wheels]