### PR TITLE
Fix `setup_py().with_binaries()` to use the default entry point

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -18,6 +18,7 @@ from pants.backend.python.target_types import (
     PythonLibrary,
     PythonRequirementLibrary,
     PythonTests,
+    resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals import binary
@@ -42,6 +43,7 @@ def rule_runner() -> RuleRunner:
             *binary.rules(),
             *package_pex_binary.rules(),
             get_filtered_environment,
+            resolve_pex_entry_point,
             QueryRule(TestResult, (PythonTestFieldSet,)),
             QueryRule(TestDebugRequest, (PythonTestFieldSet,)),
         ],

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -61,8 +61,8 @@ async def create_pex_binary_run_request(
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
             additional_args=field_set.generate_additional_args(pex_binary_defaults),
             internal_only=True,
-            # Note that the entry point file is not in the Pex itself, but only present in the
-            # chroot. This works fine!
+            # Note that the entry point file is not in the PEX itself. It's loaded by setting
+            # `PEX_EXTRA_SYS_PATH`.
             entry_point=entry_point.val,
         ),
     )

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -4,7 +4,11 @@
 import os
 
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
-from pants.backend.python.target_types import PexBinaryDefaults, PexBinarySources
+from pants.backend.python.target_types import (
+    PexBinaryDefaults,
+    ResolvedPexEntryPoint,
+    ResolvePexEntryPointRequest,
+)
 from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
@@ -13,12 +17,10 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
 )
 from pants.core.goals.run import RunFieldSet, RunRequest
-from pants.engine.fs import Digest, MergeDigests, PathGlobs, Paths
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import InvalidFieldException, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
-from pants.option.global_options import FilesNotFoundBehavior
-from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
 
 
@@ -28,26 +30,13 @@ async def create_pex_binary_run_request(
     pex_binary_defaults: PexBinaryDefaults,
     pex_env: PexEnvironment,
 ) -> RunRequest:
-    entry_point = field_set.entry_point.value
-    if entry_point is None:
-        binary_source_paths = await Get(
-            Paths, PathGlobs, field_set.sources.path_globs(FilesNotFoundBehavior.error)
-        )
-        if len(binary_source_paths.files) != 1:
-            raise InvalidFieldException(
-                "No `entry_point` was set for the target "
-                f"{repr(field_set.address)}, so it must have exactly one source, but it has "
-                f"{len(binary_source_paths.files)}"
-            )
-        entry_point_path = binary_source_paths.files[0]
-        source_root = await Get(
-            SourceRoot,
-            SourceRootRequest,
-            SourceRootRequest.for_file(entry_point_path),
-        )
-        entry_point = PexBinarySources.translate_source_file_to_entry_point(
-            os.path.relpath(entry_point_path, source_root.path)
-        )
+    entry_point, transitive_targets = await MultiGet(
+        Get(
+            ResolvedPexEntryPoint,
+            ResolvePexEntryPointRequest(field_set.entry_point, field_set.sources),
+        ),
+        Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
+    )
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address]))
 
     # Note that we get an intermediate PexRequest here (instead of going straight to a Pex)
@@ -72,9 +61,9 @@ async def create_pex_binary_run_request(
             interpreter_constraints=requirements_pex_request.interpreter_constraints,
             additional_args=field_set.generate_additional_args(pex_binary_defaults),
             internal_only=True,
-            # Note that the entry point file is not in the Pex itself, but on the
-            # PEX_PATH. This works fine!
-            entry_point=entry_point,
+            # Note that the entry point file is not in the Pex itself, but only present in the
+            # chroot. This works fine!
+            entry_point=entry_point.val,
         ),
     )
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -709,7 +709,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
     for key, binary_entry_point in zip(key_to_binary_spec.keys(), binary_entry_points):
         entry_points = setup_kwargs["entry_points"] = setup_kwargs.get("entry_points", {})
         console_scripts = entry_points["console_scripts"] = entry_points.get("console_scripts", [])
-        console_scripts.append(f"{key}={binary_entry_point}")
+        console_scripts.append(f"{key}={binary_entry_point.val}")
 
     # Generate the setup script.
     setup_py_content = SETUP_BOILERPLATE.format(

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -686,7 +686,7 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
         }
     )
 
-    # Add `.with_binries()` to the entry points.
+    # Add any `pex_binary` targets from `setup_py().with_binaries()` to the dist's entry points.
     key_to_binary_spec = exported_target.provides.binaries
     binaries = await Get(
         Targets, UnparsedAddressInputs(key_to_binary_spec.values(), owning_address=target.address)

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -40,6 +40,7 @@ from pants.backend.python.target_types import (
     PythonDistribution,
     PythonLibrary,
     PythonRequirementLibrary,
+    resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
 from pants.core.target_types import Files, Resources
@@ -47,7 +48,7 @@ from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import SubsystemRule, rule
-from pants.engine.target import Targets
+from pants.engine.target import InvalidFieldException, Targets
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -95,6 +96,7 @@ def chroot_rule_runner() -> RuleRunner:
             get_exporting_owner,
             *python_sources.rules(),
             setup_kwargs_plugin,
+            resolve_pex_entry_point,
             SubsystemRule(SetupPyGeneration),
             UnionRule(SetupKwargsRequest, PluginSetupKwargsRequest),
             QueryRule(SetupPyChroot, (SetupPyChrootRequest,)),
@@ -254,7 +256,7 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
     assert_chroot_error(
         chroot_rule_runner,
         Address("src/python/invalid_binary", target_name="invalid_bin2"),
-        InvalidEntryPoint,
+        InvalidFieldException,
     )
 
 

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from textwrap import dedent
 
 from pants.backend.python.goals import package_pex_binary
-from pants.backend.python.target_types import PexBinary
+from pants.backend.python.target_types import PexBinary, resolve_pex_entry_point
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
@@ -159,6 +159,7 @@ def test_archive() -> None:
             *target_type_rules(),
             *pex_from_targets.rules(),
             *package_pex_binary.rules(),
+            resolve_pex_entry_point,
             QueryRule(BuiltPackage, [ArchiveFieldSet]),
         ],
         target_types=[ArchiveTarget, Files, RelocatedFiles, PexBinary],


### PR DESCRIPTION
There was no particular reason we required `entry_point` to be set.

[ci skip-rust]
[ci skip-build-wheels]