### PR TITLE
Improve error message for invalid input in `Get()`s

### DIFF
--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -261,15 +261,13 @@ class SchedulerWithNestedRaiseTest(TestBase):
         )
 
     def test_get_type_match_failure(self):
-        """Test that Get(...)s are now type-checked during rule execution, to allow for union
-        types."""
-
         with self.assertRaises(ExecutionError) as cm:
             # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
             self.request(A, [TypeCheckFailWrapper(A())])
-
-        expected_regex = "WithDeps.*did not declare a dependency on JustGet"
-        self.assertRegex(str(cm.exception), expected_regex)
+        assert (
+            "Invalid input to `Get(A, B)`. Expected an object with type `B`, but got `A()` with "
+            "type `A` instead."
+        ) in str(cm.exception)
 
     def test_unhashable_root_params_failure(self):
         """Test that unhashable root params result in a structured error."""

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -236,7 +236,7 @@ def test_trace_includes_rule_exception_traceback() -> None:
            File LOCATION-INFO, in nested_raise
              fn_raises()
            File LOCATION-INFO, in fn_raises
-             raise Exception(f"An exception!")
+             raise Exception("An exception!")
          Exception: An exception!
          """
     )

--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -3,11 +3,12 @@
 
 import ast
 import re
-from typing import Any, Tuple
+from typing import Any, Callable, Tuple
 
 import pytest
 
 from pants.engine.internals.selectors import Get, GetConstraints, GetParseError, MultiGet
+from pants.engine.unions import union
 
 
 def parse_get_types(get: str) -> Tuple[str, str]:
@@ -83,47 +84,77 @@ class BClass:
 
 
 def test_create_get() -> None:
-    get = Get(AClass, BClass, 42)
+    get = Get(AClass, int, 42)
     assert get.output_type is AClass
-    assert get.input_type is BClass
+    assert get.input_type is int
     assert get.input == 42
 
-
-def test_create_get_abbreviated() -> None:
-    # Test the equivalence of the 1-arg and 2-arg versions.
+    # Also test the equivalence of the 1-arg and 2-arg versions.
     assert Get(AClass, BClass()) == Get(AClass, BClass, BClass())
 
 
-def test_invalid_get_abbreviated() -> None:
-    with pytest.raises(
-        expected_exception=TypeError,
-        match=re.escape(f"The input argument cannot be a type, but given {BClass}."),
-    ):
-        Get(AClass, BClass)
+def assert_invalid_get(create_get: Callable[[], Get], *, expected: str) -> None:
+    with pytest.raises(TypeError) as exc:
+        create_get()
+    assert str(exc.value) == expected
 
 
-def test_invalid_get_input() -> None:
-    with pytest.raises(
-        expected_exception=TypeError,
-        match=re.escape(f"The input argument cannot be a type, but given {BClass}."),
-    ):
-        Get(AClass, BClass, BClass)
+def test_invalid_get() -> None:
+    # Bad output type.
+    assert_invalid_get(
+        lambda: Get(1, str, "bob"),  # type: ignore[call-overload, no-any-return]
+        expected=(
+            "Invalid Get. The first argument (the output type) must be a type, but given "
+            f"`1` with type {int}."
+        ),
+    )
+
+    # Bad second argument.
+    assert_invalid_get(
+        lambda: Get(AClass, BClass),
+        expected=(
+            "Invalid Get. Because you are using the shorthand form "
+            "Get(OutputType, InputType(constructor args)), the second argument should be "
+            f"a constructor call, rather than a type, but given {BClass}."
+        ),
+    )
+    assert_invalid_get(
+        lambda: Get(AClass, 1, BClass),  # type: ignore[call-overload, no-any-return]
+        expected=(
+            "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, "
+            "input), the second argument must be a type, but given `1` of type "
+            f"{int}."
+        ),
+    )
+
+    # Bad third argument.
+    assert_invalid_get(
+        lambda: Get(AClass, BClass, BClass),
+        expected=(
+            "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, "
+            "input), the third argument should be an object, rather than a type, but given "
+            f"{BClass}."
+        ),
+    )
 
 
-def test_invalid_get_input_type() -> None:
-    with pytest.raises(
-        expected_exception=TypeError,
-        match=re.escape(f"The input type must be a type, but given {1} of type {type(1)}."),
-    ):
-        Get(AClass, 1, BClass)  # type: ignore[call-overload]
+def test_invalid_get_input_does_not_match_type() -> None:
+    assert_invalid_get(
+        lambda: Get(AClass, str, 1),
+        expected=(
+            f"Invalid Get. The third argument `1` must have the exact same type as the "
+            f"second argument, {str}, but had the type {int}."
+        ),
+    )
 
+    # However, if the `input_type` is a `@union`, then we do not eagerly validate.
+    @union
+    class UnionBase:
+        pass
 
-def test_invalid_get_output_type() -> None:
-    with pytest.raises(
-        expected_exception=TypeError,
-        match=re.escape(f"The output type must be a type, but given {1} of type {type(1)}."),
-    ):
-        Get(1, "bob")  # type: ignore[call-overload]
+    union_get = Get(AClass, UnionBase, 1)
+    assert union_get.input_type == UnionBase
+    assert union_get.input == 1
 
 
 def test_multiget_invalid_types() -> None:

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -452,7 +452,7 @@ py_class!(pub class PyGeneratorResponseGetMulti |py| {
 pub struct Get {
   pub output: TypeId,
   pub input: Key,
-  pub input_type: Option<TypeId>,
+  pub input_type: TypeId,
 }
 
 impl Get {
@@ -462,7 +462,7 @@ impl Get {
       input: interns
         .key_insert(py, get.subject(py).clone_ref(py).into())
         .map_err(|e| Failure::from_py_err_with_gil(py, e))?,
-      input_type: Some(interns.type_insert(py, get.declared_subject(py).clone_ref(py))),
+      input_type: interns.type_insert(py, get.declared_subject(py).clone_ref(py)),
     })
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -922,26 +922,11 @@ impl Task {
                   )),
                 }
               } else {
-                let parent_rule_func = match &*entry {
-                  rule_graph::Entry::WithDeps(entry_with_deps) => match entry_with_deps.rule() {
-                    Some(ref rule) => match rule {
-                      tasks::Rule::Task(ref task) => Some(task.func),
-                      _ => None,
-                    },
-                    None => None,
-                  },
-                  _ => None
-                };
-                let rule_context = match parent_rule_func {
-                  Some(func) => format!(
-                    " See the rule {}() in {} (line {}).",
-                    func.name(), func.module(), func.line_number()
-                  ),
-                  _ => "".to_string()
-                };
+                // NB: The Python constructor for `Get()` will have already errored if
+                // `type(input) != input_type`.
                 throw(&format!(
-                  "Invalid input to `Get({}, {})`. Expected an object with type `{}`, but got `{:?}` with type `{}` instead.{}",
-                  get.output, get.input_type, get.input_type, get.input, get.input.type_id(), rule_context
+                  "Could not find a rule to satisfy Get({}, {}, {}).",
+                  get.output, get.input_type, get.input
                 ))
               }
             })

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -904,32 +904,30 @@ impl Task {
           .edges_for_inner(&entry)
           .ok_or_else(|| throw(&format!("no edges for task {:?} exist!", entry)))
           .and_then(|edges| {
-            edges
-              .entry_for(&dependency_key)
-              .cloned()
-              .ok_or_else(|| match get.input_type {
-                Some(ty) if externs::is_union(ty) => {
-                  let value = externs::type_for_type_id(ty).into_object();
-                  match externs::call_method(
-                    &value,
-                    "non_member_error_message",
-                    &[externs::val_for(&get.input)],
-                  ) {
-                    Ok(err_msg) => throw(&externs::val_to_str(&err_msg)),
-                    // If the non_member_error_message() call failed for any reason,
-                    // fall back to a generic message.
-                    Err(_e) => throw(&format!(
-                      "Type {} is not a member of the {} @union",
-                      get.input.type_id(),
-                      ty
-                    )),
-                  }
+            edges.entry_for(&dependency_key).cloned().ok_or_else(|| {
+              if externs::is_union(get.input_type) {
+                let value = externs::type_for_type_id(get.input_type).into_object();
+                match externs::call_method(
+                  &value,
+                  "non_member_error_message",
+                  &[externs::val_for(&get.input)],
+                ) {
+                  Ok(err_msg) => throw(&externs::val_to_str(&err_msg)),
+                  // If the non_member_error_message() call failed for any reason,
+                  // fall back to a generic message.
+                  Err(_e) => throw(&format!(
+                    "Type {} is not a member of the {} @union",
+                    get.input.type_id(),
+                    get.input_type
+                  )),
                 }
-                _ => throw(&format!(
+              } else {
+                throw(&format!(
                   "{:?} did not declare a dependency on {:?}",
                   entry, dependency_key
-                )),
-              })
+                ))
+              }
+            })
           });
         // The subject of the get is a new parameter that replaces an existing param of the same
         // type.

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -23,7 +23,7 @@ impl DisplayForGraph for Rule {
   fn fmt_for_graph(&self, display_args: DisplayForGraphArgs) -> String {
     match self {
       Rule::Task(ref task) => {
-        let task_name = task.func.name();
+        let task_name = task.func.full_name();
         let product = format!("{}", task.product);
 
         let clause_portion = Self::formatted_select_clause(&task.clause, display_args);


### PR DESCRIPTION
Before:

> Exception: WithDeps(Inner(InnerEntry { params: {Specs, Console}, rule: Task(Task { product: List, can_modify_workunit: false, clause: [Addresses, ListSubsystem, Console], gets: [Get { output: UnexpandedTargets, input: Addresses }], func: pants.backend.project_info.list_targets:64:list_targets(), cacheable: false, display_info: DisplayInfo { name: "pants.backend.project_info.list_targets.list_targets", desc: Some("`list` goal"), level: Debug } }) })) did not declare a dependency on JustGet(Get { output: UnexpandedTargets, input: int })

After:

```
Engine traceback:
  in select
  in pants.backend.project_info.list_targets.list_targets
Traceback (most recent call last):
  File "/Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/native.py", line 65, in generator_send
    res = func.send(arg)
  File "/Users/eric/DocsLocal/code/projects/pants/src/python/pants/backend/project_info/list_targets.py", line 79, in list_targets
    targets = await Get(UnexpandedTargets, Addresses, 123)
  File "/Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/meta.py", line 182, in new_init
    prev_init(self, *args, **kwargs)
  File "/Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/selectors.py", line 159, in __init__
    self.input = self._validate_input(input_arg1, shorthand_form=False)
  File "/Users/eric/DocsLocal/code/projects/pants/src/python/pants/engine/internals/selectors.py", line 201, in _validate_input
    f"Invalid Get. The third argument `{input_}` must have the exact same type as the "
TypeError: Invalid Get. The third argument `123` must have the exact same type as the second argument, pants.engine.addresses.Addresses, but had the type <class 'int'>.
```

Note that the stacktrace includes the offending `Get`, including the line and file where it's set. This is because we now eagerly validate in the Python constructor for `Get`.

We can only apply this new error message for non-union `Get` calls; the engine must handle type errors relating to `unions` because Python does not have knowledge of `UnionMembership` in the `Get` constructor.

Closes https://github.com/pantsbuild/pants/issues/8349.