### PR TITLE
Use `package` to build Pants's wheels, rather than `setup-py`

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -22,6 +22,9 @@ python_distribution(
     ':entry_point',
     ':version',
   ],
+  # Because we have native code, this will cause the wheel to use whatever the ABI is for the
+  # interpreter used to run setup.py, e.g. `cp36m-macosx_10_15_x86_64`.
+  setup_py_commands=["bdist_wheel"],
   provides=setup_py(
     name='pantsbuild.pants',
     description='A scalable build tool for large, complex, heterogeneous repos.',

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -541,6 +541,7 @@ async def run_setup_py(
             # TODO: Could there be other useful files to capture?
             output_directories=(dist_dir,),
             description=f"Run setuptools for {req.exported_target.target.address}",
+            level=LogLevel.DEBUG,
         ),
     )
     output_digest = await Get(Digest, RemovePrefix(result.output_digest, dist_dir))
@@ -739,7 +740,7 @@ async def get_requirements(
     return ExportedTargetRequirements(req_strs)
 
 
-@rule(desc="Find all code to be published in the distribution", level=LogLevel.INFO)
+@rule(desc="Find all code to be published in the distribution", level=LogLevel.DEBUG)
 async def get_owned_dependencies(
     dependency_owner: DependencyOwner, union_membership: UnionMembership
 ) -> OwnedDependencies:

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -7,6 +7,7 @@ python_distribution(
     ':testutil',
     ':int-test-for-export',
   ],
+  setup_py_commands=["bdist_wheel", "--python-tag", "py36.py37.py38", "sdist"],
   provides=setup_py(
     name='pantsbuild.pants.testutil',
     description='Test support for writing Pants plugins.',


### PR DESCRIPTION
This also removes some overly chatty logging.

* `[INFO] Find all code to be published in the distribution` isn't very descriptive because it's the same message for every single distribution
* `[INFO] Run setuptools for src/python/pants/testutil:testutil_wheel` isn't very helpful because we very quickly thereafter will write `Wrote dist/pantsbuild.pants.testutil`.

[ci skip-rust]