### PR TITLE
Add `relocated_files` target type

### DIFF
--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -192,7 +192,11 @@ class VerboseTargetInfo:
         output.extend(
             [
                 "Valid fields:\n",
-                *sorted(f"{field.format_for_cli(console)}\n" for field in self.fields),
+                *sorted(
+                    f"{field.format_for_cli(console)}\n"
+                    for field in self.fields
+                    if not field.alias.startswith("_")
+                ),
             ]
         )
         return "\n".join(output).rstrip()

--- a/src/python/pants/core/BUILD
+++ b/src/python/pants/core/BUILD
@@ -2,3 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library()
+
+python_tests(name="tests")

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -7,7 +7,8 @@ These are always activated and cannot be disabled.
 """
 
 from pants.core.goals import binary, fmt, lint, repl, run, test, typecheck
-from pants.core.target_types import Files, GenericTarget, Resources
+from pants.core.target_types import Files, GenericTarget, RelocatedFiles, Resources
+from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import (
     archive,
     distdir,
@@ -43,8 +44,9 @@ def rules():
         *pants_environment.rules(),
         *subprocess_environment.rules(),
         *source_root.rules(),
+        *target_type_rules(),
     ]
 
 
 def target_types():
-    return [Files, GenericTarget, Resources]
+    return [Files, GenericTarget, Resources, RelocatedFiles]

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -1,7 +1,24 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, Sources, Target
+from pants.engine.addresses import Address, AddressInput
+from pants.engine.fs import AddPrefix, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    GeneratedSources,
+    GenerateSourcesRequest,
+    HydratedSources,
+    HydrateSourcesRequest,
+    Sources,
+    StringField,
+    StringSequenceField,
+    Target,
+    WrappedTarget,
+)
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
 
 # -----------------------------------------------------------------------------------------------
 # `files` target
@@ -23,6 +40,128 @@ class Files(Target):
 
     alias = "files"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FilesSources)
+
+
+# -----------------------------------------------------------------------------------------------
+# `relocated_files` target
+# -----------------------------------------------------------------------------------------------
+
+
+class RelocatedFilesSources(Sources):
+    # We solely register this field for codegen to work.
+    alias = "_sources"
+    required = False
+    expected_num_files = 0
+
+
+class RelocatedFilesOriginalTargets(StringSequenceField):
+    """Addresses to the original `files()` targets that you want to relocate, such as
+    `['//:json_files']`.
+
+    Every target will be relocated using the same mapping. This means that every target must include
+    the value from the `src` field in their original path.
+    """
+
+    alias = "files_targets"
+    required = True
+
+
+class RelocatedFilesSrcField(StringField):
+    """The original prefix that you want to replace, such as `src/resources`.
+
+    You can set this field to `""` to preserve the original path; the value in the `dest` field will
+    then be added to the beginning of this original path.
+    """
+
+    alias = "src"
+    required = True
+
+
+class RelocatedFilesDestField(StringField):
+    """The new prefix that you want to add to the beginning of the path, such as `data`.
+
+    You can set this field to `""` to avoid adding any new values to the path; the value in the
+    `src` field will then be stripped, rather than replaced.
+    """
+
+    alias = "dest"
+    required = True
+
+
+class RelocatedFiles(Target):
+    """Relocate the paths for `files()` targets at runtime to something more convenient than the
+    default of their actual paths in your project.
+
+    For example, you can relocate `src/resources/project1/data.json` to instead be
+    `resources/data.json`. Your other target types can then add this target to their
+    `dependencies` field, rather than using the original `files` target.
+
+    To remove a prefix:
+
+        # Results in `data.json`.
+        relocated_files(
+            file_targets=["src/resources/project1:target"],
+            src="src/resources/project1",
+            dest="",
+        )
+
+    To add a prefix:
+
+        # Results in `images/logo.svg`.
+        relocated_files(
+            file_targets=["//:logo"],
+            src="",
+            dest="images",
+        )
+
+    To replace a prefix:
+
+        # Results in `new_prefix/project1/data.json`.
+        relocated_files(
+            file_targets=["src/resources/project1:target"],
+            src="src/resources",
+            dest="new_prefix",
+        )
+    """
+
+    alias = "relocated_files"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        RelocatedFilesSources,
+        RelocatedFilesOriginalTargets,
+        RelocatedFilesSrcField,
+        RelocatedFilesDestField,
+    )
+
+
+class RelocateFilesViaCodegenRequest(GenerateSourcesRequest):
+    input = RelocatedFilesSources
+    output = FilesSources
+
+
+@rule(desc="Relocating loose files for `relocated_files` targets", level=LogLevel.DEBUG)
+async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSources:
+    # Unlike normal codegen, we operate the on the sources of the `files_targets` field, not the
+    # `sources` of the original `relocated_sources` target.
+    original_files_targets = await MultiGet(
+        Get(WrappedTarget, AddressInput, AddressInput.parse(v))
+        for v in request.protocol_target.get(RelocatedFilesOriginalTargets).value
+    )
+    original_files_sources = await MultiGet(
+        Get(HydratedSources, HydrateSourcesRequest(wrapped_tgt.target.get(Sources)))
+        for wrapped_tgt in original_files_targets
+    )
+    snapshot = await Get(
+        Snapshot, MergeDigests(sources.snapshot.digest for sources in original_files_sources)
+    )
+
+    src_val = request.protocol_target.get(RelocatedFilesSrcField).value
+    dest_val = request.protocol_target.get(RelocatedFilesDestField).value
+    if src_val:
+        snapshot = await Get(Snapshot, RemovePrefix(snapshot.digest, src_val))
+    if dest_val:
+        snapshot = await Get(Snapshot, AddPrefix(snapshot.digest, dest_val))
+    return GeneratedSources(snapshot)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -61,3 +200,7 @@ class GenericTarget(Target):
 
     alias = "target"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
+
+
+def rules():
+    return (*collect_rules(), UnionRule(GenerateSourcesRequest, RelocateFilesViaCodegenRequest))

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -52,7 +52,6 @@ class Files(Target):
 class RelocatedFilesSources(Sources):
     # We solely register this field for codegen to work.
     alias = "_sources"
-    required = False
     expected_num_files = 0
 
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.addresses import Address, AddressInput
+from typing import Tuple
+
+from pants.engine.addresses import AddressInput
 from pants.engine.fs import AddPrefix, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -64,6 +66,7 @@ class RelocatedFilesOriginalTargets(StringSequenceField):
 
     alias = "files_targets"
     required = True
+    value: Tuple[str, ...]
 
 
 class RelocatedFilesSrcField(StringField):

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -1,0 +1,100 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.core.target_types import Files, RelocatedFiles, RelocateFilesViaCodegenRequest
+from pants.core.target_types import rules as target_type_rules
+from pants.engine.addresses import Address
+from pants.engine.fs import EMPTY_SNAPSHOT
+from pants.engine.target import GeneratedSources
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_path_prefix_mapping() -> None:
+    rule_runner = RuleRunner(
+        rules=[*target_type_rules(), QueryRule(GeneratedSources, [RelocateFilesViaCodegenRequest])],
+        target_types=[Files, RelocatedFiles],
+    )
+
+    def assert_prefix_mapping(
+        *,
+        original: str,
+        src: str,
+        dest: str,
+        expected: str,
+    ) -> None:
+        rule_runner.create_file(original)
+        rule_runner.add_to_build_file(
+            "",
+            dedent(
+                f"""\
+                files(name="original", sources=[{repr(original)}])
+
+                relocated_files(
+                    name="relocated",
+                    files_targets=[":original"],
+                    src={repr(src)},
+                    dest={repr(dest)},
+                )
+                """
+            ),
+            overwrite=True,
+        )
+        tgt = rule_runner.get_target(Address("", target_name="relocated"))
+        result = rule_runner.request(
+            GeneratedSources, [RelocateFilesViaCodegenRequest(EMPTY_SNAPSHOT, tgt)]
+        )
+        assert result.snapshot.files == (expected,)
+
+    # No-op.
+    assert_prefix_mapping(original="old_prefix/f.ext", src="", dest="", expected="old_prefix/f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        src="old_prefix",
+        dest="old_prefix",
+        expected="old_prefix/f.ext",
+    )
+
+    # Remove prefix.
+    assert_prefix_mapping(original="old_prefix/f.ext", src="old_prefix", dest="", expected="f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/subdir/f.ext", src="old_prefix", dest="", expected="subdir/f.ext"
+    )
+
+    # Add prefix.
+    assert_prefix_mapping(original="f.ext", src="", dest="new_prefix", expected="new_prefix/f.ext")
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        src="",
+        dest="new_prefix",
+        expected="new_prefix/old_prefix/f.ext",
+    )
+
+    # Replace prefix.
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        src="old_prefix",
+        dest="new_prefix",
+        expected="new_prefix/f.ext",
+    )
+    assert_prefix_mapping(
+        original="old_prefix/f.ext",
+        src="old_prefix",
+        dest="new_prefix/subdir",
+        expected="new_prefix/subdir/f.ext",
+    )
+
+    # Replace prefix, but preserve a common start.
+    assert_prefix_mapping(
+        original="common_prefix/foo/f.ext",
+        src="common_prefix/foo",
+        dest="common_prefix/bar",
+        expected="common_prefix/bar/f.ext",
+    )
+    assert_prefix_mapping(
+        original="common_prefix/subdir/f.ext",
+        src="common_prefix/subdir",
+        dest="common_prefix",
+        expected="common_prefix/f.ext",
+    )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -99,8 +99,6 @@ async def generate_subtargets(address: Address, global_options: GlobalOptions) -
     sources_field_path_globs = sources_field.path_globs(
         global_options.options.files_not_found_behavior
     )
-    if sources_field_path_globs is None:
-        return Subtargets(base_target, ())
 
     # Generate a subtarget per source.
     paths = await Get(Paths, PathGlobs, sources_field_path_globs)
@@ -648,8 +646,6 @@ async def hydrate_sources(
     # Now, hydrate the `globs`. Even if we are going to use codegen, we will need the original
     # protocol sources to be hydrated.
     path_globs = sources_field.path_globs(global_options.options.files_not_found_behavior)
-    if path_globs is None:
-        return HydratedSources(EMPTY_SNAPSHOT, sources_field.filespec, sources_type=sources_type)
     snapshot = await Get(Snapshot, PathGlobs, path_globs)
     sources_field.validate_resolved_files(snapshot.files)
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1278,11 +1278,8 @@ class Sources(AsyncField):
         return str(PurePath(self.address.spec_path, glob))
 
     @final
-    def path_globs(self, files_not_found_behavior: FilesNotFoundBehavior) -> Optional[PathGlobs]:
-        globs = self.sanitized_raw_value
-        if globs is None:
-            return None
-
+    def path_globs(self, files_not_found_behavior: FilesNotFoundBehavior) -> PathGlobs:
+        globs = self.sanitized_raw_value or ()
         error_behavior = files_not_found_behavior.to_glob_match_error_behavior()
         conjunction = (
             GlobExpansionConjunction.all_match

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -255,18 +255,22 @@ class RuleRunner:
         for f in files:
             self.create_file(os.path.join(path, f), contents=f)
 
-    def add_to_build_file(self, relpath: Union[str, PurePath], target: str) -> str:
+    def add_to_build_file(
+        self, relpath: Union[str, PurePath], target: str, *, overwrite: bool = False
+    ) -> str:
         """Adds the given target specification to the BUILD file at relpath.
 
         :API: public
 
         relpath: The relative path to the BUILD file from the build root.
         target:  A string containing the target definition as it would appear in a BUILD file.
