### PR TITLE
Add `RuleRunner.set_options()`

### DIFF
--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -16,7 +16,6 @@ from pants.backend.python.target_types import PythonLibrary
 from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -32,16 +31,16 @@ def rule_runner() -> RuleRunner:
 
 
 def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, bytes]:
-    bootstrapper = create_options_bootstrapper(
-        args=[
+    rule_runner.set_options(
+        [
             "--backend-packages=pants.backend.awslambda.python",
             "--source-root-patterns=src/python",
             "--pants-distdir-legacy-paths=false",
         ]
     )
-    target = rule_runner.get_target(Address.parse(addr), bootstrapper)
+    target = rule_runner.get_target(Address.parse(addr))
     created_awslambda = rule_runner.request(
-        CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target), bootstrapper, PantsEnvironment()]
+        CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target), PantsEnvironment()]
     )
     created_awslambda_digest_contents = rule_runner.request(
         DigestContents, [created_awslambda.digest]

--- a/src/python/pants/backend/codegen/protobuf/target_types_test.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types_test.py
@@ -12,7 +12,6 @@ from pants.backend.codegen.protobuf.target_types import rules as target_type_rul
 from pants.core.target_types import Files
 from pants.engine.addresses import Address
 from pants.engine.target import InjectedDependencies
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -20,7 +19,7 @@ def test_inject_dependencies() -> None:
     rule_runner = RuleRunner(
         rules=[
             *target_type_rules(),
-            QueryRule(InjectedDependencies, (InjectProtobufDependencies, OptionsBootstrapper)),
+            QueryRule(InjectedDependencies, (InjectProtobufDependencies,)),
         ],
         target_types=[ProtobufLibrary, Files],
     )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -24,7 +24,6 @@ from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.rules import SubsystemRule
 from pants.engine.target import InferredDependencies
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -89,11 +88,11 @@ def test_infer_python_imports() -> None:
         args = ["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
         if enable_string_imports:
             args.append("--python-infer-string-imports")
-        options_bootstrapper = create_options_bootstrapper(args=args)
-        target = rule_runner.get_target(address, options_bootstrapper)
+        rule_runner.set_options(args)
+        target = rule_runner.get_target(address)
         return rule_runner.request(
             InferredDependencies,
-            [InferPythonDependencies(target[PythonSources]), options_bootstrapper],
+            [InferPythonDependencies(target[PythonSources])],
         )
 
     normal_address = Address("src/python")
@@ -134,8 +133,8 @@ def test_infer_python_inits() -> None:
         ],
         target_types=[PythonLibrary],
     )
