### PR TITLE
Fix config validation not erroring on global options in wrong scope (Cherry-pick of #10950)

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -246,7 +246,12 @@ class Options:
             for section in config.sections():
                 scope = GLOBAL_SCOPE if section == GLOBAL_SCOPE_CONFIG_SECTION else section
                 try:
-                    valid_options_under_scope = set(self.for_scope(scope))
+                    # TODO(#10834): this is broken for subscopes. Once we fix global options to no
+                    #  longer be included in self.for_scope(), we should set
+                    #  inherit_from_enclosing_scope=True.
+                    valid_options_under_scope = set(
+                        self.for_scope(scope, inherit_from_enclosing_scope=False)
+                    )
                 # Only catch ConfigValidationError. Other exceptions will be raised directly.
                 except Config.ConfigValidationError:
                     error_log.append(f"Invalid scope [{section}] in {config.config_path}")


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]