### PR TITLE
allow try/except across @rule methods and intrinsics

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -1,8 +1,11 @@
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Generic, Dict, List, Tuple, Type, TypeVar
 
 # TODO: black and flake8 disagree about the content of this file:
 #   see https://github.com/psf/black/issues/1548
 # flake8: noqa: E302
+
+_In = TypeVar("_In")
+_Out = TypeVar("_Out")
 
 class PyDigest:
     def __init__(self, fingerprint: str, serialized_bytes_length: int) -> None: ...
@@ -21,13 +24,22 @@ class PyExecutor:
     def __init__(self, **kwargs: Any) -> None: ...
 
 class PyGeneratorResponseBreak:
-    def __init__(self, **kwargs: Any) -> None: ...
+    val: Any
+    def __init__(self, val: Any) -> None: ...
 
-class PyGeneratorResponseGet:
-    def __init__(self, **kwargs: Any) -> None: ...
+class PyGeneratorResponseGet(Generic[_Out, _In]):
+    product: Type[_Out]
+    declared_subject: Type[_In]
+    subject: _In
+    def __init__(self, product: Type[_Out], declared_subject: Type[_In], subject: _In) -> None: ...
 
-class PyGeneratorResponseGetMulti:
-    def __init__(self, **kwargs: Any) -> None: ...
+class PyGeneratorResponseGetMulti(Generic[_Out]):
+    gets: Tuple[PyGeneratorResponseGet[_Out, Any], ...]
+    def __init__(self, gets: Tuple[PyGeneratorResponseGet[_Out, Any], ...]) -> None: ...
+
+class PyGeneratorResponseThrow:
+    err: Exception
+    def __init__(self, err: Exception) -> None: ...
 
 class PyNailgunServer:
     def __init__(self, **kwargs: Any) -> None: ...

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -10,6 +10,11 @@ from typing import Any
 import pytest
 
 from pants.engine.internals.engine_testutil import remove_locations_from_traceback
+from pants.engine.internals.engine_testutil import (
+    assert_equal_with_printing,
+    remove_locations_from_traceback,
+)
+from pants.engine.internals.native import IncorrectProductError
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import Get, rule
 from pants.engine.unions import UnionRule, union
@@ -187,6 +192,183 @@ def test_union_rules() -> None:
     ) in str(exc.value.args[0])
 
 