+        overwrite:  Whether to overwrite vs. append to the BUILD file.
         """
         build_path = (
             relpath if PurePath(relpath).name.startswith("BUILD") else PurePath(relpath, "BUILD")
         )
-        return self.create_file(str(build_path), target, mode="a")
+        mode = "w" if overwrite else "a"
+        return self.create_file(str(build_path), target, mode=mode)
 
     def make_snapshot(self, files: Dict[str, Union[str, bytes]]) -> Snapshot:
         """Makes a snapshot from a map of file name to file content."""


### PR DESCRIPTION
### Problem

As explained in https://github.com/pantsbuild/pants/issues/10733 and https://github.com/pantsbuild/pants/pull/10876, we are adding back an improved version of the `bundle` goal, and we need a way for users to have Pants relocate loose source files, which they previously did via `bundle(rel_path=)`.

Further, we want to allow users to relocate in other contexts, too, such as for `tests`.

### Solution

Add a new intermediate target type called `relocated_files`, which has fields for the original `files()` targets and for the desired mapping. This will then use codegen to apply the mapping and generate `FilesSources`.

This solution is chosen instead of two alternative designs:

1) Define the mapping on the `files()` target, as done in https://github.com/pantsbuild/pants/pull/10876. This implementation was messy and leaked in lots of places. We also think the risk was too high that a user would change a `files()` target and accidentally break multiple consumers.
2) Have every consumer define its own mapping. This does not scale well as it's not composable.

Instead, we find a happy medium by using this intermediate type. There is still a risk of #1, where changing the target will break every consumer. But we think this risk is much lower given the explicitness of having a `relocated_files` target type.

You can safely define multiple `relocated_files` targets over the same original `files` target if you want multiple distinct mappings for the same file.

[ci skip-rust]
[ci skip-build-wheels]