### PR TITLE
Use `TransitiveTargetsRequest` as input for resolving `TransitiveTargets`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -9,7 +9,6 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.addresses import Addresses
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -22,7 +21,13 @@ from pants.engine.fs import (
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import GeneratedSources, GenerateSourcesRequest, Sources, TransitiveTargets
+from pants.engine.target import (
+    GeneratedSources,
+    GenerateSourcesRequest,
+    Sources,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
@@ -47,7 +52,9 @@ async def generate_python_from_protobuf(
     # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't
     # actually generate those dependencies; it only needs to look at their .proto files to work
     # with imports.
-    transitive_targets = await Get(TransitiveTargets, Addresses([request.protocol_target.address]))
+    transitive_targets = await Get(
+        TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])
+    )
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`
     # for Protobuf imports to be discoverable.
     all_stripped_sources_request = Get(

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -10,7 +10,6 @@ from pants.backend.python.target_types import PythonSources
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.addresses import Address, AddressInput
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -20,25 +19,19 @@ from pants.engine.fs import (
     RemovePrefix,
     Snapshot,
 )
-from pants.engine.internals.graph import parse_dependencies_field
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
-    Dependencies,
     GeneratedSources,
     GenerateSourcesRequest,
-    RegisteredTargetTypes,
     Sources,
-    Subtargets,
-    Target,
-    WrappedTarget,
+    TransitiveTargets,
+    TransitiveTargetsRequestLite,
 )
-from pants.engine.unions import UnionMembership, UnionRule
-from pants.option.global_options import GlobalOptions
+from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 
 class GeneratePythonFromProtobufRequest(GenerateSourcesRequest):
@@ -48,11 +41,7 @@ class GeneratePythonFromProtobufRequest(GenerateSourcesRequest):
 
 @rule(desc="Generate Python from Protobuf", level=LogLevel.DEBUG)
 async def generate_python_from_protobuf(
-    request: GeneratePythonFromProtobufRequest,
-    protoc: Protoc,
-    union_membership: UnionMembership,
-    registered_target_types: RegisteredTargetTypes,
-    global_options: GlobalOptions,
+    request: GeneratePythonFromProtobufRequest, protoc: Protoc
 ) -> GeneratedSources:
     download_protoc_request = Get(
         DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)
@@ -64,54 +53,17 @@ async def generate_python_from_protobuf(
     # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't
     # actually generate those dependencies; it only needs to look at their .proto files to work
     # with imports.
-    # TODO(#10917): This monstrosity is because we are not able to use
-    # `await Get(TransitiveTargets`) without causing rule graph issues. So, we copy a hacky
-    # implementation of the rules to resolve direct deps + transitive deps. This implementation is
-    # much less robust:
-    #
-    #    - Does not use dependency injection.
-    #    - Does not use dependency inference.
-    #    - Always places dependencies on subtargets, and isn't as careful about avoiding
-    #      self-cycles.
-    #    - Worse performance, as this doesn't batch as efficiently.
-    #
-    # Normally, these restrictions would be a non-starter, but because we are solely looking for
-    # transitive dependencies on Protobuf libraries, these hacks are tolerable for now.
-    visited: OrderedSet[Target] = OrderedSet()
-    queued = OrderedSet([request.protocol_target])
-    while queued:
-        tgt = queued.pop()
-        visited.add(tgt)
-
-        # Recreate the DependenciesRequest rule.
-        parsed_deps = parse_dependencies_field(
-            tgt.get(Dependencies),
-            subproject_roots=global_options.options.subproject_roots,
-            registered_target_types=registered_target_types.types,
-            union_membership=union_membership,
-        )
-        included_wrapped_targets = await MultiGet(
-            Get(WrappedTarget, AddressInput, ai) for ai in parsed_deps.addresses
-        )
-        ignored_wrapped_targets = await MultiGet(
-            Get(WrappedTarget, AddressInput, ai) for ai in parsed_deps.ignored_addresses
-        )
-        subtargets = await Get(Subtargets, Address, tgt.address.maybe_convert_to_base_target())
-        direct_dependencies = FrozenOrderedSet(
-            wrapped_t.target for wrapped_t in included_wrapped_targets
-        ) | FrozenOrderedSet(subtargets.subtargets) - FrozenOrderedSet(
-            wrapped_t.target for wrapped_t in ignored_wrapped_targets
-        )
-
-        queued.update(direct_dependencies.difference(visited))
-    all_targets = visited
+    # TODO(#10917): Use TransitiveTargets instead of TransitiveTargetsLite.
+    transitive_targets = await Get(
+        TransitiveTargets, TransitiveTargetsRequestLite([request.protocol_target.address])
+    )
 
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`
     # for Protobuf imports to be discoverable.
     all_stripped_sources_request = Get(
         StrippedSourceFiles,
         SourceFilesRequest(
-            (tgt.get(Sources) for tgt in all_targets),
+            (tgt.get(Sources) for tgt in transitive_targets.closure),
             for_sources_types=(ProtobufSources,),
         ),
     )

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -11,7 +11,13 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import Dependencies as DependenciesField
-from pants.engine.target import DependenciesRequest, Targets, TransitiveTargets, UnexpandedTargets
+from pants.engine.target import (
+    DependenciesRequest,
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+    UnexpandedTargets,
+)
 
 
 class DependencyType(Enum):
@@ -64,7 +70,7 @@ async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
     if dependencies_subsystem.transitive:
-        transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
+        transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
         targets = Targets(transitive_targets.dependencies)
     else:
         target_roots = await Get(UnexpandedTargets, Addresses, addresses)

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     Target,
     Targets,
     TransitiveTargets,
+    TransitiveTargetsRequest,
     UnexpandedTargets,
 )
 
@@ -83,7 +84,7 @@ async def file_deps(
 ) -> Filedeps:
     targets: Iterable[Target]
     if filedeps_subsystem.transitive:
-        transitive_targets = await Get(TransitiveTargets, Addresses, addresses)
+        transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
         targets = transitive_targets.closure
     elif filedeps_subsystem.globs:
         targets = await Get(UnexpandedTargets, Addresses, addresses)

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -28,7 +28,7 @@ from pants.core.goals.test import (
     CoverageReports,
     FilesystemCoverageReport,
 )
-from pants.engine.addresses import Address
+from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -42,7 +42,7 @@ from pants.engine.fs import (
 )
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import TransitiveTargets
+from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.custom_types import file_option
 from pants.util.logging import LogLevel
@@ -270,9 +270,10 @@ async def generate_coverage_reports(
     coverage_setup: CoverageSetup,
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
-    transitive_targets: TransitiveTargets,
+    all_used_addresses: Addresses,
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(all_used_addresses))
     sources = await Get(
         PythonSourceFiles,
         PythonSourceFilesRequest(transitive_targets.closure, include_resources=False),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -41,7 +41,7 @@ from pants.core.goals.test import (
     TestSubsystem,
 )
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import FallibleProcessResult, InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -50,6 +50,7 @@ from pants.engine.target import (
     FieldSetsPerTargetRequest,
     Targets,
     TransitiveTargets,
+    TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
@@ -103,9 +104,9 @@ async def setup_pytest_for_target(
     test_extra_env: TestExtraEnv,
     global_options: GlobalOptions,
 ) -> TestSetup:
-    test_addresses = Addresses((request.field_set.address,))
-
-    transitive_targets = await Get(TransitiveTargets, Addresses, test_addresses)
+    transitive_targets = await Get(
+        TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])
+    )
     all_targets = transitive_targets.closure
 
     interpreter_constraints = PexInterpreterConstraints.create_from_compatibility_fields(
@@ -121,7 +122,7 @@ async def setup_pytest_for_target(
     requirements_pex_request = Get(
         Pex,
         PexFromTargetsRequest,
-        PexFromTargetsRequest.for_requirements(test_addresses, internal_only=True),
+        PexFromTargetsRequest.for_requirements([request.field_set.address], internal_only=True),
     )
 
     pytest_pex_request = Get(

--- a/src/python/pants/backend/python/goals/run_python_binary.py
+++ b/src/python/pants/backend/python/goals/run_python_binary.py
@@ -13,10 +13,9 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
 )
 from pants.core.goals.run import RunFieldSet, RunRequest
-from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, MergeDigests, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import InvalidFieldException, TransitiveTargets
+from pants.engine.target import InvalidFieldException, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.option.global_options import FilesNotFoundBehavior
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -49,7 +48,7 @@ async def create_python_binary_run_request(
         entry_point = PythonBinarySources.translate_source_file_to_entry_point(
             os.path.relpath(entry_point_path, source_root.path)
         )
-    transitive_targets = await Get(TransitiveTargets, Addresses([field_set.address]))
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
 
     # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
     # so that we can get the interpreter constraints for use in runner_pex_request.

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -45,6 +45,7 @@ from pants.engine.target import (
     Target,
     Targets,
     TransitiveTargets,
+    TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.python.python_setup import PythonSetup
@@ -233,7 +234,9 @@ async def pylint_lint(
         return LintResults([], linter_name="Pylint")
 
     plugin_target_addresses = await Get(Addresses, UnparsedAddressInputs, pylint.source_plugins)
-    plugin_targets_request = Get(TransitiveTargets, Addresses(plugin_target_addresses))
+    plugin_targets_request = Get(
+        TransitiveTargets, TransitiveTargetsRequest(plugin_target_addresses)
+    )
     linted_targets_request = Get(
         Targets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -37,7 +37,13 @@ from pants.engine.fs import (
     PathGlobs,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest, Targets, TransitiveTargets
+from pants.engine.target import (
+    Dependencies,
+    DependenciesRequest,
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.python.python_setup import PythonSetup, ResolveAllConstraintsOption
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
@@ -184,7 +190,9 @@ async def pex_from_targets(request: PexFromTargetsRequest, python_setup: PythonS
         )
         all_targets = FrozenOrderedSet(itertools.chain(*direct_deps, targets))
     else:
-        transitive_targets = await Get(TransitiveTargets, Addresses, request.addresses)
+        transitive_targets = await Get(
+            TransitiveTargets, TransitiveTargetsRequest(request.addresses)
+        )
         all_targets = transitive_targets.closure
 
     input_digests = []

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -7,12 +7,13 @@ from pathlib import PurePath
 from typing import ClassVar, Dict, Iterable, Mapping, Optional, Tuple, Type, cast
 
 from pants.base.build_root import BuildRoot
+from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveRunner
 from pants.engine.rules import Get, collect_rules, goal_rule
-from pants.engine.target import Targets, TransitiveTargets
+from pants.engine.target import Targets, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.util.contextutil import temporary_dir
@@ -86,11 +87,15 @@ async def run_repl(
     workspace: Workspace,
     interactive_runner: InteractiveRunner,
     repl_subsystem: ReplSubsystem,
-    transitive_targets: TransitiveTargets,
+    all_specified_addresses: Addresses,
     build_root: BuildRoot,
     union_membership: UnionMembership,
     global_options: GlobalOptions,
 ) -> Repl:
+    transitive_targets = await Get(
+        TransitiveTargets, TransitiveTargetsRequest(all_specified_addresses)
+    )
+
     # TODO: When we support multiple languages, detect the default repl to use based
     #  on the targets.  For now we default to the python repl.
     repl_shell_name = repl_subsystem.shell or "python"

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -154,7 +154,7 @@ class RelocateFilesViaCodegenRequest(GenerateSourcesRequest):
 async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSources:
     # Unlike normal codegen, we operate the on the sources of the `files_targets` field, not the
     # `sources` of the original `relocated_sources` target.
-    # TODO: using `await Get(Addresses, UnparsedAddressInputs)` causes a graph failure.
+    # TODO(#10915): using `await Get(Addresses, UnparsedAddressInputs)` causes a graph failure.
     original_files_targets = await MultiGet(
         Get(
             WrappedTarget,

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -21,9 +21,14 @@ from pants.core.target_types import (
 from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.source_files import rules as source_files_rules
-from pants.engine.addresses import Address, Addresses
+from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, FileContent
-from pants.engine.target import GeneratedSources, Sources, TransitiveTargets
+from pants.engine.target import (
+    GeneratedSources,
+    Sources,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -33,7 +38,7 @@ def test_relocated_files() -> None:
             *target_type_rules(),
             *source_files_rules(),
             QueryRule(GeneratedSources, [RelocateFilesViaCodegenRequest]),
-            QueryRule(TransitiveTargets, [Addresses]),
+            QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
         ],
         target_types=[Files, RelocatedFiles],
@@ -73,7 +78,9 @@ def test_relocated_files() -> None:
         # target and then getting all the code of that closure, we only end up with the relocated
         # files. If we naively marked the original files targets as a typical `Dependencies` field,
         # we would hit this issue.
-        transitive_targets = rule_runner.request(TransitiveTargets, [Addresses([tgt.address])])
+        transitive_targets = rule_runner.request(
+            TransitiveTargets, [TransitiveTargetsRequest([tgt.address])]
+        )
         all_sources = rule_runner.request(
             SourceFiles,
             [

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -42,6 +42,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
+    DependenciesRequestLite,
     FieldSet,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
@@ -64,6 +65,7 @@ from pants.engine.target import (
     TargetWithOrigin,
     TransitiveTargets,
     TransitiveTargetsRequest,
+    TransitiveTargetsRequestLite,
     UnexpandedTargets,
     UnrecognizedTargetTypeException,
     WrappedTarget,
@@ -339,6 +341,59 @@ async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTar
         transitive_excludes = FrozenOrderedSet(
             itertools.chain.from_iterable(excludes for excludes in nested_transitive_excludes)
         )
+
+    return TransitiveTargets(
+        tuple(roots_as_targets), FrozenOrderedSet(visited.difference(transitive_excludes))
+    )
+
+
+@rule(desc="Resolve transitive targets")
+async def transitive_targets_lite(request: TransitiveTargetsRequestLite) -> TransitiveTargets:
+    roots_as_targets = await Get(Targets, Addresses(request.roots))
+    visited: OrderedSet[Target] = OrderedSet()
+    queued = FrozenOrderedSet(roots_as_targets)
+    dependency_mapping: Dict[Address, Tuple[Address, ...]] = {}
+    while queued:
+        direct_dependencies_addresses_per_tgt = await MultiGet(
+            Get(Addresses, DependenciesRequestLite(tgt.get(Dependencies))) for tgt in queued
+        )
+        direct_dependencies_per_tgt = []
+        for addresses_per_tgt in direct_dependencies_addresses_per_tgt:
+            wrapped_tgts = await MultiGet(
+                Get(WrappedTarget, Address, addr) for addr in addresses_per_tgt
+            )
+            direct_dependencies_per_tgt.append(
+                tuple(wrapped_t.target for wrapped_t in wrapped_tgts)
+            )
+
+        dependency_mapping.update(
+            zip(
+                (t.address for t in queued),
+                (tuple(t.address for t in deps) for deps in direct_dependencies_per_tgt),
+            )
+        )
+
+        queued = FrozenOrderedSet(
+            itertools.chain.from_iterable(direct_dependencies_per_tgt)
+        ).difference(visited)
+        visited.update(queued)
+
+    # NB: We use `roots_as_targets` to get the root addresses, rather than `request.roots`. This
+    # is because expanding from the `Addresses` -> `Targets` may have resulted in generated
+    # subtargets being used, so we need to use `roots_as_targets` to have this expansion.
+    _detect_cycles(tuple(t.address for t in roots_as_targets), dependency_mapping)
+
+    # Apply any transitive excludes (`!!` ignores).
+    wrapped_transitive_excludes = await MultiGet(
+        Get(
+            WrappedTarget, AddressInput, AddressInput.parse(addr, relative_to=tgt.address.spec_path)
+        )
+        for tgt in (*roots_as_targets, *visited)
+        for addr in tgt.get(Dependencies).unevaluated_transitive_excludes.values
+    )
+    transitive_excludes = FrozenOrderedSet(
+        wrapped_t.target for wrapped_t in wrapped_transitive_excludes
+    )
 
     return TransitiveTargets(
         tuple(roots_as_targets), FrozenOrderedSet(visited.difference(transitive_excludes))
@@ -817,6 +872,52 @@ async def resolve_dependencies(
             *literal_addresses,
             *itertools.chain.from_iterable(injected),
             *itertools.chain.from_iterable(inferred),
+        )
+        if addr not in ignored_addresses
+    }
+    return Addresses(sorted(result))
+
+
+@rule(desc="Resolve direct dependencies")
+async def resolve_dependencies_lite(
+    request: DependenciesRequestLite,
+    union_membership: UnionMembership,
+    registered_target_types: RegisteredTargetTypes,
+    global_options: GlobalOptions,
+) -> Addresses:
+    provided = parse_dependencies_field(
+        request.field,
+        subproject_roots=global_options.options.subproject_roots,
+        registered_target_types=registered_target_types.types,
+        union_membership=union_membership,
+    )
+    literal_addresses = await MultiGet(Get(Address, AddressInput, ai) for ai in provided.addresses)
+    ignored_addresses = set(
+        await MultiGet(Get(Address, AddressInput, ai) for ai in provided.ignored_addresses)
+    )
+
+    # Inject any dependencies.
+    inject_request_types = union_membership.get(InjectDependenciesRequest)
+    injected = await MultiGet(
+        Get(InjectedDependencies, InjectDependenciesRequest, inject_request_type(request.field))
+        for inject_request_type in inject_request_types
+        if isinstance(request.field, inject_request_type.inject_for)
+    )
+
+    # Inject dependencies on all the base target's generated subtargets.
+    subtargets = await Get(
+        Subtargets, Address, request.field.address.maybe_convert_to_base_target()
+    )
+    subtarget_addresses = tuple(
+        t.address for t in subtargets.subtargets if t.address != request.field.address
+    )
+
+    result = {
+        addr
+        for addr in (
+            *subtarget_addresses,
+            *literal_addresses,
+            *itertools.chain.from_iterable(injected),
         )
         if addr not in ignored_addresses
     }

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -50,6 +50,7 @@ from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
+    DependenciesRequestLite,
     FieldSet,
     GeneratedSources,
     GenerateSourcesRequest,
@@ -69,6 +70,7 @@ from pants.engine.target import (
     TargetWithOrigin,
     TransitiveTargets,
     TransitiveTargetsRequest,
+    TransitiveTargetsRequestLite,
     WrappedTarget,
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -92,7 +94,9 @@ def transitive_targets_rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             QueryRule(Targets, (DependenciesRequest,)),
+            QueryRule(Targets, (DependenciesRequestLite,)),
             QueryRule(TransitiveTargets, (TransitiveTargetsRequest,)),
+            QueryRule(TransitiveTargets, (TransitiveTargetsRequestLite,)),
         ],
         target_types=[MockTarget],
     )
@@ -136,6 +140,18 @@ def test_transitive_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     assert transitive_targets.dependencies == FrozenOrderedSet([d1, d2, d3, t2, t1])
     assert transitive_targets.closure == FrozenOrderedSet([root, d2, d1, d3, t2, t1])
 
+    # Now test with TransitiveTargetsLite.
+    direct_deps = transitive_targets_rule_runner.request(
+        Targets, [DependenciesRequestLite(root[Dependencies])]
+    )
+    assert direct_deps == Targets([d1, d2, d3])
+    transitive_targets = transitive_targets_rule_runner.request(
+        TransitiveTargets, [TransitiveTargetsRequestLite([root.address, d2.address])]
+    )
+    assert transitive_targets.roots == (root, d2)
+    assert transitive_targets.dependencies == FrozenOrderedSet([d1, d2, d3, t2, t1])
+    assert transitive_targets.closure == FrozenOrderedSet([root, d2, d1, d3, t2, t1])
+
 
 def test_transitive_targets_transitive_exclude(transitive_targets_rule_runner: RuleRunner) -> None:
     transitive_targets_rule_runner.add_to_build_file(
@@ -163,6 +179,18 @@ def test_transitive_targets_transitive_exclude(transitive_targets_rule_runner: R
 
     transitive_targets = transitive_targets_rule_runner.request(
         TransitiveTargets, [TransitiveTargetsRequest([root.address, intermediate.address])]
+    )
+    assert transitive_targets.roots == (root, intermediate)
+    assert transitive_targets.dependencies == FrozenOrderedSet([intermediate])
+    assert transitive_targets.closure == FrozenOrderedSet([root, intermediate])
+
+    # Test with TransitiveTargetsLite.
+    intermediate_direct_deps = transitive_targets_rule_runner.request(
+        Targets, [DependenciesRequestLite(intermediate[Dependencies])]
+    )
+    assert intermediate_direct_deps == Targets([base])
+    transitive_targets = transitive_targets_rule_runner.request(
+        TransitiveTargets, [TransitiveTargetsRequestLite([root.address, intermediate.address])]
     )
     assert transitive_targets.roots == (root, intermediate)
     assert transitive_targets.dependencies == FrozenOrderedSet([intermediate])
@@ -1085,6 +1113,7 @@ def dependencies_rule_runner() -> RuleRunner:
             inject_custom_smalltalk_deps,
             infer_smalltalk_dependencies,
             QueryRule(Addresses, (DependenciesRequest,)),
+            QueryRule(Addresses, (DependenciesRequestLite,)),
             UnionRule(InjectDependenciesRequest, InjectSmalltalkDependencies),
             UnionRule(InjectDependenciesRequest, InjectCustomSmalltalkDependencies),
             UnionRule(InferDependenciesRequest, InferSmalltalkDependencies),
@@ -1098,12 +1127,11 @@ def assert_dependencies_resolved(
     *,
     requested_address: Address,
     expected: Iterable[Address],
+    lite: bool = False,
 ) -> None:
     target = rule_runner.get_target(requested_address)
-    result = rule_runner.request(
-        Addresses,
-        [DependenciesRequest(target[Dependencies])],
-    )
+    request_cls = DependenciesRequestLite if lite else DependenciesRequest
+    result = rule_runner.request(Addresses, [request_cls(target[Dependencies])])
     assert sorted(result) == sorted(expected)
 
 
@@ -1120,11 +1148,24 @@ def test_normal_resolution(dependencies_rule_runner: RuleRunner) -> None:
             Address("src/smalltalk", target_name="sibling"),
         ],
     )
+    assert_dependencies_resolved(
+        dependencies_rule_runner,
+        requested_address=Address("src/smalltalk"),
+        expected=[
+            Address("", target_name="dep1"),
+            Address("", target_name="dep2"),
+            Address("src/smalltalk", target_name="sibling"),
+        ],
+        lite=True,
+    )
 
     # Also test that we handle no dependencies.
     dependencies_rule_runner.add_to_build_file("no_deps", "smalltalk()")
     assert_dependencies_resolved(
         dependencies_rule_runner, requested_address=Address("no_deps"), expected=[]
+    )
+    assert_dependencies_resolved(
+        dependencies_rule_runner, requested_address=Address("no_deps"), expected=[], lite=True
     )
 
     # An ignore should override an include.
@@ -1133,6 +1174,9 @@ def test_normal_resolution(dependencies_rule_runner: RuleRunner) -> None:
     )
     assert_dependencies_resolved(
         dependencies_rule_runner, requested_address=Address("ignore"), expected=[]
+    )
+    assert_dependencies_resolved(
+        dependencies_rule_runner, requested_address=Address("ignore"), expected=[], lite=True
     )
 
 
@@ -1165,6 +1209,15 @@ def test_explicit_file_dependencies(dependencies_rule_runner: RuleRunner) -> Non
             Address("src/smalltalk/util", relative_file_path="f1.st", target_name="util"),
             Address("src/smalltalk/util", relative_file_path="f2.st", target_name="util"),
         ],
+    )
+    assert_dependencies_resolved(
+        dependencies_rule_runner,
+        requested_address=Address("src/smalltalk"),
+        expected=[
+            Address("src/smalltalk/util", relative_file_path="f1.st", target_name="util"),
+            Address("src/smalltalk/util", relative_file_path="f2.st", target_name="util"),
+        ],
+        lite=True,
     )
 
 
@@ -1318,6 +1371,15 @@ def test_depends_on_subtargets(dependencies_rule_runner: RuleRunner) -> None:
             Address("src/smalltalk", relative_file_path="f2.st"),
         ],
     )
+    assert_dependencies_resolved(
+        dependencies_rule_runner,
+        requested_address=Address("src/smalltalk"),
+        expected=[
+            Address("src/smalltalk", relative_file_path="f1.st"),
+            Address("src/smalltalk", relative_file_path="f2.st"),
+        ],
+        lite=True,
+    )
 
     # Test that a file address depends on its siblings if it has no dependency inference rule,
     # or those inference rules do not claim to infer dependencies on siblings.
@@ -1325,6 +1387,12 @@ def test_depends_on_subtargets(dependencies_rule_runner: RuleRunner) -> None:
         dependencies_rule_runner,
         requested_address=Address("src/smalltalk", relative_file_path="f1.st"),
         expected=[Address("src/smalltalk", relative_file_path="f2.st")],
+    )
+    assert_dependencies_resolved(
+        dependencies_rule_runner,
+        requested_address=Address("src/smalltalk", relative_file_path="f1.st"),
+        expected=[Address("src/smalltalk", relative_file_path="f2.st")],
+        lite=True,
     )
 
     # Now we recreate the files so that the mock dependency inference will have results, which

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -608,7 +608,23 @@ class TransitiveTargetsRequest:
     """A request to get the transitive dependencies of the input roots.
 
     Resolve the transitive targets with `await Get(TransitiveTargets,
-    TransitiveTargetsRequest([addr1, addr2])
+    TransitiveTargetsRequest([addr1, addr2])`.
+    """
+
+    roots: Tuple[Address, ...]
+
+    def __init__(self, roots: Iterable[Address]) -> None:
+        self.roots = tuple(roots)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class TransitiveTargetsRequestLite:
+    """A request to get the transitive dependencies of the input roots, but without considering
+    dependency inference.
+
+    This solely exists due to graph ambiguity with codegen implementations. Use
+    `TransitiveTargetsRequest` everywhere other than codegen.
     """
 
     roots: Tuple[Address, ...]
@@ -1471,7 +1487,6 @@ class GeneratedSources:
 # NB: To hydrate the dependencies, use one of:
 #   await Get(Addresses, DependenciesRequest(tgt[Dependencies])
 #   await Get(Targets, DependenciesRequest(tgt[Dependencies])
-#   await Get(TransitiveTargets, DependenciesRequest(tgt[Dependencies])
 class Dependencies(AsyncField):
     """Addresses to other targets that this target depends on, e.g. ['helloworld/subdir:lib'].
 
@@ -1520,6 +1535,20 @@ class Dependencies(AsyncField):
 
 @dataclass(frozen=True)
 class DependenciesRequest(EngineAwareParameter):
+    field: Dependencies
+
+    def debug_hint(self) -> str:
+        return self.field.address.spec
+
+
+@dataclass(frozen=True)
+class DependenciesRequestLite(EngineAwareParameter):
+    """Like DependenciesRequest, but does not use dependency inference.
+
+    This solely exists due to graph ambiguity with codegen. Use `DependenciesRequest` everywhere but
+    with codegen.
+    """
+
     field: Dependencies
 
     def debug_hint(self) -> str:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -604,6 +604,21 @@ class TransitiveTargets:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
+class TransitiveTargetsRequest:
+    """A request to get the transitive dependencies of the input roots.
+
+    Resolve the transitive targets with `await Get(TransitiveTargets,
+    TransitiveTargetsRequest([addr1, addr2])
+    """
+
+    roots: Tuple[Address, ...]
+
+    def __init__(self, roots: Iterable[Address]) -> None:
+        self.roots = tuple(roots)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class RegisteredTargetTypes:
     aliases_to_types: FrozenDict[str, Type[Target]]
 


### PR DESCRIPTION
### Problem

As explained in https://github.com/pantsbuild/pants/issues/10888, we are not properly handling "special-cased" dependencies-like fields, such as `python_tests`'s `runtime_package_dependencies` field.

We need those fields' dependencies to show up in project introspection, such as `./pants dependencies`, but _not_ in other contexts like when resolving the transitive targets to determine what source files are used by Pytest.

That is, we need to be able to parametrize `await Get(TransitiveTargets)` so call sites can determine the behavior they want.

### Solution

Add `TransitiveTargetsRequest`, which will allow us to add new fields to it to change its behavior. This mirrors how we have `DependenciesRequest` for direct deps.
 
Note that this means you can no longer request `TransitiveTargets` as a parameter to your rule and have it be evaluated automatically by looking at the `Specs`. You must now request `Addresses`, and then use `await Get`. There's an argument for this being a good thing. It's a bit confusing (imo) how some types like `Addresses` can be in a rule signature and will be evaluated by using the Specs. This means that you can now only do that with `Addresses` and `Targets`, but not `TransitiveTargets`.

To work around https://github.com/pantsbuild/pants/issues/10917, we add a `DependenciesRequestLite` and `TransitiveTargetsLite` for use with codegen. These behave almost the same, but don't work with dep inference.

[ci skip-rust]
[ci skip-build-wheels]