-    options_bootstrapper = create_options_bootstrapper(
-        args=[
+    rule_runner.set_options(
+        [
             "--backend-packages=pants.backend.python",
             "--python-infer-inits",
             "--source-root-patterns=src/python",
@@ -152,10 +151,10 @@ def test_infer_python_inits() -> None:
     rule_runner.add_to_build_file("src/python/root/mid/leaf", "python_library()")
 
     def run_dep_inference(address: Address) -> InferredDependencies:
-        target = rule_runner.get_target(address, options_bootstrapper)
+        target = rule_runner.get_target(address)
         return rule_runner.request(
             InferredDependencies,
-            [InferInitDependencies(target[PythonSources]), options_bootstrapper],
+            [InferInitDependencies(target[PythonSources])],
         )
 
     assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
@@ -177,11 +176,8 @@ def test_infer_python_conftests() -> None:
         ],
         target_types=[PythonTests],
     )
-    options_bootstrapper = create_options_bootstrapper(
-        args=[
-            "--backend-packages=pants.backend.python",
-            "--source-root-patterns=src/python",
-        ]
+    rule_runner.set_options(
+        ["--backend-packages=pants.backend.python", "--source-root-patterns=src/python"]
     )
 
     rule_runner.create_file("src/python/root/conftest.py")
@@ -195,10 +191,10 @@ def test_infer_python_conftests() -> None:
     rule_runner.add_to_build_file("src/python/root/mid/leaf", "python_tests()")
 
     def run_dep_inference(address: Address) -> InferredDependencies:
-        target = rule_runner.get_target(address, options_bootstrapper)
+        target = rule_runner.get_target(address)
         return rule_runner.request(
             InferredDependencies,
-            [InferConftestDependencies(target[PythonSources]), options_bootstrapper],
+            [InferConftestDependencies(target[PythonSources])],
         )
 
     assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -27,7 +27,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.process import InteractiveRunner
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -164,13 +163,11 @@ def run_pytest(
         args.append("--test-use-coverage")
     if execution_slot_var:
         args.append(f"--pytest-execution-slot-var={execution_slot_var}")
-    subjects = [
-        PythonTestFieldSet.create(test_target),
-        pants_environment,
-        create_options_bootstrapper(args=args),
-    ]
-    test_result = rule_runner.request(TestResult, subjects)
-    debug_request = rule_runner.request(TestDebugRequest, subjects)
+    rule_runner.set_options(args)
+
+    inputs = [PythonTestFieldSet.create(test_target), pants_environment]
+    test_result = rule_runner.request(TestResult, inputs)
+    debug_request = rule_runner.request(TestDebugRequest, inputs)
     if debug_request.process is not None:
         debug_result = InteractiveRunner(rule_runner.scheduler).run(debug_request.process)
         assert test_result.exit_code == debug_result.exit_code

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -47,7 +47,6 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import rule
 from pants.engine.target import Targets
 from pants.engine.unions import UnionRule
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 _namespace_decl = "__import__('pkg_resources').declare_namespace(__name__)"
@@ -106,10 +105,7 @@ def assert_chroot(
     tgt = rule_runner.get_target(Address.parse(addr))
     chroot = rule_runner.request(
         SetupPyChroot,
-        [
-            SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
-            create_options_bootstrapper(),
-        ],
+        [SetupPyChrootRequest(ExportedTarget(tgt), py2=False)],
     )
     snapshot = rule_runner.request(Snapshot, [chroot.digest])
     assert sorted(expected_files) == sorted(snapshot.files)
@@ -121,10 +117,7 @@ def assert_chroot_error(rule_runner: RuleRunner, addr: str, exc_cls: Type[Except
     with pytest.raises(ExecutionError) as excinfo:
         rule_runner.request(
             SetupPyChroot,
-            [
-                SetupPyChrootRequest(ExportedTarget(tgt), py2=False),
-                create_options_bootstrapper(),
-            ],
+            [SetupPyChrootRequest(ExportedTarget(tgt), py2=False)],
         )
     ex = excinfo.value
     assert len(ex.wrapped_exceptions) == 1
@@ -293,7 +286,7 @@ def test_get_sources() -> None:
         targets = Targets(rule_runner.get_target(Address.parse(addr)) for addr in addrs)
         srcs = rule_runner.request(
             SetupPySources,
-            [SetupPySourcesRequest(targets, py2=False), create_options_bootstrapper()],
+            [SetupPySourcesRequest(targets, py2=False)],
         )
         chroot_snapshot = rule_runner.request(Snapshot, [srcs.digest])
 
@@ -440,7 +433,7 @@ def test_get_requirements() -> None:
         tgt = rule_runner.get_target(Address.parse(addr))
         reqs = rule_runner.request(
             ExportedTargetRequirements,
-            [DependencyOwner(ExportedTarget(tgt)), create_options_bootstrapper()],
+            [DependencyOwner(ExportedTarget(tgt))],
         )
         assert sorted(expected_req_strs) == list(reqs)
 
@@ -514,10 +507,7 @@ def test_owned_dependencies() -> None:
             od.target.address.spec
             for od in rule_runner.request(
                 OwnedDependencies,
-                [
-                    DependencyOwner(ExportedTarget(tgt)),
-                    create_options_bootstrapper(),
-                ],
+                [DependencyOwner(ExportedTarget(tgt))],
             )
         )
 
@@ -553,7 +543,7 @@ def assert_is_owner(rule_runner: RuleRunner, owner: str, owned: str):
         owner
         == rule_runner.request(
             ExportedTarget,
-            [OwnedDependency(tgt), create_options_bootstrapper()],
+            [OwnedDependency(tgt)],
         ).target.address.spec
     )
 
@@ -563,7 +553,7 @@ def assert_owner_error(rule_runner, owned: str, exc_cls: Type[Exception]):
     with pytest.raises(ExecutionError) as excinfo:
         rule_runner.request(
             ExportedTarget,
-            [OwnedDependency(tgt), create_options_bootstrapper()],
+            [OwnedDependency(tgt)],
         )
     ex = excinfo.value
     assert len(ex.wrapped_exceptions) == 1

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -67,13 +66,10 @@ def run_bandit(
         args.append("--bandit-skip")
     if additional_args:
         args.extend(additional_args)
+    rule_runner.set_options(args)
     results = rule_runner.request(
         LintResults,
-        [
-            BanditRequest(BanditFieldSet.create(tgt) for tgt in targets),
-            create_options_bootstrapper(args=args),
-            PantsEnvironment(),
-        ],
+        [BanditRequest(BanditFieldSet.create(tgt) for tgt in targets), PantsEnvironment()],
     )
     return results.results
 

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -16,7 +16,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python38_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -73,17 +72,14 @@ def run_black(
         args.append(f"--black-args='{passthrough_args}'")
     if skip:
         args.append("--black-skip")
-    options_bootstrapper = create_options_bootstrapper(args=args)
+    rule_runner.set_options(args)
     field_sets = [BlackFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request(
-        LintResults, [BlackRequest(field_sets), options_bootstrapper, pants_env]
-    )
+    lint_results = rule_runner.request(LintResults, [BlackRequest(field_sets), pants_env])
     input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
-            options_bootstrapper,
             pants_env,
         ],
     )
@@ -91,7 +87,6 @@ def run_black(
         FmtResult,
         [
             BlackRequest(field_sets, prior_formatter_result=input_sources.snapshot),
-            options_bootstrapper,
             pants_env,
         ],
     )

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -15,7 +15,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -54,17 +53,14 @@ def run_docformatter(
         args.append(f"--docformatter-args='{passthrough_args}'")
     if skip:
         args.append("--docformatter-skip")
-    options_bootstrapper = create_options_bootstrapper(args=args)
+    rule_runner.set_options(args)
     field_sets = [DocformatterFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request(
-        LintResults, [DocformatterRequest(field_sets), options_bootstrapper, pants_env]
-    )
+    lint_results = rule_runner.request(LintResults, [DocformatterRequest(field_sets), pants_env])
     input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
-            options_bootstrapper,
             pants_env,
         ],
     )
@@ -72,7 +68,6 @@ def run_docformatter(
         FmtResult,
         [
             DocformatterRequest(field_sets, prior_formatter_result=input_sources.snapshot),
-            options_bootstrapper,
             pants_env,
         ],
     )

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -66,11 +65,11 @@ def run_flake8(
         args.append("--flake8-skip")
     if additional_args:
         args.extend(additional_args)
+    rule_runner.set_options(args)
     results = rule_runner.request(
         LintResults,
         [
             Flake8Request(Flake8FieldSet.create(tgt) for tgt in targets),
-            create_options_bootstrapper(args=args),
             PantsEnvironment(),
         ],
     )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -15,7 +15,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -68,17 +67,14 @@ def run_isort(
         args.append(f"--isort-args='{passthrough_args}'")
     if skip:
         args.append("--isort-skip")
-    options_bootstrapper = create_options_bootstrapper(args=args)
+    rule_runner.set_options(args)
     field_sets = [IsortFieldSet.create(tgt) for tgt in targets]
     pants_env = PantsEnvironment()
-    lint_results = rule_runner.request(
-        LintResults, [IsortRequest(field_sets), options_bootstrapper, pants_env]
-    )
+    lint_results = rule_runner.request(LintResults, [IsortRequest(field_sets), pants_env])
     input_sources = rule_runner.request(
         SourceFiles,
         [
             SourceFilesRequest(field_set.sources for field_set in field_sets),
-            options_bootstrapper,
             pants_env,
         ],
     )
@@ -86,7 +82,6 @@ def run_isort(
         FmtResult,
         [
             IsortRequest(field_sets, prior_formatter_result=input_sources.snapshot),
-            options_bootstrapper,
             pants_env,
         ],
     )

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -16,7 +16,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import skip_unless_python27_and_python3_present
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -73,9 +72,8 @@ def make_target(
             """
         ),
     )
-    return rule_runner.get_target(
-        Address(package, target_name=name), create_options_bootstrapper(args=GLOBAL_ARGS)
-    )
+    rule_runner.set_options(GLOBAL_ARGS)
+    return rule_runner.get_target(Address(package, target_name=name))
 
 
 def run_pylint(
@@ -97,13 +95,10 @@ def run_pylint(
         args.append("--pylint-skip")
     if additional_args:
         args.extend(additional_args)
+    rule_runner.set_options(args)
     results = rule_runner.request(
         LintResults,
-        [
-            PylintRequest(PylintFieldSet.create(tgt) for tgt in targets),
-            create_options_bootstrapper(args=args),
-            PantsEnvironment(),
-        ],
+        [PylintRequest(PylintFieldSet.create(tgt) for tgt in targets), PantsEnvironment()],
     )
     return results.results
 

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -14,7 +14,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.target import Targets
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -40,13 +39,13 @@ def run_black_and_isort(
     for source_file in source_files:
         rule_runner.create_file(source_file.path, source_file.content.decode())
     targets = PythonFmtTargets(Targets([PythonLibrary({}, address=Address.parse(f"test:{name}"))]))
-    args = [
-        "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
-        *(extra_args or []),
-    ]
-    results = rule_runner.request(
-        LanguageFmtResults, [targets, create_options_bootstrapper(args=args), PantsEnvironment()]
+    rule_runner.set_options(
+        [
+            "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",
+            *(extra_args or []),
+        ]
     )
+    results = rule_runner.request(LanguageFmtResults, [targets, PantsEnvironment()])
     return results
 
 

--- a/src/python/pants/backend/python/macros/pants_requirement_test.py
+++ b/src/python/pants/backend/python/macros/pants_requirement_test.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import (
 from pants.base.build_environment import pants_version
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.frozendict import FrozenDict
 
@@ -35,9 +34,7 @@ def assert_pants_requirement(
     expected_module: str = "pants",
 ) -> None:
     rule_runner.add_to_build_file("3rdparty/python", f"{build_file_entry}\n")
-    target = rule_runner.get_target(
-        Address("3rdparty/python", target_name=expected_target_name), create_options_bootstrapper()
-    )
+    target = rule_runner.get_target(Address("3rdparty/python", target_name=expected_target_name))
     assert isinstance(target, PythonRequirementLibrary)
     assert target[PythonRequirementsField].value == (
         Requirement.parse(f"{expected_dist}=={pants_version()}"),

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import PythonRequirementLibrary, PythonRe
 from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs, Specs
 from pants.engine.addresses import Address
 from pants.engine.target import Targets
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -39,10 +38,7 @@ def assert_pipenv_requirements(
     rule_runner.create_file(pipfile_lock_relpath, dumps(pipfile_lock))
     targets = rule_runner.request(
         Targets,
-        [
-            Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),
-            create_options_bootstrapper(),
-        ],
+        [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
     )
 
     assert {expected_file_dep, *expected_targets} == set(targets)

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -13,7 +13,6 @@ from pants.base.specs import AddressSpecs, DescendantAddresses, FilesystemSpecs,
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Targets
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -39,10 +38,7 @@ def assert_python_requirements(
     rule_runner.create_file(requirements_txt_relpath, requirements_txt)
     targets = rule_runner.request(
         Targets,
-        [
-            Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([])),
-            create_options_bootstrapper(),
-        ],
+        [Specs(AddressSpecs([DescendantAddresses("")]), FilesystemSpecs([]))],
     )
     assert {expected_file_dep, *expected_targets} == set(targets)
 

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -25,7 +25,6 @@ from pants.engine.target import (
     InvalidFieldException,
     InvalidFieldTypeException,
 )
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.python.python_requirement import PythonRequirement
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -125,7 +124,7 @@ def test_python_distribution_dependency_injection() -> None:
             *target_type_rules(),
             QueryRule(
                 InjectedDependencies,
-                (InjectPythonDistributionDependencies, OptionsBootstrapper),
+                (InjectPythonDistributionDependencies,),
             ),
         ],
         target_types=[PythonDistribution, PythonBinary],

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -27,7 +27,7 @@ from pants.engine.target import (
 )
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.python.python_requirement import PythonRequirement
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -148,9 +148,6 @@ def test_python_distribution_dependency_injection() -> None:
     tgt = rule_runner.get_target(Address("project", target_name="dist"))
     injected = rule_runner.request(
         InjectedDependencies,
-        [
-            InjectPythonDistributionDependencies(tgt[PythonDistributionDependencies]),
-            create_options_bootstrapper(),
-        ],
+        [InjectPythonDistributionDependencies(tgt[PythonDistributionDependencies])],
     )
     assert injected == InjectedDependencies([Address("project", target_name="my_binary")])

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -18,7 +18,6 @@ from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.python_interpreter_selection import (
     skip_unless_python27_present,
     skip_unless_python38_present,
@@ -105,9 +104,8 @@ def make_target(
             """
         ),
     )
-    return rule_runner.get_target(
-        Address(package, target_name=name), create_options_bootstrapper(args=GLOBAL_ARGS)
-    )
+    rule_runner.set_options(GLOBAL_ARGS)
+    return rule_runner.get_target(Address(package, target_name=name))
 
 
 def run_mypy(
@@ -129,13 +127,10 @@ def run_mypy(
         args.append("--mypy-skip")
     if additional_args:
         args.extend(additional_args)
+    rule_runner.set_options(args)
     result = rule_runner.request(
         TypecheckResults,
-        [
-            MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets),
-            create_options_bootstrapper(args=args),
-            PantsEnvironment(),
-        ],
+        [MyPyRequest(MyPyFieldSet.create(tgt) for tgt in targets), PantsEnvironment()],
     )
     return result.results
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.ancestor_files import (
     identify_missing_ancestor_files,
 )
 from pants.engine.fs import DigestContents
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -34,14 +33,14 @@ def assert_injected(
     original_undeclared_files: List[str],
     expected_discovered: List[str],
 ) -> None:
+    rule_runner.set_options([f"--source-root-patterns={source_roots}"])
     for f in original_undeclared_files:
         rule_runner.create_file(f, "# undeclared")
     request = AncestorFilesRequest(
         "__init__.py",
         rule_runner.make_snapshot({fp: "# declared" for fp in original_declared_files}),
     )
-    bootstrapper = create_options_bootstrapper(args=[f"--source-root-patterns={source_roots}"])
-    result = rule_runner.request(AncestorFiles, [request, bootstrapper]).snapshot
+    result = rule_runner.request(AncestorFiles, [request]).snapshot
     assert list(result.files) == sorted(expected_discovered)
 
     materialized_result = rule_runner.request(DigestContents, [result.digest])

--- a/src/python/pants/backend/python/util_rules/extract_pex_test.py
+++ b/src/python/pants/backend/python/util_rules/extract_pex_test.py
@@ -15,7 +15,6 @@ from pants.backend.python.util_rules.pex import (
 )
 from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.fs import EMPTY_DIGEST, Snapshot
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -35,6 +34,12 @@ def get_distributions(
     rule_runner: RuleRunner, *, requirements: Iterable[str], constraints: Iterable[str]
 ) -> ExtractedPexDistributions:
     # NB: The constraints are important for determinism.
+    rule_runner.set_options(
+        [
+            "--backend-packages=pants.backend.python",
+            "--python-setup-requirement-constraints=constraints.txt",
+        ]
+    )
     rule_runner.create_file("constraints.txt", "\n".join(constraints))
 
     pex_request = PexRequest(
@@ -43,13 +48,7 @@ def get_distributions(
         interpreter_constraints=PexInterpreterConstraints([">=3.6"]),
         internal_only=True,
     )
-    options_bootstrapper = create_options_bootstrapper(
-        args=[
-            "--backend-packages=pants.backend.python",
-            "--python-setup-requirement-constraints=constraints.txt",
-        ]
-    )
-    built_pex = rule_runner.request(Pex, [pex_request, options_bootstrapper, PantsEnvironment()])
+    built_pex = rule_runner.request(Pex, [pex_request, PantsEnvironment()])
     return rule_runner.request(ExtractedPexDistributions, [built_pex])
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -11,7 +11,6 @@ from pants.core.util_rules.pants_environment import PantsEnvironment
 from pants.engine.fs import DigestContents
 from pants.engine.process import Process
 from pants.engine.rules import QueryRule
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import temporary_dir
 
@@ -30,13 +29,10 @@ def test_custom_ca_certs(rule_runner: RuleRunner) -> None:
     with temporary_dir() as tmpdir:
         certs_file = Path(tmpdir) / "certsfile"
         certs_file.write_text("Some fake cert")
+        rule_runner.set_options([f"--ca-certs-path={certs_file}"])
         proc = rule_runner.request(
             Process,
-            [
-                PexCliProcess(argv=["some", "--args"], description=""),
-                PantsEnvironment(),
-                create_options_bootstrapper(args=[f"--ca-certs-path={certs_file}"]),
-            ],
+            [PexCliProcess(argv=["some", "--args"], description=""), PantsEnvironment()],
         )
         assert proc.argv[2:6] == ("some", "--args", "--cert", "certsfile")
         files = rule_runner.request(DigestContents, [proc.input_digest])

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -13,7 +13,6 @@ from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsReque
 from pants.build_graph.address import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.python.python_setup import ResolveAllConstraintsOption
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -80,7 +79,8 @@ def test_constraints_validation(rule_runner: RuleRunner) -> None:
             args.append(f"--python-setup-resolve-all-constraints={resolve_all.value}")
         if constraints_file:
             args.append(f"--python-setup-requirement-constraints={constraints_file}")
-        return rule_runner.request(PexRequest, [request, create_options_bootstrapper(args=args)])
+        rule_runner.set_options(args)
+        return rule_runner.request(PexRequest, [request])
 
     pex_req1 = get_pex_request("constraints1.txt", ResolveAllConstraintsOption.NEVER)
     assert pex_req1.requirements == PexRequirements(["foo-bar>=0.1.2", "bar==5.5.5", "baz"])

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -27,7 +27,7 @@ from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
 from pants.engine.target import FieldSet
 from pants.python.python_setup import PythonSetup
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.frozendict import FrozenDict
 
@@ -348,16 +348,8 @@ def create_pex_and_get_all_data(
         additional_inputs=additional_inputs,
         additional_args=additional_pex_args,
     )
-    pex = rule_runner.request(
-        Pex,
-        [
-            request,
-            create_options_bootstrapper(
-                args=["--backend-packages=pants.backend.python", *additional_pants_args]
-            ),
-            PantsEnvironment(),
-        ],
-    )
+    rule_runner.set_options(["--backend-packages=pants.backend.python", *additional_pants_args])
+    pex = rule_runner.request(Pex, [request, PantsEnvironment()])
     rule_runner.scheduler.write_digest(pex.digest)
     pex_path = os.path.join(rule_runner.build_root, "test.pex")
     with zipfile.ZipFile(pex_path, "r") as zipfp:
@@ -433,6 +425,12 @@ def test_pex_execution(rule_runner: RuleRunner) -> None:
 
 
 def test_pex_environment(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(
+        [
+            "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
+            "--subprocess-environment-env-vars=ftp_proxy=dummyproxy",
+        ]
+    )
     sources = rule_runner.request(
         Digest,
         [
@@ -462,12 +460,6 @@ def test_pex_environment(rule_runner: RuleRunner) -> None:
                 argv=["python", "test.pex"],
                 input_digest=pex_output["pex"].digest,
                 description="Run the pex and check its reported environment",
-            ),
-            create_options_bootstrapper(
-                args=[
-                    "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
-                    "--subprocess-environment-env-vars=ftp_proxy=dummyproxy",
-                ]
             ),
             PantsEnvironment({"LANG": "es_PY.UTF-8"}),
         ],

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -425,12 +425,6 @@ def test_pex_execution(rule_runner: RuleRunner) -> None:
 
 
 def test_pex_environment(rule_runner: RuleRunner) -> None:
-    rule_runner.set_options(
-        [
-            "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
-            "--subprocess-environment-env-vars=ftp_proxy=dummyproxy",
-        ]
-    )
     sources = rule_runner.request(
         Digest,
         [
@@ -450,7 +444,15 @@ def test_pex_environment(rule_runner: RuleRunner) -> None:
             ),
         ],
     )
-    pex_output = create_pex_and_get_all_data(rule_runner, entry_point="main", sources=sources)
+    pex_output = create_pex_and_get_all_data(
+        rule_runner,
+        entry_point="main",
+        sources=sources,
+        additional_pants_args=(
+            "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
+            "--subprocess-environment-env-vars=ftp_proxy=dummyproxy",
+        ),
+    )
 
     process = rule_runner.request(
         Process,

--- a/src/python/pants/core/util_rules/filter_empty_sources_test.py
+++ b/src/python/pants/core/util_rules/filter_empty_sources_test.py
@@ -14,7 +14,6 @@ from pants.core.util_rules.filter_empty_sources import (
 from pants.core.util_rules.filter_empty_sources import rules as filter_empty_sources_rules
 from pants.engine.addresses import Address
 from pants.engine.target import FieldSet, Sources, Tags, Target
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -49,10 +48,7 @@ def test_filter_field_sets(rule_runner: RuleRunner) -> None:
 
     result = rule_runner.request(
         FieldSetsWithSources,
-        [
-            FieldSetsWithSourcesRequest([valid_field_set, empty_field_set]),
-            create_options_bootstrapper(),
-        ],
+        [FieldSetsWithSourcesRequest([valid_field_set, empty_field_set])],
     )
     assert tuple(result) == (valid_field_set,)
 
@@ -73,9 +69,6 @@ def test_filter_targets(rule_runner: RuleRunner) -> None:
 
     result = rule_runner.request(
         TargetsWithSources,
-        [
-            TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt]),
-            create_options_bootstrapper(),
-        ],
+        [TargetsWithSourcesRequest([valid_tgt, empty_tgt, invalid_tgt])],
     )
     assert tuple(result) == (valid_tgt,)

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
 from pants.engine.target import Sources as SourcesField
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -63,10 +62,7 @@ def assert_sources_resolved(
     expected: Iterable[TargetSources],
     expected_unrooted: Iterable[str] = (),
 ) -> None:
-    result = rule_runner.request(
-        SourceFiles,
-        [SourceFilesRequest(sources_fields), create_options_bootstrapper()],
-    )
+    result = rule_runner.request(SourceFiles, [SourceFilesRequest(sources_fields)])
     assert list(result.snapshot.files) == sorted(
         set(itertools.chain.from_iterable(sources.full_paths for sources in expected))
     )

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -11,7 +11,6 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.fs import EMPTY_SNAPSHOT
 from pants.engine.internals.scheduler import ExecutionError
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -41,10 +40,8 @@ def get_stripped_files(
     if not has_source_root_patterns:
         source_root_patterns = ["src/python", "src/java", "tests/python"]
         args.append(f"--source-root-patterns={json.dumps(source_root_patterns)}")
-    result = rule_runner.request(
-        StrippedSourceFiles,
-        [request, create_options_bootstrapper(args=args)],
-    )
+    rule_runner.set_options(args)
+    result = rule_runner.request(StrippedSourceFiles, [request])
     return list(result.snapshot.files)
 
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -3,7 +3,7 @@
 
 import re
 from textwrap import dedent
-from typing import Iterable, Optional, Set, cast
+from typing import Iterable, Set, cast
 
 import pytest
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -36,8 +36,7 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.target import Dependencies, Sources, Tags, Target
 from pants.option.global_options import GlobalOptions
-from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
 from pants.util.frozendict import FrozenDict
 
@@ -179,9 +178,7 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
         ),
     )
     addr = Address("helloworld")
-    target_adaptor = target_adaptor_rule_runner.request(
-        TargetAdaptor, [addr, create_options_bootstrapper()]
-    )
+    target_adaptor = target_adaptor_rule_runner.request(TargetAdaptor, [addr])
     assert target_adaptor.name == "helloworld"
     assert target_adaptor.type_alias == "mock_tgt"
     assert target_adaptor.kwargs["dependencies"] == [
@@ -196,9 +193,8 @@ def test_target_adaptor_parsed_correctly(target_adaptor_rule_runner: RuleRunner)
 
 
 def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> None:
-    bootstrapper = create_options_bootstrapper()
     with pytest.raises(ExecutionError) as exc:
-        target_adaptor_rule_runner.request(TargetAdaptor, [Address("helloworld"), bootstrapper])
+        target_adaptor_rule_runner.request(TargetAdaptor, [Address("helloworld")])
     assert "Directory \\'helloworld\\' does not contain any BUILD files" in str(exc)
 
     target_adaptor_rule_runner.add_to_build_file("helloworld", "mock_tgt(name='other_tgt')")
@@ -206,7 +202,7 @@ def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> Non
         "'helloworld' was not found in namespace 'helloworld'. Did you mean one of:\n  :other_tgt"
     )
     with pytest.raises(ExecutionError, match=expected_rx_str):
-        target_adaptor_rule_runner.request(TargetAdaptor, [Address("helloworld"), bootstrapper])
+        target_adaptor_rule_runner.request(TargetAdaptor, [Address("helloworld")])
 
 
 def test_build_file_address() -> None:
@@ -214,11 +210,10 @@ def test_build_file_address() -> None:
         rules=[QueryRule(BuildFileAddress, (Address,))], target_types=[MockTgt]
     )
     rule_runner.create_file("helloworld/BUILD.ext", "mock_tgt()")
-    bootstrapper = create_options_bootstrapper()
 
     def assert_bfa_resolved(address: Address) -> None:
         expected_bfa = BuildFileAddress(rel_path="helloworld/BUILD.ext", address=address)
-        bfa = rule_runner.request(BuildFileAddress, [address, bootstrapper])
+        bfa = rule_runner.request(BuildFileAddress, [address])
         assert bfa == expected_bfa
 
     assert_bfa_resolved(Address("helloworld"))
@@ -237,13 +232,11 @@ def address_specs_rule_runner() -> RuleRunner:
 def resolve_address_specs(
     rule_runner: RuleRunner,
     specs: Iterable[AddressSpec],
-    bootstrapper: Optional[OptionsBootstrapper] = None,
 ) -> Set[AddressWithOrigin]:
     result = rule_runner.request(
         AddressesWithOrigins,
         [
             AddressSpecs(specs, filter_by_global_options=True),
-            bootstrapper or create_options_bootstrapper(),
         ],
     )
     return set(result)
@@ -276,6 +269,7 @@ def test_address_specs_deduplication(address_specs_rule_runner: RuleRunner) -> N
 
 
 def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> None:
+    address_specs_rule_runner.set_options(["--tag=+integration"])
     address_specs_rule_runner.create_file("demo/f.txt")
     address_specs_rule_runner.add_to_build_file(
         "demo",
@@ -287,11 +281,9 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
             """
         ),
     )
-    bootstrapper = create_options_bootstrapper(args=["--tag=+integration"])
-
-    assert resolve_address_specs(
-        address_specs_rule_runner, [SiblingAddresses("demo")], bootstrapper=bootstrapper
-    ) == {AddressWithOrigin(Address("demo", target_name="b"), SiblingAddresses("demo"))}
+    assert resolve_address_specs(address_specs_rule_runner, [SiblingAddresses("demo")]) == {
+        AddressWithOrigin(Address("demo", target_name="b"), SiblingAddresses("demo"))
+    }
 
     # The same filtering should work when given literal addresses, including file addresses.
     # For file addresses, we look up the `tags` field of the original base target.
@@ -305,7 +297,6 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
             AddressLiteralSpec("demo/f.txt", "b"),
             AddressLiteralSpec("demo/f.txt", "c"),
         ],
-        bootstrapper=bootstrapper,
     )
     assert literals_result == {
         AddressWithOrigin(
@@ -317,6 +308,7 @@ def test_address_specs_filter_by_tag(address_specs_rule_runner: RuleRunner) -> N
 
 
 def test_address_specs_filter_by_exclude_pattern(address_specs_rule_runner: RuleRunner) -> None:
+    address_specs_rule_runner.set_options(["--exclude-target-regexp=exclude_me.*"])
     address_specs_rule_runner.create_file("demo/f.txt")
     address_specs_rule_runner.add_to_build_file(
         "demo",
@@ -327,11 +319,10 @@ def test_address_specs_filter_by_exclude_pattern(address_specs_rule_runner: Rule
             """
         ),
     )
-    bootstrapper = create_options_bootstrapper(args=["--exclude-target-regexp=exclude_me.*"])
 
-    assert resolve_address_specs(
-        address_specs_rule_runner, [SiblingAddresses("demo")], bootstrapper=bootstrapper
-    ) == {AddressWithOrigin(Address("demo", target_name="not_me"), SiblingAddresses("demo"))}
+    assert resolve_address_specs(address_specs_rule_runner, [SiblingAddresses("demo")]) == {
+        AddressWithOrigin(Address("demo", target_name="not_me"), SiblingAddresses("demo"))
+    }
 
     # The same filtering should work when given literal addresses, including file addresses.
     # The filtering will operate against the normalized Address.spec.
@@ -343,7 +334,6 @@ def test_address_specs_filter_by_exclude_pattern(address_specs_rule_runner: Rule
             AddressLiteralSpec("demo/f.txt", "exclude_me"),
             AddressLiteralSpec("demo/f.txt", "not_me"),
         ],
-        bootstrapper=bootstrapper,
     )
 
     assert literals_result == {

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -5,7 +5,7 @@ import itertools
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Iterable, List, Optional, Set, Tuple, Type
+from typing import Iterable, List, Set, Tuple, Type
 
 import pytest
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -70,8 +70,6 @@ from pants.engine.target import (
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
-from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.testutil.test_base import TestBase
 from pants.util.ordered_set import FrozenOrderedSet
@@ -111,12 +109,9 @@ def test_transitive_targets(transitive_targets_rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    bootstrapper = create_options_bootstrapper()
 
     def get_target(name: str) -> Target:
-        return transitive_targets_rule_runner.get_target(
-            Address("", target_name=name), bootstrapper
-        )
+        return transitive_targets_rule_runner.get_target(Address("", target_name=name))
 
     t1 = get_target("t1")
     t2 = get_target("t2")
@@ -126,12 +121,12 @@ def test_transitive_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     root = get_target("root")
 
     direct_deps = transitive_targets_rule_runner.request(
-        Targets, [DependenciesRequest(root[Dependencies]), bootstrapper]
+        Targets, [DependenciesRequest(root[Dependencies])]
     )
     assert direct_deps == Targets([d1, d2, d3])
 
     transitive_targets = transitive_targets_rule_runner.request(
-        TransitiveTargets, [Addresses([root.address, d2.address]), bootstrapper]
+        TransitiveTargets, [Addresses([root.address, d2.address])]
     )
     assert transitive_targets.roots == (root, d2)
     # NB: `//:d2` is both a target root and a dependency of `//:root`.
@@ -151,24 +146,20 @@ def test_transitive_targets_transitive_exclude(transitive_targets_rule_runner: R
         ),
     )
 
-    bootstrapper = create_options_bootstrapper()
-
     def get_target(name: str) -> Target:
-        return transitive_targets_rule_runner.get_target(
-            Address("", target_name=name), bootstrapper
-        )
+        return transitive_targets_rule_runner.get_target(Address("", target_name=name))
 
     base = get_target("base")
     intermediate = get_target("intermediate")
     root = get_target("root")
 
     intermediate_direct_deps = transitive_targets_rule_runner.request(
-        Targets, [DependenciesRequest(intermediate[Dependencies]), bootstrapper]
+        Targets, [DependenciesRequest(intermediate[Dependencies])]
     )
     assert intermediate_direct_deps == Targets([base])
 
     transitive_targets = transitive_targets_rule_runner.request(
-        TransitiveTargets, [Addresses([root.address, intermediate.address]), bootstrapper]
+        TransitiveTargets, [Addresses([root.address, intermediate.address])]
     )
     assert transitive_targets.roots == (root, intermediate)
     assert transitive_targets.dependencies == FrozenOrderedSet([intermediate])
@@ -195,7 +186,7 @@ def test_transitive_targets_tolerates_subtarget_cycles(
     )
     result = transitive_targets_rule_runner.request(
         TransitiveTargets,
-        [Addresses([Address("", target_name="t2")]), create_options_bootstrapper()],
+        [Addresses([Address("", target_name="t2")])],
     )
     assert len(result.roots) == 1
     assert result.roots[0].address == Address("", relative_file_path="t2.txt", target_name="t2")
@@ -215,11 +206,7 @@ def assert_failed_cycle(
 ) -> None:
     with pytest.raises(ExecutionError) as e:
         rule_runner.request(
-            TransitiveTargets,
-            [
-                Addresses([Address("", target_name=root_target_name)]),
-                create_options_bootstrapper(),
-            ],
+            TransitiveTargets, [Addresses([Address("", target_name=root_target_name)])]
         )
     (cycle_exception,) = e.value.wrapped_exceptions
     assert isinstance(cycle_exception, CycleException)
@@ -306,7 +293,7 @@ def test_dep_nocycle_indirect(transitive_targets_rule_runner: RuleRunner) -> Non
     )
     result = transitive_targets_rule_runner.request(
         TransitiveTargets,
-        [Addresses([Address("", target_name="t1")]), create_options_bootstrapper()],
+        [Addresses([Address("", target_name="t1")])],
     )
     assert len(result.roots) == 1
     assert result.roots[0].address == Address("", target_name="t1")
@@ -320,9 +307,7 @@ def test_resolve_generated_subtarget() -> None:
     rule_runner = RuleRunner(target_types=[MockTarget])
     rule_runner.add_to_build_file("demo", "target(sources=['f1.txt', 'f2.txt'])")
     generated_target_address = Address("demo", relative_file_path="f1.txt", target_name="demo")
-    generated_target = rule_runner.get_target(
-        generated_target_address, create_options_bootstrapper()
-    )
+    generated_target = rule_runner.get_target(generated_target_address)
     assert generated_target == MockTarget(
         {Sources.alias: ["f1.txt"]}, address=generated_target_address
     )
@@ -345,7 +330,7 @@ def test_resolve_sources_snapshot() -> None:
     specs = SpecsParser(rule_runner.build_root).parse_specs(
         ["demo:demo", "demo/f1.txt", "demo/BUILD"]
     )
-    result = rule_runner.request(SourcesSnapshot, [specs, create_options_bootstrapper()])
+    result = rule_runner.request(SourcesSnapshot, [specs])
     assert result.snapshot.files == ("demo/BUILD", "demo/f1.txt", "demo/f2.txt")
 
 
@@ -357,9 +342,7 @@ def owners_rule_runner() -> RuleRunner:
 def assert_owners(
     rule_runner: RuleRunner, requested: Iterable[str], *, expected: Set[Address]
 ) -> None:
-    result = rule_runner.request(
-        Owners, [OwnersRequest(tuple(requested)), create_options_bootstrapper()]
-    )
+    result = rule_runner.request(Owners, [OwnersRequest(tuple(requested))])
     assert set(result) == expected
 
 
@@ -455,13 +438,8 @@ def specs_rule_runner() -> RuleRunner:
 def resolve_filesystem_specs(
     rule_runner: RuleRunner,
     specs: Iterable[FilesystemSpec],
-    *,
-    bootstrapper: Optional[OptionsBootstrapper] = None,
 ) -> Set[AddressWithOrigin]:
-    result = rule_runner.request(
-        AddressesWithOrigins,
-        [FilesystemSpecs(specs), bootstrapper or create_options_bootstrapper()],
-    )
+    result = rule_runner.request(AddressesWithOrigins, [FilesystemSpecs(specs)])
     return set(result)
 
 
@@ -509,11 +487,8 @@ def test_filesystem_specs_nonexistent_file(specs_rule_runner: RuleRunner) -> Non
         resolve_filesystem_specs(specs_rule_runner, [spec])
     assert 'Unmatched glob from file arguments: "demo/fake.txt"' in str(exc.value)
 
-    assert not resolve_filesystem_specs(
-        specs_rule_runner,
-        [spec],
-        bootstrapper=create_options_bootstrapper(args=["--owners-not-found-behavior=ignore"]),
-    )
+    specs_rule_runner.set_options(["--owners-not-found-behavior=ignore"])
+    assert not resolve_filesystem_specs(specs_rule_runner, [spec])
 
 
 def test_filesystem_specs_no_owner(specs_rule_runner: RuleRunner) -> None:
@@ -550,7 +525,7 @@ def test_resolve_addresses_from_specs() -> None:
     specs = SpecsParser(rule_runner.build_root).parse_specs(
         [*no_interaction_specs, *multiple_files_specs]
     )
-    result = rule_runner.request(AddressesWithOrigins, [specs, create_options_bootstrapper()])
+    result = rule_runner.request(AddressesWithOrigins, [specs])
     assert set(result) == {
         AddressWithOrigin(
             Address("fs_spec", relative_file_path="f.txt"),
@@ -695,7 +670,7 @@ def test_sources_normal_hydration(sources_rule_runner: RuleRunner) -> None:
     )
     sources = Sources(["f1.f95", "*.f03", "!ignored.f03", "!**/ignore*"], address=addr)
     hydrated_sources = sources_rule_runner.request(
-        HydratedSources, [HydrateSourcesRequest(sources), create_options_bootstrapper()]
+        HydratedSources, [HydrateSourcesRequest(sources)]
     )
     assert hydrated_sources.snapshot.files == ("src/fortran/f1.f03", "src/fortran/f1.f95")
 
@@ -716,15 +691,11 @@ def test_sources_output_type(sources_rule_runner: RuleRunner) -> None:
 
     addr = Address("", target_name=":lib")
     sources_rule_runner.create_files("", files=["f1.f95"])
-    bootstrapper = create_options_bootstrapper()
 
     valid_sources = SourcesSubclass(["*"], address=addr)
     hydrated_valid_sources = sources_rule_runner.request(
         HydratedSources,
-        [
-            HydrateSourcesRequest(valid_sources, for_sources_types=[SourcesSubclass]),
-            bootstrapper,
-        ],
+        [HydrateSourcesRequest(valid_sources, for_sources_types=[SourcesSubclass])],
     )
     assert hydrated_valid_sources.snapshot.files == ("f1.f95",)
     assert hydrated_valid_sources.sources_type == SourcesSubclass
@@ -732,26 +703,18 @@ def test_sources_output_type(sources_rule_runner: RuleRunner) -> None:
     invalid_sources = Sources(["*"], address=addr)
     hydrated_invalid_sources = sources_rule_runner.request(
         HydratedSources,
-        [
-            HydrateSourcesRequest(invalid_sources, for_sources_types=[SourcesSubclass]),
-            bootstrapper,
-        ],
+        [HydrateSourcesRequest(invalid_sources, for_sources_types=[SourcesSubclass])],
     )
     assert hydrated_invalid_sources.snapshot.files == ()
     assert hydrated_invalid_sources.sources_type is None
 
 
 def test_sources_unmatched_globs(sources_rule_runner: RuleRunner) -> None:
+    sources_rule_runner.set_options(["--files-not-found-behavior=error"])
     sources_rule_runner.create_files("", files=["f1.f95"])
     sources = Sources(["non_existent.f95"], address=Address("", target_name="lib"))
     with pytest.raises(ExecutionError) as exc:
-        sources_rule_runner.request(
-            HydratedSources,
-            [
-                HydrateSourcesRequest(sources),
-                create_options_bootstrapper(args=["--files-not-found-behavior=error"]),
-            ],
-        )
+        sources_rule_runner.request(HydratedSources, [HydrateSourcesRequest(sources)])
     assert "Unmatched glob" in str(exc.value)
     assert "//:lib" in str(exc.value)
     assert "non_existent.f95" in str(exc.value)
@@ -770,7 +733,7 @@ def test_sources_default_globs(sources_rule_runner: RuleRunner) -> None:
     assert set(sources.sanitized_raw_value or ()) == set(DefaultSources.default)
 
     hydrated_sources = sources_rule_runner.request(
-        HydratedSources, [HydrateSourcesRequest(sources), create_options_bootstrapper()]
+        HydratedSources, [HydrateSourcesRequest(sources)]
     )
     assert hydrated_sources.snapshot.files == ("src/fortran/default.f95", "src/fortran/f1.f08")
 
@@ -779,19 +742,18 @@ def test_sources_expected_file_extensions(sources_rule_runner: RuleRunner) -> No
     class ExpectedExtensionsSources(Sources):
         expected_file_extensions = (".f95", ".f03")
 
-    bootstrapper = create_options_bootstrapper()
     addr = Address("src/fortran", target_name="lib")
     sources_rule_runner.create_files("src/fortran", files=["s.f95", "s.f03", "s.f08"])
     sources = ExpectedExtensionsSources(["s.f*"], address=addr)
     with pytest.raises(ExecutionError) as exc:
-        sources_rule_runner.request(HydratedSources, [HydrateSourcesRequest(sources), bootstrapper])
+        sources_rule_runner.request(HydratedSources, [HydrateSourcesRequest(sources)])
     assert "s.f08" in str(exc.value)
     assert str(addr) in str(exc.value)
 
     # Also check that we support valid sources
     valid_sources = ExpectedExtensionsSources(["s.f95"], address=addr)
     assert sources_rule_runner.request(
-        HydratedSources, [HydrateSourcesRequest(valid_sources), bootstrapper]
+        HydratedSources, [HydrateSourcesRequest(valid_sources)]
     ).snapshot.files == ("src/fortran/s.f95",)
 
 
@@ -812,7 +774,6 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
                 HydrateSourcesRequest(
                     sources_cls(sources, address=Address("", target_name=":example"))
                 ),
-                create_options_bootstrapper(),
             ],
         )
 
@@ -893,23 +854,21 @@ class TestCodegen(TestBase):
         self.union_membership = self.request(UnionMembership, [])
 
     def test_generate_sources(self) -> None:
-        bootstrapper = create_options_bootstrapper()
         protocol_sources = AvroSources(["*.avro"], address=self.address)
         assert protocol_sources.can_generate(SmalltalkSources, self.union_membership) is True
 
         # First, get the original protocol sources.
         hydrated_protocol_sources = self.request(
-            HydratedSources, [HydrateSourcesRequest(protocol_sources), bootstrapper]
+            HydratedSources, [HydrateSourcesRequest(protocol_sources)]
         )
         assert hydrated_protocol_sources.snapshot.files == ("src/avro/f.avro",)
 
         # Test directly feeding the protocol sources into the codegen rule.
-        tgt = self.request(WrappedTarget, [self.address, bootstrapper]).target
+        tgt = self.request(WrappedTarget, [self.address]).target
         generated_sources = self.request(
             GeneratedSources,
             [
                 GenerateSmalltalkFromAvroRequest(hydrated_protocol_sources.snapshot, tgt),
-                bootstrapper,
             ],
         )
         assert generated_sources.snapshot.files == ("src/smalltalk/f.st",)
@@ -921,7 +880,6 @@ class TestCodegen(TestBase):
                 HydrateSourcesRequest(
                     protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
                 ),
-                bootstrapper,
             ],
         )
         assert generated_via_hydrate_sources.snapshot.files == ("src/smalltalk/f.st",)
@@ -939,7 +897,6 @@ class TestCodegen(TestBase):
                 HydrateSourcesRequest(
                     protocol_sources, for_sources_types=[SmalltalkSources], enable_codegen=True
                 ),
-                create_options_bootstrapper(),
             ],
         )
         assert generated.snapshot.files == ("src/smalltalk/f.st",)
@@ -956,7 +913,6 @@ class TestCodegen(TestBase):
                 HydrateSourcesRequest(
                     protocol_sources, for_sources_types=[AdaSources], enable_codegen=True
                 ),
-                create_options_bootstrapper(),
             ],
         )
         assert generated.snapshot.files == ()
