### PR TITLE
Clean up trace logging

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -89,7 +89,9 @@ function activate_pants_venv() {
     ensure_gcc
 
     for req in "${REQUIREMENTS[@]}"; do
-      pip install "${pip_extra[@]}" -r "${req}" || \
+      # NB: For the pip_extra reference, see:
+      #   https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+      pip install "${pip_extra[@]+"${pip_extra[@]}"}" -r "${req}" || \
         die "Failed to install requirements from ${req}."
     done
     touch "${BOOTSTRAPPED_FILE}"

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -44,7 +44,7 @@ use std::time::Duration;
 
 use fnv::FnvHasher;
 use futures::future;
-use log::{debug, info, trace, warn};
+use log::{debug, info, warn};
 use parking_lot::Mutex;
 use petgraph::graph::DiGraph;
 use petgraph::visit::EdgeRef;
@@ -500,7 +500,7 @@ impl<N: Node> Graph<N> {
         }
 
         // Valid dependency.
-        trace!(
+        test_trace_log!(
           "Adding dependency from {:?} to {:?}",
           inner.entry_for_id(src_id).unwrap().node(),
           inner.entry_for_id(dst_id).unwrap().node()
@@ -514,7 +514,7 @@ impl<N: Node> Graph<N> {
         !inner.entry_for_id(src_id).unwrap().node().cacheable()
       } else {
         // Otherwise, this is an external request: always retry.
-        trace!(
+        test_trace_log!(
           "Requesting node {:?}",
           inner.entry_for_id(dst_id).unwrap().node()
         );
@@ -908,6 +908,19 @@ impl<'a, N: Node + 'a, F: Fn(&EntryId) -> bool> Iterator for Walk<'a, N, F> {
 
     None
   }
+}
+
+///
+/// Logs at trace level, but only in `cfg(test)`.
+///
+#[macro_export]
+macro_rules! test_trace_log {
+    ($($arg:tt)+) => {
+      #[cfg(test)]
+      {
+        log::trace!($($arg)+)
+      }
+    };
 }
 
 #[cfg(test)]

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -291,7 +291,7 @@ impl<R: Rule> Builder<R> {
       }
       iteration += 1;
       if iteration % 1000 == 0 {
-        log::debug!(
+        log::trace!(
           "initial_polymorphic iteration {}: {} nodes",
           iteration,
           graph.node_count()
@@ -540,7 +540,7 @@ impl<R: Rule> Builder<R> {
             !node_ref.weight().is_deleted() && minimal_in_set.contains(&node_ref.id())
           })
           .count();
-        log::debug!(
+        log::trace!(
           "rule_graph monomorphize: iteration {}: live: {}, minimal: {}, to_visit: {}, total: {}",
           iteration,
           live_count,
@@ -596,7 +596,7 @@ impl<R: Rule> Builder<R> {
       };
       let had_dependees = !dependees_by_out_set.is_empty();
 
-      let debug_str = if looping {
+      let trace_str = if looping {
         format!(
           "creating monomorphizations (from {} dependee sets and {:?} dependencies) for {:?}: {} with {:#?} and {:#?}",
           dependees_by_out_set.len(),
@@ -670,7 +670,7 @@ impl<R: Rule> Builder<R> {
             // has a minimal in_set.
             maybe_mark_minimal_in_set(&mut minimal_in_set, &graph, node_id);
             if looping {
-              log::debug!(
+              log::trace!(
                 "not able to reduce {:?}: {} (had {} monomorphizations)",
                 node_id,
                 graph[node_id],
@@ -688,7 +688,7 @@ impl<R: Rule> Builder<R> {
         };
 
       if looping {
-        log::debug!("{}", debug_str);
+        log::trace!("{}", trace_str);
 
         maybe_in_loop.insert(node_id);
         if maybe_in_loop.len() > 5 {
@@ -742,7 +742,7 @@ impl<R: Rule> Builder<R> {
         };
 
         if looping {
-          log::debug!(
+          log::trace!(
             "   generating {:#?}, with {} dependees and {} dependencies ({} minimal) which consumes: {:#?}",
             new_node,
             dependees.len(),
@@ -763,7 +763,7 @@ impl<R: Rule> Builder<R> {
         }
 
         if looping {
-          log::debug!("node: creating: {:?}", replacement_id);
+          log::trace!("node: creating: {:?}", replacement_id);
         }
 
         // Give all dependees edges to the new node.
@@ -778,7 +778,7 @@ impl<R: Rule> Builder<R> {
             }
           }
           if looping {
-            log::debug!("dependee edge: adding: ({:?}, {})", dependee_id, edge);
+            log::trace!("dependee edge: adding: ({:?}, {})", dependee_id, edge);
           }
           graph.add_edge(*dependee_id, replacement_id, edge);
         }
@@ -793,7 +793,7 @@ impl<R: Rule> Builder<R> {
             dependency_id
           };
           if looping {
-            log::debug!(
+            log::trace!(
               "dependency edge: adding: {:?}",
               (dependency_key, dependency_id)
             );
@@ -1170,7 +1170,7 @@ impl<R: Rule> Builder<R> {
       |_, edge_weight| Some(edge_weight.clone()),
     );
 
-    log::debug!(
+    log::trace!(
       "// errored subgraph:\n{}",
       petgraph::dot::Dot::with_config(&subgraph, &[])
     );

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -139,7 +139,6 @@ impl ShardedLmdb {
     let mut lmdbs = HashMap::new();
 
     for (env, dir, fingerprint_prefix) in ShardedLmdb::envs(&root_path, max_size)? {
-      trace!("Making ShardedLmdb content database for {:?}", dir);
       let content_database = env
         .create_db(Some("content-versioned"), DatabaseFlags::empty())
         .map_err(|e| {
@@ -149,7 +148,6 @@ impl ShardedLmdb {
           )
         })?;
 
-      trace!("Making ShardedLmdb lease database for {:?}", dir);
       let lease_database = env
         .create_db(Some("leases-versioned"), DatabaseFlags::empty())
         .map_err(|e| {


### PR DESCRIPTION
### Problem

Pants' `trace` logging level (`-ltrace`) is not particularly useful currently due to the volume of logging from the `graph` crate.

### Solution

Although we could in theory filter the `graph` crate's logging via logging config, in practice the level of logging implemented there is only ever useful in tests, and never to end users. This change moves it behind a `#[cfg(test)]` check inside of a `test_trace_log` macro.

In two other tiny commits, additionally tweaks LMDB initialization logging, and `rule_graph` construction logging.

### Result

`./pants -ltrace $goal` outputs a more manageable amount of logging, of which workunit start/end messages make up about 99%.