### PR TITLE
Add option removals for most RunTracker options

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -71,6 +71,8 @@ class RunTracker(Subsystem):
             advanced=True,
             type=dict,
             default={},
+            removal_version="2.1.0.dev0",
+            removal_hint="RunTracker no longer directly supports uploading run stats to urls.",
             help="Upload stats to these URLs on run completion.  Value is a map from URL to the "
             "name of the auth provider the user must auth against in order to upload stats "
             "to that URL, or None/empty string if no auth is required.  Currently the "
@@ -80,6 +82,8 @@ class RunTracker(Subsystem):
             "--stats-upload-timeout",
             advanced=True,
             type=int,
+            removal_version="2.1.0.dev0",
+            removal_hint="RunTracker no longer directly supports uploading run stats to urls.",
             default=2,
             help="Wait at most this many seconds for the stats upload to complete.",
         )
@@ -89,12 +93,16 @@ class RunTracker(Subsystem):
             type=int,
             default=1,
             choices=cls.SUPPORTED_STATS_VERSIONS,
+            removal_version="2.1.0.dev0",
+            removal_hint="RunTracker no longer directly supports uploading run stats to urls.",
             help="Format of stats JSON for uploads and local json file.",
         )
         register(
             "--num-foreground-workers",
             advanced=True,
             type=int,
+            removal_version="2.1.0.dev0",
+            removal_hint="RunTracker no longer uses foreground workers.",
             default=multiprocessing.cpu_count(),
             help="Number of threads for foreground work.",
         )
@@ -102,6 +110,8 @@ class RunTracker(Subsystem):
             "--num-background-workers",
             advanced=True,
             type=int,
+            removal_version="2.1.0.dev0",
+            removal_hint="RunTracker no longer uses background workers.",
             default=multiprocessing.cpu_count(),
             help="Number of threads for background work.",
         )


### PR DESCRIPTION
### Problem

RunTracker defines a number of options that relate to old functionality that doesn't make sense in a v2 world. This code should be removed from RunTracker in the near future; in the meantime, it would be good to deprecate the options now ahead of the 2.0.0 final release.

### Solution

Add option removal lines to most of the RunTracker options.