### PR TITLE
Fix `setup_py.with_provides()` to respect the `:func` entry-point shorthand

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -16,7 +16,7 @@ from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import PathGlobs, Paths
-from pants.engine.rules import Get, UnionRule, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
@@ -38,6 +38,7 @@ from pants.engine.target import (
     Target,
     WrappedTarget,
 )
+from pants.engine.unions import UnionRule
 from pants.option.global_options import FilesNotFoundBehavior
 from pants.option.subsystem import Subsystem
 from pants.python.python_setup import PythonSetup

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -16,7 +16,7 @@ from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import OutputPathField
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
 from pants.engine.fs import PathGlobs, Paths
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, UnionRule, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
@@ -652,7 +652,7 @@ class InjectPythonDistributionDependencies(InjectDependenciesRequest):
 
 
 @rule
-async def inject_dependencies(
+async def inject_python_distribution_dependencies(
     request: InjectPythonDistributionDependencies,
 ) -> InjectedDependencies:
     """Inject any `.with_binaries()` values, as it would be redundant to have to include in the
@@ -673,4 +673,7 @@ async def inject_dependencies(
 
 
 def rules():
-    return collect_rules()
+    return (
+        *collect_rules(),
+        UnionRule(InjectDependenciesRequest, InjectPythonDistributionDependencies),
+    )


### PR DESCRIPTION
I accidentally forgot to wire this up in https://github.com/pantsbuild/pants/pull/11064.

Apparently https://github.com/pantsbuild/pants/pull/10829 didn't actually work either..we left off `UnionRule`.

[ci skip-rust]
[ci skip-build-wheels]
