### PR TITLE
Restore EngineAware metadata() method with non-cpython-reliant data structures

### DIFF
--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pants.engine.fs import Snapshot
 from pants.util.logging import LogLevel
@@ -55,4 +55,10 @@ class EngineAwareReturnType(ABC):
 
         `artifacts` is a mapping of arbitrary string keys to `Snapshot`s.
         """
+        return None
+
+    def metadata(self) -> Optional[Dict[str, Any]]:
+        """If implemented, adds arbitrary key-value pairs to the `metadata` entry of the `@rule`
+        workunit."""
+
         return None

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3699,13 +3699,13 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time",
- "cpython",
  "hashing",
  "log 0.4.8",
  "parking_lot",
  "petgraph",
  "rand 0.6.5",
  "tokio",
+ "uuid 0.7.4",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3699,6 +3699,7 @@ name = "workunit_store"
 version = "0.0.1"
 dependencies = [
  "concrete_time",
+ "cpython",
  "hashing",
  "log 0.4.8",
  "parking_lot",

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -247,14 +247,6 @@ impl Value {
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
   }
-
-  pub fn new_from_arc(handle: Arc<PyObject>) -> Value {
-    Value(handle)
-  }
-
-  pub fn consume_into_arc(self) -> Arc<PyObject> {
-    self.0
-  }
 }
 
 impl PartialEq for Value {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -247,6 +247,14 @@ impl Value {
       Err(arc_handle) => arc_handle.clone_ref(py),
     }
   }
+
+  pub fn new_from_arc(handle: Arc<PyObject>) -> Value {
+    Value(handle)
+  }
+
+  pub fn consume_into_arc(self) -> Arc<PyObject> {
+    self.0
+  }
 }
 
 impl PartialEq for Value {

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -43,7 +43,7 @@ impl EngineAwareInformation for Message {
   }
 }
 
-pub struct Metadata {}
+pub struct Metadata;
 
 impl EngineAwareInformation for Metadata {
   type MaybeOutput = Vec<(String, Value)>;

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -43,6 +43,46 @@ impl EngineAwareInformation for Message {
   }
 }
 
+pub struct Metadata {}
+
+impl EngineAwareInformation for Metadata {
+  type MaybeOutput = Vec<(String, Value)>;
+
+  fn retrieve(_types: &Types, value: &Value) -> Option<Self::MaybeOutput> {
+    let metadata_val = match externs::call_method(&value, "metadata", &[]) {
+      Ok(value) => value,
+      Err(py_err) => {
+        let failure = Failure::from_py_err(py_err);
+        log::error!("Error calling `metadata` method: {}", failure);
+        return None;
+      }
+    };
+
+    let metadata_val = externs::check_for_python_none(metadata_val)?;
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let mut output = Vec::new();
+    let metadata_dict: &PyDict = metadata_val.cast_as::<PyDict>(py).ok()?;
+
+    for (key, value) in metadata_dict.items(py).into_iter() {
+      let key_name: String = match key.extract(py) {
+        Ok(s) => s,
+        Err(e) => {
+          log::error!(
+            "Error in EngineAware.metadata() implementation - non-string key: {:?}",
+            e
+          );
+          return None;
+        }
+      };
+
+      output.push((key_name, Value::from(value)));
+    }
+    Some(output)
+  }
+}
+
 pub struct Artifacts {}
 
 impl EngineAwareInformation for Artifacts {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -800,7 +800,11 @@ fn scheduler_create(
   )
 }
 
-async fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResult<Value> {
+async fn workunit_to_py_value(
+  workunit: &Workunit,
+  core: &Arc<Core>,
+  session: &Session,
+) -> CPyResult<Value> {
   use std::time::UNIX_EPOCH;
 
   let mut dict_entries = vec![
@@ -891,11 +895,16 @@ async fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResul
   }
 
   let mut user_metadata_entries = Vec::new();
-  for (user_metadata_key, value_arc) in workunit.metadata.user_metadata.iter() {
-    user_metadata_entries.push((
-      externs::store_utf8(user_metadata_key.as_str()),
-      Value::new_from_arc(value_arc.clone()),
-    ));
+  for (user_metadata_key, user_metadata_item) in workunit.metadata.user_metadata.iter() {
+    match session.with_metadata_map(|map| map.get(user_metadata_item).cloned()) {
+      None => log::warn!(
+        "Workunit metadata() value not found for key: {}",
+        user_metadata_key
+      ),
+      Some(v) => {
+        user_metadata_entries.push((externs::store_utf8(user_metadata_key.as_str()), v));
+      }
+    }
   }
 
   dict_entries.push((
@@ -928,10 +937,11 @@ async fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResul
 async fn workunits_to_py_tuple_value<'a>(
   workunits: impl Iterator<Item = &'a Workunit>,
   core: &Arc<Core>,
+  session: &Session,
 ) -> CPyResult<Value> {
   let mut workunit_values = Vec::new();
   for workunit in workunits {
-    let py_value = workunit_to_py_value(workunit, core).await?;
+    let py_value = workunit_to_py_value(workunit, core, session).await?;
     workunit_values.push(py_value);
   }
   Ok(externs::store_tuple(workunit_values))
@@ -957,12 +967,14 @@ fn poll_session_workunits(
             let started = core.executor.block_on(workunits_to_py_tuple_value(
               &mut started_iter,
               &scheduler.core,
+              &session,
             ))?;
 
             let mut completed_iter = completed.iter();
             let completed = core.executor.block_on(workunits_to_py_tuple_value(
               &mut completed_iter,
               &scheduler.core,
+              &session,
             ))?;
 
             Ok(externs::store_tuple(vec![started, completed]).into())

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -890,6 +890,19 @@ async fn workunit_to_py_value(workunit: &Workunit, core: &Arc<Core>) -> CPyResul
     ))
   }
 
+  let mut user_metadata_entries = Vec::new();
+  for (user_metadata_key, value_arc) in workunit.metadata.user_metadata.iter() {
+    user_metadata_entries.push((
+      externs::store_utf8(user_metadata_key.as_str()),
+      Value::new_from_arc(value_arc.clone()),
+    ));
+  }
+
+  dict_entries.push((
+    externs::store_utf8("metadata"),
+    externs::store_dict(user_metadata_entries)?,
+  ));
+
   if let Some(stdout_digest) = &workunit.metadata.stdout.as_ref() {
     artifact_entries.push((
       externs::store_utf8("stdout_digest"),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -992,6 +992,7 @@ pub struct PythonRuleOutput {
   new_level: Option<log::Level>,
   message: Option<String>,
   new_artifacts: Vec<(String, hashing::Digest)>,
+  new_metadata: Vec<(String, Value)>,
 }
 
 #[async_trait]
@@ -1034,21 +1035,24 @@ impl WrappedNode for Task {
     }
 
     if result_type == product {
-      let (new_level, message, new_artifacts) = if can_modify_workunit {
+      let (new_level, message, new_artifacts, new_metadata) = if can_modify_workunit {
         (
           engine_aware::EngineAwareLevel::retrieve(&context.core.types, &result_val),
           engine_aware::Message::retrieve(&context.core.types, &result_val),
           engine_aware::Artifacts::retrieve(&context.core.types, &result_val)
             .unwrap_or_else(Vec::new),
+          engine_aware::Metadata::retrieve(&context.core.types, &result_val)
+            .unwrap_or_else(Vec::new),
         )
       } else {
-        (None, None, Vec::new())
+        (None, None, Vec::new(), Vec::new())
       };
       Ok(PythonRuleOutput {
         value: result_val,
         new_level,
         message,
         new_artifacts,
+        new_metadata,
       })
     } else {
       Err(throw(&format!(
@@ -1258,6 +1262,7 @@ impl Node for NodeKey {
       stdout: None,
       stderr: None,
       artifacts: Vec::new(),
+      user_metadata: Vec::new(),
     };
     let metadata2 = metadata.clone();
 
@@ -1282,6 +1287,8 @@ impl Node for NodeKey {
       let mut level = metadata.level;
       let mut message = None;
       let mut artifacts = Vec::new();
+      let mut user_metadata = Vec::new();
+
       let mut result = match self {
         NodeKey::DigestFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
         NodeKey::DownloadedFile(n) => n.run_wrapped_node(context).map_ok(NodeOutput::Digest).await,
@@ -1312,6 +1319,7 @@ impl Node for NodeKey {
               }
               message = python_rule_output.message;
               artifacts = python_rule_output.new_artifacts;
+              user_metadata = python_rule_output.new_metadata;
               NodeOutput::Value(python_rule_output.value)
             })
             .await
@@ -1333,6 +1341,10 @@ impl Node for NodeKey {
         level,
         message,
         artifacts,
+        user_metadata: user_metadata
+          .into_iter()
+          .map(|(key, val)| (key, val.consume_into_arc()))
+          .collect(),
         ..metadata
       };
       (result, final_metadata)
@@ -1453,6 +1465,7 @@ impl TryFrom<NodeOutput> for PythonRuleOutput {
         new_level: None,
         message: None,
         new_artifacts: Vec::new(),
+        new_metadata: Vec::new(),
       }),
       _ => Err(()),
     }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -13,3 +13,4 @@ rand = "0.6"
 tokio = { version = "0.2.22", features = ["rt-util"] }
 petgraph = "0.4.5"
 log = "0.4"
+cpython = "0.5"

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -13,4 +13,4 @@ rand = "0.6"
 tokio = { version = "0.2.22", features = ["rt-util"] }
 petgraph = "0.4.5"
 log = "0.4"
-cpython = "0.5"
+uuid = { version = "0.7", features = ["v4"] }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -28,7 +28,6 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
-use cpython::PyObject;
 use log::log;
 pub use log::Level;
 use parking_lot::Mutex;
@@ -129,7 +128,7 @@ pub struct WorkunitMetadata {
   pub stdout: Option<hashing::Digest>,
   pub stderr: Option<hashing::Digest>,
   pub artifacts: Vec<(String, hashing::Digest)>,
-  pub user_metadata: Vec<(String, Arc<PyObject>)>,
+  pub user_metadata: Vec<(String, UserMetadataItem)>,
 }
 
 impl WorkunitMetadata {
@@ -150,6 +149,16 @@ impl WorkunitMetadata {
     let mut metadata = WorkunitMetadata::new();
     metadata.level = level;
     metadata
+  }
+}
+
+/// Abstract id for passing user metadata items around
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct UserMetadataItem(uuid::Uuid);
+
+impl UserMetadataItem {
+  pub fn new() -> UserMetadataItem {
+    UserMetadataItem(uuid::Uuid::new_v4())
   }
 }
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -134,19 +134,7 @@ pub struct WorkunitMetadata {
 
 impl WorkunitMetadata {
   pub fn new() -> Self {
-    WorkunitMetadata::default()
-  }
-
-  pub fn with_level(level: Level) -> Self {
-    let mut metadata = WorkunitMetadata::default();
-    metadata.level = level;
-    metadata
-  }
-}
-
-impl Default for WorkunitMetadata {
-  fn default() -> Self {
-    Self {
+    WorkunitMetadata {
       level: Level::Info,
       desc: None,
       message: None,
@@ -156,6 +144,12 @@ impl Default for WorkunitMetadata {
       artifacts: Vec::new(),
       user_metadata: Vec::new(),
     }
+  }
+
+  pub fn with_level(level: Level) -> Self {
+    let mut metadata = WorkunitMetadata::new();
+    metadata.level = level;
+    metadata
   }
 }
 

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -28,6 +28,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use concrete_time::TimeSpan;
+use cpython::PyObject;
 use log::log;
 pub use log::Level;
 use parking_lot::Mutex;
@@ -61,7 +62,7 @@ impl std::fmt::Display for SpanId {
 
 type WorkunitGraph = DiGraph<SpanId, (), u32>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Workunit {
   pub name: String,
   pub span_id: SpanId,
@@ -119,7 +120,7 @@ pub enum WorkunitState {
   Completed { time_span: TimeSpan },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub message: Option<String>,
@@ -128,6 +129,7 @@ pub struct WorkunitMetadata {
   pub stdout: Option<hashing::Digest>,
   pub stderr: Option<hashing::Digest>,
   pub artifacts: Vec<(String, hashing::Digest)>,
+  pub user_metadata: Vec<(String, Arc<PyObject>)>,
 }
 
 impl WorkunitMetadata {
@@ -152,6 +154,7 @@ impl Default for WorkunitMetadata {
       stdout: None,
       stderr: None,
       artifacts: Vec::new(),
+      user_metadata: Vec::new(),
     }
   }
 }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for SpanId {
 
 type WorkunitGraph = DiGraph<SpanId, (), u32>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Workunit {
   pub name: String,
   pub span_id: SpanId,
@@ -120,7 +120,7 @@ pub enum WorkunitState {
   Completed { time_span: TimeSpan },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct WorkunitMetadata {
   pub desc: Option<String>,
   pub message: Option<String>,


### PR DESCRIPTION
### Problem

It was necessary to revert https://github.com/pantsbuild/pants/pull/11047 , which added a new EngineAware method `metadata()`, since this introduced a dependency on the `cpython` for the `workunit_store` crate, which caused problems in CI.

### Solution

This PR un-reverts the original commit, and modifies the data structures involved so that the `workunit_store` no longer needs to depend on `cpython`. Instead of `WorkunitMetadata` needing to store a (cpython-provided) `PyObject` object, it stores a bespoke `UserMetadataItem` data structure, which simply wraps a UUID. This type is now carried around on `WorkunitMetadata`, and indexes into a per-`Session` hash map storing a map from `UserMetadataItem` to `Value`, which we use when we create Python objects from Workunits. This way, only the engine crate needs to be aware of `cpython` types. 

Additionally, the `PartialEq`, `Eq`, and `Default` implementations for some of the workunit-related types proved no longer necessary, and were removed.