### PR TITLE
Various Python cleanup refactors 

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -131,7 +131,7 @@ class DaemonPantsRunner(RawFdRunner):
         # of a local run: once we allow for concurrent runs, this information should be
         # propagated down from the caller.
         #   see https://github.com/pantsbuild/pants/issues/7654
-        clean_global_runtime_state(reset_subsystem=True)
+        clean_global_runtime_state()
         options_bootstrapper = OptionsBootstrapper.create(
             env=os.environ, args=sys.argv, allow_pantsrc=True
         )

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -58,19 +58,6 @@ class LocalPantsRunner:
     profile_path: Optional[str]
 
     @classmethod
-    def parse_options(
-        cls,
-        options_bootstrapper: OptionsBootstrapper,
-    ) -> Tuple[Options, BuildConfiguration]:
-        build_config = BuildConfigInitializer.get(options_bootstrapper)
-        try:
-            options = OptionsInitializer.create(options_bootstrapper, build_config)
-        except UnknownFlagsError as err:
-            cls._handle_unknown_flags(err, options_bootstrapper)
-            raise
-        return options, build_config
-
-    @classmethod
     def _init_graph_session(
         cls,
         options_bootstrapper: OptionsBootstrapper,
@@ -131,7 +118,13 @@ class LocalPantsRunner:
         """
         build_root = get_buildroot()
         global_bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
-        options, build_config = cls.parse_options(options_bootstrapper)
+
+        build_config = BuildConfigInitializer.get(options_bootstrapper)
+        try:
+            options = OptionsInitializer.create(options_bootstrapper, build_config)
+        except UnknownFlagsError as err:
+            cls._handle_unknown_flags(err, options_bootstrapper)
+            raise
 
         union_membership = UnionMembership.from_rules(build_config.union_rules)
 

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import cast
 
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
@@ -34,11 +33,8 @@ class _Options:
 
     @memoized_property
     def options(self) -> Options:
-        return cast(
-            Options,
-            OptionsInitializer.create(
-                self.options_bootstrapper, self.build_config, init_subsystems=False
-            ),
+        return OptionsInitializer.create(
+            self.options_bootstrapper, self.build_config, init_subsystems=False
         )
 
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -28,7 +28,7 @@ from pants.engine.rules import QueryRule, collect_rules, rule
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
 from pants.init import specs_calculator
-from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, ExecutionOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
@@ -208,9 +208,6 @@ class EngineInitializer:
     ) -> GraphScheduler:
         build_root = build_root or get_buildroot()
 
-        build_configuration = build_configuration or BuildConfigInitializer.get(
-            options_bootstrapper
-        )
         rules = build_configuration.rules
         union_membership = UnionMembership.from_rules(build_configuration.union_rules)
         registered_target_types = RegisteredTargetTypes.create(build_configuration.target_types)

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -134,7 +134,7 @@ class OptionsInitializer:
             )
         )
 
-        return tuple(x for x in invalidation_globs)
+        return tuple(invalidation_globs)
 
     @classmethod
     def create(

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -33,7 +33,7 @@ class BuildConfigInitializer:
     _cached_build_config: Optional[BuildConfiguration] = None
 
     @classmethod
-    def get(cls, options_bootstrapper):
+    def get(cls, options_bootstrapper: OptionsBootstrapper) -> BuildConfiguration:
         if cls._cached_build_config is None:
             cls._cached_build_config = cls(options_bootstrapper).setup()
         return cls._cached_build_config
@@ -43,11 +43,12 @@ class BuildConfigInitializer:
         cls._cached_build_config = None
 
     def __init__(self, options_bootstrapper: OptionsBootstrapper) -> None:
-        self._options_bootstrapper = options_bootstrapper
         self._bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
-        self._working_set = PluginResolver(self._options_bootstrapper).resolve()
+        self._working_set = PluginResolver(options_bootstrapper).resolve()
 
-    def _load_plugins(self) -> BuildConfiguration:
+    def setup(self) -> BuildConfiguration:
+        """Loads backends and plugins."""
+
         # Add any extra paths to python path (e.g., for loading extra source backends).
         for path in self._bootstrap_options.pythonpath:
             if path not in sys.path:
@@ -60,13 +61,6 @@ class BuildConfigInitializer:
             self._working_set,
             self._bootstrap_options.backend_packages,
         )
-
-    def setup(self) -> BuildConfiguration:
-        """Load backends and plugins.
-
-        :returns: A `BuildConfiguration` object constructed during backend/plugin loading.
-        """
-        return self._load_plugins()
 
 
 class OptionsInitializer:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -101,7 +101,7 @@ class OptionsInitializer:
         Combines --pythonpath and --pants-config-files files that are in {buildroot} dir with those
         invalidation_globs provided by users.
         """
-        invalidation_globs: OrderedSet = OrderedSet()
+        invalidation_globs: OrderedSet[str] = OrderedSet()
 
         # Globs calculated from the sys.path and other file-like configuration need to be sanitized
         # to relative globs (where possible).

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import pkg_resources
 
@@ -14,6 +14,7 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.init.extension_loader import load_backends_and_plugins
 from pants.init.plugin_resolver import PluginResolver
 from pants.option.global_options import GlobalOptions
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.subsystem import Subsystem
@@ -92,13 +93,15 @@ class OptionsInitializer:
         return pants_ignore
 
     @staticmethod
-    def compute_pantsd_invalidation_globs(buildroot, bootstrap_options):
+    def compute_pantsd_invalidation_globs(
+        buildroot: str, bootstrap_options: OptionValueContainer
+    ) -> Tuple[str, ...]:
         """Computes the merged value of the `--pantsd-invalidation-globs` option.
 
         Combines --pythonpath and --pants-config-files files that are in {buildroot} dir with those
         invalidation_globs provided by users.
         """
-        invalidation_globs = OrderedSet()
+        invalidation_globs: OrderedSet = OrderedSet()
 
         # Globs calculated from the sys.path and other file-like configuration need to be sanitized
         # to relative globs (where possible).
@@ -131,7 +134,7 @@ class OptionsInitializer:
             )
         )
 
