### PR TITLE
Deprecate the `platforms` field allowing a bare string

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -12,6 +12,7 @@ from pkg_resources import Requirement
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PyTest
+from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import PathGlobs, Paths
@@ -188,6 +189,21 @@ class PexPlatformsField(StringOrStringSequenceField):
     """
 
     alias = "platforms"
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Optional[Iterable[str]], *, address: Address
+    ) -> Optional[Tuple[str, ...]]:
+        if isinstance(raw_value, str) and address.is_base_target:
+            warn_or_error(
+                deprecated_entity_description=f"Using a bare string for the `{cls.alias}` field",
+                removal_version="2.2.0.dev0",
+                hint=(
+                    f"Using a bare string for the `{cls.alias}` field for {address}. Please "
+                    f"instead use a list of strings, i.e. use `[{raw_value}]`."
+                ),
+            )
+        return super().compute_value(raw_value, address=address)
 
 
 class PexInheritPathField(StringField):


### PR DESCRIPTION
`StringOrStringSequenceField` is a misfeature. It's confusing, and only saves 2 characters between `["foo"]` vs. `"foo"`.

We'll remove the only remaining instance, the `compatiblity` field, as part of https://github.com/pantsbuild/pants/issues/9273.

[ci skip-rust]
[ci skip-build-wheels]