### PR TITLE
Deprecate several unused options

### DIFF
--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -59,7 +59,7 @@ class BasicAuth(Subsystem):
             removal_hint=(
                 "The option `--basicauth-provides` does not do anything and the `[basicauth]` "
                 "subsystem will be removed."
-            )
+            ),
         )
         register(
             "--allow-insecure-urls",
@@ -71,7 +71,7 @@ class BasicAuth(Subsystem):
             removal_hint=(
                 "The option `--basicauth-allow-insecure-urls` does not do anything and the "
                 "`[basicauth]` subsystem will be removed."
-            )
+            ),
         )
 
     @classmethod

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -55,6 +55,11 @@ class BasicAuth(Subsystem):
             help="Map from provider name to config dict. This dict contains the following items: "
             "{provider_name: <url of endpoint that accepts basic auth and sets a session "
             "cookie>}. For example, `{'prod': 'https://app.pantsbuild.org/auth'}`.",
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "The option `--basicauth-provides` does not do anything and the `[basicauth]` "
+                "subsystem will be removed."
+            )
         )
         register(
             "--allow-insecure-urls",
@@ -62,6 +67,11 @@ class BasicAuth(Subsystem):
             type=bool,
             default=False,
             help="Allow auth against non-HTTPS urls. Must only be set when testing!",
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "The option `--basicauth-allow-insecure-urls` does not do anything and the "
+                "`[basicauth]` subsystem will be removed."
+            )
         )
 
     @classmethod

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -24,6 +24,11 @@ class Cookies(Subsystem):
             default=os.path.join(register.bootstrap.pants_bootstrapdir, "auth", "cookies"),
             help="Path to file that stores persistent cookies. "
             "Defaults to <pants bootstrap dir>/auth/cookies.",
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "The option `--cookies-path` does not do anything and the `[cookies]` subsystem "
+                "will be removed."
+            )
         )
 
     def update(self, cookies):

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -28,7 +28,7 @@ class Cookies(Subsystem):
             removal_hint=(
                 "The option `--cookies-path` does not do anything and the `[cookies]` subsystem "
                 "will be removed."
-            )
+            ),
         )
 
     def update(self, cookies):

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -122,7 +122,7 @@ class HelpFormatter(MaybeColor):
             *description_lines,
         ]
         if ohi.deprecated_message:
-            lines.append(self.maybe_red(f"{indent}{ohi.deprecated_message}."))
+            lines.append(self.maybe_red(f"{indent}{ohi.deprecated_message}"))
             if ohi.removal_hint:
                 lines.append(self.maybe_red(f"{indent}{ohi.removal_hint}"))
         return lines

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -451,7 +451,7 @@ class HelpInfoExtracter:
         if removal_version:
             deprecated_tense = deprecated.get_deprecated_tense(removal_version)
             deprecated_message = (
-                f"Deprecated, {deprecated_tense} removed in version: {removal_version}."
+                f"Deprecated, {deprecated_tense} removed in version: {removal_version}"
             )
         removal_hint = kwargs.get("removal_hint")
         choices = self.compute_choices(kwargs)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -286,14 +286,14 @@ class GlobalOptions(Subsystem):
             advanced=True,
             metavar="<dir>",
             default=get_pants_cachedir(),
-            help="Use this dir for global cache.",
+            help="Unused. Will be deprecated in 2.1.0.",
         )
         register(
             "--pants-configdir",
             advanced=True,
             metavar="<dir>",
             default=get_pants_configdir(),
-            help="Use this dir for global config files.",
+            help="Unused. Will be deprecated in 2.1.0.",
         )
         register(
             "--pants-workdir",
@@ -318,14 +318,14 @@ class GlobalOptions(Subsystem):
             advanced=True,
             metavar="<dir>",
             default=os.path.join(buildroot, "build-support"),
-            help="Use support files from this dir.",
+            help="Unused. Will be deprecated in 2.1.0.",
         )
         register(
             "--pants-distdir",
             advanced=True,
             metavar="<dir>",
             default=os.path.join(buildroot, "dist"),
-            help="Write end-product artifacts to this dir.",
+            help="Write end-product artifacts to this dir, like the results of `./pants package`.",
         )
         # TODO: Change the default to false in 2.1, deprecate the option in 2.2 and remove in 2.3.
         register(
@@ -343,7 +343,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             default=os.path.join(buildroot, ".pids"),
             daemon=True,
-            help="The directory to use for tracking subprocess metadata, if any. This should "
+            help="The directory to use for tracking subprocess metadata. This should "
             "live outside of the dir used by `pants_workdir` to allow for tracking "
             "subprocesses that outlive the workdir data.",
         )
