### PR TITLE
Add `source_prefix_mapping` to `files` targets

### DIFF
--- a/src/python/pants/core/BUILD
+++ b/src/python/pants/core/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library()
+
+python_tests(name="tests")

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -1,7 +1,21 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from pants.engine.addresses import Address
+from pants.engine.fs import AddPrefix, RemovePrefix, Snapshot
+from pants.engine.rules import Get, rule
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    DictStringToStringField,
+    InvalidFieldException,
+    Sources,
+    Target,
+)
+from pants.util.frozendict import FrozenDict
 
 # -----------------------------------------------------------------------------------------------
 # `files` target
@@ -12,6 +26,64 @@ class FilesSources(Sources):
     required = True
 
 
+class SourcesPrefixMapping(DictStringToStringField):
+    """Change the prefix for the `sources` field to no longer be the path to the BUILD file (the
+    default).
+
+    To remove part of the original prefix, use `{"old_prefix": ""}`, which would change
+    `old_prefix/f.ext` to `f.ext`. To add to the beginning of the
+    original prefix, use `{"": "new_prefix"}`, which would change `f.ext` to `new_prefix/f.ext`.
+    To both remove and add a prefix, use `{"old_prefix": "new_prefix"}`, which would change
+    `old_prefix/f.ext` to `new_prefix/f.ext`.
+
+    When removing a prefix, that prefix must actually be part of the original prefix, i.e. the path
+    to the BUILD file.
+
+    You should only use entry in the dictionary because this mapping will be applied to every file
+    in the `sources` field.
+
+    You can run `./pants filedeps` to verify that the mapping is working as you intended.
+    """
+
+    alias = "sources_prefix_mapping"
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Dict[str, str]], *, address: Address
+    ) -> Optional[FrozenDict[str, str]]:
+        value = super().compute_value(raw_value, address=address)
+        if value is None:
+            return None
+        if len(value) > 1:
+            raise InvalidFieldException(
+                f"The {repr(cls.alias)} field in target {address} should not have more than one "
+                f"entry in its dictionary, but it had {len(value)} entries.\n\nWhy is this an "
+                "issue? The path manipulation will be able to be applied to every file in the "
+                "target's `sources` field, so they must all have a common prefix.\n\nIf you want "
+                "more complex logic, such as conditional path manipulation, instead use more "
+                "granular targets."
+            )
+        return value
+
+    @property
+    def remove_prefix(self) -> Optional[str]:
+        """What prefix to remove from the hydrated sources, if any."""
+        if not self.value:
+            return None
+        return tuple(self.value.keys())[0] or None
+
+    @property
+    def add_prefix(self) -> Optional[str]:
+        """What prefix to add to the hydrated sources, if any.
+
+        This should only be applied after first removing the prefix via the property
+        `remove_prefix`.
+        """
+        if not self.value:
+            return None
+        return tuple(self.value.values())[0] or None
+
+
 class Files(Target):
     """A collection of loose files which do not have their source roots stripped.
 
@@ -19,10 +91,38 @@ class Files(Target):
     `open()`. Unlike the similar `resources()` target type, Pants will not strip the source root of
     `files()`, meaning that `src/python/project/f1.txt` will not be stripped down to
     `project/f1.txt`.
+
+    Unlike other target types, you may also change the prefix for the `sources` field to be different
+    than the path to the BUILD file by setting `sources_prefix_mapping`.
     """
 
     alias = "files"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FilesSources)
