### PR TITLE
[proposal] move ./pants awslambda to ./pants binary with UnionRules, remove python_awslambda()

### DIFF
--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -3,79 +3,82 @@
 
 from abc import ABCMeta
 from dataclasses import dataclass
+from enum import Enum
 from textwrap import dedent
+from typing import Any, Match, Optional, Tuple, Type, cast
+import re
 
+from pants.backend.python.goals.create_python_binary import (
+    AlternateImplementationAck,
+    PythonBinaryFieldSet,
+    PythonBinaryImplementation,
+)
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.console import Console
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, TargetRootsToFieldSets, TargetRootsToFieldSetsRequest
-from pants.engine.unions import union
+from pants.engine.unions import UnionRule, union
+from pants.option.subsystem import Subsystem
 
 
-class AWSLambdaError(Exception):
-    pass
+PYTHON_RUNTIME_REGEX = r"python(?P<major>\d)\.(?P<minor>\d+)"
+
+
+class AWSLambdaPythonRuntime(Enum):
+    python36 = 'python3.6'
+    python37 = 'python3.7'
+    python38 = 'python3.8'
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def to_interpreter_version(self) -> Tuple[int, int]:
+        """Returns the Python version implied by the runtime, as (major, minor)."""
+        mo = cast(Match, re.match(PYTHON_RUNTIME_REGEX, str(self)))
+        return int(mo.group("major")), int(mo.group("minor"))
+
+
+class AWSLambdaSubsystem(Subsystem):
+    """Configuration when generating code to upload to an AWS Lambda."""
+
+    options_scope = "awslambda"
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register('--python-runtime', type=AWSLambdaPythonRuntime, choices=list(AWSLambdaPythonRuntime),
+                 default=None,
+                 help='Use this version of the AWS Lambda python environment. '
+                      'If set, this option will produce python outputs compatible with AWS.')
+
+    @property
+    def python_runtime(self) -> Optional[AWSLambdaPythonRuntime]:
+        return cast(Optional[AWSLambdaPythonRuntime], self.options.python_runtime)
 
 
 @dataclass(frozen=True)
-class CreatedAWSLambda:
-    digest: Digest
-    zip_file_relpath: str
-    runtime: str
-    handler: str
+class AWSLambdaPythonRequest(PythonBinaryImplementation):
+    field_set: PythonBinaryFieldSet
+
+    @classmethod
+    def create(
+        cls: Type['AWSLambdaPythonRequest'],
+        field_set: PythonBinaryFieldSet,
+    ) -> 'AWSLambdaPythonRequest':
+        return cls(field_set)
 
 
-@union
-class AWSLambdaFieldSet(FieldSet, metaclass=ABCMeta):
-    """The fields necessary to create an AWS Lambda from a target."""
-
-
-class AWSLambdaSubsystem(LineOriented, GoalSubsystem):
-    """Generate an AWS Lambda."""
-
-    name = "awslambda"
-
-
-class AWSLambdaGoal(Goal):
-    subsystem_cls = AWSLambdaSubsystem
-
-
-@goal_rule
-async def create_awslambda(
-    console: Console,
-    awslambda_subsystem: AWSLambdaSubsystem,
-    distdir: DistDir,
-    workspace: Workspace,
-) -> AWSLambdaGoal:
-    targets_to_valid_field_sets = await Get(
-        TargetRootsToFieldSets,
-        TargetRootsToFieldSetsRequest(
-            AWSLambdaFieldSet,
-            goal_description="the `awslambda` goal",
-            error_if_no_applicable_targets=True,
-        ),
-    )
-    awslambdas = await MultiGet(
-        Get(CreatedAWSLambda, AWSLambdaFieldSet, field_set)
-        for field_set in targets_to_valid_field_sets.field_sets
-    )
-    merged_digest = await Get(Digest, MergeDigests(awslambda.digest for awslambda in awslambdas))
-    workspace.write_digest(merged_digest, path_prefix=str(distdir.relpath))
-    with awslambda_subsystem.line_oriented(console) as print_stdout:
-        for awslambda in awslambdas:
-            output_path = distdir.relpath / awslambda.zip_file_relpath
-            print_stdout(
-                dedent(
-                    f"""\
-                    Wrote code bundle to {output_path}
-                      Runtime: {awslambda.runtime}
-                      Handler: {awslambda.handler}
-                    """
-                )
-            )
-    return AWSLambdaGoal(exit_code=0)
+@rule
+def whether_to_use_aws_python_lambda(
+    _request: AWSLambdaPythonRequest,
+    awslambda: AWSLambdaSubsystem,
+) -> AlternateImplementationAck:
+    if awslambda.python_runtime is None:
+        return AlternateImplementationAck.not_applicable
+    return AlternateImplementationAck.can_be_used
 
 
 def rules():
-    return collect_rules()
+    return [*collect_rules(), UnionRule(PythonBinaryImplementation, AWSLambdaPythonRequest)]

--- a/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
+++ b/src/python/pants/backend/awslambda/python/awslambda_python_rules_test.py
@@ -8,13 +8,23 @@ from zipfile import ZipFile
 
 import pytest
 
-from pants.backend.awslambda.common.awslambda_common_rules import CreatedAWSLambda
-from pants.backend.awslambda.python.awslambda_python_rules import PythonAwsLambdaFieldSet
+from pants.backend.awslambda.common.awslambda_common_rules import (
+    AWSLambdaPythonRuntime,
+    AWSLambdaPythonRequest,
+)
+from pants.backend.awslambda.common.awslambda_common_rules import rules as awslambda_common_rules
 from pants.backend.awslambda.python.awslambda_python_rules import rules as awslambda_python_rules
 from pants.backend.awslambda.python.target_types import PythonAWSLambda
