### PR TITLE
Add new `py-constraints` goal through new `pants.backend.python.mixed_interpreter_constraints` backend

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -12,6 +12,7 @@ backend_packages.add = [
   "pants.backend.python.lint.flake8",
   "pants.backend.python.lint.isort",
   "pants.backend.python.typecheck.mypy",
+  "pants.backend.python.mixed_interpreter_constraints",
   "internal_plugins.releases",
 ]
 

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/BUILD
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library()
+
+python_tests(name="tests")

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -47,9 +47,9 @@ async def py_constraints(
             continue
         constraints_to_addresses[constraints].add(tgt.address)
 
-    for constraint, addresses in sorted(constraints_to_addresses.items()):
+    for constraint, addrs in sorted(constraints_to_addresses.items()):
         console.print_stdout(f"\n{constraint}")
-        for addr in sorted(addresses):
+        for addr in sorted(addrs):
             console.print_stdout(f"  {addr}")
 
     return PyConstraintsGoal(exit_code=0)

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -3,6 +3,7 @@
 
 import logging
 from collections import defaultdict
+from textwrap import fill, indent
 
 from pants.backend.python.util_rules.pex import PexInterpreterConstraints
 from pants.engine.addresses import Addresses
@@ -39,6 +40,13 @@ async def py_constraints(
         return PyConstraintsGoal(exit_code=0)
 
     console.print_stdout(f"Final merged constraints: {final_constraints}")
+    if len(addresses) > 1:
+        merged_constraints_warning = (
+            "(These are the constraints used if you were to depend on all of the input "
+            "files/targets together, even though they may end up never being used together in the "
+            "real world. Consider using a more precise query.)"
+        )
+        console.print_stdout(indent(fill(merged_constraints_warning, 80), "  "))
 
     constraints_to_addresses = defaultdict(set)
     for tgt in transitive_targets.closure:

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -71,3 +71,7 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
           lib1
         """
     )
+
+    # If we run on >1 input, we include a warning about what the "final merged constraints" mean.
+    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["app", "lib1"])
+    assert "Consider using a more precise query" in result.stdout

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -1,0 +1,73 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.python.mixed_interpreter_constraints.py_constraints import PyConstraintsGoal
+from pants.backend.python.mixed_interpreter_constraints.py_constraints import (
+    rules as py_constraints_rules,
+)
+from pants.backend.python.target_types import PythonLibrary
+from pants.core.target_types import Files
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(rules=py_constraints_rules(), target_types=[Files, PythonLibrary])
+
+
+def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.create_file("f.txt")
+    rule_runner.add_to_build_file("", "files(name='tgt', sources=['f.txt'])")
+    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["f.txt"])
+    assert result.exit_code == 0
+    assert len(caplog.records) == 1
+    assert "No Python files/targets matched" in caplog.text
+
+
+def test_render_constraints(rule_runner: RuleRunner) -> None:
+    rule_runner.add_to_build_file(
+        "lib1", "python_library(sources=[], interpreter_constraints=['==2.7.*', '>=3.5'])"
+    )
+
+    # We leave off `interpreter_constraints`, which results in using
+    # `[python-setup].interpreter_constraints` instead. Also, we create files so that we can test
+    # how file addresses render.
+    rule_runner.create_file("lib2/a.py")
+    rule_runner.create_file("lib2/b.py")
+    rule_runner.add_to_build_file("lib2", "python_library()")
+
+    rule_runner.add_to_build_file(
+        "app",
+        dedent(
+            """\
+            python_library(
+              sources=[],
+              dependencies=['lib1', 'lib2/a.py', 'lib2/b.py'],
+              interpreter_constraints=['==3.7.*'],
+            )
+            """
+        ),
+    )
+
+    rule_runner.set_options(["--python-setup-interpreter-constraints=['>=3.6']"])
+
+    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["app"])
+    assert result.stdout == dedent(
+        """\
+        Final merged constraints: CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6
+        
+        CPython==3.7.*
+          app
+
+        CPython>=3.6
+          lib2/a.py
+          lib2/b.py
+
+        CPython==2.7.* OR CPython>=3.5
+          lib1
+        """
+    )

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -59,7 +59,7 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
     assert result.stdout == dedent(
         """\
         Final merged constraints: CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6
-        
+
         CPython==3.7.*
           app
 

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/register.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/register.py
@@ -1,0 +1,8 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.mixed_interpreter_constraints import py_constraints
+
+
+def rules():
+    return py_constraints.rules()

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -328,8 +328,11 @@ class PexInterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParame
             allowed_versions=["3.8", "3.9"], prior_version="3.7"
         )
 
-    def debug_hint(self) -> str:
+    def __str__(self) -> str:
         return " OR ".join(str(constraint) for constraint in self)
+
+    def debug_hint(self) -> str:
+        return str(self)
 
 
 class PexPlatforms(DeduplicatedCollection[str]):

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -20,6 +20,7 @@ target(
     'src/python/pants/backend/python/lint/flake8',
     'src/python/pants/backend/python/lint/isort',
     'src/python/pants/backend/python/lint/pylint',
+    'src/python/pants/backend/python/mixed_interpreter_constraints',
     'src/python/pants/backend/python/typecheck/mypy',
     'src/python/pants/core',
   ],
@@ -28,6 +29,5 @@ target(
 python_integration_tests(
   name="integration",
   uses_pants_run=True,
-  # TODO(#10504): Lower this to ~120 once fixed.
-  timeout=600,
+  timeout=200,
 )

--- a/src/python/pants/python/python_setup.py
+++ b/src/python/pants/python/python_setup.py
@@ -51,11 +51,13 @@ class PythonSetup(Subsystem):
             type=list,
             default=["CPython>=3.6"],
             metavar="<requirement>",
-            help="Constrain the selected Python interpreter. Specify with requirement syntax, "
-            "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
-            "or 'PyPy' (A pypy interpreter of any version). Multiple constraint strings will "
-            "be ORed together. These constraints are used as the default value for the "
-            "`compatibility` field of Python targets.",
+            help=(
+                "The Python interpreters your codebase is compatible with. Specify with "
+                "requirement syntax, e.g. 'CPython>=2.7,<3' (A CPython interpreter with version "
+                ">=2.7 AND version <3) or 'PyPy' (A pypy interpreter of any version). Multiple "
+                "constraint strings will be ORed together. These constraints are used as the "
+                "default value for the `interpreter_constraints` field of Python targets."
+            ),
         )
         register(
             "--requirement-constraints",


### PR DESCRIPTION
### Problem

It's difficult to reason about what constraints are used at runtime, and to trace where those values are coming from.

### Solution

Add a new goal to calculate the final constraints, and show where each constraint comes from.

Usually, users will run this on a single file/target:

```
▶ ./pants py-constraints src/python/pants/util/strutil_test.py
Final merged constraints: CPython==3.7.*,>=3.6

CPython==3.7.*
  src/python/pants/util/strutil_test.py:tests

CPython>=3.6
  src/python/pants/util/strutil.py
```

They can also run over multiple, if they'd like.

```
▶ ./pants py-constraints src/python/pants/util:
Final merged constraints: CPython==3.7.*,>=3.6
  (These are the constraints used if you were to depend on all of the input
  files/targets together, even though they may end up never being used together in
  the real world. Consider using a more precise query.)

CPython==3.7.*
  src/python/pants/util/collections_test.py:tests
  src/python/pants/util/contextutil_test.py:tests
  src/python/pants/util/dirutil_test.py:tests
  src/python/pants/util/enums_test.py:tests
  src/python/pants/util/eval_test.py:tests
  src/python/pants/util/filtering_test.py:tests
  src/python/pants/util/frozendict_test.py:tests
  src/python/pants/util/memo_test.py:tests
  src/python/pants/util/meta_test.py:tests
  src/python/pants/util/objects_test.py:tests
  src/python/pants/util/ordered_set_test.py:tests
  src/python/pants/util/osutil_test.py:tests
  src/python/pants/util/socket_test.py:tests
  src/python/pants/util/strutil_test.py:tests

CPython>=3.6
  src/python/pants/util/__init__.py
  src/python/pants/util/collections.py
  src/python/pants/util/contextutil.py
  src/python/pants/util/dirutil.py
  src/python/pants/util/enums.py
  src/python/pants/util/eval.py
  src/python/pants/util/filtering.py
  src/python/pants/util/frozendict.py
  src/python/pants/util/logging.py
  src/python/pants/util/memo.py
  src/python/pants/util/meta.py
  src/python/pants/util/objects.py
  src/python/pants/util/ordered_set.py
  src/python/pants/util/osutil.py
  src/python/pants/util/rwbuf.py
  src/python/pants/util/socket.py
  src/python/pants/util/strutil.py
```

### Why a new backend?

This goal is only relevant if you have mixed interpreter constraints. We don't want to clutter the goals if you don't need this. V1's idea of "activate everything by default" proved a bad idea.

We use the generic name "mixed_interpreter_constraints" because this is relevant even if you've finished migrating from Py2 to Py3. For example, Toolchain has some code that's Py3.7+, and other code that's 3.8+. This backend is relevant there too, so we don't want a name like "2to3".

### Upcoming feature: `./pants py-constraints --repo-status` (name pending)

While this goal is focused entirely on debugging, we also want a goal to help with _prioritization_ by giving an overview of your whole repo, including finding which targets are the most used so higher priority in a migration. See https://github.com/pantsbuild/pants/issues/11071.

This new mechanism will be implemented as an option on this new `py-constraints` goal.

[ci skip-rust]
[ci skip-build-wheels]