### PR TITLE
Add `archive` target type to replace `python_app`

### DIFF
--- a/src/python/pants/backend/awslambda/common/rules.py
+++ b/src/python/pants/backend/awslambda/common/rules.py
@@ -35,7 +35,7 @@ class AWSLambdaFieldSet(FieldSet, metaclass=ABCMeta):
 
 
 class AWSLambdaSubsystem(LineOriented, GoalSubsystem):
-    """Deprecated in favor of the `build` goal."""
+    """Deprecated in favor of the `package` goal."""
 
     name = "awslambda"
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -274,8 +274,8 @@ class PythonRuntimePackageDependencies(StringSequenceField):
     assets should be included in the test run.
 
     Pants will build the assets as if you had run `./pants package`. It will include the
-    results in your archive using the same name they would normally have, but without the `dist/`
-    prefix.
+    results in your archive using the same name they would normally have, but without the
+    `--distdir` prefix (e.g. `dist/`).
 
     You can include anything that can be built by `./pants package`, e.g. a `python_binary`,
     `python_awslambda`, or even another `archive`.

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -273,9 +273,12 @@ class PythonRuntimePackageDependencies(StringSequenceField):
     """Addresses to targets that can be built with the `./pants package` goal and whose resulting
     assets should be included in the test run.
 
-    Pants will build the asset as if it had run `./pants package`, and will include the result in
-    your test environment using the same name it would normally have, but without the `dist/`
-    prefix. For example, you can include a `python_binary`, `python_awslambda`, or `archive`.
+    Pants will build the assets as if you had run `./pants package`. It will include the
+    results in your archive using the same name they would normally have, but without the `dist/`
+    prefix.
+
+    You can include anything that can be built by `./pants package`, e.g. a `python_binary`,
+    `python_awslambda`, or even another `archive`.
     """
 
     alias = "runtime_package_dependencies"

--- a/src/python/pants/backend/python/util_rules/extract_pex.py
+++ b/src/python/pants/backend/python/util_rules/extract_pex.py
@@ -22,7 +22,7 @@ class ExtractedPexDistributions:
 async def extract_distributions(pex: Pex, unzip_binary: UnzipBinary) -> ExtractedPexDistributions:
     # We only unzip the `.deps` folder to avoid unnecessary work. Note that this will cause the
     # process to fail if there is no `.deps` folder, so we need to use `FallibleProcessResult`.