-from pants.backend.python.target_types import PythonLibrary
+from pants.backend.python.goals.create_python_binary import (
+    PythonBinaryFieldSet,
+    PythonBinaryImplementation,
+    PythonEntryPointWrapper,
+)
+from pants.backend.python.target_types import PythonBinary, PythonLibrary
+from pants.core.goals.binary import BinaryFieldSet, CreatedBinary
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
+from pants.engine.rules import rule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -22,30 +32,37 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            *awslambda_common_rules(),
             *awslambda_python_rules(),
-            QueryRule(CreatedAWSLambda, (PythonAwsLambdaFieldSet,)),
+            QueryRule(CreatedBinary, (PythonBinaryFieldSet,)),
         ],
-        target_types=[PythonAWSLambda, PythonLibrary],
+        target_types=[PythonBinary, PythonLibrary],
     )
 
 
-def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, bytes]:
+def create_python_awslambda(
+    rule_runner: RuleRunner,
+    addr: str,
+    *,
+    runtime: AWSLambdaPythonRuntime,
+) -> Tuple[str, bytes]:
     rule_runner.set_options(
         [
             "--backend-packages=pants.backend.awslambda.python",
             "--source-root-patterns=src/python",
             "--pants-distdir-legacy-paths=false",
+            f"--awslambda-python-runtime={runtime}",
         ]
     )
     target = rule_runner.get_target(Address.parse(addr))
     created_awslambda = rule_runner.request(
-        CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target)]
+        CreatedBinary, [PythonBinaryFieldSet.create(target)]
     )
     created_awslambda_digest_contents = rule_runner.request(
         DigestContents, [created_awslambda.digest]
     )
     assert len(created_awslambda_digest_contents) == 1
-    return created_awslambda.zip_file_relpath, created_awslambda_digest_contents[0].content
+    return created_awslambda.binary_name, created_awslambda_digest_contents[0].content
 
 
 def test_create_hello_world_lambda(rule_runner: RuleRunner) -> None:
@@ -68,18 +85,18 @@ def test_create_hello_world_lambda(rule_runner: RuleRunner) -> None:
               sources=['hello_world.py']
             )
 
-            python_awslambda(
+            python_binary(
               name='hello_world_lambda',
               dependencies=[':hello_world'],
-              handler='foo.bar.hello_world',
-              runtime='python3.7'
+              entry_point='foo.bar.hello_world',
             )
             """
         ),
     )
 
     zip_file_relpath, content = create_python_awslambda(
-        rule_runner, "src/python/foo/bar:hello_world_lambda"
+        rule_runner, "src/python/foo/bar:hello_world_lambda",
+        runtime=AWSLambdaPythonRuntime.python37,
     )
     assert "src.python.foo.bar/hello_world_lambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))


### PR DESCRIPTION
[ci skip-rust]

### Problem

This is one alternate proposal to the proposal doc (https://docs.google.com/document/d/1q77XvcIU9dCzuzA2iFRQQ9AGIfV9jpR269415HdEt0E/edit?usp=sharing) that sprung out of the discussion on #10881.

In particular, I was interested in exploring whether the `runtime` and `handler` arguments to lambdex could be drawn from a subsystem option, and the `entry_point` of `python_binary()` target instead of requiring a separate `python_awslambda()` target. See comments at https://docs.google.com/document/d/1q77XvcIU9dCzuzA2iFRQQ9AGIfV9jpR269415HdEt0E/edit?disco=AAAAJ8b8Sd8.

**In particular, there was a concern that our current application of `FieldSet`s imposed a hard requirement on separating the `python_binary()` and `python_awslambda()` targets (see https://docs.google.com/document/d/1q77XvcIU9dCzuzA2iFRQQ9AGIfV9jpR269415HdEt0E/edit?disco=AAAAJ8b8SeI).** This diff demonstrates that requirement is actually somewhat flexible.

**EVERYTHING ELSE IN THIS DIFF IS IRRELEVANT! I only wish to demonstrate this application of UnionRule for python binary creation which can support both PEX and Lambdex!**

### Solution

- The `--awslambda-python-runtime=pythonX.Y` option is now registered on the `awslambda` subsystem.
  - This enables a unified syntax for writing multiple types of deployable artifacts to `dist/` which does not require rewriting BUILD files or pants command lines.
- Plugins (in this case, the `...awslambda.python` plugin) may implement a `PythonBinaryImplementation` UnionRule if they wish to **replace** the output of `./pants binary`.

### Result

First, this branch of the `example-python` repo works with these changes (https://github.com/cosmicexplorer/example-python/tree/try-out-awslambda-subsystem). In particular, see how it is possible to put both the command-line and Lambdex entry point methods into the same file, and configure just the things that are different in the target definitions. 

```

python_library(
    name='multi-deployable-main',
    sources=["main.py"],
    # Dependencies inferred from main.py.
)

python_binary(
    # name defaults to the name of this directory, i.e., `helloworld`.
    entry_point="helloworld.main",
    dependencies=[':multi-deployable-main'],
)

python_binary(
    name="helloworld-awslambda",
    entry_point="helloworld.awslambda:handler",
    dependencies=[':multi-deployable-main'],
    # Note: Has sdist dependencies, so must be built on Linux.
    platforms=['linux_x86_64-cp-37-m'],
)
```

Also, note that we can now impose a `platforms` requirement on the Lambdex target, which can also be configured via `--python-setup-platforms` as desired.