@@ -398,7 +398,8 @@ class GlobalOptions(Subsystem):
         register(
             "--spec-files",
             type=list,
-            # NB: See `--pants-config-files`.
+            # NB: We don't fingerprint spec files because the content of the files independently
+            # affects fingerprints.
             fingerprint=False,
             help=(
                 "Read additional specs (target addresses, files, and/or globs), one per line,"
@@ -557,6 +558,8 @@ class GlobalOptions(Subsystem):
             default=None,
             daemon=True,
             help="The directory to log pantsd output to.",
+            removal_version="2.1.0.dev0",
+            removal_hint="The global option `pantsd_log_dir` does not do anything.",
         )
         register(
             "--pantsd-invalidation-globs",
@@ -585,12 +588,6 @@ class GlobalOptions(Subsystem):
             default=os.path.join(get_pants_cachedir(), "lmdb_store"),
         )
         register(
-            "--local-execution-root-dir",
-            advanced=True,
-            help=f"Directory to use for local process execution sandboxing. {cache_instructions}",
-            default=tempfile.gettempdir(),
-        )
-        register(
             "--named-caches-dir",
             advanced=True,
             help=(
@@ -598,6 +595,28 @@ class GlobalOptions(Subsystem):
                 f"concurrency-safe caches. {cache_instructions}"
             ),
             default=os.path.join(get_pants_cachedir(), "named_caches"),
+        )
+
+        register(
+            "--local-execution-root-dir",
+            advanced=True,
+            help=f"Directory to use for local process execution sandboxing. {cache_instructions}",
+            default=tempfile.gettempdir(),
+        )
+        register(
+            "--process-execution-use-local-cache",
+            type=bool,
+            default=True,
+            advanced=True,
+            help="Whether to keep process executions in a local cache persisted to disk.",
+        )
+        register(
+            "--process-execution-cleanup-local-dirs",
+            type=bool,
+            default=True,
+            advanced=True,
+            help="Whether or not to cleanup directories used for local process execution "
+            "(primarily useful for e.g. debugging).",
         )
 
         register(
@@ -624,14 +643,6 @@ class GlobalOptions(Subsystem):
             help="Number of concurrent processes that may be executed remotely.",
         )
         register(
-            "--process-execution-cleanup-local-dirs",
-            type=bool,
-            default=True,
-            advanced=True,
-            help="Whether or not to cleanup directories used for local process execution "
-            "(primarily useful for e.g. debugging).",
-        )
-        register(
             "--process-execution-speculation-delay",
             type=float,
             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation_delay,
@@ -651,13 +662,6 @@ class GlobalOptions(Subsystem):
             "and fall back to the local host if remote calls take longer than the speculation timeout.\n"
             "`none`: Do not speculate about long running processes.",
             advanced=True,
-        )
-        register(
-            "--process-execution-use-local-cache",
-            type=bool,
-            default=True,
-            advanced=True,
-            help="Whether to keep process executions in a local cache persisted to disk.",
         )
         register(
             "--process-execution-local-enable-nailgun",
@@ -906,6 +910,8 @@ class GlobalOptions(Subsystem):
             default=True,
             help="Use a global lock to exclude other versions of Pants from running during "
             "critical operations.",
+            removal_version="2.1.0.dev0",
+            removal_hint="The global option `lock` does not do anything.",
         )
 
         register(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -325,7 +325,7 @@ class GlobalOptions(Subsystem):
             advanced=True,
             metavar="<dir>",
             default=os.path.join(buildroot, "dist"),
-            help="Write end-product artifacts to this dir, like the results of `./pants package`.",
+            help="Write end products, such as the results of `./pants package`, to this dir.",
         )
         # TODO: Change the default to false in 2.1, deprecate the option in 2.2 and remove in 2.3.
         register(

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -20,7 +20,10 @@ class Reporting(Subsystem):
                 advanced=True,
                 help="DEPRECATED: This option is no longer applicable.",
                 removal_version="2.1.0.dev0",
-                removal_hint="This option is no longer applicable.",
+                removal_hint=(
+                    "This option is no longer applicable. The `[reporting]` subsystem will be "
+                    "removed."
+                ),
             )
 
         register_deprecated("--reports-dir")

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -106,6 +106,11 @@ class SourceRootConfig(Subsystem):
             help="Configures the behavior when sources are defined outside of any configured "
             "source root. `create` will cause a source root to be implicitly created at "
             "the definition location of the sources; `fail` will trigger an error.",
+            removal_version="2.1.0.dev0",
+            removal_hint=(
+                "The option `--source-unmatched` does not do anything. Pants will always fail if "
+                "the source root does not exist."
+            )
         )
 
         register(

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -110,7 +110,7 @@ class SourceRootConfig(Subsystem):
             removal_hint=(
                 "The option `--source-unmatched` does not do anything. Pants will always fail if "
                 "the source root does not exist."
-            )
+            ),
         )
 
         register(


### PR DESCRIPTION
We don't deprecate 3 options because they are used as seed values for string interpolation in config files, and it's too risky to deprecate that on the eve of 2.0.0.

[ci skip-rust]
[ci skip-build-wheels]