### PR TITLE
Revert using Ubuntu Bionic in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
     - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -63,7 +63,7 @@ jobs:
       - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - CACHE_NAME=bootstrap.linux.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
@@ -106,7 +106,7 @@ jobs:
     - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -115,7 +115,7 @@ jobs:
       - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - CACHE_NAME=bootstrap.linux.py37
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
@@ -241,7 +241,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
       | tar -zxvf - travis-wait-enhanced
     - mv travis-wait-enhanced /home/travis/bin/
@@ -252,7 +252,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - CACHE_NAME=lint.py36
@@ -291,7 +291,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
       | tar -zxvf - travis-wait-enhanced
     - mv travis-wait-enhanced /home/travis/bin/
@@ -302,7 +302,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - CACHE_NAME=lint.py37
@@ -375,7 +375,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
       | tar -zxvf - travis-wait-enhanced
     - mv travis-wait-enhanced /home/travis/bin/
@@ -386,7 +386,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - CACHE_NAME=python_tests.py36
@@ -425,7 +425,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
       | tar -zxvf - travis-wait-enhanced
     - mv travis-wait-enhanced /home/travis/bin/
@@ -436,7 +436,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - CACHE_NAME=python_tests.py37
@@ -539,7 +539,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     cache:
@@ -547,7 +547,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PREPARE_DEPLOY=1
@@ -793,7 +793,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     cache:
@@ -811,7 +811,7 @@ jobs:
         tags: true
       provider: releases
       skip_cleanup: true
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - RUN_PANTS_FROM_PEX=1
@@ -849,7 +849,7 @@ jobs:
     before_install:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.17 3.6.10 3.7.6 3.8.1
+    - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${AWS_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     cache:
@@ -857,7 +857,7 @@ jobs:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
       timeout: 500
-    dist: bionic
+    dist: xenial
     env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - RUN_PANTS_FROM_PEX=1

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -299,7 +299,7 @@ def linux_shard(
         raise ValueError("Must provide the Python version if using a test config.")
     setup = {
         "os": "linux",
-        "dist": "bionic",
+        "dist": "xenial",
         "python": ["2.7", "3.6", "3.7"],
         "addons": {
             "apt": {
@@ -319,7 +319,9 @@ def linux_shard(
         },
         "language": "python",
         "before_install": _linux_before_install(
-            include_test_config=load_test_config, install_travis_wait=install_travis_wait
+            include_test_config=load_test_config,
+            install_travis_wait=install_travis_wait,
+            xenial=True,
         ),
         "after_failure": ["./build-support/bin/ci-failure.sh"],
         "stage": python_version.default_stage().value,


### PR DESCRIPTION
The Build Wheels shard is flaky when building `fs_util` due to a linker error: https://travis-ci.com/github/pantsbuild/pants/jobs/407077261#L4843

Until we have time to fix this properly, we should revert the cause of the error.