### PR TITLE
Include a host fingerprint in pantsd's identity

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -170,7 +170,7 @@ class PantsDaemon(PantsDaemonProcessManager):
             self._logger.debug("Logging reinitialized in pantsd context")
             yield
 
-    def _initialize_metadata(self):
+    def _initialize_metadata(self) -> None:
         """Writes out our pid and other metadata.
 
         Order matters a bit here, because technically all that is necessary to connect is the port,

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -152,18 +152,18 @@ class ProcessMetadataManager:
         return cls._deadline_until(file_waiter, ongoing_msg, completed_msg, timeout=timeout)
 
     @classmethod
-    def _get_metadata_dir_by_name(cls, name: str, metadata_base_dir: str):
+    def _get_metadata_dir_by_name(cls, name: str, metadata_base_dir: str) -> str:
         """Retrieve the metadata dir by name.
 
         This should always live outside of the workdir to survive a clean-all.
         """
         return os.path.join(metadata_base_dir, cls.host_fingerprint, name)
 
-    def _metadata_file_path(self, name, metadata_key):
+    def _metadata_file_path(self, name, metadata_key) -> str:
         return self.metadata_file_path(name, metadata_key, self._metadata_base_dir)
 
     @classmethod
-    def metadata_file_path(cls, name, metadata_key, metadata_base_dir):
+    def metadata_file_path(cls, name, metadata_key, metadata_base_dir) -> str:
         return os.path.join(cls._get_metadata_dir_by_name(name, metadata_base_dir), metadata_key)
 
     def read_metadata_by_name(self, name, metadata_key, caster=None):
@@ -180,7 +180,7 @@ class ProcessMetadataManager:
         except (IOError, OSError):
             return None
 
-    def write_metadata_by_name(self, name, metadata_key, metadata_value):
+    def write_metadata_by_name(self, name, metadata_key, metadata_value) -> None:
         """Write process metadata using a named identity.
 
         :param string name: The ProcessMetadataManager identity/name (e.g. 'pantsd').
@@ -209,7 +209,7 @@ class ProcessMetadataManager:
         self._wait_for_file(file_path, ongoing_msg, completed_msg, timeout=timeout)
         return self.read_metadata_by_name(name, metadata_key, caster)
 
