### PR TITLE
Add `output_path` field to `python_binary`, `python_awslambda`, and `archive`

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -12,6 +12,7 @@ from pkg_resources import Requirement
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.base.deprecated import warn_or_error
+from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address, AddressInput
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -233,6 +234,7 @@ class PythonBinary(Target):
     alias = "python_binary"
     core_fields = (
         *COMMON_PYTHON_FIELDS,
+        OutputPathField,
         PythonBinarySources,
         PythonBinaryDependencies,
         PythonEntryPoint,

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -2,15 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+import os
 from abc import ABCMeta
 from dataclasses import dataclass
 from typing import Optional
 
 from pants.core.util_rules.distdir import DistDir
+from pants.engine.addresses import Address
 from pants.engine.fs import Digest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import FieldSet, TargetRootsToFieldSets, TargetRootsToFieldSetsRequest
+from pants.engine.target import (
+    FieldSet,
+    StringField,
+    TargetRootsToFieldSets,
+    TargetRootsToFieldSetsRequest,
+)
 from pants.engine.unions import union
 
 logger = logging.getLogger(__name__)
@@ -26,6 +33,41 @@ class BuiltPackage:
     digest: Digest
     relpath: str
     extra_log_info: Optional[str] = None
+
+
+class OutputPathField(StringField):
+    """Where the built asset should be located.
+
+    If undefined, this will use the path to the the BUILD, followed by the target name. For
+    example, `src/python/project:app` would be `src.python.project/app.ext`.
+
+    When running `./pants package`, this path will be prefixed by `--distdir` (e.g. `dist/`).
+
+    Warning: setting this value risks naming collisions with other package targets you may have.
+    """
+
+    alias = "output_path"
+
+    def value_or_default(
+        self, address: Address, *, file_ending: str, use_legacy_format: bool
+    ) -> str:
+        assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
+        if self.value is not None:
+            return self.value
+        disambiguated = os.path.join(
+            address.spec_path.replace(os.sep, "."), f"{address.target_name}.{file_ending}"
+        )
+        if use_legacy_format:
+            ambiguous_name = f"{address.target_name}.{file_ending}"
+            logger.warning(
+                f"Writing to the legacy subpath: {ambiguous_name}, which may not be unique. An "
+                "upcoming version of Pants will switch to writing to the fully-qualified "
+                f"subpath: {disambiguated}. You can effect that switch now (and silence this "
+                "warning) by setting `pants_distdir_legacy_paths = false` in the [GLOBAL] section "
+                "of pants.toml."
+            )
+            return ambiguous_name
+        return disambiguated
 
 
 class PackageSubsystem(GoalSubsystem):

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -60,11 +60,13 @@ class OutputPathField(StringField):
         if use_legacy_format:
             ambiguous_name = f"{address.target_name}.{file_ending}"
             logger.warning(
-                f"Writing to the legacy subpath: {ambiguous_name}, which may not be unique. An "
-                "upcoming version of Pants will switch to writing to the fully-qualified "
-                f"subpath: {disambiguated}. You can effect that switch now (and silence this "
-                "warning) by setting `pants_distdir_legacy_paths = false` in the [GLOBAL] section "
-                "of pants.toml."
+                f"Writing to the legacy subpath {repr(ambiguous_name)} for the target {address}. "
+                f"This location may not be unique. An upcoming version of Pants will switch to "
+                f"writing to the fully-qualified subpath: {disambiguated}.\n\nYou can make that "
+                "switch now (and silence this warning) by setting "
+                "`pants_distdir_legacy_paths = false` in the [GLOBAL] section "
+                "of pants.toml.\n\nAlternatively, you can set the field `output_path` on the "
+                f"target {address} to a hardcoded value."
             )
             return ambiguous_name
         return disambiguated

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -197,6 +197,7 @@ def test_archive() -> None:
                 packages=[":archive1"],
                 files=["resources:relocated_files"],
                 format="tar",
+                output_path="output/archive2.tar",
             )
             """
         ),
@@ -227,6 +228,7 @@ def test_archive() -> None:
     assert_archive1_is_valid(archive1.content)
 
     archive2 = get_archive("archive2")
+    assert archive2.path == "output/archive2.tar"
     io = BytesIO()
     io.write(archive2.content)
     io.seek(0)

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1012,7 +1012,7 @@ class BoolField(PrimitiveField, metaclass=ABCMeta):
         return value_or_default
 
 
-class IntField(ScalarField, metaclass=ABCMeta):
+class IntField(ScalarField[int], metaclass=ABCMeta):
     expected_type = int
     expected_type_description = "an integer"
 
@@ -1021,7 +1021,7 @@ class IntField(ScalarField, metaclass=ABCMeta):
         return super().compute_value(raw_value, address=address)
 
 
-class FloatField(ScalarField, metaclass=ABCMeta):
+class FloatField(ScalarField[float], metaclass=ABCMeta):
     expected_type = float
     expected_type_description = "a float"
 
@@ -1030,7 +1030,7 @@ class FloatField(ScalarField, metaclass=ABCMeta):
         return super().compute_value(raw_value, address=address)
 
 
-class StringField(ScalarField, metaclass=ABCMeta):
+class StringField(ScalarField[str], metaclass=ABCMeta):
     """A field whose value is a string.
 
     If you expect the string to only be one of several values, set the class property
