### PR TITLE
Fix several bad usages of `itertools.groupby()`

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -242,6 +242,12 @@ async def lint(
             for request in valid_requests
             for field_set in request.field_sets
         )
+
+        def key_fn(results: LintResults):
+            return results.linter_name
+
+        # NB: We must pre-sort the data for itertools.groupby() to work properly.
+        sorted_all_per_files_results = sorted(all_per_file_results, key=key_fn)
         # We consolidate all results for each linter into a single `LintResults`.
         all_results = tuple(
             LintResults(
@@ -251,7 +257,7 @@ async def lint(
                 linter_name=linter_name,
             )
             for linter_name, all_linter_results in itertools.groupby(
-                all_per_file_results, key=lambda results: results.linter_name
+                sorted_all_per_files_results, key=key_fn
             )
         )
     else:


### PR DESCRIPTION
We discovered in https://github.com/pantsbuild/pants/pull/10974 that `itertools.groupby()` requires you to pre-sort the data to work properly:

From https://docs.python.org/3/library/itertools.html#itertools.groupby:

> The operation of groupby() is similar to the uniq filter in Unix. It generates a break or new group every time the value of the key function changes (which is why it is usually necessary to have sorted the data using the same key function). That behavior differs from SQL’s GROUP BY which aggregates common elements regardless of their input order.

[ci skip-rust]
[ci skip-build-wheels]