-    def purge_metadata_by_name(self, name):
+    def purge_metadata_by_name(self, name) -> None:
         """Purge a processes metadata directory.
 
         :raises: `ProcessManager.MetadataError` when OSError is encountered on metadata dir removal.

--- a/tests/python/pants_test/pantsd/pantsd_integration_test.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import datetime
+import glob
 import os
 import re
 import signal
@@ -14,7 +15,7 @@ import pytest
 
 from pants.testutil.pants_integration_test import read_pantsd_log, temporary_workdir
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
-from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, safe_open, touch
+from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, safe_open, safe_rmtree, touch
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
@@ -284,7 +285,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
             ctx.checker.assert_running()
             subprocess_dir = ctx.pantsd_config["GLOBAL"]["pants_subprocessdir"]
-            os.unlink(os.path.join(subprocess_dir, "pantsd", "pid"))
+            safe_rmtree(subprocess_dir)
 
             ctx.checker.assert_stopped()
 
@@ -298,7 +299,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
             ctx.checker.assert_running()
             subprocess_dir = ctx.pantsd_config["GLOBAL"]["pants_subprocessdir"]
-            pidpath = os.path.join(subprocess_dir, "pantsd", "pid")
+            (pidpath,) = glob.glob(os.path.join(subprocess_dir, "*", "pantsd", "pid"))
             with open(pidpath, "w") as f:
                 f.write("9")
 

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -46,17 +46,8 @@ class TestProcessMetadataManager(unittest.TestCase):
         self.pmm = ProcessMetadataManager(metadata_base_dir=self.BUILDROOT)
         self.assertEqual(
             self.pmm._get_metadata_dir_by_name(self.NAME, self.BUILDROOT),
-            os.path.join(self.BUILDROOT, self.NAME),
+            os.path.join(self.BUILDROOT, self.pmm.host_fingerprint, self.NAME),
         )
-
-    def test_maybe_init_metadata_dir_by_name(self):
-        with unittest.mock.patch(
-            "pants.pantsd.process_manager.safe_mkdir", **PATCH_OPTS
-        ) as mock_mkdir:
-            self.pmm._maybe_init_metadata_dir_by_name(self.NAME)
-            mock_mkdir.assert_called_once_with(
-                self.pmm._get_metadata_dir_by_name(self.NAME, self.SUBPROCESS_DIR)
-            )
 
     def test_readwrite_metadata_by_name(self):
         with temporary_dir() as tmpdir, unittest.mock.patch(

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -4,8 +4,6 @@
 import errno
 import logging
 import os
-import subprocess
-import sys
 import unittest
 import unittest.mock
 from contextlib import contextmanager
@@ -129,71 +127,9 @@ class TestProcessMetadataManager(unittest.TestCase):
 
 
 class TestProcessManager(unittest.TestCase):
-    SUBPROCESS_DIR = safe_mkdtemp()
-
     def setUp(self):
         super().setUp()
-        # N.B. We pass in `metadata_base_dir` here because ProcessManager (itself a non-task/non-
-        # subsystem) depends on an initialized `GlobalOptions` subsystem for the value of
-        # `--pants-subprocessdir` in the default case. This is normally provided by subsystem
-        # dependencies in a typical pants run (and integration tests), but not in unit tests.
-        # Thus, passing this parameter here short-circuits the subsystem-reliant path for the
-        # purposes of unit testing without requiring adhoc subsystem initialization.
-        self.pm = ProcessManager("test", metadata_base_dir=self.SUBPROCESS_DIR)
-
-    def test_process_properties(self):
-        with unittest.mock.patch.object(
-            ProcessManager, "_as_process", **PATCH_OPTS
-        ) as mock_as_process:
-            mock_as_process.return_value = fake_process(
-                name="name", cmdline=["cmd", "line"], status="status"
-            )
-            self.assertEqual(self.pm.cmdline, ["cmd", "line"])
-            self.assertEqual(self.pm.cmd, "cmd")
-
-    def test_process_properties_cmd_indexing(self):
-        with unittest.mock.patch.object(
-            ProcessManager, "_as_process", **PATCH_OPTS
-        ) as mock_as_process:
-            mock_as_process.return_value = fake_process(cmdline="")
-            self.assertEqual(self.pm.cmd, None)
-
-    def test_process_properties_none(self):
-        with unittest.mock.patch.object(ProcessManager, "_as_process", **PATCH_OPTS) as mock_asproc:
-            mock_asproc.return_value = None
-            self.assertEqual(self.pm.cmdline, None)
-            self.assertEqual(self.pm.cmd, None)
-
-    def test_get_subprocess_output(self):
-        test_str = "333"
-        self.assertEqual(self.pm.get_subprocess_output(["echo", "-n", test_str]), test_str)
-
-    def test_get_subprocess_output_interleaved(self):
-        cmd_payload = "import sys; " + (
-            'sys.stderr.write("9"); sys.stderr.flush(); sys.stdout.write("3"); sys.stdout.flush();'
-            * 3
-        )
-        cmd = [sys.executable, "-c", cmd_payload]
-
-        self.assertEqual(self.pm.get_subprocess_output(cmd), "333")
-        self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), "939393")
-        self.assertEqual(self.pm.get_subprocess_output(cmd, stderr=subprocess.STDOUT), "939393")
-
-    def test_get_subprocess_output_interleaved_bash(self):
-        cmd_payload = 'printf "9">&2; printf "3";' * 3
-        cmd = ["/bin/bash", "-c", cmd_payload]
-
-        self.assertEqual(self.pm.get_subprocess_output(cmd), "333")
-        self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), "939393")
-        self.assertEqual(self.pm.get_subprocess_output(cmd, stderr=subprocess.STDOUT), "939393")
-
-    def test_get_subprocess_output_oserror_exception(self):
-        with self.assertRaises(ProcessManager.ExecutionError):
-            self.pm.get_subprocess_output(["i_do_not_exist"])
-
-    def test_get_subprocess_output_failure_exception(self):
-        with self.assertRaises(ProcessManager.ExecutionError):
-            self.pm.get_subprocess_output(["false"])
+        self.pm = ProcessManager("test", metadata_base_dir=safe_mkdtemp())
 
     def test_await_pid(self):
         with unittest.mock.patch.object(ProcessManager, "await_metadata_by_name") as mock_await:
@@ -228,19 +164,20 @@ class TestProcessManager(unittest.TestCase):
         sentinel = 3333
         with unittest.mock.patch("psutil.Process", **PATCH_OPTS) as mock_proc:
             mock_proc.return_value = sentinel
-            self.pm._pid = sentinel
+            self.pm.write_pid(sentinel)
             self.assertEqual(self.pm._as_process(), sentinel)
 
     def test_as_process_no_pid(self):
         fake_pid = 3
         with unittest.mock.patch("psutil.Process", **PATCH_OPTS) as mock_proc:
             mock_proc.side_effect = psutil.NoSuchProcess(fake_pid)
-            self.pm._pid = fake_pid
+            self.pm.write_pid(fake_pid)
             with self.assertRaises(psutil.NoSuchProcess):
                 self.pm._as_process()
 
     def test_as_process_none(self):
-        self.assertEqual(self.pm._as_process(), None)
+        with self.assertRaises(self.pm.NotStarted):
+            self.pm._as_process()
 
     def test_is_alive_neg(self):
         with unittest.mock.patch.object(
@@ -285,7 +222,7 @@ class TestProcessManager(unittest.TestCase):
             mock_as_process.return_value = fake_process(
                 name="not_test", pid=3, status=psutil.STATUS_IDLE
             )
-            self.pm._process_name = "test"
+            self.pm.write_process_name("test")
             self.assertFalse(self.pm.is_alive())
             mock_as_process.assert_called_with(self.pm)
 
@@ -316,7 +253,7 @@ class TestProcessManager(unittest.TestCase):
 
     def test_kill(self):
         with unittest.mock.patch("os.kill", **PATCH_OPTS) as mock_kill:
-            self.pm._pid = 42
+            self.pm.write_pid(42)
             self.pm._kill(0)
             mock_kill.assert_called_once_with(42, 0)
 


### PR DESCRIPTION
### Problem

`pantsd` uses only options values to decide which instances are potentially valid for use. But on a well-configured system, option values will be stable across virtual machines and docker images, which means that `pantsd` will fruitlessly attempt to connect to a pid/socket that exists only on a different host. See #10847.

### Solution

In two commits: clean up some unnecessary abstraction around process metadata management, and include a host fingerprint in process metadata.

### Result

Multiple docker or virtual machine instances running in the same workspace should ignore one another's instances of `pantsd`. If we're able to include the uptime in the fingerprint in the future, it would further strengthen this check, but the fact that `docker` generates a random hostname means that this is sufficient to fix #10847.