### PR TITLE
Fix `setup_py().with_binaries()` to use the default entry point (Cherry-pick of #11021)

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -18,6 +18,7 @@ from pants.backend.python.target_types import (
     PythonLibrary,
     PythonRequirementLibrary,
     PythonTests,
+    resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals import binary
@@ -42,6 +43,7 @@ def rule_runner() -> RuleRunner:
             *binary.rules(),
             *package_pex_binary.rules(),
             get_filtered_environment,
+            resolve_pex_entry_point,
             QueryRule(TestResult, (PythonTestFieldSet,)),
             QueryRule(TestDebugRequest, (PythonTestFieldSet,)),
         ],

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -15,11 +15,14 @@ from typing import Any, Dict, List, Mapping, Set, Tuple, cast
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.target_types import (
+    PexBinarySources,
     PexEntryPointField,
     PythonInterpreterCompatibility,
     PythonProvidesField,
     PythonRequirementsField,
     PythonSources,
+    ResolvedPexEntryPoint,
+    ResolvePexEntryPointRequest,
     SetupPyCommandsField,
 )
 from pants.backend.python.util_rules.pex import (
@@ -682,19 +685,31 @@ async def generate_chroot(request: SetupPyChrootRequest) -> SetupPyChroot:
             "install_requires": (*requirements, *setup_kwargs.get("install_requires", [])),
         }
     )
+
+    # Add any `pex_binary` targets from `setup_py().with_binaries()` to the dist's entry points.
     key_to_binary_spec = exported_target.provides.binaries
     binaries = await Get(
         Targets, UnparsedAddressInputs(key_to_binary_spec.values(), owning_address=target.address)
     )
-    for key, binary in zip(key_to_binary_spec.keys(), binaries):
-        binary_entry_point = binary.get(PexEntryPointField).value
-        if not binary_entry_point:
+    entry_point_requests = []
+    for binary in binaries:
+        if not binary.has_fields([PexEntryPointField, PexBinarySources]):
             raise InvalidEntryPoint(
-                f"The binary {key} exported by {target.address} is not a valid entry point."
+                "Expected addresses to `pex_binary` targets in `.with_binaries()` for the "
+                f"`provides` field for {exported_target.target.address}, "
+                f"but found {binary.address} with target type {binary.alias}."
             )
+        entry_point_requests.append(
+            ResolvePexEntryPointRequest(binary[PexEntryPointField], binary[PexBinarySources])
+        )
+    binary_entry_points = await MultiGet(
+        Get(ResolvedPexEntryPoint, ResolvePexEntryPointRequest, request)
+        for request in entry_point_requests
+    )
+    for key, binary_entry_point in zip(key_to_binary_spec.keys(), binary_entry_points):
         entry_points = setup_kwargs["entry_points"] = setup_kwargs.get("entry_points", {})
         console_scripts = entry_points["console_scripts"] = entry_points.get("console_scripts", [])
-        console_scripts.append(f"{key}={binary_entry_point}")
+        console_scripts.append(f"{key}={binary_entry_point.val}")
 
     # Generate the setup script.
     setup_py_content = SETUP_BOILERPLATE.format(

--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -40,6 +40,7 @@ from pants.backend.python.target_types import (
     PythonDistribution,
     PythonLibrary,
     PythonRequirementLibrary,
+    resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
 from pants.core.target_types import Files, Resources
@@ -47,7 +48,7 @@ from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import SubsystemRule, rule
-from pants.engine.target import Targets
+from pants.engine.target import InvalidFieldException, Targets
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -95,6 +96,7 @@ def chroot_rule_runner() -> RuleRunner:
             get_exporting_owner,
             *python_sources.rules(),
             setup_kwargs_plugin,
+            resolve_pex_entry_point,
             SubsystemRule(SetupPyGeneration),
             UnionRule(SetupKwargsRequest, PluginSetupKwargsRequest),
             QueryRule(SetupPyChroot, (SetupPyChrootRequest,)),
@@ -250,7 +252,7 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
         chroot_rule_runner, "src/python/invalid_binary:invalid_bin1", InvalidEntryPoint
     )
     assert_chroot_error(
-        chroot_rule_runner, "src/python/invalid_binary:invalid_bin2", InvalidEntryPoint
+        chroot_rule_runner, "src/python/invalid_binary:invalid_bin2", InvalidFieldException
     )
 
 

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from textwrap import dedent
 
 from pants.backend.python.goals import package_pex_binary
-from pants.backend.python.target_types import PexBinary
+from pants.backend.python.target_types import PexBinary, resolve_pex_entry_point
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
@@ -159,6 +159,7 @@ def test_archive() -> None:
             *target_type_rules(),
             *pex_from_targets.rules(),
             *package_pex_binary.rules(),
+            resolve_pex_entry_point,
             QueryRule(BuiltPackage, [ArchiveFieldSet]),
         ],
         target_types=[ArchiveTarget, Files, RelocatedFiles, PexBinary],


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]