### PR TITLE
Improve error message for invalid unions in `Get()`s

### DIFF
--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -147,7 +147,6 @@ def motorcycle_num_wheels(motorcycle: Motorcycle) -> int:
     return motorcycle.num_wheels()
 
 
-# We want to test that using a union in a `Get` works correctly, so we
 @dataclass(frozen=True)
 class WrappedVehicle:
     vehicle: Vehicle

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -593,7 +593,7 @@ async def MultiGet(  # noqa: F811
                     map(str, likely_args_exlicitly_passed)
                 )}
 
-                When constructing a MultiGet from individual Gets all leading arguments must be
+                When constructing a MultiGet from individual Gets, all leading arguments must be
                 Gets.
                 """
             )
@@ -609,8 +609,8 @@ async def MultiGet(  # noqa: F811
             2. MultiGet(Get[T1], Get[T2], ...) -> Tuple[T1, T2, ...]
 
             The 1st form is intended for homogenous collections of Gets and emulates an
-            async for ... comprehension used to iterate over the collection in parallel and collect
-            the results in a homogenous Tuple when all are complete.
+            async `for ...` comprehension used to iterate over the collection in parallel and
+            collect the results in a homogenous tuple when all are complete.
 
             The 2nd form supports executing heterogeneous Gets in parallel and collecting them in a
             heterogenous tuple when all are complete. Currently up to 10 heterogenous Gets can be

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -18,8 +18,8 @@ def union(cls):
     Annotating a class with @union allows other classes to register a `UnionRule(BaseClass,
     MemberClass)`. Then, you can use `await Get(Output, UnionBase, concrete_union_member)`. This
     would be similar to writing `UnionRule(Output, ConcreteUnionMember,
-    concrete_union_member_instance)`, but allows you to write generic code without knowing at the
-    time of writing that.
+    concrete_union_member_instance)`, but allows you to write generic code without knowing what
+    concrete classes might later implement that union.
 
     Often, union bases are abstract classes, but they need not be.
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -910,21 +910,18 @@ impl Task {
           .and_then(|edges| {
             edges.entry_for(&dependency_key).cloned().ok_or_else(|| {
               if externs::is_union(get.input_type) {
-                let value = externs::type_for_type_id(get.input_type).into_object();
-                match externs::call_method(
-                  &value,
-                  "non_member_error_message",
-                  &[externs::val_for(&get.input)],
-                ) {
-                  Ok(err_msg) => throw(&externs::val_to_str(&err_msg)),
-                  // If the non_member_error_message() call failed for any reason,
-                  // fall back to a generic message.
-                  Err(_e) => throw(&format!(
-                    "Type {} is not a member of the {} @union",
-                    get.input.type_id(),
-                    get.input_type
-                  )),
-                }
+                throw(&format!(
+                  "Invalid Get. Because the second argument to `Get({}, {}, {:?})` is annotated \
+                    with `@union`, the third argument should be a member of that union. Did you \
+                    intend to register `UnionRule({}, {})`? If not, you may be using the wrong \
+                    type ({}) for the third argument.",
+                  get.output,
+                  get.input_type,
+                  get.input,
+                  get.input_type,
+                  get.input.type_id(),
+                  get.input.type_id(),
+                ))
               } else {
                 // NB: The Python constructor for `Get()` will have already errored if
                 // `type(input) != input_type`.


### PR DESCRIPTION
Before:

```
Engine traceback:
  in select
  in pants.core.goals.lint.lint
Traceback (no traceback):
  <pants native internals>
Exception: Type int is not a member of the LintRequest @union ("A union for StyleRequests that should be lintable.

    Subclass and install a member of this type to provide a linter.
    ")
```

After:

```
Engine traceback:
  in select
  in pants.core.goals.lint.lint
Traceback (no traceback):
  <pants native internals>
Exception: Invalid Get. Because the second argument to `Get(LintResults, LintRequest, 1)` is annotated with `@union`, the third argument should be a member of that union. Did you intend to register `UnionRule(LintRequest, int)`? If not, you may be using the wrong type (int) for the third argument.
```

This also drops the ability for union bases to customize the error message, which hasn't been used for some time. We are using unions very differently than a year ago. For example, we now usually introspect `UnionMembership` to proactively find all valid combinations. At least in our own code, a user should never hit a union error based on something they did, unless us developers had an issue in our code. So, we no longer need to worry about the message making sense to end users; we instead want it to make sense to plugin authors. This is the same logic, for example, for why our wording of the error message for `Get(Snapshot, Digest, 1)` is optimized for plugin authors. 

[ci skip-build-wheels]