### PR TITLE
Add `./pants help subsystems`

### DIFF
--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -35,6 +35,16 @@ def test_help_targets() -> None:
     assert "to get help for a specific target" in pants_run.stdout
 
 
+def test_help_subsystems() -> None:
+    pants_run = run_pants(["--backend-packages=pants.backend.python", "help", "subsystems"])
+    pants_run.assert_success()
+    assert (
+        "pex                     How Pants uses Pex to run Python subprocesses" in pants_run.stdout
+    )
+    assert "to get help for a specific subsystem" in pants_run.stdout
+    assert "test            Run tests." not in pants_run.stdout
+
+
 def test_help_specific_target() -> None:
     pants_run = run_pants(["help", "archive"])
     pants_run.assert_success()

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
+import re
 import textwrap
 
 from pants.testutil.pants_integration_test import run_pants
@@ -42,7 +43,7 @@ def test_help_subsystems() -> None:
         "pex                     How Pants uses Pex to run Python subprocesses" in pants_run.stdout
     )
     assert "to get help for a specific subsystem" in pants_run.stdout
-    assert "test            Run tests." not in pants_run.stdout
+    assert not re.search(r"^test\s+", pants_run.stdout)
 
 
 def test_help_specific_target() -> None:

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -151,7 +151,7 @@ class HelpPrinter(MaybeColor):
             alias_str = self.maybe_cyan(f"{alias}".ljust(chars_before_description))
             print(f"{alias_str}{description}\n")
 
-        specific_help_cmd = f"{self._bin_name} help $subsystem_type"
+        specific_help_cmd = f"{self._bin_name} help $subsystem"
         print(
             f"Use `{self.maybe_green(specific_help_cmd)}` to get help for a "
             f"specific subsystem.\n"

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -96,6 +96,8 @@ class HelpPrinter(MaybeColor):
                     self._print_goals_help()
                 elif thing == "targets":
                     self._print_targets_help()
+                elif thing == "subsystems":
+                    print("Subsystems")
                 elif thing == "global":
                     self._print_options_help(GLOBAL_SCOPE, help_request.advanced)
                 elif thing in self._all_help_info.scope_to_help_info:
@@ -149,6 +151,7 @@ class HelpPrinter(MaybeColor):
         print_cmd("help", "Display this usage message.")
         print_cmd("help goals", "List all installed goals.")
         print_cmd("help targets", "List all installed target types.")
+        print_cmd("help subsystems", "List all installed subsystems.")
         print_cmd("help global", "Help for global options.")
         print_cmd("help-advanced global", "Help for global advanced options.")
         print_cmd("help [target_type/goal/subsystem]", "Help for a target type, goal or subsystem.")

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -94,10 +94,10 @@ class HelpPrinter(MaybeColor):
             for thing in sorted(things):
                 if thing == "goals":
                     self._print_goals_help()
+                elif thing == "subsystems":
+                    self._print_subsystems_help()
                 elif thing == "targets":
                     self._print_targets_help()
-                elif thing == "subsystems":
-                    print("Subsystems")
                 elif thing == "global":
                     self._print_options_help(GLOBAL_SCOPE, help_request.advanced)
                 elif thing in self._all_help_info.scope_to_help_info:
@@ -136,6 +136,26 @@ class HelpPrinter(MaybeColor):
             print(format_goal(name, description))
         specific_help_cmd = f"{self._bin_name} help $goal"
         print(f"Use `{self.maybe_green(specific_help_cmd)}` to get help for a specific goal.\n")
+
+    def _print_subsystems_help(self) -> None:
+        self._print_title("Subsystems")
+
+        subsystem_description: Dict[str, str] = {}
+        for alias, help_info in self._all_help_info.scope_to_help_info.items():
+            if not help_info.is_goal and alias:
+                subsystem_description[alias] = help_info.description
+
+        longest_subsystem_alias = max(len(alias) for alias in subsystem_description.keys())
+        chars_before_description = longest_subsystem_alias + 2
+        for alias, description in sorted(subsystem_description.items()):
+            alias_str = self.maybe_cyan(f"{alias}".ljust(chars_before_description))
+            print(f"{alias_str}{description}\n")
+
+        specific_help_cmd = f"{self._bin_name} help $subsystem_type"
+        print(
+            f"Use `{self.maybe_green(specific_help_cmd)}` to get help for a "
+            f"specific subsystem.\n"
+        )
 
     def _print_global_help(self):
         def print_cmd(args: str, desc: str):

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -171,7 +171,7 @@ class HelpPrinter(MaybeColor):
         print_cmd("help", "Display this usage message.")
         print_cmd("help goals", "List all installed goals.")
         print_cmd("help targets", "List all installed target types.")
-        print_cmd("help subsystems", "List all installed subsystems.")
+        print_cmd("help subsystems", "List all configurable subsystems.")
         print_cmd("help global", "Help for global options.")
         print_cmd("help-advanced global", "Help for global advanced options.")
         print_cmd("help [target_type/goal/subsystem]", "Help for a target type, goal or subsystem.")


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]

### Problem

As described on #11032:

> As a user I would like to see all the available subsystem options that I currently have in order to make changes to them inside my pants.toml file.

### Solution

Implement the "category" `subsystems` inside the help function. 

### Result

When running the command `./pants help subsystems` the user should be able to see what are the subsystems availables.
```
> ./pants help subsystems

Subsystems
------------

pex                                Lorem ipsum dolor sit amet.

download-pex-bin       Lorem ipsum dolor sit amet.

...

Use `./pants help $subsystem` to get help for a specific subsystem.
```