@@ -1134,11 +1090,10 @@ def assert_dependencies_resolved(
     requested_address: Address,
     expected: Iterable[Address],
 ) -> None:
-    bootstrapper = create_options_bootstrapper()
-    target = rule_runner.get_target(requested_address, bootstrapper)
+    target = rule_runner.get_target(requested_address)
     result = rule_runner.request(
         Addresses,
-        [DependenciesRequest(target[Dependencies]), bootstrapper],
+        [DependenciesRequest(target[Dependencies])],
     )
     assert sorted(result) == sorted(expected)
 
@@ -1212,9 +1167,7 @@ def test_dependency_injection(dependencies_rule_runner: RuleRunner) -> None:
         if injected:
             provided_deps.append("!//:injected2")
         deps_field = deps_cls(provided_deps, address=Address("", target_name="target"))
-        result = dependencies_rule_runner.request(
-            Addresses, [DependenciesRequest(deps_field), create_options_bootstrapper()]
-        )
+        result = dependencies_rule_runner.request(Addresses, [DependenciesRequest(deps_field)])
         assert result == Addresses(sorted([*injected, Address("", target_name="provided")]))
 
     assert_injected(Dependencies, injected=[])

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -6,7 +6,6 @@ import pytest
 from pants.engine.rules import SubsystemRule
 from pants.option.scope import GLOBAL_SCOPE, Scope, ScopedOptions
 from pants.python.python_setup import PythonSetup
