### PR TITLE
Fix `!!` transitive excludes when used multiple times in a repo (Cherry-pick of #11103)

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -343,9 +343,12 @@ async def transitive_targets(request: TransitiveTargetsRequest) -> TransitiveTar
     for t in (*roots_as_targets, *visited):
         unparsed = t.get(Dependencies).unevaluated_transitive_excludes
         if unparsed.values:
-            unevaluated_transitive_excludes.append(Get(Targets, UnparsedAddressInputs, unparsed))
+            unevaluated_transitive_excludes.append(unparsed)
     if unevaluated_transitive_excludes:
-        nested_transitive_excludes = await MultiGet(*unevaluated_transitive_excludes)
+        nested_transitive_excludes = await MultiGet(
+            Get(Targets, UnparsedAddressInputs, unparsed)
+            for unparsed in unevaluated_transitive_excludes
+        )
         transitive_excludes = FrozenOrderedSet(
             itertools.chain.from_iterable(excludes for excludes in nested_transitive_excludes)
         )


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/11101. We were unintentionally using the positional args style for `MultiGet`, when we meant to use the comprehension style.

[ci skip-build-wheels]
[ci skip-rust]