### PR TITLE
Differentiate between User API vs. Plugin API changes in changelog

### DIFF
--- a/build-support/bin/release-changelog-helper.sh
+++ b/build-support/bin/release-changelog-helper.sh
@@ -41,8 +41,12 @@ echo "Potentially relevant headers:"
 echo "----------------------------------------------------------------------------------------------------"
 cat <<EOF
 
-API Changes
-~~~~~~~~~~~
+User API Changes
+~~~~~~~~~~~~~~~~
+
+
+Plugin API Changes
+~~~~~~~~~~~~~~~~~~
 
 
 New Features
@@ -55,10 +59,6 @@ Bugfixes
 
 Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-Testing
-~~~~~~~
 
 
 Documentation

--- a/build-support/bin/release-changelog-helper.sh
+++ b/build-support/bin/release-changelog-helper.sh
@@ -37,7 +37,10 @@ else
 fi
 
 echo
-echo "Potentially relevant headers:"
+echo "Headers. Delete any that are unused."
+echo "We do not include internal-only changes. However, in the release prep PR, it's helpful to put" \
+     "these internal-only changes in a comment so that other reviewers can check if any should be added" \
+     "back to the changelog."
 echo "----------------------------------------------------------------------------------------------------"
 cat <<EOF
 
@@ -55,10 +58,6 @@ New Features
 
 Bugfixes
 ~~~~~~~~
-
-
-Refactoring, Improvements, and Tooling
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Documentation


### PR DESCRIPTION
Now that users are starting to write plugins, we need to start putting changes to the Plugin API in the "API changes" section, rather than "Refactoring". 

But, unless you're writing plugins, these changes are irrelevant. So, we differentiate between changes that impact every user—like deprecating options—vs. plugin changes.

We also remove both "testing" and "refactoring" from the changelog. Our changelogs are extremely long, and by definition, users don't need to know about internal-only changes. They can use `git log` if they want to see everything.

[ci skip-rust]
[ci skip-build-wheels]