### PR TITLE
Fix `--pex-verbosity` to work with the interpreter selection PEX

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -462,7 +462,9 @@ logger = logging.getLogger(__name__)
 
 
 @rule(desc="Find Python interpreter for constraints", level=LogLevel.DEBUG)
-async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -> PythonExecutable:
+async def find_interpreter(
+    interpreter_constraints: PexInterpreterConstraints, pex_runtime_env: PexRuntimeEnvironment
+) -> PythonExecutable:
     formatted_constraints = " OR ".join(str(constraint) for constraint in interpreter_constraints)
     process = await Get(
         Process,
@@ -505,6 +507,12 @@ async def find_interpreter(interpreter_constraints: PexInterpreterConstraints) -
         ProcessResult, UncacheableProcess(process=process, scope=ProcessScope.PER_SESSION)
     )
     path, fingerprint = result.stdout.decode().strip().splitlines()
+
+    if pex_runtime_env.verbosity > 0:
+        log_output = result.stderr.decode()
+        if log_output:
+            logger.info("%s", log_output)
+
     return PythonExecutable(path=path, fingerprint=fingerprint)
 
 
@@ -514,7 +522,7 @@ async def create_pex(
     python_setup: PythonSetup,
     python_repos: PythonRepos,
     platform: Platform,
-    pex_runtime_environment: PexRuntimeEnvironment,
+    pex_runtime_env: PexRuntimeEnvironment,
 ) -> Pex:
     """Returns a PEX with the given settings."""
 
@@ -555,9 +563,6 @@ async def create_pex(
             argv.extend(request.interpreter_constraints.generate_pex_arg_list())
 
     argv.append("--no-emit-warnings")
-    verbosity = pex_runtime_environment.verbosity
-    if verbosity > 0:
-        argv.append(f"-{'v' * verbosity}")
 
     if python_setup.resolver_jobs:
         argv.extend(["--jobs", str(python_setup.resolver_jobs)])
@@ -638,7 +643,7 @@ async def create_pex(
         ),
     )
 
-    if verbosity > 0:
+    if pex_runtime_env.verbosity > 0:
         log_output = result.stderr.decode()
         if log_output:
             logger.info("%s", log_output)

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -9,7 +9,11 @@ from typing import Iterable, List, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.util_rules import pex_environment
-from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
+from pants.backend.python.util_rules.pex_environment import (
+    PexEnvironment,
+    PexRuntimeEnvironment,
+    PythonExecutable,
+)
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -97,6 +101,7 @@ async def setup_pex_cli_process(
     pex_env: PexEnvironment,
     python_native_code: PythonNativeCode,
     global_options: GlobalOptions,
+    pex_runtime_env: PexRuntimeEnvironment,
 ) -> Process:
     tmpdir = ".tmp"
     gets: List[Get] = [
@@ -126,7 +131,7 @@ async def setup_pex_cli_process(
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     pex_root_path = ".cache/pex_root"
-    argv = pex_env.create_argv(
+    argv = [
         downloaded_pex_bin.exe,
         *cert_args,
         "--python-path",
@@ -144,11 +149,14 @@ async def setup_pex_cli_process(
         # CWD can find the TMPDIR.
         "--tmpdir",
         tmpdir,
-        # NB: This comes at the end of the argv because the request may use `--` passthrough args,
-        # which must come at the end.
-        *request.argv,
-        python=request.python,
-    )
+    ]
+    if pex_runtime_env.verbosity > 0:
+        argv.append(f"-{'v' * pex_runtime_env.verbosity}")
+
+    # NB: This comes at the end of the argv because the request may use `--` passthrough args,
+    # which must come at the end.
+    argv.extend(request.argv)
+    normalized_argv = pex_env.create_argv(*argv, python=request.python)
     env = {
         **pex_env.environment_dict(python_configured=request.python is not None),
         **python_native_code.environment_dict,
@@ -156,7 +164,7 @@ async def setup_pex_cli_process(
     }
 
     return Process(
-        argv,
+        normalized_argv,
         description=request.description,
         input_digest=input_digest,
         env=env,


### PR DESCRIPTION
We don't wire up correctly when building the PEX that chooses which interpreter to use for `internal_only` PEXes.

[ci skip-rust]
[ci skip-build-wheels]