### PR TITLE
Store per-run logs on RunTracker

### DIFF
--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -136,6 +136,9 @@ class Native(metaclass=SingletonMetaclass):
             level, log_show_rust_3rdparty, use_color, show_target, log_levels_as_ints
         )
 
+    def set_per_run_log_path(self, path: Optional[str]) -> None:
+        self.lib.set_per_run_log_path(path)
+
     def default_cache_path(self) -> str:
         return cast(str, self.lib.default_cache_path())
 

--- a/src/python/pants/engine/internals/native.py
+++ b/src/python/pants/engine/internals/native.py
@@ -137,6 +137,8 @@ class Native(metaclass=SingletonMetaclass):
         )
 
     def set_per_run_log_path(self, path: Optional[str]) -> None:
+        """Instructs the logging code to also write emitted logs to a run-specific log file; or
+        disables writing to any run-specific file if `None` is passed."""
         self.lib.set_per_run_log_path(path)
 
     def default_cache_path(self) -> str:

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -244,7 +244,7 @@ class RunTracker(Subsystem):
         goal_names: Tuple[str, ...] = tuple(all_options.goals)
         self._v2_goal_rule_names = goal_names
 
-        self.run_logs_file = Path(self.run_info_dir, "per-run-logs")
+        self.run_logs_file = Path(self.run_info_dir, "logs")
         self.native.set_per_run_log_path(str(self.run_logs_file))
 
     def set_root_outcome(self, outcome):
@@ -528,10 +528,8 @@ class RunTracker(Subsystem):
         output = []
         try:
             with open(self.run_logs_file, "r") as f:
-                for line in f:
-                    output.append(line)
+                output = f.readlines()
         except OSError as e:
-            logger.warning("Error retrieving per-run logs from RunTracker:")
-            logger.warning(e)
+            logger.warning("Error retrieving per-run logs from RunTracker.", exc_info=e)
 
         return output

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -3,6 +3,7 @@
 
 import copy
 import json
+import logging
 import multiprocessing
 import os
 import sys
@@ -10,7 +11,8 @@ import threading
 import time
 import uuid
 from collections import OrderedDict
-from typing import Any, Dict, Optional, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -19,6 +21,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
+from pants.engine.internals.native import Native
 from pants.goal.aggregated_timings import AggregatedTimings
 from pants.option.config import Config
 from pants.option.options import Options
@@ -28,6 +31,8 @@ from pants.option.subsystem import Subsystem
 from pants.reporting.report import Report
 from pants.util.dirutil import relative_symlink, safe_file_dump
 from pants.version import VERSION
+
+logger = logging.getLogger(__name__)
 
 
 class RunTrackerOptionEncoder(CoercingOptionEncoder):
@@ -172,6 +177,10 @@ class RunTracker(Subsystem):
 
         self._end_memoized_result: Optional[ExitCode] = None
 
+        self.native = Native()
+
+        self.run_logs_file: Optional[Path] = None
+
     @property
     def v2_goals_rule_names(self) -> Tuple[str, ...]:
         return self._v2_goal_rule_names
@@ -234,6 +243,9 @@ class RunTracker(Subsystem):
 
         goal_names: Tuple[str, ...] = tuple(all_options.goals)
         self._v2_goal_rule_names = goal_names
+
+        self.run_logs_file = Path(self.run_info_dir, "per-run-logs")
+        self.native.set_per_run_log_path(str(self.run_logs_file))
 
     def set_root_outcome(self, outcome):
         """Useful for setup code that doesn't have a reference to a workunit."""
@@ -421,6 +433,9 @@ class RunTracker(Subsystem):
         run_failed = outcome in [WorkUnit.FAILURE, WorkUnit.ABORTED]
         result = PANTS_FAILED_EXIT_CODE if run_failed else PANTS_SUCCEEDED_EXIT_CODE
         self._end_memoized_result = result
+
+        self.native.set_per_run_log_path(None)
+
         return self._end_memoized_result
 
     def end_workunit(self, workunit):
@@ -503,3 +518,20 @@ class RunTracker(Subsystem):
             raise ValueError(
                 f"Couldn't find option scope {scope}{option_str} for recording ({e!r})"
             )
+
+    def retrieve_logs(self) -> List[str]:
+        """Get a list of every log entry recorded during this run."""
+
+        if not self.run_logs_file:
+            return []
+
+        output = []
+        try:
+            with open(self.run_logs_file, "r") as f:
+                for line in f:
+                    output.append(line)
+        except OSError as e:
+            logger.warning("Error retrieving per-run logs from RunTracker:")
+            logger.warning(e)
+
+        return output

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -110,6 +110,13 @@ py_module_initializer!(native_engine, |py, m| {
     "write_log",
     py_fn!(py, write_log(a: String, b: u64, c: String)),
   )?;
+
+  m.add(
+    py,
+    "set_per_run_log_path",
+    py_fn!(py, set_per_run_log_path(a: Option<String>)),
+  )?;
+
   m.add(
     py,
     "write_stdout",
@@ -1687,6 +1694,13 @@ fn setup_pantsd_logger(py: Python, log_file: String) -> CPyResult<i64> {
 fn setup_stderr_logger(_: Python) -> PyUnitResult {
   logging::set_thread_destination(Destination::Stderr);
   Ok(None)
+}
+
+fn set_per_run_log_path(py: Python, log_path: Option<String>) -> PyUnitResult {
+  py.allow_threads(|| {
+    PANTS_LOGGER.set_per_run_logs(log_path.map(PathBuf::from));
+    Ok(None)
+  })
 }
 
 fn write_log(py: Python, msg: String, level: u64, path: String) -> PyUnitResult {


### PR DESCRIPTION
### Problem

We would like to enable pants plugins to have programatic access to the logs emitted by pants during a run, so plugins can do useful analysis with those log entries.

### Solution

This PR adds a new method `retrieve_logs(self) -> List[str]` on the `RunTracker` subsystem, which returns a list of each log entry emitted during a given run. RunTracker generates this by creating a text file in the `.pants.d/run-tracker/pants_run_*` directory for a specific run, then passes this file path to the Rust logging system and writes log lines that it would log that per-run file.
