### PR TITLE
Add new EngineAware method metadata()

### DIFF
--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -59,7 +59,6 @@ class EngineAwareReturnType(ABC):
 
     def metadata(self) -> Optional[Dict[str, str]]:
         """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
-        workunit.
-        """
+        workunit."""
 
         return None

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pants.engine.fs import Snapshot
 from pants.util.logging import LogLevel
@@ -57,7 +57,7 @@ class EngineAwareReturnType(ABC):
         """
         return None
 
-    def metadata(self) -> Optional[Dict[str, str]]:
+    def metadata(self) -> Optional[Dict[str, Any]]:
         """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
         workunit."""
 

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -56,3 +56,10 @@ class EngineAwareReturnType(ABC):
         `artifacts` is a mapping of arbitrary string keys to `Snapshot`s.
         """
         return None
+
+    def metadata(self) -> Optional[Dict[str, str]]:
+        """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
+        workunit.
+        """
+
+        return None

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3699,6 +3699,7 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time",
+ "cpython",
  "hashing",
  "log 0.4.8",
  "parking_lot",

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -247,6 +247,14 @@ impl Value {
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
   }
+
+  pub fn new_from_arc(handle: Arc<PyObject>) -> Value {
+    Value(handle)
+  }
+
+  pub fn consume_into_arc(self) -> Arc<PyObject> {
+    self.0
+  }
 }
 
 impl PartialEq for Value {

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -43,6 +43,46 @@ impl EngineAwareInformation for Message {
   }
 }
 
+pub struct Metadata {}
+
+impl EngineAwareInformation for Metadata {
+  type MaybeOutput = Vec<(String, Value)>;
+
+  fn retrieve(_types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
+    let metadata_val = match externs::call_method(&value, "metadata", &[]) {
+      Ok(value) => value,
+      Err(py_err) => {
+        let failure = Failure::from_py_err(py_err);
+        log::error!("Error calling `metadata` method: {}", failure);
+        return None;
+      }
+    };
+
+    let metadata_val = externs::check_for_python_none(metadata_val)?;
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let mut output = Vec::new();
+    let metadata_dict: &PyDict = metadata_val.cast_as::<PyDict>(py).ok()?;
+
+    for (key, value) in metadata_dict.items(py).into_iter() {
+      let key_name: String = match key.extract(py) {
+        Ok(s) => s,
+        Err(e) => {
+          log::error!(
+            "Error in EngineAware.metadata() implementation - non-string key: {:?}",
+            e
+          );
+          return None;
+        }
+      };
+
+      output.push((key_name, Value::from(value)));
+    }
+    Some(output)
+  }
+}
+
 pub struct Artifacts {}
 
 impl EngineAwareInformation for Artifacts {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -890,6 +890,19 @@ async fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResul
     ))
   }
 
+  let mut user_metadata_entries = Vec::new();
+  for (user_metadata_key, value_arc) in workunit.metadata.user_metadata.iter() {
+    user_metadata_entries.push((
+      externs::store_utf8(user_metadata_key.as_str()),
+      Value::new_from_arc(value_arc.clone()),
+    ));
+  }
+
+  dict_entries.push((
+    externs::store_utf8("metadata"),
+    externs::store_dict(user_metadata_entries)?,
+  ));
+
   if let Some(stdout_digest) = &workunit.metadata.stdout.as_ref() {
     artifact_entries.push((
       externs::store_utf8("stdout_digest"),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1262,6 +1262,7 @@ impl Node for NodeKey {
       stdout: None,
       stderr: None,
       artifacts: Vec::new(),
+      user_metadata: Vec::new(),
     };
     let metadata2 = metadata.clone();
 
@@ -1340,6 +1341,10 @@ impl Node for NodeKey {
         level,
         message,
         artifacts,
+        user_metadata: user_metadata
+          .into_iter()
+          .map(|(key, val)| (key, val.consume_into_arc()))
+          .collect(),
         ..metadata
       };
       (result, final_metadata)

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -992,6 +992,7 @@ pub struct PythonRuleOutput {
   new_level: Option<log::Level>,
   message: Option<String>,
   new_artifacts: Vec<(String, hashing::Digest)>,
+  new_metadata: Vec<(String, Value)>,
 }
 
 #[async_trait]
@@ -1034,21 +1035,24 @@ impl WrappedNode for Task {
     }
 
     if result_type == product {
-      let (new_level, message, new_artifacts) = if can_modify_workunit {
+      let (new_level, message, new_artifacts, new_metadata) = if can_modify_workunit {
         (
           engine_aware::EngineAwareLevel::retrieve(&context.core.types, &result_val),
           engine_aware::Message::retrieve(&context.core.types, &result_val),
           engine_aware::Artifacts::retrieve(&context.core.types, &result_val)
             .unwrap_or_else(Vec::new),
+          engine_aware::Metadata::retrieve(&context.core.types, &result_val)
+            .unwrap_or_else(Vec::new),
         )
       } else {
-        (None, None, Vec::new())
+        (None, None, Vec::new(), Vec::new())
       };
       Ok(PythonRuleOutput {
         value: result_val,
         new_level,
         message,
         new_artifacts,
+        new_metadata,
       })
     } else {
       Err(throw(&format!(
@@ -1282,6 +1286,8 @@ impl Node for NodeKey {
       let mut level = metadata.level;
       let mut message = None;
       let mut artifacts = Vec::new();
+      let mut user_metadata = Vec::new();
+
       let mut result = match self {
         NodeKey::DigestFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
         NodeKey::DownloadedFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
@@ -1312,6 +1318,7 @@ impl Node for NodeKey {
               }
               message = python_rule_output.message;
               artifacts = python_rule_output.new_artifacts;
+              user_metadata = python_rule_output.new_metadata;
               NodeOutput::Value(python_rule_output.value)
             })
             .await
@@ -1453,6 +1460,7 @@ impl TryFrom<NodeOutput> for PythonRuleOutput {
         new_level: None,
         message: None,
         new_artifacts: Vec::new(),
+        new_metadata: Vec::new(),
       }),
       _ => Err(()),
     }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -13,3 +13,4 @@ rand = "0.6"
 tokio = { version = "0.2.22", features = ["rt-util"] }
 petgraph = "0.4.5"
 log = "0.4"
+cpython = "0.5"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -28,6 +28,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
+use cpython::PyObject;
 use log::log;
 pub use log::Level;
 use parking_lot::Mutex;
@@ -61,7 +62,7 @@ impl std::fmt::Display for SpanId {
 
 type WorkunitGraph = DiGraph<SpanId, (), u32>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Workunit {
   pub name: String,
   pub span_id: SpanId,
@@ -119,7 +120,7 @@ pub enum WorkunitState {
   Completed { time_span: TimeSpan },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub message: Option<String>,
@@ -128,6 +129,7 @@ pub struct WorkunitMetadata {
   pub stdout: Option<hashing::Digest>,
   pub stderr: Option<hashing::Digest>,
   pub artifacts: Vec<(String, hashing::Digest)>,
+  pub user_metadata: Vec<(String, Arc<PyObject>)>,
 }
 
 impl WorkunitMetadata {
@@ -152,6 +154,7 @@ impl Default for WorkunitMetadata {
       stdout: None,
       stderr: None,
       artifacts: Vec::new(),
+      user_metadata: Vec::new(),
     }
   }
 }


### PR DESCRIPTION
This commit introduces a new method that can be defined on `EngineAwareReturnType` called `metadata()`. This method allows rule authors to associate with a workunit a dictionary that maps string keys to arbitrary Python values.