+    core_fields = (*COMMON_TARGET_FIELDS, SourcesPrefixMapping, Dependencies, FilesSources)
+
+
+@dataclass(frozen=True)
+class ApplyPrefixMappingRequest:
+    hydrated_sources: Snapshot
+    prefix_mapping: SourcesPrefixMapping
+
+
+@dataclass(frozen=True)
+class PrefixMappedSnapshot:
+    snapshot: Snapshot
+
+
+@rule
+async def apply_prefix_mapping(request: ApplyPrefixMappingRequest) -> PrefixMappedSnapshot:
+    snapshot = request.hydrated_sources
+    if request.prefix_mapping.remove_prefix:
+        snapshot = await Get(
+            Snapshot, RemovePrefix(snapshot.digest, request.prefix_mapping.remove_prefix)
+        )
+    if request.prefix_mapping.add_prefix:
+        snapshot = await Get(
+            Snapshot, AddPrefix(snapshot.digest, request.prefix_mapping.add_prefix)
+        )
+    return PrefixMappedSnapshot(snapshot)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -1,0 +1,70 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Dict
+
+from pants.core.target_types import (
+    ApplyPrefixMappingRequest,
+    PrefixMappedSnapshot,
+    SourcesPrefixMapping,
+)
+from pants.engine.addresses import Address
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_path_prefix_mapping() -> None:
+    rule_runner = RuleRunner(rules=[QueryRule(PrefixMappedSnapshot, (ApplyPrefixMappingRequest,))])
+
+    def assert_prefix_mapping(
+        *,
+        original: str,
+        mapping: Dict[str, str],
+        expected: str,
+    ) -> None:
+        original_snapshot = rule_runner.make_snapshot_of_empty_files([original])
+        field = SourcesPrefixMapping(mapping, address=Address("foo"))
+        result = rule_runner.request(
+            PrefixMappedSnapshot, [ApplyPrefixMappingRequest(original_snapshot, field)]
+        )
+        assert result.snapshot.files == (expected,)
+
+    assert_prefix_mapping(original="old_prefix/f.ext", mapping={}, expected="old_prefix/f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        mapping={"old_prefix": "old_prefix"},
+        expected="old_prefix/f.ext",
+    )
+
+    assert_prefix_mapping(original="old_prefix/f.ext", mapping={"old_prefix": ""}, expected="f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/subdir/f.ext", mapping={"old_prefix": ""}, expected="subdir/f.ext"
+    )
+
+    assert_prefix_mapping(original="f.ext", mapping={"": "new_prefix"}, expected="new_prefix/f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        mapping={"": "new_prefix"},
+        expected="new_prefix/old_prefix/f.ext",
+    )
+
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        mapping={"old_prefix": "new_prefix"},
+        expected="new_prefix/f.ext",
+    )
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        mapping={"old_prefix": "new_prefix/subdir"},
+        expected="new_prefix/subdir/f.ext",
+    )
+
+    assert_prefix_mapping(
+        original="common_prefix/foo/f.ext",
+        mapping={"common_prefix/foo": "common_prefix/bar"},
+        expected="common_prefix/bar/f.ext",
+    )
+    assert_prefix_mapping(
+        original="common_prefix/subdir/f.ext",
+        mapping={"common_prefix/subdir": "common_prefix"},
+        expected="common_prefix/f.ext",
+    )


### PR DESCRIPTION
### Problem

We want to add back `python_app` and `bundle`, but better. Within that, we need to add back the `rel_path` field that `bundle` had, which allows for changing the location of the loose files, e.g. moving `src/resources/f.ext` to instead be `new_prefix/f.ext`.

However, we want this `rel_path` feature to be consistent. It was confusing that `bundle` would use the transformed path, but `test` would use the original.

### Solution

Add a field `source_prefix_mapping` to the `files` target so that users can express how they want to transform the prefix to their `sources`. See https://github.com/pantsbuild/pants/issues/10733#issuecomment-700340859 for justification of using a single field—even though it's a little complex—rather than multiple fields like we had with `bundle`.

To avoid introducing more symbols to the BUILD file, we use a dictionary, even though it's a little weird this only allows 0-1 entries.

#### Rejected alternative: source roots manipulation

One idea for implementing this was to leverage source roots, such as moving source root calculation eagerly into `HydrateSources`, so that the `HydratedSources` use this manipulated source root. However, this would not work cleanly for a few reasons:

1) Source roots are always stripped at the moment, but never added to. In contrast, this requires both stripping _and_ then adding, in that specific order.
     * Source roots is up to the call site to handle. Some call sites ignore it (Black, Isort), some strip them (Protoc), and some modify things like PYTHONPATH (MyPy, Pytest). Every call site must now ensure it is correctly applying this special case.
    * We could change our general source roots code such that a typical source root has the mapping `{"src/python": ""}`. However, this leaks the feature to several places and it's not clear how you would add a new prefix for Python, which sets `PYTHONPATH`, rather than mutating file paths.
    * Source roots are already fairly complex, both for users and plugin authors. Adding more semantic meaning to them would be costly.

### Result

We can change `3rdparty/python/constraints.txt` to have the path `new_prefix/python/constraints.txt`:

```python
files(
  name = '3rdparty_directory',
  sources = ['3rdparty/**/*'],
  sources_prefix_mapping={"3rdparty": "new_prefix"},
)

```

```
▶ ./pants filedeps 3rdparty/python/constraints.txt
BUILD
new_prefix/python/constraints.txt
```

This new mapping will be used in all generated chroots. For example, `test` will use the mapping, along with `typecheck` if you depend on `files` targets.

File arguments are still working as we'd want, as shown above. That is, file arguments still use the original path. Likewise, file addresses still use the original paths, along with the generated subtargets code in general. 

#### Likely bad edge: `./pants filedeps`

`./pants filedeps` will show the transformed files, rather than the concrete files. This is the first time we're changing `filedeps` to include files that may not actually exist on disk; for example, we do not include codegen with `filedeps`, and only show the protocol targets.

On one hand, this is a useful debugging mechanism for people using this feature. On the other hand, we're now breaking an invariant that you can always safely pipe `./pants filedeps` to external tools like Git.

This PR was implemented this way mostly for simplicity: we likely do not want to start having call sites need to decide whether they should use the original vs. transformed `files` sources, as that's confusing and error-prone. We already make them decide if they should use codegen or not, which is complex enough. However, we could easily add this toggle and simply make it private with a leading `_` and default to using the transformation.

[ci skip-rust]
[ci skip-build-wheels]
