### PR TITLE
make ImmutableValue Hashable, and add more type safety to fields

### DIFF
--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -25,7 +25,7 @@ RUN chown -R ${TRAVIS_USER} ${TRAVIS_WORK_DIR_PATH}
 
 USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 
-# Our newly created user is unlikely to have a sane environment: set a locale at least.
+# Our newly created user is unlikely to have a sensible environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
 WORKDIR ${TRAVIS_WORK_DIR_PATH}

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -31,8 +31,8 @@ class PythonAwsLambdaRuntime(StringField):
     value: str
 
     @classmethod
-    def sanitize_raw_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value = cast(str, super().sanitize_raw_value(raw_value, address=address))
+    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
+        value = cast(str, super().compute_value(raw_value, address=address))
         if not re.match(cls.PYTHON_RUNTIME_REGEX, value):
             raise InvalidFieldException(
                 f"runtime field in python_awslambda target at {address.spec} must "

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -31,8 +31,8 @@ class PythonAwsLambdaRuntime(StringField):
     value: str
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], *, address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address=address))
+    def sanitize_raw_value(cls, raw_value: Optional[str], *, address: Address) -> str:
+        value = cast(str, super().sanitize_raw_value(raw_value, address=address))
         if not re.match(cls.PYTHON_RUNTIME_REGEX, value):
             raise InvalidFieldException(
                 f"runtime field in python_awslambda target at {address.spec} must "

--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -19,7 +19,6 @@ from pants.engine.target import (
     Field,
     FloatField,
     IntField,
-    PrimitiveField,
     RegisteredTargetTypes,
     ScalarField,
     SequenceField,
@@ -108,7 +107,7 @@ class FieldInfo:
         # requiring the Field author to rewrite the docstring.
         #
         # However, if the original `Field` author did not define docstring, then this means we
-        # would typically fall back to the docstring for `AsyncField`, `PrimitiveField`, or a
+        # would typically fall back to the docstring for `AsyncField`, `Field`, or a
         # helper class like `StringField`. This is a quirk of this heuristic and it's not
         # intentional since these core `Field` types have documentation oriented to the custom
         # `Field` author and not the end user filling in fields in a BUILD file target.
@@ -119,7 +118,7 @@ class FieldInfo:
             ignored_ancestors={
                 *Field.mro(),
                 AsyncField,
-                PrimitiveField,
+                Field,
                 BoolField,
                 DictStringToStringField,
                 DictStringToStringSequenceField,
@@ -134,12 +133,7 @@ class FieldInfo:
                 TriBoolField,
             },
         )
-        if issubclass(field, PrimitiveField):
-            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
-        elif issubclass(field, AsyncField):
-            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
-        else:
-            raw_value_type = get_type_hints(field.__init__)["raw_value"]
+        raw_value_type = get_type_hints(field.compute_value)["raw_value"]
         type_hint = pretty_print_type_hint(raw_value_type)
 
         # Check if the field only allows for certain choices.
@@ -154,7 +148,7 @@ class FieldInfo:
         if field.required:
             # We hackily remove `None` as a valid option for the field when it's required. This
             # greatly simplifies Field definitions because it means that they don't need to
-            # override the type hints for `PrimitiveField.compute_value()` and
+            # override the type hints for `Field.compute_value()` and
             # `AsyncField.compute_value()` to indicate that `None` is an invalid type.
             type_hint = type_hint.replace(" | None", "")
 

--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -135,9 +135,9 @@ class FieldInfo:
             },
         )
         if issubclass(field, PrimitiveField):
-            raw_value_type = get_type_hints(field.sanitize_raw_value)["raw_value"]
+            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
         elif issubclass(field, AsyncField):
-            raw_value_type = get_type_hints(field.sanitize_raw_value)["raw_value"]
+            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
         else:
             raw_value_type = get_type_hints(field.__init__)["raw_value"]
         type_hint = pretty_print_type_hint(raw_value_type)
@@ -154,8 +154,8 @@ class FieldInfo:
         if field.required:
             # We hackily remove `None` as a valid option for the field when it's required. This
             # greatly simplifies Field definitions because it means that they don't need to
