### PR TITLE
Remove .*/ from --build-ignore defaults

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -931,7 +931,7 @@ class GlobalOptions(Subsystem):
             "--build-ignore",
             advanced=True,
             type=list,
-            default=[".*/", "bower_components/", "node_modules/", "*.egg-info/"],
+            default=["bower_components/", "node_modules/", "*.egg-info/"],
             help=(
                 "Paths to ignore when identifying BUILD files. This does not affect any other "
                 "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -931,7 +931,7 @@ class GlobalOptions(Subsystem):
             "--build-ignore",
             advanced=True,
             type=list,
-            default=["bower_components/", "node_modules/", "*.egg-info/"],
+            default=[],
             help=(
                 "Paths to ignore when identifying BUILD files. This does not affect any other "
                 "filesystem operations; use `--pants-ignore` for that instead. Patterns use the "


### PR DESCRIPTION
### Problem

We currently have `.*/` as a default glob in the defaults for the `--build-ignore` option; that is, by default ignoring all directories beginning with a dot. This, confusingly, leads to certain situations where it's possible to un-ignore a directory beginning with a dot in the `--pants-ignore` option, and still have that directory fail to appear as a possible target because of the `--build-ignore` default.

### Solution

This commit  removes ".*/" as a default glob in `--build-ignore`, leaving that glob as an overridable default for `--pants-ignore`. It also removes the other defaults for `--build-ignore`, since these pertain to standard directory names for tooling pants doesn't support at this time.

### Result

Explicit overrides of the ".*/" default for `--pants-ignore` now work as intended.