### PR TITLE
Add several rule descriptions and debug hints

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -143,7 +143,7 @@ class InferInitDependencies(InferDependenciesRequest):
     infer_from = PythonSources
 
 
-@rule
+@rule(desc="Inferring dependencies on `__init__.py` files")
 async def infer_python_init_dependencies(
     request: InferInitDependencies, python_inference: PythonInference
 ) -> InferredDependencies:
@@ -173,7 +173,7 @@ class InferConftestDependencies(InferDependenciesRequest):
     infer_from = PythonTestsSources
 
 
-@rule
+@rule(desc="Inferring dependencies on `conftest.py` files")
 async def infer_python_conftest_dependencies(
     request: InferConftestDependencies,
     python_inference: PythonInference,

--- a/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
+++ b/src/python/pants/backend/python/typecheck/mypy/plugin_target_type.py
@@ -22,8 +22,8 @@ class MyPySourcePlugin(Target):
             `pants-plugins/mypy_plugins/custom_plugin.py`, and you set `pants-plugins` as a source root,
             then set `plugins = mypy_plugins.custom_plugin`. Set the `config`
             option in the `[mypy]` scope to point to your MyPy config file.
-        5. Set the option `source_plugins` in the `[mypy]` scope to include this target's
-            address, e.g. `source_plugins = ["build-support/mypy_plugins:plugin"]`.
+        4. Set the option `source_plugins` in the `[mypy]` scope to include this target's
+            address, e.g. `source_plugins = ["pants-plugins/mypy_plugins:plugin"]`.
 
     To instead load a third-party plugin, set the option `extra_requirements` in the `[mypy]`
     scope (see https://www.pantsbuild.org/v2.0/docs/python-typecheck-goal). Set `plugins` in
@@ -32,8 +32,9 @@ class MyPySourcePlugin(Target):
     This target type is treated similarly to a `python_library` target. For example, Python linters
     and formatters will run on this target.
 
-    You can include other targets in the `dependencies` field, including third-party requirements
-    and other source files (even if those source files live in a different directory).
+    You can depend on other targets and Pants's dependency inference will add them to the `dependencies` field,
+    including any third-party requirements and `python_library` targets (even if their source files live in a different
+    directory).
 
     Other targets can depend on this target. This allows you to write a `python_tests` target for
     this code or a `python_distribution` target to distribute the plugin externally.

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -641,7 +641,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
 
             noop()
 
-            class AutoAddFieldPlugin(Plugin):
+            class ChangeReturnTypePlugin(Plugin):
                 def get_function_hook(
                     self, fullname: str
                 ) -> Optional[Callable[[FunctionContext], MyPyType]]:
@@ -653,7 +653,7 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
 
 
             def plugin(_version: str) -> Type[Plugin]:
-                return AutoAddFieldPlugin
+                return ChangeReturnTypePlugin
             """
         ),
     )

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -143,7 +143,7 @@ class PexEnvironment(EngineAwareReturnType):
         return f"Selected {self.bootstrap_python.path} to bootstrap PEXes with."
 
 
-@rule(desc="Find PEX Python", level=LogLevel.DEBUG)
+@rule(desc="Find Python interpreter to bootstrap PEX", level=LogLevel.DEBUG)
 async def find_pex_python(
     python_setup: PythonSetup,
     pex_runtime_env: PexRuntimeEnvironment,

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -7,6 +7,7 @@ from pathlib import PurePath
 from typing import Optional, Sequence
 
 from pants.base.deprecated import deprecated
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
@@ -197,7 +198,7 @@ class AddressInput:
         return Address(spec_path=self.path_component, target_name=self.target_component)
 
 
-class Address:
+class Address(EngineAwareParameter):
     """A target address.
 
     An address is a unique name for a `pants.engine.target.Target`, and optionally a particular file
@@ -378,6 +379,9 @@ class Address:
             (other._relative_file_path or ""),
             (other._target_name or ""),
         )
+
+    def debug_hint(self) -> str:
+        return self.spec
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -18,7 +18,7 @@ from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
-from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
+from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, InteractiveRunner
@@ -142,15 +142,12 @@ class TestDebugRequest:
 
 
 @union
-class TestFieldSet(FieldSet, EngineAwareParameter, metaclass=ABCMeta):
+class TestFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary to run tests on a target."""
 
     sources: Sources
 
     __test__ = False
-
-    def debug_hint(self):
-        return self.address.spec
 
 
 class CoverageData(ABC):

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -48,7 +48,7 @@ class UnzipBinary(BinaryPath):
         return (self.path, "-q", archive_path, "-d", output_dir)
 
 
-@rule(level=LogLevel.DEBUG)
+@rule(desc="Finding the `unzip` binary", level=LogLevel.DEBUG)
 async def find_unzip() -> UnzipBinary:
     request = BinaryPathRequest(
         binary_name="unzip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
@@ -67,7 +67,7 @@ class TarBinary(BinaryPath):
         return (self.path, "xf", archive_path, "-C", output_dir)
 
 
-@rule(level=LogLevel.DEBUG)
+@rule(desc="Finding the `tar` binary", level=LogLevel.DEBUG)
 async def find_tar() -> TarBinary:
     request = BinaryPathRequest(
         binary_name="tar", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["--version"])
@@ -79,7 +79,7 @@ async def find_tar() -> TarBinary:
     return TarBinary(first_path.path, first_path.fingerprint)
 
 
-@rule(level=LogLevel.DEBUG)
+@rule(desc="Extracting an archive file", level=LogLevel.DEBUG)
 async def maybe_extract(
     extractable: MaybeExtractable, tar_binary: TarBinary, unzip_binary: UnzipBinary
 ) -> ExtractedDigest:

--- a/src/python/pants/core/util_rules/source_files.py
+++ b/src/python/pants/core/util_rules/source_files.py
@@ -50,7 +50,7 @@ class SourceFilesRequest:
         self.enable_codegen = enable_codegen
 
 
-@rule
+@rule(desc="Get all relevant source files")
 async def determine_source_files(request: SourceFilesRequest) -> SourceFiles:
     """Merge all `Sources` fields into one Snapshot."""
     unrooted_files: Set[str] = set()

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -15,6 +15,7 @@ from pants.engine.addresses import (
     AddressWithOrigin,
     BuildFileAddress,
 )
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.internals.mapper import AddressFamily, AddressMap, AddressSpecsFilter
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, error_on_imports
@@ -26,7 +27,7 @@ from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
 
 
-@rule
+@rule(desc="Expand macros")
 async def evaluate_preludes(global_options: GlobalOptions) -> BuildFilePreludeSymbols:
     prelude_digest_contents = await Get(
         DigestContents,
@@ -76,7 +77,7 @@ async def resolve_address(address_input: AddressInput) -> Address:
 
 
 @dataclass(frozen=True)
-class AddressFamilyDir:
+class AddressFamilyDir(EngineAwareParameter):
     """The directory to find addresses for.
 
     This does _not_ recurse into subdirectories.
@@ -84,8 +85,11 @@ class AddressFamilyDir:
 
     path: str
 
+    def debug_hint(self) -> str:
+        return self.path
 
-@rule
+
+@rule(desc="Search for addresses in BUILD files.")
 async def parse_address_family(
     parser: Parser,
     global_options: GlobalOptions,

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -293,7 +293,7 @@ def _detect_cycles(
             )
 
 
-@rule
+@rule(desc="Resolve transitive targets")
 async def transitive_targets(targets: Targets) -> TransitiveTargets:
     """Find all the targets transitively depended upon by the target roots.
 
@@ -358,7 +358,7 @@ class Owners(Collection[Address]):
     pass
 
 
-@rule
+@rule(desc="Find which targets own certain files")
 async def find_owners(owners_request: OwnersRequest) -> Owners:
     # Determine which of the sources are live and which are deleted.
     sources_paths = await Get(Paths, PathGlobs(owners_request.sources))
@@ -598,7 +598,7 @@ class AmbiguousCodegenImplementationsException(Exception):
             )
 
 
-@rule
+@rule(desc="Hydrate the `sources` field")
 async def hydrate_sources(
     request: HydrateSourcesRequest,
     global_options: GlobalOptions,
@@ -740,7 +740,7 @@ def parse_dependencies_field(
     return ParsedDependencies(addresses, ignored_addresses)
 
 
-@rule
+@rule(desc="Resolve direct dependencies")
 async def resolve_dependencies(
     request: DependenciesRequest,
     union_membership: UnionMembership,

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -31,6 +31,7 @@ from typing_extensions import final
 from pants.base.specs import Spec
 from pants.engine.addresses import Address, AddressInput, assert_single_address
 from pants.engine.collection import Collection, DeduplicatedCollection
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import GlobExpansionConjunction, GlobMatchErrorBehavior, PathGlobs, Snapshot
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import FilesNotFoundBehavior
@@ -712,7 +713,7 @@ def generate_subtarget(
 
 
 @dataclass(frozen=True)
-class _AbstractFieldSet(ABC):
+class _AbstractFieldSet(EngineAwareParameter, ABC):
     required_fields: ClassVar[Tuple[Type[Field], ...]]
 
     address: Address
@@ -732,6 +733,9 @@ class _AbstractFieldSet(ABC):
             for target_type in target_types
             if target_type.class_has_fields(cls.required_fields, union_membership=union_membership)
         )
+
+    def debug_hint(self) -> str:
+        return self.address.spec
 
 
 def _get_field_set_fields_from_target(
@@ -1352,7 +1356,7 @@ class Sources(AsyncField):
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class HydrateSourcesRequest:
+class HydrateSourcesRequest(EngineAwareParameter):
     field: Sources
     for_sources_types: Tuple[Type[Sources], ...]
     enable_codegen: bool
@@ -1389,6 +1393,9 @@ class HydrateSourcesRequest:
                 "generate Python files."
             )
 
+    def debug_hint(self) -> str:
+        return self.field.address.spec
+
 
 @dataclass(frozen=True)
 class HydratedSources:
@@ -1409,7 +1416,7 @@ class HydratedSources:
 
 @union
 @dataclass(frozen=True)
-class GenerateSourcesRequest:
+class GenerateSourcesRequest(EngineAwareParameter):
     """A request to go from protocol sources -> a particular language.
 
     This should be subclassed for each distinct codegen implementation. The subclasses must define
@@ -1441,6 +1448,9 @@ class GenerateSourcesRequest:
 
     input: ClassVar[Type[Sources]]
     output: ClassVar[Type[Sources]]
+
+    def debug_hint(self) -> str:
+        return "{self.protocol_target.address.spec}"
 
 
 @dataclass(frozen=True)
@@ -1502,13 +1512,16 @@ class Dependencies(AsyncField):
 
 
 @dataclass(frozen=True)
-class DependenciesRequest:
+class DependenciesRequest(EngineAwareParameter):
     field: Dependencies
+
+    def debug_hint(self) -> str:
+        return self.field.address.spec
 
 
 @union
 @dataclass(frozen=True)
-class InjectDependenciesRequest(ABC):
+class InjectDependenciesRequest(EngineAwareParameter, ABC):
     """A request to inject dependencies, in addition to those explicitly provided.
 
     To set up a new injection, subclass this class. Set the class property `inject_for` to the
@@ -1543,6 +1556,9 @@ class InjectDependenciesRequest(ABC):
     dependencies_field: Dependencies
     inject_for: ClassVar[Type[Dependencies]]
 
+    def debug_hint(self) -> str:
+        return self.dependencies_field.address.spec
+
 
 class InjectedDependencies(DeduplicatedCollection[Address]):
     sort_input = True
@@ -1550,7 +1566,7 @@ class InjectedDependencies(DeduplicatedCollection[Address]):
 
 @union
 @dataclass(frozen=True)
-class InferDependenciesRequest:
+class InferDependenciesRequest(EngineAwareParameter):
     """A request to infer dependencies by analyzing source files.
 
     To set up a new inference implementation, subclass this class. Set the class property
@@ -1582,6 +1598,9 @@ class InferDependenciesRequest:
 
     sources_field: Sources
     infer_from: ClassVar[Type[Sources]]
+
+    def debug_hint(self) -> str:
+        return self.sources_field.address.spec
 
 
 @frozen_after_init

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -10,11 +10,13 @@ from typing import Dict, Iterable, Optional, Set, Tuple, Union
 
 from pants.build_graph.address import Address
 from pants.engine.collection import DeduplicatedCollection
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Target
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
 from pants.util.meta import frozen_after_init
 
@@ -167,7 +169,7 @@ class SourceRootsRequest:
 
 
 @dataclass(frozen=True)
-class SourceRootRequest:
+class SourceRootRequest(EngineAwareParameter):
     """Find the source root for the given path.
 
     If you have multiple paths, particularly if many of them share parent directories, you'll get
@@ -197,6 +199,9 @@ class SourceRootRequest:
     @classmethod
     def for_target(cls, target: Target) -> "SourceRootRequest":
         return cls.for_address(target.address)
+
+    def debug_hint(self) -> str:
+        return str(self.path)
 
 
 @dataclass(frozen=True)
@@ -308,7 +313,7 @@ class AllSourceRoots(DeduplicatedCollection[SourceRoot]):
     sort_input = True
 
 
-@rule(desc="Compute all source roots")
+@rule(desc="Compute all source roots", level=LogLevel.DEBUG)
 async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
     source_root_pattern_matcher = source_root_config.get_pattern_matcher()
 


### PR DESCRIPTION
Right now, the dynamic UI spends a lot of time saying it's snapshotting files, when really it's doing other things. By adding rule descriptions, we give more insight into what Pants is doing, which makes the system feel less slow and magical (what does "snapshotting" mean to a user?)

We also add `EngineAwareParameter` to several core rules. This improves stack traces to provide some dynamic information. We don't do this everywhere, though, especially in places where the parameter is huge, like a collection of N targets.

[ci skip-rust]
[ci skip-build-wheels] the pull request._)
