### PR TITLE
Add information to error message.

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -800,7 +800,7 @@ impl DownloadedFile {
           if new_size > self.size_limit {
             Err(std::io::Error::new(
               std::io::ErrorKind::InvalidData,
-              "Downloaded file was larger than expected digest",
+              format!("Downloaded file size ({}) was larger than expected digest ({}).", new_size, self.size_limit)
             ))
           } else {
             self.written = new_size;


### PR DESCRIPTION
### Problem

When this error occurs, it doesn't show any infomation about the problematic values.

### Solution

Display the values that triggered the error condition as part of the error message