### PR TITLE
Add a 'coverage_' prefix to artifact key

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -213,7 +213,7 @@ class FilesystemCoverageReport(CoverageReport):
         return self.report_file
 
     def get_artifact(self) -> Optional[Tuple[str, Snapshot]]:
-        return f"coverage_{self.report_type}" , self.result_snapshot
+        return f"coverage_{self.report_type}", self.result_snapshot
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -213,7 +213,7 @@ class FilesystemCoverageReport(CoverageReport):
         return self.report_file
 
     def get_artifact(self) -> Optional[Tuple[str, Snapshot]]:
-        return self.report_type, self.result_snapshot
+        return f"coverage_{self.report_type}" , self.result_snapshot
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Problem

the artifact name/key is just "raw", "xml", etc... which is somewhat ambiguous.

### Solution

Add a prefix to make the artifacts name less ambiguous.