### PR TITLE
Eagerly validate entry points for `setup_py().with_binaries()`

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py_test.py
+++ b/src/python/pants/backend/python/goals/setup_py_test.py
@@ -48,7 +48,7 @@ from pants.engine.addresses import Address
 from pants.engine.fs import Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import SubsystemRule, rule
-from pants.engine.target import InvalidFieldException, Targets
+from pants.engine.target import Targets
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 


### PR DESCRIPTION
Setuptools requires that every entry in `console_scripts` has the form `path.to.module:my_func`, unlike PEX working with `:func` left off. So, our fix in https://github.com/pantsbuild/pants/pull/11021 was bogus.

This reverts trying to automatically set the entry-point, and adds new eager validation. It's possible that an explicit `entry_point` may still be malformed.

[ci skip-rust]
[ci skip-build-wheels]