@@ -1100,10 +1100,7 @@ class SequenceField(Generic[T], PrimitiveField, metaclass=ABCMeta):
         return tuple(value_or_default)
 
 
-class StringSequenceField(SequenceField, metaclass=ABCMeta):
-    value: Optional[Tuple[str, ...]]
-    default: ClassVar[Optional[Tuple[str, ...]]] = None
-
+class StringSequenceField(SequenceField[str], metaclass=ABCMeta):
     expected_element_type = str
     expected_type_description = "an iterable of strings (e.g. a list of strings)"
 
@@ -1114,7 +1111,7 @@ class StringSequenceField(SequenceField, metaclass=ABCMeta):
         return super().compute_value(raw_value, address=address)
 
 
-class StringOrStringSequenceField(SequenceField, metaclass=ABCMeta):
+class StringOrStringSequenceField(SequenceField[str], metaclass=ABCMeta):
     """The raw_value may either be a string or be an iterable of strings.
 
     This is syntactic sugar that we use for certain fields to make BUILD files simpler when the user
@@ -1122,9 +1119,6 @@ class StringOrStringSequenceField(SequenceField, metaclass=ABCMeta):
 
     Generally, this should not be used by any new Fields. This mechanism is a misfeature.
     """
-
-    value: Optional[Tuple[str, ...]]
-    default: ClassVar[Optional[Tuple[str, ...]]] = None
 
     expected_element_type = str
     expected_type_description = (


### PR DESCRIPTION
### Problem

When building an `archive`, we believe users will want to be able to control where certain files/packages show up. This is why we added `relocated_files` in https://github.com/pantsbuild/pants/pull/10880. 

However, `relocated_files` would not work with a package. If you tried using `relocated_files` with a package, then it would not build the actual package, as it's not `FilesSources`.

Further, even if you're not using `archive`, users may want to control the output path when running `./pants package` or using `runtime_package_dependencies` in `python_tests`. For example, they may want to hardcode a certain value so that changing the target name or directory path would not change the final package name.

In v1, we had `basename` for this. But `basename` is not adequate because this solely changes the final file name, but not the full path, like `src.python.pants/pants.pex`.

### Solution

For package target types, allow users to override the default path.

We warn that this can result in ambiguous paths if the user is not careful, whereas our default is always unambiguous. While this could be surprising, the user must go out of their way to opt-in, and we will warn both in `./pants target-types` and the online docs.

[ci skip-build-wheels]
[ci skip-rust]