+
+class SomeInput:
+    s: str
+
+
+@dataclass(frozen=True)
+class SomeOutput:
+    s: str
+
+
+@rule
+def raise_an_exception(some_input: SomeInput) -> SomeOutput:
+    raise Exception(some_input.s)
+
+
+@dataclass(frozen=True)
+class OuterInput:
+    s: str
+
+
+@rule
+async def catch_an_exception(outer_input: OuterInput) -> SomeOutput:
+    try:
+        return await Get(SomeOutput, SomeInput(outer_input.s))
+    except Exception as e:
+        return SomeOutput(str(e))
+
+
+@rule
+async def catch_and_reraise(outer_input: OuterInput) -> SomeOutput:
+    try:
+        return await Get(SomeOutput, SomeInput(outer_input.s))
+    except Exception:
+        raise Exception("nested exception!")
+
+
+class InputWithNothing:
+    pass
+
+
+GLOBAL_FLAG: bool = True
+
+
+@rule
+def raise_an_exception_upon_global_state(input_with_nothing: InputWithNothing) -> SomeOutput:
+    if GLOBAL_FLAG:
+        raise Exception("global flag is set!")
+    return SomeOutput("asdf")
+
+
+@rule
+def return_a_wrong_product_type(input_with_nothing: InputWithNothing) -> A:
+    return B()  # type: ignore[return-value]
+
+
+@rule
+async def catch_a_wrong_product_type(input_with_nothing: InputWithNothing) -> B:
+    try:
+        _ = await Get(A, InputWithNothing, input_with_nothing)
+    except IncorrectProductError as e:
+        raise Exception(f"caught product type error: {e}")
+    return B()
+
+
+@contextmanager
+def assert_execution_error(test_case, expected_msg):
+    with test_case.assertRaises(ExecutionError) as cm:
+        yield
+    test_case.assertIn(expected_msg, remove_locations_from_traceback(str(cm.exception)))
+
+
+class SchedulerTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            consumes_a_and_b,
+            QueryRule(str, (A, B)),
+            transitive_b_c,
+            QueryRule(str, (A, C)),
+            transitive_coroutine_rule,
+            QueryRule(D, (C,)),
+            UnionRule(UnionBase, UnionA),
+            UnionRule(UnionWithNonMemberErrorMsg, UnionWrapper),
+            select_union_a,
+            UnionRule(union_base=UnionBase, union_member=UnionB),
+            select_union_b,
+            a_union_test,
+            QueryRule(A, (UnionWrapper,)),
+            error_msg_test_rule,
+            QueryRule(UnionX, (UnionWrapper,)),
+            boolean_and_int,
+            QueryRule(A, (int, bool)),
+            raise_an_exception,
+            QueryRule(SomeOutput, (SomeInput,)),
+            catch_an_exception,
+            QueryRule(SomeOutput, (OuterInput,)),
+            raise_an_exception_upon_global_state,
+            QueryRule(SomeOutput, (InputWithNothing,)),
+            return_a_wrong_product_type,
+            QueryRule(A, (InputWithNothing,)),
+            catch_a_wrong_product_type,
+            QueryRule(B, (InputWithNothing,)),
+        )
+
+    def test_use_params(self):
+        # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
+        a, b = A(), B()
+        result_str = self.request(str, [a, b])
+        self.assertEqual(result_str, consumes_a_and_b(a, b))
+
+        # And confirm that a superset of Params is also accepted.
+        result_str = self.request(str, [a, b, self])
+        self.assertEqual(result_str, consumes_a_and_b(a, b))
+
+        # But not a subset.
+        expected_msg = "No installed QueryRules can compute str given input Params(A), but"
+        with self.assertRaisesRegex(Exception, re.escape(expected_msg)):
+            self.request(str, [a])
+
+    def test_transitive_params(self):
+        # Test that C can be provided and implicitly converted into a B with transitive_b_c() to satisfy
+        # the selectors of consumes_a_and_b().
+        a, c = A(), C()
+        result_str = self.request(str, [a, c])
+        self.assertEqual(
+            remove_locations_from_traceback(result_str),
+            remove_locations_from_traceback(consumes_a_and_b(a, transitive_b_c(c))),
+        )
+
+        # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to
+        # the existence of transitive_b_c().
+        self.request(D, [c])
+
+    def test_consumed_types(self):
+        assert {A, B, C, str} == set(
+            self.scheduler.scheduler.rule_graph_consumed_types([A, C], str)
+        )
+
+    def test_strict_equals(self):
+        # With the default implementation of `__eq__` for boolean and int, `1 == True`. But in the
+        # engine that behavior would be surprising, and would cause both of these Params to intern
+        # to the same value, triggering an error. Instead, the engine additionally includes the
+        # type of a value in equality.
+        assert A() == self.request(A, [1, True])
+
+    @contextmanager
+    def _assert_execution_error(self, expected_msg):
+        with assert_execution_error(self, expected_msg):
+            yield
+
+    def test_union_rules(self):
+        self.request(A, [UnionWrapper(UnionA())])
+        self.request(A, [UnionWrapper(UnionB())])
+        # Fails due to no union relationship from A -> UnionBase.
+        with self._assert_execution_error("Type A is not a member of the UnionBase @union"):
+            self.request(A, [UnionWrapper(A())])
+
+    def test_union_rules_no_docstring(self):
+        with self._assert_execution_error("specific error message for UnionA instance"):
+            self.request(UnionX, [UnionWrapper(UnionA())])
+
+    def test_catch_inner_exception(self):
+        assert self.request(SomeOutput, [OuterInput("asdf")]) == SomeOutput("asdf")
+
+    def test_exceptions_uncached(self):
+        global GLOBAL_FLAG
+        with self._assert_execution_error("global flag is set!"):
+            self.request(SomeOutput, [InputWithNothing()])
+        GLOBAL_FLAG = False
+        assert self.request(SomeOutput, [InputWithNothing()]) == SomeOutput("asdf")
+
+    def test_incorrect_product_type(self):
+        with self._assert_execution_error("caught product type error"):
+            self.request(B, [InputWithNothing()])
+
+
 # -----------------------------------------------------------------------------------------------
 # Test tracebacks
 # -----------------------------------------------------------------------------------------------
