### PR TITLE
Add `./pants py-constraints --summary` for project overview

### DIFF
--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -4,7 +4,6 @@
 import csv
 import logging
 from collections import defaultdict
-from io import StringIO
 from textwrap import fill, indent
 from typing import cast
 
@@ -128,23 +127,21 @@ async def py_constraints(
             )
         ]
 
-        output_stream = StringIO()
-        writer = csv.DictWriter(
-            output_stream,
-            fieldnames=[
-                "Target",
-                "Constraints",
-                "Transitive Constraints",
-                "# Dependencies",
-                "# Dependees",
-            ],
-        )
-        writer.writeheader()
-        for entry in data:
-            writer.writerow(entry)
+        with py_constraints_subsystem.output_sink(console) as stdout:
+            writer = csv.DictWriter(
+                stdout,
+                fieldnames=[
+                    "Target",
+                    "Constraints",
+                    "Transitive Constraints",
+                    "# Dependencies",
+                    "# Dependees",
+                ],
+            )
+            writer.writeheader()
+            for entry in data:
+                writer.writerow(entry)
 
-        with py_constraints_subsystem.output(console) as output_stdout:
-            output_stdout(output_stream.getvalue())
         return PyConstraintsGoal(exit_code=0)
 
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -1,25 +1,61 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import csv
 import logging
 from collections import defaultdict
+from io import StringIO
 from textwrap import fill, indent
+from typing import cast
 
+from pants.backend.project_info.dependees import Dependees, DependeesRequest
+from pants.backend.python.target_types import (
+    InterpreterConstraintsField,
+    PythonInterpreterCompatibility,
+)
 from pants.backend.python.util_rules.pex import PexInterpreterConstraints
+from pants.base.specs import AddressSpecs, DescendantAddresses
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
-from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import Get, collect_rules, goal_rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.goal import Goal, GoalSubsystem, Outputting
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.target import (
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+    UnexpandedTargets,
+)
 from pants.python.python_setup import PythonSetup
 
 logger = logging.getLogger(__name__)
 
 
-class PyConstraintsSubsystem(GoalSubsystem):
+class PyConstraintsSubsystem(Outputting, GoalSubsystem):
     """Determine what Python interpreter constraints are used by files/targets."""
 
     name = "py-constraints"
+
+    @classmethod
+    def register_options(cls, register) -> None:
+        super().register_options(register)
+        register(
+            "--summary",
+            type=bool,
+            default=False,
+            help=(
+                "Output a CSV with each per-target information about interpreter constraints. The "
+                "headers are `Target`, `Constraints`, `Transitive Constraints`, `# Dependencies`, "
+                "and `# Dependees`.\n\nThis information can be useful when prioritizing a Python "
+                "migration, such as Python 3 migrations. Use `# Dependencies` and `# Dependees` to "
+                "help prioritize which targets are easiest to port (low # dependencies) and "
+                "highest impact to port (high # dependees).\n\nYou may want to import into Excel "
+                "or Google Sheets to post-process/filter the data."
+            ),
+        )
+
+    @property
+    def summary(self) -> bool:
+        return cast(bool, self.options.summary)
 
 
 class PyConstraintsGoal(Goal):
@@ -28,8 +64,89 @@ class PyConstraintsGoal(Goal):
 
 @goal_rule
 async def py_constraints(
-    addresses: Addresses, console: Console, python_setup: PythonSetup
+    addresses: Addresses,
+    console: Console,
+    py_constraints_subsystem: PyConstraintsSubsystem,
+    python_setup: PythonSetup,
 ) -> PyConstraintsGoal:
