### PR TITLE
Remove bad deprecation for `--run-tracker-stats-version`

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -93,8 +93,6 @@ class RunTracker(Subsystem):
             type=int,
             default=1,
             choices=cls.SUPPORTED_STATS_VERSIONS,
-            removal_version="2.1.0.dev0",
-            removal_hint="RunTracker no longer directly supports uploading run stats to urls.",
             help="Format of stats JSON for uploads and local json file.",
         )
         register(


### PR DESCRIPTION
This is still in use through the streaming workunits API.

[ci skip-rust]
[ci skip-build-wheels]