-from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.logging import LogLevel
 

--- a/src/python/pants/engine/internals/options_parsing_test.py
+++ b/src/python/pants/engine/internals/options_parsing_test.py
@@ -17,13 +17,11 @@ def rule_runner() -> RuleRunner:
 
 
 def test_options_parse_scoped(rule_runner: RuleRunner) -> None:
-    options_bootstrapper = create_options_bootstrapper(
-        args=["-ldebug"], env=dict(PANTS_PANTSD="True", PANTS_BUILD_IGNORE='["ignoreme/"]')
+    rule_runner.set_options(
+        ["-ldebug"], env=dict(PANTS_PANTSD="True", PANTS_BUILD_IGNORE='["ignoreme/"]')
     )
-    global_options = rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE), options_bootstrapper])
-    python_setup_options = rule_runner.request(
-        ScopedOptions, [Scope("python-setup"), options_bootstrapper]
-    )
+    global_options = rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE)])
+    python_setup_options = rule_runner.request(ScopedOptions, [Scope("python-setup")])
 
     assert global_options.options.level == LogLevel.DEBUG
     assert global_options.options.pantsd is True
@@ -34,17 +32,14 @@ def test_options_parse_scoped(rule_runner: RuleRunner) -> None:
 def test_options_parse_memoization(rule_runner: RuleRunner) -> None:
     # Confirm that re-executing with a new-but-identical Options object results in memoization.
 
