### PR TITLE
Add `await Get(Addresses, UnparsedAddressInputs)` 

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.codegen.protobuf.protoc import Protoc
-from pants.engine.addresses import Address, AddressInput
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -48,8 +48,8 @@ class InjectProtobufDependencies(InjectDependenciesRequest):
 async def inject_dependencies(
     _: InjectProtobufDependencies, protoc: Protoc
 ) -> InjectedDependencies:
-    addresses = await MultiGet(
-        Get(Address, AddressInput, AddressInput.parse(addr)) for addr in protoc.runtime_targets
+    addresses = await Get(
+        Addresses, UnparsedAddressInputs((v for v in protoc.runtime_targets), owning_address=None)
     )
     return InjectedDependencies(addresses)
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -27,7 +27,7 @@ from pants.backend.python.util_rules.python_sources import (
 )
 from pants.core.goals.lint import LintRequest, LintResult, LintResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import Address, Addresses, AddressInput
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import (
     EMPTY_DIGEST,
     AddPrefix,
@@ -232,9 +232,7 @@ async def pylint_lint(
     if pylint.skip:
         return LintResults([], linter_name="Pylint")
 
-    plugin_target_addresses = await MultiGet(
-        Get(Address, AddressInput, plugin_addr) for plugin_addr in pylint.source_plugins
-    )
+    plugin_target_addresses = await Get(Addresses, UnparsedAddressInputs, pylint.source_plugins)
     plugin_targets_request = Get(TransitiveTargets, Addresses(plugin_target_addresses))
     linted_targets_request = Get(
         Targets, Addresses(field_set.address for field_set in request.field_sets)

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -1,10 +1,10 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.engine.addresses import AddressInput
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 
 
@@ -66,5 +66,5 @@ class Pylint(PythonToolBase):
         return cast(Optional[str], self.options.config)
 
     @property
-    def source_plugins(self) -> Tuple[AddressInput, ...]:
-        return tuple(AddressInput.parse(v) for v in self.options.source_plugins)
+    def source_plugins(self) -> UnparsedAddressInputs:
+        return UnparsedAddressInputs(self.options.source_plugins, owning_address=None)

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -13,8 +13,8 @@ from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
-from pants.engine.addresses import Address, AddressInput
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
@@ -569,13 +569,11 @@ async def inject_dependencies(
         return InjectedDependencies()
     # Note that we don't validate that these are all `python_binary` targets; we don't care about
     # that here. `setup_py.py` will do that validation.
-    addresses = await MultiGet(
-        Get(
-            Address,
-            AddressInput,
-            AddressInput.parse(addr, relative_to=request.dependencies_field.address.spec_path),
-        )
-        for addr in with_binaries.values()
+    addresses = await Get(
+        Addresses,
+        UnparsedAddressInputs(
+            with_binaries.values(), owning_address=request.dependencies_field.address
+        ),
     )
     return InjectedDependencies(addresses)
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -31,7 +31,7 @@ from pants.backend.python.util_rules.python_sources import (
 )
 from pants.core.goals.typecheck import TypecheckRequest, TypecheckResult, TypecheckResults
 from pants.core.util_rules import pants_bin
-from pants.engine.addresses import Address, Addresses, AddressInput
+from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -186,10 +186,7 @@ LAUNCHER_FILE = FileContent(
 
 @rule
 async def mypy_typecheck_partition(partition: MyPyPartition, mypy: MyPy) -> TypecheckResult:
-    plugin_target_addresses = await MultiGet(
-        Get(Address, AddressInput, plugin_addr) for plugin_addr in mypy.source_plugins
-    )
-
+    plugin_target_addresses = await Get(Addresses, UnparsedAddressInputs, mypy.source_plugins)
     plugin_transitive_targets_request = Get(TransitiveTargets, Addresses(plugin_target_addresses))
     plugin_transitive_targets, launcher_script = await MultiGet(
         plugin_transitive_targets_request, Get(Digest, CreateDigest([LAUNCHER_FILE]))

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -4,7 +4,7 @@
 from typing import Optional, Tuple, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.engine.addresses import AddressInput
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.option.custom_types import file_option, shell_str, target_option
 
 
@@ -70,5 +70,5 @@ class MyPy(PythonToolBase):
         return cast(Optional[str], self.options.config)
 
     @property
-    def source_plugins(self) -> Tuple[AddressInput, ...]:
-        return tuple(AddressInput.parse(v) for v in self.options.source_plugins)
+    def source_plugins(self) -> UnparsedAddressInputs:
+        return UnparsedAddressInputs(self.options.source_plugins, owning_address=None)

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -96,7 +96,7 @@ def test_address_input_parse_bad_path_component() -> None:
 def test_address_input_parse_bad_target_component() -> None:
     def assert_bad_target_component(spec: str) -> None:
         with pytest.raises(InvalidTargetName):
-            print(repr(AddressInput.parse(spec)))
+            repr(AddressInput.parse(spec))
 
     # Missing target_component
     assert_bad_target_component("")

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Iterable, Optional, Sequence, Tuple
 
 from pants.base.exceptions import ResolveError
 from pants.base.specs import Spec
@@ -10,6 +10,7 @@ from pants.build_graph.address import Address as Address
 from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexport.
 from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # noqa: F401: rexport.
 from pants.engine.collection import Collection
+from pants.util.meta import frozen_after_init
 
 
 def assert_single_address(addresses: Sequence[Address]) -> None:
@@ -42,3 +43,32 @@ class AddressesWithOrigins(Collection[AddressWithOrigin]):
     def expect_single(self) -> AddressWithOrigin:
         assert_single_address([address_with_origin.address for address_with_origin in self])
         return self[0]
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class UnparsedAddressInputs:
+    """Raw addresses that have not been parsed yet.
+
+    You can convert these into fully normalized `Addresses` and `Targets` like this:
+
+        await Get(Addresses, UnparsedAddressInputs(["//:tgt1", "//:tgt2"], owning_address=None)
+        await Get(Targets, UnparsedAddressInputs([...], owning_address=Address("original"))
+
+    This is intended for contexts where the user specifies addresses outside of the `dependencies`
+    field, such as through an option or a special field on a target that is not normal
+    `dependencies`. You should not use this to resolve the `dependencies` field; use
+    `await Get(Addresses, DependenciesRequest)` for that.
+
+    If the addresses are coming from a target's fields, set `owning_address` so that relative
+    references like `:sibling` work properly.
+
+    Unlike the `dependencies` field, this type does not work with `!` and `!!` ignores.
+    """
+
+    values: Tuple[str, ...]
+    relative_to: Optional[str]
+
+    def __init__(self, values: Iterable[str], *, owning_address: Optional[Address]) -> None:
+        self.values = tuple(values)
+        self.relative_to = owning_address.spec_path if owning_address else None


### PR DESCRIPTION
### Problem

There are now ~dozen instances where we allow the user to specify an address somewhere other than the `dependencies` field, such as options like `--protoc-runtime-targets`.

We had lots of duplication for parsing these raw string values. Likewise, every single implementation failed to handle subprojects correctly.

### Solution

Factor up a new `UnparsedAddressInputs` type. This stores strings, rather than `AddressInput`, so that we can make sure we consider subprojects correctly without callers needing to know this exists.

This is a much simpler implementation than the dependencies field, e.g. not allowing for `!` and `!!` ignores.

[ci skip-rust]
[ci skip-build-wheels]