### PR TITLE
add ConvertibleFrom and convert_compatible_from() for filtering target fields

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -41,7 +41,7 @@ class ProtobufLibrary(Target):
 
 
 class InjectProtobufDependencies(InjectDependenciesRequest):
-    inject_for = ProtobufDependencies
+    convert_from = ProtobufDependencies
 
 
 @rule

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -96,7 +96,7 @@ class PythonInference(Subsystem):
 
 
 class InferPythonDependencies(InferDependenciesRequest):
-    infer_from = PythonSources
+    convert_from = PythonSources
 
 
 @rule(desc="Inferring Python dependencies.")
@@ -140,7 +140,7 @@ async def infer_python_dependencies(
 
 
 class InferInitDependencies(InferDependenciesRequest):
-    infer_from = PythonSources
+    convert_from = PythonSources
 
 
 @rule(desc="Inferring dependencies on `__init__.py` files")
@@ -170,7 +170,7 @@ async def infer_python_init_dependencies(
 
 
 class InferConftestDependencies(InferDependenciesRequest):
-    infer_from = PythonTestsSources
+    convert_from = PythonTestsSources
 
 
 @rule(desc="Inferring dependencies on `conftest.py` files")

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -554,7 +554,7 @@ class PythonDistribution(Target):
 
 
 class InjectPythonDistributionDependencies(InjectDependenciesRequest):
-    inject_for = PythonDistributionDependencies
+    convert_from = PythonDistributionDependencies
 
 
 @rule

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -76,6 +76,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
 from pants.source.filespec import matches_filespec
+from pants.util.filtering import convert_compatible_from
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1055,11 +1055,11 @@ class CustomSmalltalkDependencies(SmalltalkDependencies):
 
 
 class InjectSmalltalkDependencies(InjectDependenciesRequest):
-    inject_for = SmalltalkDependencies
+    convert_from = SmalltalkDependencies
 
 
 class InjectCustomSmalltalkDependencies(InjectDependenciesRequest):
-    inject_for = CustomSmalltalkDependencies
+    convert_from = CustomSmalltalkDependencies
 
 
 @rule
@@ -1085,7 +1085,7 @@ class SmalltalkLibrary(Target):
 
 
 class InferSmalltalkDependencies(InferDependenciesRequest):
-    infer_from = SmalltalkSources
+    convert_from = SmalltalkSources
 
 
 @rule

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -37,6 +37,7 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import FilesNotFoundBehavior
 from pants.source.filespec import Filespec, matches_filespec
 from pants.util.collections import ensure_list, ensure_str_list
+from pants.util.filtering import ConvertibleFrom
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_classproperty, memoized_property
 from pants.util.meta import frozen_after_init
@@ -1557,7 +1558,7 @@ class DependenciesRequestLite(EngineAwareParameter):
 
 @union
 @dataclass(frozen=True)
-class InjectDependenciesRequest(EngineAwareParameter, ABC):
+class InjectDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Dependencies], ABC):
     """A request to inject dependencies, in addition to those explicitly provided.
 
     To set up a new injection, subclass this class. Set the class property `inject_for` to the
@@ -1604,7 +1605,7 @@ class InjectedDependencies(DeduplicatedCollection[Address]):
 
 @union
 @dataclass(frozen=True)
-class InferDependenciesRequest(EngineAwareParameter):
+class InferDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Sources]):
     """A request to infer dependencies by analyzing source files.
 
     To set up a new inference implementation, subclass this class. Set the class property

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1561,7 +1561,7 @@ class DependenciesRequestLite(EngineAwareParameter):
 class InjectDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Dependencies], ABC):
     """A request to inject dependencies, in addition to those explicitly provided.
 
-    To set up a new injection, subclass this class. Set the class property `inject_for` to the
+    To set up a new injection, subclass this class. Set the class property `convert_from` to the
     type of `Dependencies` field you want to inject for, such as `FortranDependencies`. This will
     cause the class, and any subclass, to have the injection. Register this subclass with
     `UnionRule(InjectDependenciesRequest, InjectFortranDependencies)`, for example.
@@ -1574,7 +1574,7 @@ class InjectDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Dependenci
             pass
 
         class InjectFortranDependencies(InjectDependenciesRequest):
-            inject_for = FortranDependencies
+            convert_from = FortranDependencies
 
         @rule
         async def inject_fortran_dependencies(
@@ -1593,7 +1593,11 @@ class InjectDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Dependenci
     """
 
     dependencies_field: Dependencies
-    inject_for: ClassVar[Type[Dependencies]]
+    convert_from: ClassVar[Type[Dependencies]]
+
+    @classmethod
+    def convert(cls, arg: Dependencies) -> "InjectDependenciesRequest":
+        return cls(arg)
 
     def debug_hint(self) -> str:
         return self.dependencies_field.address.spec
@@ -1609,7 +1613,7 @@ class InferDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Sources]):
     """A request to infer dependencies by analyzing source files.
 
     To set up a new inference implementation, subclass this class. Set the class property
-    `infer_from` to the type of `Sources` field you are able to infer from, such as
+    `convert_from` to the type of `Sources` field you are able to infer from, such as
     `FortranSources`. This will cause the class, and any subclass, to use your inference
     implementation. Note that there cannot be more than one implementation for a particular
     `Sources` class. Register this subclass with
@@ -1636,7 +1640,11 @@ class InferDependenciesRequest(EngineAwareParameter, ConvertibleFrom[Sources]):
     """
 
     sources_field: Sources
-    infer_from: ClassVar[Type[Sources]]
+    convert_from: ClassVar[Type[Sources]]
+
+    @classmethod
+    def convert(cls, arg: Sources) -> "InferDependenciesRequest":
+        return cls(arg)
 
     def debug_hint(self) -> str:
         return self.sources_field.address.spec

--- a/src/python/pants/util/filtering.py
+++ b/src/python/pants/util/filtering.py
@@ -73,7 +73,7 @@ def and_filters(filters: Iterable[Filter]) -> Filter:
 
 
 _In = TypeVar("_In")
-_Out = TypeVar("_Out", bound='ConvertibleFrom')
+_Out = TypeVar("_Out", bound="ConvertibleFrom")
 
 
 class ConvertibleFrom(Generic[_In], metaclass=ABCMeta):


### PR DESCRIPTION
### Problem

I happened to take a look at the code for `resolve_dependencies()` in `graph.py`, and noticed a pattern being implemented twice, to iterate over `@union` implementations and merge their results. In particular, it seemed like the `inject_for` and `infer_from` fields for injected and inferred dependencies were adding some boilerplate code, and it might be easier to introduce a common interface for that.

### Solution

- add `ConvertibleFrom` and `convert_compatible_from()` in `util/filtering.py` to remove some boilerplate when extracting different engine "request" types from a single field.

### Result

- `@union` and subclassing can be used to resolve for *all* members of a `@union` from a single input by filtering with `convert_compatible_from()` for #10923.
  - Some code in `graph.py` can be made a little smaller.