-    def parse(ob):
-        return rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE), ob])
-
-    # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
-    one_opts = create_options_bootstrapper()
-    two_opts = create_options_bootstrapper()
-    assert one_opts == two_opts
-    assert hash(one_opts) == hash(two_opts)
+    def parse() -> ScopedOptions:
+        # This will create a new `OptionsBootstrapper` and set it as a `SessionValue` on the engine
+        # session.
+        rule_runner.set_options([])
+        return rule_runner.request(ScopedOptions, [Scope(GLOBAL_SCOPE)])
 
     # If they are equal, executing parsing on them should result in a memoized object.
-    one = parse(one_opts)
-    two = parse(two_opts)
+    one = parse()
+    two = parse()
     assert one == two
     assert one is one

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -20,7 +20,7 @@ from pants.source.source_root import (
     get_optional_source_root,
 )
 from pants.source.source_root import rules as source_root_rules
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 
 
@@ -288,19 +288,12 @@ def test_source_roots_request() -> None:
             QueryRule(SourceRootsResult, (SourceRootsRequest,)),
         ]
     )
+    rule_runner.set_options(["--source-root-patterns=['src/python','tests/python']"])
     req = SourceRootsRequest(
         files=(PurePath("src/python/foo/bar.py"), PurePath("tests/python/foo/bar_test.py")),
         dirs=(PurePath("src/python/foo"), PurePath("src/python/baz/qux")),
     )
