### PR TITLE
Remove deprecated `runtime_binary_dependencies` field

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -153,15 +153,12 @@ async def setup_pytest_for_target(
         request.field_set.runtime_package_dependencies.to_unparsed_address_inputs()
     )
     if unparsed_runtime_packages.values:
-        runtime_package_targets, runtime_binary_dependencies = await Get(
+        runtime_package_targets = await Get(
             Targets, UnparsedAddressInputs, unparsed_runtime_packages
         )
         field_sets_per_target = await Get(
             FieldSetsPerTarget,
-            FieldSetsPerTargetRequest(
-                PackageFieldSet,
-                itertools.chain(runtime_package_targets, runtime_binary_dependencies),
-            ),
+            FieldSetsPerTargetRequest(PackageFieldSet, runtime_package_targets),
         )
         assets = await MultiGet(
             Get(BuiltPackage, PackageFieldSet, field_set)

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -14,7 +14,6 @@ from pants.backend.python.goals.coverage_py import (
 )
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.target_types import (
-    PythonRuntimeBinaryDependencies,
     PythonRuntimePackageDependencies,
     PythonTestsSources,
     PythonTestsTimeout,
@@ -65,7 +64,6 @@ class PythonTestFieldSet(TestFieldSet):
 
     sources: PythonTestsSources
     timeout: PythonTestsTimeout
-    runtime_binary_dependencies: PythonRuntimeBinaryDependencies
     runtime_package_dependencies: PythonRuntimePackageDependencies
 
     def is_conftest_or_type_stub(self) -> bool:
@@ -154,13 +152,9 @@ async def setup_pytest_for_target(
     unparsed_runtime_packages = (
         request.field_set.runtime_package_dependencies.to_unparsed_address_inputs()
     )
-    unparsed_runtime_binaries = (
-        request.field_set.runtime_binary_dependencies.to_unparsed_address_inputs()
-    )
-    if unparsed_runtime_packages.values or unparsed_runtime_binaries.values:
-        runtime_package_targets, runtime_binary_dependencies = await MultiGet(
-            Get(Targets, UnparsedAddressInputs, unparsed_runtime_packages),
-            Get(Targets, UnparsedAddressInputs, unparsed_runtime_binaries),
+    if unparsed_runtime_packages.values:
+        runtime_package_targets, runtime_binary_dependencies = await Get(
+            Targets, UnparsedAddressInputs, unparsed_runtime_packages
         )
         field_sets_per_target = await Get(
             FieldSetsPerTarget,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -391,15 +391,6 @@ class PythonRuntimePackageDependencies(SpecialCasedDependencies):
     alias = "runtime_package_dependencies"
 
 
-class PythonRuntimeBinaryDependencies(SpecialCasedDependencies):
-    """Deprecated in favor of the `runtime_build_dependencies` field, which works with more target
-    types like `archive` and `python_awslambda`."""
-
-    alias = "runtime_binary_dependencies"
-    deprecated_removal_version = "2.1.0dev0"
-    deprecated_removal_hint = "Use the more flexible `runtime_package_dependencies` field instead."
-
-
 class PythonTestsTimeout(IntField):
     """A timeout (in seconds) which covers the total runtime of all tests in this target.
 
@@ -450,7 +441,6 @@ class PythonTests(Target):
         PythonTestsSources,
         PythonTestsDependencies,
         PythonRuntimePackageDependencies,
-        PythonRuntimeBinaryDependencies,
         PythonTestsTimeout,
     )
 


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]
