### PR TITLE
Fix logger declaration in lint.py

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -25,7 +25,7 @@ from pants.util.memo import memoized_property
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import strip_v2_chroot_path
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Problem

A Python logger accessed with `logger = logging.Logger(__name__)` does not actually interact with the Rust logging code for some reason, causing logs emitted using this object to never be displayed anywhere. ``logger = logging.getLogger(__name__)`, which is the idiom we use everywhere in the pants codebase other than lint.py, works fine.

### Solution

Change the code to `logger = logging.getLogger(__name__)`.

Obviously it is confusing that one these two superficially-similar-seeming ways of interacting with the Python logging API simply fails to work, and that's probably worth looking into in the future.
