### PR TITLE
Remove deprecated `Address.parse()` and `Address.reference()`

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, bytes]:
+def create_python_awslambda(rule_runner: RuleRunner, addr: Address) -> Tuple[str, bytes]:
     rule_runner.set_options(
         [
             "--backend-packages=pants.backend.awslambda.python",
@@ -39,7 +39,7 @@ def create_python_awslambda(rule_runner: RuleRunner, addr: str) -> Tuple[str, by
             "--pants-distdir-legacy-paths=false",
         ]
     )
-    target = rule_runner.get_target(Address.parse(addr))
+    target = rule_runner.get_target(addr)
     created_awslambda = rule_runner.request(
         CreatedAWSLambda, [PythonAwsLambdaFieldSet.create(target)]
     )
@@ -88,7 +88,7 @@ def test_create_hello_world_lambda(rule_runner: RuleRunner) -> None:
     )
 
     zip_file_relpath, content = create_python_awslambda(
-        rule_runner, "src/python/foo/bar:hello_world_lambda"
+        rule_runner, Address("src/python/foo/bar", target_name="hello_world_lambda")
     )
     assert "src.python.foo.bar/hello_world_lambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -21,11 +21,13 @@ from pants.engine.target import InvalidFieldException
 )
 def test_to_interpreter_version(runtime, expected_major, expected_minor):
     assert (expected_major, expected_minor) == PythonAwsLambdaRuntime(
-        raw_value=runtime, address=Address.parse("foo/bar:baz")
+        raw_value=runtime, address=Address("foo/bar", target_name="baz")
     ).to_interpreter_version()
 
 
 @pytest.mark.parametrize(["invalid_runtime"], (["python88.99"], ["fooobar"]))
 def test_runtime_validation(invalid_runtime):
     with pytest.raises(InvalidFieldException):
