### PR TITLE
[WIP] remoting: add headers middleware support

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -240,7 +240,6 @@ class Native(metaclass=SingletonMetaclass):
             execution_process_cache_namespace=execution_options.remote_execution_process_cache_namespace,
             instance_name=execution_options.remote_instance_name,
             root_ca_certs_path=execution_options.remote_ca_certs_path,
-            oauth_bearer_token_path=execution_options.remote_oauth_bearer_token_path,
             store_thread_count=execution_options.remote_store_thread_count,
             store_chunk_bytes=execution_options.remote_store_chunk_bytes,
             store_chunk_upload_timeout=execution_options.remote_store_chunk_upload_timeout_seconds,

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Union, cast
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Union, cast, Callable
 
 from typing_extensions import Protocol
 
@@ -228,7 +228,7 @@ class Native(metaclass=SingletonMetaclass):
         ca_certs_path: Optional[str],
         ignore_patterns: List[str],
         use_gitignore: bool,
-        execution_options,
+        execution_options: Union[None, List[Tuple[str, str]], Callable[[Optional[str]], dict]],
         types: PyTypes,
     ) -> PyScheduler:
         """Create and return a native Scheduler."""
@@ -249,9 +249,7 @@ class Native(metaclass=SingletonMetaclass):
                 tuple(pair.split("=", 1))
                 for pair in execution_options.remote_execution_extra_platform_properties
             ),
-            execution_headers=tuple(
-                (k, v) for (k, v) in execution_options.remote_execution_headers.items()
-            ),
+            execution_headers=execution_options.remote_execution_headers,
             execution_overall_deadline_secs=execution_options.remote_execution_overall_deadline_secs,
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -81,7 +81,6 @@ class ExecutionOptions:
     remote_execution_process_cache_namespace: Any
     remote_instance_name: Any
     remote_ca_certs_path: Any
-    remote_oauth_bearer_token_path: Any
     remote_execution_extra_platform_properties: Any
     remote_execution_headers: Any
     remote_execution_overall_deadline_secs: int
@@ -89,6 +88,12 @@ class ExecutionOptions:
 
     @classmethod
     def from_bootstrap_options(cls, bootstrap_options):
+        headers = bootstrap_options.remote_execution_headers
+        if bootstrap_options.remote_oauth_bearer_token_path is not None:
+            with open(bootstrap_options.remote_oauth_bearer_token_path) as f:
+                token = f.read().strip()
+            headers["authorization"] = f"Bearer {token}"
+
         return cls(
             remote_execution=bootstrap_options.remote_execution,
             remote_store_server=bootstrap_options.remote_store_server,
@@ -107,9 +112,8 @@ class ExecutionOptions:
             remote_execution_process_cache_namespace=bootstrap_options.remote_execution_process_cache_namespace,
             remote_instance_name=bootstrap_options.remote_instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
-            remote_oauth_bearer_token_path=bootstrap_options.remote_oauth_bearer_token_path,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
-            remote_execution_headers=bootstrap_options.remote_execution_headers,
+            remote_execution_headers=headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
         )
@@ -133,7 +137,6 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_process_cache_namespace=None,
     remote_instance_name=None,
     remote_ca_certs_path=None,
