### PR TITLE
Local process cache validates that digests exist locally before hitting (cherrypick of #10789)

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -283,8 +283,8 @@ class Scheduler:
     def lease_files_in_graph(self, session):
         self._native.lib.lease_files_in_graph(self._scheduler, session)
 
-    def garbage_collect_store(self):
-        self._native.lib.garbage_collect_store(self._scheduler)
+    def garbage_collect_store(self, target_size_bytes: int) -> None:
+        self._native.lib.garbage_collect_store(self._scheduler, target_size_bytes)
 
     def new_session(
         self,
@@ -613,5 +613,5 @@ class SchedulerSession:
     def lease_files_in_graph(self):
         self._scheduler.lease_files_in_graph(self._session)
 
-    def garbage_collect_store(self):
-        self._scheduler.garbage_collect_store()
+    def garbage_collect_store(self, target_size_bytes: int) -> None:
+        self._scheduler.garbage_collect_store(target_size_bytes)

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -13,14 +13,19 @@ class StoreGCService(PantsService):
 
     This service both ensures that in-use files continue to be present in the engine's Store, and
     performs occasional garbage collection to bound the size of the engine's Store.
+
+    NB: The lease extension interval should be significantly less than the rust-side
+    sharded_lmdb::DEFAULT_LEASE_TIME to ensure that valid leases are extended well before they
+    might expire.
     """
 
     def __init__(
         self,
         scheduler: Scheduler,
         period_secs=10,
-        lease_extension_interval_secs=(30 * 60),
-        gc_interval_secs=(4 * 60 * 60),
+        lease_extension_interval_secs=(15 * 60),
+        gc_interval_secs=(1 * 60 * 60),
+        target_size_bytes=(4 * 1024 * 1024 * 1024),
     ):
         super().__init__()
         self._scheduler_session = scheduler.new_session(
@@ -31,6 +36,7 @@ class StoreGCService(PantsService):
         self._period_secs = period_secs
         self._lease_extension_interval_secs = lease_extension_interval_secs
         self._gc_interval_secs = gc_interval_secs
+        self._target_size_bytes = target_size_bytes
 
         self._set_next_gc()
         self._set_next_lease_extension()
@@ -53,7 +59,7 @@ class StoreGCService(PantsService):
         if time.time() < self._next_gc:
             return
         self._logger.info("Garbage collecting store")
-        self._scheduler_session.garbage_collect_store()
+        self._scheduler_session.garbage_collect_store(self._target_size_bytes)
         self._logger.info("Done garbage collecting store")
         self._set_next_gc()
 

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -240,6 +240,14 @@ impl ByteStore {
     Ok(())
   }
 
+  pub async fn remove(&self, entry_type: EntryType, digest: Digest) -> Result<bool, String> {
+    let dbs = match entry_type {
+      EntryType::Directory => self.inner.directory_dbs.clone(),
+      EntryType::File => self.inner.file_dbs.clone(),
+    };
+    dbs?.remove(digest.0).await
+  }
+
   pub async fn store_bytes(
     &self,
     entry_type: EntryType,

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -2,10 +2,12 @@ use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, NamedCaches,
   Process, ProcessMetadata,
 };
+
+use std::convert::TryInto;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
 
+use futures::compat::Future01CompatExt;
 use sharded_lmdb::{ShardedLmdb, DEFAULT_LEASE_TIME};
 use store::Store;
 use tempfile::TempDir;
@@ -17,41 +19,27 @@ struct RoundtripResults {
   maybe_cached: Result<FallibleProcessResultWithPlatform, String>,
 }
 
-async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
+fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
   let runtime = task_executor::Executor::new(Handle::current());
-  let work_dir = TempDir::new().unwrap();
-  let named_cache_dir = TempDir::new().unwrap();
-  let store_dir = TempDir::new().unwrap();
-  let store = Store::local_only(runtime.clone(), store_dir.path()).unwrap();
-  let local = crate::local::CommandRunner::new(
+  let base_dir = TempDir::new().unwrap();
+  let named_cache_dir = base_dir.path().join("named_cache_dir");
+  let store_dir = base_dir.path().join("store_dir");
+  let store = Store::local_only(runtime.clone(), store_dir).unwrap();
+  let runner = Box::new(crate::local::CommandRunner::new(
     store.clone(),
     runtime.clone(),
-    work_dir.path().to_owned(),
-    NamedCaches::new(named_cache_dir.path().to_owned()),
+    base_dir.path().to_owned(),
+    NamedCaches::new(named_cache_dir),
     true,
-  );
+  ));
+  (runner, store, base_dir)
+}
 
-  let script_dir = TempDir::new().unwrap();
-  let script_path = script_dir.path().join("script");
-  std::fs::File::create(&script_path)
-    .and_then(|mut file| {
-      writeln!(
-        file,
-        "echo -n {} > roland && echo Hello && echo >&2 World; exit {}",
-        TestData::roland().string(),
-        script_exit_code
-      )
-    })
-    .unwrap();
-
-  let request = Process::new(vec![
-    testutil::path::find_bash(),
-    format!("{}", script_path.display()),
-  ])
-  .output_files(vec![PathBuf::from("roland")].into_iter().collect());
-
-  let local_result = local.run(request.clone().into(), Context::default()).await;
-
+fn create_cached_runner(
+  local: Box<dyn CommandRunnerTrait>,
+  store: Store,
+) -> (Box<dyn CommandRunnerTrait>, TempDir) {
+  let runtime = task_executor::Executor::new(Handle::current());
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
 
@@ -69,15 +57,49 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
     platform_properties: vec![],
   };
 
-  let caching = crate::cache::CommandRunner::new(
-    Arc::new(local),
+  let runner = Box::new(crate::cache::CommandRunner::new(
+    local.into(),
     process_execution_store,
-    store.clone(),
+    store,
     metadata,
-  );
+  ));
+
+  (runner, cache_dir)
+}
+
+fn create_script(script_exit_code: i8) -> (Process, PathBuf, TempDir) {
+  let script_dir = TempDir::new().unwrap();
+  let script_path = script_dir.path().join("script");
+  std::fs::File::create(&script_path)
+    .and_then(|mut file| {
+      writeln!(
+        file,
+        "echo -n {} > roland && echo Hello && echo >&2 World; exit {}",
+        TestData::roland().string(),
+        script_exit_code
+      )
+    })
+    .unwrap();
+
+  let process = Process::new(vec![
+    testutil::path::find_bash(),
+    format!("{}", script_path.display()),
+  ])
+  .output_files(vec![PathBuf::from("roland")].into_iter().collect());
+
+  (process, script_path, script_dir)
+}
+
+async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
+  let (local, store, _local_runner_dir) = create_local_runner();
+  let (process, script_path, _script_dir) = create_script(script_exit_code);
+
+  let local_result = local.run(process.clone().into(), Context::default()).await;
+
+  let (caching, _cache_dir) = create_cached_runner(local, store.clone());
 
   let uncached_result = caching
-    .run(request.clone().into(), Context::default())
+    .run(process.clone().into(), Context::default())
     .await;
 
   assert_eq!(local_result, uncached_result);
@@ -86,7 +108,7 @@ async fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
   // fail due to a FileNotFound error. So, If the second run succeeds, that implies that the
   // cache was successfully used.
   std::fs::remove_file(&script_path).unwrap();
-  let maybe_cached_result = caching.run(request.into(), Context::default()).await;
+  let maybe_cached_result = caching.run(process.into(), Context::default()).await;
 
   RoundtripResults {
     uncached: uncached_result,
@@ -106,4 +128,57 @@ async fn failures_not_cached() {
   assert_ne!(results.uncached, results.maybe_cached);
   assert_eq!(results.uncached.unwrap().exit_code, 1);
   assert_eq!(results.maybe_cached.unwrap().exit_code, 127); // aka the return code for file not found
+}
+
+#[tokio::test]
+async fn recover_from_missing_store_contents() {
+  let (local, store, _local_runner_dir) = create_local_runner();
+  let (caching, _cache_dir) = create_cached_runner(local, store.clone());
+  let (process, _script_path, _script_dir) = create_script(0);
+
+  // Run once to cache the process.
+  let first_result = caching
+    .run(process.clone().into(), Context::default())
+    .await
+    .unwrap();
+
+  // Delete the first child of the output directory parent to confirm that we ensure that more
+  // than just the root of the output is present when hitting the cache.
+  {
+    let output_dir_digest = first_result.output_directory;
+    let (output_dir, _) = store
+      .load_directory(output_dir_digest)
+      .await
+      .unwrap()
+      .unwrap();
+    let output_child_digest = output_dir
+      .get_files()
+      .first()
+      .unwrap()
+      .get_digest()
+      .try_into()
+      .unwrap();
+    let removed = store.remove_file(output_child_digest).await.unwrap();
+    assert!(removed);
+    assert!(store
+      .contents_for_directory(output_dir_digest)
+      .compat()
+      .await
+      .err()
+      .is_some())
+  }
+
+  // Ensure that we don't fail if we re-run.
+  let second_result = caching
+    .run(process.clone().into(), Context::default())
+    .await
+    .unwrap();
+
+  // And that the entire output directory can be loaded.
+  assert!(store
+    .contents_for_directory(second_result.output_directory)
+    .compat()
+    .await
+    .ok()
+    .is_some())
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -202,7 +202,7 @@ py_module_initializer!(native_engine, |py, m| {
   m.add(
     py,
     "garbage_collect_store",
-    py_fn!(py, garbage_collect_store(a: PyScheduler)),
+    py_fn!(py, garbage_collect_store(a: PyScheduler, b: usize)),
   )?;
   m.add(
     py,
@@ -1228,13 +1228,17 @@ fn set_panic_handler(_: Python) -> PyUnitResult {
   Ok(None)
 }
 
-fn garbage_collect_store(py: Python, scheduler_ptr: PyScheduler) -> PyUnitResult {
+fn garbage_collect_store(
+  py: Python,
+  scheduler_ptr: PyScheduler,
+  target_size_bytes: usize,
+) -> PyUnitResult {
   with_scheduler(py, scheduler_ptr, |scheduler| {
     py.allow_threads(|| {
-      scheduler.core.store().garbage_collect(
-        store::DEFAULT_LOCAL_STORE_GC_TARGET_BYTES,
-        store::ShrinkBehavior::Fast,
-      )
+      scheduler
+        .core
+        .store()
+        .garbage_collect(target_size_bytes, store::ShrinkBehavior::Fast)
     })
     .map_err(|e| PyErr::new::<exc::Exception, _>(py, (e,)))
     .map(|()| None)


### PR DESCRIPTION
### Problem

#10719 likely describes two different variants of "we hit the local process cache, but then failed to actually use the result because it had been garbage collected". In one of the cases it is crystal clear that the result was collected, because it is the stdout of the process that is missing. In the other case, the failure occurs while attempting to merge directories produced by process runs.

### Solution

When hitting the local process cache, ensure that all of the process outputs exist (and as a sideffect, that they are downloaded locally if a remote cache is configured). Added and fixed a test for this case.

An alternative implementation would have been to guarantee that a cache entry must exist only if all of the digests it requires are transitively reachable. But the local cache and the filesystem store use two different LMDB stores, which means that we cannot transactionally update them in a way that would rule out a cache entry existing even though its file content had been garbage collected... and it's not clear that merging those stores is desirable.

### Result

Fixes #10719. In addition to the test, I lowered the lease time and garbage collection times and validated that the case described on #10719 is no longer reproducible.