### PR TITLE
remote caching: upload stdout/stderr content to remote cache

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -256,6 +256,12 @@ impl CommandRunner {
       .ok_or_else(|| format!("File {:?} did not exist locally.", file_path))
   }
 
+  /// Converts a REAPI `Command` and a `FallibleProcessResultWithPlatform` produced from executing
+  /// that Command into a REAPI `ActionResult` suitable for upload to the REAPI Action Cache.
+  ///
+  /// This function also returns a vector of all `Digest`s referenced directly and indirectly by
+  /// the `ActionResult` suitable for passing to `Store::ensure_remote_has_recursive`. (The
+  /// digests may include both File and Tree digests.)
   pub(crate) async fn make_action_result(
     &self,
     command: &Command,


### PR DESCRIPTION
[ci skip-build-wheels]

### Problem

With remote caching enabled, stdout and stderr outputs were not uploaded to the remote cache.

### Solution

Teach `make_action_result` to include the digests for stdout and stderr content in the list of digests to upload.

`make_action_result` now returns that list of digests so it can be verified in a unit test.

### Result

Added unit test.