-    res = rule_runner.request(
-        SourceRootsResult,
-        [
-            req,
-            create_options_bootstrapper(
-                args=["--source-root-patterns=['src/python','tests/python']"]
-            ),
-        ],
-    )
+    res = rule_runner.request(SourceRootsResult, [req])
     assert {
         PurePath("src/python/foo/bar.py"): SourceRoot("src/python"),
         PurePath("tests/python/foo/bar_test.py"): SourceRoot("tests/python"),

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -107,9 +107,7 @@ class RuleRunner:
         build_config_builder.register_target_types(target_types or ())
         self.build_config = build_config_builder.create()
 
-        options_bootstrapper = OptionsBootstrapper.create(
-            env={}, args=["--pants-config-files=[]"], allow_pantsrc=False
-        )
+        options_bootstrapper = create_options_bootstrapper()
         global_options = options_bootstrapper.bootstrap_options.for_global_scope()
         local_store_dir = global_options.local_store_dir
         local_execution_root_dir = global_options.local_execution_root_dir
@@ -126,7 +124,11 @@ class RuleRunner:
             build_root=self.build_root,
             build_configuration=self.build_config,
             execution_options=ExecutionOptions.from_bootstrap_options(global_options),
-        ).new_session(build_id="buildid_for_test", should_report_workunits=True)
+        ).new_session(
+            build_id="buildid_for_test",
+            session_values=SessionValues({OptionsBootstrapper: options_bootstrapper}),
+            should_report_workunits=True,
+        )
         self.scheduler = graph_session.scheduler_session
 
     def __repr__(self) -> str:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -49,7 +49,6 @@ from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import recursive_dirname, safe_file_dump, safe_mkdir, safe_open
