### PR TITLE
Rename pex-binary/python-distribution subsystems to avoid naming collisions. (Cherry-pick of #10007)

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -317,10 +317,10 @@ class FirstPartyDependencyVersionScheme(enum.Enum):
     ANY = "any"  # i.e., no specifier
 
 
-class PythonDistributionSubsystem(Subsystem):
-    """Options for packaging wheels/sdists from a `python_distribution` target."""
+class SetupPyGeneration(Subsystem):
+    """Options to control how setup.py is generated from a `python_distribution` target."""
 
-    options_scope = "python-distribution"
+    options_scope = "setup-py-generation"
 
     @classmethod
     def register_options(cls, register):
@@ -757,7 +757,7 @@ async def get_sources(request: SetupPySourcesRequest) -> SetupPySources:
 async def get_requirements(
     dep_owner: DependencyOwner,
     union_membership: UnionMembership,
-    python_distribution_subsystem: PythonDistributionSubsystem,
+    setup_py_generation: SetupPyGeneration,
 ) -> ExportedTargetRequirements:
     transitive_targets = await Get(
         TransitiveTargets, TransitiveTargetsRequest([dep_owner.exported_target.target.address])
@@ -794,7 +794,7 @@ async def get_requirements(
         Get(SetupKwargs, OwnedDependency(tgt)) for tgt in owned_by_others
     )
     req_strs.extend(
-        f"{kwargs.name}{python_distribution_subsystem.first_party_dependency_version(kwargs.version)}"
+        f"{kwargs.name}{setup_py_generation.first_party_dependency_version(kwargs.version)}"
         for kwargs in set(kwargs_for_exported_targets_we_depend_on)
     )
 

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -17,11 +17,11 @@ from pants.backend.python.goals.setup_py import (
     NoOwnerError,
     OwnedDependencies,
     OwnedDependency,
-    PythonDistributionSubsystem,
     SetupKwargs,
     SetupKwargsRequest,
     SetupPyChroot,
     SetupPyChrootRequest,
+    SetupPyGeneration,
     SetupPySources,
     SetupPySourcesRequest,
     declares_pkg_resources_namespace_package,
@@ -95,7 +95,7 @@ def chroot_rule_runner() -> RuleRunner:
             get_exporting_owner,
             *python_sources.rules(),
             setup_kwargs_plugin,
-            SubsystemRule(PythonDistributionSubsystem),
+            SubsystemRule(SetupPyGeneration),
             UnionRule(SetupKwargsRequest, PluginSetupKwargsRequest),
             QueryRule(SetupPyChroot, (SetupPyChrootRequest,)),
         ]
@@ -369,7 +369,7 @@ def test_get_requirements() -> None:
             get_requirements,
             get_owned_dependencies,
             get_exporting_owner,
-            SubsystemRule(PythonDistributionSubsystem),
+            SubsystemRule(SetupPyGeneration),
             QueryRule(ExportedTargetRequirements, (DependencyOwner,)),
         ]
     )
@@ -443,7 +443,7 @@ def test_get_requirements() -> None:
         version_scheme: FirstPartyDependencyVersionScheme = FirstPartyDependencyVersionScheme.EXACT,
     ):
         rule_runner.set_options(
-            [f"--python-distribution-first-party-dependency-version-scheme={version_scheme.value}"]
+            [f"--setup-py-generation-first-party-dependency-version-scheme={version_scheme.value}"]
         )
         tgt = rule_runner.get_target(addr)
         reqs = rule_runner.request(

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -84,7 +84,7 @@ COMMON_PYTHON_FIELDS = (*COMMON_TARGET_FIELDS, PythonInterpreterCompatibility)
 class PexBinaryDefaults(Subsystem):
     """Default settings for creating PEX executables."""
 
-    options_scope = "pex-binary"
+    options_scope = "pex-binary-defaults"
     deprecated_options_scope = "python-binary"
     deprecated_options_scope_removal_version = "2.1.0.dev0"
 


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]