-    argv = (*unzip_binary.extract_argv(archive_path=pex.name, output_dir="."), ".deps/*")
+    argv = (*unzip_binary.extract_archive_argv(archive_path=pex.name, output_dir="."), ".deps/*")
     unzipped_pex = await Get(
         FallibleProcessResult,
         Process(

--- a/src/python/pants/core/goals/binary.py
+++ b/src/python/pants/core/goals/binary.py
@@ -27,7 +27,7 @@ class CreatedBinary:
 
 
 class BinarySubsystem(GoalSubsystem):
-    """Deprecated in favor of the `build` goal."""
+    """Deprecated in favor of the `package` goal."""
 
     name = "binary"
 

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -7,7 +7,7 @@ These are always activated and cannot be disabled.
 """
 
 from pants.core.goals import binary, fmt, lint, package, repl, run, test, typecheck
-from pants.core.target_types import Files, GenericTarget, RelocatedFiles, Resources
+from pants.core.target_types import ArchiveTarget, Files, GenericTarget, RelocatedFiles, Resources
 from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import (
     archive,
@@ -50,4 +50,4 @@ def rules():
 
 
 def target_types():
-    return [Files, GenericTarget, Resources, RelocatedFiles]
+    return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles]

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -226,8 +226,8 @@ class ArchivePackages(StringSequenceField):
     """Addresses to any targets that can be built with `./pants package`.
 
     Pants will build the assets as if you had run `./pants package`. It will include the
-    results in your archive using the same name they would normally have, but without the `dist/`
-    prefix.
+    results in your archive using the same name they would normally have, but without the
+    `--distdir` prefix (e.g. `dist/`).
 
     You can include anything that can be built by `./pants package`, e.g. a `python_binary`,
     `python_awslambda`, or even another `archive`.
@@ -254,10 +254,7 @@ class ArchiveFiles(StringSequenceField):
 
 
 class ArchiveFormatField(StringField):
-    """The type of archive file to be generated.
-
-    Note that `zip` files will not be compressed.
-    """
+    """The type of archive file to be generated."""
 
     alias = "format"
     valid_choices = ArchiveFormat

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -1,14 +1,20 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+from dataclasses import dataclass
 from typing import Tuple
 
+from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.core.util_rules.archive import ArchiveFormat, CreateArchive
 from pants.engine.addresses import AddressInput
-from pants.engine.fs import AddPrefix, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import AddPrefix, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
+    FieldSetsPerTarget,
+    FieldSetsPerTargetRequest,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -148,7 +154,11 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
     # Unlike normal codegen, we operate the on the sources of the `files_targets` field, not the
     # `sources` of the original `relocated_sources` target.
     original_files_targets = await MultiGet(
-        Get(WrappedTarget, AddressInput, AddressInput.parse(v))
+        Get(
+            WrappedTarget,
+            AddressInput,
+            AddressInput.parse(v, relative_to=request.protocol_target.address.spec_path),
+        )
         for v in request.protocol_target.get(RelocatedFilesOriginalTargets).value
     )
     original_files_sources = await MultiGet(
@@ -206,5 +216,142 @@ class GenericTarget(Target):
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
 
 
+# -----------------------------------------------------------------------------------------------
+# `archive` target
+# -----------------------------------------------------------------------------------------------
+
+# TODO(#10888): Teach project introspection goals that this is a special type of the `Dependencies`
+#  field.
+class ArchivePackages(StringSequenceField):
+    """Addresses to any targets that can be built with `./pants package`.
+
+    Pants will build the assets as if you had run `./pants package`. It will include the
+    results in your archive using the same name they would normally have, but without the `dist/`
+    prefix.
+
+    You can include anything that can be built by `./pants package`, e.g. a `python_binary`,
+    `python_awslambda`, or even another `archive`.
+    """
+
+    alias = "packages"
+
+
+# TODO(#10888): Teach project introspection goals that this is a special type of the `Dependencies`
+#  field.
+class ArchiveFiles(StringSequenceField):
+    """Addresses to any `files` or `relocated_files` targets to include in the archive, e.g.
+    `["resources:logo"]`.
+
+    This is useful to include any loose files, like data files, image assets, or config files.
+
+    This will ignore any targets that are not `files` or `relocated_files` targets. If you instead
+    want those files included in any packages specified in the `packages` field for this target,
+    then use a `resources` target and have the original package (e.g. the `python_library`)
+    depend on the resources.
+    """
+
+    alias = "files"
+
+
+class ArchiveFormatField(StringField):
+    """The type of archive file to be generated.
+
+    Note that `zip` files will not be compressed.
+    """
+
+    alias = "format"
+    valid_choices = ArchiveFormat
+    required = True
+    value: str
+
+
+class ArchiveTarget(Target):
+    """An archive (e.g. zip file) containing loose files and/or packages built via `./pants
+    package`."""
+
+    alias = "archive"
+    core_fields = (*COMMON_TARGET_FIELDS, ArchivePackages, ArchiveFiles, ArchiveFormatField)
+
+
+@dataclass(frozen=True)
+class ArchiveFieldSet(PackageFieldSet):
+    required_fields = (ArchiveFormatField,)
+
+    packages: ArchivePackages
+    files: ArchiveFiles
+    format_field: ArchiveFormatField
+
+
+@rule(level=LogLevel.DEBUG)
+async def package_archive_target(field_set: ArchiveFieldSet) -> BuiltPackage:
+    package_targets = await MultiGet(
+        Get(
+            WrappedTarget,
+            AddressInput,
+            AddressInput.parse(v, relative_to=field_set.address.spec_path),
+        )
+        for v in field_set.packages.value or ()
+    )
+    package_field_sets_per_target = await Get(
+        FieldSetsPerTarget,
+        FieldSetsPerTargetRequest(
+            PackageFieldSet,
+            (wrapped_tgt.target for wrapped_tgt in package_targets),
+        ),
+    )
+    packages = await MultiGet(
+        Get(BuiltPackage, PackageFieldSet, field_set)
+        for field_set in package_field_sets_per_target.field_sets
+    )
+
+    files_targets = await MultiGet(
+        Get(
+            WrappedTarget,
+            AddressInput,
+            AddressInput.parse(v, relative_to=field_set.address.spec_path),
+        )
+        for v in field_set.files.value or ()
+    )
+    files_sources = await MultiGet(
+        Get(
+            HydratedSources,
+            HydrateSourcesRequest(
+                wrapped_tgt.target.get(Sources),
+                for_sources_types=(FilesSources,),
+                enable_codegen=True,
+            ),
+        )
+        for wrapped_tgt in files_targets
+    )
+
+    input_snapshot = await Get(
+        Snapshot,
+        MergeDigests(
+            (
+                *(package.digest for package in packages),
+                *(sources.snapshot.digest for sources in files_sources),
+            )
+        ),
+    )
+    file_ending = field_set.format_field.value
+    output_filename = os.path.join(
+        field_set.address.spec_path.replace(os.sep, "."),
+        f"{field_set.address.target_name}.{file_ending}",
+    )
+    archive = await Get(
+        Digest,
+        CreateArchive(
+            input_snapshot,
+            output_filename=output_filename,
+            format=ArchiveFormat(field_set.format_field.value),
+        ),
+    )
+    return BuiltPackage(archive, relpath=output_filename)
+
+
 def rules():
-    return (*collect_rules(), UnionRule(GenerateSourcesRequest, RelocateFilesViaCodegenRequest))
+    return (
+        *collect_rules(),
+        UnionRule(GenerateSourcesRequest, RelocateFilesViaCodegenRequest),
+        UnionRule(PackageFieldSet, ArchiveFieldSet),
+    )

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 import tarfile
 import zipfile
 from io import BytesIO
@@ -228,11 +227,10 @@ def test_archive() -> None:
     assert_archive1_is_valid(archive1.content)
 
     archive2 = get_archive("archive2")
-    # For some reason, writing the result to BytesIO, then passing via `fileobj` to
-    # `tarfile.open()` does not work properly, even if calling `.flush()` before. So we write to
-    # disk.
-    rule_runner.create_file(archive2.path, archive2.content, mode="wb")
-    with tarfile.open(os.path.join(rule_runner.build_root, archive2.path), mode="r:") as tf:
+    io = BytesIO()
+    io.write(archive2)
+    io.seek(0)
+    with tarfile.open(fileobj=io, mode="r:") as tf:
         assert set(tf.getnames()) == {"data/d1.json", "data/d2.json", "archive1.zip"}
 
         def get_file(fp: str) -> bytes:

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -1,9 +1,19 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os.path
+import tarfile
+import zipfile
+from io import BytesIO
 from textwrap import dedent
 
+from pants.backend.python.goals import package_python_binary
+from pants.backend.python.target_types import PythonBinary
+from pants.backend.python.util_rules import pex_from_targets
+from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
+    ArchiveFieldSet,
+    ArchiveTarget,
     Files,
     FilesSources,
     RelocatedFiles,
@@ -13,7 +23,7 @@ from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address, Addresses
-from pants.engine.fs import EMPTY_SNAPSHOT
+from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, FileContent
 from pants.engine.target import GeneratedSources, Sources, TransitiveTargets
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -128,3 +138,108 @@ def test_relocated_files() -> None:
         dest="common_prefix",
         expected="common_prefix/f.ext",
     )
+
+
+def test_archive() -> None:
+    """Integration test for the `archive` target type.
+
+    This tests some edges:
+    * Using both `files` and `relocated_files`.
+    * An `archive` containing another `archive`.
+    """
+
+    rule_runner = RuleRunner(
+        rules=[
+            *target_type_rules(),
+            *pex_from_targets.rules(),
+            *package_python_binary.rules(),
+            QueryRule(BuiltPackage, [ArchiveFieldSet]),
+        ],
+        target_types=[ArchiveTarget, Files, RelocatedFiles, PythonBinary],
+    )
+    rule_runner.set_options(
+        ["--backend-packages=pants.backend.python", "--no-pants-distdir-legacy-paths"]
+    )
+
+    rule_runner.create_file("resources/d1.json", "{'k': 1}")
+    rule_runner.create_file("resources/d2.json", "{'k': 2}")
+    rule_runner.add_to_build_file(
+        "resources",
+        dedent(
+            """\
+            files(name='original_files', sources=['*.json'])
+
+            relocated_files(
+                name='relocated_files',
+                files_targets=[':original_files'],
+                src="resources",
+                dest="data",
+            )
+            """
+        ),
+    )
+
+    rule_runner.create_file("project/app.py", "print('hello world!')")
+    rule_runner.add_to_build_file("project", "python_binary(sources=['app.py'])")
+
+    rule_runner.add_to_build_file(
+        "",
+        dedent(
+            """\
+            archive(
+                name="archive1",
+                packages=["project"],
+                files=["resources:original_files"],
+                format="zip",
+            )
+
+            archive(
+                name="archive2",
+                packages=[":archive1"],
+                files=["resources:relocated_files"],
+                format="tar",
+            )
+            """
+        ),
+    )
+
+    def get_archive(target_name: str) -> FileContent:
+        tgt = rule_runner.get_target(Address("", target_name=target_name))
+        built_package = rule_runner.request(BuiltPackage, [ArchiveFieldSet.create(tgt)])
+        digest_contents = rule_runner.request(DigestContents, [built_package.digest])
+        assert len(digest_contents) == 1
+        return digest_contents[0]
+
+    def assert_archive1_is_valid(zip_bytes: bytes) -> None:
+        io = BytesIO()
+        io.write(zip_bytes)
+        with zipfile.ZipFile(io) as zf:
+            assert set(zf.namelist()) == {
+                "resources/d1.json",
+                "resources/d2.json",
+                "project/project.pex",
+            }
+            with zf.open("resources/d1.json", "r") as f:
+                assert f.read() == b"{'k': 1}"
+            with zf.open("resources/d2.json", "r") as f:
+                assert f.read() == b"{'k': 2}"
+
+    archive1 = get_archive("archive1")
+    assert_archive1_is_valid(archive1.content)
+
+    archive2 = get_archive("archive2")
+    # For some reason, writing the result to BytesIO, then passing via `fileobj` to
+    # `tarfile.open()` does not work properly, even if calling `.flush()` before. So we write to
+    # disk.
+    rule_runner.create_file(archive2.path, archive2.content, mode="wb")
+    with tarfile.open(os.path.join(rule_runner.build_root, archive2.path), mode="r:") as tf:
+        assert set(tf.getnames()) == {"data/d1.json", "data/d2.json", "archive1.zip"}
+
+        def get_file(fp: str) -> bytes:
+            reader = tf.extractfile(fp)
+            assert reader is not None
+            return reader.read()
+
+        assert get_file("data/d1.json") == b"{'k': 1}"
+        assert get_file("data/d2.json") == b"{'k': 2}"
+        assert_archive1_is_valid(get_file("archive1.zip"))

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -228,7 +228,7 @@ def test_archive() -> None:
 
     archive2 = get_archive("archive2")
     io = BytesIO()
-    io.write(archive2)
+    io.write(archive2.content)
     io.seek(0)
     with tarfile.open(fileobj=io, mode="r:") as tf:
         assert set(tf.getnames()) == {"data/d1.json", "data/d2.json", "archive1.zip"}

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -3,6 +3,7 @@
 
 import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import Tuple
 
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
@@ -19,33 +20,58 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.logging import LogLevel
 
 
-@dataclass(frozen=True)
-class MaybeExtractable:
-    """A newtype to work around rule graph resolution issues.
-
-    Possibly https://github.com/pantsbuild/pants/issues/9320. Either way, we should fix the
-    underlying issue and get rid of this type.
-    """
-
-    digest: Digest
+# Note that updating this will impact the `archive` target defined in `core/target_types.py`.
+class ArchiveFormat(Enum):
+    TAR = "tar"
+    TGZ = "tgz"
+    TBZ2 = "tbz2"
+    TXZ = "txz"
+    ZIP = "zip"
 
 
-@dataclass(frozen=True)
-class ExtractedDigest:
-    """The result of extracting an archive."""
-
-    digest: Digest
-
+# -----------------------------------------------------------------------------------------------
+# Find binaries to create/extract archives
+# -----------------------------------------------------------------------------------------------
 
 # TODO: Should this be configurable?
 SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin")
 
 
+class ZipBinary(BinaryPath):
+    def create_archive_argv(self, request: "CreateArchive") -> Tuple[str, ...]:
+        return (self.path, request.output_filename, *request.snapshot.files)
+
+
 class UnzipBinary(BinaryPath):
-    def extract_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
-        # Note that the `output_dir` does not need to already exist. The caller should also
-        # validate that it's a valid `.zip` file.
-        return (self.path, "-q", archive_path, "-d", output_dir)
+    def extract_archive_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
+        # Note that the `output_dir` does not need to already exist.
+        # The caller should validate that it's a valid `.zip` file.
+        return (self.path, archive_path, "-d", output_dir)
+
+
+class TarBinary(BinaryPath):
+    def create_archive_argv(self, request: "CreateArchive") -> Tuple[str, ...]:
+        # Note that the parent directory for the output_filename must already exist.
+        #
+        # The `a` arg means `tar` will choose the compression based on the file ending.
+        return (self.path, "caf", request.output_filename, *request.snapshot.files)
+
+    def extract_archive_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
+        # Note that the `output_dir` must already exist.
+        # The caller should validate that it's a valid `.tar` file.
+        return (self.path, "xf", archive_path, "-C", output_dir)
+
+
+@rule(desc="Finding the `zip` binary", level=LogLevel.DEBUG)
+async def find_zip() -> ZipBinary:
+    request = BinaryPathRequest(
+        binary_name="zip", search_path=SEARCH_PATHS, test=BinaryPathTest(args=["-v"])
+    )
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path
+    if not first_path:
+        raise BinaryNotFoundError(request, rationale="create `.zip` archives")
+    return ZipBinary(first_path.path, first_path.fingerprint)
 
 
 @rule(desc="Finding the `unzip` binary", level=LogLevel.DEBUG)
@@ -60,13 +86,6 @@ async def find_unzip() -> UnzipBinary:
     return UnzipBinary(first_path.path, first_path.fingerprint)
 
 
-class TarBinary(BinaryPath):
-    def extract_argv(self, *, archive_path: str, output_dir: str) -> Tuple[str, ...]:
-        # Note that the `output_dir` must already exist. The caller should also
-        # validate that it's a valid `.tar` file.
-        return (self.path, "xf", archive_path, "-C", output_dir)
-
-
 @rule(desc="Finding the `tar` binary", level=LogLevel.DEBUG)
 async def find_tar() -> TarBinary:
     request = BinaryPathRequest(
@@ -79,31 +98,91 @@ async def find_tar() -> TarBinary:
     return TarBinary(first_path.path, first_path.fingerprint)
 
 
+# -----------------------------------------------------------------------------------------------
+# Create archives
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CreateArchive:
+    """A request to create an archive.
+
+    All files in the input snapshot will be included in the resulting archive.
+    """
+
+    snapshot: Snapshot
+    output_filename: str
+    format: ArchiveFormat
+
+
+@rule(desc="Creating an archive file", level=LogLevel.DEBUG)
+async def create_archive(
+    request: CreateArchive, tar_binary: TarBinary, zip_binary: ZipBinary
+) -> Digest:
+    if request.format == ArchiveFormat.ZIP:
+        argv = zip_binary.create_archive_argv(request)
+        env = {}
+        input_digest = request.snapshot.digest
+    else:
+        argv = tar_binary.create_archive_argv(request)
+        # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
+        env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
+        # `tar` requires that the output filename's parent directory exists.
+        output_dir_digest = await Get(
+            Digest, CreateDigest([Directory(os.path.dirname(request.output_filename))])
+        )
+        input_digest = await Get(Digest, MergeDigests([output_dir_digest, request.snapshot.digest]))
+
+    result = await Get(
+        ProcessResult,
+        Process(
+            argv=argv,
+            env=env,
+            input_digest=input_digest,
+            description=f"Create {request.output_filename}",
+            level=LogLevel.DEBUG,
+            output_files=(request.output_filename,),
+        ),
+    )
+    return result.output_digest
+
+
+# -----------------------------------------------------------------------------------------------
+# Extract archives
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExtractedArchive:
+    """The result of extracting an archive."""
+
+    digest: Digest
+
+
 @rule(desc="Extracting an archive file", level=LogLevel.DEBUG)
-async def maybe_extract(
-    extractable: MaybeExtractable, tar_binary: TarBinary, unzip_binary: UnzipBinary
-) -> ExtractedDigest:
+async def maybe_extract_archive(
+    digest: Digest, tar_binary: TarBinary, unzip_binary: UnzipBinary
+) -> ExtractedArchive:
     """If digest contains a single archive file, extract it, otherwise return the input digest."""
-    extractable_digest = extractable.digest
-    output_dir = "out"
+    output_dir = "__output"
     snapshot, output_dir_digest = await MultiGet(
-        Get(Snapshot, Digest, extractable_digest),
+        Get(Snapshot, Digest, digest),
         Get(Digest, CreateDigest([Directory(output_dir)])),
     )
     if len(snapshot.files) != 1:
-        return ExtractedDigest(extractable_digest)
+        return ExtractedArchive(digest)
 
-    input_digest = await Get(Digest, MergeDigests((extractable_digest, output_dir_digest)))
+    input_digest = await Get(Digest, MergeDigests((digest, output_dir_digest)))
     fp = snapshot.files[0]
     if fp.endswith(".zip"):
-        argv = unzip_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+        argv = unzip_binary.extract_archive_argv(archive_path=fp, output_dir=output_dir)
         env = {}
     elif fp.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz")):
-        argv = tar_binary.extract_argv(archive_path=fp, output_dir=output_dir)
+        argv = tar_binary.extract_archive_argv(archive_path=fp, output_dir=output_dir)
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
     else:
-        return ExtractedDigest(extractable_digest)
+        return ExtractedArchive(digest)
 
     result = await Get(
         ProcessResult,
@@ -117,7 +196,7 @@ async def maybe_extract(
         ),
     )
     strip_output_dir = await Get(Digest, RemovePrefix(result.output_digest, output_dir))
-    return ExtractedDigest(strip_output_dir)
+    return ExtractedArchive(strip_output_dir)
 
 
 def rules():

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -23,9 +23,9 @@ from pants.util.logging import LogLevel
 # Note that updating this will impact the `archive` target defined in `core/target_types.py`.
 class ArchiveFormat(Enum):
     TAR = "tar"
-    TGZ = "tgz"
-    TBZ2 = "tbz2"
-    TXZ = "txz"
+    TGZ = "tar.gz"
+    TBZ2 = "tar.bz2"
+    TXZ = "tar.xz"
     ZIP = "zip"
 
 

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import List, Tuple, cast
 
 from pants.core.util_rules import archive
-from pants.core.util_rules.archive import ExtractedDigest, MaybeExtractable
+from pants.core.util_rules.archive import ExtractedArchive
 from pants.engine.fs import Digest, DownloadFile
 from pants.engine.platform import Platform
 from pants.engine.rules import Get, collect_rules, rule
@@ -172,8 +172,8 @@ class ExternalTool(Subsystem):
 @rule(level=LogLevel.DEBUG)
 async def download_external_tool(request: ExternalToolRequest) -> DownloadedExternalTool:
     digest = await Get(Digest, DownloadFile, request.download_file_request)
-    extracted_digest = await Get(ExtractedDigest, MaybeExtractable(digest))
-    return DownloadedExternalTool(extracted_digest.digest, request.exe)
+    extracted_archive = await Get(ExtractedArchive, Digest, digest)
+    return DownloadedExternalTool(extracted_archive.digest, request.exe)
 
 
 def rules():

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -229,7 +229,7 @@ class RuleRunner:
         self._invalidate_for(relpath)
         return path
 
-    def create_file(self, relpath: str, contents: str = "", mode: str = "w") -> str:
+    def create_file(self, relpath: str, contents: Union[bytes, str] = "", mode: str = "w") -> str:
         """Writes to a file under the buildroot.
 
         :API: public
@@ -272,7 +272,7 @@ class RuleRunner:
         mode = "w" if overwrite else "a"
         return self.create_file(str(build_path), target, mode=mode)
 
-    def make_snapshot(self, files: Dict[str, Union[str, bytes]]) -> Snapshot:
+    def make_snapshot(self, files: Mapping[str, Union[str, bytes]]) -> Snapshot:
         """Makes a snapshot from a map of file name to file content."""
         with temporary_dir() as temp_dir:
             for file_name, content in files.items():


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10733.

Users liked being able to use `bundle` to be able to create archives which included loose files + binaries. This adds back that feature, but in a simpler way:

* `archive` is used regardless of language. No more `python_app` vs. `jvm_app`.
* Depending on loose files is down like a normal dependency now, no more `bundle`. To relocate files, you can use the `relocated_files` target.
* Your `archive` can contain other `archive`s, or anything built via `./pants package`.

For example:

```python
archive(
    files=["src/resources:relocated_json"],
    packages=["src/python:app"],
    format="tgz",
)
```

```bash
> ./pants package '//:app_archive'
```

[ci skip-rust]
[ci skip-build-wheels]