### PR TITLE
Improve support of MyPy requirements when Python 2 used

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -31,6 +31,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types import rules as target_type_rules
 from pants.backend.python.util_rules import (
     ancestor_files,
+    extract_pex,
     pex,
     pex_cli,
     pex_environment,
@@ -60,6 +61,7 @@ def rules():
     return (
         *coverage_py.rules(),
         *ancestor_files.rules(),
+        *extract_pex.rules(),
         *python_sources.rules(),
         *dependency_inference_rules.rules(),
         *pex.rules(),

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -6,5 +6,5 @@ python_library()
 python_integration_tests(
   name='integration',
   uses_pants_run=False,
-  timeout=300,
+  timeout=360,
 )

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -13,7 +13,8 @@ from pants.backend.python.target_types import (
     PythonSources,
 )
 from pants.backend.python.typecheck.mypy.subsystem import MyPy
-from pants.backend.python.util_rules import pex_from_targets
+from pants.backend.python.util_rules import extract_pex, pex_from_targets
+from pants.backend.python.util_rules.extract_pex import ExtractedPexDistributions
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexInterpreterConstraints,
@@ -70,7 +71,9 @@ def generate_args(mypy: MyPy, *, file_list_path: str) -> Tuple[str, ...]:
 # a sibling `<package>-stubs` package as per PEP-0561. Going further than that PEP, MyPy restricts
 # its search to `site-packages`. Since PEX deliberately isolates itself from `site-packages` as
 # part of its raison d'être, we monkey-patch `site.getsitepackages` to look inside the scrubbed
-# PEX sys.path before handing off to `mypy`.
+# PEX sys.path before handing off to `mypy`. This will find dependencies installed via `mypy.pex`,
+# along with the wheels we've extracted from `requirements.pex` and prefixed with the `.deps/`
+# folder. Note that these extracted wheels
 #
 # As a complication, MyPy does its own validation to ensure packages aren't both available in
 # site-packages and on the PYTHONPATH. As such, we elide all PYTHONPATH entries from artificial
@@ -98,7 +101,9 @@ LAUNCHER_FILE = FileContent(
         )
         site.getsitepackages = lambda: [
             p for p in sys.path
-            if os.path.realpath(p) not in PYTHONPATH and os.path.isabs(p)
+            if p.startswith(".deps") or (
+                os.path.realpath(p) not in PYTHONPATH and os.path.isabs(p)
+            )
         ]
         site.getusersitepackages = lambda: ''  # i.e, the CWD.
 
@@ -167,15 +172,17 @@ async def mypy_typecheck(
         ),
         python_setup,
     )
-    use_subsystem_constraints = (
-        not mypy.options.is_default("interpreter_constraints")
-        or code_interpreter_constraints.includes_python2()
-    )
-    tool_interpreter_constraints = (
-        PexInterpreterConstraints(mypy.interpreter_constraints)
-        if use_subsystem_constraints
-        else code_interpreter_constraints
-    )
+
+    if not mypy.options.is_default("interpreter_constraints"):
+        tool_interpreter_constraints = mypy.interpreter_constraints
+    elif code_interpreter_constraints.requires_python38_or_newer():
+        tool_interpreter_constraints = ("CPython>=3.8",)
+    elif code_interpreter_constraints.requires_python37_or_newer():
+        tool_interpreter_constraints = ("CPython>=3.7",)
+    elif code_interpreter_constraints.requires_python36_or_newer():
+        tool_interpreter_constraints = ("CPython>=3.6",)
+    else:
+        tool_interpreter_constraints = mypy.interpreter_constraints
 
     plugin_sources_request = Get(
         PythonSourceFiles, PythonSourceFilesRequest(plugin_transitive_targets.closure)
@@ -202,9 +209,8 @@ async def mypy_typecheck(
             requirements=PexRequirements(
                 itertools.chain(mypy.all_requirements, plugin_requirements)
             ),
-            interpreter_constraints=tool_interpreter_constraints,
+            interpreter_constraints=PexInterpreterConstraints(tool_interpreter_constraints),
             entry_point=PurePath(LAUNCHER_FILE.path).stem,
-            additional_args=("--pex-path", requirements_pex_request.input.output_filename),
         ),
     )
 
@@ -236,9 +242,13 @@ async def mypy_typecheck(
     python_files = "\n".join(
         f for f in typechecked_sources.source_files.snapshot.files if f.endswith(".py")
     )
-    file_list_digest = await Get(
+    create_file_list_request = Get(
         Digest,
         CreateDigest([FileContent(file_list_path, python_files.encode())]),
+    )
+
+    file_list_digest, extracted_pex_distributions = await MultiGet(
+        create_file_list_request, Get(ExtractedPexDistributions, Pex, requirements_pex)
     )
 
     merged_input_files = await Get(
@@ -249,7 +259,7 @@ async def mypy_typecheck(
                 plugin_sources.source_files.snapshot.digest,
                 typechecked_srcs_snapshot.digest,
                 mypy_pex.digest,
-                requirements_pex.digest,
+                extracted_pex_distributions.digest,
                 config_digest,
             ]
         ),
@@ -258,11 +268,13 @@ async def mypy_typecheck(
     all_used_source_roots = sorted(
         set(itertools.chain(plugin_sources.source_roots, typechecked_sources.source_roots))
     )
-    extra_env = {"PEX_EXTRA_SYS_PATH": ":".join(all_used_source_roots)}
-    # If the constraints are different for the tool than for the requirements, we must tell Pex to
-    # ignore errors. Otherwise, we risk runtime errors about missing dependencies.
-    if code_interpreter_constraints != tool_interpreter_constraints:
-        extra_env["PEX_IGNORE_ERRORS"] = "true"
+    env = {
+        "PEX_EXTRA_SYS_PATH": ":".join(
+            itertools.chain(
+                all_used_source_roots, extracted_pex_distributions.wheel_directory_paths
+            )
+        )
+    }
 
     result = await Get(
         FallibleProcessResult,
@@ -270,7 +282,7 @@ async def mypy_typecheck(
             mypy_pex,
             argv=generate_args(mypy, file_list_path=file_list_path),
             input_digest=merged_input_files,
-            extra_env=extra_env,
+            extra_env=env,
             description=f"Run MyPy on {pluralize(len(typechecked_srcs_snapshot.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
@@ -284,6 +296,7 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(TypecheckRequest, MyPyRequest),
+        *extract_pex.rules(),
         *pants_bin.rules(),
         *pex_from_targets.rules(),
     ]

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from textwrap import dedent
 from typing import List, Optional, Sequence
 
@@ -292,33 +292,6 @@ def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
             "--mypy-version=mypy==0.770",
             f"--mypy-source-plugins={PACKAGE}/settings.py",
         ],
-    )
-    assert len(result) == 1
-    assert result[0].exit_code == 1
-    assert "src/python/project/app.py:4" in result[0].stdout
-
-    # We also test that loading a plugin by using a 3rd-party requirement still works.
-    Path(rule_runner.build_root, PACKAGE, "BUILD").unlink()
-    rule_runner.add_to_build_file(
-        PACKAGE,
-        dedent(
-            """\
-            python_requirement_library(
-                name="django-stubs",
-                requirements=["django-stubs==1.5.0"],
-            )
-
-            # The `./settings.py` dependency ensures that it will always be loaded.
-            python_library(dependencies=[":django-stubs", "./settings.py"])
-            """
-        ),
-    )
-    app_tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="app.py"))
-    result = run_mypy(
-        rule_runner,
-        [app_tgt],
-        config=config_content,
-        additional_args=["--mypy-version=mypy==0.770"],
     )
     assert len(result) == 1
     assert result[0].exit_code == 1

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -361,8 +361,8 @@ def test_works_with_python27(rule_runner: RuleRunner) -> None:
         dedent(
             """\
             # Both requirements are a) typed and b) compatible with Py2 and Py3. However, `x690`
-            # has a distinct wheel for Py2 vs. Py3, whereas libumi has a universal wheel. We expect 
-            # both to be usable, even though libumi is not compatible with Py3. 
+            # has a distinct wheel for Py2 vs. Py3, whereas libumi has a universal wheel. We expect
+            # both to be usable, even though libumi is not compatible with Py3.
 
             python_requirement_library(
                 name="libumi",

--- a/src/python/pants/backend/python/util_rules/extract_pex.py
+++ b/src/python/pants/backend/python/util_rules/extract_pex.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from pants.backend.python.util_rules.pex import Pex
+from pants.core.util_rules.archive import UnzipBinary
+from pants.engine.fs import Digest, Snapshot
+from pants.engine.process import FallibleProcessResult, Process
+from pants.engine.rules import Get, collect_rules, rule
+from pants.util.logging import LogLevel
+
+
+@dataclass(frozen=True)
+class ExtractedPexDistributions:
+    digest: Digest
+    wheel_directory_paths: Tuple[str, ...]
+
+
+@rule
+async def extract_distributions(pex: Pex, unzip_binary: UnzipBinary) -> ExtractedPexDistributions:
+    # We only unzip the `.deps` folder to avoid unnecessary work. Note that this will cause the
+    # process to fail if there is no `.deps` folder, so we need to use `FallibleProcessResult`.
+    argv = (*unzip_binary.extract_argv(archive_path=pex.name, output_dir="."), ".deps/*")
+    unzipped_pex = await Get(
+        FallibleProcessResult,
+        Process(
+            argv=argv,
+            input_digest=pex.digest,
+            output_directories=(".deps",),
+            description=f"Unzip {pex.name} to determine its distributions",
+            level=LogLevel.DEBUG,
+        ),
+    )
+    snapshot = await Get(Snapshot, Digest, unzipped_pex.output_digest)
+    directory_paths = tuple(sorted(d for d in snapshot.dirs if d.endswith(".whl")))
+    return ExtractedPexDistributions(snapshot.digest, directory_paths)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/python/util_rules/extract_pex_test.py
+++ b/src/python/pants/backend/python/util_rules/extract_pex_test.py
@@ -1,0 +1,83 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Iterable
+
+import pytest
+
+from pants.backend.python.util_rules import extract_pex, pex
+from pants.backend.python.util_rules.extract_pex import ExtractedPexDistributions
+from pants.backend.python.util_rules.pex import (
+    Pex,
+    PexInterpreterConstraints,
+    PexRequest,
+    PexRequirements,
+)
+from pants.core.util_rules.pants_environment import PantsEnvironment
+from pants.engine.fs import EMPTY_DIGEST, Snapshot
+from pants.testutil.option_util import create_options_bootstrapper
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *extract_pex.rules(),
+            *pex.rules(),
+            QueryRule(Pex, [PexRequest, PantsEnvironment]),
+            QueryRule(ExtractedPexDistributions, [Pex]),
+        ]
+    )
+
+
+def get_distributions(
+    rule_runner: RuleRunner, *, requirements: Iterable[str], constraints: Iterable[str]
+) -> ExtractedPexDistributions:
+    # NB: The constraints are important for determinism.
+    rule_runner.create_file("constraints.txt", "\n".join(constraints))
+
+    pex_request = PexRequest(
+        output_filename="test.pex",
+        requirements=PexRequirements(requirements),
+        interpreter_constraints=PexInterpreterConstraints([">=3.6"]),
+        internal_only=True,
+    )
+    options_bootstrapper = create_options_bootstrapper(
+        args=[
+            "--backend-packages=pants.backend.python",
+            "--python-setup-requirement-constraints=constraints.txt",
+        ]
+    )
+    built_pex = rule_runner.request(Pex, [pex_request, options_bootstrapper, PantsEnvironment()])
+    return rule_runner.request(ExtractedPexDistributions, [built_pex])
+
+
+def test_extract_distributions(rule_runner: RuleRunner) -> None:
+    constraints = ["six==1.15.0", "t61codec==1.0.1", "x690==0.2.0"]
+    result = get_distributions(
+        rule_runner,
+        requirements=["x690"],
+        constraints=constraints,
+    )
+
+    assert len(result.wheel_directory_paths) == len(constraints)
+    # Note that we expect the `wheel_directory_paths` to have been sorted.
+    assert result.wheel_directory_paths[0] == ".deps/six-1.15.0-py2.py3-none-any.whl"
+    assert result.wheel_directory_paths[1] == ".deps/t61codec-1.0.1-py2.py3-none-any.whl"
+    assert result.wheel_directory_paths[2] == ".deps/x690-0.2.0-py3-none-any.whl"
+
+    # Spot check that some expected files are included.
+    result_snapshot = rule_runner.request(Snapshot, [result.digest])
+    for f in [
+        ".deps/t61codec-1.0.1-py2.py3-none-any.whl/t61codec-1.0.1.dist-info/INSTALLER",
+        ".deps/six-1.15.0-py2.py3-none-any.whl/six.py",
+        ".deps/x690-0.2.0-py3-none-any.whl/x690/types.py",
+    ]:
+        assert f in result_snapshot.files
+
+
+def test_extract_distributions_none_found(rule_runner: RuleRunner) -> None:
+    result = get_distributions(rule_runner, requirements=[], constraints=[])
+    assert not result.wheel_directory_paths
+    assert result.digest == EMPTY_DIGEST

--- a/src/python/pants/backend/python/util_rules/extract_pex_test.py
+++ b/src/python/pants/backend/python/util_rules/extract_pex_test.py
@@ -54,6 +54,9 @@ def get_distributions(
 
 
 def test_extract_distributions(rule_runner: RuleRunner) -> None:
+    # We use these requirements because all of their wheels are prebuilt (faster test) and they all
+    # work with any Python 3 interpreter, rather than something interpreter-specific like `cp36`
+    # (deterministic test).
     constraints = ["six==1.15.0", "t61codec==1.0.1", "x690==0.2.0"]
     result = get_distributions(
         rule_runner,


### PR DESCRIPTION
### Problem

The wheels used by third-party code might not use the same constraints as what the MyPy Pex uses. This was causing errors (https://github.com/pantsbuild/pants/issues/10819), which we fixed in https://github.com/pantsbuild/pants/pull/10820.

However, that fix was not perfect. Even if there were valid typed Python 2 wheels, we would ignore them. WIth Python 3, we had to be careful that `mypy.pex` used the exact same constraints as `requirements.pex`, so that, for example, we don't run MyPy with Py36 but resolve requirements with Py37.

### Solution

Stop using `--pex-path` to join the `requirements.pex`, which has the effect of the wheels being put on `PYTHONPATH`. (We were then teaching MyPy to read from this PYTHONPATH through a custom launcher script.)

Instead, we extract the wheel folders from `requirements.pex`, and teach our custom launcher script to look in these extracted `.deps/` folders through a new `EXTRACTED_WHEELS` env var. MyPy will use this to resolve the requirements, without us actually including the wheels in the final PEX or modifying PYTHONPATH.

### Result

Our Python 2 test now fully works, even though one of the wheels is not compatible with Python 3.

We no longer need to align `mypy.pex` with `requirements.pex`.

#### Caveat: MyPy plugins must be installed with `--mypy-extra-requirements`

An initial implementation did not use `EXTRACTED_WHEELS` and instead loaded the wheels via `PYTHONPATH`. This allowed for you to specify MyPy plugins via normal dependencies on `python_requirement_library` targets, because that requirement would get loaded via PYTHONPATH. Now, you cannot do this; you must specify the requirement via `--mypy-extra-requirements`.

This caveat seems acceptable. For Pytest, it's convenient that we allow you to load plugins via normal requirements, as it allows you to only sometimes use the plugin. MyPy is much more uniform, however; MyPy runs in a single batch over the entire transitive closure, unlike Pytest running one test file at-a-time. Likewise, without Pants, it's hard to imagine how you could only sometimes use a MyPy plugin, given that MyPy only works with a single config file.