-from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 
 # -----------------------------------------------------------------------------------------------
@@ -71,8 +70,8 @@ class GoalRuleResult:
         return GoalRuleResult(0, stdout="", stderr="")
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+# This is not frozen because we need to update the `scheduler` when setting options.
+@dataclass
 class RuleRunner:
     build_root: str
     build_config: BuildConfiguration
@@ -130,6 +129,9 @@ class RuleRunner:
         ).new_session(build_id="buildid_for_test", should_report_workunits=True)
         self.scheduler = graph_session.scheduler_session
 
+    def __repr__(self) -> str:
+        return f"RuleRunner(build_root={self.build_root})"
+
     @property
     def pants_workdir(self) -> str:
         return os.path.join(self.build_root, ".pants.d")
@@ -143,17 +145,9 @@ class RuleRunner:
         return self.build_config.target_types
 
     def request(self, output_type: Type[_O], inputs: Iterable[Any]) -> _O:
-        # TODO: Update all callsites to pass this explicitly via session values.
-        session = self.scheduler
-        for value in inputs:
-            if type(value) == OptionsBootstrapper:
-                session = self.scheduler.scheduler.new_session(
-                    build_id="buildid_for_test",
-                    should_report_workunits=True,
-                    session_values=SessionValues({OptionsBootstrapper: value}),
-                )
-
-        result = assert_single_element(session.product_request(output_type, [Params(*inputs)]))
+        result = assert_single_element(
+            self.scheduler.product_request(output_type, [Params(*inputs)])
+        )
         return cast(_O, result)
 
     def run_goal_rule(
@@ -164,10 +158,9 @@ class RuleRunner:
         args: Optional[Iterable[str]] = None,
         env: Optional[Mapping[str, str]] = None,
     ) -> GoalRuleResult:
