### PR TITLE
Fix `ResourceWarning` with stdio

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -158,17 +158,14 @@ class PantsDaemon(PantsDaemonProcessManager):
             except OSError:
                 pass
 
-        # Redirect stdio to /dev/null for the rest of the run, to reserve those file descriptors
-        # for further forks.
+        # Redirect stdio to /dev/null for the rest of the run to reserve those file descriptors.
         with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
             # Reinitialize logging for the daemon context.
             global_options = self._bootstrap_options.for_global_scope()
-
             setup_logging(global_options, stderr_logging=False)
 
             log_dir = os.path.join(self._work_dir, self.name)
-            log_level = global_options.level
-            setup_logging_to_file(log_level, log_dir=log_dir, log_filename=self.LOG_NAME)
+            setup_logging_to_file(global_options.level, log_dir=log_dir, log_filename=self.LOG_NAME)
 
             self._logger.debug("Logging reinitialized in pantsd context")
             yield

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -96,6 +96,7 @@ def argv_as(args: Tuple[str, ...]) -> Iterator[None]:
 @contextmanager
 def _stdio_stream_as(src_fd: int, dst_fd: int, dst_sys_attribute: str, mode: str) -> Iterator[None]:
     """Replace the given dst_fd and attribute on `sys` with an open handle to the given src_fd."""
+    src = None
     if src_fd == -1:
         src = open("/dev/null", mode)
         src_fd = src.fileno()
@@ -114,6 +115,8 @@ def _stdio_stream_as(src_fd: int, dst_fd: int, dst_sys_attribute: str, mode: str
         yield
     finally:
         try:
+            if src:
+                src.close()
             if is_atty:
                 termios.tcdrain(dst_fd)
             else:


### PR DESCRIPTION
Before, we would see warnings like:

```
21:19:06.21 [WARN] /data/home/asher/.cache/pants/setup/bootstrap-Linux-x86_64/2.0.0rc1_py38/lib/python3.8/site-packages/pants/util/contextutil.py:147: ResourceWarning: unclosed file <_io.TextIOWrapper $
ame='/dev/null' mode='w' encoding='UTF-8'>
  yield
21:19:06.22 [WARN] /data/home/asher/.pyenv/versions/3.8.5/lib/python3.8/contextlib.py:131: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='r' encoding='UTF-8'>
  self.gen.throw(type, value, traceback)
```

[ci skip-rust]
[ci skip-build-wheels]