-        PythonAwsLambdaRuntime(raw_value=invalid_runtime, address=Address.parse("foo/bar:baz"))
+        PythonAwsLambdaRuntime(
+            raw_value=invalid_runtime, address=Address("foo/bar", target_name="baz")
+        )

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -60,7 +60,7 @@ def run_goal(
 
 def test_no_filters_provided() -> None:
     # `filter` behaves like `list` when there are no specified filters.
-    targets = [MockTarget({}, address=Address.parse(addr)) for addr in (":t3", ":t2", ":t1")]
+    targets = [MockTarget({}, address=Address("", target_name=name)) for name in ("t3", "t2", "t1")]
     assert run_goal(targets) == dedent(
         """\
         //:t1
@@ -79,8 +79,10 @@ def test_filter_by_target_type() -> None:
         alias = "smalltalk"
         core_fields = ()
 
-    fortran_targets = [Fortran({}, address=Address.parse(addr)) for addr in (":f1", ":f2")]
-    smalltalk_targets = [Smalltalk({}, address=Address.parse(addr)) for addr in (":s1", ":s2")]
+    fortran_targets = [Fortran({}, address=Address("", target_name=name)) for name in ("f1", "f2")]
+    smalltalk_targets = [
+        Smalltalk({}, address=Address("", target_name=name)) for name in ("s1", "s2")
+    ]
     targets = [*fortran_targets, *smalltalk_targets]
 
     assert run_goal(targets, target_type=["fortran"]).strip() == "//:f1\n//:f2"
@@ -105,8 +107,12 @@ def test_filter_by_target_type() -> None:
 
 def test_filter_by_address_regex() -> None:
     targets = [
-        MockTarget({}, address=Address.parse(addr))
-        for addr in ("dir1:lib", "dir2:lib", "common:tests")
+        MockTarget({}, address=addr)
+        for addr in (
+            Address("dir1", target_name="lib"),
+            Address("dir2", target_name="lib"),
+            Address("common", target_name="tests"),
+        )
     ]
     assert run_goal(targets, address_regex=[r"^dir"]).strip() == "dir1:lib\ndir2:lib"
     assert run_goal(targets, address_regex=[r"+dir1:lib$"]).strip() == "dir1:lib"
@@ -123,10 +129,10 @@ def test_filter_by_address_regex() -> None:
 
 def test_filter_by_tag_regex() -> None:
     targets = [
-        MockTarget({"tags": ["tag1"]}, address=Address.parse(":t1")),
-        MockTarget({"tags": ["tag2"]}, address=Address.parse(":t2")),
-        MockTarget({"tags": ["tag1", "tag2"]}, address=Address.parse(":both")),
-        MockTarget({}, address=Address.parse(":no_tags")),
+        MockTarget({"tags": ["tag1"]}, address=Address("", target_name="t1")),
+        MockTarget({"tags": ["tag2"]}, address=Address("", target_name="t2")),
+        MockTarget({"tags": ["tag1", "tag2"]}, address=Address("", target_name="both")),
+        MockTarget({}, address=Address("", target_name="no_tags")),
     ]
     assert run_goal(targets, tag_regex=[r"t.?g2$"]).strip() == "//:both\n//:t2"
     assert run_goal(targets, tag_regex=["+tag1"]).strip() == "//:both\n//:t1"

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -52,8 +52,10 @@ def run_goal(
 
 def test_list_normal() -> None:
     # Note that these are unsorted.
-    addresses = (":t3", ":t2", ":t1")
-    stdout, _ = run_goal([MockTarget({}, address=Address.parse(addr)) for addr in addresses])
+    target_names = ("t3", "t2", "t1")
+    stdout, _ = run_goal(
+        [MockTarget({}, address=Address("", target_name=name)) for name in target_names]
+    )
     assert stdout == dedent(
         """\
         //:t1
@@ -73,9 +75,9 @@ def test_list_documented() -> None:
         [
             MockTarget(
                 {DescriptionField.alias: "Description of a target.\n\tThis target is the best."},
-                address=Address.parse(":described"),
+                address=Address("", target_name="described"),
             ),
-            MockTarget({}, address=Address.parse(":not_described")),
+            MockTarget({}, address=Address("", target_name="not_described")),
         ],
         show_documented=True,
     )
@@ -91,8 +93,10 @@ def test_list_documented() -> None:
 def test_list_provides() -> None:
     sample_artifact = PythonArtifact(name="project.demo")
     targets = [
-        MockTarget({ProvidesField.alias: sample_artifact}, address=Address.parse(":provided")),
-        MockTarget({}, address=Address.parse(":not_provided")),
+        MockTarget(
+            {ProvidesField.alias: sample_artifact}, address=Address("", target_name="provided")
+        ),
+        MockTarget({}, address=Address("", target_name="not_provided")),
     ]
     stdout, _ = run_goal(targets, show_provides=True)
     assert stdout.strip() == f"//:provided {sample_artifact}"

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -54,8 +54,8 @@ def test_first_party_modules_mapping() -> None:
 
 
 def test_third_party_modules_mapping() -> None:
-    colors_addr = Address.parse("//:ansicolors")
-    pants_addr = Address.parse("//:pantsbuild")
+    colors_addr = Address("", target_name="ansicolors")
+    pants_addr = Address("", target_name="pantsbuild")
     mapping = ThirdPartyModuleToAddressMapping(
         FrozenDict({"colors": colors_addr, "pants": pants_addr})
     )

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -160,7 +160,7 @@ def test_infer_python_inits() -> None:
             [InferInitDependencies(target[PythonSources])],
         )
 
