### PR TITLE
Fix `./pants repl` to use global constrains when no targets specified

### DIFF
--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -16,12 +16,12 @@ class IPython(PythonToolBase):
         super().register_options(register)
         register(
             "--ignore-cwd",
-            type=str,
+            type=bool,
             advanced=True,
             default=True,
             help="Whether to tell IPython not to put the CWD on the import path. "
             "Normally you want this to be True, so that imports come from the hermetic "
-            "environment Pants creates.  However IPython<7.13.0 doesn't support this option, "
+            "environment Pants creates. However IPython<7.13.0 doesn't support this option, "
             "so if you're using an earlier version (e.g., because you have Python 2.7 code) "
             "then you will need to set this to False, and you may have issues with imports "
             "from your CWD shading the hermetic environment.",


### PR DESCRIPTION
As pointed out in https://github.com/pantsbuild/pants/issues/10987, it's reasonable to expect that setting `--python-setup-interpreter-constraints` should influence the interpreter used when running `./pants repl` with no files/targets. Without this, we use empty constraints, and could end up choosing any interpreter, which is a bug.

Result:

```
▶ ./pants --python-setup-interpreter-constraints='["CPython==2.7.*"]' --python-setup-resolve-all-constraints=never repl
13:55:22.01 [INFO] Completed: Building requirements.pex
Python 2.7.16 (default, Jun  5 2020, 22:59:21)
```
This also fixes an invalid type for `--ipython-ignore-cwd`.

[ci skip-rust]
[ci skip-build-wheels]