### PR TITLE
Upgrade Pex to 2.1.17.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ mypy==0.782
 
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.16
+pex==2.1.17
 psutil==5.7.0
 pystache==0.5.4
 # This should be kept in sync with `pytest.py`.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -32,7 +32,7 @@ class PexBinary(ExternalTool):
 
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.16"
+    default_version = "v2.1.17"
 
     @classproperty
     def default_known_versions(cls):
@@ -41,8 +41,8 @@ class PexBinary(ExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "38712847654254088a23394728f9a5fb93c6c83631300e7ab427ec780a88f653",
-                    "2662638",
+                    "df836ddd102d8fc9fb390cc4c7fc478caf5afa1600cbdeb7753b185e27a6a8b0",
+                    "2673293",
                 )
             )
             for plat in ["darwin", "linux"]


### PR DESCRIPTION
This pulls in a fix for interpreter selection under macOS framework
Python builds.

Fixes #10855

[ci skip-rust]
[ci skip-build-wheels]