### PR TITLE
copy over ipex shebang

### DIFF
--- a/src/python/pants/backend/python/subsystems/ipex/ipex_launcher.py
+++ b/src/python/pants/backend/python/subsystems/ipex/ipex_launcher.py
@@ -8,11 +8,12 @@ This script will "hydrate" a normal .pex file in the same directory, then execut
 
 import json
 import os
+import shutil
 import sys
 import tempfile
 
 from pex import resolver
-from pex.common import open_zip, safe_copy
+from pex.common import open_zip
 from pex.fetcher import Fetcher, PyPIFetcher
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
@@ -90,7 +91,7 @@ def _hydrate_pex_file(self, hydrated_pex_dir):
     # modules we just added to the chroot.
     # NB: Bytecode compilation can take an extremely long time for large 3rdparty modules.
     bootstrap_builder.freeze(bytecode_compile=False)
-    safe_copy(source=bootstrap_builder.path(), dest=hydrated_pex_dir)
+    shutil.copytree(bootstrap_builder.path(), hydrated_pex_dir, symlinks=True)
 
 
 def main(self):

--- a/src/python/pants/backend/python/subsystems/ipex/ipex_launcher.py
+++ b/src/python/pants/backend/python/subsystems/ipex/ipex_launcher.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 
 from pex import resolver
-from pex.common import open_zip
+from pex.common import open_zip, safe_copy
 from pex.fetcher import Fetcher, PyPIFetcher
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
@@ -90,7 +90,7 @@ def _hydrate_pex_file(self, hydrated_pex_dir):
     # modules we just added to the chroot.
     # NB: Bytecode compilation can take an extremely long time for large 3rdparty modules.
     bootstrap_builder.freeze(bytecode_compile=False)
-    os.rename(src=bootstrap_builder.path(), dst=hydrated_pex_dir)
+    safe_copy(source=bootstrap_builder.path(), dest=hydrated_pex_dir)
 
 
 def main(self):

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -176,6 +176,12 @@ class PythonBinaryCreate(Task):
                 ),
                 log=self.context.log,
                 generate_ipex=self._generate_ipex,
+                # NB: Because the ipex creation process (which creates a new PEXBuilder instance)
+                # takes place entirely within the PexBuilderWrapper.freeze() call, we need to
+                # provide the shebang line as state to the PexBuilderWrapper instance, so it can be
+                # applied *after* swapping out the PEXBuilder, but *before* it calls the inner
+                # PEXBuilder.freeze().
+                ipex_shebang=binary_tgt.shebang,
             )
 
             if binary_tgt.shebang:

--- a/src/python/pants/python/pex_build_util_test_integration.py
+++ b/src/python/pants/python/pex_build_util_test_integration.py
@@ -48,3 +48,20 @@ class PexBuildUtilIntegrationTest(PantsRunIntegrationTest):
                 info = json.loads(zf.read("PEX-INFO"))
                 constraint = assert_single_element(info["interpreter_constraints"])
                 assert constraint == imprecise_constraint
+
+    def test_eepython_shebang(self) -> None:
+        with temporary_dir() as tmp_dir:
+            self.do_command(
+                "--binary-py-generate-ipex",
+                "binary",
+                self.binary_target_address,
+                config={
+                    "GLOBAL": {"pants_distdir": tmp_dir},
+                },
+            )
+
+            pex_path = os.path.join(tmp_dir, "test.ipex")
+            assert os.path.isfile(pex_path)
+
+            with open(pex_path, 'rb') as f:
+                assert f.readline() == b'#!/opt/ee/python/3.6/bin/python3.6\n'

--- a/testprojects/src/python/python_targets/BUILD
+++ b/testprojects/src/python/python_targets/BUILD
@@ -3,6 +3,7 @@
 
 python_binary(
   name='test',
+  shebang='/opt/ee/python/3.6/bin/python3.6',
   source='test_binary.py',
   dependencies=[':test_library']
 )


### PR DESCRIPTION
### Problem

The `--generate-ipex` flag does not copy over shebang lines. This causes errors in our infrastructure which expects pex files to have a particular shebang line set.

### Solution

- Add `ipex_shebang` argument to `PexBuilderWrapper.Factory.create()`.
- Call `self.set_shebang(self._ipex_shebang)` after swapping out the `PEXBuilder` instance when creating an ipex.
- Add a test which unfortunately hardcodes a path to a python binary which only exists within Twitter (open to suggestions for improving this).

### Result
The following passes:
```bash
> ./pants test src/python/pants/python/pex_build_util_test_integration.py -- -vs -k test_eepython_shebang
```