### PR TITLE
Deprecate `[protoc].runtime_targets` in favor of `[python-protobuf].runtime_dependencies`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -33,6 +33,11 @@ class Protoc(ExternalTool):
                 "will be automatically injected into the `dependencies` field of every "
                 "`protobuf_library`."
             ),
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "Use the option `runtime_dependencies` in the new `[python-protobuf]` scope, which "
+                "behaves identically."
+            ),
         )
 
     def generate_url(self, plat: Platform) -> str:

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -1,0 +1,52 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.codegen.protobuf.target_types import ProtobufDependencies
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import InjectDependenciesRequest, InjectedDependencies
+from pants.engine.unions import UnionRule
+from pants.option.custom_types import target_option
+from pants.option.subsystem import Subsystem
+
+
+class PythonProtobufSubsystem(Subsystem):
+    options_scope = "python-protobuf"
+
+    @classmethod
+    def register_options(cls, register):
+        super().register_options(register)
+        register(
+            "--runtime-dependencies",
+            type=list,
+            member_type=target_option,
+            help=(
+                "A list of addresses to `python_requirement_library` targets for the runtime "
+                "dependencies needed for generated Python code to work. For example, "
+                "`['3rdparty/python:protobuf', '3rdparty/python:grpcio']`. These dependencies will "
+                "be automatically added to every `protobuf_library` target"
+            ),
+        )
+
+    @property
+    def runtime_dependencies(self) -> UnparsedAddressInputs:
+        return UnparsedAddressInputs(self.options.runtime_dependencies, owning_address=None)
+
+
+class InjectPythonProtobufDependencies(InjectDependenciesRequest):
+    inject_for = ProtobufDependencies
+
+
+@rule
+async def inject_dependencies(
+    _: InjectPythonProtobufDependencies, python_protobuf: PythonProtobufSubsystem
+) -> InjectedDependencies:
+    addresses = await Get(Addresses, UnparsedAddressInputs, python_protobuf.runtime_dependencies)
+    return InjectedDependencies(addresses)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(InjectDependenciesRequest, InjectPythonProtobufDependencies),
+    ]

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -11,6 +11,11 @@ from pants.option.subsystem import Subsystem
 
 
 class PythonProtobufSubsystem(Subsystem):
+    """Options related to the Protobuf Python backend.
+
+    See https://www.pantsbuild.org/docs/protobuf.
+    """
+
     options_scope = "python-protobuf"
 
     @classmethod

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.backend.codegen.protobuf.python import python_protobuf_subsystem
+from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
+    InjectPythonProtobufDependencies,
+)
+from pants.backend.codegen.protobuf.target_types import ProtobufDependencies, ProtobufLibrary
+from pants.core.target_types import Files
+from pants.engine.addresses import Address
+from pants.engine.target import InjectedDependencies
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_inject_dependencies() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *python_protobuf_subsystem.rules(),
+            QueryRule(InjectedDependencies, (InjectPythonProtobufDependencies,)),
+        ],
+        target_types=[ProtobufLibrary, Files],
+    )
+    rule_runner.set_options(
+        [
+            "--backend-packages=pants.backend.codegen.protobuf.python",
+            "--python-protobuf-runtime-dependencies=protos:injected_dep",
+        ]
+    )
+    # Note that injected deps can be any target type for `--python-protobuf-runtime-dependencies`.
+    rule_runner.add_to_build_file(
+        "protos",
+        dedent(
+            """\
+            protobuf_library()
+            files(name="injected_dep", sources=[])
+            """
+        ),
+    )
+    tgt = rule_runner.get_target(Address("protos"))
+    injected = rule_runner.request(
+        InjectedDependencies, [InjectPythonProtobufDependencies(tgt[ProtobufDependencies])]
+    )
+    assert injected == InjectedDependencies([Address("protos", target_name="injected_dep")])

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -6,14 +6,19 @@
 See https://www.pantsbuild.org/docs/protobuf.
 """
 
-from pants.backend.codegen.protobuf.python import additional_fields
+from pants.backend.codegen.protobuf.python import additional_fields, python_protobuf_subsystem
 from pants.backend.codegen.protobuf.python.rules import rules as python_rules
 from pants.backend.codegen.protobuf.target_types import ProtobufLibrary
 from pants.backend.codegen.protobuf.target_types import rules as target_rules
 
 
 def rules():
-    return [*additional_fields.rules(), *python_rules(), *target_rules()]
+    return [
+        *additional_fields.rules(),
+        *python_protobuf_subsystem.rules(),
+        *python_rules(),
+        *target_rules(),
+    ]
 
 
 def target_types():

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -49,7 +49,7 @@ async def inject_dependencies(
     _: InjectProtobufDependencies, protoc: Protoc
 ) -> InjectedDependencies:
     addresses = await Get(
-        Addresses, UnparsedAddressInputs((v for v in protoc.runtime_targets), owning_address=None)
+        Addresses, UnparsedAddressInputs(protoc.runtime_targets, owning_address=None)
     )
     return InjectedDependencies(addresses)
 


### PR DESCRIPTION
As sketched in https://github.com/pantsbuild/pants/issues/10497#issuecomment-705257453, we will have a global option to enable MyPy Protobuf support. This option should not live on `[protoc]` because `[protoc]` is meant to be language agnostic.

This allows us to move `runtime_targets` from `[protoc]` to `[python-protobuf]`, which made more sense from the start. Our help message can be more focused.

Note that this works because it's valid to have >1 dependency injection rule for the same dependencies field.

[ci skip-rust]
[ci skip-build-wheels]