### PR TITLE
Add `[python-setup].resolver_http_cache_ttl` option

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -479,7 +479,7 @@ async def create_pex(
         *(f"--index={index}" for index in python_repos.indexes),
         *(f"--repo={repo}" for repo in python_repos.repos),
         "--cache-ttl",
-        python_setup.resolver_http_cache_ttl,
+        str(python_setup.resolver_http_cache_ttl),
         *request.additional_args,
     ]
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -478,6 +478,8 @@ async def create_pex(
         "--no-pypi",
         *(f"--index={index}" for index in python_repos.indexes),
         *(f"--repo={repo}" for repo in python_repos.repos),
+        "--cache-ttl",
+        python_setup.resolver_http_cache_ttl,
         *request.additional_args,
     ]
 

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -120,6 +120,17 @@ class PythonSetup(Subsystem):
                 "high, may result in starvation and Out of Memory errors."
             ),
         )
+        register(
+            "--resolver-http-cache-ttl",
+            type=int,
+            default=3_600,  # This matches PEX's default.
+            advanced=True,
+            help=(
+                "The maximum time (in seconds) for items in the HTTP cache. When the cache expires,"
+                "the PEX resolver will make network requests to see if new versions of your "
+                "requirements are available."
+            ),
+        )
 
     @property
     def interpreter_constraints(self) -> Tuple[str, ...]:
@@ -151,6 +162,10 @@ class PythonSetup(Subsystem):
     @property
     def resolver_jobs(self) -> int:
         return cast(int, self.options.resolver_jobs)
+
+    @property
+    def resolver_http_cache_ttl(self) -> int:
+        return cast(int, self.options.resolver_http_cache_ttl)
 
     @property
     def scratch_dir(self):


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/10994. Even with the PEX bug fix proposed in https://github.com/pantsbuild/pex/issues/1084, users may want to configure this advanced option.

[ci skip-rust]
[ci skip-build-wheels]