### PR TITLE
Add `:my_func` shorthand for the `entry_point` field

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -167,7 +167,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
         Paths, PathGlobs, request.sources.path_globs(FilesNotFoundBehavior.error)
     )
     if len(binary_source_paths.files) != 1:
-        instructions_url = "https://www.pantsbuild.org/v2.1/docs/python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
+        instructions_url = "https://www.pantsbuild.org/docs/python-package-goal#creating-a-pex-file-from-a-pex_binary-target"
         if not entry_point_value:
             raise InvalidFieldException(
                 f"Both the `entry_point` and `sources` fields are not set for the target "

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -92,7 +92,10 @@ def test_resolve_pex_binary_entry_point() -> None:
     assert_resolved(
         entry_point="custom.entry_point:func", source="app.py", expected="custom.entry_point:func"
     )
+    assert_resolved(entry_point=":func", source="app.py", expected="project.app:func")
     assert_resolved(entry_point=None, source="app.py", expected="project.app")
+    with pytest.raises(ExecutionError):
+        assert_resolved(entry_point=":func", source=None, expected="doesnt matter")
     with pytest.raises(ExecutionError):
         assert_resolved(entry_point=None, source=None, expected="doesnt matter")
 


### PR DESCRIPTION
## Problem

A user pointed out it's clunky to have to set `path.to.module:my_func`. They need to set the `:my_func` portion so that it works with `setuptools`, so they can't use the default entry point when you set `sources` and leave off `entry_point`.

## Solution

Add a third option: an explicit `sources` field + explicit `entry_point` field that starts with `:` will be expanded to `path.to.module:my_func`.

```python
# Results in `project.app:my_func`
pex_binary(
  sources=["app.py"],
  entry_point=":my_func"
)
```