### PR TITLE
Remove more unused code from RunTracker

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -255,7 +255,6 @@ class LocalPantsRunner:
 
             goals = tuple(self.options.goals)
             with streaming_reporter.session():
-                run_tracker.set_v2_goal_rule_names(goals)
                 engine_result = PANTS_FAILED_EXIT_CODE
                 try:
                     engine_result = self._run_v2(goals)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -217,6 +217,7 @@ class LocalPantsRunner:
         run_tracker.set_pantsd_scheduler_metrics(metrics)
         outcome = WorkUnit.SUCCESS if code == PANTS_SUCCEEDED_EXIT_CODE else WorkUnit.FAILURE
         run_tracker.set_root_outcome(outcome)
+        run_tracker.end()
 
     def _print_help(self, request: HelpRequest) -> ExitCode:
         global_options = self.options.for_global_scope()
@@ -261,5 +262,5 @@ class LocalPantsRunner:
                 except Exception as e:
                     ExceptionSink.log_exception(e)
 
-            self._finish_run(run_tracker, engine_result)
+                self._finish_run(run_tracker, engine_result)
             return engine_result

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import ast
 import copy
 import json
 import multiprocessing
@@ -192,20 +191,6 @@ class RunTracker(Subsystem):
         SubprocPool.foreground()
 
         self._aborted = False
-
-        # Data will be organized first by target and then scope.
-        # Eg:
-        # {
-        #   'target/address:name': {
-        #     'running_scope': {
-        #       'run_duration': 356.09
-        #     },
-        #     'GLOBAL': {
-        #       'target_type': 'pants.test'
-        #     }
-        #   }
-        # }
-        self._target_to_data = {}
 
         self._end_memoized_result: Optional[ExitCode] = None
 
@@ -467,9 +452,6 @@ class RunTracker(Subsystem):
     def run_information(self):
         """Basic information about this run."""
         run_information = self.run_info.get_as_dict()
-        target_data = run_information.get("target_data", None)
-        if target_data:
-            run_information["target_data"] = ast.literal_eval(target_data)
         return run_information
 
     def _stats(self) -> dict:
@@ -543,9 +525,6 @@ class RunTracker(Subsystem):
         if self.run_info.get_info("outcome") is None:
             # If the goal is clean-all then the run info dir no longer exists, so ignore that error.
             self.run_info.add_info("outcome", outcome_str, ignore_errors=True)
-
-        if self._target_to_data:
-            self.run_info.add_info("target_data", self._target_to_data)
 
         self.report.close()
         self.store_stats()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -209,9 +209,6 @@ class RunTracker(Subsystem):
 
         self._end_memoized_result: Optional[ExitCode] = None
 
-    def set_v2_goal_rule_names(self, v2_goal_rule_names: Tuple[str, ...]) -> None:
-        self._v2_goal_rule_names = v2_goal_rule_names
-
     @property
     def v2_goals_rule_names(self) -> Tuple[str, ...]:
         return self._v2_goal_rule_names
@@ -271,6 +268,10 @@ class RunTracker(Subsystem):
         # Set the true start time in the case of e.g. the daemon.
         self._main_root_workunit.start(run_start_time)
         self.report.start_workunit(self._main_root_workunit)
+
+
+        goal_names: Tuple[str, ...] = tuple(all_options.goals)
+        self._v2_goal_rule_names = goal_names
 
     def set_root_outcome(self, outcome):
         """Useful for setup code that doesn't have a reference to a workunit."""


### PR DESCRIPTION
There's a lot of code in RunTracker that is no longer used, and this commit removes more of it. Also restores a call to `RunTracker.end()` in local_pants_runner.py, which is still necessary.