-            # override the type hints for `PrimitiveField.sanitize_raw_value()` and
-            # `AsyncField.sanitize_raw_value()` to indicate that `None` is an invalid type.
+            # override the type hints for `PrimitiveField.compute_value()` and
+            # `AsyncField.compute_value()` to indicate that `None` is an invalid type.
             type_hint = type_hint.replace(" | None", "")
 
         return cls(

--- a/src/python/pants/backend/pants_info/list_target_types.py
+++ b/src/python/pants/backend/pants_info/list_target_types.py
@@ -27,6 +27,7 @@ from pants.engine.target import (
     StringOrStringSequenceField,
     StringSequenceField,
     Target,
+    TriBoolField,
 )
 from pants.engine.unions import UnionMembership
 from pants.util.objects import get_docstring, get_docstring_summary, pretty_print_type_hint
@@ -130,10 +131,11 @@ class FieldInfo:
                 StringField,
                 StringOrStringSequenceField,
                 StringSequenceField,
+                TriBoolField,
             },
         )
         if issubclass(field, PrimitiveField):
-            raw_value_type = get_type_hints(field.compute_value)["raw_value"]
+            raw_value_type = get_type_hints(field.sanitize_raw_value)["raw_value"]
         elif issubclass(field, AsyncField):
             raw_value_type = get_type_hints(field.sanitize_raw_value)["raw_value"]
         else:
@@ -152,7 +154,7 @@ class FieldInfo:
         if field.required:
             # We hackily remove `None` as a valid option for the field when it's required. This
             # greatly simplifies Field definitions because it means that they don't need to
-            # override the type hints for `PrimitiveField.compute_value()` and
+            # override the type hints for `PrimitiveField.sanitize_raw_value()` and
             # `AsyncField.sanitize_raw_value()` to indicate that `None` is an invalid type.
             type_hint = type_hint.replace(" | None", "")
 

--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -163,6 +163,8 @@ def test_list_all_json() -> None:
 
 
 def test_list_single() -> None:
+    # The reason we want this to still be TriBoolField is that we want to test that required = True
+    # results in stripping | None from the help message.
     class CustomField(TriBoolField):
         """My custom field!
 

--- a/src/python/pants/backend/pants_info/list_target_types_test.py
+++ b/src/python/pants/backend/pants_info/list_target_types_test.py
@@ -8,7 +8,7 @@ from typing import Optional, cast
 
 from pants.backend.pants_info.list_target_types import TargetTypesSubsystem, list_target_types
 from pants.core.util_rules.pants_bin import PantsBin
-from pants.engine.target import BoolField, IntField, RegisteredTargetTypes, StringField, Target
+from pants.engine.target import IntField, RegisteredTargetTypes, StringField, Target, TriBoolField
 from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.rule_runner import MockConsole, run_rule_with_mocks
@@ -163,7 +163,7 @@ def test_list_all_json() -> None:
 
 
 def test_list_single() -> None:
-    class CustomField(BoolField):
+    class CustomField(TriBoolField):
         """My custom field!
 
         Use this field to...

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -191,12 +191,12 @@ class PexInheritPathField(StringField):
 
     # TODO(#9388): deprecate allowing this to be a `bool`.
     @classmethod
