### PR TITLE
Deprecate `--print-exception-stacktrace` to `--print-stacktrace`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-print_exception_stacktrace = true
+print_stacktrace = true
 
 pants_distdir_legacy_paths = false
 

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -300,7 +300,7 @@ def resolve_conflicting_options(
 ):
     """Utility for resolving an option that's been migrated to a new location.
 
-    This ensures that the user does not try to specify both options.
+    The option names should use snake_case, rather than --kebab-case.
     """
     old_configured = not old_container.is_default(old_option)
     new_configured = not new_container.is_default(new_option)

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -297,8 +297,12 @@ def resolve_conflicting_options(
     new_scope: str,
     old_container: Any,
     new_container: Any,
-):
+) -> Any:
     """Utility for resolving an option that's been migrated to a new location.
+
+    This will check if either option was explicitly configured, and if so, use that. If both were
+    configured, it will error. Otherwise, it will use the default value for the new, preferred
+    option.
 
     The option names should use snake_case, rather than --kebab-case.
     """

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -80,8 +80,8 @@ def test_logs_unhandled_exception() -> None:
         pants_run = run_pants_with_workdir(
             ["--no-pantsd", "list", f"{directory}:this-target-does-not-exist"],
             workdir=tmpdir,
-            # The backtrace should be omitted when --print-exception-stacktrace=False.
-            print_exception_stacktrace=False,
+            # The backtrace should be omitted when --print-stacktrace=False.
+            print_stacktrace=False,
             hermetic=False,
         )
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, Iterable, List, Optional, Set, Tuple, Type, ca
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
+from pants.base.deprecated import resolve_conflicting_options
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.specs import Specs
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -164,6 +165,14 @@ class EngineInitializer:
         native = Native()
         build_root = get_buildroot()
         bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+        print_stacktrace = resolve_conflicting_options(
+            old_option="print_exception_stacktrace",
+            new_option="print_stacktrace",
+            old_scope="",
+            new_scope="",
+            old_container=bootstrap_options,
+            new_container=bootstrap_options,
+        )
         return EngineInitializer.setup_graph_extended(
             options_bootstrapper,
             build_configuration,
@@ -178,7 +187,7 @@ class EngineInitializer:
             ca_certs_path=bootstrap_options.ca_certs_path,
             build_root=build_root,
             native=native,
-            include_trace_on_error=bootstrap_options.print_exception_stacktrace,
+            include_trace_on_error=print_stacktrace,
         )
 
     @staticmethod

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -9,6 +9,7 @@ from logging import Formatter, Handler, LogRecord, StreamHandler
 from typing import Dict, Iterable, Optional, Tuple
 
 import pants.util.logging as pants_logging
+from pants.base.deprecated import resolve_conflicting_options
 from pants.engine.internals.native import Native
 from pants.option.option_value_container import OptionValueContainer
 from pants.util.dirutil import safe_mkdir
@@ -64,7 +65,7 @@ class NativeHandler(StreamHandler):
 
 
 class ExceptionFormatter(Formatter):
-    """Uses the `--print-exception-stacktrace` option to decide whether to render stacktraces."""
+    """Uses the `--print-stacktrace` option to decide whether to render stacktraces."""
 
     def __init__(self, print_stacktrace: bool):
         super().__init__(None)
@@ -73,7 +74,7 @@ class ExceptionFormatter(Formatter):
     def formatException(self, exc_info):
         if self.print_stacktrace:
             return super().formatException(exc_info)
-        return "\n(Use --print-exception-stacktrace to see more error details.)"
+        return "\n(Use --print-stacktrace to see more error details.)"
 
 
 def clear_logging_handlers():
@@ -135,9 +136,16 @@ def setup_logging(global_bootstrap_options: OptionValueContainer, stderr_logging
         global_level, log_show_rust_3rdparty, use_color, show_target, log_levels_by_target
     )
 
-    print_exception_stacktrace = global_bootstrap_options.print_exception_stacktrace
+    print_stacktrace = resolve_conflicting_options(
+        old_option="print_exception_stacktrace",
+        new_option="print_stacktrace",
+        old_scope="",
+        new_scope="",
+        old_container=global_bootstrap_options,
+        new_container=global_bootstrap_options,
+    )
     if stderr_logging:
-        setup_logging_to_stderr(global_level, print_exception_stacktrace)
+        setup_logging_to_stderr(global_level, print_stacktrace)
 
     if log_dir:
         setup_logging_to_file(global_level, log_dir=log_dir)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -563,15 +563,20 @@ class GlobalOptions(Subsystem):
             "of the directory will be overwritten if any filenames collide.",
         )
         register(
+            "--print-stacktrace",
+            advanced=True,
+            type=bool,
+            default=False,
+            help="Print the full exception stack trace for any errors.",
+        )
+        register(
             "--print-exception-stacktrace",
             advanced=True,
             type=bool,
             default=False,
-            # TODO: We must restart the daemon because of global mutable state in `init/logging.py`
-            #  from `ExceptionSink.should_print_exception_stacktrace`. Fix this and only use
-            #  `fingerprint=True` instead.
-            daemon=True,
             help="Print to console the full exception stack trace if encountered.",
+            removal_version="2.1.0.dev0",
+            removal_hint="Use `--print-stacktrace` instead of `--print-exception-stacktrace`.",
         )
 
         # BinaryUtil options.

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -125,13 +125,20 @@ def run_pants_with_workdir_without_waiting(
     use_pantsd: bool = True,
     config: Optional[Mapping] = None,
     extra_env: Optional[Mapping[str, str]] = None,
-    print_exception_stacktrace: bool = True,
+    print_stacktrace: bool = True,
     **kwargs: Any,
 ) -> PantsJoinHandle:
+    if "print_exception_stacktrace" in kwargs:
+        warn_or_error(
+            removal_version="2.1.0.dev0",
+            deprecated_entity_description="the kwarg `print_exception_stacktrace`",
+            hint="Use the kwarg `print_stacktrace` instead",
+        )
+        print_stacktrace = kwargs["print_exception_stacktrace"]
     args = [
         "--no-pantsrc",
         f"--pants-workdir={workdir}",
-        f"--print-exception-stacktrace={print_exception_stacktrace}",
+        f"--print-stacktrace={print_stacktrace}",
     ]
 
     pantsd_in_command = "--no-pantsd" in command or "--pantsd" in command
@@ -378,7 +385,6 @@ class PantsIntegrationTest(unittest.TestCase):
         workdir: str,
         config: Optional[Mapping] = None,
         extra_env: Optional[Mapping[str, str]] = None,
-        print_exception_stacktrace: bool = True,
         **kwargs: Any,
     ) -> PantsJoinHandle:
         warn_or_error(
@@ -396,7 +402,6 @@ class PantsIntegrationTest(unittest.TestCase):
             use_pantsd=self.use_pantsd,
             config=config,
             extra_env=extra_env,
-            print_exception_stacktrace=print_exception_stacktrace,
             **kwargs,
         )
 


### PR DESCRIPTION
Exception is a hard word to spell, and makes this option longer than it needs to be.

[ci skip-rust]
[ci skip-build-wheels]