### PR TITLE
Do not error if `./pants package` does not match any targets

### DIFF
--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -101,9 +101,12 @@ async def package_asset(workspace: Workspace, dist_dir: DistDir) -> Package:
         TargetRootsToFieldSetsRequest(
             PackageFieldSet,
             goal_description="the `package` goal",
-            error_if_no_applicable_targets=True,
+            error_if_no_applicable_targets=False,
         ),
     )
+    if not target_roots_to_field_sets.field_sets:
+        return Package(exit_code=0)
+
     packages = await MultiGet(
         Get(BuiltPackage, PackageFieldSet, field_set)
         for field_set in target_roots_to_field_sets.field_sets


### PR DESCRIPTION
A user pointed out that it's useful to run `./pants --changed-since=foo package`, which would error if no relevant targets are returned.

We were only erroring as a convenience to users to help them realize if things were not behaving how they want. But, that's not necessary; it's pretty obvious with our logging when we are building a package.

Now, we only error on unmatched globs for `./pants run`, which makes sense because it can only run on one target.

[ci skip-rust]
[ci skip-build-wheels]
