### PR TITLE
Upgrade Pex to 2.1.20

### DIFF
--- a/3rdparty/python/constraints.txt
+++ b/3rdparty/python/constraints.txt
@@ -17,7 +17,7 @@ mypy==0.782
 mypy-extensions==0.4.3
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.19
+pex==2.1.20
 pip==18.1
 pluggy==0.13.1
 psutil==5.7.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ mypy==0.782
 
 packaging==20.4
 pathspec==0.8.0
-pex==2.1.19
+pex==2.1.20
 psutil==5.7.0
 pystache==0.5.4
 # This should be kept in sync with `pytest.py`.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -33,7 +33,7 @@ class PexBinary(ExternalTool):
 
     options_scope = "download-pex-bin"
     name = "pex"
-    default_version = "v2.1.19"
+    default_version = "v2.1.20"
 
     @classproperty
     def default_known_versions(cls):
@@ -42,8 +42,8 @@ class PexBinary(ExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "9d3c492c8b5847ce52d806cf188562c5d5acac3e95ae9df65b8fcf451edde296",
-                    "2680733",
+                    "885970ed8dfbbe25abb39eac2b6f1a0feb1f6eefc4d0d5631ac67870f60e9511",
+                    "2681620",
                 )
             )
             for plat in ["darwin", "linux"]


### PR DESCRIPTION
This brings several important improvements to Pants:

* Fixes interpreter selection when `interpreter_search_paths` has only one value.
* Fixes race condition encountered in CI (hopefully).
* Prefers more recent patch versions for interpreter discovery, meaning Pyenv/Homebrew interpreters will typically be used over macOS system Python.
 
[ci skip-rust]
[ci skip-build-wheels]
