### PR TITLE
Fix some dependencies-like fields not showing up with project introspection

### DIFF
--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -34,7 +34,8 @@ async def map_addresses_to_dependees() -> AddressToDependees:
     )
     all_targets = {*all_expanded_targets, *all_explicit_targets}
     dependencies_per_target = await MultiGet(
-        Get(Addresses, DependenciesRequest(tgt.get(Dependencies))) for tgt in all_targets
+        Get(Addresses, DependenciesRequest(tgt.get(Dependencies), include_special_cased_deps=True))
+        for tgt in all_targets
     )
 
     address_to_dependees = defaultdict(set)

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -70,12 +70,18 @@ async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
     if dependencies_subsystem.transitive:
-        transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
+        transitive_targets = await Get(
+            TransitiveTargets, TransitiveTargetsRequest(addresses, include_special_cased_deps=True)
+        )
         targets = Targets(transitive_targets.dependencies)
     else:
         target_roots = await Get(UnexpandedTargets, Addresses, addresses)
         dependencies_per_target_root = await MultiGet(
-            Get(Targets, DependenciesRequest(tgt.get(DependenciesField))) for tgt in target_roots
+            Get(
+                Targets,
+                DependenciesRequest(tgt.get(DependenciesField), include_special_cased_deps=True),
+            )
+            for tgt in target_roots
         )
         targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
 

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -84,7 +84,9 @@ async def file_deps(
 ) -> Filedeps:
     targets: Iterable[Target]
     if filedeps_subsystem.transitive:
-        transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
+        transitive_targets = await Get(
+            TransitiveTargets, TransitiveTargetsRequest(addresses, include_special_cased_deps=True)
+        )
         targets = transitive_targets.closure
     elif filedeps_subsystem.globs:
         targets = await Get(UnexpandedTargets, Addresses, addresses)

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -446,11 +446,17 @@ def test_runtime_package_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.create_file(
         f"{PACKAGE}/test_binary_call.py",
         dedent(
-            """\
+            f"""\
+            import os.path
             import subprocess
 
             def test_embedded_binary():
                 assert  b"Hello, test!" in subprocess.check_output(args=['./bin.pex'])
+
+                # Ensure that we didn't accidentally pull in the binary's sources. This is a
+                # special type of dependency that should not be included with the rest of the
+                # normal dependencies.
+                assert os.path.exists("{BINARY_SOURCE.path}") is False
             """
         ),
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -29,9 +29,9 @@ from pants.engine.target import (
     ProvidesField,
     ScalarField,
     Sources,
+    SpecialCasedDependencies,
     StringField,
     StringOrStringSequenceField,
-    StringSequenceField,
     Target,
     WrappedTarget,
 )
@@ -269,9 +269,7 @@ class PythonTestsDependencies(Dependencies):
     supports_transitive_excludes = True
 
 
-# TODO(#10888): Teach project introspection goals that this is a special type of the `Dependencies`
-#  field.
-class PythonRuntimePackageDependencies(StringSequenceField):
+class PythonRuntimePackageDependencies(SpecialCasedDependencies):
     """Addresses to targets that can be built with the `./pants package` goal and whose resulting
     assets should be included in the test run.
 
@@ -286,14 +284,14 @@ class PythonRuntimePackageDependencies(StringSequenceField):
     alias = "runtime_package_dependencies"
 
 
-class PythonRuntimeBinaryDependencies(StringSequenceField):
+class PythonRuntimeBinaryDependencies(SpecialCasedDependencies):
     """Deprecated in favor of the `runtime_build_dependencies` field, which works with more target
     types like `archive` and `python_awslambda`."""
 
     alias = "runtime_binary_dependencies"
 
     @classmethod
-    def compute_value(
+    def sanitize_raw_value(
         cls, raw_value: Optional[Iterable[str]], *, address: Address
     ) -> Optional[Tuple[str, ...]]:
         if raw_value is not None:
@@ -302,7 +300,7 @@ class PythonRuntimeBinaryDependencies(StringSequenceField):
                 "field is now deprecated in favor of the more flexible "
                 "`runtime_package_dependencies` field, and it will be removed in 2.1.0.dev0."
             )
-        return super().compute_value(raw_value, address=address)
+        return super().sanitize_raw_value(raw_value, address=address)
 
 
 class PythonTestsTimeout(IntField):


### PR DESCRIPTION
### Problem

Closes https://github.com/pantsbuild/pants/issues/10888.

We now have several fields that act like dependencies, but are not quite it. In most code, we don't want the dependencies showing up with `TransitiveTargets` and `DependenciesRequest`; for example, with `relocated_files()`, it's important that the original files targets are not included when we're hydrating sources for the transitive closure.

But with project introspection, we do need these dependencies-like fields to be used. This is important for `--changed-since --changed-dependees` to work properly.

### Solution

Add a new `SpecialCasedDependencies` superclass. This is not a normal field, e.g. not setting `alias`. It's closer in spirit to a "Field template", e.g. `StringField` and `BoolField`.

Both `DependenciesRequest` and `TransitiveTargetsRequest` get new boolean flags to determine if they should include any subclasses of `SpecialCasedDependencies` or not. Then, we teach the project introspection goals to use the new behavior.
