### PR TITLE
Add process return value as workunit metadata item

### DIFF
--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -837,6 +837,8 @@ class StreamingWorkunitProcessTests(TestBase):
         assert stdout_digest == EMPTY_FILE_DIGEST
         assert stderr_digest.serialized_bytes_length == len(result.stderr)
 
+        assert process_workunit["metadata"]["exit_code"] == 0
+
         try:
             self._scheduler.ensure_remote_has_recursive([stdout_digest, stderr_digest])
         except Exception as e:

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -40,7 +40,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use store::UploadSummary;
-use workunit_store::{with_workunit, WorkunitMetadata, WorkunitStore};
+use workunit_store::{with_workunit, UserMetadataItem, WorkunitMetadata, WorkunitStore};
 
 use async_semaphore::AsyncSemaphore;
 use hashing::Digest;
@@ -519,10 +519,15 @@ impl CommandRunner for BoundedCommandRunner {
           Ok(FallibleProcessResultWithPlatform {
             stdout_digest,
             stderr_digest,
+            exit_code,
             ..
           }) => WorkunitMetadata {
             stdout: Some(*stdout_digest),
             stderr: Some(*stderr_digest),
+            user_metadata: vec![(
+              "exit_code".to_string(),
+              UserMetadataItem::ImmediateId(*exit_code as i64),
+            )],
             ..old_metadata
           },
         };

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -389,19 +389,21 @@ impl WrappedNode for MultiPlatformExecuteProcess {
 
   async fn run_wrapped_node(self, context: Context) -> NodeResult<ProcessResult> {
     let request = self.process;
-    let execution_context = process_execution::Context::new(
-      context.session.workunit_store(),
-      context.session.build_id().to_string(),
-    );
+
     if context
       .core
       .command_runner
       .extract_compatible_request(&request)
       .is_some()
     {
-      let res = context
-        .core
-        .command_runner
+      let command_runner = &context.core.command_runner;
+
+      let execution_context = process_execution::Context::new(
+        context.session.workunit_store(),
+        context.session.build_id().to_string(),
+      );
+
+      let res = command_runner
         .run(request, execution_context)
         .await
         .map_err(|e| throw(&e))?;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -36,7 +36,9 @@ use process_execution::{
 use graph::{Entry, Node, NodeError, NodeVisualizer};
 use hashing::Digest;
 use store::{self, StoreFileByDigest};
-use workunit_store::{with_workunit, Level, UserMetadataItem, WorkunitMetadata};
+use workunit_store::{
+  with_workunit, Level, UserMetadataItem, UserMetadataPyValue, WorkunitMetadata,
+};
 
 pub type NodeResult<T> = Result<T, Failure>;
 
@@ -1348,11 +1350,11 @@ impl Node for NodeKey {
         user_metadata: user_metadata
           .into_iter()
           .map(|(key, val)| {
-            let umi = UserMetadataItem::new();
+            let py_value_handle = UserMetadataPyValue::new();
+            let umi = UserMetadataItem::PyValue(py_value_handle.clone());
             session.with_metadata_map(|map| {
               let val = val.clone();
-              let umi = umi.clone();
-              map.insert(umi, val);
+              map.insert(py_value_handle.clone(), val);
             });
             (key, umi)
           })

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -23,7 +23,7 @@ use task_executor::Executor;
 use ui::ConsoleUI;
 use uuid::Uuid;
 use watch::Invalidatable;
-use workunit_store::{UserMetadataItem, WorkunitStore};
+use workunit_store::{UserMetadataPyValue, WorkunitStore};
 
 pub enum ExecutionTermination {
   // Raised as a vanilla keyboard interrupt on the python side.
@@ -92,7 +92,7 @@ struct InnerSession {
   // Session/build_id would be stable.
   run_id: Mutex<Uuid>,
   should_report_workunits: bool,
-  workunit_metadata_map: RwLock<HashMap<UserMetadataItem, Value>>,
+  workunit_metadata_map: RwLock<HashMap<UserMetadataPyValue, Value>>,
 }
 
 #[derive(Clone)]
@@ -137,7 +137,7 @@ impl Session {
 
   pub fn with_metadata_map<F, T>(&self, f: F) -> T
   where
-    F: Fn(&mut HashMap<UserMetadataItem, Value>) -> T,
+    F: Fn(&mut HashMap<UserMetadataPyValue, Value>) -> T,
   {
     f(&mut self.0.workunit_metadata_map.write())
   }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -159,11 +159,17 @@ impl WorkunitMetadata {
 
 /// Abstract id for passing user metadata items around
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct UserMetadataItem(uuid::Uuid);
+pub enum UserMetadataItem {
+  PyValue(UserMetadataPyValue),
+  ImmediateId(i64),
+}
 
-impl UserMetadataItem {
-  pub fn new() -> UserMetadataItem {
-    UserMetadataItem(uuid::Uuid::new_v4())
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct UserMetadataPyValue(uuid::Uuid);
+
+impl UserMetadataPyValue {
+  pub fn new() -> UserMetadataPyValue {
+    UserMetadataPyValue(uuid::Uuid::new_v4())
   }
 }
 


### PR DESCRIPTION
### Problem

Now that we have the `metadata` item on workunits, we want to be able to have certain intrinsics add their own metadata to worknits. In this case, we want the intrinsic that runs `Process`es to add a metadata item reflecting the exit code.

### Solution

This was a little bit tricky to code up without introducing the `Value` type to sub-crates of the main engine crate. The `UserMetadataItem` type has been split into an enum, where one variant is the wrapped UUID type that lets the workunit type pass around references to Python `Value`s in a session-specific HashMap; the other variant being an "immediate" signed integer. Now, the `process_execution` crate can place a signed integer value in the workunit metadata, and does so with the return value of the process.
