### PR TITLE
Increase default `[python-setup].resolver_jobs` to `cpu_count / 2`

### DIFF
--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+import multiprocessing
 import os
 import subprocess
 from enum import Enum
@@ -110,11 +111,11 @@ class PythonSetup(Subsystem):
         register(
             "--resolver-jobs",
             type=int,
-            default=2,
+            default=multiprocessing.cpu_count() // 2,
             advanced=True,
             help=(
                 "The maximum number of concurrent jobs to build wheels with. Because Pants "
-                "can run multiple subprocesses in parallel, the total parallelism will be "
+                "can run multiple subprocesses in parallel, the maximum total parallelism will be "
                 "`--process-execution-{local,remote}-parallelism x --python-setup-resolver-jobs`. "
                 "Setting this option higher may result in better parallelism, but, if set too "
                 "high, may result in starvation and Out of Memory errors."


### PR DESCRIPTION
This option controls the concurrency of each Pex subprocess. 

We had set the default low to 2 because—before we added the single resolve optimization—it was common to build multiple PEXes at the same time. This resulted in exhaustion / an OOM issue for Toolchain, which was tricky to figure out.

Now, the user normally builds no more than 1-3 PEXes at a time, unless running `./pants package ::` or does not use a constraints file so we can't use a single resolve. So, our default is missing out on performance.

PEX's normal default is `cpu_count`. Instead, we use `cpu_count / 2` to try to balance performance vs. safety.

[ci skip-rust]
[ci skip-build-wheels]