### PR TITLE
Remove project_ methods from the externs module

### DIFF
--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -157,8 +157,8 @@ impl Function {
   pub fn name(&self) -> String {
     let Function(key) = self;
     let val = externs::val_for(&key);
-    let module = externs::project_str(&val, "__module__");
-    let name = externs::project_str(&val, "__name__");
+    let module = externs::getattr_as_string(&val, "__module__");
+    let name = externs::getattr_as_string(&val, "__name__");
     // NB: this is a custom dunder method that Python code should populate before sending the
     // function (e.g. an `@rule`) through FFI.
     let line_number: u64 = externs::getattr(&val, "__line_number__").unwrap();

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1566,7 +1566,7 @@ fn run_local_interactive_process(
           if hermetic_env {
             command.env_clear();
           }
-          let env = externs::project_frozendict(&value, "env");
+          let env = externs::collect_frozendict(&value, "env");
           command.envs(env);
 
           let mut subprocess = command.spawn().map_err(|e| format!("Error executing interactive process: {}", e.to_string()))?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1367,7 +1367,7 @@ fn capture_snapshots(
       session.workunit_store().init_thread_state(None);
       let core = scheduler.core.clone();
 
-      let values = externs::project_iterable(&path_globs_and_root_tuple_wrapper.into());
+      let values = externs::collect_iterable(&path_globs_and_root_tuple_wrapper).unwrap();
       let path_globs_and_roots = values
         .iter()
         .map(|value| {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -694,9 +694,10 @@ fn nailgun_server_create(
         ];
         match externs::call_function(&runner, &runner_args) {
           Ok(exit_code) => {
-            // TODO: We don't currently expose a "project_i32", but it will not be necessary with
-            // https://github.com/pantsbuild/pants/pull/9593.
-            nailgun::ExitCode(externs::val_to_str(&exit_code).parse().unwrap())
+            let gil = Python::acquire_gil();
+            let py = gil.python();
+            let code: i32 = exit_code.extract(py).unwrap();
+            nailgun::ExitCode(code)
           }
           Err(e) => {
             error!("Uncaught exception in nailgun handler: {:#?}", e);

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1372,7 +1372,7 @@ fn capture_snapshots(
       let path_globs_and_roots = values
         .iter()
         .map(|value| {
-          let root = PathBuf::from(externs::project_str(&value, "root"));
+          let root = PathBuf::from(externs::getattr_as_string(&value, "root"));
           let path_globs = nodes::Snapshot::lift_prepared_path_globs(
             &externs::getattr(&value, "path_globs").unwrap(),
           );
@@ -1566,7 +1566,7 @@ fn run_local_interactive_process(
           if hermetic_env {
             command.env_clear();
           }
-          let env = externs::collect_frozendict(&value, "env");
+          let env = externs::getattr_from_frozendict(&value, "env");
           command.envs(env);
 
           let mut subprocess = command.spawn().map_err(|e| format!("Error executing interactive process: {}", e.to_string()))?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1511,7 +1511,7 @@ fn run_local_interactive_process(
 
           let value: Value = request.into();
 
-          let argv: Vec<String> = externs::project_multi_strs(&value, "argv");
+          let argv: Vec<String> = externs::getattr(&value, "argv").unwrap();
           if argv.is_empty() {
             return Err("Empty argv list not permitted".to_string());
           }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1373,14 +1373,17 @@ fn capture_snapshots(
         .map(|value| {
           let root = PathBuf::from(externs::project_str(&value, "root"));
           let path_globs = nodes::Snapshot::lift_prepared_path_globs(
-            &externs::project_ignoring_type(&value, "path_globs"),
+            &externs::getattr(&value, "path_globs").unwrap(),
           );
           let digest_hint = {
-            let maybe_digest = externs::project_ignoring_type(&value, "digest_hint");
-            if maybe_digest == Value::from(externs::none()) {
+            let maybe_digest: PyObject = externs::getattr(&value, "digest_hint").unwrap();
+            if maybe_digest == externs::none() {
               None
             } else {
-              Some(nodes::lift_directory_digest(&core.types, &maybe_digest)?)
+              Some(nodes::lift_directory_digest(
+                &core.types,
+                &Value::new(maybe_digest),
+              )?)
             }
           };
           path_globs.map(|path_globs| (path_globs, root, digest_hint))
@@ -1520,7 +1523,7 @@ fn run_local_interactive_process(
             Some(TempDir::new().map_err(|err| format!("Error creating tempdir: {}", err))?)
           };
 
-          let input_digest_value = externs::project_ignoring_type(&value, "input_digest");
+          let input_digest_value: Value = externs::getattr(&value, "input_digest").unwrap();
           let digest: Digest = nodes::lift_directory_digest(types, &input_digest_value)?;
           if digest != EMPTY_DIGEST {
             if run_in_workspace {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -224,19 +224,8 @@ fn collect_iterable(value: &Value) -> Result<Vec<Value>, String> {
   }
 }
 
-///
-/// Pulls out the value specified by the field name from a given Value
-///
-pub fn project_ignoring_type(value: &PyObject, field: &str) -> Value {
-  getattr(value, field).unwrap()
-}
-
 pub fn project_iterable(value: &Value) -> Vec<Value> {
   collect_iterable(value).unwrap()
-}
-
-pub fn project_multi(value: &PyObject, field: &str) -> Vec<Value> {
-  getattr(value, field).unwrap()
 }
 
 pub fn project_multi_strs(value: &PyObject, field: &str) -> Vec<String> {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -224,7 +224,7 @@ pub fn collect_iterable(value: &PyObject) -> Result<Vec<PyObject>, String> {
   }
 }
 
-pub fn project_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
+pub fn collect_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
   let frozendict = getattr(value, field).unwrap();
   let pydict: PyDict = getattr(&frozendict, "_data").unwrap();
   let gil = Python::acquire_gil();

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -197,16 +197,16 @@ where
 }
 
 ///
-/// Collect the Values contained within an outer Python Iterable Value.
+/// Collect the Values contained within an outer Python Iterable PyObject.
 ///
-fn collect_iterable(value: &Value) -> Result<Vec<Value>, String> {
+pub fn collect_iterable(value: &PyObject) -> Result<Vec<PyObject>, String> {
   let gil = Python::acquire_gil();
   let py = gil.python();
   match value.iter(py) {
     Ok(py_iter) => py_iter
       .enumerate()
       .map(|(i, py_res)| {
-        py_res.map(Value::from).map_err(|py_err| {
+        py_res.map_err(|py_err| {
           format!(
             "Could not iterate {}, failed to extract {}th item: {:?}",
             val_to_str(value),
@@ -222,10 +222,6 @@ fn collect_iterable(value: &Value) -> Result<Vec<Value>, String> {
       py_err
     )),
   }
-}
-
-pub fn project_iterable(value: &Value) -> Vec<Value> {
-  collect_iterable(value).unwrap()
 }
 
 pub fn project_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -228,10 +228,6 @@ pub fn project_iterable(value: &Value) -> Vec<Value> {
   collect_iterable(value).unwrap()
 }
 
-pub fn project_multi_strs(value: &PyObject, field: &str) -> Vec<String> {
-  getattr(value, field).unwrap()
-}
-
 pub fn project_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
   let frozendict = getattr(value, field).unwrap();
   let pydict: PyDict = getattr(&frozendict, "_data").unwrap();

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -224,7 +224,7 @@ pub fn collect_iterable(value: &PyObject) -> Result<Vec<PyObject>, String> {
   }
 }
 
-pub fn collect_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
+pub fn getattr_from_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, String> {
   let frozendict = getattr(value, field).unwrap();
   let pydict: PyDict = getattr(&frozendict, "_data").unwrap();
   let gil = Python::acquire_gil();
@@ -236,7 +236,7 @@ pub fn collect_frozendict(value: &PyObject, field: &str) -> BTreeMap<String, Str
     .collect()
 }
 
-pub fn project_str(value: &PyObject, field: &str) -> String {
+pub fn getattr_as_string(value: &PyObject, field: &str) -> String {
   // TODO: It's possible to view a python string as a `Cow<str>`, so we could avoid actually
   // cloning in some cases.
   // TODO: We can't directly extract as a string here, because val_to_str defaults to empty string
@@ -249,7 +249,7 @@ pub fn key_to_str(key: &Key) -> String {
 }
 
 pub fn type_to_str(type_id: TypeId) -> String {
-  project_str(&type_for_type_id(type_id).into_object(), "__name__")
+  getattr_as_string(&type_for_type_id(type_id).into_object(), "__name__")
 }
 
 pub fn val_to_str(obj: &PyObject) -> String {

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -230,7 +230,7 @@ fn remove_prefix_request_to_digest(
     let input_digest =
       lift_directory_digest(&core.types, &externs::getattr(&args[0], "digest").unwrap())
         .map_err(|e| throw(&e))?;
-    let prefix = externs::project_str(&args[0], "prefix");
+    let prefix = externs::getattr_as_string(&args[0], "prefix");
     let prefix = RelativePath::new(PathBuf::from(prefix))
       .map_err(|e| throw(&format!("The `prefix` must be relative: {:?}", e)))?;
     let digest = store
@@ -252,7 +252,7 @@ fn add_prefix_request_to_digest(
     let input_digest =
       lift_directory_digest(&core.types, &externs::getattr(&args[0], "digest").unwrap())
         .map_err(|e| throw(&e))?;
-    let prefix = externs::project_str(&args[0], "prefix");
+    let prefix = externs::getattr_as_string(&args[0], "prefix");
     let prefix = RelativePath::new(PathBuf::from(prefix))
       .map_err(|e| throw(&format!("The `prefix` must be relative: {:?}", e)))?;
     let digest = store
@@ -347,7 +347,7 @@ fn create_digest_to_digest(
   let digests: Vec<_> = file_contents_and_directories
     .into_iter()
     .map(|file_content_or_directory| {
-      let path = externs::project_str(&file_content_or_directory, "path");
+      let path = externs::getattr_as_string(&file_content_or_directory, "path");
       let store = context.core.store();
       async move {
         let path = RelativePath::new(PathBuf::from(path))

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -343,7 +343,7 @@ fn create_digest_to_digest(
   context: Context,
   args: Vec<Value>,
 ) -> BoxFuture<'static, NodeResult<Value>> {
-  let file_contents_and_directories = externs::project_iterable(&args[0]);
+  let file_contents_and_directories = externs::collect_iterable(&args[0]).unwrap();
   let digests: Vec<_> = file_contents_and_directories
     .into_iter()
     .map(|file_content_or_directory| {
@@ -353,7 +353,7 @@ fn create_digest_to_digest(
         let path = RelativePath::new(PathBuf::from(path))
           .map_err(|e| format!("The `path` must be relative: {:?}", e))?;
 
-        if externs::hasattr(file_content_or_directory.as_ref(), "content") {
+        if externs::hasattr(&file_content_or_directory, "content") {
           let bytes = bytes::Bytes::from(
             externs::getattr::<Vec<u8>>(&file_content_or_directory, "content").unwrap(),
           );

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -262,12 +262,14 @@ impl MultiPlatformExecuteProcess {
     let digest = lift_directory_digest(types, &py_digest)
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
-    let output_files = externs::project_multi_strs(&value, "output_files")
+    let output_files = externs::getattr::<Vec<String>>(&value, "output_files")
+      .unwrap()
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
 
-    let output_directories = externs::project_multi_strs(&value, "output_directories")
+    let output_directories = externs::getattr::<Vec<String>>(&value, "output_directories")
+      .unwrap()
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
@@ -312,7 +314,7 @@ impl MultiPlatformExecuteProcess {
     let cache_failures: bool = externs::getattr(&value, "cache_failures").unwrap();
 
     Ok(process_execution::Process {
-      argv: externs::project_multi_strs(&value, "argv"),
+      argv: externs::getattr(&value, "argv").unwrap(),
       env,
       working_directory,
       input_files: digest,
@@ -331,7 +333,7 @@ impl MultiPlatformExecuteProcess {
   }
 
   pub fn lift(types: &Types, value: &Value) -> Result<MultiPlatformExecuteProcess, String> {
-    let constraint_parts = externs::project_multi_strs(&value, "platform_constraints");
+    let constraint_parts: Vec<String> = externs::getattr(&value, "platform_constraints").unwrap();
     if constraint_parts.len() % 2 != 0 {
       return Err("Error parsing platform_constraints: odd number of parts".to_owned());
     }
@@ -611,7 +613,7 @@ impl Snapshot {
   }
 
   pub fn lift_path_globs(item: &Value) -> Result<PathGlobs, String> {
-    let globs = externs::project_multi_strs(item, "globs");
+    let globs: Vec<String> = externs::getattr(item, "globs").unwrap();
 
     let description_of_origin_field = externs::project_str(item, "description_of_origin");
     let description_of_origin = if description_of_origin_field.is_empty() {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -247,7 +247,7 @@ impl MultiPlatformExecuteProcess {
     value: &Value,
     target_platform: PlatformConstraint,
   ) -> Result<Process, String> {
-    let env = externs::project_frozendict(&value, "env");
+    let env = externs::collect_frozendict(&value, "env");
 
     let working_directory = {
       let val = externs::project_str(&value, "working_directory");
@@ -286,7 +286,7 @@ impl MultiPlatformExecuteProcess {
     let py_level: PyObject = externs::getattr(&value, "level").unwrap();
     let level = externs::val_to_log_level(&py_level)?;
 
-    let append_only_caches = externs::project_frozendict(&value, "append_only_caches")
+    let append_only_caches = externs::collect_frozendict(&value, "append_only_caches")
       .into_iter()
       .map(|(name, dest)| Ok((CacheName::new(name)?, CacheDest::new(dest)?)))
       .collect::<Result<_, String>>()?;


### PR DESCRIPTION
This commit removes all the `project_` functions in `externs` in favor of `externs::getattr` with type specialization at each callsite. `project_frozendict` and `project_str` both have a little bit of custom logic, so it makes sense to leave these two functions alone, although they have been renamed to `getattr_from_frozendict` and `getattr_as_string` to make it clear that these functions are variations on the fundamental `getattr` operation.