### PR TITLE
Fix config validation not erroring on global options in wrong scope

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -246,6 +246,9 @@ class Options:
             for section in config.sections():
                 scope = GLOBAL_SCOPE if section == GLOBAL_SCOPE_CONFIG_SECTION else section
                 try:
+                    # TODO(#10834): this is broken for subscopes. Once we fix global options to no
+                    #  longer be included in self.for_scope(), we should set
+                    #  inherit_from_enclosing_scope=True.
                     valid_options_under_scope = set(
                         self.for_scope(scope, inherit_from_enclosing_scope=False)
                     )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -246,7 +246,9 @@ class Options:
             for section in config.sections():
                 scope = GLOBAL_SCOPE if section == GLOBAL_SCOPE_CONFIG_SECTION else section
                 try:
-                    valid_options_under_scope = set(self.for_scope(scope))
+                    valid_options_under_scope = set(
+                        self.for_scope(scope, inherit_from_enclosing_scope=False)
+                    )
                 # Only catch ConfigValidationError. Other exceptions will be raised directly.
                 except Config.ConfigValidationError:
                     error_log.append(f"Invalid scope [{section}] in {config.config_path}")


### PR DESCRIPTION
This used to not complain:

```toml
[source]
backend_packages = ["pants.backend.python"]
```

Closes https://github.com/pantsbuild/pants/issues/3713.

[ci skip-rust]
[ci skip-build-wheels]