-        options_bootstrapper = create_options_bootstrapper(
-            args=(*(global_args or []), goal.name, *(args or [])),
-            env=env,
-        )
+        merged_args = (*(global_args or []), goal.name, *(args or []))
+        self.set_options(merged_args, env=env)
+        options_bootstrapper = create_options_bootstrapper(args=merged_args, env=env)
 
         raw_specs = options_bootstrapper.get_full_options(
             [*GlobalOptions.known_scope_infos(), *goal.subsystem_cls.known_scope_infos()]
@@ -177,13 +170,7 @@ class RuleRunner:
         stdout, stderr = StringIO(), StringIO()
         console = Console(stdout=stdout, stderr=stderr)
 
-        session = self.scheduler.scheduler.new_session(
-            build_id="buildid_for_test",
-            should_report_workunits=True,
-            session_values=SessionValues({OptionsBootstrapper: options_bootstrapper}),
-        )
-
-        exit_code = session.run_goal_rule(
+        exit_code = self.scheduler.run_goal_rule(
             goal,
             Params(
                 specs,
@@ -196,6 +183,18 @@ class RuleRunner:
 
         console.flush()
         return GoalRuleResult(exit_code, stdout.getvalue(), stderr.getvalue())
+
+    def set_options(self, args: Iterable[str], *, env: Optional[Mapping[str, str]] = None) -> None:
+        """Update the engine session with new options.
+
+        This will override any previously configured values.
+        """
+        options_bootstrapper = create_options_bootstrapper(args=args, env=env)
+        self.scheduler = self.scheduler.scheduler.new_session(
+            build_id="buildid_for_test",
+            should_report_workunits=True,
+            session_values=SessionValues({OptionsBootstrapper: options_bootstrapper}),
+        )
 
     def _invalidate_for(self, *relpaths):
         """Invalidates all files from the relpath, recursively up to the root.
@@ -278,17 +277,13 @@ class RuleRunner:
         """
         return self.make_snapshot({fp: "" for fp in files})
 
-    def get_target(
-        self, address: Address, options_bootstrapper: Optional[OptionsBootstrapper] = None
-    ) -> Target:
+    def get_target(self, address: Address) -> Target:
         """Find the target for a given address.
 
         This requires that the target actually exists, i.e. that you called
         `rule_runner.add_to_build_file()`.
         """
-        return self.request(
-            WrappedTarget, [address, options_bootstrapper or create_options_bootstrapper()]
-        ).target
+        return self.request(WrappedTarget, [address]).target
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
As of https://github.com/pantsbuild/pants/pull/10827, options are now set up through a new `SessionValues` mechanism. This means that our tests should no longer be passing `OptionsBootstrapper` as a `Param` anymore.

Instead, we must mutate the `SchedulerSession` when setting options. We surface a new entry-point `.set_options()`, which will change the options for the life of the `RuleRunner` instance.

```python
rule_runner.set_options(["--pants-ignore=['foo']"])
```

`RuleRunner` already was high on mutation, such as `rule_runner.create_file()` mutating the build root. This is why we encourage using Pytest fixtures to ensure each test is a new instance.

A followup will move `PantsEnvironment` to a `SessionValue`.

[ci skip-rust]
[ci skip-build-wheels]