-    remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
     remote_execution_headers={},
     remote_execution_overall_deadline_secs=60 * 60,  # one hour

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Union, Tuple, List, Callable, Optional
 
 from pants.base.build_environment import (
     get_buildroot,
@@ -82,7 +82,7 @@ class ExecutionOptions:
     remote_instance_name: Any
     remote_ca_certs_path: Any
     remote_execution_extra_platform_properties: Any
-    remote_execution_headers: Any
+    remote_execution_headers: Union[None, List[Tuple[str, str]], Callable[[Optional[str]], dict]]
     remote_execution_overall_deadline_secs: int
     process_execution_local_enable_nailgun: bool
 
@@ -93,6 +93,12 @@ class ExecutionOptions:
             with open(bootstrap_options.remote_oauth_bearer_token_path) as f:
                 token = f.read().strip()
             headers["authorization"] = f"Bearer {token}"
+
+        headers_as_list = [(k, v) for (k, v) in headers.items()]
+
+        def get_headers(build_id: Optional[str]) -> List[Tuple[str, str]]:
+            print(f"get_headers: build_id={build_id}")
+            return headers_as_list
 
         return cls(
             remote_execution=bootstrap_options.remote_execution,
@@ -113,7 +119,7 @@ class ExecutionOptions:
             remote_instance_name=bootstrap_options.remote_instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
             remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
-            remote_execution_headers=headers,
+            remote_execution_headers=get_headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
         )

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -107,11 +107,13 @@ dependencies = [
  "build_utils 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpython 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dir-diff 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.1 (git+https://github.com/pantsbuild/grpc-rs.git?rev=ed3afa3c24ddf1fdd86826e836f57c00757dfc00)",
  "grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
+ "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -627,6 +629,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "async_semaphore 0.0.1",
+ "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "concrete_time 0.0.1",
@@ -763,6 +766,7 @@ dependencies = [
 name = "fs_util"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1955,6 +1959,7 @@ dependencies = [
 name = "process_executor"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -95,6 +95,7 @@ default = []
 [dependencies]
 async_semaphore = { path = "async_semaphore" }
 async-trait = "0.1"
+bazel_protos = { path = "process_execution/bazel_protos" }
 boxfuture = { path = "boxfuture" }
 bytes = "0.4.5"
 concrete_time = { path = "concrete_time" }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+bazel_protos = { path = "../../process_execution/bazel_protos" }
 boxfuture = { path = "../../boxfuture" }
 bytes = "0.4.5"
 clap = "2"

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -38,7 +38,7 @@ mod snapshot_tests;
 pub use crate::snapshot_ops::{SnapshotOps, SnapshotOpsError, StoreWrapper, SubsetParams};
 
 use async_trait::async_trait;
-use bazel_protos::remote_execution as remexec;
+use bazel_protos::{remote_execution as remexec, RequestHeaders};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use concrete_time::TimeSpan;
@@ -256,7 +256,7 @@ impl Store {
     cas_addresses: Vec<String>,
     instance_name: Option<String>,
     root_ca_certs: Option<Vec<u8>>,
-    oauth_bearer_token: Option<String>,
+    request_headers: RequestHeaders,
     thread_count: usize,
     chunk_size_bytes: usize,
     upload_timeout: Duration,
@@ -270,7 +270,7 @@ impl Store {
         cas_addresses,
         instance_name,
         root_ca_certs,
-        oauth_bearer_token,
+        request_headers,
         thread_count,
         chunk_size_bytes,
         upload_timeout,

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -1,11 +1,11 @@
 use std::cmp::min;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bazel_protos::{self, call_option};
+use bazel_protos::{self, call_option, RequestHeaders};
 use bytes::{Bytes, BytesMut};
 use futures::compat::{Future01CompatExt, Sink01CompatExt};
 use futures::future::{FutureExt, TryFutureExt};
@@ -26,7 +26,7 @@ pub struct ByteStore {
   rpc_attempts: usize,
   env: Arc<grpcio::Environment>,
   serverset: Serverset<grpcio::Channel>,
-  headers: BTreeMap<String, String>,
+  headers: RequestHeaders,
 }
 
 impl fmt::Debug for ByteStore {
@@ -40,7 +40,7 @@ impl ByteStore {
     cas_addresses: Vec<String>,
     instance_name: Option<String>,
     root_ca_certs: Option<Vec<u8>>,
-    oauth_bearer_token: Option<String>,
+    request_headers: RequestHeaders,
     thread_count: usize,
     chunk_size_bytes: usize,
     upload_timeout: Duration,
@@ -72,15 +72,7 @@ impl ByteStore {
       rpc_attempts: rpc_retries + 1,
       env,
       serverset,
-      headers: oauth_bearer_token
-        .iter()
-        .map(|t| {
-          (
-            String::from("authorization"),
-            format!("Bearer {}", t.trim()),
-          )
-        })
-        .collect(),
+      headers: request_headers,
     })
   }
 

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -7,10 +7,12 @@ publish = false
 
 [dependencies]
 bytes = "0.4.5"
+cpython = "0.5"
 futures = "^0.1.16"
 # TODO: This is 0.5.1 + https://github.com/tikv/grpc-rs/pull/457 + a workaround for https://github.com/rust-lang/cargo/issues/8258
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "ed3afa3c24ddf1fdd86826e836f57c00757dfc00", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
+parking_lot = "0.11"
 prost = "0.4"
 prost-derive = "0.4"
 prost-types = "0.4"

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -17,7 +17,7 @@ mod conversions;
 mod conversions_tests;
 
 mod metadata;
-pub use metadata::call_option;
+pub use metadata::{call_option, RequestHeaders};
 
 mod verification;
 pub use crate::verification::verify_directory_canonical;

--- a/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
@@ -1,16 +1,74 @@
-use protobuf::Message;
 use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use cpython::{ObjectProtocol, PyObject, Python};
+use parking_lot::Mutex;
+use protobuf::Message;
+
+#[derive(Clone)]
+pub enum RequestHeaders {
+  None,
+  Static {
+    headers: BTreeMap<String, String>,
+  },
+  Dynamic {
+    // Must be a Python callable which will receive the name of the gRPC service
+    // being called and a mutable Dict[str, str] for the headers.
+    callback: Arc<Mutex<PyObject>>,
+  },
+}
+
+impl std::fmt::Debug for RequestHeaders {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      RequestHeaders::None => f.write_str("RequestHeaders::None"),
+      RequestHeaders::Static { headers } => headers.fmt(f),
+      RequestHeaders::Dynamic { .. } => f.write_str("RequestHeaders::Dynamic(callback)"),
+    }
+  }
+}
 
 pub fn call_option(
-  headers: &BTreeMap<String, String>,
+  headers_provider: &RequestHeaders,
   build_id: Option<String>,
 ) -> Result<grpcio::CallOption, String> {
-  let mut builder = grpcio::MetadataBuilder::with_capacity(headers.len() + 1);
-  for (header_name, header_value) in headers {
-    builder
-      .add_str(header_name, header_value)
-      .map_err(|err| format!("Error setting header {}: {}", header_name, err))?;
-  }
+  // Convert a `RequestHeaders` headers into a specific list of headers to send.
+  const OTHER_METADATA_ENTRIES: usize = 1;
+  let mut builder = match headers_provider {
+    RequestHeaders::None => grpcio::MetadataBuilder::with_capacity(OTHER_METADATA_ENTRIES),
+    RequestHeaders::Static { headers } => {
+      let mut builder =
+        grpcio::MetadataBuilder::with_capacity(headers.len() + OTHER_METADATA_ENTRIES);
+      for (header_name, header_value) in headers {
+        builder
+          .add_str(header_name.as_str(), header_value.as_str())
+          .map_err(|err| format!("Error setting header {}: {}", header_name, err))?;
+      }
+      builder
+    }
+    RequestHeaders::Dynamic { callback } => {
+      let headers_callable = callback.lock();
+      let headers = {
+        let gil = Python::acquire_gil();
+        let result = headers_callable
+          .call(gil.python(), (build_id.clone(),), None)
+          .map_err(|err| format!("Error getting headers from Python: {:?}", err))?;
+        result
+          .extract::<Vec<(String, String)>>(gil.python())
+          .map_err(|err| format!("Error getting headers from Python: {:?}", err))?
+      };
+
+      let mut builder =
+        grpcio::MetadataBuilder::with_capacity(headers.len() + OTHER_METADATA_ENTRIES);
+      for (header_name, header_value) in headers {
+        builder
+          .add_str(&header_name, &header_value)
+          .map_err(|err| format!("Error setting header {}: {}", header_name, err))?;
+      }
+      builder
+    }
+  };
+
   if let Some(build_id) = build_id {
     let mut metadata = crate::remote_execution::RequestMetadata::new();
     metadata.set_tool_details({

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+bazel_protos = { path = "../process_execution/bazel_protos" }
 clap = "2"
 dirs = "1"
 env_logger = "0.5.4"

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -505,7 +505,6 @@ py_class!(class PyRemotingOptions |py| {
     execution_process_cache_namespace: Option<String>,
     instance_name: Option<String>,
     root_ca_certs_path: Option<String>,
-    oauth_bearer_token_path: Option<String>,
     store_thread_count: u64,
     store_chunk_bytes: u64,
     store_chunk_upload_timeout: u64,


### PR DESCRIPTION
### Problem

The authorization tokens for remote execution requests may be short-lived. Third party plugins (for example, Toolchain's Buildsense plugin) are able to renew authorization tokens on demand. Those plugins need a way to hook a middleware into remote execution requests to provide headers.

### Solution

Allow Python half of Pants to provide a Python callable to the Rust engine so the Rust engine can call into Python on demand to obtain gRPC headers.

**This PR is incomplete. It needs feedback on several points.**

### Result

Running tests in example-python repository against the Toolchain build.toolchain.com cluster runs successfully. The print statement in the closure actually produces output:


```
07:10:27.87 [DEBUG] Starting: check_action_cache
get_headers: build_id=pants_run_2020_10_01_07_10_11_743_95376b3348174a4aae3eef4a95066837
07:10:27.97 [DEBUG] Completed: check_action_cache
07:10:27.97 [DEBUG] action cache response: build_id=pants_run_2020_10_01_07_10_11_743_95376b3348174a4aae3eef4a95066837; digest=Digest(Fingerprint<ba795267f3a6b4dbdd94effb8226510780a1cebd2f1fe66b645b9afeb928554c>, 142): Some(FallibleProcessResultWithPlatform { stdout_digest: Digest(Fingerprint<3cb59e657fd11d30da84dcfccb734afd6c9db8e60c80b2c6af46913227125508>, 454), stderr_digest: Digest(Fingerprint<e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>, 0), exit_code: 0, platform: Linux, output_directory: Digest(Fingerprint<e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855>, 0), execution_attempts: [] })
```