+    if py_constraints_subsystem.summary:
+        if addresses:
+            console.print_stderr(
+                "The `py-constraints --summary` goal does not take file/target arguments. It will "
+                "generate a summary of your entire repository. You can then use Google "
+                "Sheets/Excel to post-process/filter the data."
+            )
+            return PyConstraintsGoal(exit_code=1)
+
+        all_expanded_targets, all_explicit_targets = await MultiGet(
+            Get(Targets, AddressSpecs([DescendantAddresses("")])),
+            Get(UnexpandedTargets, AddressSpecs([DescendantAddresses("")])),
+        )
+        all_python_targets = sorted(
+            {
+                t
+                for t in (*all_expanded_targets, *all_explicit_targets)
+                if t.has_field(InterpreterConstraintsField)
+                or t.has_field(PythonInterpreterCompatibility)
+            },
+            key=lambda tgt: tgt.address,
+        )
+
+        constraints_per_tgt = [
+            PexInterpreterConstraints.create_from_targets([tgt], python_setup)
+            for tgt in all_python_targets
+        ]
+
+        transitive_targets_per_tgt = await MultiGet(
+            Get(TransitiveTargets, TransitiveTargetsRequest([tgt.address]))
+            for tgt in all_python_targets
+        )
+        transitive_constraints_per_tgt = [
+            PexInterpreterConstraints.create_from_targets(transitive_targets.closure, python_setup)
+            for transitive_targets in transitive_targets_per_tgt
+        ]
+
+        dependees_per_root = await MultiGet(
+            Get(Dependees, DependeesRequest([tgt.address], transitive=True, include_roots=False))
+            for tgt in all_python_targets
+        )
+
+        data = [
+            {
+                "Target": tgt.address.spec,
+                "Constraints": str(constraints),
+                "Transitive Constraints": str(transitive_constraints),
+                "# Dependencies": len(transitive_targets.dependencies),
+                "# Dependees": len(dependees),
+            }
+            for tgt, constraints, transitive_constraints, transitive_targets, dependees in zip(
+                all_python_targets,
+                constraints_per_tgt,
+                transitive_constraints_per_tgt,
+                transitive_targets_per_tgt,
+                dependees_per_root,
+            )
+        ]
+
+        output_stream = StringIO()
+        writer = csv.DictWriter(
+            output_stream,
+            fieldnames=[
+                "Target",
+                "Constraints",
+                "Transitive Constraints",
+                "# Dependencies",
+                "# Dependees",
+            ],
+        )
+        writer.writeheader()
+        for entry in data:
+            writer.writerow(entry)
+
+        with py_constraints_subsystem.output(console) as output_stdout:
+            output_stdout(output_stream.getvalue())
+        return PyConstraintsGoal(exit_code=0)
+
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addresses))
     final_constraints = PexInterpreterConstraints.create_from_targets(
         transitive_targets.closure, python_setup
@@ -39,15 +156,6 @@ async def py_constraints(
         logger.warning("No Python files/targets matched for the `py-constraints` goal.")
         return PyConstraintsGoal(exit_code=0)
 
-    console.print_stdout(f"Final merged constraints: {final_constraints}")
-    if len(addresses) > 1:
-        merged_constraints_warning = (
-            "(These are the constraints used if you were to depend on all of the input "
-            "files/targets together, even though they may end up never being used together in the "
-            "real world. Consider using a more precise query.)"
-        )
-        console.print_stdout(indent(fill(merged_constraints_warning, 80), "  "))
-
     constraints_to_addresses = defaultdict(set)
     for tgt in transitive_targets.closure:
         constraints = PexInterpreterConstraints.create_from_targets([tgt], python_setup)
@@ -55,10 +163,21 @@ async def py_constraints(
             continue
         constraints_to_addresses[constraints].add(tgt.address)
 
-    for constraint, addrs in sorted(constraints_to_addresses.items()):
-        console.print_stdout(f"\n{constraint}")
-        for addr in sorted(addrs):
-            console.print_stdout(f"  {addr}")
+    with py_constraints_subsystem.output(console) as output_stdout:
+        output_stdout(f"Final merged constraints: {final_constraints}\n")
+        if len(addresses) > 1:
+            merged_constraints_warning = (
+                "(These are the constraints used if you were to depend on all of the input "
+                "files/targets together, even though they may end up never being used together in "
+                "the real world. Consider using a more precise query or running "
+                "`./pants py-constriants --summary`.)\n"
+            )
+            output_stdout(indent(fill(merged_constraints_warning, 80), "  "))
+
+        for constraint, addrs in sorted(constraints_to_addresses.items()):
+            output_stdout(f"\n{constraint}\n")
+            for addr in sorted(addrs):
+                output_stdout(f"  {addr}\n")
 
     return PyConstraintsGoal(exit_code=0)
 

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -19,16 +19,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(rules=py_constraints_rules(), target_types=[Files, PythonLibrary])
 
 
-def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.create_file("f.txt")
-    rule_runner.add_to_build_file("", "files(name='tgt', sources=['f.txt'])")
-    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["f.txt"])
-    assert result.exit_code == 0
-    assert len(caplog.records) == 1
-    assert "No Python files/targets matched" in caplog.text
-
-
-def test_render_constraints(rule_runner: RuleRunner) -> None:
+def setup_project(rule_runner: RuleRunner) -> None:
     rule_runner.add_to_build_file(
         "lib1", "python_library(sources=[], interpreter_constraints=['==2.7.*', '>=3.5'])"
     )
@@ -55,6 +46,18 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
 
     rule_runner.set_options(["--python-setup-interpreter-constraints=['>=3.6']"])
 
+
+def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.create_file("f.txt")
+    rule_runner.add_to_build_file("", "files(name='tgt', sources=['f.txt'])")
+    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["f.txt"])
+    assert result.exit_code == 0
+    assert len(caplog.records) == 1
+    assert "No Python files/targets matched" in caplog.text
+
+
+def test_render_constraints(rule_runner: RuleRunner) -> None:
+    setup_project(rule_runner)
     result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["app"])
     assert result.stdout == dedent(
         """\
@@ -75,3 +78,18 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
     # If we run on >1 input, we include a warning about what the "final merged constraints" mean.
     result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["app", "lib1"])
     assert "Consider using a more precise query" in result.stdout
+
+
+def test_constraints_summary(rule_runner: RuleRunner) -> None:
+    setup_project(rule_runner)
+    result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["--summary"])
+    assert result.stdout == dedent(
+        """\
+        Target,Constraints,Transitive Constraints,# Dependencies,# Dependees\r
+        app,CPython==3.7.*,"CPython==2.7.*,==3.7.*,>=3.6 OR CPython==3.7.*,>=3.5,>=3.6",3,0\r
+        lib1,CPython==2.7.* OR CPython>=3.5,CPython==2.7.* OR CPython>=3.5,0,1\r
+        lib2,CPython>=3.6,CPython>=3.6,2,0\r
+        lib2/a.py,CPython>=3.6,CPython>=3.6,2,3\r
+        lib2/b.py,CPython>=3.6,CPython>=3.6,2,3\r
+        """
+    )

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -9,14 +9,16 @@ from pants.backend.python.mixed_interpreter_constraints.py_constraints import Py
 from pants.backend.python.mixed_interpreter_constraints.py_constraints import (
     rules as py_constraints_rules,
 )
-from pants.backend.python.target_types import PythonLibrary
+from pants.backend.python.target_types import PythonLibrary, PythonTests
 from pants.core.target_types import Files
 from pants.testutil.rule_runner import RuleRunner
 
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(rules=py_constraints_rules(), target_types=[Files, PythonLibrary])
+    return RuleRunner(
+        rules=py_constraints_rules(), target_types=[Files, PythonLibrary, PythonTests]
+    )
 
 
 def setup_project(rule_runner: RuleRunner) -> None:
@@ -53,7 +55,10 @@ def test_no_matches(rule_runner: RuleRunner, caplog) -> None:
     result = rule_runner.run_goal_rule(PyConstraintsGoal, args=["f.txt"])
     assert result.exit_code == 0
     assert len(caplog.records) == 1
-    assert "No Python files/targets matched" in caplog.text
+    assert (
+        "No Python files/targets matched for the `py-constraints` goal. All target types with "
+        "Python interpreter constraints: python_library, python_tests"
+    ) in caplog.text
 
 
 def test_render_constraints(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -492,31 +492,29 @@ class Target(ABC):
 
     @final
     @classmethod
-    def class_has_field(cls, field: Type[Field], *, union_membership: UnionMembership) -> bool:
+    def class_has_field(cls, field: Type[Field], union_membership: UnionMembership) -> bool:
         """Behaves like `Target.has_field()`, but works as a classmethod rather than an instance
         method."""
-        return cls.class_has_fields([field], union_membership=union_membership)
+        return cls.class_has_fields([field], union_membership)
 
     @final
     @classmethod
     def class_has_fields(
-        cls, fields: Iterable[Type[Field]], *, union_membership: UnionMembership
+        cls, fields: Iterable[Type[Field]], union_membership: UnionMembership
     ) -> bool:
         """Behaves like `Target.has_fields()`, but works as a classmethod rather than an instance
         method."""
-        return cls._has_fields(
-            fields, registered_fields=cls.class_field_types(union_membership=union_membership)
-        )
+        return cls._has_fields(fields, registered_fields=cls.class_field_types(union_membership))
 
     @final
     @classmethod
-    def class_get_field(cls, field: Type[_F], *, union_membership: UnionMembership) -> Type[_F]:
+    def class_get_field(cls, field: Type[_F], union_membership: UnionMembership) -> Type[_F]:
         """Get the requested Field type registered with this target type.
 
         This will error if the field is not registered, so you should call Target.class_has_field()
         first.
         """
-        class_fields = cls.class_field_types(union_membership=union_membership)
+        class_fields = cls.class_field_types(union_membership)
         result = next(
             (
                 registered_field


### PR DESCRIPTION
This is intended to give an overview of the current status of your project, and to help with prioritization for things like Python 3. In contrast, `./pants py-constraints` without `--summary` is intended for debugging on the local terminal.

We export as a CSV and expect users to import into Excel or Google Sheets to analyze the data. For example, https://docs.google.com/spreadsheets/d/1B_2WNmXuXCMbhU6h8nwhSV3YdArJZtE_qODYcI2968o/edit?usp=sharing.

We always run over the entire repo, rather than looking at user specs. This simplifies handling of subtargets and differences between file args vs. target args; both types of addresses are included in the analysis.

[ci skip-rust]
[ci skip-build-wheels]