### PR TITLE
Allow changing the versioning scheme for `python_distribution` first-party dependencies

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -328,7 +328,7 @@ class PythonDistributionSubsystem(Subsystem):
         register(
             "--first-party-dependency-version-scheme",
             type=FirstPartyDependencyVersionScheme,
-            default=FirstPartyDependencyVersionScheme.COMPATIBLE,
+            default=FirstPartyDependencyVersionScheme.EXACT,
             help=(
                 "What version to set in `install_requires` when a `python_distribution` depends on "
                 "other `python_distribution`s. If `exact`, will use `==`. If `compatible`, will "

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import enum
 import io
 import itertools
 import logging
@@ -9,7 +10,6 @@ import pickle
 from abc import ABC, abstractmethod
 from collections import abc, defaultdict
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Dict, List, Mapping, Set, Tuple, cast
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
@@ -310,7 +310,8 @@ class RunSetupPyResult:
     output: Digest  # The state of the chroot after running setup.py.
 
 
-class FirstPartyDependencyVersionScheme(Enum):
+@enum.unique
+class FirstPartyDependencyVersionScheme(enum.Enum):
     EXACT = "exact"  # i.e., ==
     COMPATIBLE = "compatible"  # i.e., ~=
     ANY = "any"  # i.e., no specifier

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -216,7 +216,7 @@ def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
             "packages": ("foo", "foo.qux"),
             "namespace_packages": ("foo",),
             "package_data": {"foo": ("resources/js/code.js",)},
-            "install_requires": ("baz~=1.1.1",),
+            "install_requires": ("baz==1.1.1",),
             "entry_points": {"console_scripts": ["foo_main=foo.qux.bin"]},
         },
         "src/python/foo:foo-dist",


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10908. 

Users can now choose between no version requirements, compatible versions (`~=`), and exact requirements (`==`). See https://www.python.org/dev/peps/pep-0440/#compatible-release.

[ci skip-rust]
[ci skip-build-wheels]