### PR TITLE
Add gRPC Python code generation

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -232,3 +232,39 @@ def test_mypy_plugin(rule_runner: RuleRunner) -> None:
         mypy=True,
         expected_files=["src/protobuf/dir1/f_pb2.py", "src/protobuf/dir1/f_pb2.pyi"],
     )
+
+
+def test_grpc(rule_runner: RuleRunner) -> None:
+    rule_runner.create_file(
+        "src/protobuf/dir1/f.proto",
+        dedent(
+            """\
+            syntax = "proto3";
+
+            package dir1;
+
+            // The greeter service definition.
+            service Greeter {
+              // Sends a greeting
+              rpc SayHello (HelloRequest) returns (HelloReply) {}
+            }
+
+            // The request message containing the user's name.
+            message HelloRequest {
+              string name = 1;
+            }
+
+            // The response message containing the greetings
+            message HelloReply {
+              string message = 1;
+            }
+            """
+        ),
+    )
+    rule_runner.add_to_build_file("src/protobuf/dir1", "protobuf_library(grpc=True)")
+    assert_files_generated(
+        rule_runner,
+        "src/protobuf/dir1",
+        source_roots=["src/protobuf"],
+        expected_files=["src/protobuf/dir1/f_pb2.py", "src/protobuf/dir1/f_pb2_grpc.py"],
+    )

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -6,6 +6,7 @@ from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    BoolField,
     Dependencies,
     InjectDependenciesRequest,
     InjectedDependencies,
@@ -30,6 +31,13 @@ class ProtobufSources(Sources):
     expected_file_extensions = (".proto",)
 
 
+class ProtobufGrcpToggle(BoolField):
+    """Whether to generate gRPC code or not."""
+
+    alias = "grpc"
+    default = False
+
+
 class ProtobufLibrary(Target):
     """Protobuf files used to generate various languages.
 
@@ -37,7 +45,7 @@ class ProtobufLibrary(Target):
     """
 
     alias = "protobuf_library"
-    core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources)
+    core_fields = (*COMMON_TARGET_FIELDS, ProtobufDependencies, ProtobufSources, ProtobufGrcpToggle)
 
 
 class InjectProtobufDependencies(InjectDependenciesRequest):


### PR DESCRIPTION
Users activate this on a per-target basis:

```python
# BUILD
protobuf_library(grpc=True)
```

This signals that all relevant code generators should use the gRPC plugin. For now, that is only Python. But when adding other languages like Java, it will need to respect this flag.

Closes https://github.com/pantsbuild/pants/issues/10497.

[ci skip-rust]
[ci skip-build-wheels]

