### PR TITLE
Improve performance of dependency inference

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -20,6 +19,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Targets
 from pants.option.global_options import GlobalOptions
 from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.dirutil import fast_relpath
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -89,10 +89,9 @@ async def _stripped_file_names(
         Get(SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.sources.address)),
         Get(Paths, PathGlobs, sources_field_path_globs),
     )
-    if source_root == ".":
+    if source_root.path == ".":
         return _StrippedFileNames(paths.files)
-    # NB: `os.path` is faster than `PurePath()`.
-    return _StrippedFileNames(os.path.relpath(f, source_root.path) for f in paths.files)
+    return _StrippedFileNames(fast_relpath(f, source_root.path) for f in paths.files)
 
 
 @rule(desc="Creating map of first party targets to Python modules", level=LogLevel.DEBUG)


### PR DESCRIPTION
Before, 50 times:

```
./pants --no-pantsd dependencies src/python/pants/util:util
            Mean        Std.Dev.    Min         Median      Max
real        4.748       0.871       4.303       4.572       10.230
user        5.202       0.677       4.765       5.050       9.076
sys         3.747       0.210       3.512       3.706       4.697
```

After, 50 times:

```
./pants --no-pantsd dependencies src/python/pants/util:util
            Mean        Std.Dev.    Min         Median      Max
real        3.673       0.459       3.288       3.440       4.713
user        3.812       0.490       3.418       3.578       4.957
sys         1.917       0.192       1.745       1.825       2.384
```

[ci skip-rust]
[ci skip-build-wheels]