### PR TITLE
Bump deprecations 2.1.0.dev0 -> 2.1.0.dev1

### DIFF
--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -38,7 +38,7 @@ class PantsResult:
     @property
     def returncode(self) -> int:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="the property PantsResult.returncode",
             hint="Use `PantsResult.exit_code` instead.",
         )
@@ -47,7 +47,7 @@ class PantsResult:
     @property
     def stdout_data(self) -> str:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="the property PantsResult.stdout_data",
             hint="Use `PantsResult.stdout` instead.",
         )
@@ -56,7 +56,7 @@ class PantsResult:
     @property
     def stderr_data(self) -> str:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="the property PantsResult.stderr_data",
             hint="Use `PantsResult.stderr` instead.",
         )
@@ -381,7 +381,7 @@ class PantsIntegrationTest(unittest.TestCase):
         **kwargs: Any,
     ) -> PantsJoinHandle:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.run_pants_with_workdir_without_waiting()",
             hint=(
                 "Use the top-level function `run_pants_with_workdir_without_waiting()`. "
@@ -409,7 +409,7 @@ class PantsIntegrationTest(unittest.TestCase):
         **kwargs: Any,
     ) -> PantsResult:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.run_pants_with_workdir()",
             hint=(
                 "Use the top-level function `run_pants_with_workdir()`. "
@@ -437,7 +437,7 @@ class PantsIntegrationTest(unittest.TestCase):
         **kwargs: Any,
     ) -> PantsResult:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.run_pants()",
             hint=(
                 "Use the top-level function `run_pants()`. `PantsIntegrationTest` is deprecated."
@@ -456,7 +456,7 @@ class PantsIntegrationTest(unittest.TestCase):
     @staticmethod
     def assert_success(pants_run: PantsResult, msg: Optional[str] = None) -> None:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.assert_success()",
             hint="Use `PantsResult.assert_success()`. `PantsIntegrationTest` is deprecated.",
         )
@@ -465,7 +465,7 @@ class PantsIntegrationTest(unittest.TestCase):
     @staticmethod
     def assert_failure(pants_run: PantsResult, msg: Optional[str] = None) -> None:
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.assert_failure()",
             hint="Use `PantsResult.assert_failure()`. `PantsIntegrationTest` is deprecated.",
         )
@@ -474,7 +474,7 @@ class PantsIntegrationTest(unittest.TestCase):
     @staticmethod
     def temporary_workdir(cleanup: bool = True):
         warn_or_error(
-            removal_version="2.1.0.dev0",
+            removal_version="2.1.0.dev1",
             deprecated_entity_description="PantsIntegrationTest.temporary_workdir()",
             hint=(
                 "Use the top-level function `temporary_workdir`. `PantsIntegrationTest` is "

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -10,5 +10,5 @@ from pants.testutil.pants_integration_test import (  # noqa: F401
 from pants.testutil.pants_integration_test import PantsResult as PantsResult  # noqa: F401
 
 deprecated_module(
-    removal_version="2.1.0.dev0", hint_message="Use pants.testutil.pants_integration_test"
+    removal_version="2.1.0.dev1", hint_message="Use pants.testutil.pants_integration_test"
 )

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 from pants.base.build_root import BuildRoot
-from pants.base.deprecated import warn_or_error
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -268,18 +267,6 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
 
         BuildRoot().path = self.build_root
         self.addCleanup(BuildRoot().reset)
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        warn_or_error(
-            removal_version="2.1.0.dev0",
-            deprecated_entity_description="pants.testutil.test_base.TestBase",
-            hint=(
-                "Use `pants.testutil.rule_runner.RuleRunner` instead, which uses a Pytest fixture "
-                "style. See https://www.pantsbuild.org/v2.0/docs/rules-api-testing."
-            ),
-        )
 
     def _reset_engine(self):
         if self._scheduler is not None:


### PR DESCRIPTION
Removes some deprecated code in advance of 2.1.0.dev0, and bumps some dev0 deprecations to dev1.