### PR TITLE
Add back `blocked` flag on BoundedCommandRunner workunit

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -488,7 +488,12 @@ impl CommandRunner for BoundedCommandRunner {
     let name = format!("{}-waiting", req.workunit_name());
     let desc = req.user_facing_name();
     let mut outer_metadata = WorkunitMetadata::with_level(Level::Debug);
-    outer_metadata.desc = Some(desc.clone());
+
+    outer_metadata.desc = Some(format!("(Waiting) {}", desc));
+    // We don't want to display the workunit associated with processes waiting on a
+    // BoundedCommandRunner to show in the dynamic UI, so set the `blocked` flag
+    // on the workunit metadata in order to prevent this.
+    outer_metadata.blocked = true;
     let bounded_fut = {
       let inner = self.inner.clone();
       let semaphore = self.inner.1.clone();


### PR DESCRIPTION
### Problem

We're seeing some cases where lines are appearing in the dynamic UI corresponding to the outer workunit in the `BoundedCommandRunner`, that is, the workunit for a process that has been scheduled and is waiting for the opportunity to run. This is problematic because the timer representing how long a workunit has been running for isn't useful in this case. We only want to show workunits representing an actively-running process (or in general an actively-running Pants rule or intrinsic).

The `blocked` flag on `WorkunitMetadata` was added specifically to handle this case, but for some reason it was removed from the metadata for the outer workunit in this code.

### Solution

Add back the `blocked` flag for this outer workunit along with a clarifying comment, and also add the text "(Waiting)" to the description of this workunit, to make it more obvious what's going on if this flag is removed.