-    assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+    assert run_dep_inference(Address("src/python/root/mid/leaf")) == InferredDependencies(
         [
             Address("src/python/root", relative_file_path="__init__.py", target_name="root"),
             Address("src/python/root/mid", relative_file_path="__init__.py", target_name="mid"),
@@ -200,7 +200,7 @@ def test_infer_python_conftests() -> None:
             [InferConftestDependencies(target[PythonSources])],
         )
 
-    assert run_dep_inference(Address.parse("src/python/root/mid/leaf")) == InferredDependencies(
+    assert run_dep_inference(Address("src/python/root/mid/leaf")) == InferredDependencies(
         [
             Address("src/python/root", relative_file_path="conftest.py", target_name="root"),
             Address("src/python/root/mid", relative_file_path="conftest.py", target_name="mid"),

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -42,7 +42,7 @@ def make_target(
         rule_runner.create_file(source_file.path, source_file.content.decode())
     return PythonLibrary(
         {PythonInterpreterCompatibility.alias: interpreter_constraints},
-        address=Address.parse(":target"),
+        address=Address("", target_name="target"),
     )
 
 

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -30,15 +30,15 @@ def rule_runner() -> RuleRunner:
     )
 
 
-GOOD_SOURCE = FileContent(path="good.py", content=b'"""Good docstring."""\n')
-BAD_SOURCE = FileContent(path="bad.py", content=b'"""Oops, missing a period"""\n')
-FIXED_BAD_SOURCE = FileContent(path="bad.py", content=b'"""Oops, missing a period."""\n')
+GOOD_SOURCE = FileContent("good.py", b'"""Good docstring."""\n')
+BAD_SOURCE = FileContent("bad.py", b'"""Oops, missing a period"""\n')
+FIXED_BAD_SOURCE = FileContent("bad.py", b'"""Oops, missing a period."""\n')
 
 
 def make_target(rule_runner: RuleRunner, source_files: List[FileContent]) -> Target:
     for source_file in source_files:
         rule_runner.create_file(f"{source_file.path}", source_file.content.decode())
-    return PythonLibrary({}, address=Address.parse(":target"))
+    return PythonLibrary({}, address=Address("", target_name="target"))
 
 
 def run_docformatter(

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -26,9 +26,9 @@ def rule_runner() -> RuleRunner:
     )
 
 
-GOOD_SOURCE = FileContent(path="good.py", content=b"print('Nothing suspicious here..')\n")
-BAD_SOURCE = FileContent(path="bad.py", content=b"import typing\n")  # unused import
-PY3_ONLY_SOURCE = FileContent(path="py3.py", content=b"version: str = 'Py3 > Py2'\n")
+GOOD_SOURCE = FileContent("good.py", b"print('Nothing suspicious here..')\n")
+BAD_SOURCE = FileContent("bad.py", b"import typing\n")  # unused import
+PY3_ONLY_SOURCE = FileContent("py3.py", b"version: str = 'Py3 > Py2'\n")
 
 
 def make_target(
@@ -41,7 +41,7 @@ def make_target(
         rule_runner.create_file(source_file.path, source_file.content.decode())
     return PythonLibrary(
         {PythonInterpreterCompatibility.alias: interpreter_constraints},
-        address=Address.parse(":target"),
+        address=Address("", target_name="target"),
     )
 
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -47,7 +47,7 @@ FIXED_NEEDS_CONFIG_SOURCE = FileContent(
 def make_target(rule_runner: RuleRunner, source_files: List[FileContent]) -> Target:
     for source_file in source_files:
         rule_runner.create_file(f"{source_file.path}", source_file.content.decode())
-    return PythonLibrary({}, address=Address.parse(":target"))
+    return PythonLibrary({}, address=Address("", target_name="target"))
 
 
 def run_isort(

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -283,7 +283,7 @@ def test_pep420_namespace_packages(rule_runner: RuleRunner) -> None:
             rule_runner,
             [test_fc],
             package="tests/python/project",
-            dependencies=[Address.parse(f"{PACKAGE}:target")],
+            dependencies=[Address(PACKAGE, target_name="target")],
         ),
     ]
     result = run_pylint(rule_runner, targets)

--- a/src/python/pants/backend/python/lint/python_fmt_integration_test.py
+++ b/src/python/pants/backend/python/lint/python_fmt_integration_test.py
@@ -37,7 +37,9 @@ def run_black_and_isort(
 ) -> LanguageFmtResults:
     for source_file in source_files:
         rule_runner.create_file(source_file.path, source_file.content.decode())
-    targets = PythonFmtTargets(Targets([PythonLibrary({}, address=Address.parse(f"test:{name}"))]))
+    targets = PythonFmtTargets(
+        Targets([PythonLibrary({}, address=Address("test", target_name=name))])
+    )
     rule_runner.set_options(
         [
             "--backend-packages=['pants.backend.python.lint.black', 'pants.backend.python.lint.isort']",

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -32,10 +32,10 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 def test_timeout_validation() -> None:
     with pytest.raises(InvalidFieldException):
-        PythonTestsTimeout(-100, address=Address.parse(":tests"))
+        PythonTestsTimeout(-100, address=Address("", target_name="tests"))
     with pytest.raises(InvalidFieldException):
-        PythonTestsTimeout(0, address=Address.parse(":tests"))
-    assert PythonTestsTimeout(5, address=Address.parse(":tests")).value == 5
+        PythonTestsTimeout(0, address=Address("", target_name="tests"))
+    assert PythonTestsTimeout(5, address=Address("", target_name="tests")).value == 5
 
 
 def test_timeout_calculation() -> None:
@@ -47,7 +47,7 @@ def test_timeout_calculation() -> None:
         global_max: Optional[int] = None,
         timeouts_enabled: bool = True,
     ) -> None:
-        field = PythonTestsTimeout(field_value, address=Address.parse(":tests"))
+        field = PythonTestsTimeout(field_value, address=Address("", target_name="tests"))
         pytest = create_subsystem(
             PyTest,
             timeouts=timeouts_enabled,

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional, Sequence
 
-from pants.base.deprecated import deprecated
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.util.dirutil import fast_relpath, longest_dir_prefix
 from pants.util.strutil import strip_prefix
@@ -215,29 +214,6 @@ class Address(EngineAwareParameter):
     Where `path/to/buildfile:targetname` is the dependent target address.
     """
 
-    @classmethod
-    @deprecated(
-        "2.1.0.dev0",
-        hint_message=(
-            "An Address object should be resolved from an AddressInput using the engine. "
-            "This does not work properly with generated subtargets."
-        ),
-    )
-    def parse(cls, spec: str, relative_to: str = "", subproject_roots=None) -> "Address":
-        """Parses an address from its serialized form.
-
-        NB: This method is oblivious to file Addresses.
-
-        :param spec: An address in string form <path>:<name>.
-        :param relative_to: For sibling specs, ie: ':another_in_same_build_family', interprets
-                            the missing spec_path part as `relative_to`.
-        :param list subproject_roots: Paths that correspond with embedded build roots
-                                      under the current build root.
-        """
-        return AddressInput.parse(
-            spec, relative_to=relative_to, subproject_roots=subproject_roots
-        ).dir_to_address()
-
     def __init__(
         self,
         spec_path: str,
@@ -334,14 +310,6 @@ class Address(EngineAwareParameter):
             target_name = self._target_name or os.path.basename(self.spec_path)
             target_portion = f"{parent_prefix}{target_name}"
         return f"{self.spec_path.replace(os.path.sep, '.')}{file_portion}{target_portion}"
-
-    @deprecated(
-        removal_version="2.1.0.dev0",
-        hint_message="Use the property .spec, which is the same thing.",
-    )
-    def reference(self) -> str:
-        """How to reference this address in a BUILD file."""
-        return self.spec
 
     def maybe_convert_to_base_target(self) -> "Address":
         """If this address is a generated subtarget, convert it back into its original base target.

--- a/src/python/pants/build_graph/address_test.py
+++ b/src/python/pants/build_graph/address_test.py
@@ -236,7 +236,6 @@ def test_address_spec() -> None:
     def assert_spec(address: Address, *, expected: str, expected_path_spec: str) -> None:
         assert address.spec == expected
         assert str(address) == expected
-        assert address.reference() == expected
         assert address.path_safe_spec == expected_path_spec
 
     assert_spec(Address("a/b"), expected="a/b", expected_path_spec="a.b")
@@ -331,22 +330,3 @@ def test_address_spec_to_address_input() -> None:
         Address("a/b/c", relative_file_path="subdir/f.txt", target_name="tgt"),
         expected=AddressInput("a/b/c/subdir/f.txt", "../tgt"),
     )
-
-
-def test_address_parse_method() -> None:
-    def assert_parsed(spec_path: str, target_name: str, address: Address) -> None:
-        assert spec_path == address.spec_path
-        assert target_name == address.target_name
-
-    assert_parsed("a/b", "target", Address.parse("a/b:target"))
-    assert_parsed("a/b", "target", Address.parse("//a/b:target"))
-    assert_parsed("a/b", "b", Address.parse("a/b"))
-    assert_parsed("a/b", "b", Address.parse("//a/b"))
-    assert_parsed("a/b", "target", Address.parse(":target", relative_to="a/b"))
-    assert_parsed("", "target", Address.parse("//:target", relative_to="a/b"))
-    assert_parsed("", "target", Address.parse(":target"))
-    assert_parsed("a/b", "target", Address.parse(":target", relative_to="a/b"))
-
-    # Do not attempt to parse generated subtargets, as we would have no way to find the
-    # generated_base_target_name.
-    assert_parsed("a/b/f.py", "f.py", Address.parse("a/b/f.py"))

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -136,7 +136,7 @@ class FmtTest(TestBase):
     def make_target(
         address: Optional[Address] = None, *, target_cls: Type[Target] = FortranTarget
     ) -> Target:
-        return target_cls({}, address=address or Address.parse(":tests"))
+        return target_cls({}, address=address or Address("", target_name="tests"))
 
     def run_fmt_rule(
         self,
@@ -234,8 +234,11 @@ class FmtTest(TestBase):
             `--per-file-caching`).
         * Correctly distinguish between skipped, changed, and did not change.
         """
-        fortran_addresses = [Address.parse(":f1"), Address.parse(":needs_formatting")]
-        smalltalk_addresses = [Address.parse(":s1"), Address.parse(":s2")]
+        fortran_addresses = [
+            Address("", target_name="f1"),
+            Address("", target_name="needs_formatting"),
+        ]
+        smalltalk_addresses = [Address("", target_name="s1"), Address("", target_name="s2")]
 
         fortran_targets = [
             self.make_target(addr, target_cls=FortranTarget) for addr in fortran_addresses

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -107,7 +107,7 @@ def rule_runner() -> RuleRunner:
 
 
 def make_target(address: Optional[Address] = None) -> Target:
-    return MockTarget({}, address=address or Address.parse(":tests"))
+    return MockTarget({}, address=address or Address("", target_name="tests"))
 
 
 def run_lint_rule(
@@ -189,8 +189,8 @@ def test_summary(rule_runner: RuleRunner) -> None:
     * Merge multiple results belonging to the same linter (`--per-file-caching`).
     * Decide correctly between skipped, failed, and succeeded.
     """
-    good_address = Address.parse(":good")
-    bad_address = Address.parse(":bad")
+    good_address = Address("", target_name="good")
+    bad_address = Address("", target_name="bad")
 
     def assert_expected(*, per_file_caching: bool) -> None:
         exit_code, stderr = run_lint_rule(

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -38,10 +38,10 @@ def create_mock_run_request(rule_runner: RuleRunner, program_text: bytes) -> Run
 
 def single_target_run(
     rule_runner: RuleRunner,
-    *,
+    address: Address,
     console: MockConsole,
+    *,
     program_text: bytes,
-    address_spec: str,
 ) -> Run:
     workspace = Workspace(rule_runner.scheduler)
     interactive_runner = InteractiveRunner(rule_runner.scheduler)
@@ -53,7 +53,6 @@ def single_target_run(
         alias = "binary"
         core_fields = ()
 
-    address = Address.parse(address_spec)
     target = TestBinaryTarget({}, address=address)
     target_with_origin = TargetWithOrigin(
         target, AddressLiteralSpec(address.spec_path, address.target_name)
@@ -91,9 +90,9 @@ def test_normal_run(rule_runner: RuleRunner) -> None:
     program_text = b'#!/usr/bin/python\nprint("hello")'
     res = single_target_run(
         rule_runner,
-        console=console,
+        Address("some/addr"),
+        console,
         program_text=program_text,
-        address_spec="some/addr",
     )
     assert res.exit_code == 0
 
@@ -114,7 +113,5 @@ def test_materialize_input_files(rule_runner: RuleRunner) -> None:
 def test_failed_run(rule_runner: RuleRunner) -> None:
     console = MockConsole(use_colors=False)
     program_text = b'#!/usr/bin/python\nraise RuntimeError("foo")'
-    res = single_target_run(
-        rule_runner, console=console, program_text=program_text, address_spec="some/addr"
-    )
+    res = single_target_run(rule_runner, Address("some/addr"), console, program_text=program_text)
     assert res.exit_code == 1

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -97,7 +97,7 @@ def rule_runner() -> RuleRunner:
 
 def make_target_with_origin(address: Optional[Address] = None) -> TargetWithOrigin:
     if address is None:
-        address = Address.parse(":tests")
+        address = Address("", target_name="tests")
     return TargetWithOrigin(
         MockTarget({}, address=address),
         origin=AddressLiteralSpec(address.spec_path, address.target_name),
@@ -233,8 +233,8 @@ def test_invalid_target_noops(rule_runner: RuleRunner) -> None:
 
 
 def test_summary(rule_runner: RuleRunner) -> None:
-    good_address = Address.parse(":good")
-    bad_address = Address.parse(":bad")
+    good_address = Address("", target_name="good")
+    bad_address = Address("", target_name="bad")
 
     exit_code, stderr = run_test_rule(
         rule_runner,
@@ -262,8 +262,8 @@ def test_debug_target(rule_runner: RuleRunner) -> None:
 
 
 def test_coverage(rule_runner: RuleRunner) -> None:
-    addr1 = Address.parse(":t1")
-    addr2 = Address.parse(":t2")
+    addr1 = Address("", target_name="t1")
+    addr2 = Address("", target_name="t2")
     exit_code, stderr = run_test_rule(
         rule_runner,
         field_set=SuccessfulFieldSet,

--- a/src/python/pants/core/goals/typecheck_test.py
+++ b/src/python/pants/core/goals/typecheck_test.py
@@ -111,7 +111,7 @@ class InvalidRequest(MockTypecheckRequest):
 
 def make_target(address: Optional[Address] = None) -> Target:
     if address is None:
-        address = Address.parse(":tests")
+        address = Address("", target_name="tests")
     return MockTarget({}, address=address)
 
 
@@ -159,8 +159,8 @@ def test_invalid_target_noops() -> None:
 
 
 def test_summary() -> None:
-    good_address = Address.parse(":good")
-    bad_address = Address.parse(":bad")
+    good_address = Address("", target_name="good")
+    bad_address = Address("", target_name="bad")
     exit_code, stderr = run_typecheck_rule(
         request_types=[
             ConditionallySucceedsRequest,

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -49,7 +49,7 @@ def mock_sources_field(
 ) -> SourcesField:
     sources_field = sources_field_cls(
         sources.source_files if include_sources else [],
-        address=Address.parse(f"{sources.source_root}:lib"),
+        address=Address(sources.source_root, target_name="lib"),
     )
     rule_runner.create_files(path=sources.source_root, files=sources.source_files)
     return sources_field

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -107,7 +107,7 @@ def test_prelude_parsing_illegal_import() -> None:
 
 
 def test_strip_address_origin() -> None:
-    addr = Address.parse("//:demo")
+    addr = Address("", target_name="demo")
     result = run_rule_with_mocks(
         strip_address_origins,
         rule_args=[AddressesWithOrigins([AddressWithOrigin(addr, AddressLiteralSpec("", "demo"))])],

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -69,8 +69,8 @@ def test_address_family_create_single() -> None:
     )
     assert "" == address_family.namespace
     assert {
-        Address.parse("//:one"): TargetAdaptor(type_alias="thing", name="one", age=42),
-        Address.parse("//:two"): TargetAdaptor(type_alias="thing", name="two", age=37),
+        Address("", target_name="one"): TargetAdaptor(type_alias="thing", name="one", age=42),
+        Address("", target_name="two"): TargetAdaptor(type_alias="thing", name="two", age=37),
     } == dict(address_family.addresses_to_target_adaptors.items())
 
 
@@ -89,8 +89,12 @@ def test_address_family_create_multiple() -> None:
 
     assert "name/space" == address_family.namespace
     assert {
-        Address.parse("name/space:one"): TargetAdaptor(type_alias="thing", name="one", age=42),
-        Address.parse("name/space:two"): TargetAdaptor(type_alias="thing", name="two", age=37),
+        Address("name/space", target_name="one"): TargetAdaptor(
+            type_alias="thing", name="one", age=42
+        ),
+        Address("name/space", target_name="two"): TargetAdaptor(
+            type_alias="thing", name="two", age=37
+        ),
     } == dict(address_family.addresses_to_target_adaptors.items())
 
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -122,14 +122,16 @@ class FortranTarget(Target):
 
 def test_invalid_fields_rejected() -> None:
     with pytest.raises(InvalidFieldException) as exc:
-        FortranTarget({"invalid_field": True}, address=Address.parse(":lib"))
+        FortranTarget({"invalid_field": True}, address=Address("", target_name="lib"))
     assert "Unrecognized field `invalid_field=True`" in str(exc)
     assert "//:lib" in str(exc)
 
 
 def test_get_field() -> None:
     extensions = ("FortranExt1",)
-    tgt = FortranTarget({FortranExtensions.alias: extensions}, address=Address.parse(":lib"))
+    tgt = FortranTarget(
+        {FortranExtensions.alias: extensions}, address=Address("", target_name="lib")
+    )
 
     assert tgt[FortranExtensions].value == extensions
     assert tgt.get(FortranExtensions).value == extensions
@@ -142,7 +144,7 @@ def test_get_field() -> None:
     # the field is not registered on the target type. To override the default field value, either
     # subclass the Field and create a new target, or, in your call site, interpret the result and
     # and apply your default.
-    default_field_tgt = FortranTarget({}, address=Address.parse(":default"))
+    default_field_tgt = FortranTarget({}, address=Address("", target_name="default"))
     assert default_field_tgt[FortranExtensions].value == ()
     assert default_field_tgt.get(FortranExtensions).value == ()
     assert default_field_tgt.get(FortranExtensions, default_raw_value=["FortranExt2"]).value == ()
@@ -173,7 +175,7 @@ def test_primitive_field_hydration_is_eager() -> None:
     with pytest.raises(InvalidFieldException) as exc:
         FortranTarget(
             {FortranExtensions.alias: ["FortranExt1", "DoesNotStartWithFortran"]},
-            address=Address.parse(":bad_extension"),
+            address=Address("", target_name="bad_extension"),
         )
     assert "DoesNotStartWithFortran" in str(exc)
     assert "//:bad_extension" in str(exc)
@@ -181,7 +183,7 @@ def test_primitive_field_hydration_is_eager() -> None:
 
 def test_has_fields() -> None:
     empty_union_membership = UnionMembership({})
-    tgt = FortranTarget({}, address=Address.parse(":lib"))
+    tgt = FortranTarget({}, address=Address("", target_name="lib"))
 
     assert tgt.field_types == (FortranExtensions, FortranSources)
     assert FortranTarget.class_field_types(union_membership=empty_union_membership) == (
@@ -228,7 +230,7 @@ def test_async_field() -> None:
         *, raw_source_files: List[str], hydrated_source_files: Tuple[str, ...]
     ) -> FortranSourcesResult:
         sources_field = FortranTarget(
-            {FortranSources.alias: raw_source_files}, address=Address.parse(":lib")
+            {FortranSources.alias: raw_source_files}, address=Address("", target_name="lib")
         )[FortranSources]
         result: FortranSourcesResult = run_rule_with_mocks(
             hydrate_fortran_sources,
@@ -254,7 +256,7 @@ def test_async_field() -> None:
 
     # Test that `raw_value` gets sanitized/validated eagerly.
     with pytest.raises(ValueError) as exc:
-        FortranTarget({FortranSources.alias: [0, 1, 2]}, address=Address.parse(":lib"))
+        FortranTarget({FortranSources.alias: [0, 1, 2]}, address=Address("", target_name="lib"))
     assert "Not all elements of the iterable have type" in str(exc)
 
     # Test post-hydration validation.
@@ -274,7 +276,7 @@ def test_add_custom_fields() -> None:
     )
     tgt_values = {CustomField.alias: True}
     tgt = FortranTarget(
-        tgt_values, address=Address.parse(":lib"), union_membership=union_membership
+        tgt_values, address=Address("", target_name="lib"), union_membership=union_membership
     )
 
     assert tgt.field_types == (FortranExtensions, FortranSources, CustomField)
@@ -295,7 +297,7 @@ def test_add_custom_fields() -> None:
     assert tgt[CustomField].value is True
 
     default_tgt = FortranTarget(
-        {}, address=Address.parse(":default"), union_membership=union_membership
+        {}, address=Address("", target_name="default"), union_membership=union_membership
     )
     assert default_tgt[CustomField].value is False
 
@@ -304,7 +306,7 @@ def test_add_custom_fields() -> None:
         alias = "other_target"
         core_fields = ()
 
-    other_tgt = OtherTarget({}, address=Address.parse(":other"))
+    other_tgt = OtherTarget({}, address=Address("", target_name="other"))
     assert other_tgt.plugin_fields == ()
     assert other_tgt.has_field(CustomField) is False
 
@@ -349,7 +351,7 @@ def test_override_preexisting_field_via_new_target() -> None:
         )
 
     custom_tgt = CustomFortranTarget(
-        {FortranExtensions.alias: ["FortranExt1"]}, address=Address.parse(":custom")
+        {FortranExtensions.alias: ["FortranExt1"]}, address=Address("", target_name="custom")
     )
 
     assert custom_tgt.has_field(FortranExtensions) is True
@@ -363,7 +365,7 @@ def test_override_preexisting_field_via_new_target() -> None:
     # Ensure that subclasses not defined on a target are not accepted. This allows us to, for
     # example, filter every target with `PythonSources` (or a subclass) and to ignore targets with
     # only `Sources`.
-    normal_tgt = FortranTarget({}, address=Address.parse(":normal"))
+    normal_tgt = FortranTarget({}, address=Address("", target_name="normal"))
     assert normal_tgt.has_field(FortranExtensions) is True
     assert normal_tgt.has_field(CustomFortranExtensions) is False
 
@@ -375,7 +377,7 @@ def test_override_preexisting_field_via_new_target() -> None:
 
     # Check custom default value
     assert (
-        CustomFortranTarget({}, address=Address.parse(":default"))[FortranExtensions].value
+        CustomFortranTarget({}, address=Address("", target_name="default"))[FortranExtensions].value
         == CustomFortranExtensions.default_extensions
     )
 
@@ -383,7 +385,7 @@ def test_override_preexisting_field_via_new_target() -> None:
     with pytest.raises(InvalidFieldException) as exc:
         CustomFortranTarget(
             {FortranExtensions.alias: CustomFortranExtensions.banned_extensions},
-            address=Address.parse(":invalid"),
+            address=Address("", target_name="invalid"),
         )
     assert str(list(CustomFortranExtensions.banned_extensions)) in str(exc)
     assert "//:invalid" in str(exc)
@@ -407,7 +409,7 @@ def test_required_field() -> None:
         alias = "required_target"
         core_fields = (RequiredPrimitiveField, RequiredAsyncField)
 
-    address = Address.parse(":lib")
+    address = Address("", target_name="lib")
 
     # No errors when all defined
     RequiredTarget({"primitive": "present", "async": 0}, address=address)
@@ -437,7 +439,7 @@ def test_generate_subtarget() -> None:
     # different address.
     single_source_tgt = MockTarget(
         {Sources.alias: ["demo.f95"], Tags.alias: ["demo"]},
-        address=Address.parse("src/fortran:demo"),
+        address=Address("src/fortran", target_name="demo"),
     )
     expected_single_source_address = Address(
         "src/fortran", relative_file_path="demo.f95", target_name="demo"
@@ -453,7 +455,8 @@ def test_generate_subtarget() -> None:
     )
 
     subdir_tgt = MockTarget(
-        {Sources.alias: ["demo.f95", "subdir/demo.f95"]}, address=Address.parse("src/fortran:demo")
+        {Sources.alias: ["demo.f95", "subdir/demo.f95"]},
+        address=Address("src/fortran", target_name="demo"),
     )
     expected_subdir_address = Address(
         "src/fortran", relative_file_path="subdir/demo.f95", target_name="demo"
@@ -515,11 +518,11 @@ def test_field_set() -> None:
 
         unrelated_field: UnrelatedField
 
-    fortran_addr = Address.parse(":fortran")
+    fortran_addr = Address("", target_name="fortran")
     fortran_tgt = FortranTarget({}, address=fortran_addr)
-    unrelated_addr = Address.parse(":unrelated")
+    unrelated_addr = Address("", target_name="unrelated")
     unrelated_tgt = UnrelatedTarget({UnrelatedField.alias: "configured"}, address=unrelated_addr)
-    no_fields_addr = Address.parse(":no_fields")
+    no_fields_addr = Address("", target_name="no_fields")
     no_fields_tgt = NoFieldsTarget({}, address=no_fields_addr)
 
     assert FortranFieldSet.is_applicable(fortran_tgt) is True
@@ -560,7 +563,7 @@ def test_scalar_field() -> None:
         ) -> Optional[CustomObject]:
             return super().compute_value(raw_value, address=address)
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
 
     with pytest.raises(InvalidFieldTypeException) as exc:
         Example(1, address=addr)
@@ -584,7 +587,7 @@ def test_string_field_valid_choices() -> None:
         valid_choices = LeafyGreens
         default = LeafyGreens.KALE.value
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
     assert GivenStrings("spinach", address=addr).value == "spinach"
     assert GivenEnum("spinach", address=addr).value == "spinach"
 
@@ -613,7 +616,7 @@ def test_sequence_field() -> None:
         ) -> Optional[Tuple[CustomObject, ...]]:
             return super().compute_value(raw_value, address=address)
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
 
     def assert_flexible_constructor(raw_value: Iterable[CustomObject]) -> None:
         assert Example(raw_value, address=addr).value == tuple(raw_value)
@@ -636,7 +639,7 @@ def test_string_sequence_field() -> None:
     class Example(StringSequenceField):
         alias = "example"
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
     assert Example(["hello", "world"], address=addr).value == ("hello", "world")
     assert Example(None, address=addr).value is None
     with pytest.raises(InvalidFieldTypeException):
@@ -649,7 +652,7 @@ def test_string_or_string_sequence_field() -> None:
     class Example(StringOrStringSequenceField):
         alias = "example"
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
     assert Example(["hello", "world"], address=addr).value == ("hello", "world")
     assert Example("hello world", address=addr).value == ("hello world",)
     with pytest.raises(InvalidFieldTypeException):
@@ -686,7 +689,7 @@ def test_dict_string_to_string_sequence_field() -> None:
     class Example(DictStringToStringSequenceField):
         alias = "example"
 
-    addr = Address.parse(":example")
+    addr = Address("", target_name="example")
 
     def assert_flexible_constructor(raw_value: Dict[str, Iterable[str]]) -> None:
         assert Example(raw_value, address=addr).value == FrozenDict(


### PR DESCRIPTION
`Address.parse()` is not safe because it cannot accommodate file addresses.

[ci skip-rust]
[ci skip-build-wheels]