### PR TITLE
print stacktraces during import errors

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -110,9 +110,9 @@ class ExceptionSink:
     # Where to log stacktraces to in a SIGUSR2 handler.
     _interactive_output_stream = None
 
-    # An instance of `SignalHandler` which is invoked to handle a static set of specific
-    # nonfatal signals (these signal handlers are allowed to make pants exit, but unlike SIGSEGV they
-    # don't need to exit immediately).
+    # An instance of `SignalHandler` which is invoked to handle a static set of specific nonfatal
+    # signals (these signal handlers are allowed to make pants exit, but unlike SIGSEGV they don't
+    # need to exit immediately).
     _signal_handler: SignalHandler = SignalHandler(pantsd_instance=False)
 
     # These persistent open file descriptors are kept so the signal handler can do almost no work
@@ -120,7 +120,11 @@ class ExceptionSink:
     _pid_specific_error_fileobj = None
     _shared_error_fileobj = None
 
+    # Set in methods on SignalHandler and exposed to the engine rust code.
     _signal_sent: Optional[int] = None
+
+    # Whether the rust logger has been initialized so we can stop doing extra work in this class.
+    _logging_initialized: bool = False
 
     def __new__(cls, *args, **kwargs):
         raise TypeError("Instances of {} are not allowed to be constructed!".format(cls.__name__))
@@ -187,6 +191,16 @@ class ExceptionSink:
         cls._log_dir = new_log_location
         cls._pid_specific_error_fileobj = pid_specific_error_stream
         cls._shared_error_fileobj = shared_error_stream
+
+    @classmethod
+    def set_logging_initialized(cls):
+        """Set the flag (to True) which indicates that the rust logger has been initialized.
+
+        Class state:
+        - Overwrites `cls._logging_initialized`.
+        """
+        # NB: mutate the class variables!
+        cls._logging_initialized = True
 
     @classmethod
     def exceptions_log_path(cls, for_pid=None, in_dir=None):
@@ -360,7 +374,8 @@ Exception message: {exception_message}{maybe_newline}
 
         extra_err_msg = None
         try:
-            # Always output the unhandled exception details into a log file, including the traceback.
+            # Always output the unhandled exception details into a log file, including the
+            # traceback.
             exception_log_entry = cls._format_unhandled_exception_log(
                 exc, tb, add_newline, should_print_backtrace=True
             )
@@ -369,8 +384,15 @@ Exception message: {exception_message}{maybe_newline}
             extra_err_msg = "Additional error logging unhandled exception {}: {}".format(exc, e)
             logger.error(extra_err_msg)
 
-        # Generate an unhandled exception report fit to be printed to the terminal.
-        logger.exception(exc)
+        # The rust logger implementation is used for most of pants's execution, but at import time,
+        # we want to be able to see any stacktrace to know where the error is being raised.
+        if cls._logging_initialized:
+            logger.exception(exc)
+        else:
+            exception_log_entry = cls._format_unhandled_exception_log(
+                exc, tb, add_newline, should_print_backtrace=True
+            )
+            logger.error(exception_log_entry)
 
     @classmethod
     def _handle_signal_gracefully(cls, signum, signame, traceback_lines):

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -75,7 +75,6 @@ class PantsRunner:
         # We enable logging here, and everything before it will be routed through regular
         # Python logging.
         setup_logging(global_bootstrap_options, stderr_logging=True)
-        ExceptionSink.set_logging_initialized()
 
         if self._should_run_with_pantsd(global_bootstrap_options):
             try:

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -75,6 +75,7 @@ class PantsRunner:
         # We enable logging here, and everything before it will be routed through regular
         # Python logging.
         setup_logging(global_bootstrap_options, stderr_logging=True)
+        ExceptionSink.set_logging_initialized()
 
         if self._should_run_with_pantsd(global_bootstrap_options):
             try:


### PR DESCRIPTION
[ci skip-rust]

### Problem

Pants only prints *what* failed to import upon an `ImportError`, not *where*.