-        return list(invalidation_globs)
+        return tuple(x for x in invalidation_globs)
 
     @classmethod
     def create(

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -52,14 +52,10 @@ def init_workdir(global_options: OptionValueContainer) -> str:
     return workdir_src
 
 
-def clean_global_runtime_state(reset_subsystem=False):
-    """Resets the global runtime state of a pants runtime for cleaner forking.
+def clean_global_runtime_state() -> None:
+    """Resets the global runtime state of a pants runtime."""
 
-    :param bool reset_subsystem: Whether or not to clean Subsystem global state.
-    """
-    if reset_subsystem:
-        # Reset subsystem state.
-        Subsystem.reset()
+    Subsystem.reset()
 
     # Reset global plugin state.
     BuildConfigInitializer.reset()

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -3,7 +3,7 @@
 
 import logging
 import time
-from typing import List, Optional, Tuple, cast
+from typing import Optional, Tuple, cast
 
 import psutil
 
@@ -32,7 +32,7 @@ class SchedulerService(PantsService):
         *,
         graph_scheduler: GraphScheduler,
         build_root: str,
-        invalidation_globs: List[str],
+        invalidation_globs: Tuple[str, ...],
         pidfile: str,
         pid: int,
         max_memory_usage_in_bytes: int,
@@ -40,7 +40,7 @@ class SchedulerService(PantsService):
         """
         :param graph_scheduler: The GraphScheduler instance for graph construction.
         :param build_root: The current build root.
-        :param invalidation_globs: A list of `globs` that when encountered in filesystem event
+        :param invalidation_globs: A tuple of `globs` that when encountered in filesystem event
                                    subscriptions will tear down the daemon.
         :param pidfile: A pidfile which should contain this processes' pid in order for the daemon
                         to remain valid.
@@ -62,7 +62,7 @@ class SchedulerService(PantsService):
 
         # NB: We declare these as a single field so that they can be changed atomically.
         self._invalidation_globs_and_snapshot: Tuple[Tuple[str, ...], Optional[Snapshot]] = (
-            tuple(invalidation_globs),
+            invalidation_globs,
             None,
         )
 

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -258,7 +258,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
         """
         super().setUp()
         # Avoid resetting the Runtracker here, as that is specific to fork'd process cleanup.
-        clean_global_runtime_state(reset_subsystem=True)
+        clean_global_runtime_state()
 
         self.addCleanup(self._reset_engine)
 


### PR DESCRIPTION
This commit goes through a number of places in the Python parts of the pants codebase where the code is more complex and verbose than it needs to be (presumably because of complexity in previous versions of pants that has since been removed), and simplifies that code. Also adds type annotations in a number of places.