### PR TITLE
Fix dependency inference AST parsing to include file names

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -50,8 +50,8 @@ def parse_file(*, filename: str, content: str) -> Optional[Tuple]:
         return tree, visitor_cls
     except SyntaxError:
         try:
-            tree = ast27.parse(content, filename=filename)
-            return tree, _Py27AstVisitor
+            py27_tree = ast27.parse(content, filename=filename)
+            return py27_tree, _Py27AstVisitor
         except SyntaxError:
             return None
 

--- a/src/python/pants/backend/python/dependency_inference/import_parser.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser.py
@@ -35,7 +35,7 @@ class ParsedPythonImports:
         return FrozenOrderedSet(sorted([*self.explicit_imports, *self.inferred_imports]))
 
 
-def parse_file(source_code: str) -> Optional[Tuple]:
+def parse_file(*, filename: str, content: str) -> Optional[Tuple]:
     try:
         # NB: The Python 3 ast is generally backwards-compatible with earlier versions. The only
         # breaking change is `async` `await` becoming reserved keywords in Python 3.7 (deprecated
@@ -45,18 +45,19 @@ def parse_file(source_code: str) -> Optional[Tuple]:
         # We will also fail to parse Python 3.8 syntax if Pants is run with Python 3.6 or 3.7.
         # There is no known workaround for this, beyond users changing their `./pants` script to
         # always use >= 3.8.
-        tree = ast3.parse(source_code)
+        tree = ast3.parse(content, filename=filename)
         visitor_cls = _Py3AstVisitor if sys.version_info[:2] < (3, 8) else _Py38AstVisitor
         return tree, visitor_cls
     except SyntaxError:
         try:
-            return ast27.parse(source_code), _Py27AstVisitor
+            tree = ast27.parse(content, filename=filename)
+            return tree, _Py27AstVisitor
         except SyntaxError:
             return None
 
 
-def find_python_imports(source_code: str, *, module_name: str) -> ParsedPythonImports:
-    parse_result = parse_file(source_code)
+def find_python_imports(*, filename: str, content: str, module_name: str) -> ParsedPythonImports:
+    parse_result = parse_file(filename=filename, content=content)
     # If there were syntax errors, gracefully early return. This is more user friendly than
     # propagating the exception. Dependency inference simply won't be used for that file, and
     # it'll be up to the tool actually being run (e.g. Pytest or Flake8) to error.

--- a/src/python/pants/backend/python/dependency_inference/import_parser_test.py
+++ b/src/python/pants/backend/python/dependency_inference/import_parser_test.py
@@ -11,7 +11,8 @@ from pants.backend.python.dependency_inference.import_parser import find_python_
 
 def test_normal_imports() -> None:
     imports = find_python_imports(
-        dedent(
+        filename="foo.py",
+        content=dedent(
             """\
             from __future__ import print_function
 
@@ -54,7 +55,8 @@ def test_normal_imports() -> None:
 
 def test_relative_imports() -> None:
     imports = find_python_imports(
-        dedent(
+        filename="foo.py",
+        content=dedent(
             """\
             from . import sibling
             from .subdir.child import Child
@@ -73,7 +75,8 @@ def test_relative_imports() -> None:
 
 def test_imports_from_strings() -> None:
     imports = find_python_imports(
-        dedent(
+        filename="foo.py",
+        content=dedent(
             """\
             modules = [
                 # Valid strings
@@ -118,14 +121,15 @@ def test_imports_from_strings() -> None:
 
 
 def test_gracefully_handle_syntax_errors() -> None:
-    imports = find_python_imports("x =", module_name="project.app")
+    imports = find_python_imports(filename="foo.py", content="x =", module_name="project.app")
     assert not imports.explicit_imports
     assert not imports.inferred_imports
 
 
 def test_works_with_python2() -> None:
     imports = find_python_imports(
-        dedent(
+        filename="foo.py",
+        content=dedent(
             """\
             print "Python 2 lives on."
 
@@ -148,7 +152,8 @@ def test_works_with_python2() -> None:
 )
 def test_works_with_python38() -> None:
     imports = find_python_imports(
-        dedent(
+        filename="foo.py",
+        content=dedent(
             """\
             is_py38 = True
             if walrus := is_py38:

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -116,7 +116,9 @@ async def infer_python_dependencies(
     owner_requests: List[Get[PythonModuleOwner, PythonModule]] = []
     for file_content, module in zip(digest_contents, modules):
         file_imports_obj = find_python_imports(
-            file_content.content.decode(), module_name=module.module
+            filename=file_content.path,
+            content=file_content.content.decode(),
+            module_name=module.module,
         )
         detected_imports = (
             file_imports_obj.all_imports


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10826.

Arguably, Pants should instead be capturing these warnings, but Python's mechanism for this is not thread-safe.

[ci skip-rust]
[ci skip-build-wheels]