### PR TITLE
Locate bash before using it to locate BinaryPaths for other tools

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -501,17 +501,17 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
 
     # Note: the backslash after the """ marker ensures that the shebang is at the start of the
     # script file. Many OSs will not see the shebang if there is intervening whitespace.
-    script_path = "./script.sh"
+    script_path = "./find_binary.sh"
     script_content = dedent(
         f"""\
         {shebang}
 
-        set -euo pipefail
+        set -euox pipefail
 
         if command -v which > /dev/null; then
-            command which -a $1
+            command which -a $1 || true
         else
-            command -v $1
+            command -v $1 || true
         fi
         """
     )

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -10,6 +10,8 @@ import pytest
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, PathGlobs, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import (
+    BinaryPathRequest,
+    BinaryPaths,
     FallibleProcessResult,
     InteractiveProcess,
     Process,
@@ -17,9 +19,18 @@ from pants.engine.process import (
     ProcessResult,
 )
 from pants.engine.rules import Get, rule
-from pants.testutil.rule_runner import QueryRule
+from pants.testutil.pants_integration_test import setup_tmpdir
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
+
+
+def process_rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            QueryRule(BinaryPaths, [BinaryPathRequest]),
+        ],
+    )
 
 
 @dataclass(frozen=True)
@@ -442,3 +453,18 @@ def test_running_interactive_process_in_workspace_cannot_have_input_files() -> N
     mock_digest = Digest("fake", 1)
     with pytest.raises(ValueError):
         InteractiveProcess(argv=["/bin/echo"], input_digest=mock_digest, run_in_workspace=True)
+
+
+def test_find_binary_on_path_without_bash() -> None:
+    # Test that locating a binary on a PATH which does not include bash works (by recursing to
+    # locate bash first).
+    binary_name = "mybin"
+    binary_dir = "bin"
+    with setup_tmpdir({f"{binary_dir}/{binary_name}": "this just needs to exist"}) as tmpdir:
+        binary_dir_abs = os.path.join(os.getcwd(), tmpdir, binary_dir)
+        search_path = [binary_dir_abs]
+        binary_paths = process_rule_runner().request(
+            BinaryPaths, [BinaryPathRequest(binary_name=binary_name, search_path=search_path)]
+        )
+        assert binary_paths.first_path is not None
+        assert binary_paths.first_path.path == os.path.join(binary_dir_abs, binary_name)


### PR DESCRIPTION
### Problem

The first error in #10855 is that when we search a search path which does not include `bash`, lookups fail silently because the discovery script fails to start. The usecase described on #9760 (setting `interpreter_search_path=["<PYENV>"]`) is one example where `bash` will not be present.

### Solution

Recurse to locate an absolute path for `bash` before using `bash`. Additionally, change the "discovery" portion of `BinaryPaths` from `FallibleProcessResult` to `ProcessResult` to fail more quickly in cases where discovery errors, as opposed to succeeding with an empty result.

### Result

The added test passes, and the usecase from #9760 works on my machine.

[ci skip-rust]
[ci skip-build-wheels]