-    def sanitize_raw_value(
+    def compute_value(
         cls, raw_value: Optional[Union[str, bool]], *, address: Address
     ) -> Optional[str]:
         if isinstance(raw_value, bool):
             return "prefer" if raw_value else "false"
-        return super().sanitize_raw_value(raw_value, address=address)
+        return super().compute_value(raw_value, address=address)
 
 
 class PexZipSafeField(BoolField):
@@ -341,8 +341,8 @@ class PythonTestsTimeout(IntField):
     alias = "timeout"
 
     @classmethod
-    def sanitize_raw_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
-        value = super().sanitize_raw_value(raw_value, address=address)
+    def compute_value(cls, raw_value: Optional[int], *, address: Address) -> Optional[int]:
+        value = super().compute_value(raw_value, address=address)
         if value is not None and value < 1:
             raise InvalidFieldException(
                 f"The value for the `timeout` field in target {address} must be > 0, but was "
@@ -447,10 +447,10 @@ class PythonRequirementsField(PrimitiveField[Tuple[Requirement, ...]]):
     required = True
 
     @classmethod
-    def sanitize_raw_value(
+    def compute_value(
         cls, raw_value: Optional[Union[str, PythonRequirement, Iterable[str]]], *, address: Address
     ) -> Tuple[Requirement, ...]:
-        value = super().sanitize_raw_value(raw_value, address=address)
+        value = super().compute_value(raw_value, address=address)
 
         def invalid_type_error():
             raise InvalidFieldTypeException(
@@ -569,10 +569,10 @@ class PythonProvidesField(ScalarField, ProvidesField):
     required = True
 
     @classmethod
-    def sanitize_raw_value(
+    def compute_value(
         cls, raw_value: Optional[PythonArtifact], *, address: Address
     ) -> PythonArtifact:
-        return cast(PythonArtifact, super().sanitize_raw_value(raw_value, address=address))
+        return cast(PythonArtifact, super().compute_value(raw_value, address=address))
 
 
 class SetupPyCommandsField(StringSequenceField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -20,12 +20,12 @@ from pants.engine.target import (
     BoolField,
     Dependencies,
     DictStringToStringSequenceField,
+    Field,
     InjectDependenciesRequest,
     InjectedDependencies,
     IntField,
     InvalidFieldException,
     InvalidFieldTypeException,
-    PrimitiveField,
     ProvidesField,
     ScalarField,
     Sources,
@@ -439,7 +439,7 @@ def format_invalid_requirement_string_error(
     )
 
 
-class PythonRequirementsField(PrimitiveField[Tuple[Requirement, ...]]):
+class PythonRequirementsField(Field[Tuple[Requirement, ...]]):
     """A sequence of pip-style requirement strings, e.g. ['foo==1.8', 'bar<=3 ;
     python_version<'3']."""
 
@@ -452,8 +452,8 @@ class PythonRequirementsField(PrimitiveField[Tuple[Requirement, ...]]):
     ) -> Tuple[Requirement, ...]:
         value = super().compute_value(raw_value, address=address)
 
-        def invalid_type_error():
-            raise InvalidFieldTypeException(
+        def invalid_type_error() -> InvalidFieldTypeException:
+            return InvalidFieldTypeException(
                 address,
                 cls.alias,
                 value,

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -786,7 +786,7 @@ def parse_dependencies_field(
 
     addresses: List[AddressInput] = []
     ignored_addresses: List[AddressInput] = []
-    for v in field.sanitized_raw_value or ():
+    for v in field.value or ():
         is_ignore = v.startswith("!")
         if is_ignore:
             # Check if it's a transitive exclude, rather than a direct exclude.

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -828,7 +828,7 @@ def test_sources_default_globs(sources_rule_runner: RuleRunner) -> None:
     # than the normal `all` conjunction.
     sources_rule_runner.create_files("src/fortran", files=["default.f95", "f1.f08", "ignored.f08"])
     sources = DefaultSources(None, address=addr)
-    assert set(sources.sanitized_raw_value or ()) == set(DefaultSources.default)
+    assert set(sources.value or ()) == set(DefaultSources.default)
 
     hydrated_sources = sources_rule_runner.request(
         HydratedSources, [HydrateSourcesRequest(sources)]

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -24,7 +24,6 @@ from pants.engine.target import (
     InvalidFieldChoiceException,
     InvalidFieldException,
     InvalidFieldTypeException,
-    PrimitiveField,
     RequiredFieldMissingException,
     ScalarField,
     SequenceField,
@@ -48,7 +47,7 @@ from pants.util.ordered_set import OrderedSet
 # -----------------------------------------------------------------------------------------------
 
 
-class FortranExtensions(PrimitiveField[Tuple[str, ...]]):
+class FortranExtensions(Field[Tuple[str, ...]]):
     alias = "fortran_extensions"
     default = ()
 
@@ -56,9 +55,7 @@ class FortranExtensions(PrimitiveField[Tuple[str, ...]]):
     def compute_value(
         cls, raw_value: Optional[Iterable[str]], *, address: Address
     ) -> Tuple[str, ...]:
-        value_or_default = cast(
-            Iterable[str], super().compute_value(raw_value, address=address)
-        )
+        value_or_default = cast(Iterable[str], super().compute_value(raw_value, address=address))
         # Add some arbitrary validation to test that hydration/validation works properly.
         bad_extensions = [
             extension for extension in value_or_default if not extension.startswith("Fortran")
@@ -394,7 +391,7 @@ def test_override_preexisting_field_via_new_target() -> None:
 
 
 def test_required_field() -> None:
-    class RequiredPrimitiveField(StringField):
+    class RequiredField(StringField):
         alias = "primitive"
         required = True
 
@@ -409,7 +406,7 @@ def test_required_field() -> None:
 
     class RequiredTarget(Target):
         alias = "required_target"
-        core_fields = (RequiredPrimitiveField, RequiredAsyncField)
+        core_fields = (RequiredField, RequiredAsyncField)
 
     address = Address.parse(":lib")
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -53,11 +53,11 @@ class FortranExtensions(PrimitiveField[Tuple[str, ...]]):
     default = ()
 
     @classmethod
-    def sanitize_raw_value(
+    def compute_value(
         cls, raw_value: Optional[Iterable[str]], *, address: Address
     ) -> Tuple[str, ...]:
         value_or_default = cast(
-            Iterable[str], super().sanitize_raw_value(raw_value, address=address)
+            Iterable[str], super().compute_value(raw_value, address=address)
         )
         # Add some arbitrary validation to test that hydration/validation works properly.
         bad_extensions = [
@@ -81,10 +81,10 @@ class FortranSources(AsyncField[Optional[Tuple[str, ...]]]):
     default = None
 
     @classmethod
-    def sanitize_raw_value(
+    def compute_value(
         cls, raw_value: Optional[Iterable[str]], address: Address
     ) -> Optional[Tuple[str, ...]]:
-        value_or_default = super().sanitize_raw_value(raw_value, address=address)
+        value_or_default = super().compute_value(raw_value, address=address)
         if value_or_default is None:
             return None
         return tuple(ensure_str_list(value_or_default))
@@ -326,11 +326,11 @@ def test_override_preexisting_field_via_new_target() -> None:
         default_extensions = ("FortranCustomExt",)
 
         @classmethod
-        def sanitize_raw_value(
+        def compute_value(
             cls, raw_value: Optional[Iterable[str]], *, address: Address
         ) -> Tuple[str, ...]:
             # Ensure that we avoid certain problematic extensions and always use some defaults.
-            specified_extensions = super().sanitize_raw_value(raw_value, address=address)
+            specified_extensions = super().compute_value(raw_value, address=address)
             banned = [
                 extension
                 for extension in specified_extensions
@@ -558,10 +558,10 @@ def test_scalar_field() -> None:
         expected_type_description = "a `CustomObject` instance"
 
         @classmethod
-        def sanitize_raw_value(
+        def compute_value(
             cls, raw_value: Optional[CustomObject], *, address: Address
         ) -> Optional[CustomObject]:
-            return super().sanitize_raw_value(raw_value, address=address)
+            return super().compute_value(raw_value, address=address)
 
     addr = Address.parse(":example")
 
@@ -611,10 +611,10 @@ def test_sequence_field() -> None:
         expected_type_description = "an iterable of `CustomObject` instances"
 
         @classmethod
-        def sanitize_raw_value(
+        def compute_value(
             cls, raw_value: Optional[Iterable[CustomObject]], *, address: Address
         ) -> Optional[Tuple[CustomObject, ...]]:
-            return super().sanitize_raw_value(raw_value, address=address)
+            return super().compute_value(raw_value, address=address)
 
     addr = Address.parse(":example")
 


### PR DESCRIPTION
### Problem

It's (arguably) not clear what the distinction is between `compute_value` and `sanitize_raw_value`. After seeing that they do the same thing, and that our `ImmutableValue` wasn't checking hashability, I thought there might be some room to simplify some of our `Field` definitions.

### Solution

- Make `pants.engine.target.ImmutableValue = typing.Hashable`, and make `Field` a generic type.
  - **The hashability is now automatically enforced for the `default` and `value` fields!**
  - The types of `default` and `value` in subclasses are also now verified to be compatible with the type parameter for `Field` (i.e. it's not possible to override them with the wrong type in a subclass).
  - Also, `default` is now type-checked to be compatible with `value`.
- Rename `PrimitiveField.compute_value` to `sanitize_raw_value`, `AsyncField.sanitized_raw_value` to `value`, and move both the field and the classmethod into the base `Field` struct.
  - This allows removing a `type: ignore[attr-defined]` in the `Target` class where we deal with just the `Field` superclass type.
- Split out the `TriBoolField` type for where the `None` state is desired.