@@ -265,3 +447,120 @@ def test_unhashable_types_failure() -> None:
     # Fail if the `input` in a `Get` is not hashable.
     with pytest.raises(ExecutionError, match="unhashable type: 'list'"):
         rule_runner.request(C, [])
+
+
+class SchedulerWithNestedRaiseTest(TestBase):
+    @classmethod
+    def rules(cls):
+        return (
+            *super().rules(),
+            a_typecheck_fail_test,
+            c_unhashable,
+            nested_raise,
+            QueryRule(A, (TypeCheckFailWrapper,)),
+            QueryRule(A, (B,)),
+            QueryRule(C, (CollectionType,)),
+            raise_an_exception,
+            QueryRule(SomeOutput, (SomeInput,)),
+            catch_and_reraise,
+            QueryRule(SomeOutput, (OuterInput,)),
+        )
+
+    def test_get_type_match_failure(self):
+        """Test that Get(...)s are now type-checked during rule execution, to allow for union
+        types."""
+
+        with self.assertRaises(ExecutionError) as cm:
+            # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
+            self.request(A, [TypeCheckFailWrapper(A())])
+
+        expected_regex = "WithDeps.*did not declare a dependency on JustGet"
+        self.assertRegex(str(cm.exception), expected_regex)
+
+    def test_unhashable_root_params_failure(self):
+        """Test that unhashable root params result in a structured error."""
+        # This will fail at the rust boundary, before even entering the engine.
+        with self.assertRaisesRegex(TypeError, "unhashable type: 'list'"):
+            self.request(C, [CollectionType([1, 2, 3])])
+
+    def test_unhashable_get_params_failure(self):
+        """Test that unhashable Get(...) params result in a structured error."""
+        # This will fail inside of `c_unhashable_dataclass`.
+        with self.assertRaisesRegex(ExecutionError, "unhashable type: 'list'"):
+            self.request(C, [CollectionType(tuple())])
+
+    def test_trace_includes_rule_exception_traceback(self):
+        # Execute a request that will trigger the nested raise, and then directly inspect its trace.
+        request = self.scheduler.execution_request([A], [B()])
+        _, throws = self.scheduler.execute(request)
+
+        with self.assertRaises(ExecutionError) as cm:
+            self.scheduler._raise_on_error([t for _, t in throws])
+
+        trace = remove_locations_from_traceback(str(cm.exception))
+        assert_equal_with_printing(
+            self,
+            dedent(
+                f"""\
+                 1 Exception encountered:
+
+                 Engine traceback:
+                   in select
+                   in {self.__module__}.{nested_raise.__name__}
+                 Traceback (most recent call last):
+                   File LOCATION-INFO, in nested_raise
+                     fn_raises(b)
+                   File LOCATION-INFO, in fn_raises
+                     raise Exception(f"An exception for {{type(x).__name__}}")
+                 Exception: An exception for B
+                 """
+            ),
+            trace,
+        )
+
+    def test_trace_includes_nested_exception_traceback(self):
+        request = self.scheduler.execution_request([SomeOutput], [OuterInput("asdf")])
+        _, throws = self.scheduler.execute(request)
+
+        with self.assertRaises(ExecutionError) as cm:
+            self.scheduler._raise_on_error([t for _, t in throws])
+
+        trace = remove_locations_from_traceback(str(cm.exception))
+        assert_equal_with_printing(
+            self,
+            dedent(
+                f"""\
+                 1 Exception encountered:
+
+                 Engine traceback:
+                   in select
+                   in {self.__module__}.{catch_and_reraise.__name__}
+                   in {self.__module__}.{raise_an_exception.__name__}
+                 Traceback (most recent call last):
+                   File LOCATION-INFO, in raise_an_exception
+                     raise Exception(some_input.s)
+                 Exception: asdf
+
+                 While handling that, another exception was raised:
+
+                 Traceback (most recent call last):
+                   File LOCATION-INFO, in catch_and_reraise
+                     return await Get(SomeOutput, SomeInput(outer_input.s))
+                   File LOCATION-INFO, in __await__
+                     result = yield self
+                 Exception: asdf
+
+                 During handling of the above exception, another exception occurred:
+
+                 Traceback (most recent call last):
+                   File LOCATION-INFO, in generator_send
+                     res = self._send_to_coroutine(func, arg)
+                   File LOCATION-INFO, in _send_to_coroutine
+                     return func.throw(arg)  # type: ignore[arg-type]
+                   File LOCATION-INFO, in catch_and_reraise
+                     raise Exception("nested exception!")
+                 Exception: nested exception!
+                 """
+            ),
+            trace,
+        )

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -208,7 +208,7 @@ class Get(GetConstraints, Generic[_Output, _Input]):
     ) -> "Generator[Get[_Output, _Input], None, _Output]":
         """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
-        The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in
+        The `yield`ed value `self` is interpreted by the engine within `generator_send()` in
         `native.py`. This class will yield a single Get instance, which is converted into
         `PyGeneratorResponse::Get` from `externs.rs` via the python `cffi` library and the rust
         `cbindgen` crate.
@@ -219,8 +219,8 @@ class Get(GetConstraints, Generic[_Output, _Input]):
         - The engine will call `.send(None)` on the coroutine, which will either:
           - raise StopIteration with a value (if the coroutine `return`s), or
           - return a `Get` instance to the engine (if the rule instead called `await Get(...)`).
-        - The engine will fulfill the `Get` request to produce `x`, then call `.send(x)` and repeat the
-          above until StopIteration.
+        - The engine will fulfill the `Get` request to produce `x`, then call `.send(x)` and repeat
+          the above until StopIteration.
 
         See more information about implementing this method at
         https://www.python.org/dev/peps/pep-0492/#await-expression.
@@ -401,7 +401,7 @@ async def MultiGet(  # noqa: F811
     """Yield a tuple of Get instances all at once.
 
     The `yield`ed value `self.gets` is interpreted by the engine within
