### PR TITLE
add lifecycle handlers to allow extensions to hook session lifecycle

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from dataclasses import dataclass, replace
-from typing import Mapping, Optional, Set, Tuple
+from typing import List, Mapping, Optional, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
@@ -56,7 +56,7 @@ class LocalPantsRunner:
     union_membership: UnionMembership
     profile_path: Optional[str]
     _run_tracker: RunTracker
-    _session_lifecycle_handlers: Set[SessionLifecycleHandler]
+    _session_lifecycle_handlers: List[SessionLifecycleHandler]
 
     @classmethod
     def parse_options(
@@ -168,7 +168,9 @@ class LocalPantsRunner:
         # for this session.
         session_lifecycle_handlers = []
         for lifecycle_handler in build_config.lifecycle_handlers:
-            session_lifecycle_handler = lifecycle_handler.on_session_create(options)
+            session_lifecycle_handler = lifecycle_handler.on_session_create(
+                build_root=build_root, options=options, specs=specs
+            )
             if session_lifecycle_handler:
                 session_lifecycle_handlers.append(session_lifecycle_handler)
 
@@ -298,6 +300,6 @@ class LocalPantsRunner:
 
                 # Invoke the session lifecycle handlers, if any.
                 for session_lifecycle_handler in self._session_lifecycle_handlers:
-                    session_lifecycle_handler.on_session_end()
+                    session_lifecycle_handler.on_session_end(engine_result=engine_result)
 
             return self._merge_exit_codes(engine_result, run_tracker_result)

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -166,7 +166,9 @@ class BuildConfiguration:
                 )
             self._target_types.update(target_types)
 
-        def register_lifecycle_handlers(self, handlers: typing.Iterable[ExtensionLifecycleHandler]):
+        def register_lifecycle_handlers(
+            self, handlers: Union[typing.Iterable[ExtensionLifecycleHandler], typing.Any]
+        ):
             if not isinstance(handlers, Iterable):
                 raise TypeError(
                     f"The entrypoint `lifecycle_handlers` must return an iterable. Given {repr(handlers)}"

--- a/src/python/pants/build_graph/lifecycle.py
+++ b/src/python/pants/build_graph/lifecycle.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Optional
+
+from pants.option.options import Options
+
+
+class SessionLifecycleHandler:
+    def on_session_start(self):
+        pass
+
+    def on_session_end(self):
+        pass
+
+
+class ExtensionLifecycleHandler:
+    # Returns a SessionLifecycleHandler that will receive lifecycle events for the session.
+    def on_session_create(self, options: Options) -> Optional[SessionLifecycleHandler]:
+        pass

--- a/src/python/pants/build_graph/lifecycle.py
+++ b/src/python/pants/build_graph/lifecycle.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from typing import Optional
 
+from pants.base.exiter import ExitCode
+from pants.base.specs import Specs
 from pants.option.options import Options
 
 
@@ -9,11 +11,13 @@ class SessionLifecycleHandler:
     def on_session_start(self):
         pass
 
-    def on_session_end(self):
+    def on_session_end(self, *, engine_result: ExitCode):
         pass
 
 
 class ExtensionLifecycleHandler:
     # Returns a SessionLifecycleHandler that will receive lifecycle events for the session.
-    def on_session_create(self, options: Options) -> Optional[SessionLifecycleHandler]:
+    def on_session_create(
+        self, *, build_root: str, options: Options, specs: Specs
+    ) -> Optional[SessionLifecycleHandler]:
         pass

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -5,9 +5,7 @@
 
 These are always activated and cannot be disabled.
 """
-from typing import Optional
 
-from pants.build_graph.lifecycle import ExtensionLifecycleHandler, SessionLifecycleHandler
 from pants.core.goals import binary, fmt, lint, package, repl, run, test, typecheck
 from pants.core.target_types import ArchiveTarget, Files, GenericTarget, RelocatedFiles, Resources
 from pants.core.target_types import rules as target_type_rules
@@ -22,7 +20,6 @@ from pants.core.util_rules import (
     stripped_source_files,
     subprocess_environment,
 )
-from pants.option.options import Options
 from pants.source import source_root
 
 
@@ -54,25 +51,3 @@ def rules():
 
 def target_types():
     return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles]
-
-
-import logging
-logger = logging.getLogger(__name__)
-
-
-class CoreSessionLifecycleHandler(SessionLifecycleHandler):
-    def on_session_start(self):
-        logger.info("on_session_start")
-
-    def on_session_end(self):
-        logger.info("on_session_end")
-
-
-class CoreLifecycleHandler(ExtensionLifecycleHandler):
-    def on_session_create(self, options: Options) -> Optional[SessionLifecycleHandler]:
-        logger.info("on_session_create")
-        return CoreSessionLifecycleHandler()
-
-
-def lifecycle_handlers():
-    return [CoreLifecycleHandler()]

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -5,7 +5,9 @@
 
 These are always activated and cannot be disabled.
 """
+from typing import Optional
 
+from pants.build_graph.lifecycle import ExtensionLifecycleHandler, SessionLifecycleHandler
 from pants.core.goals import binary, fmt, lint, package, repl, run, test, typecheck
 from pants.core.target_types import ArchiveTarget, Files, GenericTarget, RelocatedFiles, Resources
 from pants.core.target_types import rules as target_type_rules
@@ -20,6 +22,7 @@ from pants.core.util_rules import (
     stripped_source_files,
     subprocess_environment,
 )
+from pants.option.options import Options
 from pants.source import source_root
 
 
@@ -51,3 +54,25 @@ def rules():
 
 def target_types():
     return [ArchiveTarget, Files, GenericTarget, Resources, RelocatedFiles]
+
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class CoreSessionLifecycleHandler(SessionLifecycleHandler):
+    def on_session_start(self):
+        logger.info("on_session_start")
+
+    def on_session_end(self):
+        logger.info("on_session_end")
+
+
+class CoreLifecycleHandler(ExtensionLifecycleHandler):
+    def on_session_create(self, options: Options) -> Optional[SessionLifecycleHandler]:
+        logger.info("on_session_create")
+        return CoreSessionLifecycleHandler()
+
+
+def lifecycle_handlers():
+    return [CoreLifecycleHandler()]

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -96,6 +96,9 @@ def load_plugins(
         if "rules" in entries:
             rules = entries["rules"].load()()
             build_configuration.register_rules(rules)
+        if "lifecycle_handlers" in entries:
+            lifecycle_handlers = entries["lifecycle_handlers"].load()()
+            build_configuration.register_lifecycle_handlers(lifecycle_handlers)
         loaded[dist.as_requirement().key] = dist
 
 
@@ -151,3 +154,6 @@ def load_backend(build_configuration: BuildConfiguration.Builder, backend_packag
     rules = invoke_entrypoint("rules")
     if rules:
         build_configuration.register_rules(rules)
+    lifecycle_handlers = invoke_entrypoint("lifecycle_handlers")
+    if lifecycle_handlers:
+        build_configuration.register_lifecycle_handlers(lifecycle_handlers)


### PR DESCRIPTION
### Problem

Extensions have no generic way to hook into the lifecycle of a Pants session.

### Solution

Add a `lifecycle_handlers` entry point to extensions to allow extensions to hook session creation and start/end. This will be used in https://github.com/pantsbuild/pants/pull/10889 to allow the metrics reporting to manage mutable state during the lifetime of each session.

### Result

Added test for life cycle registration.