### PR TITLE
Correctly terminate child processes to fix ./pants repl bug

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -59,14 +59,23 @@ class SignalHandler:
             with self._ignore_sigint_lock:
                 self._ignoring_sigint = toggle
 
-    def handle_sigint(self, signum: int, _frame):
+    def _send_signal_to_children(self, received_signal: int, signame: str) -> None:
+        """Send a signal to any children of this process in order.
+
+        Pants may have spawned multiple subprocesses via Python or Rust. Upon receiving a signal,
+        this method is invoked to propagate the signal to all children, regardless of how they were
+        spawned.
+        """
+
         self_process = psutil.Process()
         children = self_process.children()
-        logger.debug(f"Sending SIGINT to child processes: {children}")
+        logger.debug(f"Sending signal {signame} ({received_signal}) to child processes: {children}")
         for child_process in children:
-            child_process.send_signal(signal.SIGINT)
+            child_process.send_signal(received_signal)
 
+    def handle_sigint(self, signum: int, _frame):
         ExceptionSink._signal_sent = signum
+        self._send_signal_to_children(int(signal.SIGTERM), "SIGTERM")
         raise KeyboardInterrupt("User interrupted execution with control-c!")
 
     # TODO(#7406): figure out how to let sys.exit work in a signal handler instead of having to raise
@@ -93,10 +102,12 @@ class SignalHandler:
 
     def handle_sigquit(self, signum, _frame):
         ExceptionSink._signal_sent = signum
+        self._send_signal_to_children(int(signal.SIGQUIT), "SIGQUIT")
         raise self.SignalHandledNonLocalExit(signum, "SIGQUIT")
 
     def handle_sigterm(self, signum, _frame):
         ExceptionSink._signal_sent = signum
+        self._send_signal_to_children(int(signal.SIGTERM), "SIGTERM")
         raise self.SignalHandledNonLocalExit(signum, "SIGTERM")
 
 


### PR DESCRIPTION
### Problem

Currently if a user hits Ctrl-C while at the Python REPL spawned by `./pants repl` on Python targets, pants will quit but the repl process will remain running, listening to stdin on the terminal pants just exited in some kind of indeterminate state, which screws up further input into that terminal.

### Solution

The problem was that when pants receives a SIGINT signal from the user hitting Ctrl-C, it sends SIGINT to all child processes. However, SIGINT does not actually terminate a Python REPL - it prints the text "KeyboardInterrupt" and continues to run. In order to actually shut down the Python process (or any other process that has similar behavior with respect to SIGINT), we need to send the SIGTERM signal instead.

### Result

Hitting Ctrl-C when at the Python REPL now correctly terminates all of pants, pantsd, and the underlying Python REPL process.