-    `extern_generator_send()` in `native.py`. This class will yield a tuple of Get instances,
+    `generator_send()` in `native.py`. This class will yield a tuple of Get instances,
     which is converted into `PyGeneratorResponse::GetMulti` from `externs.rs`.
 
     The engine will fulfill these Get instances in parallel, and return a tuple of _Output

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -417,6 +417,15 @@ impl Failure {
       Failure::Throw { val, .. } => Ok(val),
     }
   }
+  ///
+  /// Get a handle to the exception Value, if applicable, or wrap this in an InternalFailure.
+  ///
+  pub fn into_py_err(self) -> Result<Value, Failure> {
+    match self {
+      Failure::Invalidated => Err(Failure::Invalidated),
+      Failure::Throw { val, .. } => Ok(val),
+    }
+  }
 
   pub fn from_py_err_value(val: Value) -> Failure {
     let gil = Python::acquire_gil();

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -346,21 +346,6 @@ pub enum Failure {
   },
 }
 
-///
-/// Because we may represent either an internal error or a normal raised python exception with a
-/// Failure instance, we want to make it explicit when we convert a Failure into a Value. In that
-/// case, we wrap a Failure which cannot be converted into a Value (such as a Failure::Invalidated)
-/// with an InternalFailure instance, which ensures that we propagate it to the top level without
-/// exposing it to python code.
-///
-pub struct InternalFailure(Failure);
-
-impl InternalFailure {
-  pub fn into_failure(self) -> Failure {
-    self.0
-  }
-}
-
 impl Failure {
   ///
   /// Consumes this Failure to produce a new Failure with an additional engine_traceback entry.
@@ -426,9 +411,9 @@ impl Failure {
   ///
   /// Get a handle to the exception Value, if applicable, or wrap this in an InternalFailure.
   ///
-  pub fn as_py_err(&self) -> Result<&Value, InternalFailure> {
+  pub fn as_py_err(&self) -> Result<&Value, Failure> {
     match self {
-      Failure::Invalidated => Err(InternalFailure(Failure::Invalidated)),
+      Failure::Invalidated => Err(Failure::Invalidated),
       Failure::Throw { val, .. } => Ok(val),
     }
   }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -592,9 +592,8 @@ py_class!(class PySession |py| {
           should_render_ui,
           build_id,
           should_report_workunits,
-          externs::InvocationResult::SuccessfulReturn(session_values.into()),
-        )
-      )
+          session_values.into(),
+        ))
     }
 });
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -410,6 +410,7 @@ py_module_initializer!(native_engine, |py, m| {
   m.add_class::<externs::PyGeneratorResponseBreak>(py)?;
   m.add_class::<externs::PyGeneratorResponseGet>(py)?;
   m.add_class::<externs::PyGeneratorResponseGetMulti>(py)?;
+  m.add_class::<externs::PyGeneratorResponseThrow>(py)?;
 
   m.add_class::<externs::fs::PyDigest>(py)?;
 
@@ -591,7 +592,7 @@ py_class!(class PySession |py| {
           should_render_ui,
           build_id,
           should_report_workunits,
-          session_values.into(),
+          externs::InvocationResult::SuccessfulReturn(session_values.into()),
         )
       )
     }
@@ -740,7 +741,7 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> CPyResult<
         f @ Failure::Invalidated => {
           let msg = format!("{}", f);
           (
-            externs::create_exception(&msg),
+            externs::create_value_error(&msg),
             Failure::native_traceback(&msg),
             Vec::new(),
           )

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -299,10 +299,10 @@ pub fn call_method(value: &PyObject, method: &str, args: &[Value]) -> Result<PyO
 }
 
 pub fn into_value_result(py_result: Result<PyObject, PyErr>) -> Result<Value, Failure> {
-    match py_result {
-      Ok(obj) => Ok(Value::from(obj)),
-      Err(err) => Err(Failure::from_py_err(err)),
-    }
+  match py_result {
+    Ok(obj) => Ok(Value::from(obj)),
+    Err(err) => Err(Failure::from_py_err(err)),
+  }
 }
 
 pub fn call_function(func: &PyObject, args: &[Value]) -> Result<PyObject, PyErr> {
@@ -374,7 +374,7 @@ pub fn generator_send(
   } else if let Ok(throw) = response.cast_as::<PyGeneratorResponseThrow>(py) {
     let new_err_val = Value::new(throw.err(py).clone_ref(py));
     match arg {
-        Err(err) => {
+      Err(err) => {
         // If this is the same error that we previously sent, then just return the previous error to
         // preserve the stacktraces.
         let err_is_same_as_last_time = err
@@ -391,10 +391,10 @@ pub fn generator_send(
           Ok(GeneratorResponse::Throw(joined_failure))
         }
       }
-        // We didn't have an error before, but we do now, so just return a new Failure instance.
-        Ok(_) => Ok(GeneratorResponse::Throw(
-            Failure::from_py_err_value(new_err_val),
-        )),
+      // We didn't have an error before, but we do now, so just return a new Failure instance.
+      Ok(_) => Ok(GeneratorResponse::Throw(Failure::from_py_err_value(
+        new_err_val,
+      ))),
     }
   } else {
     panic!("generator_send returned unrecognized type: {:?}", response);

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -19,7 +19,7 @@ use std::convert::{AsRef, Into, TryInto};
 use std::fmt;
 use std::sync::atomic;
 
-use crate::core::{Failure, InternalFailure, Key, TypeId, Value};
+use crate::core::{Failure, Key, TypeId, Value};
 use crate::interning::Interns;
 
 use cpython::{
@@ -349,7 +349,7 @@ impl InvocationResult {
   ///
   /// Get a handle to the inner value (which may be an exception).
   ///
-  pub fn as_error_value_ref(&self) -> Result<&Value, InternalFailure> {
+  pub fn as_error_value_ref(&self) -> Result<&Value, Failure> {
     match self {
       InvocationResult::SuccessfulReturn(val) => Ok(val),
       InvocationResult::Exception(err) => err.as_py_err(),
@@ -376,7 +376,7 @@ pub fn generator_send(
     let input: &Value = match &arg {
       // If we last received an raised exception from an inner coroutine, extract the exception
       // value, and send it to the current coroutine.
-      InvocationResult::Exception(err) => err.as_py_err().map_err(|e| e.into_failure())?,
+      InvocationResult::Exception(err) => err.as_py_err()?,
       InvocationResult::SuccessfulReturn(obj) => obj,
     };
     with_externs(|py, e| {

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -416,8 +416,7 @@ fn session_values(context: Context, _args: Vec<Value>) -> BoxFuture<'static, Nod
   async move {
     context
       .get(SessionValues)
-      .await
-      .and_then(|result| result.into_result())
+      .await?
   }
   .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -413,5 +413,11 @@ fn digest_subset_to_digest(
 }
 
 fn session_values(context: Context, _args: Vec<Value>) -> BoxFuture<'static, NodeResult<Value>> {
-  async move { context.get(SessionValues).await }.boxed()
+  async move {
+    context
+      .get(SessionValues)
+      .await
+      .and_then(|result| result.into_result())
+  }
+  .boxed()
 }

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -413,10 +413,5 @@ fn digest_subset_to_digest(
 }
 
 fn session_values(context: Context, _args: Vec<Value>) -> BoxFuture<'static, NodeResult<Value>> {
-  async move {
-    context
-      .get(SessionValues)
-      .await?
-  }
-  .boxed()
+  async move { context.get(SessionValues).await? }.boxed()
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1097,8 +1097,7 @@ impl WrappedNode for Task {
       // Get the returned object or raised exception as a Value, and extract any engine-aware
       // parameters.
       let result_val = function_call_result
-        .as_error_value_ref()
-        .map_err(|e| e.into_failure())?;
+        .as_error_value_ref()?;
       if can_modify_workunit {
         (
           engine_aware::EngineAwareLevel::retrieve(&context.core.types, &result_val),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -12,7 +12,7 @@ use futures::{future, FutureExt};
 
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
-use crate::externs::{self, InvocationResult};
+use crate::externs::{self};
 use crate::nodes::{NodeKey, Select, Visualizer};
 
 use cpython::Python;
@@ -82,7 +82,7 @@ struct InnerSession {
   // The unique id for this Session: used for metrics gathering purposes.
   build_id: String,
   // Per-Session values that have been set for this session.
-  session_values: Mutex<InvocationResult>,
+  session_values: Mutex<Value>,
   // An id used to control the visibility of uncacheable rules. Generally this is identical for an
   // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
   // same Session while still observing new values for uncacheable rules like Goals.
@@ -104,7 +104,7 @@ impl Session {
     should_render_ui: bool,
     build_id: String,
     should_report_workunits: bool,
-    session_values: InvocationResult,
+    session_values: Value,
   ) -> Session {
     let workunit_store = WorkunitStore::new(!should_render_ui);
     let display = Mutex::new(if should_render_ui {
@@ -163,7 +163,7 @@ impl Session {
     roots.keys().map(|r| r.clone().into()).collect()
   }
 
-  pub fn session_values(&self) -> InvocationResult {
+  pub fn session_values(&self) -> Value {
     self.0.session_values.lock().clone()
   }
 
@@ -451,8 +451,8 @@ impl Scheduler {
       .try_into()
       .unwrap_or_else(|e| panic!("A Node implementation was ambiguous: {:?}", e));
     match invocation_result {
-      InvocationResult::Exception(err) => Err(err),
-      InvocationResult::SuccessfulReturn(val) => Ok((val, last_observed)),
+      Err(err) => Err(err),
+      Ok(val) => Ok((val, last_observed)),
     }
   }
 


### PR DESCRIPTION
### Problem

Closes #8706.

#### Why Exception Handling is Good for Plugin Authors
If anything goes wrong in a v2 `@rule` or in any pants intrinsics, pants will immediately stop all `@rule` executions and raise the error up to the top level. Even with mypy enabled, idiomatic python code still uses exception handling, so this restriction may be somewhat awkward for plugin authors. This is one of the few remaining elements of normal python code that is not allowed within `@rule`s. It may be difficult to make use of 3rdparty python libraries which use exceptions without this feature.

Idiomatic python code would still prefer to "ask forgiveness rather than permission" (very unfortunate phrasing which Guido van Rossum has since disavowed), and write code for the happy path, and handle the failure case when needed. Since python doesn't have rust-style enums, it is still clumsy to try to turn errors into data. Therefore, it may become more natural to write easily-memoizable pure functions in python when exception handling is enabled.

#### Why Exception Handling is Bad for Plugin Authors

It should be noted that the v2 engine intentionally (to an extent) forces plugin authors to express rules through a more functional API than they may be used to from other python code, requiring pure functions, for example. This is key to the engine's ability to parallelize and memoize build steps.

**Because a `@rule` which raises an exception, or fails to catch a raised exception from an `await Get(...)`, is still not memoized, we should encourage plugin authors to avoid trying to catch exceptions from deeply-nested `@rule` invocations, and to handle exceptions close to where they are raised.**

#### Why Exception Handling is Good for Pants Contributors
It is currently annoying and time-consuming to generate error messages for intrinsics implemented in rust. We would like to be able to focus on just generating the minimum amount of information necessary in rust to represent the error, and do the work of formatting that error nicely in python code.

### Solution

- Create the `externs::InvocationResult` enum, which holds either a successful return value, or a raised exception.
- In `Native.generator_send()`, call `.send()` to send an argument to a coroutine if the argument was a successful return value, or `.throw()` if it was an exception.
  - In the same method, add a `._formatted_traceback` attribute to all exceptions raised from `@rule` methods.
- Create `core::Failure::join_tracebacks()` to join the engine and python tracebacks of any exceptions which were raised when trying to handle another exception.
- If any `Get` within a `MultiGet` fails, raise that error and discard the other results.
- Convert any `Failure`s from intrinsics into an `InvocationResult` so they can also be caught.
- Test that raising an exception while handling another exception is represented clearly to the user.
- Test that exceptions are still not memoized in the graph.
- Test that returning an incorrect product type is converted into a `TypeError`.

### Result
We can now do this in `@rule`s:
```python
@rule
async def catch_merge_digests_error(file_input: FileInput) -> MergedOutput:
    # Create two separate digests writing different contents to the same file path.
    input_1 = CreateDigest((FileContent(path=file_input.filename, content=b"yes"),))
    input_2 = CreateDigest((FileContent(path=file_input.filename, content=b"no"),))
    digests = await MultiGet(Get(Digest, CreateDigest, input_1), Get(Digest, CreateDigest, input_2))
    try:
        merged = await Get(Digest, MergeDigests(digests))
    except Exception as e:
        raise Exception(f"error merging digests for input {file_input}: {e}")
    return MergedOutput(merged)
```