### PR TITLE
add requests_ca_bundle to settable_env_vars

### DIFF
--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -22,11 +22,13 @@ SETTABLE_ENV_VARS = (
     "ftp_proxy",
     "all_proxy",
     "no_proxy",
+    "requests_ca_bundle",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "FTP_PROXY",
     "ALL_PROXY",
     "NO_PROXY",
+    "REQUESTS_CA_BUNDLE",
 )
 
 

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -22,12 +22,13 @@ SETTABLE_ENV_VARS = (
     "ftp_proxy",
     "all_proxy",
     "no_proxy",
-    "requests_ca_bundle",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "FTP_PROXY",
     "ALL_PROXY",
     "NO_PROXY",
+    # Allow Requests to verify SSL certificates for HTTPS requests
+    # https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification
     "REQUESTS_CA_BUNDLE",
 )
 


### PR DESCRIPTION
### Problem

If the user has a proxy set with _http_proxy_ and _https_proxy_ and the proxy uses a self-signed certificate you might still get invalid SSL Cert errors when the subprocess tries to get the packages externally. 

```
  Complete output (10 lines):
  Looking in indexes: https://pypi.org/simple/
  WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /simple/setuptools/
  WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /simple/setuptools/
  WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /simple/setuptools/
  WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /simple/setuptools/
  WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /simple/setuptools/
  Could not fetch URL https://pypi.org/simple/setuptools/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/setuptools/ (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)) - skipping
  ERROR: Could not find a version that satisfies the requirement setuptools>=41.0 (from versions: none)
  ERROR: No matching distribution found for setuptools>=41.0
  Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)) - skipping
```

### Solution

Allow the user to pass the REQUESTS_CA_BUNDLE environment variable that points to the self-signed certificate.
