### PR TITLE
Remove tokio Handle type from Executor::new

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -41,7 +41,6 @@ use hashing::{Digest, Fingerprint};
 use log::{debug, error, warn};
 use parking_lot::Mutex;
 use store::Store;
-use tokio::runtime::Handle;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::stream::StreamExt;
 use tokio::task;
@@ -719,7 +718,7 @@ async fn main() {
     None
   };
 
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
 
   let store = match args.value_of("server-address") {
     Some(address) => Store::with_remote(

--- a/src/rust/engine/fs/brfs/src/syscall_tests.rs
+++ b/src/rust/engine/fs/brfs/src/syscall_tests.rs
@@ -9,12 +9,11 @@ use std::ffi::CString;
 use std::path::Path;
 use store::Store;
 use testutil::data::TestData;
-use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn read_file_by_digest_exact_bytes() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -8,13 +8,12 @@ use testutil::{
   data::{TestData, TestDirectory},
   file,
 };
-use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn missing_digest() {
   let (store_dir, mount_dir) = make_dirs();
 
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -30,7 +29,7 @@ async fn missing_digest() {
 #[tokio::test]
 async fn read_file_by_digest() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -54,7 +53,7 @@ async fn read_file_by_digest() {
 #[tokio::test]
 async fn list_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -82,7 +81,7 @@ async fn list_directory() {
 #[tokio::test]
 async fn read_file_from_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -112,7 +111,7 @@ async fn read_file_from_directory() {
 #[tokio::test]
 async fn list_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -151,7 +150,7 @@ async fn list_recursive_directory() {
 #[tokio::test]
 async fn read_file_from_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -195,7 +194,7 @@ async fn read_file_from_recursive_directory() {
 #[tokio::test]
 async fn files_are_correctly_executable() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new2();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -13,7 +13,7 @@ use testutil::{
 async fn missing_digest() {
   let (store_dir, mount_dir) = make_dirs();
 
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -29,7 +29,7 @@ async fn missing_digest() {
 #[tokio::test]
 async fn read_file_by_digest() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -53,7 +53,7 @@ async fn read_file_by_digest() {
 #[tokio::test]
 async fn list_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -81,7 +81,7 @@ async fn list_directory() {
 #[tokio::test]
 async fn read_file_from_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -111,7 +111,7 @@ async fn read_file_from_directory() {
 #[tokio::test]
 async fn list_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -150,7 +150,7 @@ async fn list_recursive_directory() {
 #[tokio::test]
 async fn read_file_from_recursive_directory() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");
@@ -194,7 +194,7 @@ async fn read_file_from_recursive_directory() {
 #[tokio::test]
 async fn files_are_correctly_executable() {
   let (store_dir, mount_dir) = make_dirs();
-  let runtime = task_executor::Executor::new2();
+  let runtime = task_executor::Executor::new();
 
   let store =
     Store::local_only(runtime.clone(), store_dir.path()).expect("Error creating local store");

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -52,7 +52,6 @@ use serde_derive::Serialize;
 use store::{
   Snapshot, SnapshotOps, SnapshotOpsError, Store, StoreFileByDigest, SubsetParams, UploadSummary,
 };
-use tokio::runtime::Handle;
 
 #[derive(Debug)]
 enum ExitCode {
@@ -281,7 +280,7 @@ async fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
     .value_of("local-store-path")
     .map(PathBuf::from)
     .unwrap_or_else(Store::default_path);
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let (store, store_has_remote) = {
     let (store_result, store_has_remote) = match top_match.values_of("server-address") {
       Some(cas_address) => {

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::path::{Components, Path, PathBuf};
 use std::sync::Arc;
 use testutil::make_file;
-use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn is_executable_false() {
@@ -387,7 +386,7 @@ fn new_posixfs<P: AsRef<Path>>(dir: P) -> PosixFS {
   PosixFS::new(
     dir.as_ref(),
     GitignoreStyleExcludes::empty(),
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
   )
   .unwrap()
 }
@@ -396,7 +395,7 @@ fn new_posixfs_symlink_oblivious<P: AsRef<Path>>(dir: P) -> PosixFS {
   PosixFS::new_with_symlink_behavior(
     dir.as_ref(),
     GitignoreStyleExcludes::empty(),
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     SymlinkBehavior::Oblivious,
   )
   .unwrap()
@@ -430,7 +429,7 @@ async fn test_basic_gitignore_functionality() {
   let gitignore_content = "*.tmp\n!*.x";
   let gitignore_path = root_path.join(".gitignore");
   make_file(&gitignore_path, gitignore_content.as_bytes(), 0o700);
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let ignorer =
     GitignoreStyleExcludes::create_with_gitignore_file(vec![], Some(gitignore_path.clone()))
       .unwrap();
@@ -453,7 +452,7 @@ async fn test_basic_gitignore_functionality() {
   assert!(!posix_fs.is_ignored(&stats[3]));
 
   // Test that .gitignore files work in tandem with explicit ignores.
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let ignorer = GitignoreStyleExcludes::create_with_gitignore_file(
     vec!["unimportant.x".to_string()],
     Some(gitignore_path),

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -53,8 +53,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
   // Create an executor, store containing the stuff to materialize, and a digest for the stuff.
   // To avoid benchmarking the deleting of things, we create a parent temporary directory (which
   // will be deleted at the end of the benchmark) and then skip deletion of the per-run directories.
-  let rt = Runtime::new().unwrap();
-  let executor = Executor::new(rt.handle().clone());
+  let executor = Executor::new_owned();
   let (store, _tempdir, digest) = large_snapshot(&executor, 100);
   let parent_dest = TempDir::new().unwrap();
   let parent_dest_path = parent_dest.path();
@@ -78,8 +77,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
 }
 
 pub fn criterion_benchmark_subset_wildcard(c: &mut Criterion) {
-  let rt = Runtime::new().unwrap();
-  let executor = Executor::new(rt.handle().clone());
+  let executor = Executor::new_owned();
   // NB: We use a much larger snapshot size compared to the materialize benchmark!
   let (store, _tempdir, digest) = large_snapshot(&executor, 1000);
 
@@ -107,8 +105,7 @@ pub fn criterion_benchmark_subset_wildcard(c: &mut Criterion) {
 }
 
 pub fn criterion_benchmark_merge(c: &mut Criterion) {
-  let rt = Runtime::new().unwrap();
-  let executor = Executor::new(rt.handle().clone());
+  let executor = Executor::new_owned();
   let num_files: usize = 4000;
   let (store, _tempdir, digest) = large_snapshot(&executor, num_files);
 

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -8,7 +8,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 use hashing::{Digest, Fingerprint};
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
-use tokio::runtime::Handle;
 use tokio::time::delay_for;
 use walkdir::WalkDir;
 
@@ -561,16 +560,11 @@ async fn all_digests() {
 }
 
 pub fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
-  ByteStore::new(task_executor::Executor::new(Handle::current()), dir).unwrap()
+  ByteStore::new(task_executor::Executor::new(), dir).unwrap()
 }
 
 pub fn new_store_with_lease_time<P: AsRef<Path>>(dir: P, lease_time: Duration) -> ByteStore {
-  ByteStore::new_with_lease_time(
-    task_executor::Executor::new(Handle::current()),
-    dir,
-    lease_time,
-  )
-  .unwrap()
+  ByteStore::new_with_lease_time(task_executor::Executor::new(), dir, lease_time).unwrap()
 }
 
 pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -7,7 +7,6 @@ use task_executor;
 use tempfile;
 use testutil::data::TestDirectory;
 use testutil::make_file;
-use tokio::runtime::Handle;
 
 use crate::{OneOffStoreFileByDigest, RelativePath, Snapshot, SnapshotOps, Store};
 use fs::{
@@ -24,7 +23,7 @@ pub fn setup() -> (
   Arc<PosixFS>,
   OneOffStoreFileByDigest,
 ) {
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   // TODO: Pass a remote CAS address through.
   let store = Store::local_only(
     executor.clone(),

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -21,7 +21,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
-use tokio::runtime::Handle;
 
 impl LoadMetadata {
   fn is_remote(&self) -> bool {
@@ -91,8 +90,7 @@ pub fn new_cas(chunk_size_bytes: usize) -> StubCAS {
 /// Create a new local store with whatever was already serialized in dir.
 ///
 fn new_local_store<P: AsRef<Path>>(dir: P) -> Store {
-  Store::local_only(task_executor::Executor::new(Handle::current()), dir)
-    .expect("Error creating local store")
+  Store::local_only(task_executor::Executor::new(), dir).expect("Error creating local store")
 }
 
 ///
@@ -100,7 +98,7 @@ fn new_local_store<P: AsRef<Path>>(dir: P) -> Store {
 ///
 fn new_store<P: AsRef<Path>>(dir: P, cas_address: String) -> Store {
   Store::with_remote(
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     dir,
     vec![cas_address],
     None,
@@ -862,7 +860,7 @@ async fn instance_name_upload() {
     .expect("Error storing catnip locally");
 
   let store_with_remote = Store::with_remote(
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     dir.path(),
     vec![cas.address()],
     Some("dark-tower".to_owned()),
@@ -893,7 +891,7 @@ async fn instance_name_download() {
     .build();
 
   let store_with_remote = Store::with_remote(
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     dir.path(),
     vec![cas.address()],
     Some("dark-tower".to_owned()),
@@ -943,7 +941,7 @@ async fn auth_upload() {
     .expect("Error storing catnip locally");
 
   let store_with_remote = Store::with_remote(
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     dir.path(),
     vec![cas.address()],
     None,
@@ -974,7 +972,7 @@ async fn auth_download() {
     .build();
 
   let store_with_remote = Store::with_remote(
-    task_executor::Executor::new(Handle::current()),
+    task_executor::Executor::new(),
     dir.path(),
     vec![cas.address()],
     None,

--- a/src/rust/engine/nailgun/src/tests.rs
+++ b/src/rust/engine/nailgun/src/tests.rs
@@ -15,7 +15,7 @@ use tokio::time::delay_for;
 
 #[tokio::test]
 async fn spawn_and_bind() {
-  let server = Server::new(Executor::new(Handle::current()), 0, |_| ExitCode(0))
+  let server = Server::new(Executor::new(), 0, |_| ExitCode(0))
     .await
     .unwrap();
   // Should have bound a random port.
@@ -26,7 +26,7 @@ async fn spawn_and_bind() {
 #[tokio::test]
 async fn accept() {
   let exit_code = ExitCode(42);
-  let server = Server::new(Executor::new(Handle::current()), 0, move |_| exit_code)
+  let server = Server::new(Executor::new(), 0, move |_| exit_code)
     .await
     .unwrap();
 
@@ -43,7 +43,7 @@ async fn shutdown_awaits_ongoing() {
   let connection_accepted = Arc::new(Notify::new());
   let should_complete_connection = Arc::new(Notify::new());
   let exit_code = ExitCode(42);
-  let server = Server::new(Executor::new(Handle::current()), 0, {
+  let server = Server::new(Executor::new(), 0, {
     let connection_accepted = connection_accepted.clone();
     let should_complete_connection = should_complete_connection.clone();
     move |_| {

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -13,7 +13,6 @@ use store::Store;
 use tempfile::TempDir;
 use testutil::data::TestData;
 use testutil::relative_paths;
-use tokio::runtime::Handle;
 
 struct RoundtripResults {
   uncached: Result<FallibleProcessResultWithPlatform, String>,
@@ -21,7 +20,7 @@ struct RoundtripResults {
 }
 
 fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let base_dir = TempDir::new().unwrap();
   let named_cache_dir = base_dir.path().join("named_cache_dir");
   let store_dir = base_dir.path().join("store_dir");
@@ -40,7 +39,7 @@ fn create_cached_runner(
   local: Box<dyn CommandRunnerTrait>,
   store: Store,
 ) -> (Box<dyn CommandRunnerTrait>, TempDir) {
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let cache_dir = TempDir::new().unwrap();
   let max_lmdb_size = 50 * 1024 * 1024; //50 MB - I didn't pick that number but it seems reasonable.
 

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -19,7 +19,6 @@ use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
 use testutil::path::find_bash;
 use testutil::{owned_string_vec, relative_paths};
-use tokio::runtime::Handle;
 
 #[derive(PartialEq, Debug)]
 struct LocalTestResult {
@@ -492,7 +491,7 @@ async fn timeout() {
 #[tokio::test]
 async fn working_directory() {
   let store_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
 
   // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
@@ -550,7 +549,7 @@ async fn run_command_locally_in_dir(
 ) -> Result<LocalTestResult, String> {
   let store_dir = TempDir::new().unwrap();
   let named_cache_dir = TempDir::new().unwrap();
-  let executor = executor.unwrap_or_else(|| task_executor::Executor::new(Handle::current()));
+  let executor = executor.unwrap_or_else(|| task_executor::Executor::new());
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
   let runner = crate::local::CommandRunner::new(

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -7,12 +7,11 @@ use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use store::Store;
 use tempfile::TempDir;
-use tokio::runtime::Handle;
 
 fn mock_nailgun_runner(workdir_base: Option<PathBuf>) -> CommandRunner {
   let store_dir = TempDir::new().unwrap();
   let named_cache_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
   let local_runner = crate::local::CommandRunner::new(
     store,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -21,7 +21,6 @@ use store::Store;
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory, TestTree};
 use testutil::{owned_string_vec, relative_paths};
-use tokio::runtime::Handle;
 use workunit_store::{Level, SpanId, Workunit, WorkunitMetadata, WorkunitState, WorkunitStore};
 
 use crate::remote::{digest, CommandRunner, ExecutionError, OperationOrStatus};
@@ -907,7 +906,7 @@ async fn sends_headers() {
     )
   };
   let cas = mock::StubCAS::empty();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let store_dir = TempDir::new().unwrap();
   let store = Store::with_remote(
     runtime.clone(),
@@ -1071,7 +1070,7 @@ async fn ensure_inline_stdio_is_stored() {
   let workunit_store = WorkunitStore::new(false);
   workunit_store.init_thread_state(None);
 
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
 
   let test_stdout = TestData::roland();
   let test_stderr = TestData::catnip();
@@ -1464,7 +1463,7 @@ async fn execute_missing_file_uploads_if_known() {
   let workunit_store = WorkunitStore::new(false);
   workunit_store.init_thread_state(None);
 
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
 
   let roland = TestData::roland();
 
@@ -1606,7 +1605,7 @@ async fn execute_missing_file_errors_if_unknown() {
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())
     .build();
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let store = Store::with_remote(
     runtime.clone(),
     store_dir,
@@ -2322,7 +2321,7 @@ fn create_command_runner(
   cas: &mock::StubCAS,
   platform: Platform,
 ) -> (CommandRunner, Store) {
-  let runtime = task_executor::Executor::new(Handle::current());
+  let runtime = task_executor::Executor::new();
   let store_dir = TempDir::new().unwrap();
   let store = make_store(store_dir.path(), cas, runtime.clone());
   let command_runner = CommandRunner::new(
@@ -2436,7 +2435,7 @@ async fn extract_output_files_from_response(
     .tree(&TestTree::roland_at_root())
     .tree(&TestTree::robin_at_root())
     .build();
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let store_dir = TempDir::new().unwrap();
   let store = make_store(store_dir.path(), &cas, executor.clone());
   crate::remote::extract_output_files(store, execute_response.get_result(), false)

--- a/src/rust/engine/process_execution/src/speculate_tests.rs
+++ b/src/rust/engine/process_execution/src/speculate_tests.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 use store::Store;
 use tempfile::TempDir;
 use tokio;
-use tokio::runtime::Handle;
 use tokio::time::delay_for;
 
 #[tokio::test]
@@ -121,7 +120,7 @@ async fn run_speculation_test(
   let execute_request = echo_foo_request();
 
   let store_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
   let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
   let msg1: String = "m1".into();
   let msg2: String = "m2".into();

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -41,7 +41,6 @@ use futures::compat::Future01CompatExt;
 use hashing::{Digest, Fingerprint};
 use process_execution::{Context, NamedCaches, Platform, PlatformConstraint, ProcessMetadata};
 use store::{BackoffConfig, Store};
-use tokio::runtime::Handle;
 use workunit_store::WorkunitStore;
 
 /// A binary which takes args of format:
@@ -297,7 +296,7 @@ async fn main() {
     .unwrap_or_default();
   let overall_deadline_secs = value_t!(args.value_of("overall-deadline-secs"), u64).unwrap_or(3600);
 
-  let executor = task_executor::Executor::new(Handle::current());
+  let executor = task_executor::Executor::new();
 
   let store = match (server_arg, args.value_of("cas-server")) {
     (Some(_server), Some(cas_server)) => {

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -56,6 +56,13 @@ impl Executor {
     }
   }
 
+  pub fn new2() -> Executor {
+    Executor {
+      runtime: None,
+      handle: Handle::current(),
+    }
+  }
+
   ///
   /// Creates an Executor with an owned tokio::Runtime.
   ///

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -49,14 +49,8 @@ impl Executor {
   /// existence of a Handle does not prevent a Runtime from shutting down. This is guaranteed by
   /// the scope of the tokio::{test, main} macros.
   ///
-  pub fn new(handle: Handle) -> Executor {
-    Executor {
-      runtime: None,
-      handle,
-    }
-  }
 
-  pub fn new2() -> Executor {
+  pub fn new() -> Executor {
     Executor {
       runtime: None,
       handle: Handle::current(),

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -13,7 +13,6 @@ use notify;
 use parking_lot::Mutex;
 use task_executor::Executor;
 use testutil::{append_to_existing_file, make_file};
-use tokio::runtime::Handle;
 
 fn setup_fs() -> (tempfile::TempDir, PathBuf) {
   // setup a build_root with a file in it to watch.
@@ -32,7 +31,7 @@ async fn setup_watch(
   build_root: PathBuf,
   file_path: PathBuf,
 ) -> Arc<InvalidationWatcher> {
-  let executor = Executor::new(Handle::current());
+  let executor = Executor::new();
   let watcher = InvalidationWatcher::new(executor, build_root, ignorer)
     .expect("Couldn't create InvalidationWatcher");
   watcher.watch(file_path).await.unwrap();


### PR DESCRIPTION
### Problem

Version 0.3 of the `tokio` library no longer has a type called `Handle`, instead unifying the functionality of this type with the `Runtime` type. We currently use the `Handle` type in a bunch of places, particularly tests, where we create our own wrapper around the tokio executor, and we will have to change this in order to upgrade to tokio 0.3.

### Solution

Nearly every call site that invokes the `Executor::new` method passes in `Handle::current`, so this commit modifies that `new` associated function to call `Handle::current` internally, which lets us remove the reference to `Handle` at each call site. This will make it easier to upgrade to tokio 0.3 in the near future.
