### PR TITLE
Restore several removed targets and fields to help with upgrading

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -367,6 +367,16 @@ class PythonTestsTimeout(IntField):
         return result
 
 
+class DeprecatedCoverageField(StringOrStringSequenceField):
+    alias = "coverage"
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "The `coverage` field no longer does anything, as Pants now gets coverage data for all "
+        "files encountered. Use the option `--coverage-py-filter` if you want more precise "
+        "results. See https://www.pantsbuild.org/docs/python-test-goal#coverage."
+    )
+
+
 class PythonTests(Target):
     """Python tests.
 
@@ -386,6 +396,7 @@ class PythonTests(Target):
         PythonRuntimePackageDependencies,
         PythonRuntimeBinaryDependencies,
         PythonTestsTimeout,
+        DeprecatedCoverageField,
     )
 
 
@@ -398,11 +409,35 @@ class PythonLibrarySources(PythonSources):
     default = ("*.py", "*.pyi") + tuple(f"!{pat}" for pat in PythonTestsSources.default)
 
 
+class DeprecatedProvidesField(ScalarField, ProvidesField):
+    expected_type = PythonArtifact
+    expected_type_description = "setup_py(name='my-dist', **kwargs)"
+    value: PythonArtifact
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "Rather than using the `provides` field on a `python_library` target, create a dedicated "
+        "`python_distribution` target. See "
+        "https://www.pantsbuild.org/docs/how-to-upgrade-pants-2-0#use--python_distribution-"
+        "target-type-for-providessetup_py-130-vs-20 for instructions."
+    )
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[PythonArtifact], *, address: Address
+    ) -> PythonArtifact:
+        return cast(PythonArtifact, super().compute_value(raw_value, address=address))
+
+
 class PythonLibrary(Target):
     """A Python library that may be imported by other targets."""
 
     alias = "python_library"
-    core_fields = (*COMMON_PYTHON_FIELDS, Dependencies, PythonLibrarySources)
+    core_fields = (
+        *COMMON_PYTHON_FIELDS,
+        Dependencies,
+        PythonLibrarySources,
+        DeprecatedProvidesField,
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/core/deprecated_v1_target_types.py
+++ b/src/python/pants/core/deprecated_v1_target_types.py
@@ -1,0 +1,184 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonInterpreterCompatibility
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    BoolField,
+    Dependencies,
+    SequenceField,
+    Sources,
+    StringField,
+    StringSequenceField,
+    Target,
+)
+
+# -----------------------------------------------------------------------------------------------
+# `alias` target
+# -----------------------------------------------------------------------------------------------
+
+
+class AliasTargetRequestedAddress(StringField):
+    alias = "target"
+
+
+class AliasTarget(Target):
+    alias = "alias"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, AliasTargetRequestedAddress)
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "The `alias` target was removed. If you found this feature useful, we'd be happy to add it"
+        "back in a more powerful way. Please message us on Slack or open a GitHub issue "
+        "(https://www.pantsbuild.org/docs/community)."
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `prep_command` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PrepCommandExecutable(StringField):
+    alias = "prep_executable"
+    required = True
+
+
+class PrepCommandArgs(StringSequenceField):
+    alias = "prep_args"
+
+
+class PrepCommandEnviron(BoolField):
+    alias = "prep_environ"
+    default = False
+
+
+class PrepCommandGoals(StringSequenceField):
+    alias = "goals"
+    default = ("test",)
+
+
+class PrepCommand(Target):
+    alias = "prep_command"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PrepCommandExecutable,
+        PrepCommandArgs,
+        PrepCommandEnviron,
+        PrepCommandGoals,
+    )
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "The `prep_command` target was removed, as it does not fit well with the v2 engine's "
+        "execution model. If you needed this functionality, please message us on Slack "
+        "(https://www.pantsbuild.org/docs/community) and we will help to recreate your setup."
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `python_app` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonAppBinaryField(StringField):
+    alias = "binary"
+
+
+class PythonAppBasename(StringField):
+    alias = "basename"
+
+
+class PythonAppArchiveFormat(StringField):
+    alias = "archive"
+
+
+class Bundle:
+    def __init__(self, parse_context):
+        self._parse_context = parse_context
+
+    def __call__(self, rel_path=None, mapper=None, relative_to=None, fileset=None):
+        pass
+
+
+class BundlesField(SequenceField):
+    alias = "bundles"
+    expected_element_type = Bundle
+    expected_type_description = "an iterable of `bundle` objects"
+
+
+class PythonApp(Target):
+    alias = "python_app"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        BundlesField,
+        PythonAppBinaryField,
+        PythonAppBasename,
+        PythonAppArchiveFormat,
+    )
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "Instead of `python_app`, use the simpler `archive` target. If you still need to relocate "
+        "files, use the new `relocated_files` target. See "
+        "https://www.pantsbuild.org/docs/resources."
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `unpacked_wheels` target
+# -----------------------------------------------------------------------------------------------
+
+
+class UnpackedWheelsModuleName(StringField):
+    alias = "module_name"
+    required = True
+
+
+class UnpackedWheelsRequestedLibraries(StringSequenceField):
+    alias = "libraries"
+    required = True
+
+
+class UnpackedWheelsIncludePatterns(StringSequenceField):
+    alias = "include_patterns"
+
+
+class UnpackedWheelsExcludePatterns(StringSequenceField):
+    alias = "exclude_patterns"
+
+
+class UnpackedWheelsWithinDataSubdir(BoolField):
+    alias = "within_data_subdir"
+    default = False
+
+
+class UnpackedWheels(Target):
+    alias = "unpacked_whls"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonInterpreterCompatibility,
+        UnpackedWheelsModuleName,
+        UnpackedWheelsRequestedLibraries,
+        UnpackedWheelsIncludePatterns,
+        UnpackedWheelsExcludePatterns,
+        UnpackedWheelsWithinDataSubdir,
+    )
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "The `unpacked_wheels` target type was removed. Please reach out if you'd still like this "
+        "functionality (https://www.pantsbuild.org/docs/community)."
+    )
+
+
+# -----------------------------------------------------------------------------------------------
+# `python_grpcio_library` target
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonGrpcioLibrary(Target):
+    alias = "python_grpcio_library"
+    core_fields = (*COMMON_PYTHON_FIELDS, Dependencies, Sources)
+    deprecated_removal_version = "2.1.0.dev0"
+    deprecated_removal_hint = (
+        "Instead of `python_grpcio_library`, use `protobuf_library(grpc=True)`. See "
+        "https://www.pantsbuild.org/docs/protobuf."
+    )

--- a/src/python/pants/core/deprecated_v1_target_types.py
+++ b/src/python/pants/core/deprecated_v1_target_types.py
@@ -1,11 +1,15 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Iterable, Optional
+
 from pants.backend.python.target_types import COMMON_PYTHON_FIELDS, PythonInterpreterCompatibility
+from pants.engine.addresses import Address
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
     Dependencies,
+    InvalidFieldException,
     SequenceField,
     Sources,
     StringField,
@@ -103,6 +107,14 @@ class BundlesField(SequenceField):
     alias = "bundles"
     expected_element_type = Bundle
     expected_type_description = "an iterable of `bundle` objects"
+
+    @classmethod
+    def compute_value(cls, raw_value: Optional[Iterable[Bundle]], *, address: Address) -> None:
+        try:
+            super().compute_value(raw_value, address=address)
+        except InvalidFieldException:
+            pass
+        return None
 
 
 class PythonApp(Target):

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -6,6 +6,15 @@
 These are always activated and cannot be disabled.
 """
 
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.deprecated_v1_target_types import (
+    AliasTarget,
+    Bundle,
+    PrepCommand,
+    PythonApp,
+    PythonGrpcioLibrary,
+    UnpackedWheels,
+)
 from pants.core.goals import binary, fmt, lint, package, repl, run, test, typecheck
 from pants.core.target_types import ArchiveTarget, Files, GenericTarget, RelocatedFiles, Resources
 from pants.core.target_types import rules as target_type_rules
@@ -21,6 +30,10 @@ from pants.core.util_rules import (
     subprocess_environment,
 )
 from pants.source import source_root
+
+
+def build_file_aliases():
+    return BuildFileAliases(context_aware_object_factories={"bundle": Bundle})
 
 
 def rules():
@@ -50,4 +63,16 @@ def rules():
 
 
 def target_types():
-    return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles]
+    return [
+        ArchiveTarget,
+        Files,
+        GenericTarget,
+        Resources,
+        RelocatedFiles,
+        # Deprecated targets.
+        AliasTarget,
+        PrepCommand,
+        PythonApp,
+        UnpackedWheels,
+        PythonGrpcioLibrary,
+    ]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10963.

Even though these restored types no-op, a user pointed out that this will help with upgrading to 2.0. You can use `pants_ignore_warnings` to ignore these no-ops until you're ready to deal with them. We had no good reason to eagerly error, other than oversight.
