### PR TITLE
add MergedGet and convert_compatible_from() for extensible Sources and Dependencies fields

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -104,7 +104,7 @@ async def infer_python_dependencies(
     request: InferPythonDependencies, python_inference: PythonInference
 ) -> InferredDependencies:
     if not python_inference.imports:
-        return InferredDependencies([], sibling_dependencies_inferrable=False)
+        return InferredDependencies.as_group([], sibling_dependencies_inferrable=False)
 
     stripped_sources = await Get(StrippedSourceFiles, SourceFilesRequest([request.sources_field]))
     modules = tuple(
@@ -136,7 +136,7 @@ async def infer_python_dependencies(
     merged_result = sorted(
         set(itertools.chain.from_iterable(owners_per_import)) - {request.sources_field.address}
     )
-    return InferredDependencies(merged_result, sibling_dependencies_inferrable=True)
+    return InferredDependencies.as_group(merged_result, sibling_dependencies_inferrable=True)
 
 
 class InferInitDependencies(InferDependenciesRequest):
@@ -148,7 +148,7 @@ async def infer_python_init_dependencies(
     request: InferInitDependencies, python_inference: PythonInference
 ) -> InferredDependencies:
     if not python_inference.inits:
-        return InferredDependencies([], sibling_dependencies_inferrable=False)
+        return InferredDependencies.as_group([], sibling_dependencies_inferrable=False)
 
     # Locate __init__.py files not already in the Snapshot.
     hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
@@ -164,7 +164,7 @@ async def infer_python_init_dependencies(
     owners = await MultiGet(
         Get(Owners, OwnersRequest((f,))) for f in extra_init_files.snapshot.files
     )
-    return InferredDependencies(
+    return InferredDependencies.as_group(
         itertools.chain.from_iterable(owners), sibling_dependencies_inferrable=False
     )
 
@@ -179,7 +179,7 @@ async def infer_python_conftest_dependencies(
     python_inference: PythonInference,
 ) -> InferredDependencies:
     if not python_inference.conftests:
-        return InferredDependencies([], sibling_dependencies_inferrable=False)
+        return InferredDependencies.as_group([], sibling_dependencies_inferrable=False)
 
     # Locate conftest.py files not already in the Snapshot.
     hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
@@ -194,7 +194,7 @@ async def infer_python_conftest_dependencies(
         Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
         for f in extra_conftest_files.snapshot.files
     )
-    return InferredDependencies(
+    return InferredDependencies.as_group(
         itertools.chain.from_iterable(owners), sibling_dependencies_inferrable=False
     )
 

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -98,7 +98,7 @@ def test_infer_python_imports() -> None:
         )
 
     normal_address = Address("src/python")
-    assert run_dep_inference(normal_address) == InferredDependencies(
+    assert run_dep_inference(normal_address) == InferredDependencies.as_group(
         [
             Address("3rdparty/python", target_name="Django"),
             Address("src/python", relative_file_path="app.py"),
@@ -110,13 +110,13 @@ def test_infer_python_imports() -> None:
     generated_subtarget_address = Address(
         "src/python", relative_file_path="f2.py", target_name="python"
     )
-    assert run_dep_inference(generated_subtarget_address) == InferredDependencies(
+    assert run_dep_inference(generated_subtarget_address) == InferredDependencies.as_group(
         [Address("src/python", relative_file_path="app.py", target_name="python")],
         sibling_dependencies_inferrable=True,
     )
     assert run_dep_inference(
         generated_subtarget_address, enable_string_imports=True
-    ) == InferredDependencies(
+    ) == InferredDependencies.as_group(
         [
             Address("src/python", relative_file_path="app.py", target_name="python"),
             Address("src/python/str_import/subdir", relative_file_path="f.py"),
@@ -160,7 +160,9 @@ def test_infer_python_inits() -> None:
             [InferInitDependencies(target[PythonSources])],
         )
 
-    assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+    assert run_dep_inference(
+        Address.parse("src/python/root/mid/leaf")
+    ) == InferredDependencies.as_group(
         [
             Address("src/python/root", relative_file_path="__init__.py", target_name="root"),
             Address("src/python/root/mid", relative_file_path="__init__.py", target_name="mid"),
@@ -200,7 +202,9 @@ def test_infer_python_conftests() -> None:
             [InferConftestDependencies(target[PythonSources])],
         )
 
-    assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+    assert run_dep_inference(
+        Address.parse("src/python/root/mid/leaf")
+    ) == InferredDependencies.as_group(
         [
             Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
             Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -3,12 +3,13 @@
 
 from typing import Any, ClassVar, Iterable, Tuple, TypeVar, Union, cast, overload
 
+from pants.util.collections import MergeableOutput
 from pants.util.ordered_set import FrozenOrderedSet
 
 T = TypeVar("T")
 
 
-class Collection(Tuple[T, ...]):
+class Collection(Tuple[T, ...], MergeableOutput[T]):
     """A light newtype around immutable sequences for use with the V2 engine.
 
     This should be subclassed when you want to create a distinct collection type, such as:
@@ -53,11 +54,15 @@ class Collection(Tuple[T, ...]):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self)})"
 
+    @classmethod
+    def from_iterable(cls, instances: Iterable[T]) -> "Collection[T]":
+        return cls(instances)
+
 
 # NB: This name is clunky. It would be more appropriate to call it `Set`, but that is claimed by
 #  `typing.Set` already. See
 #  https://github.com/pantsbuild/pants/pull/9590#pullrequestreview-395970440.
-class DeduplicatedCollection(FrozenOrderedSet[T]):
+class DeduplicatedCollection(FrozenOrderedSet[T], MergeableOutput[T]):
     """A light newtype around FrozenOrderedSet for use with the V2 engine.
 
     This should be subclassed when you want to create a distinct collection type, such as:
@@ -80,3 +85,7 @@ class DeduplicatedCollection(FrozenOrderedSet[T]):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self._items)})"
+
+    @classmethod
+    def from_iterable(cls, instances: Iterable[T]) -> "DeduplicatedCollection[T]":
+        return cls(instances)

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1102,7 +1102,7 @@ async def infer_smalltalk_dependencies(request: InferSmalltalkDependencies) -> I
     )
     # NB: See `test_depends_on_subtargets` for why we set the field
     # `sibling_dependencies_inferrable` this way.
-    return InferredDependencies(resolved, sibling_dependencies_inferrable=bool(resolved))
+    return InferredDependencies.as_group(resolved, sibling_dependencies_inferrable=bool(resolved))
 
 
 @pytest.fixture

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -62,9 +62,9 @@ class GetConstraints:
     output_type: Type
     input_type: Type
 
-    @classmethod
+    @staticmethod
     def parse_input_and_output_types(
-        cls, get_args: Sequence[ast.expr], *, source_file_name: str
+        get_args: Sequence[ast.expr], *, source_file_name: str
     ) -> Tuple[str, str]:
         parse_error = partial(GetParseError, get_args=get_args, source_file_name=source_file_name)
 
@@ -559,7 +559,7 @@ async def MultiGet(  # noqa: F811
             return f"Get({arg.output_type.__name__}, {arg.input_type.__name__}, ...)"
         return repr(arg)
 
-    likely_args_exlicitly_passed = tuple(
+    likely_args_explicitly_passed = tuple(
         reversed(
             [
                 render_arg(arg)
@@ -567,12 +567,12 @@ async def MultiGet(  # noqa: F811
             ]
         )
     )
-    if any(arg is None for arg in likely_args_exlicitly_passed):
+    if any(arg is None for arg in likely_args_explicitly_passed):
         raise ValueError(
             dedent(
                 f"""\
                 Unexpected MultiGet None arguments: {', '.join(
-                    map(str, likely_args_exlicitly_passed)
+                    map(str, likely_args_explicitly_passed)
                 )}
 
                 When constructing a MultiGet from individual Gets all leading arguments must be
@@ -584,7 +584,7 @@ async def MultiGet(  # noqa: F811
     raise TypeError(
         dedent(
             f"""\
-            Unexpected MultiGet argument types: {', '.join(map(str, likely_args_exlicitly_passed))}
+            Unexpected MultiGet argument types: {', '.join(map(str, likely_args_explicitly_passed))}
 
             A MultiGet can be constructed in two ways:
             1. MultiGet(Iterable[Get[T]]) -> Tuple[T, ...]

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 from pants.engine.goal import Goal
+from pants.engine.internals.selectors import GET_COMPATIBLE_CALLS
 from pants.engine.internals.selectors import Get as Get  # noqa: F401
 from pants.engine.internals.selectors import GetConstraints
 from pants.engine.internals.selectors import MultiGet as MultiGet  # noqa: F401
@@ -57,7 +58,7 @@ class _RuleVisitor(ast.NodeVisitor):
         """Check if the node looks like a Get(T, ...) call."""
         if not isinstance(call_node.func, ast.Name):
             return None
-        if call_node.func.id != "Get":
+        if call_node.func.id not in GET_COMPATIBLE_CALLS:
             return None
         return call_node.args
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -15,7 +15,6 @@ from typing import (
     Dict,
     Generic,
     Iterable,
-    Iterator,
     Mapping,
     Optional,
     Sequence,
@@ -1625,7 +1624,7 @@ class InferDependenciesRequest(EngineAwareParameter):
         def infer_fortran_dependencies(request: InferFortranDependencies) -> InferredDependencies:
             hydrated_sources = await Get(HydratedSources, HydrateSources(request.sources_field))
             ...
-            return InferredDependencies(...)
+            return InferredDependencies.as_group(...)
 
         def rules():
             return [
@@ -1641,30 +1640,33 @@ class InferDependenciesRequest(EngineAwareParameter):
         return self.sources_field.address.spec
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class InferredDependencies:
-    dependencies: FrozenOrderedSet[Address]
+@dataclass(frozen=True, order=True)
+class InferredDependency:
+    """The result of inferring dependencies.
+
+    If the inference implementation is able to infer file-level dependencies on sibling files
+    belonging to the same target, set sibling_dependencies_inferrable=True. This allows for finer-
+    grained caching because the dependency rule will not automatically add a dependency on all
+    sibling files.
+    """
+
+    address: Address
     sibling_dependencies_inferrable: bool
 
-    def __init__(
-        self, dependencies: Iterable[Address], *, sibling_dependencies_inferrable: bool
-    ) -> None:
-        """The result of inferring dependencies.
 
-        If the inference implementation is able to infer file-level dependencies on sibling files
-        belonging to the same target, set sibling_dependencies_inferrable=True. This allows for
-        finer-grained caching because the dependency rule will not automatically add a dependency on
-        all sibling files.
-        """
-        self.dependencies = FrozenOrderedSet(sorted(dependencies))
-        self.sibling_dependencies_inferrable = sibling_dependencies_inferrable
+class InferredDependencies(DeduplicatedCollection[InferredDependency]):
+    sort_input = True
 
-    def __bool__(self) -> bool:
-        return bool(self.dependencies)
+    @classmethod
+    def as_group(
+        cls,
+        dependencies: Iterable[Address],
+        sibling_dependencies_inferrable: bool,
+    ) -> "InferredDependencies":
+        return cls(InferredDependency(dep, sibling_dependencies_inferrable) for dep in dependencies)
 
-    def __iter__(self) -> Iterator[Address]:
-        return iter(self.dependencies)
+    def to_raw_addresses(self) -> Iterable[Address]:
+        return [inf_dep.address for inf_dep in self]
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -3,7 +3,8 @@
 
 import collections
 import collections.abc
-from typing import Any, Iterable, List, MutableMapping, Type, TypeVar, Union
+from abc import ABCMeta, abstractmethod
+from typing import Any, Generic, Iterable, List, MutableMapping, Type, TypeVar, Union
 
 
 def recursively_update(d: MutableMapping, d2: MutableMapping) -> None:
@@ -69,3 +70,21 @@ def ensure_str_list(val: Union[str, Iterable[str]], *, allow_single_str: bool = 
     If `allow_single_str` is True, a single `str` will be wrapped into a `List[str]`.
     """
     return ensure_list(val, expected_type=str, allow_single_scalar=allow_single_str)
+
+
+_Mergeable = TypeVar("_Mergeable", bound="MergeableOutput")
+
+
+class MergeableOutput(Generic[_T], metaclass=ABCMeta):
+    """Mixin to allow merging of collections."""
+
+    # NB: @abstractmethod @classmethod methods are not yet checked *to exist* by mypy
+    # the way abstract instance methods are, but any *implementations* will be correctly checked!
+    @classmethod
+    @abstractmethod
+    def from_iterable(cls: Type["_Mergeable"], instances: Iterable[_T]) -> "_Mergeable":
+        ...
+
+    @classmethod
+    def from_multiple(cls: Type["_Mergeable"], instances: Iterable[Iterable[_T]]) -> "_Mergeable":
+        return cls.from_iterable(element for instance in instances for element in instance)


### PR DESCRIPTION
### Problem

*This PR is on top of #10925, see [here for the diff against that change](https://github.com/cosmicexplorer/pants/compare/add-mergeable-output...cosmicexplorer:add-merged-get).*

I happened to take a look at the code for `resolve_dependencies()` in `graph.py`, and noticed a pattern being implemented twice, to iterate over `@union` implementations and merge their results. I recognized that the use case was very similar to the implementation I suggested in https://github.com/pantsbuild/pants/issues/10888#issuecomment-703002810.

### Solution

- add `MergedGet` in `selectors.py` to reduce the boilerplate in running a `MultiGet` and merging the results.
- consume `MergedGet` in `graph.py`.

### Result

Getting the injected dependencies for an `InjectDependenciesRequest` now looks like:
```python
    inject_request_types = union_membership.get(InjectDependenciesRequest)
    injected = await MergedGet(
        InjectedDependencies,
        InjectDependenciesRequest,
        (
            inject_request_type(request.field)
            for inject_request_type in inject_request_types
            if isinstance(request.field, inject_request_type.inject_for)
        ),
    )
```