### PR TITLE
An ExternalTool for downloading the grpc_python_plugin.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
+++ b/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
@@ -7,7 +7,7 @@ from pants.util.enums import match
 
 
 class GrpcPythonPlugin(ExternalTool):
-    """The grpc protobuf plugin."""
+    """The grpc protobuf plugin for python."""
 
     options_scope = "grpc_python_plugin"
     default_version = "1.32.0"

--- a/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
+++ b/src/python/pants/backend/codegen/protobuf/python/grpc_python_plugin.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.core.util_rules.external_tool import ExternalTool
+from pants.engine.platform import Platform
+from pants.util.enums import match
+
+
+class GrpcPythonPlugin(ExternalTool):
+    """The grpc protobuf plugin."""
+
+    options_scope = "grpc_python_plugin"
+    default_version = "1.32.0"
+    default_known_versions = [
+        "1.32.0|darwin|b2db586656463841aa2fd4aab34fb6bd3ef887b522d80e4f2f292146c357f533|6215304",
+        "1.32.0|linux |1af99df9bf733c17a75cbe379f3f9d9ff1627d8a8035ea057c3c78575afe1687|4965728",
+    ]
+
+    def generate_url(self, plat: Platform) -> str:
+        plat_str = match(plat, {Platform.darwin: "macos", Platform.linux: "linux"})
+        return (
+            f"https://binaries.pantsbuild.org/bin/grpc_python_plugin/{self.version}/"
+            f"{plat_str}/x86_64/grpc_python_plugin"
+        )

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -51,9 +51,6 @@ class PexBinary(ExternalTool):
     def generate_url(self, _: Platform) -> str:
         return f"https://github.com/pantsbuild/pex/releases/download/{self.version}/pex"
 
-    def generate_exe(self, _: Platform) -> str:
-        return "./pex"
-
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -138,10 +138,15 @@ class ExternalTool(Subsystem):
         to a URL. The raised exception need not have a message - a sensible one will be generated.
         """
 
-    @abstractmethod
     def generate_exe(self, plat: Platform) -> str:
-        """Returns the relative path in the downloaded archive to the given version of the tool,
-        e.g. `./bin/protoc`."""
+        """Returns the path to the tool executable.
+
+        If the downloaded artifact is the executable itself, you can leave this unimplemented.
+
+        If the downloaded artifact is an archive, this should be overridden to provide a
+        relative path in the downloaded archive, e.g. `bin/protoc`.
+        """
+        return self.generate_url(plat).rsplit("/", 1)[-1]
 
     def get_request(self, plat: Platform) -> ExternalToolRequest:
         """Generate a request for this tool."""

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -144,9 +144,9 @@ class ExternalTool(Subsystem):
         If the downloaded artifact is the executable itself, you can leave this unimplemented.
 
         If the downloaded artifact is an archive, this should be overridden to provide a
-        relative path in the downloaded archive, e.g. `bin/protoc`.
+        relative path in the downloaded archive, e.g. `./bin/protoc`.
         """
-        return self.generate_url(plat).rsplit("/", 1)[-1]
+        return f"./{self.generate_url(plat).rsplit('/', 1)[-1]}"
 
     def get_request(self, plat: Platform) -> ExternalToolRequest:
         """Generate a request for this tool."""


### PR DESCRIPTION
The default versions mentioned in this change have been
uploaded to the relevant location, along with a README.md
explaining how to build and upload other versions.

[ci skip-rust]

[ci skip-build-wheels]
